### PR TITLE
Update editor.service.js ngdoc for templateEditor fn

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -784,7 +784,7 @@ When building a custom infinite editor view you can use the same components as a
          * @methodOf umbraco.services.editorService
          *
          * @description
-         * Opens the user group picker in infinite editing, the submit callback returns the saved template
+         * Opens the template editor in infinite editing, the submit callback returns the saved template
          * @param {Object} editor rendering options
          * @param {String} editor.id The template id
          * @param {Callback} editor.submit Submits the editor


### PR DESCRIPTION
Fix ngdoc description for templateEditor fn => description previously referred to user group picker, should be `template editor`. Quick n easy.
