### PR TITLE
#7672 checking allowed image types on each folder switch

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -213,14 +213,14 @@ angular.module("umbraco")
                                     return f.path.indexOf($scope.startNodeId) !== -1;
                                 });
                         });
-
-                    mediaTypeHelper.getAllowedImagetypes(folder.id)
-                        .then(function (types) {
-                            vm.acceptedMediatypes = types;
-                        });
                 } else {
                     $scope.path = [];
                 }
+
+                mediaTypeHelper.getAllowedImagetypes(folder.id)
+                    .then(function (types) {
+                        vm.acceptedMediatypes = types;
+                    });
 
                 $scope.lockedFolder = (folder.id === -1 && $scope.model.startNodeIsVirtual) || hasFolderAccess(folder) === false;
                 $scope.currentFolder = folder;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #7672 

### Description

1. Set the Image Media Types AllowAtRoot property to false in Setting>Media Types>Image.
2. Create a Doc Type with a Media Picker property on it and create a node with this Doc Type.
3. Open the Media Picker.
4. Click upload while viewing the root of the Media folder. This will not open the file upload window.
5. Create a new media folder.
6. Go into the folder.
7. Click to return to the root.
8. Click upload while viewing the root. This will **no longer** open the file upload window.
