### PR TITLE
Some decoupling from underscorejs

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -232,11 +232,6 @@ function dependencies() {
             "name": "typeahead.js",
             "src":  ["./node_modules/typeahead.js/dist/typeahead.bundle.min.js"],
             "base": "./node_modules/typeahead.js/dist"
-        },
-        {
-            "name": "underscore",
-            "src":  ["node_modules/underscore/underscore-min.js"],
-            "base": "./node_modules/underscore"
         }
     ];
 

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -105,7 +105,7 @@ function dependencies() {
             "name": "angular-messages",
             "src":  ["./node_modules/angular-messages/angular-messages.js"],
             "base": "./node_modules/angular-messages"
-        },        
+        },
         {
             "name": "angular-mocks",
             "src":  ["./node_modules/angular-mocks/angular-mocks.js"],
@@ -252,7 +252,7 @@ function dependencies() {
 
     //Copies all static assets into /root / assets folder
     //css, fonts and image files
-    
+
     var assetsTask = gulp.src(config.sources.globs.assets, { allowEmpty: true });
     assetsTask = assetsTask.pipe(imagemin([
         imagemin.gifsicle({interlaced: true}),
@@ -265,9 +265,9 @@ function dependencies() {
             ]
         })
     ]));
-    
+
     assetsTask = assetsTask.pipe(gulp.dest(config.root + config.targets.assets));
-    
+
     stream.add(assetsTask);
 
     // Copies all the less files related to the preview into their folder

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
@@ -19,12 +19,12 @@ function js() {
         gulp.src(config.sources.globs.js).pipe( gulp.dest(config.root + config.targets.js) )
     );
 
-    for(const group in config.sources.js){
-        const groupItem = config.sources.js[group];
+    Object.keys(config.sources.js).forEach(key => {
+        const groupItem = config.sources.js[key];
         stream.add(processJs(groupItem.files, groupItem.out));
-    }
+    });
 
-     return stream;
+    return stream;
 };
 
 module.exports = { js: js };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
@@ -3,7 +3,6 @@
 var config = require('../config');
 var gulp = require('gulp');
 
-var _ = require('lodash');
 var MergeStream = require('merge-stream');
 
 var processJs = require('../util/processJs');
@@ -20,11 +19,10 @@ function js() {
         gulp.src(config.sources.globs.js).pipe( gulp.dest(config.root + config.targets.js) )
     );
 
-    _.forEach(config.sources.js, function (group) {
-        stream.add(
-            processJs(group.files, group.out)
-        );
-    });
+    for(const group in config.sources.js){
+        const groupItem = config.sources.js[group];
+        stream.add(processJs(groupItem.files, groupItem.out));
+    }
 
      return stream;
 };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/less.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/less.js
@@ -1,19 +1,17 @@
 'use strict';
 
 var config = require('../config');
-
-var _ = require('lodash');
 var MergeStream = require('merge-stream');
-
 var processLess = require('../util/processLess');
 
 function less() {
 
     var stream = new MergeStream();
 
-    _.forEach(config.sources.less, function (group) {
-        stream.add( processLess(group.files, group.out) );
-    });
+    for(const group in config.sources.less){
+        const groupItem = config.sources.less[group];
+        stream.add(processLess(groupItem.files, groupItem.out));
+    }
 
     return stream;
 };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/less.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/less.js
@@ -8,10 +8,10 @@ function less() {
 
     var stream = new MergeStream();
 
-    for(const group in config.sources.less){
-        const groupItem = config.sources.less[group];
+    Object.keys(config.sources.less).forEach(key => {
+        const groupItem = config.sources.less[key];
         stream.add(processLess(groupItem.files, groupItem.out));
-    }
+    });
 
     return stream;
 };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/views.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/views.js
@@ -8,15 +8,15 @@ function views() {
 
     var stream = new MergeStream();
 
-    for(const group in config.sources.views){
-        const groupItem = config.sources.views[group];
+    Object.keys(config.sources.views).forEach(key => {
+        const groupItem = config.sources.views[key];
 
         console.log(`Copying ${groupItem.files} to ${config.root}${config.targets.views}${groupItem.folder}`);
         stream.add (
             gulp.src(groupItem.files)
                 .pipe( gulp.dest(config.root + config.targets.views + groupItem.folder) )
         );
-    }
+    });
 
     return stream;
 };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/views.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/views.js
@@ -2,24 +2,21 @@
 
 var config = require('../config');
 var gulp = require('gulp');
-
-var _ = require('lodash');
 var MergeStream = require('merge-stream');
 
 function views() {
 
     var stream = new MergeStream();
 
-    _.forEach(config.sources.views, function (group) {
+    for(const group in config.sources.views){
+        const groupItem = config.sources.views[group];
 
-        console.log("copying " + group.files + " to " + config.root + config.targets.views + group.folder)
-
+        console.log(`Copying ${groupItem.files} to ${config.root}${config.targets.views}${groupItem.folder}`);
         stream.add (
-            gulp.src(group.files)
-                .pipe( gulp.dest(config.root + config.targets.views + group.folder) )
+            gulp.src(groupItem.files)
+                .pipe( gulp.dest(config.root + config.targets.views + groupItem.folder) )
         );
-
-    });
+    }
 
     return stream;
 };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/watchTask.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/watchTask.js
