### PR TITLE
property group header adjustment

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/html/umb-group-panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/html/umb-group-panel.less
@@ -8,11 +8,11 @@
 .umb-group-panel__header {
     padding: 12px 20px;
     font-weight: bold;
-    font-size: 16px;
+    font-size: 14px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    color: @grayDark;
+    color: @grayDarker;
     border-bottom: 1px solid @gray-9;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -23,7 +23,7 @@
 
                     <umb-property-actions actions="propertyActions"></umb-property-actions>
 
-                    <small class="control-description" ng-bind-html="property.description | preserveNewLineInHtml"></small>
+                    <small class="control-description" ng-if="property.description" ng-bind-html="property.description | preserveNewLineInHtml"></small>
                 </div>
 
                 <div class="controls" ng-transclude>


### PR DESCRIPTION
I want to make the property group header slightly more discreet, and hide property description if not present.

Minor adjustments made to accomplish a simple UI in Block Editors.