### PR TITLE
Added elements to improve default security and caching for performance

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -87,6 +87,8 @@
 
         <httpRuntime requestValidationMode="2.0" enableVersionHeader="false" targetFramework="4.7.2" maxRequestLength="51200" fcnMode="Single" />
 
+        <httpCookies httpOnlyCookies="true" requireSSL="false"/>
+
         <httpModules>
             <add name="ScriptModule" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
             <add name="UmbracoModule" type="Umbraco.Web.UmbracoModule,Umbraco.Web" />
@@ -160,6 +162,7 @@
             <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
             <remove name="OPTIONSVerbHandler" />
             <remove name="TRACEVerbHandler" />
+            <remove name="TRACKVerbHandler"/>
 
             <add name="ScriptHandlerFactory" verb="*" path="*.asmx" preCondition="integratedMode" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
             <add name="ScriptHandlerFactoryAppServices" verb="*" path="*_AppService.axd" preCondition="integratedMode" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
@@ -170,28 +173,99 @@
         </handlers>
 
         <staticContent>
-            <remove fileExtension=".air" />
-            <mimeMap fileExtension=".air" mimeType="application/vnd.adobe.air-application-installer-package+zip" />
-            <remove fileExtension=".svg" />
-            <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
-            <remove fileExtension=".woff" />
-            <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
-            <remove fileExtension=".woff2" />
-            <mimeMap fileExtension=".woff2" mimeType="application/x-font-woff2" />
-            <remove fileExtension=".less" />
-            <mimeMap fileExtension=".less" mimeType="text/css" />
-            <remove fileExtension=".mp4" />
-            <mimeMap fileExtension=".mp4" mimeType="video/mp4" />
-            <remove fileExtension=".json" />
-            <mimeMap fileExtension=".json" mimeType="application/json" />
+            <clientCache cacheControlCustom="public" cacheControlMode="UseMaxAge" cacheControlMaxAge="90.00:00:00" />
+            <remove fileExtension=".air"/>
+            <mimeMap fileExtension=".air" mimeType="application/vnd.adobe.air-application-installer-package+zip"/>
+            <remove fileExtension=".svg"/>
+            <mimeMap fileExtension=".svg" mimeType="image/svg+xml"/>
+            <remove fileExtension=".eot"/>
+            <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
+            <remove fileExtension=".otf"/>
+            <mimeMap fileExtension=".otf" mimeType="font/otf" />
+            <remove fileExtension=".woff"/>
+            <mimeMap fileExtension=".woff" mimeType="application/font-woff"/>
+            <remove fileExtension=".woff2"/>
+            <mimeMap fileExtension=".woff2" mimeType="application/font-woff2"/>
+            <remove fileExtension=".less"/>
+            <mimeMap fileExtension=".less" mimeType="text/css"/>
+            <remove fileExtension=".mp3"/>
+            <mimeMap fileExtension=".mp3" mimeType="audio/mpeg"/>
+            <remove fileExtension=".mp4"/>
+            <mimeMap fileExtension=".mp4" mimeType="video/mp4"/>
+            <remove fileExtension=".ogg"/>
+            <mimeMap fileExtension=".ogg" mimeType="video/ogg" />
+            <remove fileExtension=".ogv"/>
+            <mimeMap fileExtension=".ogv" mimeType="video/ogg" />
+            <remove fileExtension=".webm"/>
+            <mimeMap fileExtension=".webm" mimeType="video/webm" />
+            <remove fileExtension=".oga"/>
+            <mimeMap fileExtension=".oga" mimeType="audio/ogg" />
+            <remove fileExtension=".spx"/>
+            <mimeMap fileExtension=".spx" mimeType="audio/ogg" />
+            <remove fileExtension=".js"/>
+            <mimeMap fileExtension=".js" mimeType="text/javascript" />
+            <remove fileExtension=".json"/>
+            <mimeMap fileExtension=".json" mimeType="application/json"/>
+            <remove fileExtension=".webmanifest" />
+            <mimeMap fileExtension=".webmanifest" mimeType="application/manifest+json" />
+            <remove fileExtension=".webp" />
+            <mimeMap fileExtension=".webp" mimeType="image/webp" />
         </staticContent>
-
+        <!-- Enable output caching and set the maximum output cache size to 1GB and the maximum reponse size that can be stored in the output cache to 512KB. -->
+        <caching enabled="true" enableKernelCache="true" maxCacheSize="1000" maxResponseSize="512000">
+          <profiles>
+            <add extension=".gif" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".png" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".js" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".css" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".jpg" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".jpeg" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".svg" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+            <add extension=".webp" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" location="Any" />
+          </profiles>
+        </caching>
         <!-- Ensure the powered by header is not returned -->
         <httpProtocol>
