### PR TITLE
Obsoleting UmbracoHelper properties

### DIFF
--- a/src/Umbraco.Web/Composing/Current.cs
+++ b/src/Umbraco.Web/Composing/Current.cs
@@ -88,6 +88,12 @@ namespace Umbraco.Web.Composing
 
         public static UmbracoHelper UmbracoHelper
             => Factory.GetInstance<UmbracoHelper>();
+        public static IUmbracoComponentRenderer UmbracoComponentRenderer
+            => Factory.GetInstance<IUmbracoComponentRenderer>();
+        public static ITagQuery TagQuery
+            => Factory.GetInstance<ITagQuery>();
+        public static IPublishedContentQuery PublishedContentQuery
+            => Factory.GetInstance<IPublishedContentQuery>();
 
         public static DistributedCache DistributedCache
             => Factory.GetInstance<DistributedCache>();

--- a/src/Umbraco.Web/Models/RegisterModel.cs
+++ b/src/Umbraco.Web/Models/RegisterModel.cs
@@ -5,7 +5,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Web;
 using System.Web.Mvc;
 using Umbraco.Core;
-using Umbraco.Core.Composing;
 using Umbraco.Web.Security;
 using Current = Umbraco.Web.Composing.Current;
 
@@ -65,7 +64,7 @@ namespace Umbraco.Web.Models
         /// </summary>
         [Required]
         public string Password { get; set; }
-        
+
         /// <summary>
         /// The username of the model, if UsernameIsEmail is true then this is ignored.
         /// </summary>

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -94,7 +94,7 @@ namespace Umbraco.Web
         /// <summary>
         /// Gets the membership helper.
         /// </summary>
-        [Obsolete("Inject and use an instance of " + nameof(Security.MembershipHelper) + " in the constructor instead")]
+        [Obsolete("Inject and use an instance of " + nameof(Security.MembershipHelper) + " in the constructor instead. In views you can use @Members.")]
         public MembershipHelper MembershipHelper => Ensure(_membershipHelper);
 
         /// <summary>

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -72,23 +72,23 @@ namespace Umbraco.Web
         // ensures that we can return the specified value
         [Obsolete("This method is only used in Obsolete properties")]
         T Ensure<T>(T o) where T : class => o ?? throw new InvalidOperationException("This UmbracoHelper instance has not been initialized.");
-        
-        [Obsolete("Inject and use an instance of " + nameof(IUmbracoComponentRenderer) + " in the constructor for using it in classes or get it from Current in views")]
+
+        [Obsolete("Inject and use an instance of " + nameof(IUmbracoComponentRenderer) + " in the constructor for using it in classes or get it from Current.UmbracoComponentRenderer in views.")]
         private IUmbracoComponentRenderer ComponentRenderer => Ensure(_componentRenderer);
 
-        [Obsolete("Inject and use an instance of " + nameof(ICultureDictionaryFactory) + " in the constructor instead")]
+        [Obsolete("Inject and use an instance of " + nameof(ICultureDictionaryFactory) + " in the constructor for using it in classes or get it from Current.CultureDictionaryFactory in views.")]
         private ICultureDictionaryFactory CultureDictionaryFactory => Ensure(_cultureDictionaryFactory);
 
         /// <summary>
         /// Gets the tag context.
         /// </summary>
-        [Obsolete("Inject and use an instance of " + nameof(ITagQuery) + " in the constructor instead")]
+        [Obsolete("Inject and use an instance of " + nameof(ITagQuery) + " in the constructor for using it in classes or get it from Current.TagQuery in views.")]
         public ITagQuery TagQuery => Ensure(_tagQuery);
 
         /// <summary>
         /// Gets the query context.
         /// </summary>
-        [Obsolete("Inject and use an instance of " + nameof(IPublishedContentQuery) + " in the constructor for using it in classes or get it from Current in views")]
+        [Obsolete("Inject and use an instance of " + nameof(IPublishedContentQuery) + " in the constructor for using it in classes or get it from Current.PublishedContentQuery in views")]
         public IPublishedContentQuery ContentQuery => Ensure(_publishedContentQuery);
 
         /// <summary>

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -70,24 +70,31 @@ namespace Umbraco.Web
         #endregion
 
         // ensures that we can return the specified value
+        [Obsolete("This method is only used in Obsolete properties")]
         T Ensure<T>(T o) where T : class => o ?? throw new InvalidOperationException("This UmbracoHelper instance has not been initialized.");
-
+        
+        [Obsolete("Inject and use an instance of " + nameof(IUmbracoComponentRenderer) + " in the constructor for using it in classes or get it from Current in views")]
         private IUmbracoComponentRenderer ComponentRenderer => Ensure(_componentRenderer);
+
+        [Obsolete("Inject and use an instance of " + nameof(ICultureDictionaryFactory) + " in the constructor instead")]
         private ICultureDictionaryFactory CultureDictionaryFactory => Ensure(_cultureDictionaryFactory);
 
         /// <summary>
         /// Gets the tag context.
         /// </summary>
+        [Obsolete("Inject and use an instance of " + nameof(ITagQuery) + " in the constructor instead")]
         public ITagQuery TagQuery => Ensure(_tagQuery);
 
         /// <summary>
         /// Gets the query context.
         /// </summary>
+        [Obsolete("Inject and use an instance of " + nameof(IPublishedContentQuery) + " in the constructor for using it in classes or get it from Current in views")]
         public IPublishedContentQuery ContentQuery => Ensure(_publishedContentQuery);
 
         /// <summary>
         /// Gets the membership helper.
         /// </summary>
+        [Obsolete("Inject and use an instance of " + nameof(Security.MembershipHelper) + " in the constructor instead")]
         public MembershipHelper MembershipHelper => Ensure(_membershipHelper);
 
         /// <summary>


### PR DESCRIPTION
This PR obsolete some of the properties on UmbracoHelper that is removed in the .NET Core branch.

- `ContentQuery`
- `TagQuery`
- `CultureDictionaryFactory`
- `ComponentRenderer`
- `MembershipHelper`