### PR TITLE
v8: Bug fix/make groups to use paginated list of users

### DIFF
--- a/src/Umbraco.Core/Models/Membership/IUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/IUserGroup.cs
@@ -20,6 +20,8 @@ namespace Umbraco.Core.Models.Membership
         /// </summary>
         string Name { get; set; }
 
+        int MaxUsers { get; set; }
+        int UsersPage { get; set; }
         /// <summary>
         /// The set of default permissions
         /// </summary>

--- a/src/Umbraco.Core/Models/Membership/UserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/UserGroup.cs
@@ -88,6 +88,9 @@ namespace Umbraco.Core.Models.Membership
             set => SetPropertyValueAndDetectChanges(value, ref _name, nameof(Name));
         }
 
+        public int MaxUsers { get; set; } = 0;
+        public int UsersPage { get; set; } = 0;
+
         /// <summary>
         /// The set of default permissions for the user group
         /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
@@ -29,6 +29,7 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="groupId">Id of group</param>
         IEnumerable<IUser> GetAllInGroup(int groupId);
 
+        IEnumerable<IUser> GetUsersInGroup(int groupId, int page, int maxUsers, out long totalRecords);
         /// <summary>
         /// Gets a list of <see cref="IUser"/> objects not associated with a given group
         /// </summary>
@@ -91,5 +92,6 @@ namespace Umbraco.Core.Persistence.Repositories
         int ClearLoginSessions(int userId);
         int ClearLoginSessions(TimeSpan timespan);
         void ClearLoginSession(Guid sessionId);
+
     }
 }

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -199,6 +199,7 @@ namespace Umbraco.Core.Services
         /// <returns><see cref="IEnumerable{IUser}"/></returns>
         IEnumerable<IUser> GetAllInGroup(int groupId);
 
+        IEnumerable<IUser> GetUsersInGroup(int groupId, int page, int maxUsers,out long totalRecords);
         /// <summary>
         /// Gets a list of <see cref="IUser"/> objects not associated with a given group
         /// </summary>
@@ -255,5 +256,6 @@ namespace Umbraco.Core.Services
         void DeleteUserGroup(IUserGroup userGroup);
 
         #endregion
+
     }
 }

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -971,6 +971,35 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public IEnumerable<int> GetAllRolesIds()
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Constants.Locks.MemberTree);
+                return _memberGroupRepository.GetMany().Select(x => x.Id).Distinct();
+            }
+        }
+
+        public IEnumerable<int> GetAllRolesIds(int memberId)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Constants.Locks.MemberTree);
+                var result = _memberGroupRepository.GetMemberGroupsForMember(memberId);
+                return result.Select(x => x.Id).Distinct();
+            }
+        }
+
+        public IEnumerable<int> GetAllRolesIds(string username)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Constants.Locks.MemberTree);
+                var result = _memberGroupRepository.GetMemberGroupsForMember(username);
+                return result.Select(x => x.Id).Distinct();
+            }
+        }
+
         public IEnumerable<IMember> GetMembersInRole(string roleName)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/src/Umbraco.Core/Services/Implement/UserService.cs
+++ b/src/Umbraco.Core/Services/Implement/UserService.cs
@@ -205,7 +205,7 @@ namespace Umbraco.Core.Services.Implement
                         //NOTE: this will not be cached
                         return _userRepository.GetByUsername(username, includeSecurityData: false);
                     }
-                    
+
                     throw;
                 }
             }
@@ -641,7 +641,15 @@ namespace Umbraco.Core.Services.Implement
                 return _userRepository.GetAllInGroup(groupId);
             }
         }
+        public IEnumerable<IUser> GetUsersInGroup(int groupId, int page, int maxUsers,out long totalRecords)
+        {
 
+                using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+                {
+                    return _userRepository.GetUsersInGroup(groupId,page,maxUsers, out totalRecords);
+                }
+
+        }
         /// <summary>
         /// Gets a list of <see cref="IUser"/> objects not associated with a given group
         /// </summary>
@@ -710,7 +718,7 @@ namespace Umbraco.Core.Services.Implement
                         //NOTE: this will not be cached
                         return _userRepository.Get(id, includeSecurityData: false);
                     }
-                    
+
                     throw;
                 }
             }
@@ -898,6 +906,8 @@ namespace Umbraco.Core.Services.Implement
                 scope.Complete();
             }
         }
+
+
 
         /// <summary>
         /// Removes a specific section from all users

--- a/src/Umbraco.Web.UI.Client/src/common/resources/usergroups.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/usergroups.resource.js
@@ -63,7 +63,7 @@
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "userGroupsApiBaseUrl",
-                        "GetUserGroups",
+                        "GetUserGroupPaginated",
                         args)),
                 "Failed to retrieve user groups");
         }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/usergroups.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/usergroups.resource.js
