### PR TITLE
7434 do not use umb outline for select

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -297,7 +297,6 @@ select[size] {
 }
 
 // Focus for select, file, radio, and checkbox
-select,
 input[type="file"],
 input[type="radio"],
 input[type="checkbox"] {


### PR DESCRIPTION
Stop using umb-outline for select — cause it does not work for select input.