### PR TITLE
Fixing when a start node is a content item in a nested list view

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepositoryBase.cs
@@ -28,6 +28,13 @@ namespace Umbraco.Core.Persistence.Repositories
         bool HasContainerInPath(string contentPath);
 
         /// <summary>
+        /// Gets a value indicating whether there is a list view content item in the path.
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <returns></returns>
+        bool HasContainerInPath(params int[] ids);
+
+        /// <summary>
         /// Returns true or false depending on whether content nodes have been created based on the provided content type id.
         /// </summary>
         bool HasContentNodes(int id);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -1309,14 +1309,16 @@ WHERE cmsContentType." + aliasColumn + @" LIKE @pattern",
             return test;
         }
 
-        /// <summary>
-        /// Given the path of a content item, this will return true if the content item exists underneath a list view content item
-        /// </summary>
-        /// <param name="contentPath"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public bool HasContainerInPath(string contentPath)
         {
-            var ids = contentPath.Split(',').Select(int.Parse);
+            var ids = contentPath.Split(',').Select(int.Parse).ToArray();
+            return HasContainerInPath(ids);
+        }
+
+        /// <inheritdoc />
+        public bool HasContainerInPath(params int[] ids)
+        {
             var sql = new Sql($@"SELECT COUNT(*) FROM cmsContentType
 INNER JOIN {Constants.DatabaseSchema.Tables.Content} ON cmsContentType.nodeId={Constants.DatabaseSchema.Tables.Content}.contentTypeId
 WHERE {Constants.DatabaseSchema.Tables.Content}.nodeId IN (@ids) AND cmsContentType.isContainer=@isContainer", new { ids, isContainer = true });

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -69,6 +69,13 @@ namespace Umbraco.Core.Services
         /// <returns></returns>
         bool HasContainerInPath(string contentPath);
 
+        /// <summary>
+        /// Gets a value indicating whether there is a list view content item in the path.
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <returns></returns>
+        bool HasContainerInPath(params int[] ids);
+
         Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentContainerId, string name, int userId = Constants.Security.SuperUserId);
         Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = Constants.Security.SuperUserId);
         EntityContainer GetContainer(int containerId);

--- a/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -321,6 +321,15 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public bool HasContainerInPath(params int[] ids)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                // can use same repo for both content and media
+                return Repository.HasContainerInPath(ids);
+            }
+        }
+
         public IEnumerable<TItem> GetDescendants(int id, bool andSelf)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -869,7 +869,7 @@ namespace Umbraco.Web.Editors
             return true;
         }
 
-        
+
 
         /// <summary>
         /// Helper method to perform the saving of the content and add the notifications to the result
@@ -1161,14 +1161,14 @@ namespace Umbraco.Web.Editors
             //validate if we can publish based on the mandatory language requirements
             var canPublish = ValidatePublishingMandatoryLanguages(
                 cultureErrors,
-                contentItem, cultureVariants, mandatoryCultures, 
+                contentItem, cultureVariants, mandatoryCultures,
                 mandatoryVariant => mandatoryVariant.Publish);
 
             //Now check if there are validation errors on each variant.
             //If validation errors are detected on a variant and it's state is set to 'publish', then we
             //need to change it to 'save'.
             //It is a requirement that this is performed AFTER ValidatePublishingMandatoryLanguages.
-            
+
             foreach (var variant in contentItem.Variants)
             {
                 if (cultureErrors.Contains(variant.Culture))
@@ -1656,14 +1656,14 @@ namespace Umbraco.Web.Editors
         [HttpPost]
         public DomainSave PostSaveLanguageAndDomains(DomainSave model)
         {
-            foreach(var domain in model.Domains)
+            foreach (var domain in model.Domains)
             {
                 try
                 {
                     var uri = DomainUtilities.ParseUriFromDomainName(domain.Name, Request.RequestUri);
                 }
                 catch (UriFormatException)
-                {                    
+                {
                     var response = Request.CreateValidationErrorResponse(Services.TextService.Localize("assignDomain/invalidDomain"));
                     throw new HttpResponseException(response);
                 }
@@ -1829,7 +1829,7 @@ namespace Umbraco.Web.Editors
             base.HandleInvalidModelState(display);
 
         }
-        
+
         /// <summary>
         /// Maps the dto property values and names to the persisted model
         /// </summary>
@@ -1842,7 +1842,7 @@ namespace Umbraco.Web.Editors
                 var culture = property.PropertyType.VariesByCulture() ? variant.Culture : null;
                 var segment = property.PropertyType.VariesBySegment() ? variant.Segment : null;
                 return (culture, segment);
-            }            
+            }
 
             var variantIndex = 0;
 
@@ -1884,15 +1884,15 @@ namespace Umbraco.Web.Editors
                     (save, property) =>
                     {
                         // Get property value
-                        (var culture, var segment) = PropertyCultureAndSegment(property, variant);                        
-                        return property.GetValue(culture, segment);                        
+                        (var culture, var segment) = PropertyCultureAndSegment(property, variant);
+                        return property.GetValue(culture, segment);
                     },
                     (save, property, v) =>
                     {
                         // Set property value
                         (var culture, var segment) = PropertyCultureAndSegment(property, variant);
-                        property.SetValue(v, culture, segment);                        
-                    },  
+                        property.SetValue(v, culture, segment);
+                    },
                     variant.Culture);
 
                 variantIndex++;
@@ -2172,7 +2172,10 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         private ContentItemDisplay MapToDisplay(IContent content)
         {
-            var display = Mapper.Map<ContentItemDisplay>(content);
+            var display = Mapper.Map<ContentItemDisplay>(content, context =>
+            {
+                context.Items["CurrentUser"] = Security.CurrentUser;
+            });
             display.AllowPreview = display.AllowPreview && content.Trashed == false && content.ContentType.IsElement == false;
             return display;
         }

--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -364,7 +364,12 @@ namespace Umbraco.Web.Trees
                 var startNodes = Services.EntityService.GetAll(UmbracoObjectType, UserStartNodes);
                 //if any of these start nodes' parent is current, then we need to render children normally so we need to switch some logic and tell
                 // the UI that this node does have children and that it isn't a container
-                if (startNodes.Any(x => x.ParentId == e.Id))
+
+                if (startNodes.Any(x =>
+                {
+                    var pathParts = x.Path.Split(',');
+                    return pathParts.Contains(e.Id.ToInvariantString());
+                }))
                 {
                     renderChildren = true;
                 }


### PR DESCRIPTION
If you have a user with a start node that is nested within 2 or more list views, the tree will not expand when the user logs in and therefore the user cannot actually navigate to or edit their start node.

## Testing

Create a tree structure like:

* Home
  * List View
    * List View
      * Content

And then create a new user and set their start node to `Content`. When you log in the tree will expand to show `Content`. Be creative, try nesting a start node in a bunch of list views, maybe even have a content -> list view -> content -> list view type scenario, it should all work.

