### PR TITLE
V8: Do not allow removing all items in NC when a minimum is being enforced

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -592,7 +592,8 @@
 
         function updatePropertyActionStates() {
             copyAllEntriesAction.isDisabled = !model.value || !model.value.length;
-            removeAllEntriesAction.isDisabled = copyAllEntriesAction.isDisabled;
+            // in addition to the copy action state, remove all entries should be disallowed if a minimum number of items is being enforced
+            removeAllEntriesAction.isDisabled = copyAllEntriesAction.isDisabled || (model.config.contentTypes.length == 1 && vm.minItems !== 0);
         }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If Nested Content is configured with:

- Only one element type.
- A minimum number of items required.

...the editor automatically creates and enforces this minimum number of items - meaning you can't delete items beyond the minimum number of items required:

![image](https://user-images.githubusercontent.com/7405322/75718809-e0f18180-5cd3-11ea-8fc0-3829f26cfa3f.png)

But you can circumvent this by using the property action "Remove all entries":

![image](https://user-images.githubusercontent.com/7405322/75718875-01214080-5cd4-11ea-838f-17a4a0c35f73.png)

What's more... Nested Content actually lets you save and publish without the minimum number of items (probably because it shouldn't be possible to remove them in the first place):

![image](https://user-images.githubusercontent.com/7405322/75718997-4180be80-5cd4-11ea-95a9-dcf461dbbb76.png)

This PR disables "Remove all items" when a minimum number of items is being enforced by the editor:

![image](https://user-images.githubusercontent.com/7405322/75718672-a982d500-5cd3-11ea-84ef-b6e32f486884.png)
