### PR TITLE
NetCore: Make WebRuntime netstandard compatible

### DIFF
--- a/src/Umbraco.Core/Cache/DeepCloneAppCache.cs
+++ b/src/Umbraco.Core/Cache/DeepCloneAppCache.cs
@@ -73,7 +73,7 @@ namespace Umbraco.Core.Cache
                 var result = SafeLazy.GetSafeLazy(factory);
                 var value = result.Value; // force evaluation now - this may throw if cacheItem throws, and then nothing goes into cache
                 // do not store null values (backward compat), clone / reset to go into the cache
-                return value == null ? null : CheckCloneableAndTracksChanges(value); 
+                return value == null ? null : CheckCloneableAndTracksChanges(value);
 
                 // clone / reset to go into the cache
             }, timeout, isSliding, dependentFiles);
@@ -107,9 +107,9 @@ namespace Umbraco.Core.Cache
         }
 
         /// <inheritdoc />
-        public void ClearOfType(string typeName)
+        public void ClearOfType(Type type)
         {
-            InnerCache.ClearOfType(typeName);
+            InnerCache.ClearOfType(type);
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Cache/DictionaryAppCache.cs
+++ b/src/Umbraco.Core/Cache/DictionaryAppCache.cs
@@ -71,16 +71,16 @@ namespace Umbraco.Core.Cache
         }
 
         /// <inheritdoc />
