### PR TITLE
V8: Ensure that the recycle bin doesn't delete content at root

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
@@ -220,7 +220,7 @@ function startupLatestEditsController($scope) {
 }
 angular.module("umbraco").controller("Umbraco.Dashboard.StartupLatestEditsController", startupLatestEditsController);
 
-function MediaFolderBrowserDashboardController($rootScope, $scope, $location, contentTypeResource, userService) {
+function MediaFolderBrowserDashboardController($scope, $routeParams, $location, contentTypeResource, userService) {
 
     var currentUser = {};
 
@@ -251,6 +251,8 @@ function MediaFolderBrowserDashboardController($rootScope, $scope, $location, co
                         view: dt.view
                     };
 
+                    // tell the list view to list content at root
+                    $routeParams.id = -1;
             });
 
         } else if (currentUser.startMediaIds.length > 0){

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -276,6 +276,9 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     $scope.reloadView = function (id, reloadActiveNode) {
+        if (!id) {
+            return;
+        }
         $scope.viewLoaded = false;
         $scope.folders = [];
 
@@ -713,10 +716,10 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     function initView() {
-        //default to root id if the id is undefined
         var id = $routeParams.id;
         if (id === undefined) {
-            id = -1;
+            // no ID found in route params - don't list anything as we don't know for sure where we are
+            return;
         }
 
         getContentTypesCallback(id).then(function (listViewAllowedTypes) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7590

### Description

#7590 outlines the issue quite well. 

The root cause is that the listview assumes it should show content at root if no ID is passed to the listview in `$routeParams.id` (kudos to @stevemegson for investigating). _That is a really dangerous assumption!_

This PR removes that assumption. As a result the listview remains in a loading state because nothing ever loads. 

![image](https://user-images.githubusercontent.com/7405322/74425209-9b1f6700-4e53-11ea-8c03-28543be0f429.png)

It is also possible to make the listview appear empty (remove the loading state), but the loading state seems like the better alternative. After all, this is an exception state that _Should Not Happen™_.

I tried getting rid of the layout switcher and search input while the listview is in loading state, but that makes it impossible to search for anything at all in any listview so... that's not gonna happen, at least not in this PR 😆 

The only place I could find that exploits the assumption of `-1` is the listview on the media root dashboard. To counter that I have explicitly defined `-1` for `$routeParams.id` in the dashboard controller, that seems to work just fine.

#### Testing this PR

First and foremost you must have a culture variant setup to test this.

1. Verify that the recycle bin still works for both media and content.
2. Go to `/umbraco#/content/content/recyclebin` (without `mculture` in the querystring) - you may have to do this in a new tab. Verify that the recycle bin either remains in a loading state or lists the correct recycle bin content (there is a timing thing going on, sometimes it actually does list the recycle bin content). _Under no circumstance should it list anything from the content root._
3. Open the media root and verify that it lists folders and files at root as usual.