@@ -38,18 +38,18 @@
                 "Failed to save user group");
         }
 
-        function getUserGroup(id) {
+     
+        function getUserGroup(id, page=0) {
 
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "userGroupsApiBaseUrl",
-                        "GetUserGroup",
-                        { id: id })),
+                        "GetUserGroupPaginated",
+                        { id: id, page: page })),
                 "Failed to retrieve data for user group " + id);
 
         }
-
         function getUserGroups(args) {
 
             if (!args) {
@@ -63,7 +63,8 @@
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "userGroupsApiBaseUrl",
-                        "GetUserGroupPaginated",
+                        "GetUserGroups",
+                        
                         args)),
                 "Failed to retrieve user groups");
         }

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -23,7 +23,8 @@
         vm.save = save;
         vm.openGranularPermissionsPicker = openGranularPermissionsPicker;
         vm.setPermissionsForNode = setPermissionsForNode;
-
+        vm.changePageNumber = changePageNumber;
+        
         function init() {
 
             vm.loading = true;
@@ -74,7 +75,12 @@
             }
 
         }
-
+        function changePageNumber(page) {
+       
+            userGroupsResource.getUserGroup($routeParams.id, page-1).then(function (userGroup) {
+                vm.userGroup = userGroup;
+            });
+        }
         function save() {
             vm.page.saveButtonState = "busy";
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -76,9 +76,10 @@
 
         }
         function changePageNumber(page) {
-       
+            vm.loading = true;
             userGroupsResource.getUserGroup($routeParams.id, page-1).then(function (userGroup) {
                 vm.userGroup = userGroup;
+                vm.loading = false;
             });
         }
         function save() {

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -7,6 +7,7 @@
         var contentPickerOpen = false;
 
         vm.page = {};        
+        
         vm.page.rootIcon = "icon-folder";
         vm.userGroup = {};
         vm.labels = {};

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -155,7 +155,7 @@
                                     <div ng-if="!vm.loading" class="flex justify-center">
                                         <umb-pagination
                                             ng-if="vm.userGroup.usersPages"
-                                            page-number="vm.userGroup.currentUsersPage"
+                                            page-number="vm.userGroup.currentUsersPage+1"
                                             total-pages="vm.userGroup.usersPages"
                                             on-next="vm.changePageNumber"
                                             on-prev="vm.changePageNumber"

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -154,10 +154,12 @@
                                     </umb-user-preview>
                                     <div ng-if="!vm.loading" class="flex justify-center">
                                         <umb-pagination
-                                            ng-if="20"
-                                            page-number="3"
-                                            total-pages="20"
-                                            on-change="vm.changePageNumber(pageNumber)">
+                                            ng-if="vm.userGroup.usersPages"
+                                            page-number="vm.userGroup.currentUsersPage"
+                                            total-pages="vm.userGroup.usersPages"
+                                            on-next="vm.changePageNumber"
+                                            on-prev="vm.changePageNumber"
+                                            on-go-to-page="vm.changePageNumber">
                                         </umb-pagination>
                                     </div>
                                     <button type="button"

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -72,7 +72,7 @@
                                     </umb-control-group>
 
                                     <umb-control-group label="@user_mediastartnode" description="@user_mediastartnodehelp">
-                                        
+
                                         <umb-node-preview
                                             ng-if="vm.userGroup.mediaStartNode.id"
                                             style="max-width: 100%;"
@@ -113,7 +113,7 @@
                                 <umb-box-header title-key="user_permissionsGranular"></umb-box-header>
                                 <umb-box-content class="block-form">
                                     <umb-control-group label="Nodes" description="@user_permissionsGranularHelp">
-                                        
+
                                         <umb-node-preview
                                             ng-repeat="node in vm.userGroup.assignedPermissions"
                                             style="max-width: 100%;"
@@ -133,7 +133,7 @@
                                             <localize key="general_add">Add</localize>
                                         </button>
                                     </umb-control-group>
-                                    
+
                                 </umb-box-content>
                             </umb-box>
 
@@ -142,9 +142,9 @@
                         <div class="umb-package-details__sidebar">
 
                             <umb-box>
-                                <umb-box-header title-key="sections_users"></umb-box-header>
+                                <umb-box-header title-key="sections_users" description="{{vm.userGroup.userCount}}"></umb-box-header>
                                 <umb-box-content>
-                                    
+
                                     <umb-user-preview
                                         ng-repeat="user in vm.userGroup.users"
                                         name="user.name"
@@ -152,7 +152,14 @@
                                         allow-remove="true"
                                         on-remove="vm.removeSelectedItem($index, vm.userGroup.users)">
                                     </umb-user-preview>
-
+                                    <div ng-if="!vm.loading" class="flex justify-center">
+                                        <umb-pagination
+                                            ng-if="20"
+                                            page-number="3"
+                                            total-pages="20"
+                                            on-change="vm.changePageNumber(pageNumber)">
+                                        </umb-pagination>
+                                    </div>
                                     <button type="button"
                                             class="umb-node-preview-add"
                                             ng-click="vm.openUserPicker()">

--- a/src/Umbraco.Web/Editors/UserGroupsController.cs
+++ b/src/Umbraco.Web/Editors/UserGroupsController.cs
@@ -137,6 +137,7 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <returns></returns>
         [UserGroupAuthorization("id")]
+        [Obsolete("This method is not recommended as it cause performance degradation with big users lists, use GetUserGroupPaginated")]
         public UserGroupDisplay GetUserGroup(int id)
         {
             var found = Services.UserService.GetUserGroupById(id);
@@ -147,7 +148,18 @@ namespace Umbraco.Web.Editors
 
             return display;
         }
+        [UserGroupAuthorization("id")]
+        public UserGroupDisplay GetUserGroupPaginated(int id, int page)
+        {
+            var found = Services.UserService.GetUserGroupById(id);
+            if (found == null)
+                throw new HttpResponseException(Request.CreateResponse(HttpStatusCode.NotFound));
+            found.MaxUsers = 10;
+            found.UsersPage = page;
+            var display =  Mapper.Map<UserGroupDisplay>(found);
 
+            return display;
+        }
         [HttpPost]
         [HttpDelete]
         [UserGroupAuthorization("userGroupIds")]

--- a/src/Umbraco.Web/Editors/UserGroupsController.cs
+++ b/src/Umbraco.Web/Editors/UserGroupsController.cs
@@ -148,6 +148,7 @@ namespace Umbraco.Web.Editors
 
             return display;
         }
