### PR TITLE
Fixes Memory Leak in GetCacheItem cache dependency #7773

### DIFF
--- a/src/Umbraco.Core/Cache/WebCachingAppCache.cs
+++ b/src/Umbraco.Core/Cache/WebCachingAppCache.cs
@@ -37,28 +37,13 @@ namespace Umbraco.Core.Cache
         /// <inheritdoc />
         public object Get(string key, Func<object> factory, TimeSpan? timeout, bool isSliding = false, CacheItemPriority priority = CacheItemPriority.Normal, CacheItemRemovedCallback removedCallback = null, string[] dependentFiles = null)
         {
-            return Get(key, factory, timeout, isSliding, priority, removedCallback,
-                // NOTE: We don't want to allocate an object if it isn't going to be used so we create the CacheDependency
-                // in a callback if it's needed ... but more importantly and we didn't anticipate this, just constructing
-                // a CacheDependency object is expensive and allocates a bunch of stuff, just check the code out for it:
-                // https://referencesource.microsoft.com/#system.web/Cache/CacheDependency.cs,304
-                // Init is called as part of the ctor!! yikes.
-                // This change fixes https://github.com/umbraco/Umbraco-CMS/issues/7773
-                () => dependentFiles != null && dependentFiles.Length > 0 ? new CacheDependency(dependentFiles) : null);
+            return GetInternal(key, factory, timeout, isSliding, priority, removedCallback, dependentFiles);
         }
 
         /// <inheritdoc />
         public void Insert(string key, Func<object> factory, TimeSpan? timeout = null, bool isSliding = false, CacheItemPriority priority = CacheItemPriority.Normal, CacheItemRemovedCallback removedCallback = null, string[] dependentFiles = null)
         {
-            
-            Insert(key, factory, timeout, isSliding, priority, removedCallback,
-                // NOTE: We don't want to allocate an object if it isn't going to be used so we create the CacheDependency
-                // in a callback if it's needed ... but more importantly and we didn't anticipate this, just constructing
-                // a CacheDependency object is expensive and allocates a bunch of stuff, just check the code out for it:
-                // https://referencesource.microsoft.com/#system.web/Cache/CacheDependency.cs,304
-                // Init is called as part of the ctor!! yikes.
-                // This change fixes https://github.com/umbraco/Umbraco-CMS/issues/7773
-                () => dependentFiles != null && dependentFiles.Length > 0 ? new CacheDependency(dependentFiles) : null);
+            InsertInternal(key, factory, timeout, isSliding, priority, removedCallback, dependentFiles);
         }
 
         #region Dictionary
@@ -108,7 +93,7 @@ namespace Umbraco.Core.Cache
 
         #endregion
 
-        private object Get(string key, Func<object> factory, TimeSpan? timeout, bool isSliding = false, CacheItemPriority priority = CacheItemPriority.Normal, CacheItemRemovedCallback removedCallback = null, Func<CacheDependency> dependency = null)
+        private object GetInternal(string key, Func<object> factory, TimeSpan? timeout, bool isSliding = false, CacheItemPriority priority = CacheItemPriority.Normal, CacheItemRemovedCallback removedCallback = null, string[] dependentFiles = null)
         {
             key = GetCacheKey(key);
 
@@ -168,8 +153,12 @@ namespace Umbraco.Core.Cache
                     var sliding = isSliding == false ? System.Web.Caching.Cache.NoSlidingExpiration : (timeout ?? System.Web.Caching.Cache.NoSlidingExpiration);
 
                     lck.UpgradeToWriteLock();
+
+                    // create a cache dependency if one is needed. 
+                    var dependency = dependentFiles != null && dependentFiles.Length > 0 ? new CacheDependency(dependentFiles) : null;
+
                     //NOTE: 'Insert' on System.Web.Caching.Cache actually does an add or update!
-                    _cache.Insert(key, result, dependency(), absolute, sliding, priority, removedCallback);
+                    _cache.Insert(key, result, dependency, absolute, sliding, priority, removedCallback);
                 }
             }
 
@@ -185,7 +174,7 @@ namespace Umbraco.Core.Cache
             return value;
         }
 
-        private void Insert(string cacheKey, Func<object> getCacheItem, TimeSpan? timeout = null, bool isSliding = false, CacheItemPriority priority = CacheItemPriority.Normal, CacheItemRemovedCallback removedCallback = null, Func<CacheDependency> dependency = null)
+        private void InsertInternal(string cacheKey, Func<object> getCacheItem, TimeSpan? timeout = null, bool isSliding = false, CacheItemPriority priority = CacheItemPriority.Normal, CacheItemRemovedCallback removedCallback = null, string[] dependentFiles = null)
         {
             // NOTE - here also we must insert a Lazy<object> but we can evaluate it right now
             // and make sure we don't store a null value.
@@ -202,8 +191,12 @@ namespace Umbraco.Core.Cache
             try
             {
                 _locker.EnterWriteLock();
+
+                // create a cache dependency if one is needed. 
+                var dependency = dependentFiles != null && dependentFiles.Length > 0 ? new CacheDependency(dependentFiles) : null;
+
                 //NOTE: 'Insert' on System.Web.Caching.Cache actually does an add or update!
-                _cache.Insert(cacheKey, result, dependency(), absolute, sliding, priority, removedCallback);
+                _cache.Insert(cacheKey, result, dependency, absolute, sliding, priority, removedCallback);
             }
             finally
             {


### PR DESCRIPTION
## Fixes Memory Leak in GetCacheItem cache dependency #7773

This fixes a memory leak in the `WebCachingAppCache` which is the implementation of `IAppPolicyCache`

It turns out we were allocating an instance of `CacheDependency` any time `Insert` or `Get` was called even if we weren't going to insert/add to the cache. So a new instance of `CacheDependency` was allocated for every Get. But one object allocation isn't the end of the world ... normally. Turns out that this particular ugly object in .NET Framework runs a lot of code in it's constructor and allocates more objects. 

I ran the test mentioned in #7773 with 1,000,000 iterations before the fix and the code took roughly 20 seconds to execute. With the fix and 3,000,000 iterations it took a couple seconds and there's no more memory leak. It seems that just creating a CacheDependency instance allocates and pins stuff in memory. 

If you are interested in this nasty code it's here https://referencesource.microsoft.com/#system.web/Cache/CacheDependency.cs,304 and this `Init` method is called as part of the ctor! yikes.

Here's the before and after snapshots of the memory and the before is only with 1,000,000 iterations, the after is with 3,000,000. 

![image](https://user-images.githubusercontent.com/1742685/77640929-4bce6980-6faf-11ea-9da8-3fc20f4d3c19.png)

This is a good candidate to backport to a patch release of 7.15.x IMO.
