### PR TITLE
Add migrations for various pre-value errors

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -7,6 +7,7 @@ using Umbraco.Core.Migrations.Upgrade.V_8_0_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_0_1;
 using Umbraco.Core.Migrations.Upgrade.V_8_1_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_6_0;
+using Umbraco.Core.Migrations.Upgrade.V_8_7_0;
 
 namespace Umbraco.Core.Migrations.Upgrade
 {
@@ -193,6 +194,14 @@ namespace Umbraco.Core.Migrations.Upgrade
 
 
             To<MissingDictionaryIndex>("{a78e3369-8ea3-40ec-ad3f-5f76929d2b20}");
+
+            // to 8.7.0...
+            To<NestedContentUpgrade>("{C697CE68-FE7B-4E05-AD0A-E189E5AB980B}");
+            To<ColorPickerPreValueMigrator>("{24D8C07C-08A5-4088-A4DC-2B19BF1F0EB6}");
+            To<MultiNodeTreePickerPreValueMigrator>("{AF424C79-1869-4FE6-9101-F20ACFEC313F}");
+            To<SliderPreValueMigrator>("{2E2FAD22-0D63-4360-88AC-1D581D7989EE}");
+            To<GridPreValueMigrator>("{42A51FED-627A-46D1-87D6-668E96563739}");
+            To<MultipleTextstringPreValueMigrator>("{A93768A9-EAAD-44F5-8341-3CF61B676D65}");
 
             //FINAL
         }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/ColorPickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/ColorPickerPreValueMigrator.cs