+        [HttpGet]
         [UserGroupAuthorization("id")]
         public UserGroupDisplay GetUserGroupPaginated(int id, int page)
         {

--- a/src/Umbraco.Web/Models/ContentEditing/UserGroupDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/UserGroupDisplay.cs
@@ -29,5 +29,7 @@ namespace Umbraco.Web.Models.ContentEditing
         /// </summary>
         [DataMember(Name = "assignedPermissions")]
         public IEnumerable<AssignedContentPermissions> AssignedPermissions { get; set; }
+      [DataMember(Name = "currentUsersPage")]
+        public int CurrentUserPage { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/ContentEditing/UserGroupDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/UserGroupDisplay.cs
@@ -15,6 +15,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "users")]
         public IEnumerable<UserBasic> Users { get; set; }
+        [DataMember(Name = "usersPages")]
+        public long UsersPages { get; set; }
 
         /// <summary>
         /// The default permissions for the user group organized by permission group name

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -230,6 +230,7 @@ namespace Umbraco.Web.Models.Mapping
             {
                  users = _userService.GetUsersInGroup(source.Id, source.UsersPage, source.MaxUsers, out long usersPages);
                  target.UsersPages = usersPages;
+                 target.CurrentUserPage = source.UsersPage;
             }
             target.Users = context.MapEnumerable<IUser, UserBasic>(users);
 

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -87,6 +87,8 @@ namespace Umbraco.Web.Models.Mapping
             target.ClearAllowedSections();
             foreach (var section in source.Sections)
                 target.AddAllowedSection(section);
+            target.MaxUsers = 0;
+            target.UsersPage = 0;
         }
 
         // Umbraco.Code.MapAll -CreateDate -UpdateDate -DeleteDate
@@ -219,8 +221,16 @@ namespace Umbraco.Web.Models.Mapping
             MapUserGroupBasic(target, source.AllowedSections, source.StartContentId, source.StartMediaId, context);
 
             //Important! Currently we are never mapping to multiple UserGroupDisplay objects but if we start doing that
-            // this will cause an N+1 and we'll need to change how this works.
-            var users = _userService.GetAllInGroup(source.Id);
+            // this will cause an N+1 and we'll need to change how this works..
+            IEnumerable<IUser> users;
+            if(source.MaxUsers == 0){
+                users = _userService.GetAllInGroup(source.Id);
+            }
+            else
+            {
+                 users = _userService.GetUsersInGroup(source.Id, source.UsersPage, source.MaxUsers, out long usersPages);
+                 target.UsersPages = usersPages;
+            }
             target.Users = context.MapEnumerable<IUser, UserBasic>(users);
 
             //Deal with assigned permissions:


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6112 
To see the differences you need:
Add more than 10 users into 1 user group and you should be to see newly paginated users list like here:
![image](https://user-images.githubusercontent.com/2244074/76878485-d48d2d00-686c-11ea-9caf-729845f057fe.png)
This will actually prevent really big performance degradation described in the issue.

I will backport that for v7 as soon @nul800sebastiaan will confirm it will be accepted for v7.