### PR TITLE
V8: Show image thumbnails for media picker search results (regression)

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -654,10 +654,14 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var entity = new MediaEntitySlim();
             BuildContentEntity(entity, dto);
 
-            if (dto is MediaEntityDto contentDto)
+            // fill in the media info
+            if (dto is MediaEntityDto mediaEntityDto)
             {
-                // fill in the media info
-                entity.MediaPath = contentDto.MediaPath;
+                entity.MediaPath = mediaEntityDto.MediaPath;
+            }
+            else if (dto is GenericContentEntityDto genericContentEntityDto)
+            {
+                entity.MediaPath = genericContentEntityDto.MediaPath;
             }
 
             return entity;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#7066 introduced `GenericContentEntityDto` for use in `EntityRepository` when fetching paged search results (`GetPagedResultsByQuery`). 

Unfortunately the `MediaPath` property of `GenericContentEntityDto` isn't mapped to the media search results entities. This leaves the thumbnails empty when searching for media in the media picker:

![image](https://user-images.githubusercontent.com/7405322/75632129-71a75f00-5bf9-11ea-90da-e1ac246e637a.png)

...and adds a bunch of matching warnings in the JS console:

![image](https://user-images.githubusercontent.com/7405322/75632146-8f74c400-5bf9-11ea-8728-25d62a8c7f31.png)

With this PR applied, the image thumbnails are shown as you'd expect:

![image](https://user-images.githubusercontent.com/7405322/75632123-63f1d980-5bf9-11ea-8c92-9de9bcbf320b.png)

