### PR TITLE
7713 - changing CSS directory breaks RTE

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/StylesheetRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/StylesheetRepository.cs
@@ -25,8 +25,17 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             path = path.EnsureEndsWith(".css");
 
-            if (FileSystem.FileExists(path) == false)
+            // if the css directory is changed, references to the old path can still exist (ie in RTE config)
+            // these old references will throw an error, which breaks the RTE
+            // try-catch here makes the request fail silently, and allows RTE to load correctly
+            try
+            {
+                if (FileSystem.FileExists(path) == false)
+                    return null;
+            } catch
+            {
                 return null;
+            }
 
             // content will be lazy-loaded when required
             var created = FileSystem.GetCreated(path).UtcDateTime;

--- a/src/Umbraco.Tests/Persistence/Repositories/StylesheetRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/StylesheetRepositoryTest.cs
@@ -294,15 +294,13 @@ namespace Umbraco.Tests.Persistence.Repositories
                 stylesheet = repository.Get("missing.css");
                 Assert.IsNull(stylesheet);
 
-                // fixed in 7.3 - 7.2.8 used to...
-                Assert.Throws<UnauthorizedAccessException>(() =>
-                {
-                    stylesheet = repository.Get("\\test-path-4.css"); // outside the filesystem, does not exist
-                });
-                Assert.Throws<UnauthorizedAccessException>(() =>
-                {
-                    stylesheet = repository.Get("../packages.config"); // outside the filesystem, exists
-                });
+                // #7713 changes behaviour to return null when outside the filesystem
+                // to accomodate changing the CSS path and not flooding the backoffice with errors
+                stylesheet = repository.Get("\\test-path-4.css"); // outside the filesystem, does not exist
+                Assert.IsNull(stylesheet);
+
+                stylesheet = repository.Get("../packages.config"); // outside the filesystem, exists
+                Assert.IsNull(stylesheet);                
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -39,8 +39,14 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
 
         stylesheetResource.getAll().then(function(stylesheets){
             $scope.stylesheets = stylesheets;
-
-            _.each($scope.stylesheets, function (stylesheet) {
+            
+            // if the CSS directory changes, previously assigned stylesheets are retained, but will not be visible
+            // and will throw a 404 when loading the RTE. Remove them here. Still needs to be saved...
+            let cssPath = Umbraco.Sys.ServerVariables.umbracoSettings.cssPath;
+            $scope.model.value.stylesheets = $scope.model.value.stylesheets
+                .filter(sheet => sheet.startsWith(cssPath));
+            
+            $scope.stylesheets.forEach(stylesheet => {
                 // support both current format (full stylesheet path) and legacy format (stylesheet name only) 
                 stylesheet.selected = $scope.model.value.stylesheets.indexOf(stylesheet.path) >= 0 ||$scope.model.value.stylesheets.indexOf(stylesheet.name) >= 0;
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7713 

### Description

This is a file system security exception, thrown when the requested file is outside the scope of the current file system's root. The CSS files still exist, we're just not permitted to access them. The exception bubbles up into the backoffice, and the RTE dies. 

Changes here wraps a try-catch around the file-exists check in the stylesheets repo. If the check fails, or throws, the stylesheet request returns null, and it's business as usual in the RTE, just without the requested CSS. 

I don't know how often a dev would be changing the CSS directory on an established site, but this will suppress the error.

Have added a bit of cleanup code in the rte prevalues, nothing flash, but filters out assigned CSS from the RTE config when the path doesn't match the current Umbraco CSS directory. Datatype still needs the config to be saved to persist the change.

To verify, follow the reproduction steps in #7713, should be no more error (404s will still be logged to the console, which is expected behaviour since the request for the stylesheets didn't find anything. Better than throwing a 500 though). 