### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,24 +14,29 @@ indent_size = 4
 trim_trailing_whitespace = true
 
 
-# Code files
-[*.{cs,csx,vb,vbx}]
-indent_size = 4
-insert_final_newline = true
-charset = utf-8-bom
+###############################
+# JS & Less                   #
+###############################
+
+[*.{js,less}]
+trim_trailing_whitespace = false
+
 
 ###############################
-# .NET Coding Conventions     #
+# .NET & CSharp               #
 ###############################
-[*.{cs,vb}]
+
+[*.cs]
+
 # Organize usings
-# dotnet_sort_system_directives_first = true
+# dotnet_separate_import_directive_groups = false
+# dotnet_sort_system_directives_first = false
 
-# this. preferences
-# dotnet_style_qualification_for_field = false:silent
-# dotnet_style_qualification_for_property = false:silent
-# dotnet_style_qualification_for_method = false:silent
+# this. and Me. preferences
 # dotnet_style_qualification_for_event = false:silent
+# dotnet_style_qualification_for_field = false:silent
+# dotnet_style_qualification_for_method = false:silent
+# dotnet_style_qualification_for_property = false:silent
 
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:error
@@ -39,127 +44,178 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:error
 
 # Parentheses preferences
 # dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-# dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
 # dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
 # dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
 
 # Modifier preferences
 # dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-# dotnet_style_readonly_field = true:suggestion
 
 # Expression-level preferences
-# dotnet_style_object_initializer = true:suggestion
+# dotnet_style_coalesce_expression = true:suggestion
 # dotnet_style_collection_initializer = true:suggestion
 # dotnet_style_explicit_tuple_names = true:suggestion
 # dotnet_style_null_propagation = true:suggestion
-# dotnet_style_coalesce_expression = true:suggestion
-# dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
-# dotnet_style_prefer_inferred_tuple_names = true:suggestion
-# dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+# dotnet_style_object_initializer = true:suggestion
 # dotnet_style_prefer_auto_properties = true:silent
+# dotnet_style_prefer_compound_assignment = true:suggestion
 # dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 # dotnet_style_prefer_conditional_expression_over_return = true:silent
+# dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+# dotnet_style_prefer_inferred_tuple_names = true:suggestion
+# dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 
+# Field preferences
+# dotnet_style_readonly_field = true:suggestion
 
-###############################
-# Naming Conventions          #
-###############################
-# Style Definitions
-# dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Parameter preferences
+# dotnet_code_quality_unused_parameters = all:suggestion
 
-# Use PascalCase for constant fields
-# dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-# dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-# dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-# dotnet_naming_symbols.constant_fields.applicable_kinds            = field
-# dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
-# dotnet_naming_symbols.constant_fields.required_modifiers          = constant
+#### C# Coding Conventions ####
 
-dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
-dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
-dotnet_naming_rule.private_members_with_underscore.severity = suggestion
-
-dotnet_naming_symbols.private_fields.applicable_kinds           = field
-dotnet_naming_symbols.private_fields.applicable_accessibilities = private
-
-dotnet_naming_style.prefix_underscore.capitalization = camel_case
-dotnet_naming_style.prefix_underscore.required_prefix = _
-
-
-###############################
-# C# Coding Conventions       #
-###############################
-[*.cs]
 # var preferences
+csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
 
 # Expression-bodied members
-# csharp_style_expression_bodied_methods = false:silent
+# csharp_style_expression_bodied_accessors = true:silent
 # csharp_style_expression_bodied_constructors = false:silent
+# csharp_style_expression_bodied_indexers = true:silent
+# csharp_style_expression_bodied_lambdas = true:silent
+# csharp_style_expression_bodied_local_functions = false:silent
+# csharp_style_expression_bodied_methods = false:silent
 # csharp_style_expression_bodied_operators = false:silent
 # csharp_style_expression_bodied_properties = true:silent
-# csharp_style_expression_bodied_indexers = true:silent
-# csharp_style_expression_bodied_accessors = true:silent
 
 # Pattern matching preferences
-# csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 # csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+# csharp_style_prefer_switch_expression = true:suggestion
 
 # Null-checking preferences
-# csharp_style_throw_expression = true:suggestion
 # csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
-# csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# csharp_prefer_static_local_function = true:suggestion
+# csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = false : none
+# csharp_prefer_simple_using_statement = true:suggestion
 
 # Expression-level preferences
-csharp_prefer_braces = false : none
-# csharp_style_deconstructed_variable_declaration = true:suggestion
 # csharp_prefer_simple_default_expression = true:suggestion
