### PR TITLE
V8: Remove create option in listviews for deleted content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -719,39 +719,6 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             id = -1;
         }
 
-        getContentTypesCallback(id).then(function (listViewAllowedTypes) {
-          $scope.listViewAllowedTypes = listViewAllowedTypes;
-
-          var blueprints = false;
-          _.each(listViewAllowedTypes, function (allowedType) {
-              if (_.isEmpty(allowedType.blueprints)) {
-                // this helps the view understand that there are no blueprints available
-                allowedType.blueprints = null;
-              }
-              else {
-                blueprints = true;
-                // turn the content type blueprints object into an array of sortable objects for the view
-                allowedType.blueprints = _.map(_.pairs(allowedType.blueprints || {}), function (pair) {
-                  return {
-                    id: pair[0],
-                    name: pair[1]
-                  };
-                });
-              }
-            });
-
-            if (listViewAllowedTypes.length === 1 && blueprints === false) {
-                $scope.createAllowedButtonSingle = true;
-            }
-            if (listViewAllowedTypes.length === 1 && blueprints === true) {
-                $scope.createAllowedButtonSingleWithBlueprints = true;
-            }
-            if (listViewAllowedTypes.length > 1) {
-                $scope.createAllowedButtonMultiWithBlueprints = true;
-            }
-        });
-
-
         $scope.contentId = id;
         $scope.isTrashed = editorState.current ? editorState.current.trashed : id === "-20" || id === "-21";
 
@@ -764,6 +731,40 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             $scope.options.allowBulkCopy ||
             $scope.options.allowBulkMove ||
             $scope.options.allowBulkDelete;
+
+        if ($scope.isTrashed === false) {
+            getContentTypesCallback(id).then(function (listViewAllowedTypes) {
+                $scope.listViewAllowedTypes = listViewAllowedTypes;
+
+                var blueprints = false;
+                _.each(listViewAllowedTypes, function (allowedType) {
+                    if (_.isEmpty(allowedType.blueprints)) {
+                        // this helps the view understand that there are no blueprints available
+                        allowedType.blueprints = null;
+                    }
+                    else {
+                        blueprints = true;
+                        // turn the content type blueprints object into an array of sortable objects for the view
+                        allowedType.blueprints = _.map(_.pairs(allowedType.blueprints || {}), function (pair) {
+                            return {
+                                id: pair[0],
+                                name: pair[1]
+                            };
+                        });
+                    }
+                });
+
+                if (listViewAllowedTypes.length === 1 && blueprints === false) {
+                    $scope.createAllowedButtonSingle = true;
+                }
+                if (listViewAllowedTypes.length === 1 && blueprints === true) {
+                    $scope.createAllowedButtonSingleWithBlueprints = true;
+                }
+                if (listViewAllowedTypes.length > 1) {
+                    $scope.createAllowedButtonMultiWithBlueprints = true;
+                }
+            });
+        }
 
         $scope.reloadView($scope.contentId);
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It shouldn't be possible to create new content in the recycle bin. Hence the context menus for deleted items do not contain a "Create" option:

![image](https://user-images.githubusercontent.com/7405322/74427618-c015d900-4e57-11ea-88da-df9995cdc192.png)

But deleted content with listview enabled still allows creation of new content:

![trashed-create-before](https://user-images.githubusercontent.com/7405322/74427643-cc9a3180-4e57-11ea-86ac-eb7164058214.gif)

That's silly 😄 so this PR removes that option. Turns out this also saves an XHR since we no longer need to fetch the allowed child content types for the current (deleted) content item:

![trashed-create-after](https://user-images.githubusercontent.com/7405322/74427740-f6535880-4e57-11ea-823f-05828237cbda.gif)

#### Testing this PR

1. Verify that you can still create new content from list views for non-deleted content items.
2. Verify that that you can no longer create new content from list views for deleted content items.