### PR TITLE
Remove dependency on Media Service in migration

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_1_0/ConvertTinyMceAndGridMediaUrlsToLocalLink.cs
@@ -150,7 +150,7 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_1_0
                 .Where<NodeDto>(x => x.NodeObjectType == Constants.ObjectTypes.Media)
                 .Where<ContentVersionDto>(x => x.Current);
 
-            var medias = Database.Fetch<MediaVersionDto>(sql);
+            var medias = Database.Fetch<MediaVersionDto>(sql).Where(m => !m.Path.IsNullOrWhiteSpace()).ToList();
             var udis = new Dictionary<string, Udi>(medias.Count, StringComparer.InvariantCultureIgnoreCase);
 
             medias.ForEach(m => udis[m.Path] = new GuidUdi(Constants.UdiEntityType.Media, m.ContentVersionDto.ContentDto.NodeDto.UniqueId));


### PR DESCRIPTION
### Prerequisites

This fixes the bug at #7914 

### Description
Replaces a call to the Media Service with direct database access, so that the migration code is more resilient to changes introduced by newer versions.