-# csharp_style_pattern_local_over_anonymous_function = true:suggestion
+# csharp_style_deconstructed_variable_declaration = true:suggestion
 # csharp_style_inlined_variable_declaration = true:suggestion
+# csharp_style_pattern_local_over_anonymous_function = true:suggestion
+# csharp_style_prefer_index_operator = true:suggestion
+# csharp_style_prefer_range_operator = true:suggestion
+# csharp_style_throw_expression = true:suggestion
+# csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+# csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
+# 'using' directive preferences
+# csharp_using_directive_placement = outside_namespace:silent
 
-###############################
-# C# Formatting Rules         #
-###############################
+#### C# Formatting Rules ####
+
 # New line preferences
-# csharp_new_line_before_open_brace = all
-# csharp_new_line_before_else = true
 # csharp_new_line_before_catch = true
+# csharp_new_line_before_else = true
 # csharp_new_line_before_finally = true
-# csharp_new_line_before_members_in_object_initializers = true
 # csharp_new_line_before_members_in_anonymous_types = true
+# csharp_new_line_before_members_in_object_initializers = true
+# csharp_new_line_before_open_brace = all
 # csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
+# csharp_indent_block_contents = true
+# csharp_indent_braces = false
 # csharp_indent_case_contents = true
+# csharp_indent_case_contents_when_block = true
+# csharp_indent_labels = one_less_than_current
 # csharp_indent_switch_labels = true
-# csharp_indent_labels = flush_left
 
 # Space preferences
 # csharp_space_after_cast = false
+# csharp_space_after_colon_in_inheritance_clause = true
+# csharp_space_after_comma = true
+# csharp_space_after_dot = false
 # csharp_space_after_keywords_in_control_flow_statements = true
+# csharp_space_after_semicolon_in_for_statement = true
+# csharp_space_around_binary_operators = before_and_after
+# csharp_space_around_declaration_statements = false
+# csharp_space_before_colon_in_inheritance_clause = true
+# csharp_space_before_comma = false
+# csharp_space_before_dot = false
+# csharp_space_before_open_square_brackets = false
+# csharp_space_before_semicolon_in_for_statement = false
+# csharp_space_between_empty_square_brackets = false
+# csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# csharp_space_between_method_call_name_and_opening_parenthesis = false
 # csharp_space_between_method_call_parameter_list_parentheses = false
+# csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+# csharp_space_between_method_declaration_name_and_open_parenthesis = false
 # csharp_space_between_method_declaration_parameter_list_parentheses = false
 # csharp_space_between_parentheses = false
-# csharp_space_before_colon_in_inheritance_clause = true
-# csharp_space_after_colon_in_inheritance_clause = true
-# csharp_space_around_binary_operators = before_and_after
-# csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-# csharp_space_between_method_call_name_and_opening_parenthesis = false
-# csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# csharp_space_between_square_brackets = false
 
 # Wrapping preferences
-# csharp_preserve_single_line_statements = true
 # csharp_preserve_single_line_blocks = true
+# csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+# dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+# dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+# dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+# dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+# dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+# dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+# dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+# dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+# dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_members_with_underscore.severity = suggestion
+dotnet_naming_rule.private_members_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_members_with_underscore.style = prefix_underscore
+
+# Symbol specifications
+
+# dotnet_naming_symbols.interface.applicable_kinds = interface
+# dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+# dotnet_naming_symbols.interface.required_modifiers =
+
+# dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+# dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+# dotnet_naming_symbols.types.required_modifiers =
+
+# dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+# dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+# dotnet_naming_symbols.non_field_members.required_modifiers =
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+# Naming styles
+
+# dotnet_naming_style.pascal_case.required_prefix =
+# dotnet_naming_style.pascal_case.required_suffix =
+# dotnet_naming_style.pascal_case.word_separator =
+# dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# dotnet_naming_style.begins_with_i.required_prefix = I
+# dotnet_naming_style.begins_with_i.required_suffix =
+# dotnet_naming_style.begins_with_i.word_separator =
+# dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.prefix_underscore.required_prefix = _
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
 
 
-###############################
-# JS & Less                   #
-###############################
 
-[*.{js,less}]
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,221 +1,46 @@
-# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+# editorconfig.org
 
-###############################
-# Core EditorConfig Options   #
-###############################
+# top-most EditorConfig file
 root = true
 
