### PR TITLE
Fix regression from valpropertymsg directive changes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
@@ -39,7 +39,9 @@ function valPropertyMsg(serverValidationManager, localizationService) {
             scope.currentProperty = currentProperty;
 
             var currentCulture = currentProperty.culture;         
-            var isMandatory = currentProperty.validation.mandatory;
+            
+            // validation object won't exist when editor loads outside the content form (ie in settings section when modifying a content type)
+            var isMandatory = currentProperty.validation ? currentProperty.validation.mandatory : undefined;
 
             var labels = {};
             localizationService.localize("errors_propertyHasErrors").then(function (data) {
@@ -141,7 +143,7 @@ function valPropertyMsg(serverValidationManager, localizationService) {
                     else if (_.without(_.keys(formCtrl.$error), "valPropertyMsg").length > 0) {
                         
                         // errors exist, but if the property is NOT mandatory and has no value, the errors should be cleared
-                        if (!isMandatory && !currentProperty.value) {
+                        if (isMandatory !== undefined && isMandatory === false && !currentProperty.value) {
                             hasError = false;
                             showValidation = false;
                             scope.errorMsg = "";


### PR DESCRIPTION
Fixes regression where validation object doesn't always exist on the property, depending on context - when adding an editor to a content type, the validation logic runs, but the validation property on the editor doesn't exist.

Changes here add an explicit check for `currentProperty.validation` before trying to access `.mandatory`

This relates to the changes from #7662 - ping @poornimanayar since she's across those changes 😄 

### Prerequisites

- [x] I have added steps to test this contribution in the description below

To test, edit a content type, adding a new property editor, should be no JS errors logged into the console. Validation should clear as expected when editing the property value on a content item.
