### PR TITLE
Making DataEditor.GetValueEditor method virtual

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -105,7 +105,7 @@ namespace Umbraco.Core.PropertyEditors
         /// <para>Technically, it could be cached by datatype but let's keep things
         /// simple enough for now.</para>
         /// </remarks>
-        public IDataValueEditor GetValueEditor(object configuration)
+        public virtual IDataValueEditor GetValueEditor(object configuration)
         {
             // if an explicit value editor has been set (by the manifest parser)
             // then return it, and ignore the configuration, which is going to be


### PR DESCRIPTION
Based on #7709, I think it makes good sense to make the `DataEditor.GetValueEditor` method virtual, so it can be overridden by classes inheriting from the `DataEditor` class.

Overriding the method could then be something like:

```csharp
public override IDataValueEditor GetValueEditor(object configuration)
{

    var editor = base.GetValueEditor(configuration);

    if (editor is DataValueEditor valueEditor && configuration is MyConfiguration config)
    {
        valueEditor.HideLabel = config.HideLabel;
    }

    return editor;

}
```

For testing that the overriden method is actually hit, I made this custom property editor:

```csharp
using Umbraco.Core.Logging;
using Umbraco.Core.PropertyEditors;
using Umbraco.Web.PropertyEditors;

namespace Umbraco.Web.Test{

    [DataEditor("Test", EditorType.PropertyValue, "Test", "mediapicker", ValueType = ValueTypes.String)]
    public class TestEditor : DataEditor {

        public TestEditor(ILogger logger) : base(logger)  { }

        protected override IConfigurationEditor CreateConfigurationEditor() => new MediaPickerConfigurationEditor();

        public override IDataValueEditor GetValueEditor(object configuration) {

            var editor = base.GetValueEditor(configuration);

            if (editor is DataValueEditor valueEditor && configuration is MediaPickerConfiguration config)  {
                valueEditor.HideLabel = true;
                valueEditor.View = "nope.html";
            }

            return editor;

        }

    }

}
```

It uses the view and configuration of the media picker, and adding it to a document type, the changes made in the `GetValueEditor` method should be visible to the user.