### PR TITLE
Make the 'GetBackOfficeFields' methods virtual

### DIFF
--- a/src/Umbraco.Web/Search/UmbracoTreeSearcherFields.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcherFields.cs
@@ -7,23 +7,23 @@ namespace Umbraco.Web.Search
     public class UmbracoTreeSearcherFields : IUmbracoTreeSearcherFields
     {
         private IReadOnlyList<string> _backOfficeFields = new List<string> {"id", "__NodeId", "__Key"};
-        public IEnumerable<string> GetBackOfficeFields()
+        public virtual IEnumerable<string> GetBackOfficeFields()
         {
             return _backOfficeFields;
         }
 
 
         private IReadOnlyList<string> _backOfficeMembersFields = new List<string> {"email", "loginName"};
-        public IEnumerable<string> GetBackOfficeMembersFields()
+        public virtual IEnumerable<string> GetBackOfficeMembersFields()
         {
             return _backOfficeMembersFields;
         }
         private IReadOnlyList<string> _backOfficeMediaFields = new List<string> {UmbracoExamineIndex.UmbracoFileFieldName };
-        public IEnumerable<string> GetBackOfficeMediaFields()
+        public virtual IEnumerable<string> GetBackOfficeMediaFields()
         {
             return _backOfficeMediaFields;
         }
-        public IEnumerable<string> GetBackOfficeDocumentFields()
+        public virtual IEnumerable<string> GetBackOfficeDocumentFields()
         {
             return Enumerable.Empty<string>();
         }


### PR DESCRIPTION
When implementing your own IUmbracoTreeSearcherFields, would it be good to be able to inherit from this default UmbracoTreeSearcherFields implementation, and then override whichever method you'd like to manipulate to add an additional field to, instead, and I'm not super sure, would you have to implement all four methods in your custom implementation?

I was just looking at @bielu 's PR for the docs, and was trying to work out how best to suggest a realworld example, and from @Shazwazza 's comments on the original PR the intention with this approach is to make it easy to allow people to override the SearcherFields list as required... so was thinking the sort of example to put into the docs would be something like this:

```
public class CustomTreeSearcherFields : UmbracoTreeSearcherFields
    {
        public override IEnumerable<string> GetBackOfficeDocumentFields()
        {
            var currentDocumentFields = base.GetBackOfficeDocumentFields().ToList();
            currentDocumentFields.Add("bodyText");
            return currentDocumentFields;
        }
    }
```
But I don't think that's possible if those methods aren't virtual?
But also I may not have understood correctly!

To test this PR Create the class as above and register using a composer:

```
   public void Compose(Composition composition)
        {
            composition.RegisterUnique<IUmbracoTreeSearcherFields, CustomTreeSearcherFields>();
        }
```
Using the starter kit, you would be able to 'search' the backoffice for terms included in any bodyText fields in the site.



### Prerequisites

- [x] I have added steps to test this contribution in the description below




Thanks for considering this contribution to Umbraco CMS!
