### PR TITLE
7728 - show elipsis only when > length

### DIFF
--- a/src/Umbraco.Web/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web/HtmlStringUtilities.cs
@@ -227,21 +227,27 @@ namespace Umbraco.Web
                                         }
                                     }
 
-                                    if (!lengthReached && currentTextLength >= length)
+                                    if (!lengthReached)
                                     {
-                                        // if the last character added was the first of a two character unicode pair, add the second character
-                                        if (Char.IsHighSurrogate((char)ic))
+                                        if (currentTextLength == length)
                                         {
-                                            var lowSurrogate = tr.Read();
-                                            outputtw.Write((char)lowSurrogate);
-                                        }
+                                            // if the last character added was the first of a two character unicode pair, add the second character
+                                            if (char.IsHighSurrogate((char)ic))
+                                            {
+                                                var lowSurrogate = tr.Read();
+                                                outputtw.Write((char)lowSurrogate);
+                                            }
 
-                                        // Reached truncate limit.
-                                        if (addElipsis)
-                                        {
-                                            outputtw.Write(hellip);
                                         }
-                                        lengthReached = true;
+                                        // only add elipsis if current length greater than original length
+                                        if (currentTextLength > length)
+                                        {
+                                            if (addElipsis)
+                                            {
+                                                outputtw.Write(hellip);
+                                            }
+                                            lengthReached = true;
+                                        }
                                     }
 
                                 }


### PR DESCRIPTION
Fixed the elipsis issue, only adds an elipisis if the text length exceeds the length that is being truncated too.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7728 

### Description
Updates the Truncate method, only adds the elipsis if the length of the string passed in exceeds the truncate amount.  If they are equal then no elipsis is added.
