### PR TITLE
7720 - make internal UserService events public

### DIFF
--- a/src/Umbraco.Core/Events/UserGroupWithUsers.cs
+++ b/src/Umbraco.Core/Events/UserGroupWithUsers.cs
@@ -3,7 +3,7 @@ using Umbraco.Core.Models.Membership;
 
 namespace Umbraco.Core.Events
 {
-    internal class UserGroupWithUsers
+    public class UserGroupWithUsers
     {
         public UserGroupWithUsers(IUserGroup userGroup, IUser[] addedUsers, IUser[] removedUsers)
         {

--- a/src/Umbraco.Core/Services/Implement/UserService.cs
+++ b/src/Umbraco.Core/Services/Implement/UserService.cs
@@ -1197,12 +1197,12 @@ namespace Umbraco.Core.Services.Implement
         /// <summary>
         /// Occurs before Save
         /// </summary>
-        internal static event TypedEventHandler<IUserService, SaveEventArgs<UserGroupWithUsers>> SavingUserGroup;
+        public static event TypedEventHandler<IUserService, SaveEventArgs<UserGroupWithUsers>> SavingUserGroup;
 
         /// <summary>
         /// Occurs after Save
         /// </summary>
-        internal static event TypedEventHandler<IUserService, SaveEventArgs<UserGroupWithUsers>> SavedUserGroup;
+        public static event TypedEventHandler<IUserService, SaveEventArgs<UserGroupWithUsers>> SavedUserGroup;
 
         /// <summary>
         /// Occurs before Delete


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7720 

### Description

Changes [Saving|Saved]UserGroup events in UserService from internal to public

Looks like these were always intended to be public, but got mixed up in the 7=>8 changes. Have also had to make UserGroupWithUsers public as it's referenced by the event so must be equally accessible.

Have verified by adding an event handler in an existing Composer in Umbraco.Web, events are raised, parameters are correct.