-        public virtual void ClearOfType(string typeName)
+        public virtual void ClearOfType(Type type)
         {
-            _items.RemoveAll(kvp => kvp.Value != null && kvp.Value.GetType().ToString().InvariantEquals(typeName));
+            _items.RemoveAll(kvp => kvp.Value != null && kvp.Value.GetType() == type);
         }
 
         /// <inheritdoc />
         public virtual void ClearOfType<T>()
         {
             var typeOfT = typeof(T);
-            _items.RemoveAll(kvp => kvp.Value != null && kvp.Value.GetType() == typeOfT);
+            ClearOfType(typeOfT);
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Cache/FastDictionaryAppCache.cs
+++ b/src/Umbraco.Core/Cache/FastDictionaryAppCache.cs
@@ -12,12 +12,6 @@ namespace Umbraco.Core.Cache
     /// </summary>
     public class FastDictionaryAppCache : IAppCache
     {
-        private readonly ITypeFinder _typeFinder;
-
-        public FastDictionaryAppCache(ITypeFinder typeFinder)
-        {
-            _typeFinder = typeFinder ?? throw new ArgumentNullException(nameof(typeFinder));
-        }
 
         /// <summary>
         /// Gets the internal items dictionary, for tests only!
@@ -83,9 +77,8 @@ namespace Umbraco.Core.Cache
         }
 
         /// <inheritdoc />
-        public void ClearOfType(string typeName)
+        public void ClearOfType(Type type)
         {
-            var type = _typeFinder.GetTypeByName(typeName);
             if (type == null) return;
             var isInterface = type.IsInterface;
 

--- a/src/Umbraco.Core/Cache/FastDictionaryAppCacheBase.cs
+++ b/src/Umbraco.Core/Cache/FastDictionaryAppCacheBase.cs
@@ -12,13 +12,6 @@ namespace Umbraco.Core.Cache
     /// </summary>
     public abstract class FastDictionaryAppCacheBase : IAppCache
     {
-        private readonly ITypeFinder _typeFinder;
-
-        protected FastDictionaryAppCacheBase(ITypeFinder typeFinder)
-        {
-            _typeFinder = typeFinder ?? throw new ArgumentNullException(nameof(typeFinder));
-        }
-
         // prefix cache keys so we know which one are ours
         protected const string CacheItemPrefix = "umbrtmche";
 
@@ -121,9 +114,8 @@ namespace Umbraco.Core.Cache
         }
 
         /// <inheritdoc />
-        public virtual void ClearOfType(string typeName)
+        public virtual void ClearOfType(Type type)
         {
-            var type = _typeFinder.GetTypeByName(typeName);
             if (type == null) return;
             var isInterface = type.IsInterface;
             try

--- a/src/Umbraco.Core/Cache/HttpRequestAppCache.cs
+++ b/src/Umbraco.Core/Cache/HttpRequestAppCache.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Core.Cache
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpRequestAppCache"/> class with a context, for unit tests!
         /// </summary>
-        public HttpRequestAppCache(Func<IDictionary> requestItems, ITypeFinder typeFinder) : base(typeFinder)
+        public HttpRequestAppCache(Func<IDictionary> requestItems) : base()
         {
             ContextItems = requestItems;
         }

--- a/src/Umbraco.Core/Cache/IAppCache.cs
+++ b/src/Umbraco.Core/Cache/IAppCache.cs
@@ -51,14 +51,14 @@ namespace Umbraco.Core.Cache
         /// <summary>
         /// Removes items of a specified type from the cache.
         /// </summary>
-        /// <param name="typeName">The name of the type to remove.</param>
+        /// <param name="type">The type to remove.</param>
         /// <remarks>
         /// <para>If the type is an interface, then all items of a type implementing that interface are
         /// removed. Otherwise, only items of that exact type are removed (items of type inheriting from
         /// the specified type are not removed).</para>
         /// <para>Performs a case-sensitive search.</para>
         /// </remarks>
-        void ClearOfType(string typeName);
+        void ClearOfType(Type type);
 
         /// <summary>
         /// Removes items of a specified type from the cache.

--- a/src/Umbraco.Core/Cache/NoAppCache.cs
+++ b/src/Umbraco.Core/Cache/NoAppCache.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Core.Cache
         { }
 
         /// <inheritdoc />
-        public virtual void ClearOfType(string typeName)
+        public virtual void ClearOfType(Type type)
         { }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
+++ b/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
@@ -13,15 +13,13 @@ namespace Umbraco.Core.Cache
     /// </summary>
     public class ObjectCacheAppCache : IAppPolicyCache
     {
-        private readonly ITypeFinder _typeFinder;
         private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectCacheAppCache"/>.
         /// </summary>
-        public ObjectCacheAppCache(ITypeFinder typeFinder)
+        public ObjectCacheAppCache()
         {
-            _typeFinder = typeFinder ?? throw new ArgumentNullException(nameof(typeFinder));
             // the MemoryCache is created with name "in-memory". That name is
             // used to retrieve configuration options. It does not identify the memory cache, i.e.
             // each instance of this class has its own, independent, memory cache.
@@ -178,9 +176,8 @@ namespace Umbraco.Core.Cache
         }
 
         /// <inheritdoc />
-        public virtual void ClearOfType(string typeName)
+        public virtual void ClearOfType(Type type)
         {
-            var type = _typeFinder.GetTypeByName(typeName);
             if (type == null) return;
             var isInterface = type.IsInterface;
             try

--- a/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
@@ -403,9 +403,9 @@ namespace Umbraco.Core.Runtime
             // is overridden by the web runtime
 
             return new AppCaches(
-                new DeepCloneAppCache(new ObjectCacheAppCache(TypeFinder)),
+                new DeepCloneAppCache(new ObjectCacheAppCache()),
                 NoAppCache.Instance,
-                new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache(TypeFinder))));
+                new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache())));
         }
 
         // by default, returns null, meaning that Umbraco should auto-detect the application root path.

--- a/src/Umbraco.Infrastructure/Runtime/WebRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/WebRuntime.cs
@@ -1,6 +1,4 @@
-﻿using System.Web;
-using Umbraco.Configuration;
-using Umbraco.Core;
+﻿using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration;
@@ -9,9 +7,6 @@ using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Runtime;
-using Umbraco.Web.Composing;
-using Umbraco.Web.Logging;
-using Current = Umbraco.Web.Composing.Current;
 
 namespace Umbraco.Web.Runtime
 {
@@ -21,6 +16,8 @@ namespace Umbraco.Web.Runtime
     /// <remarks>On top of CoreRuntime, handles all of the web-related runtime aspects of Umbraco.</remarks>
     public class WebRuntime : CoreRuntime
     {
+        private readonly IRequestCache _requestCache;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WebRuntime"/> class.
         /// </summary>
@@ -33,27 +30,12 @@ namespace Umbraco.Web.Runtime
             IHostingEnvironment hostingEnvironment,
             IBackOfficeInfo backOfficeInfo,
             IDbProviderFactoryCreator dbProviderFactoryCreator,
-            IMainDom mainDom):
-            base(configs, umbracoVersion, ioHelper, logger, profiler ,new AspNetUmbracoBootPermissionChecker(), hostingEnvironment, backOfficeInfo, dbProviderFactoryCreator, mainDom)
+            IMainDom mainDom,
+            IRequestCache requestCache,
+            IUmbracoBootPermissionChecker umbracoBootPermissionChecker):
+            base(configs, umbracoVersion, ioHelper, logger, profiler ,umbracoBootPermissionChecker, hostingEnvironment, backOfficeInfo, dbProviderFactoryCreator, mainDom)
         {
-
-            Profiler = GetWebProfiler();
-        }
-
-        private IProfiler GetWebProfiler()
-        {
-            // create and start asap to profile boot
-            if (!State.Debug)
-            {
-                // should let it be null, that's how MiniProfiler is meant to work,
-                // but our own IProfiler expects an instance so let's get one
-                return new VoidProfiler();
-            }
-
-            var webProfiler = new WebProfiler();
-            webProfiler.Start();
-
-            return webProfiler;
+            _requestCache = requestCache;
         }
 
         /// <inheritdoc/>
