### PR TITLE
Possible fix for issue #7870

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -19,7 +19,6 @@ namespace Umbraco.Core.PropertyEditors
     public class DataEditor : IDataEditor
     {
         private IDictionary<string, object> _defaultConfiguration;
-        private IDataValueEditor _dataValueEditor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataEditor"/> class.
@@ -91,7 +90,7 @@ namespace Umbraco.Core.PropertyEditors
         /// simple enough for now.</para>
         /// </remarks>
         // TODO: point of that one? shouldn't we always configure?
-        public IDataValueEditor GetValueEditor() => ExplicitValueEditor ?? (_dataValueEditor ?? (_dataValueEditor = CreateValueEditor()));
+        public IDataValueEditor GetValueEditor() => ExplicitValueEditor ?? CreateValueEditor();
 
         /// <inheritdoc />
         /// <remarks>


### PR DESCRIPTION
### Summary

Possible fix for issue: #7870

### Description
This reverts DataEditor.GetValueEditor() to not cache the result of CreateValueEditor() via a property. In my testing this has fixed #7870 but I am not sure if it causes other issues. At the very least it might cause a performance degradation.
