### PR TITLE
CSS class added to the h3 on members dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
@@ -4,7 +4,7 @@
 
 	<umb-box>
 		<umb-box-content>
-			<h3><localize key="settingsDashboardVideos_trainingHeadline">Hours of Umbraco training videos are only a click away</localize></h3>
+			<h3 class="bold"><localize key="settingsDashboardVideos_trainingHeadline">Hours of Umbraco training videos are only a click away</localize></h3>
 			<localize key="settingsDashboardVideos_trainingDescription">
         <p>Want to master Umbraco? Spend a couple of minutes learning some best practices by watching one of these videos about using Umbraco. And visit <a href="http://umbraco.tv" target="_blank">umbraco.tv</a> for even more Umbraco videos</p>
       </localize>


### PR DESCRIPTION
The members dashboard `h3` heading is not very consistent with the settings welcome dashboard. The heading is bolder in the settings dashboard. The headings are bold across other Settings dashboard like Modelsbuilder and Performance Profiling which makes me think that the members dashboard should reflect the same.
**Settings Dashboard**
![image](https://user-images.githubusercontent.com/3941753/74596206-eac48500-5043-11ea-91e8-713f23585b32.png)

**Members Dashoard - Before**
![image](https://user-images.githubusercontent.com/3941753/74596229-28c1a900-5044-11ea-9c29-e27929826599.png)


**Members Dashboard -After**
![image](https://user-images.githubusercontent.com/3941753/74596230-3ecf6980-5044-11ea-9ad6-fd057cc29fa4.png)
