### PR TITLE
Replaced angular.toJson with Utilities.toJson [#CanConHackathon]

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbrawmodel.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbrawmodel.directive.js
@@ -49,7 +49,7 @@ angular.module("umbraco.directives")
 				function jsonToString(object) {
 					// better than JSON.stringify(), because it formats + filters $$hashKey etc.
 					// NOTE that this will remove all $-prefixed values
-					return angular.toJson(object, true);
+					return Utilities.toJson(object, true);
 				}
 
 				function isValidJson(model) {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/auth.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/auth.resource.js
@@ -30,7 +30,7 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
           umbRequestHelper.getApiUrl(
             "authenticationApiBaseUrl",
             "PostSend2FACode"),
-          angular.toJson(provider)),
+          Utilities.toJson(provider)),
         'Could not send code');
     },
 

--- a/src/Umbraco.Web.UI.Client/src/common/resources/currentuser.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/currentuser.resource.js
@@ -87,7 +87,7 @@ function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
                     umbRequestHelper.getApiUrl(
                         "currentUserApiBaseUrl",
                         "PostSetInvitedUserPassword"),
-                    angular.toJson(newPassword)),
+                    Utilities.toJson(newPassword)),
                 'Failed to change password');
         },
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -67,7 +67,7 @@ function macroService() {
                     }
                     else {
                         //if it's not a string we'll send it through the json serializer
-                        var json = angular.toJson(val);
+                        var json = Utilities.toJson(val);
                         //then we need to url encode it so that it's safe
                         var encoded = encodeURIComponent(json);
                         keyVal = key + "=\"" + encoded + "\" ";
@@ -142,7 +142,7 @@ function macroService() {
 
                 if (item.value !== null && item.value !== undefined && !_.isString(item.value)) {
                     try {
-                        val = angular.toJson(val);
+                        val = Utilities.toJson(val);
                     }
                     catch (e) {
                         // not json

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -342,11 +342,11 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                     //add the json data
                     if (angular.isArray(data)) {
                         _.each(data, function(item) {
-                            formData.append(item.key, !angular.isString(item.value) ? angular.toJson(item.value) : item.value);
+                            formData.append(item.key, !angular.isString(item.value) ? Utilities.toJson(item.value) : item.value);
                         });
                     }
                     else {
-                        formData.append(data.key, !angular.isString(data.value) ? angular.toJson(data.value) : data.value);
+                        formData.append(data.key, !angular.isString(data.value) ? Utilities.toJson(data.value) : data.value);
                     }
 
                     //call the callback

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -210,7 +210,7 @@ function umbSessionStorage($window) {
         },
 
         set: function (key, value) {
-            storage["umb_" + key] = angular.toJson(value);
+            storage["umb_" + key] = Utilities.toJson(value);
         }
 
     };

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -66,6 +66,34 @@
      */
     const isObject = val => val !== null && typeof val === 'object';
 
+    const isWindow = obj => obj && obj.window === obj;
+
+    const isScope = obj => obj && obj.$evalAsync && obj.$watch;
+
+    const toJsonReplacer = (key, value) => {
+        var val = value;      
+        if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
+          val = undefined;
+        } else if (isWindow(value)) {
+          val = '$WINDOW';
+        } else if (value &&  window.document === value) {
+          val = '$DOCUMENT';
+        } else if (isScope(value)) {
+          val = '$SCOPE';
+        }      
+        return val;
+      }
+    /**
+     * Equivalent to angular.toJson
+     */
+    const toJson = (obj, pretty) => {
+        if (isUndefined(obj)) return undefined;
+        if (!isNumber(pretty)) {
+          pretty = pretty ? 2 : null;
+        }
+        return JSON.stringify(obj, toJsonReplacer, pretty);
+    }
+
     let _utilities = {
         noop: noop,
         copy: copy,
@@ -77,7 +105,8 @@
         isDefined: isDefined,
         isString: isString,
         isNumber: isNumber,
-        isObject: isObject
+        isObject: isObject,
+        toJson: toJson
     };
 
     if (typeof (window.Utilities) === 'undefined') {

--- a/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
@@ -1,0 +1,55 @@
+(function () {
+    describe("Utilities", function () {
+        describe("toJson", function () {
+            it("should delegate to JSON.stringify", function () {
+                var spy = spyOn(JSON, "stringify").and.callThrough();
+
+                expect(Utilities.toJson({})).toEqual("{}");
+                expect(spy).toHaveBeenCalled();
+            });
+
+            it("should format objects pretty", function () {
+                expect(Utilities.toJson({ a: 1, b: 2 }, true)).toBe(
+                    '{\n  "a": 1,\n  "b": 2\n}'
+                );
+                expect(Utilities.toJson({ a: { b: 2 } }, true)).toBe(
+                    '{\n  "a": {\n    "b": 2\n  }\n}'
+                );
+                expect(Utilities.toJson({ a: 1, b: 2 }, false)).toBe('{"a":1,"b":2}');
+                expect(Utilities.toJson({ a: 1, b: 2 }, 0)).toBe('{"a":1,"b":2}');
+                expect(Utilities.toJson({ a: 1, b: 2 }, 1)).toBe(
+                    '{\n "a": 1,\n "b": 2\n}'
+                );
+                expect(Utilities.toJson({ a: 1, b: 2 }, {})).toBe(
+                    '{\n  "a": 1,\n  "b": 2\n}'
+                );
+            });
+
+            it("should not serialize properties starting with $$", function () {
+                expect(Utilities.toJson({ $$some: "value" }, false)).toEqual("{}");
+            });
+
+            it("should serialize properties starting with $", function () {
+                expect(Utilities.toJson({ $few: "v" }, false)).toEqual('{"$few":"v"}');
+            });
+
+            it("should not serialize $window object", function () {
+                expect(Utilities.toJson(window)).toEqual('"$WINDOW"');
+            });
+
+            it("should not serialize $document object", function () {
+                expect(Utilities.toJson(document)).toEqual('"$DOCUMENT"');
+            });
+
+            it("should not serialize scope instances", inject(function (
+                $rootScope
+            ) {
+                expect(Utilities.toJson({ key: $rootScope })).toEqual('{"key":"$SCOPE"}');
+            }));
+
+            it("should serialize undefined as undefined", function () {
+                expect(Utilities.toJson(undefined)).toEqual(undefined);
+            });
+        });
+    });
+})();


### PR DESCRIPTION
https://trello.com/c/UTjBLFQd/17-replace-instances-of-angulartojson

Decouples angulars toJson to es6 this is a direct port of the angular code to ensure we keep its features. I also ported the unit tests to make make testing easier for everyone.

Matt