@@ -74,7 +56,7 @@ namespace Umbraco.Web.Runtime
                     NetworkHelper.MachineName);
                 Logger.Debug<CoreRuntime>("Runtime: {Runtime}", GetType().FullName);
 
-                var factory = Current.Factory = base.Boot(register);
+                var factory =  base.Boot(register);
 
                 // now (and only now) is the time to switch over to perWebRequest scopes.
                 // up until that point we may not have a request, and scoped services would
@@ -93,13 +75,13 @@ namespace Umbraco.Web.Runtime
         protected override AppCaches GetAppCaches() => new AppCaches(
                 // we need to have the dep clone runtime cache provider to ensure
                 // all entities are cached properly (cloned in and cloned out)
-                new DeepCloneAppCache(new ObjectCacheAppCache(TypeFinder)),
+                new DeepCloneAppCache(new ObjectCacheAppCache()),
                 // we need request based cache when running in web-based context
-                new HttpRequestAppCache(() => HttpContext.Current?.Items, TypeFinder),
+                _requestCache,
                 new IsolatedCaches(type =>
                     // we need to have the dep clone runtime cache provider to ensure
                     // all entities are cached properly (cloned in and cloned out)
-                    new DeepCloneAppCache(new ObjectCacheAppCache(TypeFinder))));
+                    new DeepCloneAppCache(new ObjectCacheAppCache())));
 
         #endregion
     }

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -188,7 +188,7 @@ namespace Umbraco.Core.Scoping
                 if (ParentScope != null) return ParentScope.IsolatedCaches;
 
                 return _isolatedCaches ?? (_isolatedCaches
-                           = new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache(_typeFinder))));
+                           = new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache())));
             }
         }
 

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -49,7 +49,6 @@ namespace Umbraco.Web.PublishedCache.NuCache
         private readonly IPublishedModelFactory _publishedModelFactory;
         private readonly IDefaultCultureAccessor _defaultCultureAccessor;
         private readonly UrlSegmentProviderCollection _urlSegmentProviders;
-        private readonly ITypeFinder _typeFinder;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IShortStringHelper _shortStringHelper;
         private readonly IIOHelper _ioHelper;
@@ -88,7 +87,6 @@ namespace Umbraco.Web.PublishedCache.NuCache
             IEntityXmlSerializer entitySerializer,
             IPublishedModelFactory publishedModelFactory,
             UrlSegmentProviderCollection urlSegmentProviders,
-            ITypeFinder typeFinder,
             IHostingEnvironment hostingEnvironment,
             IShortStringHelper shortStringHelper,
             IIOHelper ioHelper,
@@ -109,7 +107,6 @@ namespace Umbraco.Web.PublishedCache.NuCache
             _defaultCultureAccessor = defaultCultureAccessor;
             _globalSettings = globalSettings;
             _urlSegmentProviders = urlSegmentProviders;
-            _typeFinder = typeFinder;
             _hostingEnvironment = hostingEnvironment;
             _shortStringHelper = shortStringHelper;
             _ioHelper = ioHelper;
@@ -1207,7 +1204,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     _contentGen = contentSnap.Gen;
                     _mediaGen = mediaSnap.Gen;
                     _domainGen = domainSnap.Gen;
