### PR TITLE
Creates a new base class UmbracoRenderController

### DIFF
--- a/src/Umbraco.Web/Composing/CompositionExtensions/Controllers.cs
+++ b/src/Umbraco.Web/Composing/CompositionExtensions/Controllers.cs
@@ -60,9 +60,9 @@ namespace Umbraco.Web.Composing.CompositionExtensions
             var nonUmbracoWebPluginController = composition.TypeLoader.GetTypes<PluginController>().Where(x => x.Assembly != umbracoWebAssembly);
             composition.RegisterControllers(nonUmbracoWebPluginController);
 
-            // can and register every IRenderMvcController in everything (IRenderMvcController is IDiscoverable)
-            var renderMvcControllers = composition.TypeLoader.GetTypes<IRenderMvcController>().Where(x => x.Assembly != umbracoWebAssembly);
-            composition.RegisterControllers(renderMvcControllers);
+            // can and register every IRenderController in everything (IRenderController is IDiscoverable)
+            var renderControllers = composition.TypeLoader.GetTypes<IRenderController>().Where(x => x.Assembly != umbracoWebAssembly);
+            composition.RegisterControllers(renderControllers);
 
             // scan and register every IHttpController in Umbraco.Web
             var umbracoWebHttpControllers = composition.TypeLoader.GetTypes<IHttpController>(specificAssemblies: new[] { umbracoWebAssembly });

--- a/src/Umbraco.Web/Mvc/IRenderController.cs
+++ b/src/Umbraco.Web/Mvc/IRenderController.cs
@@ -1,11 +1,12 @@
 ﻿using System.Web.Mvc;
