### PR TITLE
V8: Correct cursor for list view search icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-mini-search.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-mini-search.less
@@ -23,6 +23,7 @@
         background-color: transparent;
         border-color: @ui-action-discreet-border;
         transition: background-color .1s linear, border-color .1s linear, color .1s linear, width .1s ease-in-out, padding-left .1s ease-in-out;
+        cursor: pointer;
     }
 
     &:focus-within, &:hover {
@@ -39,6 +40,7 @@
         background-color: white;
         color: @ui-action-discreet-border-hover;
         border-color: @ui-action-discreet-border-hover;
+        cursor: unset;
     }
     
     input:focus, &:focus-within input, &.--has-value input {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When the listview search input field is collapsed it should probably have a pointer cursor because it looks and acts like a button - right now the cursor is the default input field cursor:

![listview-search-before](https://user-images.githubusercontent.com/7405322/74430519-500a5180-4e5d-11ea-9c86-e17a925e8f80.gif)

With this PR applied the cursor is a pointer by default and turns into an input field cursor when the search field is expanded:

![listview-search-after](https://user-images.githubusercontent.com/7405322/74430564-687a6c00-4e5d-11ea-8278-d0e653fc87a3.gif)