-                    elementsCache = _elementsCache = new FastDictionaryAppCache(_typeFinder);
+                    elementsCache = _elementsCache = new FastDictionaryAppCache();
                 }
             }
 

--- a/src/Umbraco.Tests/Cache/AppCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/AppCacheTests.cs
@@ -229,7 +229,7 @@ namespace Umbraco.Tests.Cache
             Assert.AreEqual(4, GetTotalItemCount);
 
             //Provider.ClearCacheObjectTypes("umbraco.MacroCacheContent");
-            AppCache.ClearOfType(typeof(MacroCacheContent).ToString());
+            AppCache.ClearOfType<MacroCacheContent>();
 
             Assert.AreEqual(1, GetTotalItemCount);
         }

--- a/src/Umbraco.Tests/Cache/DeepCloneAppCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/DeepCloneAppCacheTests.cs
@@ -29,8 +29,7 @@ namespace Umbraco.Tests.Cache
         public override void Setup()
         {
             base.Setup();
-            var typeFinder = TestHelper.GetTypeFinder();
-            _memberCache = new ObjectCacheAppCache(typeFinder);
+            _memberCache = new ObjectCacheAppCache();
 
             _provider = new DeepCloneAppCache(_memberCache);
         }

--- a/src/Umbraco.Tests/Cache/HttpRequestAppCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/HttpRequestAppCacheTests.cs
@@ -16,9 +16,8 @@ namespace Umbraco.Tests.Cache
         public override void Setup()
         {
             base.Setup();
-            var typeFinder = TestHelper.GetTypeFinder();
             _ctx = new FakeHttpContextFactory("http://localhost/test");
-            _appCache = new HttpRequestAppCache(() => _ctx.HttpContext.Items, typeFinder);
+            _appCache = new HttpRequestAppCache(() => _ctx.HttpContext.Items);
         }
 
         internal override IAppCache AppCache

--- a/src/Umbraco.Tests/Cache/ObjectAppCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/ObjectAppCacheTests.cs
@@ -18,8 +18,7 @@ namespace Umbraco.Tests.Cache
         public override void Setup()
         {
             base.Setup();
-            var typeFinder = TestHelper.GetTypeFinder();
-            _provider = new ObjectCacheAppCache(typeFinder);
+            _provider = new ObjectCacheAppCache();
         }
 
         internal override IAppCache AppCache

--- a/src/Umbraco.Tests/Macros/MacroTests.cs
+++ b/src/Umbraco.Tests/Macros/MacroTests.cs
@@ -17,12 +17,11 @@ namespace Umbraco.Tests.Macros
         [SetUp]
         public void Setup()
         {
-            var typeFinder = TestHelper.GetTypeFinder();
             //we DO want cache enabled for these tests
             var cacheHelper = new AppCaches(
-                new ObjectCacheAppCache(typeFinder),
+                new ObjectCacheAppCache(),
                 NoAppCache.Instance,
-                new IsolatedCaches(type => new ObjectCacheAppCache(typeFinder)));
+                new IsolatedCaches(type => new ObjectCacheAppCache()));
         }
 
         [TestCase("anything", true)]

--- a/src/Umbraco.Tests/Models/ContentTests.cs
+++ b/src/Umbraco.Tests/Models/ContentTests.cs
@@ -270,8 +270,7 @@ namespace Umbraco.Tests.Models
             content.UpdateDate = DateTime.Now;
             content.WriterId = 23;
 
-            var typeFinder = TestHelper.GetTypeFinder();
-            var runtimeCache = new ObjectCacheAppCache(typeFinder);
+            var runtimeCache = new ObjectCacheAppCache();
             runtimeCache.Insert(content.Id.ToString(CultureInfo.InvariantCulture), () => content);
 
             var proflog = GetTestProfilingLogger();

--- a/src/Umbraco.Tests/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -83,9 +83,9 @@ namespace Umbraco.Tests.Persistence.Repositories
         public void CacheActiveForIntsAndGuids()
         {
             var realCache = new AppCaches(
-                new ObjectCacheAppCache(TypeFinder),
+                new ObjectCacheAppCache(),
                 new DictionaryAppCache(),
-                new IsolatedCaches(t => new ObjectCacheAppCache(TypeFinder)));
+                new IsolatedCaches(t => new ObjectCacheAppCache()));
 
             var provider = TestObjects.GetScopeProvider(Logger);
             using (var scope = provider.CreateScope())

