### PR TITLE
Netcore: Alter ResXFileRef to match filesystem

### DIFF
--- a/src/Umbraco.Infrastructure/WebAssets/Resources.resx
+++ b/src/Umbraco.Infrastructure/WebAssets/Resources.resx
@@ -20,16 +20,16 @@
     </resheader>
     <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
     <data name="JsInitialize" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>jsinitialize.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+        <value>JsInitialize.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
     </data>
     <data name="Main" type="System.Resources.ResXFileRef, System.Windows.Forms">
         <value>Main.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
     </data>
     <data name="PreviewInitialize" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>previewinitialize.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+        <value>PreviewInitialize.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
     </data>
     <data name="ServerVariables" type="System.Resources.ResXFileRef, System.Windows.Forms">
-        <value>servervariables.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+        <value>ServerVariables.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
     </data>
     <data name="TinyMceInitialize" type="System.Resources.ResXFileRef, System.Windows.Forms">
         <value>TinyMceInitialize.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>


### PR DESCRIPTION
Resolves build error on case sensitive file systems

ResXFileRef should match path on filesystem

```
error MSB3103: Invalid Resx file. System.IO.FileNotFoundException: Could not find file '/home/example/Dev/Umbraco-CMS/src/Umbraco.Infrastructure/WebAssets/jsinitialize.js'.
```