### PR TITLE
#7789 Prevent grid config being submitted if not valid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
@@ -5,54 +5,50 @@
         <form novalidate name="EditConfigForm" val-form-manager>
 
             <umb-editor-header
-                name="model.title"
-                name-locked="true"
-                hide-alias="true"
-                hide-icon="true"
-                hide-description="true">
+                               name="model.title"
+                               name-locked="true"
+                               hide-alias="true"
+                               hide-icon="true"
+                               hide-description="true">
             </umb-editor-header>
 
-            <umb-editor-container>
-                <umb-box>
-                    <umb-box-content>
-
-                        <ng-form name="gridConfigEditor">
-
+            <ng-form name="gridConfigEditor">
+                <umb-editor-container>
+                    <umb-box>
+                        <umb-box-content>
                             <h4>{{model.name}}</h4>
                             <p>Settings will only save if the entered json configuration is valid</p>
                             <textarea name="configSource"
-                                validate-on="'keyup'"
-                                rows="20" class="umb-property-editor umb-textarea"
-                                umb-raw-model="model.config"></textarea>
+                                      validate-on="'keyup'"
+                                      rows="20" class="umb-property-editor umb-textarea"
+                                      umb-raw-model="model.config"></textarea>
 
                             <div class="alert alert-error" ng-show="gridConfigEditor.$invalid === true">
                                 This configuration is not valid json, and will not be saved.
                             </div>
+                        </umb-box-content>
+                    </umb-box>
+                </umb-editor-container>
 
-                        </ng-form>
-
-                    </umb-box-content>
-                </umb-box>
-            </umb-editor-container>
-
-            <umb-editor-footer>
-                <umb-editor-footer-content-right>
-                    <umb-button
-                        type="button"
-                        button-style="link"
-                        label-key="general_close"
-                        shortcut="esc"
-                        action="vm.close()">
-                    </umb-button>
-                    <umb-button
-                        type="button"
-                        button-style="success"
-                        label-key="general_submit"
-                        disabled="gridConfigEditor.$invalid === true"
-                        action="vm.submit()">
-                    </umb-button>
-                </umb-editor-footer-content-right>
-            </umb-editor-footer>
+                <umb-editor-footer>
+                    <umb-editor-footer-content-right>
+                        <umb-button
+                                    type="button"
+                                    button-style="link"
+                                    label-key="general_close"
+                                    shortcut="esc"
+                                    action="vm.close()">
+                        </umb-button>
+                        <umb-button
+                                    type="button"
+                                    button-style="success"
+                                    label-key="general_submit"
+                                    disabled="gridConfigEditor.$invalid === true"
+                                    action="vm.submit()">
+                        </umb-button>
+                    </umb-editor-footer-content-right>
+                </umb-editor-footer>
+            </ng-form>
 
         </form>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
@@ -48,6 +48,7 @@
                         type="button"
                         button-style="success"
                         label-key="general_submit"
+                        disabled="gridConfigEditor.$invalid === true"
                         action="vm.submit()">
                     </umb-button>
                 </umb-editor-footer-content-right>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
@@ -21,7 +21,7 @@
                             <h4>{{model.name}}</h4>
                             <p>Settings will only save if the entered json configuration is valid</p>
                             <textarea name="configSource"
-                                validate-on="'blur'"
+                                validate-on="'keyup'"
                                 rows="20" class="umb-property-editor umb-textarea"
                                 umb-raw-model="model.config"></textarea>
 


### PR DESCRIPTION
Prerequisites

    I have added steps to test this contribution in the description below

Fixes issue: umbraco#7789
Description

I have disabled the submit button until JSON is valid.