### PR TITLE
Activate backdrop when drawer is open

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-drawer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-drawer.less
@@ -4,7 +4,7 @@
     bottom: 0;
     left: auto;
     right: 0;
-    z-index: 10;
+    z-index: 7500;
     width: @drawerWidth;
     background: @brownGrayLight;
     box-shadow: inset 5px 0 20px rgba(0,0,0,.3);

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -73,23 +73,19 @@
 
             </div>
 
-            <umb-tour
-                ng-if="tour.show"
-                model="tour">
+            <umb-tour ng-if="tour.show"
+                      model="tour">
             </umb-tour>
 
             <umb-notifications></umb-notifications>
 
         </div>
 
-        <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
-        <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
-
         <umb-search ng-if="search.show" on-close="closeSearch()"></umb-search>
 
     </div>
 
-    <umb-backdrop ng-if="backdrop.show || infiniteMode"
+    <umb-backdrop ng-if="backdrop.show || infiniteMode || drawer.show"
                   backdrop-opacity="backdrop.opacity"
                   highlight-element="backdrop.element"
                   highlight-prevent-click="backdrop.elementPreventClick"
@@ -105,9 +101,11 @@
 
     <umb-editors ng-show="infiniteMode"></umb-editors>
 
-    <umb-login
-        ng-if="login.show"
-        on-login="hideLoginScreen()">
+    <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
+    <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
+
+    <umb-login ng-if="login.show"
+               on-login="hideLoginScreen()">
     </umb-login>
 
     @Html.BareMinimumServerVariablesScript(Url, Url.Action("ExternalLogin", "BackOffice", new { area = ViewData.GetUmbracoPath() }), Model.Features, Current.Configs.Global())


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that when hitting the "Help" link in the header menu the drawer would open without the backdrop being activated. So with this PR I fixed this so it acts more like whenever we open a dialog withing the rest of the backoffice UI - In example overlays, infinite overlays etc.

This also means that it's not possible to click on anything else using your mouse - Tabbing is currently still another story 😃 

**Before**
![help-before](https://user-images.githubusercontent.com/1932158/79080439-26fb2580-7d15-11ea-923c-e3c3aad317bc.gif)

**After**
![help-after](https://user-images.githubusercontent.com/1932158/79080441-2c587000-7d15-11ea-8be2-026f2d79018b.gif)