--- a/src/Umbraco.Tests/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/MediaRepositoryTest.cs
@@ -56,9 +56,9 @@ namespace Umbraco.Tests.Persistence.Repositories
             MediaTypeRepository mediaTypeRepository;
 
             var realCache = new AppCaches(
-                new ObjectCacheAppCache(TypeFinder),
+                new ObjectCacheAppCache(),
                 new DictionaryAppCache(),
-                new IsolatedCaches(t => new ObjectCacheAppCache(TypeFinder)));
+                new IsolatedCaches(t => new ObjectCacheAppCache()));
 
             var provider = TestObjects.GetScopeProvider(Logger);
             using (var scope = provider.CreateScope())

--- a/src/Umbraco.Tests/Published/PropertyCacheLevelTests.cs
+++ b/src/Umbraco.Tests/Published/PropertyCacheLevelTests.cs
@@ -127,9 +127,8 @@ namespace Umbraco.Tests.Published
 
             var setType1 = publishedContentTypeFactory.CreateContentType(1000, "set1", CreatePropertyTypes);
 
-            var typeFinder = TestHelper.GetTypeFinder();
-            var elementsCache = new FastDictionaryAppCache(typeFinder);
-            var snapshotCache = new FastDictionaryAppCache(typeFinder);
+            var elementsCache = new FastDictionaryAppCache();
+            var snapshotCache = new FastDictionaryAppCache();
 
             var publishedSnapshot = new Mock<IPublishedSnapshot>();
             publishedSnapshot.Setup(x => x.SnapshotCache).Returns(snapshotCache);

--- a/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
@@ -167,7 +167,6 @@ namespace Umbraco.Tests.PublishedContent
                 Mock.Of<IEntityXmlSerializer>(),
                 PublishedModelFactory,
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider(TestHelper.ShortStringHelper) }),
-                typeFinder,
                 hostingEnvironment,
                 new MockShortStringHelper(),
                 TestHelper.IOHelper,

--- a/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
@@ -207,7 +207,6 @@ namespace Umbraco.Tests.PublishedContent
                 Mock.Of<IEntityXmlSerializer>(),
                 publishedModelFactory,
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider(TestHelper.ShortStringHelper) }),
-                typeFinder,
                 TestHelper.GetHostingEnvironment(),
                 new MockShortStringHelper(),
                 TestHelper.IOHelper,

--- a/src/Umbraco.Tests/Routing/RenderRouteHandlerTests.cs
+++ b/src/Umbraco.Tests/Routing/RenderRouteHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Tests.Routing
         public class TestRuntime : WebRuntime
         {
             public TestRuntime(Configs configs, IUmbracoVersion umbracoVersion, IIOHelper ioHelper, ILogger logger, IHostingEnvironment hostingEnvironment, IBackOfficeInfo backOfficeInfo)
-                : base(configs, umbracoVersion, ioHelper, Mock.Of<ILogger>(), Mock.Of<IProfiler>(), hostingEnvironment, backOfficeInfo, TestHelper.DbProviderFactoryCreator, TestHelper.MainDom)
+                : base(configs, umbracoVersion, ioHelper, Mock.Of<ILogger>(), Mock.Of<IProfiler>(), hostingEnvironment, backOfficeInfo, TestHelper.DbProviderFactoryCreator, TestHelper.MainDom, TestHelper.GetRequestCache(), new AspNetUmbracoBootPermissionChecker())
             {
             }
 

--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -106,7 +106,6 @@ namespace Umbraco.Tests.Scoping
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 new NoopPublishedModelFactory(),
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider(ShortStringHelper) }),
-                typeFinder,
                 hostingEnvironment,
                 new MockShortStringHelper(),
                 IOHelper,

--- a/src/Umbraco.Tests/Scoping/ScopedRepositoryTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedRepositoryTests.cs
@@ -43,9 +43,9 @@ namespace Umbraco.Tests.Scoping
         {
             // this is what's created core web runtime
             return new AppCaches(
-                new DeepCloneAppCache(new ObjectCacheAppCache(TypeFinder)),
+                new DeepCloneAppCache(new ObjectCacheAppCache()),
                 NoAppCache.Instance,
-                new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache(TypeFinder))));
+                new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache())));
         }
 
         [TearDown]

