### PR TITLE
Allows assembly scanning when using RegisterAssembly

### DIFF
--- a/src/Umbraco.Core/Composing/LightInject/LightInjectContainer.cs
+++ b/src/Umbraco.Core/Composing/LightInject/LightInjectContainer.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading;
 using LightInject;
 
 namespace Umbraco.Core.Composing.LightInject
 {
+
     /// <summary>
     /// Implements DI with LightInject.
     /// </summary>
@@ -32,36 +32,7 @@ namespace Umbraco.Core.Composing.LightInject
         /// </summary>
         protected static ServiceContainer CreateServiceContainer()
         {
-            var container = new ServiceContainer(new ContainerOptions { EnablePropertyInjection = false });
-
-            // note: the block below is disabled, as it is too LightInject-specific
-            //
-            // supports annotated constructor injections
-            // eg to specify the service name on some services
-            //container.EnableAnnotatedConstructorInjection();
-
-            // note: the block below is disabled, we do not allow property injection at all anymore
-            //       (see options in CreateServiceContainer)
-            //
-            // from the docs: "LightInject considers all read/write properties a dependency, but implements
-            // a loose strategy around property dependencies, meaning that it will NOT throw an exception
-            // in the case of an unresolved property dependency."
-            //
-            // in Umbraco we do NOT want to do property injection by default, so we have to disable it.
-            // from the docs, the following line will cause the container to "now only try to inject
-            // dependencies for properties that is annotated with the InjectAttribute."
-            //
-            // could not find it documented, but tests & code review shows that LightInject considers a
-            // property to be "injectable" when its setter exists and is not static, nor private, nor
-            // it is an index property. which means that eg protected or internal setters are OK.
-            //Container.EnableAnnotatedPropertyInjection();
-
-            // ensure that we do *not* scan assemblies
-            // we explicitly RegisterFrom our own composition roots and don't want them scanned
-            container.AssemblyScanner = new AssemblyScanner(/*container.AssemblyScanner*/);
-
-            // see notes in MixedLightInjectScopeManagerProvider
-            container.ScopeManagerProvider = new MixedLightInjectScopeManagerProvider();
+            var container = new UmbracoServiceContainer(new ContainerOptions { EnablePropertyInjection = false });
 
             // note: the block below is disabled, because it does not work, because collection builders
             //       are singletons, and constructor dependencies don't work on singletons, see
@@ -251,18 +222,7 @@ namespace Umbraco.Core.Composing.LightInject
             smp.EnablePerWebRequestScope();
         }
 
-        private class AssemblyScanner : IAssemblyScanner
-        {
-            public void Scan(Assembly assembly, IServiceRegistry serviceRegistry, Func<ILifetime> lifetime, Func<Type, Type, bool> shouldRegister, Func<Type, Type, string> serviceNameProvider)
-            {
-                // nothing - we don't want LightInject to scan
-            }
-
-            public void Scan(Assembly assembly, IServiceRegistry serviceRegistry)
-            {
-                // nothing - we don't want LightInject to scan
-            }
-        }
+       
 
         #endregion
     }

