### PR TITLE
Fix #7521 - Runtime error if removing email notificationMethod

### DIFF
--- a/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Web/HealthCheck/NotificationMethods/EmailNotificationMethod.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
 
         public EmailNotificationMethod(ILocalizedTextService textService, IRuntimeState runtimeState, ILogger logger)
         {
-            var recipientEmail = Settings["recipientEmail"]?.Value;
+            var recipientEmail = Settings?["recipientEmail"]?.Value;
             if (string.IsNullOrWhiteSpace(recipientEmail))
             {
                 Enabled = false;


### PR DESCRIPTION
### Description
If we remove the `<notificationMethod alias="email" ...>` element from the `HealthChecks.config` then Settings is null in EmailNotificationMethod constructor.

Just added a check on Settings if it's null then the NotificationMethod disabled itself (same behavior that when there is no `recipientEmail`)