### PR TITLE
V8: Make media picker open in a medium sized overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -588,7 +588,7 @@ When building a custom infinite editor view you can use the same components as a
          */
         function mediaPicker(editor) {
             editor.view = "views/common/infiniteeditors/mediapicker/mediapicker.html";
-            if (!editor.size) editor.size = "small";
+            if (!editor.size) editor.size = "medium";
             editor.updatedMediaNodes = [];
             open(editor);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6845

### Description

The media picker overlay is currently `small` sized:

![image](https://user-images.githubusercontent.com/7405322/75627704-ce435380-5bd2-11ea-8b3d-5416605fe0f1.png)

This PR makes the media picker open up in a `medium` sized overlay, thus giving more space picking items... particularly useful if you have a lot of media in a folder:

![media-picker-medium-size](https://user-images.githubusercontent.com/7405322/75627719-ffbc1f00-5bd2-11ea-9d48-0daf92b3d9f8.gif)