--- a/src/Umbraco.Core/Composing/LightInject/UmbracoServiceContainer.cs
+++ b/src/Umbraco.Core/Composing/LightInject/UmbracoServiceContainer.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Reflection;
+using LightInject;
+
+namespace Umbraco.Core.Composing.LightInject
+{
+    /// <summary>
+    /// Light Inject service container with modifications for Umbraco
+    /// </summary>
+    internal class UmbracoServiceContainer : ServiceContainer, IServiceRegistry
+    {
+        private readonly IAssemblyScanner _origAssemblyScanner;
+
+        public UmbracoServiceContainer(ContainerOptions options) : base(options)
+        {
+            // store ref to original (real) assembly scanner
+            _origAssemblyScanner = AssemblyScanner;
+
+            // note: the block below is disabled, as it is too LightInject-specific
+            //
+            // supports annotated constructor injections
+            // eg to specify the service name on some services
+            //container.EnableAnnotatedConstructorInjection();
+
+            // note: the block below is disabled, we do not allow property injection at all anymore
+            //       (see options in CreateServiceContainer)
+            //
+            // from the docs: "LightInject considers all read/write properties a dependency, but implements
+            // a loose strategy around property dependencies, meaning that it will NOT throw an exception
+            // in the case of an unresolved property dependency."
+            //
+            // in Umbraco we do NOT want to do property injection by default, so we have to disable it.
+            // from the docs, the following line will cause the container to "now only try to inject
+            // dependencies for properties that is annotated with the InjectAttribute."
+            //
+            // could not find it documented, but tests & code review shows that LightInject considers a
+            // property to be "injectable" when its setter exists and is not static, nor private, nor
+            // it is an index property. which means that eg protected or internal setters are OK.
+            //Container.EnableAnnotatedPropertyInjection();
+
+            // ensure that we do *not* scan assemblies
+            // we explicitly RegisterFrom our own composition roots and don't want them scanned
+            AssemblyScanner = new NullAssemblyScanner(/*container.AssemblyScanner*/);
+
+            // see notes in MixedLightInjectScopeManagerProvider
+            ScopeManagerProvider = new MixedLightInjectScopeManagerProvider();
+        }
+
+        #region RegisterAssembly - allows assembly scanning
+        IServiceRegistry IServiceRegistry.RegisterAssembly(Assembly assembly)
+        {
+            using (AllowAssemblyScan())
+            {
+                return RegisterAssembly(assembly);
+            }
+        }
+
+        IServiceRegistry IServiceRegistry.RegisterAssembly(Assembly assembly, Func<Type, Type, bool> shouldRegister)
+        {
+            using (AllowAssemblyScan())
+            {
+                return RegisterAssembly(assembly, shouldRegister);
+            }
+        }
+
+        IServiceRegistry IServiceRegistry.RegisterAssembly(Assembly assembly, Func<ILifetime> lifetimeFactory)
+        {
+            using (AllowAssemblyScan())
+            {
+                return RegisterAssembly(assembly, lifetimeFactory);
+            }
+        }
+
+        IServiceRegistry IServiceRegistry.RegisterAssembly(Assembly assembly, Func<ILifetime> lifetimeFactory, Func<Type, Type, bool> shouldRegister)
+        {
+            using (AllowAssemblyScan())
+            {
+                return RegisterAssembly(assembly, lifetimeFactory, shouldRegister);
+            }
+        }
+
+        IServiceRegistry IServiceRegistry.RegisterAssembly(Assembly assembly, Func<ILifetime> lifetimeFactory, Func<Type, Type, bool> shouldRegister, Func<Type, Type, string> serviceNameProvider)
+        {
+            using (AllowAssemblyScan())
+            {
+                return RegisterAssembly(assembly, lifetimeFactory, shouldRegister, serviceNameProvider);
+            }
+        } 
+        #endregion
+
+        private IDisposable AllowAssemblyScan() => new ReplaceAssemblyScanner(this, _origAssemblyScanner);
+
+        /// <summary>
+        /// A Noop assembly scanner
+        /// </summary>
+        private class NullAssemblyScanner : IAssemblyScanner
+        {
+            public void Scan(Assembly assembly, IServiceRegistry serviceRegistry, Func<ILifetime> lifetime, Func<Type, Type, bool> shouldRegister, Func<Type, Type, string> serviceNameProvider)
+            {
+                // nothing - we don't want LightInject to scan
+            }
+
+            public void Scan(Assembly assembly, IServiceRegistry serviceRegistry)
+            {
+                // nothing - we don't want LightInject to scan
+            }
+        }
+
+        /// <summary>
+        /// Used to replace the current IAssemblyScanner with another one in a using block
+        /// </summary>
+        private class ReplaceAssemblyScanner : IDisposable
+        {
+            private readonly ServiceContainer _serviceContainer;
+            private readonly IAssemblyScanner _origAssemblyScanner;
+
+            public ReplaceAssemblyScanner(ServiceContainer serviceContainer, IAssemblyScanner assemblyScanner)
+            {
+                _serviceContainer = serviceContainer;
+                // store orig
+                _origAssemblyScanner = _serviceContainer.AssemblyScanner;
+                // set to new one
+                _serviceContainer.AssemblyScanner = assemblyScanner;
+            }
+
+            #region IDisposable Support
+            private bool disposedValue = false; // To detect redundant calls            
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposedValue)
+                {
+                    if (disposing)
+                    {
+                        // restore the original scanner
+                        _serviceContainer.AssemblyScanner = _origAssemblyScanner;
+                    }
+                    disposedValue = true;
+                }
+            }
+
+            // This code added to correctly implement the disposable pattern.
+            public void Dispose()
+            {
+                Dispose(true);            
+            }
+            #endregion
+
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -128,6 +128,7 @@
     </Compile>
     -->
     <Compile Include="AssemblyExtensions.cs" />
+    <Compile Include="Composing\LightInject\UmbracoServiceContainer.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\ContentTypeDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyDataDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyTypeDto80.cs" />


### PR DESCRIPTION
This PR fixes this issue https://github.com/umbraco/Umbraco-CMS/issues/7502 but please read that thread and we'll need to determine if we use this PR or this one https://github.com/umbraco/Umbraco-CMS/pull/7588/files or a combination

Have moved the container customization to UmbracoServiceContainer. This captures the original assembly scanner but continues to replace it with a noop assembly scanner. Then explicitly override all calls to RegisterAssembly where we replace the assembly scanner with the original non-noop one in a using clause which when disposed re-replaces again with the noop one. This is not thread safe but that is ok since in no case is the container ever being configured by multiple threads. This is a reasonably simple approach to allow assembly scanning for the RegisterAssembly methods.