### PR TITLE
V8: Make sure mculture is set after logout and login

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/navigation.controller.js
@@ -257,6 +257,7 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
     evts.push(eventsService.on("app.ready", function (evt, data) {
         $scope.authenticated = true;
         ensureInit();
+        ensureMainCulture();
     }));
 
     // event for infinite editors
@@ -279,8 +280,22 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
         }
     }));
 
-
-    
+    /**
+     * For multi language sites, this ensures that mculture is set to either the last selected language or the default one
+     */ 
+    function ensureMainCulture() {
+        if ($location.search().mculture) {
+            return;
+        }
+        var language = lastLanguageOrDefault();
+        if (!language) {
+            return;
+        }
+        // trigger a language selection in the next digest cycle
+        $timeout(function () {
+            $scope.selectLanguage(language);
+        });
+    }    
 
     /**
      * Based on the current state of the application, this configures the scope variables that control the main tree and language drop down
@@ -385,28 +400,19 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
 
             if ($scope.languages.length > 1) {
                 //if there's already one set, check if it exists
-                var currCulture = null;
+                var language = null;
                 var mainCulture = $location.search().mculture;
                 if (mainCulture) {
-                    currCulture = _.find($scope.languages, function (l) {
+                    language = _.find($scope.languages, function (l) {
                         return l.culture.toLowerCase() === mainCulture.toLowerCase();
                     });
                 }
-                if (!currCulture) {
-                    // no culture in the request, let's look for one in the cookie that's set when changing language
-                    var defaultCulture = $cookies.get("UMB_MCULTURE");
-                    if (!defaultCulture || !_.find($scope.languages, function (l) {
-                            return l.culture.toLowerCase() === defaultCulture.toLowerCase();
-                        })) {
-                        // no luck either, look for the default language
-                        var defaultLang = _.find($scope.languages, function (l) {
-                            return l.isDefault;
-                        });
-                        if (defaultLang) {
-                            defaultCulture = defaultLang.culture;
-                        }
+                if (!language) {
+                    language = lastLanguageOrDefault();
+
+                    if (language) {
+                        $location.search("mculture", language.culture);
                     }
-                    $location.search("mculture", defaultCulture ? defaultCulture : null);
                 }
             }
 
@@ -431,6 +437,25 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
             });
         });
     }
+
+    function lastLanguageOrDefault() {
+        if (!$scope.languages || $scope.languages.length <= 1) {
+            return null;
+        }
+        // see if we can find a culture in the cookie set when changing language
+        var lastCulture = $cookies.get("UMB_MCULTURE");
+        var language = lastCulture ? _.find($scope.languages, function (l) {
+            return l.culture.toLowerCase() === lastCulture.toLowerCase();
+        }) : null;
+        if (!language) {
+            // no luck, look for the default language
+            language = _.find($scope.languages, function (l) {
+                return l.isDefault;
+            });
+        }
+        return language;
+    }
+
     function nodeExpandedHandler(args) {
         //store the reference to the expanded node path
         if (args.node) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7674

### Description

This PR ensures that `mculture` is set correctly again when you login after having logged out (on a multi lingual site).

#### Testing this PR

1. Open a new browser window and login to Umbraco.
2. Verify that `mculture` is set correctly and that the content tree reflects `mculture`.
3. Change `mculture` to something else in the language selector.
![image](https://user-images.githubusercontent.com/7405322/74968804-bb36c380-541b-11ea-9741-3514fc08db45.png)
4. Logout.
5. In the same browser window, login again.
6. Verify that `mculture` is set to one selected in step 3 and that the content tree reflects it.
7. Change `mculture` again. 
8. Logout.
9. Reload the browser window.
10. In the same browser window, login again.
11. Verify that `mculture` is set to one selected in step 7 and that the content tree reflects it.
