### PR TITLE
Removed duplications of tree routing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -578,30 +578,12 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             if (args.action.metaData["actionView"]) {
                 templateUrl = args.action.metaData["actionView"];
             }
-            else {
-
-                //by convention we will look into the /views/{treetype}/{action}.html
-                // for example: /views/content/create.html
-
-                //we will also check for a 'packageName' for the current tree, if it exists then the convention will be:
-                // for example: /App_Plugins/{mypackage}/backoffice/{treetype}/create.html
-
+            else {                
                 var treeAlias = treeService.getTreeAlias(args.node);
-                var packageTreeFolder = treeService.getTreePackageFolder(treeAlias);
-
                 if (!treeAlias) {
                     throw "Could not get tree alias for node " + args.node.id;
-                }
-
-                if (packageTreeFolder) {
-                    templateUrl = Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath +
-                        "/" + packageTreeFolder +
-                        "/backoffice/" + treeAlias + "/" + args.action.alias + ".html";
-                }
-                else {
-                    templateUrl = "views/" + treeAlias + "/" + args.action.alias + ".html";
-                }
-
+                }                            
+                templateUrl = this.getTreeTemplateUrl(treeAlias, args.action.alias);
             }
 
             setMode("dialog");
@@ -610,6 +592,31 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 appState.setMenuState("dialogTemplateUrl", templateUrl);
             }
             
+        },
+        /**
+          * @ngdoc method
+          * @name umbraco.services.navigationService#getTreeTemplateUrl
+          * @methodOf umbraco.services.navigationService
+          *
+          * @param {string} treeAlias the alias of the tree to look up
+          * @param {string} action the view file name
+          * @description
+          * creates the templateUrl based on treeAlias and action
+          * by convention we will look into the /views/{treetype}/{action}.html
+          * for example: /views/content/create.html
+          * we will also check for a 'packageName' for the current tree, if it exists then the convention will be:
+          * for example: /App_Plugins/{mypackage}/backoffice/{treetype}/create.html
+          */
+        getTreeTemplateUrl: function(treeAlias, action) {
+            var packageTreeFolder = treeService.getTreePackageFolder(treeAlias);
+            if (packageTreeFolder) {
+                return Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath +
+                    "/" + packageTreeFolder +
+                    "/backoffice/" + treeAlias + "/" + action + ".html";
+            }
+            else {
+                return "views/" + treeAlias + "/" + action + ".html";
+            }
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/routes.js
+++ b/src/Umbraco.Web.UI.Client/src/routes.js
@@ -154,7 +154,7 @@ app.config(function ($routeProvider) {
             //This allows us to dynamically change the template for this route since you cannot inject services into the templateUrl method.
             template: "<div ng-include='templateUrl'></div>",
             //This controller will execute for this route, then we replace the template dynamically based on the current tree.
-            controller: function ($scope, $routeParams, treeService) {
+            controller: function ($scope, $routeParams, navigationService) {
 
                 if (!$routeParams.method) {
                     $scope.templateUrl = "views/common/dashboard.html";
@@ -176,24 +176,7 @@ app.config(function ($routeProvider) {
                     $scope.templateUrl = "views/users/overview.html";
                     return;
                 }
-
-                // Here we need to figure out if this route is for a user's package tree and if so then we need
-                // to change it's convention view path to:
-                // /App_Plugins/{mypackage}/backoffice/{treetype}/{method}.html
-
-                // otherwise if it is a core tree we use the core paths:
-                // views/{treetype}/{method}.html
-
-                var packageTreeFolder = treeService.getTreePackageFolder($routeParams.tree);
-
-                if (packageTreeFolder) {
-                    $scope.templateUrl = (Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath +
-                        "/" + packageTreeFolder +
-                        "/backoffice/" + $routeParams.tree + "/" + $routeParams.method + ".html");
-                }
-                else {
-                    $scope.templateUrl = ('views/' + $routeParams.tree + '/' + $routeParams.method + '.html');
-                }
+                $scope.templateUrl = navigationService.getTreeTemplateUrl($routeParams.tree, $routeParams.method);
             },
             reloadOnSearch: false,
             resolve: canRoute(true)
@@ -202,30 +185,13 @@ app.config(function ($routeProvider) {
             //This allows us to dynamically change the template for this route since you cannot inject services into the templateUrl method.
             template: "<div ng-include='templateUrl'></div>",
             //This controller will execute for this route, then we replace the template dynamically based on the current tree.
-            controller: function ($scope, $route, $routeParams, treeService) {
+            controller: function ($scope, $routeParams, navigationService) {
 
                 if (!$routeParams.tree || !$routeParams.method) {
                     $scope.templateUrl = "views/common/dashboard.html";
+                    return;
                 }
-
-                // Here we need to figure out if this route is for a package tree and if so then we need
-                // to change it's convention view path to:
-                // /App_Plugins/{mypackage}/backoffice/{treetype}/{method}.html
-
-                // otherwise if it is a core tree we use the core paths:
-                // views/{treetype}/{method}.html
-
-                var packageTreeFolder = treeService.getTreePackageFolder($routeParams.tree);
-
-                if (packageTreeFolder) {
-                    $scope.templateUrl = (Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath +
-                        "/" + packageTreeFolder +
-                        "/backoffice/" + $routeParams.tree + "/" + $routeParams.method + ".html");
-                }
-                else {
-                    $scope.templateUrl = ('views/' + $routeParams.tree + '/' + $routeParams.method + '.html');
-                }
-
+                $scope.templateUrl = navigationService.getTreeTemplateUrl($routeParams.tree, $routeParams.method);
             },
             reloadOnSearch: false,
             reloadOnUrl: false,


### PR DESCRIPTION
Ran a duplication report against the backoffice code. - https://gistpreview.github.io/?600a4f0c2847e37197beba1579403bf6 expand all works no other buttons do.
 (raw: https://gist.github.com/Matthew-Wise/600a4f0c2847e37197beba1579403bf6)
Which highlights "copy paste" code. 

Whilst finding a good location to remove the duplication I also found similar code in the navigation service so created a new method they could all use.
Tested this change using the members -> All members route