-# All files
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
 [*]
 insert_final_newline = true
 end_of_line = crlf
 indent_style = space
 indent_size = 4
+
+# Trim trailing whitespace, limited support.
+# https://github.com/editorconfig/editorconfig/wiki/Property-research:-Trim-trailing-spaces
 trim_trailing_whitespace = true
 
+[*.{cs,vb}]
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
 
-###############################
-# JS & Less                   #
-###############################
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+# dotnet_naming_symbols.private_fields.required_modifiers = abstract,async,readonly,static # all except const
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+
+
+
+
+
+# https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/ide/editorconfig-code-style-settings-reference.md
+[*.cs]
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_prefer_braces = false : none
 
 [*.{js,less}]
 trim_trailing_whitespace = false
-
-
-###############################
-# .NET & CSharp               #
-###############################
-
-[*.cs]
-
-# Organize usings
-# dotnet_separate_import_directive_groups = false
-# dotnet_sort_system_directives_first = false
-
-# this. and Me. preferences
-# dotnet_style_qualification_for_event = false:silent
-# dotnet_style_qualification_for_field = false:silent
-# dotnet_style_qualification_for_method = false:silent
-# dotnet_style_qualification_for_property = false:silent
-
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:error
-# dotnet_style_predefined_type_for_member_access = true:silent
-
-# Parentheses preferences
-# dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-# dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-# dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-# dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-
-# Modifier preferences
-# dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-
-# Expression-level preferences
-# dotnet_style_coalesce_expression = true:suggestion
-# dotnet_style_collection_initializer = true:suggestion
-# dotnet_style_explicit_tuple_names = true:suggestion
-# dotnet_style_null_propagation = true:suggestion
-# dotnet_style_object_initializer = true:suggestion
-# dotnet_style_prefer_auto_properties = true:silent
-# dotnet_style_prefer_compound_assignment = true:suggestion
-# dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-# dotnet_style_prefer_conditional_expression_over_return = true:silent
-# dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-# dotnet_style_prefer_inferred_tuple_names = true:suggestion
-# dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-
-# Field preferences
-# dotnet_style_readonly_field = true:suggestion
-
-# Parameter preferences
-# dotnet_code_quality_unused_parameters = all:suggestion
-
-#### C# Coding Conventions ####
-
-# var preferences
-csharp_style_var_elsewhere = true:suggestion
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-
-# Expression-bodied members
-# csharp_style_expression_bodied_accessors = true:silent
-# csharp_style_expression_bodied_constructors = false:silent
-# csharp_style_expression_bodied_indexers = true:silent
-# csharp_style_expression_bodied_lambdas = true:silent
-# csharp_style_expression_bodied_local_functions = false:silent
-# csharp_style_expression_bodied_methods = false:silent
-# csharp_style_expression_bodied_operators = false:silent
-# csharp_style_expression_bodied_properties = true:silent
-
-# Pattern matching preferences
-# csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-# csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-# csharp_style_prefer_switch_expression = true:suggestion
-
-# Null-checking preferences
-# csharp_style_conditional_delegate_call = true:suggestion
-
-# Modifier preferences
-# csharp_prefer_static_local_function = true:suggestion
-# csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
-
-# Code-block preferences
-csharp_prefer_braces = false : none
-# csharp_prefer_simple_using_statement = true:suggestion
-
-# Expression-level preferences
-# csharp_prefer_simple_default_expression = true:suggestion
-# csharp_style_deconstructed_variable_declaration = true:suggestion
-# csharp_style_inlined_variable_declaration = true:suggestion
-# csharp_style_pattern_local_over_anonymous_function = true:suggestion
-# csharp_style_prefer_index_operator = true:suggestion
-# csharp_style_prefer_range_operator = true:suggestion
-# csharp_style_throw_expression = true:suggestion
-# csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-# csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-
-# 'using' directive preferences
-# csharp_using_directive_placement = outside_namespace:silent
-
-#### C# Formatting Rules ####
-
-# New line preferences
-# csharp_new_line_before_catch = true
-# csharp_new_line_before_else = true
-# csharp_new_line_before_finally = true
-# csharp_new_line_before_members_in_anonymous_types = true
-# csharp_new_line_before_members_in_object_initializers = true
-# csharp_new_line_before_open_brace = all
-# csharp_new_line_between_query_expression_clauses = true
-
-# Indentation preferences
-# csharp_indent_block_contents = true
-# csharp_indent_braces = false
-# csharp_indent_case_contents = true
-# csharp_indent_case_contents_when_block = true
-# csharp_indent_labels = one_less_than_current
-# csharp_indent_switch_labels = true
-
-# Space preferences
-# csharp_space_after_cast = false
-# csharp_space_after_colon_in_inheritance_clause = true
-# csharp_space_after_comma = true
-# csharp_space_after_dot = false
-# csharp_space_after_keywords_in_control_flow_statements = true
-# csharp_space_after_semicolon_in_for_statement = true
-# csharp_space_around_binary_operators = before_and_after
-# csharp_space_around_declaration_statements = false
-# csharp_space_before_colon_in_inheritance_clause = true
-# csharp_space_before_comma = false
-# csharp_space_before_dot = false
-# csharp_space_before_open_square_brackets = false
-# csharp_space_before_semicolon_in_for_statement = false
-# csharp_space_between_empty_square_brackets = false
-# csharp_space_between_method_call_empty_parameter_list_parentheses = false
-# csharp_space_between_method_call_name_and_opening_parenthesis = false
-# csharp_space_between_method_call_parameter_list_parentheses = false
-# csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-# csharp_space_between_method_declaration_name_and_open_parenthesis = false
-# csharp_space_between_method_declaration_parameter_list_parentheses = false
-# csharp_space_between_parentheses = false
-# csharp_space_between_square_brackets = false
-
-# Wrapping preferences
-# csharp_preserve_single_line_blocks = true
-# csharp_preserve_single_line_statements = true
-
-#### Naming styles ####
-
-# Naming rules
-
-# dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-# dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-# dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-# dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-# dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-# dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-# dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-# dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-# dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.private_members_with_underscore.severity = suggestion
-dotnet_naming_rule.private_members_with_underscore.symbols = private_fields
-dotnet_naming_rule.private_members_with_underscore.style = prefix_underscore
-
-# Symbol specifications
-
-# dotnet_naming_symbols.interface.applicable_kinds = interface
-# dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-# dotnet_naming_symbols.interface.required_modifiers =
-
-# dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-# dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-# dotnet_naming_symbols.types.required_modifiers =
-
-# dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-# dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-# dotnet_naming_symbols.non_field_members.required_modifiers =
-
-dotnet_naming_symbols.private_fields.applicable_kinds = field
-dotnet_naming_symbols.private_fields.applicable_accessibilities = private
-
-# Naming styles
-
-# dotnet_naming_style.pascal_case.required_prefix =
-# dotnet_naming_style.pascal_case.required_suffix =
-# dotnet_naming_style.pascal_case.word_separator =
-# dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-# dotnet_naming_style.begins_with_i.required_prefix = I
-# dotnet_naming_style.begins_with_i.required_suffix =
-# dotnet_naming_style.begins_with_i.word_separator =
-# dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.prefix_underscore.required_prefix = _
-dotnet_naming_style.prefix_underscore.capitalization = camel_case
-
-
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,23 +1,79 @@
-# editorconfig.org
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
 