-            <customHeaders>
-                <remove name="X-Powered-By" />
-            </customHeaders>
+          <customHeaders>
+            <remove name="X-Powered-By" />
+            <remove name="X-AspNet-Version" />
+            <remove name="X-AspNetMvc-Version" />
+            <remove name="X-Frame-Options" />
+            <remove name="X-Content-Type-Options" />
+            <remove name="X-XSS-Protection" />
+            <remove name="Strict-Transport-Security" />
+            <remove name="Referrer-Policy" />
+            <remove name="Access-Control-Allow-Headers" />
+            <remove name="Access-Control-Allow-Methods" />
+            <add name="X-Frame-Options" value="SAMEORIGIN" />
+            <add name="X-Content-Type-Options" value="nosniff" />
+            <add name="X-XSS-Protection" value="1; mode=block" />
+            <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
+            <add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
+            <add name="Access-Control-Allow-Headers" value="Origin, X-Requested-With, Content-Type, Accept" />
+            <add name="Access-Control-Allow-Methods" value="POST,GET,OPTIONS,PUT,DELETE" />
+          </customHeaders>
         </httpProtocol>
+        <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files" dynamicCompressionEnableCpuUsage="0" dynamicCompressionDisableCpuUsage="90" noCompressionForHttp10="false" noCompressionForProxies="false">
+          <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" staticCompressionLevel="9" doStaticCompression="true" doDynamicCompression="true" />
+          <dynamicTypes>
+            <add mimeType="text/*" enabled="true" />
+            <add mimeType="message/*" enabled="true" />
+            <add mimeType="application/javascript" enabled="true" />
+            <add mimeType="*/*" enabled="false" />
+          </dynamicTypes>
+          <staticTypes>
+            <add mimeType="text/*" enabled="true" />
+            <add mimeType="message/*" enabled="true" />
+            <add mimeType="application/javascript" enabled="true" />
+            <add mimeType="application/font-woff" enabled="true" />
+            <add mimeType="application/font-woff2" enabled="true" />
+            <add mimeType="application/vnd.ms-fontobject" enabled="true" />
+            <add mimeType="application/octet-stream" enabled="true" />
+            <add mimeType="*/*" enabled="false" />
+          </staticTypes>
+        </httpCompression>
+        <urlCompression doStaticCompression="true" doDynamicCompression="true" />
 
         <!-- Increase the default upload file size limit -->
         <security>
@@ -201,14 +275,29 @@
         </security>
 
         <!--
-      If you wish to use IIS rewrite rules, see the documentation here:
-		  https://our.umbraco.com/documentation/Reference/Routing/IISRewriteRules
-    -->
-        <!--
-    <rewrite>
-      <rules></rules>
-    </rewrite>
-    -->
+          If you wish to use IIS rewrite rules, see the documentation here:
+		      https://our.umbraco.com/documentation/Reference/Routing/IISRewriteRules
+        -->
+        
+        <rewrite>
+          <!--<rules></rules>-->
+          <!-- Outbound rules to improve security -->
+          <outboundRules>
+              <clear />
+              <rule name="Remove Server Header" enabled="true">
+                  <match serverVariable="RESPONSE_SERVER" pattern=".*" />
+                  <action type="Rewrite" value="" />
+              </rule>
+              <rule name="Add Strict-Transport-Security when using HTTPS" enabled="true">
+                  <match serverVariable="RESPONSE_Strict_Transport_Security" pattern=".*" />
+                  <conditions>
+                      <add input="{HTTPS}" pattern="on" ignoreCase="true" />
+                  </conditions>
+                  <action type="Rewrite" value="max-age=31536000" />
+              </rule>
+          </outboundRules>
+        </rewrite>
+        
     </system.webServer>
 
     <runtime>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

My first PR and there's no existing issue, but these web.config changes are something that I implement on the majority of Umbraco sites I build. I'm interested in any feedback to know if they could be included in the template release or not.

### Description - Security changes
Added `<httpCookies>` element to set `httpOnlyCookies="true"` to mark cookies as HttpOnly to help mitigate cross-site scripting (XSS) attacks
For a production site running HTTPS, the `requireSSL` attribute should be changed to "true" to ensure that cookies are marked as secure to help mitigate man-in-the-middle attacks.

Added more customHeaders to further tighten security, including cross-site scripting prevention, strict-transport-security and X-Frame options. Attempts to remove the server and ASP.Net version headers.

Added outbound rewrite rules to remove server header and enforce Strict-Transport-Security when the site is running HTTPS. This helps mitigate man-in-the-middle attacks.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

### Testing - Security changes
Security changes can be tested before and after on https://securityheaders.com by entering your site URL. Tick the "Hide results" option to exclude your results from the public list.

### Description - Mime type changes
Added mime types for common media types and updated the existing font mime types to the newer values. This helps webservers serve files using the correct mime types.

### Testing - Mime type changes
Using the Network tab in browser developer tools, check the Type column before and after applying the changes.

### Description - Caching and compression
Added caching and compression for static and dynamic files to improve site performance.
The compression settings are IIS-specific, so if this causes problems, maybe they could be included, but commented out inititially?

### Testing - Caching and compression
Using the Network tab in browser developer tools, check the "Size" column before and after applying the changes. If set, you'll also need to uncheck the "Disable cache" option temporarily. Refreshing the page should result in a lot of files showing "cached" (Firefox) / "memory cache" (Chrome).
Firefox developer tools also lists the "Transferred" size next to the resource "Size".

Thanks, and kind regards,

James.
