### PR TITLE
Remove button border radius when used in a button group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-group.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-group.less
@@ -17,15 +17,14 @@
 .umb-button-group {
 
     .umb-button__button {
-        border-radius: @baseBorderRadius;
+        border-radius: @baseBorderRadius 0 0 @baseBorderRadius;
     }
 
     .umb-button-group__toggle {
         border-radius: 0 @baseBorderRadius @baseBorderRadius 0;
         border-left: 1px solid rgba(0,0,0,0.09);
-        margin-left: -2px;
+        margin-left: -1px;
         padding-left: 10px;
         padding-right: 10px;
     }
-
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-group.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-group.less
@@ -18,11 +18,14 @@
 
     .umb-button__button {
         border-radius: @baseBorderRadius 0 0 @baseBorderRadius;
+
+        &:hover {
+            z-index: 2;
+        }
     }
 
     .umb-button-group__toggle {
         border-radius: 0 @baseBorderRadius @baseBorderRadius 0;
-        border-left: 1px solid rgba(0,0,0,0.09);
         margin-left: -1px;
         padding-left: 10px;
         padding-right: 10px;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7716

### Description

I removed the border radius from the right of umb-button when used inside a umb-button-grp. The dropdown toggle was underlapping the button slightly so I moved it right 1 pixel.

To test, visit the user management section and observe the "Invite user" button at the top of the page.

I have some more free time this week. If there are any pressing issues that you need help with, let me know. I'm comfortable working on your backend too. Thanks!