### PR TITLE
Members list on member's group page feature

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Umbraco.Core.Models;
+using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Querying;
 
 namespace Umbraco.Core.Persistence.Repositories
@@ -21,6 +22,8 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="groupName"></param>
         /// <returns></returns>
         IEnumerable<IMember> GetByMemberGroup(string groupName);
+
+        IEnumerable<IMember> FindMembersByGroup(int memberGroupId, long pageIndex, int pageSize, out long totalRecords);
 
         /// <summary>
         /// Checks if a member with the username exists

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -161,6 +161,8 @@ namespace Umbraco.Core.Services
         /// <returns><see cref="IEnumerable{IMember}"/></returns>
         IEnumerable<IMember> GetMembersByGroup(string memberGroupName);
 
+        IEnumerable<IMember> GetMembersByGroup(int memberGroupId, long pageIndex, int pageSize, out long totalRecords);
+
         /// <summary>
         /// Gets all Members with the ids specified
         /// </summary>

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -503,6 +503,15 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public IEnumerable<IMember> GetMembersByGroup(int memberGroupId, long pageNumber, int pageSize, out long totalRecords)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Constants.Locks.MemberTree);
+                return _memberRepository.FindMembersByGroup(memberGroupId, pageNumber, pageSize, out totalRecords);
+            }
+        }
+
         /// <summary>
         /// Gets all Members with the ids specified
         /// </summary>
@@ -1401,7 +1410,6 @@ namespace Umbraco.Core.Services.Implement
         {
             return Current.Services.MemberTypeService.GetDefault();
         }
-
         #endregion
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
@@ -45,7 +45,8 @@
             replace: true,
             templateUrl: 'views/components/member/umb-membergroup-node-info.html',
             scope: {
-                node: "="
+                node: "=",
+                members: "="
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
@@ -22,6 +22,30 @@ function memberResource($q, $http, umbDataFormatter, umbRequestHelper) {
     }
 
     return {
+        getMembersByGroup: function(options) {
+            var defaults = {
+                pageSize: 25,
+                pageNumber: 1
+            };
+
+            angular.extend(defaults, options);
+
+            options = defaults;
+
+            var params = [
+                { groupId: options.groupId },
+                { pageNumber: options.pageNumber },
+                { pageSize: options.pageSize }
+            ];
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "memberApiBaseUrl",
+                        "GetMembersByGroup",
+                        params)),
+                'Failed to retrieve members by group');
+        },
         getPagedResults: function(memberTypeAlias, options) {
 
             if (memberTypeAlias === 'all-members') {

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
@@ -10,7 +10,12 @@
 
             </umb-box-content>
         </umb-box>
-
+        <umb-box>
+            <umb-box-header title-key="content_membergroup"></umb-box-header>
+            <umb-box-content class="block-form">
+                <pre>{{ members | json }}</pre>
+            </umb-box-content>
+        </umb-box>
     </div>
 
     <div class="umb-package-details__sidebar">

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the member group editor
  */
-function MemberGroupsEditController($scope, $routeParams, appState, navigationService, memberGroupResource, contentEditingHelper, formHelper, editorState, eventsService) {
+function MemberGroupsEditController($scope, $routeParams, appState, navigationService, memberGroupResource, memberResource, contentEditingHelper, formHelper, editorState, eventsService) {
 
     //setup scope vars
     $scope.page = {};
@@ -38,6 +38,18 @@ function MemberGroupsEditController($scope, $routeParams, appState, navigationSe
     }
     else {
         loadMemberGroup();
+        loadMembers();
+    }
+
+    function loadMembers() {
+        $scope.page.loading = true;
+
+        memberResource.getMembersByGroup({ groupId: $routeParams.id, pageSize: 25, pageNumber: 1 })
+            .then(function (data) {
+                $scope.members = data;
+
+                $scope.page.loading = false;
+            });
     }
 
     function loadMemberGroup() {
@@ -103,6 +115,7 @@ function MemberGroupsEditController($scope, $routeParams, appState, navigationSe
 
     evts.push(eventsService.on("app.refreshEditor", function (name, error) {
         loadMemberGroup();
+        loadMembers();
     }));
 
     //ensure to unregister from all events!

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
@@ -21,8 +21,9 @@
 
             <umb-editor-container class="form-horizontal">
 
-                <umb-membergroup-node-info ng-if="content"
-                                           node="content">
+                <umb-membergroup-node-info ng-if="content && members"
+                                           node="content"
+                                           members="members">
                 </umb-membergroup-node-info>
 
             </umb-editor-container>

--- a/src/Umbraco.Web/Editors/MemberController.cs
+++ b/src/Umbraco.Web/Editors/MemberController.cs
@@ -60,6 +60,22 @@ namespace Umbraco.Web.Editors
             get { return Services.MemberService.GetMembershipScenario(); }
         }
 
+        public PagedResult<MemberBasic> GetMembersByGroup(
+            int groupId,
+            int pageNumber = 1,
+            int pageSize = 100)
+        {
+
+            var members = Services.MemberService.GetMembersByGroup(groupId, pageNumber, pageSize, out var totalRecords);
+
+            var pagedResult = new PagedResult<MemberBasic>(totalRecords, pageNumber, pageSize)
+            {
+                Items = members
+                        .Select(x => Mapper.Map<MemberBasic>(x))
+            };
+            return pagedResult;
+        }
+
         public PagedResult<MemberBasic> GetPagedResults(
             int pageNumber = 1,
             int pageSize = 100,


### PR DESCRIPTION
## This is not ready to be merged. I'm opening this PR to seek feedback on my progress.

This is for #7836 

### Description

I've created a new api call to return paginated users by member group id. This is displayed in json on the UI when you view a member group. The UI always requests the first page and it's not possible to navigate the list yet. It's only to display the results.

I'm looking for feedback on my implementation before I continue. I only have a handful of members in my umbraco test instance. If you have more, please have a look at the query performance. There are a bunch of inner joins and I don't know if they're necessary. They come from a modified version of `GetBaseQuery` on the `MemberRepository` so that I could add a join to `Member2MemberGroupDto`. I couldn't find a way to utilize `GetBaseQuery` for my needs so I copied the contents to `MemberRepository.FindMembersByGroup` and altered it to suit.

Also, which fields from a member need to be shown in the list on the UI? This might alter what needs to be returned by the query and reduce the joins.
