### PR TITLE
V8: Angular Divorce: isString

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/fixnumber.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/fixnumber.directive.js
@@ -32,7 +32,7 @@ function fixNumber($parse) {
 
             //always try to format the model value as an int
             ctrl.$formatters.push(function (value) {
-                if (angular.isString(value)) {
+                if (Utilities.isString(value)) {
                     return parseFloat(value, 10);
                 }
                 return value;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -29,7 +29,7 @@ angular.module("umbraco.directives")
                 }
 
                 var editorConfig = scope.configuration ? scope.configuration : null;
-                if (!editorConfig || angular.isString(editorConfig)) {
+                if (!editorConfig || Utilities.isString(editorConfig)) {
                     editorConfig = tinyMceService.defaultPrevalues();
                     //for the grid by default, we don't want to include the macro toolbar
                     editorConfig.toolbar = _.without(editorConfig, "umbmacro");

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -159,7 +159,7 @@
 
         function configureViewModel(isInitLoad) {
             if (vm.value) {
-                if (angular.isString(vm.value) && vm.value.length > 0) {
+                if (Utilities.isString(vm.value) && vm.value.length > 0) {
                     if (vm.config.storageType === "Json") {
                         //json storage
                         vm.viewModel = JSON.parse(vm.value);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -100,7 +100,7 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
              * @param {any} args either a string representing the 'section' or an object containing: 'section', 'treeAlias', 'customTreeParams', 'cacheKey'
              */
             function load(args) {
-                if (angular.isString(args)) {
+                if (Utilities.isString(args)) {
                     $scope.section = args;
                 }
                 else if (args) {
@@ -147,7 +147,7 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
                     throw "args.path cannot be null";
                 }
 
-                if (angular.isString(args.path)) {
+                if (Utilities.isString(args.path)) {
                     args.path = args.path.replace('"', '').split(',');
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbaceeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbaceeditor.directive.js
@@ -72,10 +72,10 @@
             }
 
             // Basic options
-            if (angular.isString(opts.theme)) {
+            if (Utilities.isString(opts.theme)) {
                 acee.setTheme('ace/theme/' + opts.theme);
             }
-            if (angular.isString(opts.mode)) {
+            if (Utilities.isString(opts.mode)) {
                 session.setMode('ace/mode/' + opts.mode);
             }
             // Advanced options

--- a/src/Umbraco.Web.UI.Client/src/common/filters/umbwordlimit.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/umbwordlimit.filter.js
@@ -13,7 +13,7 @@
     function umbWordLimitFilter() {
         return function (collection, property) {
 
-            if (!angular.isString(collection)) {
+            if (!Utilities.isString(collection)) {
                 return collection;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -613,7 +613,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 if (angular.isNumber(v)) {
                     return v > 0;
                 }
-                if (angular.isString(v)) {
+                if (Utilities.isString(v)) {
                     return v === "true";
                 }
                 if (typeof v === "boolean") {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -351,7 +351,7 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 if (angular.isNumber(v)) {
                     return v > 0;
                 }
-                if (angular.isString(v)) {
+                if (Utilities.isString(v)) {
                     return v === "true";
                 }
                 if (typeof v === "boolean") {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
@@ -56,7 +56,7 @@ function memberResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 if (angular.isNumber(v)) {
                     return v > 0;
                 }
-                if (angular.isString(v)) {
+                if (Utilities.isString(v)) {
                     return v === "true";
                 }
                 if (typeof v === "boolean") {

--- a/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
@@ -27,7 +27,7 @@ function fileManager($rootScope) {
         setFiles: function (args) {
 
             //propertyAlias, files
-            if (!angular.isString(args.propertyAlias)) {
+            if (!Utilities.isString(args.propertyAlias)) {
                 throw "args.propertyAlias must be a non empty string";
             }
             if (!angular.isObject(args.files)) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -62,7 +62,7 @@ function macroService() {
                     val = val ? val : "";
                     //need to detect if the val is a string or an object
                     var keyVal;
-                    if (angular.isString(val)) {
+                    if (Utilities.isString(val)) {
                         keyVal = key + "=\"" + (val ? val : "") + "\" ";
                     }
                     else {

--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -45,7 +45,7 @@ function mediaHelper(umbRequestHelper, $log) {
 
                 //this performs a simple check to see if we have a media file as value
                 //it doesnt catch everything, but better then nothing
-                if (angular.isString(item.value) && item.value.indexOf(mediaRoot) === 0) {
+                if (Utilities.isString(item.value) && item.value.indexOf(mediaRoot) === 0) {
                     return true;
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -88,7 +88,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
      * @param {any} requestPath
      */
     function pathToRouteParts(requestPath) {
-        if (!angular.isString(requestPath)) {
+        if (!Utilities.isString(requestPath)) {
             throw "The value for requestPath is not a string";
         }
         var pathAndQuery = requestPath.split("#")[1];
@@ -130,11 +130,11 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
          */
         isRouteChangingNavigation: function (currUrlParams, nextUrlParams) {
 
-            if (angular.isString(currUrlParams)) {
+            if (Utilities.isString(currUrlParams)) {
                 currUrlParams = pathToRouteParts(currUrlParams);
             }
 
-            if (angular.isString(nextUrlParams)) {
+            if (Utilities.isString(nextUrlParams)) {
                 nextUrlParams = pathToRouteParts(nextUrlParams);
             }
 
@@ -483,14 +483,14 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
 
             appState.setMenuState("currentNode", node);
 
-            if (action.metaData && action.metaData["actionRoute"] && angular.isString(action.metaData["actionRoute"])) {
+            if (action.metaData && action.metaData["actionRoute"] && Utilities.isString(action.metaData["actionRoute"])) {
                 //first check if the menu item simply navigates to a route
                 var parts = action.metaData["actionRoute"].split("?");
                 $location.path(parts[0]).search(parts.length > 1 ? parts[1] : "");
                 this.hideNavigation();
                 return;
             }
-            else if (action.metaData && action.metaData["jsAction"] && angular.isString(action.metaData["jsAction"])) {
+            else if (action.metaData && action.metaData["jsAction"] && Utilities.isString(action.metaData["jsAction"])) {
 
                 //we'll try to get the jsAction from the injector
                 var menuAction = action.metaData["jsAction"].split('.');

--- a/src/Umbraco.Web.UI.Client/src/common/services/servervalidationmgr.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/servervalidationmgr.service.js
@@ -25,7 +25,7 @@ function serverValidationManager($timeout) {
     }
 
     function getFieldErrors(self, fieldName) {
-        if (!angular.isString(fieldName)) {
+        if (!Utilities.isString(fieldName)) {
             throw "fieldName must be a string";
         }
 
@@ -36,10 +36,10 @@ function serverValidationManager($timeout) {
     }
     
     function getPropertyErrors(self, propertyAlias, culture, fieldName) {
-        if (!angular.isString(propertyAlias)) {
+        if (!Utilities.isString(propertyAlias)) {
             throw "propertyAlias must be a string";
         }
-        if (fieldName && !angular.isString(fieldName)) {
+        if (fieldName && !Utilities.isString(fieldName)) {
             throw "fieldName must be a string";
         }
         

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -158,7 +158,7 @@
                 var currGroups = saveModel.userGroups;
                 var formattedGroups = [];
                 for (var i = 0; i < currGroups.length; i++) {
-                    if (!angular.isString(currGroups[i])) {
+                    if (!Utilities.isString(currGroups[i])) {
                         formattedGroups.push(currGroups[i].alias);
                     }
                     else {
@@ -229,7 +229,7 @@
                 var currSections = saveModel.sections;
                 var formattedSections = [];
                 for (var i = 0; i < currSections.length; i++) {
-                    if (!angular.isString(currSections[i])) {
+                    if (!Utilities.isString(currSections[i])) {
                         formattedSections.push(currSections[i].alias);
                     }
                     else {

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -91,7 +91,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
             }
 
             return Umbraco.Sys.ServerVariables["umbracoUrls"][apiName] + actionName +
-                (!queryStrings ? "" : "?" + (angular.isString(queryStrings) ? queryStrings : this.dictionaryToQueryString(queryStrings)));
+                (!queryStrings ? "" : "?" + (Utilities.isString(queryStrings) ? queryStrings : this.dictionaryToQueryString(queryStrings)));
 
         },
 
@@ -129,7 +129,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
 
                 var err = {
                     //NOTE: the default error message here should never be used based on the above docs!
-                    errorMsg: (angular.isString(opts) ? opts : 'An error occurred!'),
+                    errorMsg: (Utilities.isString(opts) ? opts : 'An error occurred!'),
                     data: data,
                     status: status
                 };
@@ -342,11 +342,11 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                     //add the json data
                     if (angular.isArray(data)) {
                         _.each(data, function(item) {
-                            formData.append(item.key, !angular.isString(item.value) ? angular.toJson(item.value) : item.value);
+                            formData.append(item.key, !Utilities.isString(item.value) ? angular.toJson(item.value) : item.value);
                         });
                     }
                     else {
-                        formData.append(data.key, !angular.isString(data.value) ? angular.toJson(data.value) : data.value);
+                        formData.append(data.key, !Utilities.isString(data.value) ? angular.toJson(data.value) : data.value);
                     }
 
                     //call the callback

--- a/src/Umbraco.Web.UI.Client/src/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/navigation.controller.js
@@ -68,7 +68,7 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
             args.event.stopPropagation();
             args.event.preventDefault();
 
-            if (n.metaData && n.metaData["jsClickCallback"] && angular.isString(n.metaData["jsClickCallback"]) && n.metaData["jsClickCallback"] !== "") {
+            if (n.metaData && n.metaData["jsClickCallback"] && Utilities.isString(n.metaData["jsClickCallback"]) && n.metaData["jsClickCallback"] !== "") {
                 //this is a legacy tree node!
                 var jsPrefix = "javascript:";
                 var js;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -739,7 +739,7 @@ angular.module("umbraco")
                 //if nothing is found, set it to 12
                 if (!$scope.model.config.items.columns) {
                     $scope.model.config.items.columns = 12;
-                } else if (angular.isString($scope.model.config.items.columns)) {
+                } else if (Utilities.isString($scope.model.config.items.columns)) {
                     $scope.model.config.items.columns = parseInt($scope.model.config.items.columns);
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -95,7 +95,7 @@ angular.module('umbraco')
             //move previously saved value to the editor
             if ($scope.model.value) {
                 //backwards compat with the old file upload (incase some-one swaps them..)
-                if (angular.isString($scope.model.value)) {
+                if (Utilities.isString($scope.model.value)) {
                     setModelValueWithSrc($scope.model.value);
                 }
                 else {
@@ -232,7 +232,7 @@ angular.module('umbraco')
 
                     //this is a fallback in case the cropper has been asssigned a upload field
                 }
-                else if (angular.isString(property.value)) {
+                else if (Utilities.isString(property.value)) {
                     if (thumbnail) {
 
                         if (mediaHelper.detectIfImageByExtension(property.value)) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -709,7 +709,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     function isDate(val) {
-        if (angular.isString(val)) {
+        if (Utilities.isString(val)) {
             return val.match(/^(\d{4})\-(\d{2})\-(\d{2})\ (\d{2})\:(\d{2})\:(\d{2})$/);
         }
         return false;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -12,7 +12,7 @@ angular.module("umbraco")
             $scope.textAreaHtmlId = $scope.model.alias + "_" + String.CreateGuid();
             
             var editorConfig = $scope.model.config ? $scope.model.config.editor : null;
-            if (!editorConfig || angular.isString(editorConfig)) {
+            if (!editorConfig || Utilities.isString(editorConfig)) {
                 editorConfig = tinyMceService.defaultPrevalues();
             }
             //make sure there's a max image size

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -3,7 +3,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
         var cfg = tinyMceService.defaultPrevalues();
 
         if($scope.model.value){
-            if(angular.isString($scope.model.value)){
+            if(Utilities.isString($scope.model.value)){
                 $scope.model.value = cfg;
             }
         }else{

--- a/src/Umbraco.Web.UI.Client/test/lib/angular/angular-mocks.js
+++ b/src/Umbraco.Web.UI.Client/test/lib/angular/angular-mocks.js
@@ -165,7 +165,7 @@ angular.mock.$Browser.prototype = {
             if (value == undefined) {
                 delete this.cookieHash[name];
             } else {
-                if (angular.isString(value) &&       //strings only
+                if (Utilities.isString(value) &&       //strings only
                     value.length <= 4096) {          //strict cookie storage limits
                     this.cookieHash[name] = value;
                 }
@@ -486,7 +486,7 @@ angular.mock.$LogProvider = function () {
      */
     angular.mock.TzDate = function (offset, timestamp) {
         var self = new Date(0);
-        if (angular.isString(timestamp)) {
+        if (Utilities.isString(timestamp)) {
             var tsStr = timestamp;
 
             self.origDate = jsonStringToDate(timestamp);
@@ -943,7 +943,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
             wasExpected = false;
 
         function prettyPrint(data) {
-            return (angular.isString(data) || angular.isFunction(data) || data instanceof RegExp)
+            return (Utilities.isString(data) || angular.isFunction(data) || data instanceof RegExp)
                 ? data
                 : angular.toJson(data);
         }
@@ -1385,7 +1385,7 @@ function MockHttpExpectation(method, url, data, headers) {
     this.matchData = function (d) {
         if (angular.isUndefined(data)) return true;
         if (data && angular.isFunction(data.test)) return data.test(d);
-        if (data && !angular.isString(data)) return angular.toJson(data) == d;
+        if (data && !Utilities.isString(data)) return angular.toJson(data) == d;
         return data == d;
     };
 


### PR DESCRIPTION
This PR replaces the use of `angular.isString` in favour of `Utilities.isString` as part of #7718.