--- a/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
@@ -78,7 +78,6 @@ namespace Umbraco.Tests.Services
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider(ShortStringHelper) }),
-                typeFinder,
                 hostingEnvironment,
                 new MockShortStringHelper(),
                 IOHelper,

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -545,7 +545,6 @@
     <Compile Include="WebApi\UmbracoAuthorizedApiController.cs" />
     <Compile Include="WebApi\Filters\ValidationFilterAttribute.cs" />
     <Compile Include="WebApi\Filters\UmbracoUserTimeoutFilterAttribute.cs" />
-    <Compile Include="Runtime\WebRuntime.cs" />
     <Compile Include="Mvc\ControllerExtensions.cs" />
     <Compile Include="TypeLoaderExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/src/Umbraco.Web/UmbracoApplication.cs
+++ b/src/Umbraco.Web/UmbracoApplication.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Web;
 using Umbraco.Core;
+using Umbraco.Core.Cache;
 using Umbraco.Core.Runtime;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Hosting;
@@ -33,7 +34,9 @@ namespace Umbraco.Web
 
             var mainDom = new MainDom(logger, hostingEnvironment, mainDomLock);
 
-            return new WebRuntime(configs, umbracoVersion, ioHelper, logger, profiler, hostingEnvironment, backOfficeInfo, dbProviderFactoryCreator, mainDom);
+            var requestCache = new HttpRequestAppCache(() => HttpContext.Current?.Items);
+            var umbracoBootPermissionChecker = new AspNetUmbracoBootPermissionChecker();
+            return new WebRuntime(configs, umbracoVersion, ioHelper, logger, profiler, hostingEnvironment, backOfficeInfo, dbProviderFactoryCreator, mainDom, requestCache, umbracoBootPermissionChecker);
         }
     }
 }

--- a/src/Umbraco.Web/UmbracoApplicationBase.cs
+++ b/src/Umbraco.Web/UmbracoApplicationBase.cs
@@ -13,6 +13,7 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Logging.Serilog;
 using Umbraco.Web.AspNet;
 using Umbraco.Web.Hosting;
+using Umbraco.Web.Logging;
 using Current = Umbraco.Web.Composing.Current;
 
 namespace Umbraco.Web
@@ -43,10 +44,26 @@ namespace Umbraco.Web
                 var configs = configFactory.Create();
 
                 var backOfficeInfo = new AspNetBackOfficeInfo(globalSettings, ioHelper, logger, configFactory.WebRoutingSettings);
-                var profiler = new LogProfiler(logger);
+                var profiler = GetWebProfiler(hostingEnvironment);
                 Umbraco.Composing.Current.Initialize(logger, configs, ioHelper, hostingEnvironment, backOfficeInfo, profiler);
             }
 
+        }
+
+        private IProfiler GetWebProfiler(IHostingEnvironment hostingEnvironment)
+        {
+            // create and start asap to profile boot
+            if (!hostingEnvironment.IsDebugMode)
+            {
+                // should let it be null, that's how MiniProfiler is meant to work,
+                // but our own IProfiler expects an instance so let's get one
+                return new VoidProfiler();
+            }
+
+            var webProfiler = new WebProfiler();
+            webProfiler.Start();
+
+            return webProfiler;
         }
 
         protected UmbracoApplicationBase(ILogger logger, Configs configs, IIOHelper ioHelper, IProfiler profiler, IHostingEnvironment hostingEnvironment, IBackOfficeInfo backOfficeInfo)
@@ -114,7 +131,7 @@ namespace Umbraco.Web
                 Umbraco.Composing.Current.Profiler,
                 Umbraco.Composing.Current.HostingEnvironment,
                 Umbraco.Composing.Current.BackOfficeInfo);
-            _factory =_runtime.Boot(register);
+            _factory = Current.Factory = _runtime.Boot(register);
         }
 
         // called by ASP.NET (auto event wireup) once per app domain


### PR DESCRIPTION
- Moved `WebRuntime` to Infrastructure
  - Updated ` void ClearOfType(string typeName);` in `IAppCache` to ` void ClearOfType(Type type); ` to not have reference on TypeFinder
  - Injected `WebProfiler` in `WebRuntime`
  - Move initialized of `Current.Factory` out of  `WebRuntime`