-# top-most EditorConfig file
+###############################
+# Core EditorConfig Options   #
+###############################
 root = true
 
-# Default settings:
-# A newline ending every file
-# Use 4 spaces as indentation
+# All files
 [*]
 insert_final_newline = true
 end_of_line = crlf
 indent_style = space
 indent_size = 4
-
-# Trim trailing whitespace, limited support.
-# https://github.com/editorconfig/editorconfig/wiki/Property-research:-Trim-trailing-spaces
 trim_trailing_whitespace = true
 
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+
+###############################
+# .NET Coding Conventions     #
+###############################
 [*.{cs,vb}]
+# Organize usings
+# dotnet_sort_system_directives_first = true
+
+# this. preferences
+# dotnet_style_qualification_for_field = false:silent
+# dotnet_style_qualification_for_property = false:silent
+# dotnet_style_qualification_for_method = false:silent
+# dotnet_style_qualification_for_event = false:silent
+
+# Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:error
+# dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+# dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+# dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+# dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+# dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+
+# Modifier preferences
+# dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+# dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+# dotnet_style_object_initializer = true:suggestion
+# dotnet_style_collection_initializer = true:suggestion
+# dotnet_style_explicit_tuple_names = true:suggestion
+# dotnet_style_null_propagation = true:suggestion
+# dotnet_style_coalesce_expression = true:suggestion
+# dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+# dotnet_style_prefer_inferred_tuple_names = true:suggestion
+# dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+# dotnet_style_prefer_auto_properties = true:silent
+# dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+# dotnet_style_prefer_conditional_expression_over_return = true:silent
+
+
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+# dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+
+# Use PascalCase for constant fields
+# dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+# dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+# dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+# dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+# dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+# dotnet_naming_symbols.constant_fields.required_modifiers          = constant
 
 dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
 dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
