### PR TITLE
Allow Link Picker to get links from RTE's inside nested content

### DIFF
--- a/src/Umbraco.Core/Services/ContentServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/ContentServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -21,6 +21,7 @@ namespace Umbraco.Core.Services
             var result = new List<string>();
             var content = contentService.GetById(id);
 
+
             foreach (var contentProperty in content.Properties)
             {
                 if (contentProperty.PropertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.TinyMce))
@@ -30,7 +31,27 @@ namespace Umbraco.Core.Services
                     {
                         result.AddRange(contentService.GetAnchorValuesFromRTEContent(value));
                     }
+                    continue;
                 }
+
+                if (contentProperty.PropertyType.PropertyEditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.NestedContent))
+                {
+                    var values = contentProperty?.Values;
+                    var numberOfProperties = (values?.Count() ?? 0);
+
+                    if (numberOfProperties <= 0)
+                        continue;
+
+                    foreach (var val in values.Where(s => culture == "*" || string.IsNullOrWhiteSpace(s.Culture) || s.Culture == culture.ToLowerInvariant()))
+                    {
+                        var value = val?.PublishedValue?.ToString()?.Replace(@"\", "");
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            result.AddRange(contentService.GetAnchorValuesFromRTEContent(value));
+                        }
+                    }
+                }
+
             }
             return result;
         }


### PR DESCRIPTION
### Prerequisites

- Nested content with an RTE
- Doctype with a property type that allows multiple nested content items.
- Document type and properties allow variants 
- At least to cultures 
Steps to test this pull request.

- Add a content node with two nested content items. 
- Add one anchor link in one of the RTE's
- Save or Save and Publish your changes
- Add a link on the other RTE. 
- When the link editor dialog opens, click on the node where you have both RTE's and look at the top-right text box where you can append query string parameters, you should see the arrow icon on mouse hover, on click you should be able to see the recently created anchor link for your specific culture. 

note: If you don't set a culture this will still work and return the anchor links that are not assigned to a specific language. 

this fixes https://github.com/umbraco/Umbraco-CMS/issues/5892

Please check the [gif file](https://drive.google.com/file/d/1PPBUO_fR3Jaq8coVX4cD83UTQzKw42VA/view?usp=sharing) as this will make things much clear for you when testing the PR.