@@ -11,25 +11,25 @@ function watchTask(cb) {
     const watchInterval = 500;
 
     //Setup a watcher for all groups of JS files
-    for(const group in config.sources.js){
-        const groupItem = config.sources.js[group];
+    Object.keys(config.sources.js).forEach(key => {
+        const groupItem = config.sources.js[key];
         if(groupItem.watch !== false){
             watch(groupItem.files, { ignoreInitial: true, interval: watchInterval }, function JS_Group_Compile() { return processJs(groupItem.files, groupItem.out);});
         }
-    }
+    });
 
     //Setup a watcher for all groups of LESS files
-    for(const group in config.sources.less){
-        const groupItem = config.sources.less[group];
+    Object.keys(config.sources.less).forEach(key => {
+        const groupItem = config.sources.less[key];
         if(groupItem.watch !== false){
             watch(groupItem.watch, { ignoreInitial: true, interval: watchInterval }, function Less_Group_Compile() { return processLess(groupItem.files, groupItem.out);});
         }
-    }
+    });
 
     //Setup a watcher for all groups of view files
     let viewWatcher;
-    for(const group in config.sources.views){
-        const groupItem = config.sources.views[group];
+    Object.keys(config.sources.views).forEach(key => {
+        const groupItem = config.sources.views[key];
         if(groupItem.watch !== false){
             viewWatcher = watch(groupItem.files, { ignoreInitial: true, interval: watchInterval });
             viewWatcher.on("change", function(path, stats) {
@@ -37,7 +37,7 @@ function watchTask(cb) {
                 src(groupItem.files).pipe( dest(config.root + config.targets.views + groupItem.folder) );
             });
         }
-    }
+    });
 
     return cb();
 };

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/watchTask.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/watchTask.js
@@ -1,48 +1,44 @@
 'use strict';
 
 const config = require('../config');
-const {watch, parallel, dest, src} = require('gulp');
-
-var _ = require('lodash');
-var MergeStream = require('merge-stream');
-
-var processJs = require('../util/processJs');
-var processLess = require('../util/processLess');
-
-//const { less } = require('./less');
-//const { views } = require('./views');
+const {watch, dest, src} = require('gulp');
+const processJs = require('../util/processJs');
+const processLess = require('../util/processLess');
 
 
 function watchTask(cb) {
-    
-    var watchInterval = 500;
-    
+
+    const watchInterval = 500;
+
     //Setup a watcher for all groups of JS files
-    _.forEach(config.sources.js, function (group) {
-        if(group.watch !== false) {
-            watch(group.files, { ignoreInitial: true, interval: watchInterval }, function JS_Group_Compile() { return processJs(group.files, group.out);});
+    for(const group in config.sources.js){
+        const groupItem = config.sources.js[group];
+        if(groupItem.watch !== false){
+            watch(groupItem.files, { ignoreInitial: true, interval: watchInterval }, function JS_Group_Compile() { return processJs(groupItem.files, groupItem.out);});
         }
-    });
+    }
 
     //Setup a watcher for all groups of LESS files
-    _.forEach(config.sources.less, function (group) {
-        if(group.watch !== false) {
-            watch(group.watch, { ignoreInitial: true, interval: watchInterval }, function Less_Group_Compile() { return processLess(group.files, group.out); });
+    for(const group in config.sources.less){
+        const groupItem = config.sources.less[group];
+        if(groupItem.watch !== false){
+            watch(groupItem.watch, { ignoreInitial: true, interval: watchInterval }, function Less_Group_Compile() { return processLess(groupItem.files, groupItem.out);});
         }
-    });
-    
+    }
+
     //Setup a watcher for all groups of view files
-    var viewWatcher;
-    _.forEach(config.sources.views, function (group) {
-        if(group.watch !== false) {
-            viewWatcher = watch(group.files, { ignoreInitial: true, interval: watchInterval });
-            viewWatcher.on('change', function(path, stats) {
-                console.log("copying " + group.files + " to " + config.root + config.targets.views + group.folder);
-                src(group.files).pipe( dest(config.root + config.targets.views + group.folder) );
+    let viewWatcher;
+    for(const group in config.sources.views){
+        const groupItem = config.sources.views[group];
+        if(groupItem.watch !== false){
+            viewWatcher = watch(groupItem.files, { ignoreInitial: true, interval: watchInterval });
+            viewWatcher.on("change", function(path, stats) {
+                console.log(`Copying ${groupItem.files} to ${config.root}${config.targets.views}${groupItem.folder}`);
+                src(groupItem.files).pipe( dest(config.root + config.targets.views + groupItem.folder) );
             });
         }
-    });
-    
+    }
+
     return cb();
 };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
@@ -94,22 +94,22 @@
                 var allGroups = _.values(vm.searchResults);
                 var down = event.keyCode === 40;
                 if (vm.activeResultGroup === null) {
-                    // it's the first time navigating, pick the appropriate group and result 
+                    // it's the first time navigating, pick the appropriate group and result
                     // - first group and first result when navigating down
                     // - last group and last result when navigating up
-                    vm.activeResultGroup = down ? _.first(allGroups) : _.last(allGroups);
-                    vm.activeResult = down ? _.first(vm.activeResultGroup.results) : _.last(vm.activeResultGroup.results);
+                    vm.activeResultGroup = down ? allGroups[0] : allGroups[allGroups.length - 1];
+                    vm.activeResult = down ? vm.activeResultGroup.results[0] : vm.activeResultGroup.results[vm.activeResultGroup.results.length - 1];
                 }
                 else if (down) {
                     // handle navigation down through the groups and results
-                    if (vm.activeResult === _.last(vm.activeResultGroup.results)) {
-                        if (vm.activeResultGroup === _.last(allGroups)) {
-                            vm.activeResultGroup = _.first(allGroups);
+                    if (vm.activeResult === vm.activeResultGroup.results[vm.activeResultGroup.results.length - 1]) {
+                        if (vm.activeResultGroup === allGroups[allGroups.length - 1]) {
+                            vm.activeResultGroup = allGroups[0];
                         }
                         else {
                             vm.activeResultGroup = allGroups[allGroups.indexOf(vm.activeResultGroup) + 1];
                         }
-                        vm.activeResult = _.first(vm.activeResultGroup.results);
+                        vm.activeResult = vm.activeResultGroup.results[0];
                     }
                     else {
                         vm.activeResult = vm.activeResultGroup.results[vm.activeResultGroup.results.indexOf(vm.activeResult) + 1];
@@ -117,14 +117,14 @@
                 }
                 else {
                     // handle navigation up through the groups and results
-                    if (vm.activeResult === _.first(vm.activeResultGroup.results)) {
-                        if (vm.activeResultGroup === _.first(allGroups)) {
-                            vm.activeResultGroup = _.last(allGroups);
+                    if (vm.activeResult === vm.activeResultGroup.results[0]) {
+                        if (vm.activeResultGroup === allGroups[0]) {
+                            vm.activeResultGroup = allGroups[allGroups.length - 1];
                         }
                         else {
                             vm.activeResultGroup = allGroups[allGroups.indexOf(vm.activeResultGroup) - 1];
                         }
-                        vm.activeResult = _.last(vm.activeResultGroup.results);
+                        vm.activeResult = vm.activeResultGroup.results[vm.activeResultGroup.results.length - 1];
                     }
                     else {
                         vm.activeResult = vm.activeResultGroup.results[vm.activeResultGroup.results.indexOf(vm.activeResult) - 1];

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -41,11 +41,11 @@
         }
         // convert to array
         $scope.sliderValue = $scope.model.value ? $scope.model.value.split(',') : null;
-        
+
         // don't render values with decimal places if the step increment in a whole number
         var stepDecimalPlaces = $scope.model.config.step % 1 == 0
             ? 0
-            : _.last($scope.model.config.step.toString().replace(",", ".").split(".")).length;
+            : $scope.model.config.step.toString().replace(",", ".").split(".")[$scope.model.config.step.toString().replace(",", ".").split(".") - 1].length;
         // setup default
         $scope.sliderOptions = {
             "start": start,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -43,9 +43,10 @@
         $scope.sliderValue = $scope.model.value ? $scope.model.value.split(',') : null;
 
         // don't render values with decimal places if the step increment in a whole number
+        const stepVal = $scope.model.config.step.toString().replace(",", ".").split(".");
         var stepDecimalPlaces = $scope.model.config.step % 1 == 0
             ? 0
-            : $scope.model.config.step.toString().replace(",", ".").split(".")[$scope.model.config.step.toString().replace(",", ".").split(".") - 1].length;
+            : stepVal[stepVal.length - 1].length;
         // setup default
         $scope.sliderOptions = {
             "start": start,
@@ -76,7 +77,7 @@
         }
 
     }
-    
+
     $scope.$watch('model.value', function(newValue, oldValue){
         if(newValue && newValue !== oldValue) {
             $scope.sliderValue = newValue.split(',');


### PR DESCRIPTION
A LAB PR to tidy up the dependencies used in the Umbraco backoffice JS code & try to remove the usage of underscorejs as most of this stuff is now available natively in JS

This is a WIP/Draft until the following list & all references is gone

**Reference/guide**
https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore

- [x] _.first
- [x] _.last
- [ ] _.find _[127 results in 55 files]_
- [ ] _.each [121 _results in 53 files]_
- [ ] _.map _[59 results in 32 files]_
- [ ] _.filter _[37 results in 17 files]_
- [ ] _.contains _[34 results in 12 files]_
- [ ] _.reject _[22 results in 13 files]_
- [ ] _.forEach _[13 results, in 6 files]_
- [ ] _.debounce _[10 results in 10 files]_
- [ ] _.reduce _[6 results in 4 files]_
- [ ] _.values _[6 results in 6 files]_
- [ ] _.union _[5 results in 5 files]_
- [ ] _.isEqual _[5 results in 3 files]_
- [ ] _.where _[4 results in 4 files]_
- [ ] _.flatten _{4 results in 2 files]_