@@ -29,12 +85,81 @@ dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 dotnet_naming_style.prefix_underscore.capitalization = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
 
-# https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/ide/editorconfig-code-style-settings-reference.md
+
+###############################
+# C# Coding Conventions       #
+###############################
 [*.cs]
+# var preferences
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
+
+# Expression-bodied members
+# csharp_style_expression_bodied_methods = false:silent
+# csharp_style_expression_bodied_constructors = false:silent
+# csharp_style_expression_bodied_operators = false:silent
+# csharp_style_expression_bodied_properties = true:silent
+# csharp_style_expression_bodied_indexers = true:silent
+# csharp_style_expression_bodied_accessors = true:silent
+
+# Pattern matching preferences
+# csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+# csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+# csharp_style_throw_expression = true:suggestion
+# csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+# csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Expression-level preferences
 csharp_prefer_braces = false : none
+# csharp_style_deconstructed_variable_declaration = true:suggestion
+# csharp_prefer_simple_default_expression = true:suggestion
+# csharp_style_pattern_local_over_anonymous_function = true:suggestion
+# csharp_style_inlined_variable_declaration = true:suggestion
+
+
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+# csharp_new_line_before_open_brace = all
+# csharp_new_line_before_else = true
+# csharp_new_line_before_catch = true
+# csharp_new_line_before_finally = true
+# csharp_new_line_before_members_in_object_initializers = true
+# csharp_new_line_before_members_in_anonymous_types = true
+# csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+# csharp_indent_case_contents = true
+# csharp_indent_switch_labels = true
+# csharp_indent_labels = flush_left
+
+# Space preferences
+# csharp_space_after_cast = false
+# csharp_space_after_keywords_in_control_flow_statements = true
+# csharp_space_between_method_call_parameter_list_parentheses = false
+# csharp_space_between_method_declaration_parameter_list_parentheses = false
+# csharp_space_between_parentheses = false
+# csharp_space_before_colon_in_inheritance_clause = true
+# csharp_space_after_colon_in_inheritance_clause = true
+# csharp_space_around_binary_operators = before_and_after
+# csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+# csharp_space_between_method_call_name_and_opening_parenthesis = false
+# csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping preferences
+# csharp_preserve_single_line_statements = true
+# csharp_preserve_single_line_blocks = true
+
+
+###############################
+# JS & Less                   #
+###############################
 
 [*.{js,less}]
 trim_trailing_whitespace = false

--- a/src/Umbraco.Web.UI.Client/.vscode/extensions.json
+++ b/src/Umbraco.Web.UI.Client/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig", // Will enable editorconfig for indent style & size (aka 4 spaces for a tab)
+    ],
+    "unwantedRecommendations": []
+}

--- a/src/Umbraco.Web.UI.Client/.vscode/settings.json
+++ b/src/Umbraco.Web.UI.Client/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    // When you copy that snippet from the web - lets ensure it uses our tabsize & line endings from EditorConfig
+    // And if your working with a file that has mixed tab sizes & line endings then saving should help slowly get us consistent
+    "editor.formatOnPaste": true,
+    "editor.formatOnSave": true,
+}


### PR DESCRIPTION
## What
This PR contains an update to the **.editorconfig** found at the root of the repository with more verbose .NET & CSharp settings for VS & Rider.

In addition the Umbraco.Web.UI.Client folder where the JS/CSS & HTML lives for the backoffice SPA application to recommend that the EditorConfig extension for VSCode is installed as unfortunately VSCode does not use EditorConfig this out of the box in the core product.


## Who
This is PR is to help anyone who works on the Umbraco CMS source code be it HQ employees or external opensource contributors to the project.


## Why
This is to help uniform our codebase and to ensure anyone working with the CMS codebase edits files in a consistent way. A simple example is that across MacOS & Windows generally use different line endings in files, in an editorconfig we can specify the line ending type to be CRLF.

Another common example is to ensure consistency with indentation type. Some people have their editors set up to use tabs and others spaces, combinded with different indent size. This way we can ensure everyone uses 4 spaces as an indentation & thus when PRs come into GitHub we will have PRs with less whitespace changes

The VSCode specific settings was created for the Umrbaco,Web.UI.Client folder as this seems to the the most common editor when users are working with clientside files.