### PR TITLE
#7780 Show all filters that is more then 0 hits

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -124,7 +124,7 @@
                         <span class="caret"></span>
                     </a>
                     <umb-dropdown class="pull-right" ng-if="vm.page.showStatusFilter" on-close="vm.page.showStatusFilter = false;">
-                        <umb-dropdown-item ng-repeat="userState in vm.userStatesFilter | filter:{ count: '!0', key: '!All'}" style="padding: 8px 20px 8px 16px;">
+                        <umb-dropdown-item ng-repeat="userState in vm.userStatesFilter | filter:{key: '!All'}" ng-show="userState.count > 0" style="padding: 8px 20px 8px 16px;">
                             <div class="flex items-center">
                                 <input
                                     id="state-{{$index}}"


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

Add exakt 10 users and disable them. The disable filter should be there. 

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7780 <!-- link to the issue here! -->

### Description
There where a ng-repeat filter that removed filters that hade count = a 0 in it. So 0, 10, 20, 30 and so on did not be visible. Now we romove that filter and use a ng-show with a count more then zero. We could fix this with a custom filter but i don´t think that is not nessasary for this problem. ng-if dont work for we cant have both ng-repeat and ng-if.

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
