### PR TITLE
V8-Layout Selector Directive - Button tag isn't closed? leaving invalid markup

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-layout-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-layout-selector.html
@@ -21,7 +21,7 @@
 
            <i class="{{ layout.icon }} umb-layout-selector__dropdown-item-icon" aria-hidden="true"></i>
            <span class="sr-only">{{layout.name}}</span>
-       </div>
+       </button>
 
    </div>
 


### PR DESCRIPTION
It looks like to me there is an 'extra' closing div in this markup... but I think this is because the button isn't closed, there is a closing div where the closing button should be? - eg the icon and span are part of thee button... I've made this change locally and it operates fine, but then it operating fine before hand too...

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes - there isn't one

### Description
Was just looking at the markup for the umb layout selector directive to try to fathom how to use it elsewhere, and spotted an additional closing div... which led me to conclude there is in fact a missing closing button tag...

You can view the layout selector in the Media section of Umbraco, it's used to switch between grid and list view...


<!-- Thanks for contributing to Umbraco CMS! -->