@@ -1,0 +1,116 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
+{
+    /// <summary>
+    /// Updates the pre-values on the Color Picker data types to preserve
+    /// settings from v7
+    /// </summary>
+    public class ColorPickerPreValueMigrator : MigrationBase
+    {
+        private static readonly Regex OldPreValuesPattern = new Regex("\\s*{.*\"[0-9]+\"\\s*:\\s*(\"[0-9a-f]+\"|{[^}]*}).*}\\s*", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public ColorPickerPreValueMigrator(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var sql = Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(d => d.EditorAlias == Constants.PropertyEditors.Aliases.ColorPicker);
+
+            var dtos = Database.Fetch<DataTypeDto>(sql);
+            var changes = false;
+
+            foreach (var dto in dtos)
+            {
+                var config = ConvertPreValues(dto.Configuration);
+                if (config == dto.Configuration) continue;
+
+                changes = true;
+                dto.Configuration = config;
+                Database.Update(dto);
+            }
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (changes)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        private string ConvertPreValues(string configString)
+        {
+            if (configString.IsNullOrWhiteSpace() || !OldPreValuesPattern.IsMatch(configString)) return configString;
+
+            var obj = JObject.Parse(configString);
+            var config = new ColorPickerConfiguration();
+            var id = 0;
+
+            foreach (var prop in obj.Properties())
+            {
+                if (prop.Name.ToLowerInvariant() == "uselabel")
+                {
+                    config.UseLabel = prop.Value.ToString() == "1";
+                }
+                else
+                {
+                    id++;
+                    config.Items.Add(new ValueListConfiguration.ValueListItem
+                    {
+                        Id = id,
+                        Value = JsonConvert.SerializeObject(prop.Value is JObject val ? Convert(id, val) : Convert(id, prop.Value))
+                    });
+                }
+            }
+
+            return JsonConvert.SerializeObject(config);
+        }
+
+        private ItemValue Convert(int index, JToken token)
+        {
+            var value = token.ToString();
+            return new ItemValue
+            {
+                Color = value,
+                Label = value,
+                SortOrder = index
+            };
+        }
+
+        private ItemValue Convert(int index, JObject obj)
+        {
+            var value = obj["value"].ToString();
+            var label = obj["label"]?.ToString();
+            var order = obj["sortOrder"]?.ToString();
+
+            return new ItemValue
+            {
+                Color = value,
+                Label = label.IsNullOrWhiteSpace() ? value : label,
+                SortOrder = int.TryParse(order, out var o) ? o : index
+            };
+        }
+
+        private class ItemValue
+        {
+            [JsonProperty("value")]
+            public string Color { get; set; }
+
+            [JsonProperty("label")]
+            public string Label { get; set; }
+
+            [JsonProperty("sortOrder")]
+            public int SortOrder { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/GridPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/GridPreValueMigrator.cs
@@ -1,0 +1,73 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Linq;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
+{
+    /// <summary>
+    /// Updates the pre-values on the Grid data type to preserve value
+    /// settings from v7
+    /// </summary>
+    public class GridPreValueMigrator : MigrationBase
+    {
+        public GridPreValueMigrator(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var sql = Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(d => d.EditorAlias == Constants.PropertyEditors.Aliases.Grid);
+
+            var dtos = Database.Fetch<DataTypeDto>(sql);
+            var changes = false;
+
+            foreach (var dto in dtos)
+            {
+                if (!Migrate(dto)) continue;
+
+                changes = true;
+                Database.Update(dto);
+            }
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (changes)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        // Convert RTE code setting, and ignoreUserStartNode setting
+        private bool Migrate(DataTypeDto dto)
+        {
+            if (dto.Configuration.IsNullOrWhiteSpace() || dto.Configuration[0] != '{') return false;
+            var config = JObject.Parse(dto.Configuration);
+            var changes = false;
+
+            if (config.TryGetValue("ignoreUserStartNodes", out var ignoreToken) && ignoreToken.Type == JTokenType.String)
+            {
+                changes = true;
+                config["ignoreUserStartNodes"] = ignoreToken.ToString() == "1";
+            }
+
+            if (config.TryGetValue("rte", out var rteToken) && rteToken is JObject rte
+                && rte.TryGetValue("toolbar", out var tbToken) && tbToken is JArray tb
+                && tb.Any(t => t?.ToString() == "code" || t?.ToString() == "codemirror"))
+            {
+                changes = true;
+                tb.RemoveAll(t => t?.ToString() == "code" || t?.ToString() == "codemirror");
+                tb.Insert(0, "ace");
+            }
+
+            if (changes)
+            {
+                dto.Configuration = config.ToString();
+            }
+
+            return changes;
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/MultiNodeTreePickerPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/MultiNodeTreePickerPreValueMigrator.cs
@@ -1,0 +1,98 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
+{
+    /// <summary>
+    /// Ensures that the filter string has the correct case for content types
+    /// references, and converts string boolean values to JSON boolean values
+    /// </summary>
+    public class MultiNodeTreePickerPreValueMigrator : MigrationBase
+    {
+        public MultiNodeTreePickerPreValueMigrator(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var sql = Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(d => d.EditorAlias == Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
+
+            var dtos = Database.Fetch<DataTypeDto>(sql);
+
+            sql = Sql()
+                .Select<ContentTypeDto>()
+                .From<ContentTypeDto>();
+            var cts = Database.Fetch<ContentTypeDto>(sql).Select(c => c.Alias).ToList();
+            var changes = false;
+
+            foreach (var dto in dtos)
+            {
+                if (!Migrate(dto, cts)) continue;
+
+                changes = true;
+                Database.Update(dto);
+            }
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (changes)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        // Convert the case of the Filter string to the correct case for the document type aliases
+        // Convert boolean values from "1" or "0" to true and false
+        private bool Migrate(DataTypeDto dto, List<string> contentTypeAliases)
+        {
+            if (dto.Configuration.IsNullOrWhiteSpace() || dto.Configuration[0] != '{') return false;
+
+            var config = JObject.Parse(dto.Configuration);
+            var changes = false;
+
+            if (config.TryGetValue("filter", out var filterToken) && filterToken.Type == JTokenType.String && filterToken?.ToString() is string filter)
+            {
+                var values = new List<string>();
+
+                foreach (var contentType in filter.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var match = contentTypeAliases.FirstOrDefault(a => string.Equals(a, contentType, StringComparison.InvariantCultureIgnoreCase));
+                    if (!match.IsNullOrWhiteSpace())
+                        values.Add(match);
+                }
+
+                var vals = string.Join(",", values);
+                if (vals != filter)
+                {
+                    changes = true;
+                    config["filter"] = vals;
+                }
+            }
+
+            if (config.TryGetValue("ignoreUserStartNodes", out var ignoreToken) && ignoreToken.Type == JTokenType.String)
+            {
+                changes = true;
+                config["ignoreUserStartNodes"] = ignoreToken.ToString() == "1";
+            }
+
+            if (config.TryGetValue("showOpenButton", out var showToken) && showToken.Type == JTokenType.String)
+            {
+                changes = true;
+                config["showOpenButton"] = showToken.ToString() == "1";
+            }
+
+            if (changes)
+            {
+                dto.Configuration = config.ToString();
+            }
+
+            return changes;
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/MultipleTextstringPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/MultipleTextstringPreValueMigrator.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Linq;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
+{
+    /// <summary>
+    /// Updates the pre-values on the Multiple Textstrings data type to
+    /// preserve value settings from v7
+    /// </summary>
+    public class MultipleTextstringPreValueMigrator : MigrationBase
+    {
+        public MultipleTextstringPreValueMigrator(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var sql = Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(d => d.EditorAlias == Constants.PropertyEditors.Aliases.MultipleTextstring);
+
+            var dtos = Database.Fetch<DataTypeDto>(sql);
+            var changes = false;
+
+            foreach (var dto in dtos)
+            {
+                if (!Migrate(dto)) continue;
+
+                changes = true;
+                Database.Update(dto);
+            }
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (changes)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        // Convert from old names to new names
+        private bool Migrate(DataTypeDto dto)
+        {
+            if (dto.Configuration.IsNullOrWhiteSpace() || dto.Configuration[0] != '{') return false;
+            var config = JObject.Parse(dto.Configuration);
+            var changes = false;
+
+            if (config.TryGetValue("0", out var token) && token is JObject obj)
+            {
+                changes = true;
+                config = obj;
+            }
+
+            if (changes)
+            {
+                dto.Configuration = config.ToString();
+            }
+
+            return changes;
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/NestedContentUpgrade.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/NestedContentUpgrade.cs
@@ -1,0 +1,252 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Core.PropertyEditors;
+using static Umbraco.Core.Constants.PropertyEditors;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
+{
+    /// <summary>
+    /// Sets all content types used in a Nested Content data type, and any
+    /// compositions those content types use, to be Element types.  Also
+    /// changes checkboxlist and dropdown data within nested content data from
+    /// strings to raw JSON types
+    /// </summary>
+    public class NestedContentUpgrade : MigrationBase
+    {
+        public NestedContentUpgrade(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var changes = MigrateElementTypes();
+            changes = MigrateData() || changes;
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (changes)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        private bool MigrateElementTypes()
+        {
+            var sql = Sql()
+                .Select<ContentTypeDto>()
+                .From<ContentTypeDto>()
+                .Where<ContentTypeDto>(d => d.IsElement);
+
+            // Don't run this migration in a database where someone has already manually setup element types
+            if (Database.Fetch<ContentTypeDto>(sql).Count > 0)
+                return false;
+
+            sql = Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(d => d.EditorAlias == Constants.PropertyEditors.Aliases.NestedContent);
+
+            // Find all content types that are used in a nested content data type
+            var dataTypes = Database.Fetch<DataTypeDto>(sql);
+            var contentTypeAliases = new List<string>();
+            dataTypes.ForEach(d => contentTypeAliases.AddRange(GetUsedContentTypes(d)));
+
+            sql = Sql()
+                .Select<ContentTypeDto>()
+                .From<ContentTypeDto>()
+                .WhereIn<ContentTypeDto>(d => d.Alias, contentTypeAliases);
+            var dtos = Database.Fetch<ContentTypeDto>(sql);
+
+            // Find all compositions used on content types used in a nested content data type
+            sql = Sql()
+                .Select<ContentType2ContentTypeDto>()
+                .From<ContentType2ContentTypeDto>()
+                .WhereIn<ContentType2ContentTypeDto>(c => c.ChildId, dtos.Select(d => d.NodeId));
+            var c2cs = Database.Fetch<ContentType2ContentTypeDto>(sql);
+
+            sql = Sql()
+                .Select<ContentTypeDto>()
+                .From<ContentTypeDto>()
+                .WhereIn<ContentTypeDto>(d => d.NodeId, c2cs.Select(c => c.ParentId));
+            dtos.AddRange(Database.Fetch<ContentTypeDto>(sql));
+
+            foreach (var dto in dtos)
+            {
+                dto.IsElement = true;
+                Database.Update(dto);
+            }
+
+            return dtos.Count > 0;
+        }
+
+        private IEnumerable<string> GetUsedContentTypes(DataTypeDto dto)
+        {
+            if (dto.Configuration.IsNullOrWhiteSpace() || dto.Configuration[0] != '{') return Enumerable.Empty<string>();
+
+            var config = JsonConvert.DeserializeObject<NcConfig>(dto.Configuration);
+            return config.ContentTypes?.Select(c => c.Alias) ?? Enumerable.Empty<string>();
+        }
+
+        private bool MigrateData()
+        {
+            // Get all checkboxlist and dropdown data types so that we can identify them in the data
+            var propsToUpdate = GetPropertiesToUpdateByContentType();
+            var nestedContentPropertyIds = propsToUpdate.Values.SelectMany(v => v.Select(r => r.PropertyTypeId));
+
+            var sql = Sql()
+                .Select<PropertyDataDto>()
+                .From<PropertyDataDto>()
+                .WhereIn<PropertyDataDto>(p => p.PropertyTypeId, nestedContentPropertyIds);
+            var dtos = Database.Fetch<PropertyDataDto>(sql);
+            var changes = false;
+
+            foreach (var dto in dtos)
+            {
+                var updated = GetUpdatedNestedContent(dto.TextValue, propsToUpdate);
+                if (updated == dto.TextValue) continue;
+
+                dto.TextValue = updated;
+                changes = true;
+                Database.Update(dto);
+            }
+
+            return changes;
+        }
+
+        private Dictionary<string, IEnumerable<PropertyInfo>> GetPropertiesToUpdateByContentType()
+        {
+            var sql = Sql()
+                .Select<ContentTypeDto>(r => r.Select(x => x.NodeDto))
+                .From<ContentTypeDto>()
+                .InnerJoin<NodeDto>()
+                .On<ContentTypeDto, NodeDto>(c => c.NodeId, n => n.NodeId);
+
+            var types = Database.Fetch<ContentTypeDto>(sql);
+            var typeMap = new Dictionary<int, ContentTypeDto>(types.Count);
+            types.ForEach(t => typeMap[t.NodeId] = t);
+
+            sql = Sql()
+                .Select<ContentType2ContentTypeDto>()
+                .From<ContentType2ContentTypeDto>();
+            var joins = Database.Fetch<ContentType2ContentTypeDto>(sql);
+            // Find all relationships between types, either inherited or composited
+            var joinLk = joins
+                .Union(types
+                    .Where(t => typeMap.ContainsKey(t.NodeDto.ParentId))
+                    .Select(t => new ContentType2ContentTypeDto { ChildId = t.NodeId, ParentId = t.NodeDto.ParentId }))
+                .ToLookup(j => j.ChildId, j => j.ParentId);
+
+            sql = Sql()
+                .Select<PropertyTypeDto>(r => r.Select(x => x.DataTypeDto))
+                .From<PropertyTypeDto>()
+                .InnerJoin<DataTypeDto>()
+                .On<PropertyTypeDto, DataTypeDto>(c => c.DataTypeId, n => n.NodeId)
+                .WhereIn<DataTypeDto>(d => d.EditorAlias, new[]
+                {
+                    Aliases.NestedContent,
+                    Aliases.CheckBoxList,
+                    Aliases.DropDownListFlexible,
+                    Aliases.RadioButtonList
+                });
+            var props = Database.Fetch<PropertyTypeDto>(sql);
+            var propLk = props.ToLookup(p => p.ContentTypeId, p => new PropertyInfo(p));
+
+            // Get all properties that used to be stored as JSON data within string data, but which now need to be stored as raw JSON data
+            var propsToUpdate = new Dictionary<string, IEnumerable<PropertyInfo>>(types.Count);
+            types.ForEach(t => propsToUpdate[t.Alias] = propLk[t.NodeId].Union(joinLk[t.NodeId].SelectMany(r => propLk[r])));
+
+            return propsToUpdate;
+        }
+
+        private string GetUpdatedNestedContent(string contentString, Dictionary<string, IEnumerable<PropertyInfo>> propsToUpdate)
+        {
+            if (contentString.IsNullOrWhiteSpace() || contentString[0] != '[') return contentString;
+
+            var contents = JArray.Parse(contentString);
+            foreach (var item in contents)
+            {
+                if (!(item is JObject content)
+                    || !(content["ncContentTypeAlias"] is JValue jval)
+                    || jval.Type != JTokenType.String
+                    || !(jval?.ToString() is string contentType)
+                    || !propsToUpdate.TryGetValue(contentType, out var properties)
+                    || !properties.Any())
+                    continue;
+
+                foreach (var property in properties)
+                {
+                    var value = content[property.Alias]?.ToString();
+
+                    if (property.Recurse) content[property.Alias] = GetUpdatedNestedContent(value, propsToUpdate);
+                    else if (!property.Array && !value.IsNullOrWhiteSpace() && value[0] != '"')
+                    {
+                        value = new JValue(property.Values.TryGetValue(value, out var val) ? val : value).ToString();
+                        content[property.Alias] = value;
+                    }
+                    else if (property.Array && (value.IsNullOrWhiteSpace() || value[0] != '['))
+                    {
+                        value = new JArray((value ?? "")
+                            .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                            .Select(v => property.Values.TryGetValue(v, out var val) ? val : v)
+                            .ToArray())
+                            .ToString();
+                        content[property.Alias] = value;
+                    }
+                }
+            }
+
+            return contents.ToString(Formatting.None);
+        }
+
+        private class NcConfig
+        {
+            [JsonProperty("contentTypes")]
+            public NcContentType[] ContentTypes { get; set; }
+        }
+
+        private class NcContentType
+        {
+            [JsonProperty("ncAlias")]
+            public string Alias { get; set; }
+        }
+
+        private class KnownContentType
+        {
+            public string Alias { get; set; }
+            public string[] StringToRawProperties { get; set; }
+        }
+
+        private class PropertyInfo
+        {
+            public PropertyInfo(PropertyTypeDto dto)
+            {
+                Alias = dto.Alias;
+                PropertyTypeId = dto.Id;
+
+                if (dto.DataTypeDto.EditorAlias == Aliases.NestedContent)
+                {
+                    Recurse = true;
+                }
+                else if (!dto.DataTypeDto.Configuration.IsNullOrWhiteSpace() && dto.DataTypeDto.Configuration[0] == '{')
+                {
+                    Array = dto.DataTypeDto.EditorAlias != Aliases.RadioButtonList;
+                    var config = JsonConvert.DeserializeObject<ValueListConfiguration>(dto.DataTypeDto.Configuration);
+                    foreach (var item in config.Items)
+                    {
+                        Values[item.Id.ToString()] = item.Value;
+                    }
+                }
+            }
+
+            public string Alias { get; set; }
+            public bool Recurse { get; set; }
+            public bool Array { get; set; }
+            public Dictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
+            public int PropertyTypeId { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/SliderPreValueMigrator.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_7_0/SliderPreValueMigrator.cs
@@ -1,0 +1,100 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Linq;
+using Umbraco.Core.Migrations.PostMigrations;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_7_0
+{
+    /// <summary>
+    /// Updates the pre-values on the Slider data type to preserve value
+    /// settings from v7
+    /// </summary>
+    public class SliderPreValueMigrator : MigrationBase
+    {
+        public SliderPreValueMigrator(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            var sql = Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(d => d.EditorAlias == Constants.PropertyEditors.Aliases.Slider);
+
+            var dtos = Database.Fetch<DataTypeDto>(sql);
+            var changes = false;
+
+            foreach (var dto in dtos)
+            {
+                if (!Migrate(dto)) continue;
+
+                changes = true;
+                Database.Update(dto);
+            }
+
+            // if some data types have been updated directly in the database (editing DataTypeDto and/or PropertyDataDto),
+            // bypassing the services, then we need to rebuild the cache entirely, including the umbracoContentNu table
+            if (changes)
+                Context.AddPostMigration<RebuildPublishedSnapshot>();
+        }
+
+        // Convert from old names to new names
+        private bool Migrate(DataTypeDto dto)
+        {
+            if (dto.Configuration.IsNullOrWhiteSpace() || dto.Configuration[0] != '{') return false;
+            var config = JObject.Parse(dto.Configuration);
+            var changes = false;
+
+            if (config.ContainsKey("EnableRange"))
+            {
+                changes = true;
+                config["enableRange"] = config["EnableRange"];
+                config.Remove("EnableRange");
+            }
+
+            if (config.ContainsKey("InitialValue"))
+            {
+                changes = true;
+                config["initVal1"] = config["InitialValue"];
+                config.Remove("InitialValue");
+            }
+
+            if (config.ContainsKey("InitialValue2"))
+            {
+                changes = true;
+                config["initVal2"] = config["InitialValue2"];
+                config.Remove("InitialValue2");
+            }
+
+            if (config.ContainsKey("MinimumValue"))
+            {
+                changes = true;
+                config["minVal"] = config["MinimumValue"];
+                config.Remove("MinimumValue");
+            }
+
+            if (config.ContainsKey("MaximumValue"))
+            {
+                changes = true;
+                config["maxVal"] = config["MaximumValue"];
+                config.Remove("MaximumValue");
+            }
+
+            if (config.ContainsKey("StepIncrements"))
+            {
+                changes = true;
+                config["step"] = config["StepIncrements"];
+                config.Remove("StepIncrements");
+            }
+
+            if (changes)
+            {
+                dto.Configuration = config.ToString();
+            }
+
+            return changes;
+        }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -131,6 +131,12 @@
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\ContentTypeDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyDataDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyTypeDto80.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\ColorPickerPreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\GridPreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\MultiNodeTreePickerPreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\NestedContentUpgrade.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\MultipleTextstringPreValueMigrator.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_7_0\SliderPreValueMigrator.cs" />
     <Compile Include="Models\InstallLog.cs" />
     <Compile Include="Persistence\Repositories\IInstallationRepository.cs" />
     <Compile Include="Persistence\Repositories\Implement\InstallationRepository.cs" />


### PR DESCRIPTION
### Prerequisites

This resolves the issue at #7939 

### Description
Add migrations for color picker pre-values, slider pre-values, and multiple-textstring pre-values.  Also migrations to fix a couple pre-values that weren't migrated correctly on the grid, nested content, and multi-node tree picker.  Document types used on nested content data types were marked as elements if elements hadn't been setup in the DB already.  Finally, added a migration to update data embedded in nested content properties for checkbox lists, radio button lists and dropdowns.
