### PR TITLE
Added GetSegment() method to VariationContext and uses it when conten…

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/VariationContext.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/VariationContext.cs
@@ -23,5 +23,12 @@
         /// Gets the segment.
         /// </summary>
         public string Segment { get; }
+
+        /// <summary>
+        /// Gets the segment for the content item
+        /// </summary>
+        /// <param name="contentId"></param>
+        /// <returns></returns>
+        public virtual string GetSegment(int contentId) => Segment;
     }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/VariationContextAccessorExtensions.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/VariationContextAccessorExtensions.cs
@@ -3,13 +3,32 @@
     public static class VariationContextAccessorExtensions
     {
         public static void ContextualizeVariation(this IVariationContextAccessor variationContextAccessor, ContentVariation variations, ref string culture, ref string segment)
+            => variationContextAccessor.ContextualizeVariation(variations, null, ref culture, ref segment);
+
+        public static void ContextualizeVariation(this IVariationContextAccessor variationContextAccessor, ContentVariation variations, int contentId, ref string culture, ref string segment)
+            => variationContextAccessor.ContextualizeVariation(variations, (int?)contentId, ref culture, ref segment);
+
+        private static void ContextualizeVariation(this IVariationContextAccessor variationContextAccessor, ContentVariation variations, int? contentId, ref string culture, ref string segment)
         {
             if (culture != null && segment != null) return;
 
             // use context values
             var publishedVariationContext = variationContextAccessor?.VariationContext;
             if (culture == null) culture = variations.VariesByCulture() ? publishedVariationContext?.Culture : "";
-            if (segment == null) segment = variations.VariesBySegment() ? publishedVariationContext?.Segment : "";
+
+            if (segment == null)
+            {
+                if (variations.VariesBySegment())
+                {
+                    segment = contentId == null
+                        ? publishedVariationContext?.Segment
+                        : publishedVariationContext?.GetSegment(contentId.Value);
+                }
+                else
+                {
+                    segment = "";
+                }
+            }
         }
     }
 }

--- a/src/Umbraco.Web/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Web/Models/PublishedContent/PublishedValueFallback.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Web.Models.PublishedContent
             var propertyType = content.ContentType.GetPropertyType(alias);
             if (propertyType != null)
             {
-                _variationContextAccessor.ContextualizeVariation(propertyType.Variations, ref culture, ref segment);
+                _variationContextAccessor.ContextualizeVariation(propertyType.Variations, content.Id, ref culture, ref segment);
                 noValueProperty = content.GetProperty(alias);
             }
 
@@ -168,7 +168,7 @@ namespace Umbraco.Web.Models.PublishedContent
                 {
                     culture = null;
                     segment = null;
-                    _variationContextAccessor.ContextualizeVariation(propertyType.Variations, ref culture, ref segment);
+                    _variationContextAccessor.ContextualizeVariation(propertyType.Variations, content.Id, ref culture, ref segment);
                 }
 
                 property = content?.GetProperty(alias);

--- a/src/Umbraco.Web/PublishedCache/NuCache/Property.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/Property.cs
@@ -90,7 +90,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         // determines whether a property has value
         public override bool HasValue(string culture = null, string segment = null)
         {
-            _content.VariationContextAccessor.ContextualizeVariation(_variations, ref culture, ref segment);
+            _content.VariationContextAccessor.ContextualizeVariation(_variations, _content.Id, ref culture, ref segment);
 
             var value = GetSourceValue(culture, segment);
             var hasValue = PropertyType.IsValue(value, PropertyValueLevel.Source);
@@ -194,7 +194,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         public override object GetSourceValue(string culture = null, string segment = null)
         {
-            _content.VariationContextAccessor.ContextualizeVariation(_variations, ref culture, ref segment);
+            _content.VariationContextAccessor.ContextualizeVariation(_variations, _content.Id, ref culture, ref segment);
 
             if (culture == "" && segment == "")
                 return _sourceValue;
@@ -208,7 +208,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         public override object GetValue(string culture = null, string segment = null)
         {
-            _content.VariationContextAccessor.ContextualizeVariation(_variations, ref culture, ref segment);
+            _content.VariationContextAccessor.ContextualizeVariation(_variations, _content.Id, ref culture, ref segment);
 
             object value;
             lock (_locko)
@@ -229,7 +229,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         public override object GetXPathValue(string culture = null, string segment = null)
         {
-            _content.VariationContextAccessor.ContextualizeVariation(_variations, ref culture, ref segment);
+            _content.VariationContextAccessor.ContextualizeVariation(_variations, _content.Id, ref culture, ref segment);
 
             lock (_locko)
             {


### PR DESCRIPTION
#### Description of PR
Adds a `GetSegment(int contentId)` method to `VariationContext`. This allows implementations to vary the segment based on the `contentId` instead of only being able to provide 1 segment for a request.

This code change was proposed by @Shazwazza after a call with us. We initially wanted to change the `IVariationContextAccessor` but changes to public interfaces are not allowed as it would break all existing code.

We have also updated the usage of `VariationContext.Segment` to use `GetSegment()` with the appropriate `contentId` whenever possible.

#### Why is this useful
Being able to render segmented property data from a detail page (e.g. Product) on a page that itself does not use segments (e.g. Product overview page). So when the properties of the Product are rendered in the overview, those should use some segment (e.g. `"segment-xyz"`) whereas properties of the overview page itself should be rendered with the default segment (`""`).
Without this PR, you can only define 1 segment in total for the entire request. So all properties of the current page would rendered using a single segment. 