### PR TITLE
Move the infinite overlay to the same source order as regular overlays

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -1,6 +1,7 @@
 .umb-editors {
     .absolute();
     overflow: hidden;
+    z-index: 7501;
 
     .umb-editor {
         box-shadow: 0px 0 30px 0 rgba(0,0,0,.3);

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -1,7 +1,7 @@
 .umb-editors {
     .absolute();
     overflow: hidden;
-    z-index: 7501;
+    z-index: 7500;
 
     .umb-editor {
         box-shadow: 0px 0 30px 0 rgba(0,0,0,.3);

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -66,11 +66,7 @@
                 <section id="contentwrapper">
 
                     <div id="contentcolumn">
-
                         <div class="umb-editor" ng-view></div>
-                        <div class="umb-editor__overlay" ng-if="infiniteMode"></div>
-
-                        <umb-editors></umb-editors>
                     </div>
 
                 </section>
@@ -93,7 +89,7 @@
 
     </div>
 
-    <umb-backdrop ng-if="backdrop.show"
+    <umb-backdrop ng-if="backdrop.show || infiniteMode"
                   backdrop-opacity="backdrop.opacity"
                   highlight-element="backdrop.element"
                   highlight-prevent-click="backdrop.elementPreventClick"
@@ -106,6 +102,8 @@
                  view="overlay.view"
                  parent-scope="overlay.parentScope">
     </umb-overlay>
+
+    <umb-editors ng-show="infiniteMode"></umb-editors>
 
     <umb-login
         ng-if="login.show"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have just decided to close #4526 without having it merged in it's current state since the stuff I made no longer works.

Therefore I decided to have a deeper look at some of the root causes to some of the issues I faced when trying to implement the focus lock. One of them being that regular overlays and infinite overlays got triggered from different places within the source code meaning I had to do so weird little hacks to get it working. Move the infinite overlay out of the source order it will be a lot simpler to implement a well working focus lock - So this is what I have done with this PR 😃 

The `<umb-editors>` component has been moved to the same level in the source code as the `<umb-overlay>` component, since it's an overlay too really. I have also removed the `<div class="umb-editor__overlay" ng-if="infiniteMode"></div>` and added `<umb-backdrop ng-if="backdrop.show || infiniteMode">...<div>` to make the backdrop behave much more aligned with what you would expect from an overlay meaning that you now can't click on the content tree using your mosue - Just like with regular overlays making the overall experience much more consistent and improves the UX.

When this PR is hopefully accepted I will start looking at adding the focus lock again since this change will make it a lot easier to achieve 😄 

Visually this is what it acts like before and after

**Before**
![umb-editors-before](https://user-images.githubusercontent.com/1932158/78987231-b9d96b80-7b2d-11ea-8383-3c4c8e01f4dd.gif)


**After**
![umb-editors-after](https://user-images.githubusercontent.com/1932158/78987299-f016eb00-7b2d-11ea-81a3-231903606dfa.gif)

