### PR TITLE
Implemented fix for #7754

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -9,6 +9,7 @@ angular.module("umbraco")
             $element,
             eventsService,
             editorService,
+            overlayService,
             $interpolate
         ) {
 
@@ -320,21 +321,22 @@ angular.module("umbraco")
                 var title = "";
                 localizationService.localize("grid_insertControl").then(function (value) {
                     title = value;
-                    $scope.editorOverlay = {
-                        view: "itempicker", 
+                    overlayService.open({
+                        view: "itempicker",
                         filter: area.$allowedEditors.length > 15,
                         title: title,
                         availableItems: area.$allowedEditors,
                         event: event,
-                        show: true,
-                        submit: function (model) {
+                        submit: function(model) {
                             if (model.selectedItem) {
                                 $scope.addControl(model.selectedItem, area, index);
-                                $scope.editorOverlay.show = false;
-                                $scope.editorOverlay = null;
+                                overlayService.close();
                             }
+                        },
+                        close: function() {
+                            overlayService.close();
                         }
-                    };
+                    });
                 });
             };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -299,11 +299,4 @@
         </div>
     </div>
 
-    <umb-overlay
-      ng-if="editorOverlay.show"
-      model="editorOverlay"
-      view="editorOverlay.view"
-      position="target">
-    </umb-overlay>
-
 </div>


### PR DESCRIPTION
Following the discussion in #7754, I've updated the grid property editor so it's now using the `overlayService` instead of the deprecated `umbOverlay` directive.

![overlayService](https://user-images.githubusercontent.com/3634580/75903023-3dbe7a80-5e41-11ea-85ed-835d6977f143.gif)