### PR TITLE
7879: Handle for multiple picked media relations

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -45,8 +45,11 @@ namespace Umbraco.Web.PropertyEditors
 
                 if (string.IsNullOrEmpty(asString)) yield break;
 
-                if (Udi.TryParse(asString, out var udi))
-                    yield return new UmbracoEntityReference(udi);
+                foreach (var udiStr in asString.Split(','))
+                {
+                    if (Udi.TryParse(udiStr, out var udi))
+                        yield return new UmbracoEntityReference(udi);
+                }
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

Resolves #7879 

### Description
When trying to resolve the media references for a Media Picker property editor, it splits the value on commas before trying to create a UDI.  If there are multiple media items picked, this will ensure that all picked items get recorded as media references.