### PR TITLE
V8: Fix completely broken(tm) media pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -49,12 +49,10 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                     // when there is no match for a selected id. This will ensure that the values being set on save, are the same as before.
 
                     medias = ids.map(id => {
-                        var found = medias.find(m =>
-                            // We could use coercion (two ='s) here .. but not sure if this works equally well in all browsers and
-                            // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
-                            // compares and be completely sure it works.
-                            m.udi.toString() === id.toString() || m.id.toString() === id.toString());
-                        
+                        // We could use coercion (two ='s) here .. but not sure if this works equally well in all browsers and
+                        // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
+                        // compares and be completely sure it works.
+                        var found = medias.find(m => m.udi.toString() === id.toString() || m.id.toString() === id.toString());
                         if (found) {
                             return found;
                         } else {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#7449 introduced some rewriting of the media picker controller to replace lodash methods with native es6 equivalents. For reasons I can't really explain, this has resulted in a completely broken(™) media picker where every picked item renders as trashed even though they're really not:

![image](https://user-images.githubusercontent.com/7405322/75877179-6762ac00-5e17-11ea-96ac-8e9c3ced8551.png)

Moving the code comment outside the one-liner in `.find()` solves it, and brings back the picked items:

![image](https://user-images.githubusercontent.com/7405322/75877161-5dd94400-5e17-11ea-96b5-5184ca82f09b.png)
