### PR TITLE
Fix EnsureMemberProperties data type IDs

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
@@ -105,13 +105,13 @@ namespace Umbraco.Core.Models.PublishedContent
             { "Email", Constants.DataTypes.Textbox },
             { "Username", Constants.DataTypes.Textbox },
             { "PasswordQuestion", Constants.DataTypes.Textbox },
-            { "Comments", Constants.DataTypes.Textbox },
+            { "Comments", Constants.DataTypes.Textarea },
             { "IsApproved", Constants.DataTypes.Boolean },
             { "IsLockedOut", Constants.DataTypes.Boolean },
-            { "LastLockoutDate", Constants.DataTypes.DateTime },
-            { "CreateDate", Constants.DataTypes.DateTime },
-            { "LastLoginDate", Constants.DataTypes.DateTime },
-            { "LastPasswordChangeDate", Constants.DataTypes.DateTime },
+            { "LastLockoutDate", Constants.DataTypes.LabelDateTime },
+            { "CreateDate", Constants.DataTypes.LabelDateTime },
+            { "LastLoginDate", Constants.DataTypes.LabelDateTime },
+            { "LastPasswordChangeDate", Constants.DataTypes.LabelDateTime }
         };
 
         #region Content type


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/7919.

### Description
This updates the `EnsureMemberProperties` method to use the correct data type IDs, so no exceptions are thrown while generating models using Models Builder.