### PR TITLE
Create Content Blueprints - Semantic fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/contentblueprints/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/contentblueprints/create.html
@@ -13,7 +13,7 @@
 
             <ul class="umb-actions umb-actions-child">
                 <li class="umb-action" ng-repeat="documentType in vm.documentTypes |orderBy:'name':false">
-                    <button class="umb-action-link umb-outline btn-reset" ng-click="vm.createBlueprint(documentType)" prevent-default>
+                    <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="vm.createBlueprint(documentType)">
                         <i class="large icon {{documentType.icon}}" aria-hidden="true"></i>
                         <span class="menu-label">
                             {{documentType.name}}


### PR DESCRIPTION
As suggested [here](https://github.com/umbraco/Umbraco-CMS/pull/7020#issuecomment-593055598) I have added `type` attribute to `button` and taken away the `prevent-default` attribute.

Mentioning @abjerner as he tested the other PR :-)