### PR TITLE
RTE config tool bar options are messed up

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -1,5 +1,8 @@
-@checkboxWidth: 16px;
-@checkboxHeight: 16px;
+@checkboxWidth: 18px;
+@checkboxHeight: 18px;
+label.umb-form-check--checkbox{
+    margin:3px 0;
+}
 
 .umb-form-check {
     display: flex;
@@ -10,11 +13,11 @@
     cursor: pointer !important;
 
     .umb-form-check__symbol {
-        margin-top: 1px;
+        margin-top: 4px;
         margin-right: 10px;
     }
     .umb-form-check__info {
-
+        margin-left:20px;
     }
     
 
@@ -95,6 +98,10 @@
     &__state {
         display: flex;
         height: 18px;
+        position: absolute;
+        margin-top: 2px;
+        top: 0;
+        left: -1px;
     }
 
     &__check {


### PR DESCRIPTION
In the latest `v8/contrib` log into back office -> settings -> go to a grid data type config or RTE config, the options looks very messed up.

![image](https://user-images.githubusercontent.com/3941753/75294993-ac884c00-5821-11ea-9580-17d1de3ce418.png)
