### PR TITLE
V8: Fix broken "upload and insert media" in RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -1,7 +1,7 @@
 //used for the media picker dialog
 angular.module("umbraco")
     .controller("Umbraco.Editors.MediaPickerController",
-    function ($scope, mediaResource, entityResource, userService, mediaHelper, mediaTypeHelper, eventsService, treeService, localStorageService, localizationService, editorService, umbSessionStorage) {
+    function ($scope, $timeout, mediaResource, entityResource, userService, mediaHelper, mediaTypeHelper, eventsService, treeService, localStorageService, localizationService, editorService, umbSessionStorage) {
 
             var vm = this;
             
@@ -306,9 +306,7 @@ angular.module("umbraco")
                             });
                         } else {
                             var image = $scope.images[$scope.images.length - 1];
-                            $scope.target = image;
-                            $scope.target.url = mediaHelper.resolveFile(image);
-                            selectMedia(image);
+                            clickHandler(image);
                         }
                     });
                 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7739

### Description

If you open a media picker from an RTE and upload a new image, the media picker _should_ automatically pick the uploaded media. But it doesn't... instead it throws an error in the JS console.

![media-picker-upload-rte-before](https://user-images.githubusercontent.com/7405322/75717700-ebab1700-5cd1-11ea-8c53-c32f64c73253.gif)

This PR ensures that the "Edit selected media" dialog is opened after uploading an image in the media picker when it's opened from an RTE:

![media-picker-upload-rte](https://user-images.githubusercontent.com/7405322/75717767-11d0b700-5cd2-11ea-9f69-540f1b649e9e.gif)

...and at the same time it fixes the broken "auto select newly uploaded images" in the media picker when it's opened from a media picker property:

![media-picker-upload-rte-after-2](https://user-images.githubusercontent.com/7405322/75718011-860b5a80-5cd2-11ea-803f-d12c5b87ce94.gif)