+using Umbraco.Core.Composing;
 
 namespace Umbraco.Web.Mvc
 {
     /// <summary>
     /// A marker interface to designate that a controller will be used for Umbraco front-end requests and/or route hijacking
     /// </summary>
-    public interface IRenderController : IController
+    public interface IRenderController : IController, IDiscoverable
     {
 
     }

--- a/src/Umbraco.Web/Mvc/IRenderMvcController.cs
+++ b/src/Umbraco.Web/Mvc/IRenderMvcController.cs
@@ -1,5 +1,10 @@
-﻿using System.Web.Mvc;
+﻿using System;
+using System.Web.Mvc;
+using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Services;
 using Umbraco.Web.Models;
 
 namespace Umbraco.Web.Mvc
@@ -7,8 +12,10 @@ namespace Umbraco.Web.Mvc
     /// <summary>
     /// The interface that must be implemented for a controller to be designated to execute for route hijacking
     /// </summary>
-    public interface IRenderMvcController : IRenderController, IDiscoverable
+    public interface IRenderMvcController : IRenderController
     {
+        // TODO: In vNext remove this and the default will be IRenderController
+
         /// <summary>
         /// The default action to render the front-end view
         /// </summary>

--- a/src/Umbraco.Web/Mvc/RenderIndexActionSelectorAttribute.cs
+++ b/src/Umbraco.Web/Mvc/RenderIndexActionSelectorAttribute.cs
@@ -7,7 +7,7 @@ using System.Web.Mvc;
 namespace Umbraco.Web.Mvc
 {
     /// <summary>
-    /// A custom ActionMethodSelector which will ensure that the RenderMvcController.Index(ContentModel model) action will be executed
+    /// A custom ActionMethodSelector which will ensure that the RenderMvcController.Index action will be executed
     /// if the
     /// </summary>
     internal class RenderIndexActionSelectorAttribute : ActionMethodSelectorAttribute

--- a/src/Umbraco.Web/Mvc/RenderMvcController.cs
+++ b/src/Umbraco.Web/Mvc/RenderMvcController.cs
@@ -1,90 +1,27 @@
-using System;
 using System.Web.Mvc;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
-using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models;
-using Umbraco.Web.Routing;
 
 namespace Umbraco.Web.Mvc
 {
 
     /// <summary>
-    /// Represents the default front-end rendering controller.
+    /// The default front-end rendering controller.
     /// </summary>
-    [PreRenderViewActionFilter]
-    [ModelBindingExceptionFilter]
-    public class RenderMvcController : UmbracoController, IRenderMvcController
+    public class RenderMvcController : UmbracoRenderController, IRenderMvcController
     {
-        private PublishedRequest _publishedRequest;
+        // TODO: in vNext remove this and the default will be UmbracoRenderController
 
         public RenderMvcController()
-        {
-            ActionInvoker = new RenderActionInvoker();
+        {         
         }
 
         public RenderMvcController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ServiceContext services, AppCaches appCaches, IProfilingLogger profilingLogger, UmbracoHelper umbracoHelper)
             : base(globalSettings, umbracoContextAccessor, services, appCaches, profilingLogger, umbracoHelper)
         {
-            ActionInvoker = new RenderActionInvoker();
-        }
-
-        /// <summary>
-        /// Gets the Umbraco context.
-        /// </summary>
-        public override UmbracoContext UmbracoContext => PublishedRequest.UmbracoContext; //TODO: Why?
-
-        /// <summary>
-        /// Gets the current content item.
-        /// </summary>
-        protected IPublishedContent CurrentPage => PublishedRequest.PublishedContent;
-
-        /// <summary>
-        /// Gets the current published content request.
-        /// </summary>
-        protected internal virtual PublishedRequest PublishedRequest
-        {
-            get
-            {
-                if (_publishedRequest != null)
-                    return _publishedRequest;
-                if (RouteData.DataTokens.ContainsKey(Core.Constants.Web.PublishedDocumentRequestDataToken) == false)
-                {
-                    throw new InvalidOperationException("DataTokens must contain an 'umbraco-doc-request' key with a PublishedRequest object");
-                }
-                _publishedRequest = (PublishedRequest)RouteData.DataTokens[Core.Constants.Web.PublishedDocumentRequestDataToken];
-                return _publishedRequest;
-            }
-        }
-
-        /// <summary>
-        /// Ensures that a physical view file exists on disk.
-        /// </summary>
-        /// <param name="template">The view name.</param>
-        protected bool EnsurePhsyicalViewExists(string template)
-        {
-            var result = ViewEngines.Engines.FindView(ControllerContext, template, null);
-            if (result.View != null) return true;
-
-            Logger.Warn<RenderMvcController>("No physical template file was found for template {Template}", template);
-            return false;
-        }
-
-        /// <summary>
-        /// Gets an action result based on the template name found in the route values and a model.
-        /// </summary>
-        /// <typeparam name="T">The type of the model.</typeparam>
-        /// <param name="model">The model.</param>
-        /// <returns>The action result.</returns>
-        /// <remarks>If the template found in the route values doesn't physically exist, then an empty ContentResult will be returned.</remarks>
-        protected ActionResult CurrentTemplate<T>(T model)
-        {
-            var template = ControllerContext.RouteData.Values["action"].ToString();
-            if (EnsurePhsyicalViewExists(template) == false)
-                throw new Exception("No physical template file was found for template " + template);
-            return View(template, model);
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Mvc/UmbracoControllerFactory.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoControllerFactory.cs
@@ -35,6 +35,9 @@ namespace Umbraco.Web.Mvc
                     requestContext,
                     ControllerExtensions.GetControllerName(Current.DefaultRenderMvcControllerType));
 
+            if (controllerType == null)
+                throw new InvalidOperationException($"Could not resolve a controller with the name {controllerName} or the default name {ControllerExtensions.GetControllerName(Current.DefaultRenderMvcControllerType)}");
+
             return _innerFactory.GetControllerInstance(requestContext, controllerType);
         }
 

--- a/src/Umbraco.Web/Mvc/UmbracoRenderController.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoRenderController.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Web.Mvc;
+using Umbraco.Core.Cache;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Services;
+using Umbraco.Web.Routing;
+
+namespace Umbraco.Web.Mvc
+{
+    /// <summary>
+    /// The base class for front-end rendering controllers.
+    /// </summary>
+    [PreRenderViewActionFilter]
+    [ModelBindingExceptionFilter]
+    public abstract class UmbracoRenderController : UmbracoController, IRenderController
+    {
+        // TODO: In vNext, make this the default controller, add Index, and remove RenderMvcController
+
+        private PublishedRequest _publishedRequest;
+
+        public UmbracoRenderController()
+        {
+            ActionInvoker = new RenderActionInvoker();
+        }
+
+        protected UmbracoRenderController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ServiceContext services, AppCaches appCaches, IProfilingLogger profilingLogger, UmbracoHelper umbracoHelper) : base(globalSettings, umbracoContextAccessor, services, appCaches, profilingLogger, umbracoHelper)
+        {
+            ActionInvoker = new RenderActionInvoker();
+        }
+
+        /// <summary>
+        /// Gets the Umbraco context.
+        /// </summary>
+        public override UmbracoContext UmbracoContext => PublishedRequest.UmbracoContext; //TODO: Why?
+
+        /// <summary>
+        /// Gets the current content item.
+        /// </summary>
+        protected IPublishedContent CurrentPage => PublishedRequest.PublishedContent;
+
+        /// <summary>
+        /// Gets the current published content request.
+        /// </summary>
+        protected internal virtual PublishedRequest PublishedRequest
+        {
+            // TODO: I think this is legacy from v7, we can 'just' use UmbracoContext.PublishedRequest.PublishedContent
+            // I think perhaps in v7 it was required due to either mixing webforms and/or postbacks in some way.
+
+            get
+            {
+                if (_publishedRequest != null)
+                    return _publishedRequest;
+                if (RouteData.DataTokens.ContainsKey(Core.Constants.Web.PublishedDocumentRequestDataToken) == false)
+                {
+                    throw new InvalidOperationException("DataTokens must contain an 'umbraco-doc-request' key with a PublishedRequest object");
+                }
+                _publishedRequest = (PublishedRequest)RouteData.DataTokens[Core.Constants.Web.PublishedDocumentRequestDataToken];
+                return _publishedRequest;
+            }
+        }
+
+        /// <summary>
+        /// Ensures that a physical view file exists on disk.
+        /// </summary>
+        /// <param name="template">The view name.</param>
+        protected bool EnsurePhsyicalViewExists(string template)
+        {
+            var result = ViewEngines.Engines.FindView(ControllerContext, template, null);
+            if (result.View != null) return true;
+
+            Logger.Warn<RenderMvcController>("No physical template file was found for template {Template}", template);
+            return false;
+        }
+
+        /// <summary>
+        /// Gets an action result based on the template name found in the route values and a model.
+        /// </summary>
+        /// <typeparam name="T">The type of the model.</typeparam>
+        /// <param name="model">The model.</param>
+        /// <returns>The action result.</returns>
+        /// <remarks>If the template found in the route values doesn't physically exist, then an empty ContentResult will be returned.</remarks>
+        protected ActionResult CurrentTemplate<T>(T model)
+        {
+            var template = ControllerContext.RouteData.Values["action"].ToString();
+            if (EnsurePhsyicalViewExists(template) == false)
+                throw new Exception("No physical template file was found for template " + template);
+            return View(template, model);
+        }
+
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -234,6 +234,7 @@
     <Compile Include="Mvc\ModelBindingExceptionFilter.cs" />
     <Compile Include="Mvc\StatusCodeFilterAttribute.cs" />
     <Compile Include="Mvc\SurfaceControllerTypeCollectionBuilder.cs" />
+    <Compile Include="Mvc\UmbracoRenderController.cs" />
     <Compile Include="Mvc\ValidateUmbracoFormRouteStringAttribute.cs" />
     <Compile Include="Profiling\WebProfilingController.cs" />
     <Compile Include="PropertyEditors\ParameterEditors\MultipleMediaPickerParameterEditor.cs" />


### PR DESCRIPTION
This becomes the base class for RenderMvcController and the utlity methods are moved there. This also makes IRenderController discoverable instead of only discovering IRenderMvcController. This all should have been done before v8 release along with removing ContentModel but we are stuck with that. In the meantime, this makes it nicer to hijack routes.

This is a follow up to this issue here https://github.com/umbraco/UmbracoDocs/issues/2026 in that some things are a little confusing which is mostly due to some left over bits from v7 and not getting around to changing this behavior for 8.0 release.

With this change it means that you can implement your own render controller without being forced to know about the legacy `ContentModel` because you aren't forced to use or override the Index action which binds the ContentModel. With this change it means that you can reference the currently rendering content as it was supposed to be based on an injected service instead of being magically bound to a parameter.

For example, a custom render controller with this change could look like this:

```cs
    public class MyRenderController : UmbracoRenderController
    {
        public MyRenderController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ServiceContext services, AppCaches appCaches, IProfilingLogger profilingLogger, UmbracoHelper umbracoHelper)
            : base(globalSettings, umbracoContextAccessor, services, appCaches, profilingLogger, umbracoHelper)
        {
        }

        public ActionResult Index()
        {
            // get the current content in the request
            var model = CurrentPage;
            return CurrentTemplate(model);
        }
    }
```

I will write up more info/details on the issue mentioned above.