### PR TITLE
Remove code that does UA sniffing and explicit stuff for IE11 only

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautoresize.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautoresize.directive.js
@@ -1,161 +1,88 @@
 angular.module("umbraco.directives")
-   .directive('umbAutoResize', function($timeout) {
-      return {
-         require: ["^?umbTabs", "ngModel"],
-         link: function(scope, element, attr, controllersArr) {
+    .directive('umbAutoResize', function ($timeout) {
+        return {
+            require: ["^?umbTabs", "ngModel"],
+            link: function (scope, element, attr, controllersArr) {
 
-            var domEl = element[0];
-            var domElType = domEl.type;
-            var umbTabsController = controllersArr[0];
-            var ngModelController = controllersArr[1];
+                var domEl = element[0];
+                var domElType = domEl.type;
+                var umbTabsController = controllersArr[0];
+                var ngModelController = controllersArr[1];
 
-            // IE elements
-            var isIEFlag = false;
-            var wrapper = angular.element('#umb-ie-resize-input-wrapper');
-            var mirror = angular.element('<span style="white-space:pre;"></span>');
+                function resizeInput() {
 
-            function isIE() {
-
-               var ua = window.navigator.userAgent;
-               var msie = ua.indexOf("MSIE ");
-
-               if (msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./) || navigator.userAgent.match(/Edge\/\d+/)) {
-                  return true;
-               } else {
-                  return false;
-               }
-
-            }
-
-            function activate() {
-
-               // check if browser is Internet Explorere
-               isIEFlag = isIE();
-
-               // scrollWidth on element does not work in IE on inputs
-               // we have to do some dirty dom element copying.
-               if (isIEFlag === true && domElType === "text") {
-                  setupInternetExplorerElements();
-               }
-
-            }
-
-            function setupInternetExplorerElements() {
-
-               if (!wrapper.length) {
-                  wrapper = angular.element('<div id="umb-ie-resize-input-wrapper" style="position:fixed; top:-999px; left:0;"></div>');
-                  angular.element('body').append(wrapper);
-               }
-
-               angular.forEach(['fontFamily', 'fontSize', 'fontWeight', 'fontStyle',
-                  'letterSpacing', 'textTransform', 'wordSpacing', 'textIndent',
-                  'boxSizing', 'borderRightWidth', 'borderLeftWidth', 'borderLeftStyle', 'borderRightStyle',
-                  'paddingLeft', 'paddingRight', 'marginLeft', 'marginRight'
-               ], function(value) {
-                  mirror.css(value, element.css(value));
-               });
-
-               wrapper.append(mirror);
-
-            }
-
-            function resizeInternetExplorerInput() {
-
-               mirror.text(element.val() || attr.placeholder);
-               element.css('width', mirror.outerWidth() + 1);
-
-            }
-
-            function resizeInput() {
-
-               if (domEl.scrollWidth !== domEl.clientWidth) {
-                  if (ngModelController.$modelValue) {
-                     element.width(domEl.scrollWidth);
-                  }
-               }
-
-               if(!ngModelController.$modelValue && attr.placeholder) {
-                  attr.$set('size', attr.placeholder.length);
-                  element.width('auto');
-               }
-
-            }
-
-            function resizeTextarea() {
-
-               if(domEl.scrollHeight !== domEl.clientHeight) {
-
-                  element.height(domEl.scrollHeight);
-
-               }
-
-            }
-
-            var update = function(force) {
-
-
-               if (force === true) {
-
-                  if (domElType === "textarea") {
-                     element.height(0);
-                  } else if (domElType === "text") {
-                     element.width(0);
-                  }
-
-               }
-
-
-               if (isIEFlag === true && domElType === "text") {
-
-                  resizeInternetExplorerInput();
-
-               } else {
-
-                  if (domElType === "textarea") {
-
-                     resizeTextarea();
-
-                  } else if (domElType === "text") {
-
-                     resizeInput();
-
-                  }
-
-               }
-
-            };
-
-            activate();
-
-            //listen for tab changes
-            if (umbTabsController != null) {
-               umbTabsController.onTabShown(function(args) {
-                  update();
-               });
-            }
-
-            // listen for ng-model changes
-            var unbindModelWatcher = scope.$watch(function() {
-               return ngModelController.$modelValue;
-            }, function(newValue) {
-                $timeout(
-                    function() {
-                        update(true);
+                    if (domEl.scrollWidth !== domEl.clientWidth) {
+                        if (ngModelController.$modelValue) {
+                            element.width(domEl.scrollWidth);
+                        }
                     }
-                );
-            });
 
-            scope.$on('$destroy', function() {
-               element.off('keyup keydown keypress change', update);
-               element.off('blur', update(true));
-               unbindModelWatcher();
+                    if (!ngModelController.$modelValue && attr.placeholder) {
+                        attr.$set('size', attr.placeholder.length);
+                        element.width('auto');
+                    }
 
-               // clean up IE dom element
-               if (isIEFlag === true && domElType === "text") {
-                  mirror.remove();
-               }
+                }
 
-            });
-         }
-      };
-   });
+                function resizeTextarea() {
+
+                    if (domEl.scrollHeight !== domEl.clientHeight) {
+
+                        element.height(domEl.scrollHeight);
+
+                    }
+
+                }
+
+                var update = function (force) {
+
+
+                    if (force === true) {
+
+                        if (domElType === "textarea") {
+                            element.height(0);
+                        } else if (domElType === "text") {
+                            element.width(0);
+                        }
+
+                    }
+
+
+                    if (domElType === "textarea") {
+
+                        resizeTextarea();
+
+                    } else if (domElType === "text") {
+
+                        resizeInput();
+
+                    }
+
+                };
+
+                //listen for tab changes
+                if (umbTabsController != null) {
+                    umbTabsController.onTabShown(function (args) {
+                        update();
+                    });
+                }
+
+                // listen for ng-model changes
+                var unbindModelWatcher = scope.$watch(function () {
+                    return ngModelController.$modelValue;
+                }, function (newValue) {
+                    $timeout(
+                        function () {
+                            update(true);
+                        }
+                    );
+                });
+
+                scope.$on('$destroy', function () {
+                    element.off('keyup keydown keypress change', update);
+                    element.off('blur', update(true));
+                    unbindModelWatcher();
+                });
+            }
+        };
+    });


### PR DESCRIPTION
### Description
Working on #7928 I noticed that there was some IE11 related code in this directive and I could not resist the urge to remove it 😄 

However it appears that back in 2015 a bugfix was made adding a check to Edge in the code as well. So I'm not 100% sure it's safe to remove. However I'm not sure how to test if the original Edge issue is still there since https://issues.umbraco.org/issue/U4-7541 is not very descriptive.

But I have not noticed anything looking/acting weird in regards to the resizing in Edge after removing this functionality. But someone might need to do an extra thourough check 😅 
