### PR TITLE
Append "active" to currently selected section for screen readers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
@@ -7,7 +7,7 @@
                    ng-dblclick="sectionDblClick(section)"
                    ng-click="sectionClick($event, section)"
                    prevent-default
-                   aria-current="{{section.alias == currentSection ? 'page' : null}}"
+                   ng-attr-aria-current="{{section.alias == currentSection ? 'page' : undefined}}"
                    aria-label="{{section.name + (section.alias == currentSection ? ' (active)' : '')}}">
                     <span class="section__name">{{section.name}}</span>
                 </a>
@@ -24,7 +24,7 @@
                             ng-dblclick="sectionDblClick(section)"
                             ng-click="sectionClick($event, section)"
                             prevent-default
-                            aria-current="{{section.alias == currentSection ? 'page' : null}}"
+                            ng-attr-aria-current="{{section.alias == currentSection ? 'page' : undefined}}"
                             aria-label="{{section.name + (section.alias == currentSection ? ' (active)' : '')}}">
                             <span class="section__name">{{section.name}}</span>
                         </a>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-sections.html
@@ -6,13 +6,15 @@
                 <a href="#/{{section.alias}}"
                    ng-dblclick="sectionDblClick(section)"
                    ng-click="sectionClick($event, section)"
-                   prevent-default>
+                   prevent-default
+                   aria-current="{{section.alias == currentSection ? 'page' : null}}"
+                   aria-label="{{section.name + (section.alias == currentSection ? ' (active)' : '')}}">
                     <span class="section__name">{{section.name}}</span>
                 </a>
             </li>
 
             <li data-element="section-expand" class="expand" ng-class="{ 'open': showTray === true, current: currentSectionInOverflow() }" ng-show="visibleSections < sections.length">
-                <a href="#" ng-click="trayClick()" prevent-default>
+                <a href="#" ng-click="trayClick()" prevent-default aria-label="More sections">
                     <span class="section__name">&bull;&bull;&bull;</span>
                 </a>
 
@@ -21,7 +23,9 @@
                         <a href="#/{{section.alias}}"
                             ng-dblclick="sectionDblClick(section)"
                             ng-click="sectionClick($event, section)"
-                            prevent-default>
+                            prevent-default
+                            aria-current="{{section.alias == currentSection ? 'page' : null}}"
+                            aria-label="{{section.name + (section.alias == currentSection ? ' (active)' : '')}}">
                             <span class="section__name">{{section.name}}</span>
                         </a>
                     </li>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Accessibility fix.

Active tab is visually identified but not for screen readers, this commit provides some auditory cues to the user to ensure they are not lost within the navigation.

The currently selected section is marked as the ARIA current page `aria-current="page"`. This has limited browser/screen reader support so he word "active" is appended to currently selected section for screen readers (with `aria-label`) as well.

To test, enable a screen reader and move along the section links along the top of the page. The currently selected section will indicate it is selected in the auditory description. Changing section should also update the description of the pages. Also test at a smaller resolution so that the section navigation items collapse into a "..." menu as shown below.

![image](https://user-images.githubusercontent.com/3120611/79047161-e7e1ad00-7c0c-11ea-8fe6-b2df6ea361ab.png)


<!-- Thanks for contributing to Umbraco CMS! -->
