### PR TITLE
Revert GetData() in Block Editor List model

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockListLayoutReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListLayoutReference.cs
@@ -10,9 +10,10 @@ namespace Umbraco.Core.Models.Blocks
     [DataContract(Name = "blockListLayout", Namespace = "")]
     public class BlockListLayoutReference : IBlockElement<IPublishedElement>
     {
-        public BlockListLayoutReference(Udi udi, IPublishedElement settings)
+        public BlockListLayoutReference(Udi udi, IPublishedElement data, IPublishedElement settings)
         {
             Udi = udi ?? throw new ArgumentNullException(nameof(udi));
+            Data = data ?? throw new ArgumentNullException(nameof(data));
             Settings = settings; // can be null
         }
 
@@ -28,5 +29,13 @@ namespace Umbraco.Core.Models.Blocks
         [DataMember(Name = "settings")]
         public IPublishedElement Settings { get; }
 
+        /// <summary>
+        /// The data item referenced
+        /// </summary>
+        /// <remarks>
+        /// This is ignored from serialization since it is just a reference to the actual data element
+        /// </remarks>
+        [IgnoreDataMember]
+        public IPublishedElement Data { get; }
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockListModel.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
 using Umbraco.Core.Models.PublishedContent;
 
@@ -23,17 +22,6 @@ namespace Umbraco.Core.Models.Blocks
         [DataMember(Name = "layout")]
         public IEnumerable<BlockListLayoutReference> Layout { get; }
 
-        /// <summary>
-        /// Returns the data item associated with the layout udi reference
-        /// </summary>
-        /// <param name="udi"></param>
-        /// <returns></returns>
-        public IPublishedElement GetData(Udi udi)
-        {
-            if (!(udi is GuidUdi guidUdi))
-                return null;
-            return Data.FirstOrDefault(x => x.Key == guidUdi.Guid);
-        }
-
+        
     }
 }

--- a/src/Umbraco.Tests/PropertyEditors/BlockListPropertyValueConverterTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/BlockListPropertyValueConverterTests.cs
@@ -317,15 +317,12 @@ data: []}";
             Assert.AreEqual(2, converted.Layout.Count());
 
             var item0 = converted.Layout.ElementAt(0);
-            var item0Data = converted.GetData(item0.Udi);
-            Assert.IsNotNull(item0Data);
-            Assert.AreEqual(Guid.Parse("1304E1DD-AC87-4396-84FE-8A399231CB3D"), item0Data.Key);
-            Assert.AreEqual("home", item0Data.ContentType.Alias);
+            Assert.AreEqual(Guid.Parse("1304E1DD-AC87-4396-84FE-8A399231CB3D"), item0.Data.Key);
+            Assert.AreEqual("home", item0.Data.ContentType.Alias);
 
             var item1 = converted.Layout.ElementAt(1);
-            var item1Data = converted.GetData(item1.Udi);
-            Assert.AreEqual(Guid.Parse("0A4A416E-547D-464F-ABCC-6F345C17809A"), item1Data.Key);
-            Assert.AreEqual("home", item1Data.ContentType.Alias);
+            Assert.AreEqual(Guid.Parse("0A4A416E-547D-464F-ABCC-6F345C17809A"), item1.Data.Key);
+            Assert.AreEqual("home", item1.Data.ContentType.Alias);
 
         }
 

--- a/src/Umbraco.Web.UI/Views/Partials/BlockList/Default.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/BlockList/Default.cshtml
@@ -8,7 +8,7 @@
     @foreach (var layout in Model.Layout)
     {
         if (layout?.Udi == null) { continue; }
-        var data = Model.GetData(layout.Udi);
+        var data = layout.Data;
         @Html.Partial("BlockList/" + data.ContentType.Alias, (data, layout.Settings))
     }
 </div>

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -114,7 +114,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                     if (element != null && string.IsNullOrWhiteSpace(blockConfig.SettingsElementTypeAlias))
                         element = null;
 
-                    var layoutRef = new BlockListLayoutReference(udi, element);
+                    var layoutRef = new BlockListLayoutReference(udi, data, element);
                     layout.Add(layoutRef);
                 }
 


### PR DESCRIPTION
This reverts this final commit 45e892f3505059674779c6e1a43084a367c2862f
in this PR #7557 so you use .Data property and not a GetData() method