### PR TITLE
New ToFastDictionary ext method and changes some GroupBy/ToDictionary to ToLookup

### DIFF
--- a/src/Umbraco.Core/DictionaryExtensions.cs
+++ b/src/Umbraco.Core/DictionaryExtensions.cs
@@ -14,6 +14,20 @@ namespace Umbraco.Core
     ///</summary>
     internal static class DictionaryExtensions
     {
+        /// <summary>
+        /// Efficiently copies a readonly dictionary to a normal dictionary
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="readonlyDictionary"></param>
+        /// <returns></returns>
+        public static Dictionary<TKey, TValue> CopyToDictionary<TKey, TValue>(this IReadOnlyCollection<KeyValuePair<TKey, TValue>> readonlyDictionary)
+        {
+            var d = new Dictionary<TKey, TValue>(readonlyDictionary.Count);
+            foreach (var i in readonlyDictionary)
+                d[i.Key] = i.Value;
+            return d;
+        }
 
         /// <summary>
         /// Method to Get a value by the key. If the key doesn't exist it will create a new TVal object for the key and return it.

--- a/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
@@ -182,12 +182,14 @@ namespace Umbraco.Core.Packaging
                     LanguagesInstalled = ImportLanguages(compiledPackage.Languages, userId),
                     DictionaryItemsInstalled = ImportDictionaryItems(compiledPackage.DictionaryItems, userId),
                     MacrosInstalled = ImportMacros(compiledPackage.Macros, userId),
-                    TemplatesInstalled = ImportTemplates(compiledPackage.Templates.ToList(), userId),
-                    DocumentTypesInstalled = ImportDocumentTypes(compiledPackage.DocumentTypes, userId)
+                    TemplatesInstalled = ImportTemplates(compiledPackage.Templates.ToList(), userId),                    
                 };
 
+                var docTypesInstalled = ImportDocumentTypes(compiledPackage.DocumentTypes, userId);
+                installationSummary.DocumentTypesInstalled = docTypesInstalled;
+
                 //we need a reference to the imported doc types to continue
-                var importedDocTypes = installationSummary.DocumentTypesInstalled.ToDictionary(x => x.Alias, x => x);
+                var importedDocTypes = docTypesInstalled.ToFastDictionary(x => x.Alias, x => x);
 
                 installationSummary.StylesheetsInstalled = ImportStylesheets(compiledPackage.Stylesheets, userId);
                 installationSummary.ContentInstalled = ImportContent(compiledPackage.Documents, importedDocTypes, userId);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -839,7 +839,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             //lookup in the DB all INT ids for the GUIDs and chuck into a dictionary
             var keyToIds = Database.Fetch<NodeIdKey>(Sql().Select<NodeDto>(x => x.NodeId, x => x.UniqueId).From<NodeDto>().WhereIn<NodeDto>(x => x.UniqueId, udiToGuids.Values))
-                .ToDictionary(x => x.UniqueId, x => x.NodeId);
+                .ToFastDictionary(x => x.UniqueId, x => x.NodeId);
 
             var allRelationTypes = RelationTypeRepository.GetMany(Array.Empty<int>())
                 .ToDictionary(x => x.Alias, x => x);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             // prepare
             // note: same alias could be used for media, content... but always different ids = ok
-            var aliases = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.Alias);
+            var aliases = contentTypeDtos.ToFastDictionary(x => x.NodeId, x => x.Alias);
 
             // create
             var allowedDtoIx = 0;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -1096,6 +1096,7 @@ AND umbracoNode.id <> @id",
                             .WhereIn<DocumentCultureVariationDto>(x => x.LanguageId, editedLanguageVersions.Keys.Select(x => x.langId).ToList())
                             .WhereIn<DocumentCultureVariationDto>(x => x.NodeId, editedLanguageVersions.Keys.Select(x => x.nodeId))))
                 //convert to dictionary with the same key type
+                // TODO: Could resolving the SelectMany ToList and using ToFastDictionary be faster since this is could be a large collection?
                 .ToDictionary(x => (x.NodeId, (int?)x.LanguageId), x => x);
 
             var toUpdate = new List<DocumentCultureVariationDto>();

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -296,7 +296,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             var dtos = Database.FetchOneToMany<ContentTypeReferenceDto>(ct => ct.PropertyTypes, sql);
 
-            return dtos.ToDictionary(
+            return dtos.ToFastDictionary(
                 x => (Udi)new GuidUdi(ObjectTypes.GetUdiType(x.NodeDto.NodeObjectType.Value), x.NodeDto.UniqueId).EnsureClosed(),
                 x => (IEnumerable<string>)x.PropertyTypes.Select(p => p.Alias).ToList());
         }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -244,7 +244,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             var columns = new[] { "key", "id" }.Select(x => (object) SqlSyntax.GetQuotedColumnName(x)).ToArray();
             var sql = Sql().Select(columns).From<DictionaryDto>();
-            return Database.Fetch<DictionaryItemKeyIdDto>(sql).ToDictionary(x => x.Key, x => x.Id);
+            return Database.Fetch<DictionaryItemKeyIdDto>(sql).ToFastDictionary(x => x.Key, x => x.Id);
         }
 
         private class DictionaryItemKeyIdDto

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1520,8 +1520,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             // get names per culture, at same level (ie all siblings)
             var sql = SqlEnsureVariantNamesAreUnique.Sql(true, NodeObjectTypeId, content.ParentId, content.Id);
             var names = Database.Fetch<CultureNodeName>(sql)
-                .GroupBy(x => x.LanguageId)
-                .ToDictionary(x => x.Key, x => x);
+                .ToLookup(x => x.LanguageId);
 
             if (names.Count == 0) return;
 
@@ -1533,7 +1532,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             {
                 var langId = LanguageRepository.GetIdByIsoCode(cultureInfo.Culture);
                 if (!langId.HasValue) continue;
-                if (!names.TryGetValue(langId.Value, out var cultureNames)) continue;
+                var cultureNames = names[langId.Value];
+                if (!cultureNames.Any()) continue;
 
                 // get a unique name
                 var otherNames = cultureNames.Select(x => new SimilarNodeName { Id = x.Id, Name = x.Name });

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/EntityRepository.cs
@@ -284,7 +284,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var dtos = Database.FetchByGroups<VariantInfoDto, int>(v.Select(x => x.Id), 2000, GetVariantInfos);
 
             // group by node id (each group contains all languages)
-            var xdtos = dtos.GroupBy(x => x.NodeId).ToDictionary(x => x.Key, x => x);
+            var xdtos = dtos.ToLookup(x => x.NodeId);
 
             foreach (var e in v)
             {

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -309,7 +309,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             var nodes = Database.Fetch<NodeDto>(Sql().Select<NodeDto>().From<NodeDto>()
                     .WhereIn<NodeDto>(x => x.NodeId, entityIds))
-                .ToDictionary(x => x.NodeId, x => x.NodeObjectType);
+                .ToFastDictionary(x => x.NodeId, x => x.NodeObjectType);
 
             foreach (var e in entities)
             {

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -306,7 +306,7 @@ ORDER BY colName";
             if (dtos.Count == 0) return;
 
             var userIds = dtos.Count == 1 ? new List<int> { dtos[0].Id } : dtos.Select(x => x.Id).ToList();
-            var xUsers = dtos.Count == 1 ? null : dtos.ToDictionary(x => x.Id, x => x);
+            var xUsers = dtos.Count == 1 ? null : dtos.ToFastDictionary(x => x.Id, x => x);
 
             // get users2groups
 
@@ -326,7 +326,7 @@ ORDER BY colName";
                 .WhereIn<UserGroupDto>(x => x.Id, groupIds);
 
             var groups = Database.Fetch<UserGroupDto>(sql)
-                .ToDictionary(x => x.Id, x => x);
+                .ToFastDictionary(x => x.Id, x => x);
 
             // get groups2apps
 
@@ -336,8 +336,7 @@ ORDER BY colName";
                 .WhereIn<UserGroup2AppDto>(x => x.UserGroupId, groupIds);
 
             var groups2apps = Database.Fetch<UserGroup2AppDto>(sql)
-                .GroupBy(x => x.UserGroupId)
-                .ToDictionary(x => x.Key, x => x);
+                .ToLookup(x => x.UserGroupId);
 
             // get start nodes
 
@@ -371,8 +370,7 @@ ORDER BY colName";
 
             foreach (var group in groups.Values)
             {
-                if (groups2apps.TryGetValue(group.Id, out var list))
-                    group.UserGroup2AppDtos = list.ToList(); // groups2apps is distinct
+                group.UserGroup2AppDtos = groups2apps[group.Id].ToList(); // groups2apps is distinct
             }
         }
 

--- a/src/Umbraco.Core/Persistence/SqlTemplate.cs
+++ b/src/Umbraco.Core/Persistence/SqlTemplate.cs
@@ -69,7 +69,7 @@ namespace Umbraco.Core.Persistence
         {
             var isBuilt = true;
             var args = new object[_args.Count];
-            var properties = nargs.GetType().GetProperties().ToDictionary(x => x.Name, x => x.GetValue(nargs));
+            var properties = nargs.GetType().GetProperties().ToFastDictionary(x => x.Name, x => x.GetValue(nargs));
             for (var i = 0; i < _args.Count; i++)
             {
                 object value;

--- a/src/Umbraco.Core/Scoping/ScopeProvider.cs
+++ b/src/Umbraco.Core/Scoping/ScopeProvider.cs
@@ -92,8 +92,8 @@ namespace Umbraco.Core.Scoping
             {
                 lock (StaticCallContextObjectsLock)
                 {
-                    // capture in a dictionary
-                    return StaticCallContextObjects.ToDictionary(x => x.Key, x => x.Value);
+                    // capture/copy dictionary
+                    return new Dictionary<Guid, object>(StaticCallContextObjects);
                 }
             }
         }

--- a/src/Umbraco.Examine/UmbracoExamineIndexDiagnostics.cs
+++ b/src/Umbraco.Examine/UmbracoExamineIndexDiagnostics.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Examine
         {
             get
             {
-                var d = base.Metadata.ToDictionary(x => x.Key, x => x.Value);
+                var d = base.Metadata.CopyToDictionary();
 
                 d[nameof(UmbracoExamineIndex.EnableDefaultEventHandler)] = _index.EnableDefaultEventHandler;
                 d[nameof(UmbracoExamineIndex.PublishedValuesOnly)] = _index.PublishedValuesOnly;

--- a/src/Umbraco.ModelsBuilder.Embedded/Building/TypeModel.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Building/TypeModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Core;
 using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.ModelsBuilder.Embedded.Building

--- a/src/Umbraco.Tests/Cache/PublishedCache/PublishedMediaCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/PublishedCache/PublishedMediaCacheTests.cs
@@ -206,7 +206,7 @@ namespace Umbraco.Tests.Cache.PublishedCache
                 {"creatorName", "Shannon"}
             };
 
-            var result = new SearchResult("1234", 1, () => fields.ToDictionary(x => x.Key, x => new List<string> { x.Value }));
+            var result = new SearchResult("1234", 1, () => fields.ToFastDictionary(x => x.Key, x => new List<string> { x.Value }));
 
             var store = new PublishedMediaCache(new XmlStore((XmlDocument)null, null, null, null), ServiceContext.MediaService, ServiceContext.UserService, new DictionaryAppCache(), ContentTypesCache, Factory.GetInstance<IEntityXmlSerializer>(), Factory.GetInstance<IUmbracoContextAccessor>());
             var doc = store.CreateFromCacheValues(store.ConvertFromSearchResult(result));

--- a/src/Umbraco.Tests/Clr/ReflectionUtilitiesTests.cs
+++ b/src/Umbraco.Tests/Clr/ReflectionUtilitiesTests.cs
@@ -470,10 +470,10 @@ namespace Umbraco.Tests.Clr
 
             var getters4 = type4
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
-                .ToDictionary(x => x.Name, x => (object) ReflectionUtilities.EmitPropertyGetter<Class4, object>(x));
+                .ToFastDictionary(x => x.Name, x => (object) ReflectionUtilities.EmitPropertyGetter<Class4, object>(x));
 
             Console.WriteLine("Getting object4 values...");
-            var values4 = getters4.ToDictionary(kvp => kvp.Key, kvp => ((Func<Class4, object>) kvp.Value)(object4));
+            var values4 = getters4.ToFastDictionary(kvp => kvp.Key, kvp => ((Func<Class4, object>) kvp.Value)(object4));
 
             Console.WriteLine("Writing object4 values...");
             foreach ((var name, var value) in values4)
@@ -489,7 +489,7 @@ namespace Umbraco.Tests.Clr
 
             var getters5 = type5
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
-                .ToDictionary(x => x.Name, x => (object) ReflectionUtilities.EmitPropertyGetter<Class5, object>(x));
+                .ToFastDictionary(x => x.Name, x => (object) ReflectionUtilities.EmitPropertyGetter<Class5, object>(x));
 
             var object5 = new Class5
             {
@@ -502,7 +502,7 @@ namespace Umbraco.Tests.Clr
             };
 
             Console.WriteLine("Getting object5 values...");
-            var values5 = getters5.ToDictionary(kvp => kvp.Key, kvp => ((Func<Class5, object>) kvp.Value)(object5));
+            var values5 = getters5.ToFastDictionary(kvp => kvp.Key, kvp => ((Func<Class5, object>) kvp.Value)(object5));
 
             Console.WriteLine("Writing object5 values...");
             foreach ((var name, var value) in values5)

--- a/src/Umbraco.Tests/Packaging/PackageDataInstallationTests.cs
+++ b/src/Umbraco.Tests/Packaging/PackageDataInstallationTests.cs
@@ -322,7 +322,7 @@ namespace Umbraco.Tests.Packaging
             // Act
             var dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             var contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0);
-            var importedContentTypes = contentTypes.ToDictionary(x => x.Alias, x => x);
+            var importedContentTypes = contentTypes.ToFastDictionary(x => x.Alias, x => x);
             var contents = PackageDataInstallation.ImportContent(packageDocument, -1, importedContentTypes, 0);
             var numberOfDocs = (from doc in element.Descendants()
                                 where (string) doc.Attribute("isDoc") == ""
@@ -356,7 +356,7 @@ namespace Umbraco.Tests.Packaging
             // Act
             var dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             var contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0);
-            var importedContentTypes = contentTypes.ToDictionary(x => x.Alias, x => x);
+            var importedContentTypes = contentTypes.ToFastDictionary(x => x.Alias, x => x);
             var contents = PackageDataInstallation.ImportContent(packageDocument, -1, importedContentTypes, 0);
             var numberOfDocs = (from doc in element.Descendants()
                                 where (string)doc.Attribute("isDoc") == ""

--- a/src/Umbraco.Tests/TestHelpers/TestObjects-Mocks.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestObjects-Mocks.cs
@@ -223,7 +223,7 @@ namespace Umbraco.Tests.TestHelpers
 
             public TestDataTypeService(params IDataType[] dataTypes)
             {
-                DataTypes = dataTypes.ToDictionary(x => x.Id, x => x);
+                DataTypes = dataTypes.ToFastDictionary(x => x.Id, x => x);
             }
 
             public TestDataTypeService(IEnumerable<IDataType> dataTypes)

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Web.Editors
 
             //current permissions explicitly assigned to this content item
             var contentPermissions = Services.ContentService.GetPermissions(content)
-                .ToDictionary(x => x.UserGroupId, x => x);
+                .ToFastDictionary(x => x.UserGroupId, x => x);
 
             var allUserGroups = Services.UserService.GetAllUserGroups().ToArray();
 
@@ -194,7 +194,7 @@ namespace Umbraco.Web.Editors
             var defaultPermissionsByGroup = Mapper.MapEnumerable<IUserGroup, AssignedUserGroupPermissions>(allUserGroups);
 
             var defaultPermissionsAsDictionary = defaultPermissionsByGroup
-                .ToDictionary(x => Convert.ToInt32(x.Id), x => x);
+                .ToFastDictionary(x => Convert.ToInt32(x.Id), x => x);
 
             //get the actual assigned permissions
             var assignedPermissionsByGroup = Services.ContentService.GetPermissions(content).ToArray();

--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -80,6 +80,7 @@ namespace Umbraco.Web.Editors
                     Id = x.Id,
                     Score = x.Score,
                     //order the values by key
+                    // TODO: This is creating a new dictionary with ToDictionary and then copying that new dictionary again in this ctor?
                     Values = new Dictionary<string, string>(x.Values.OrderBy(y => y.Key).ToDictionary(y => y.Key, y => y.Value))
                 })
             };

--- a/src/Umbraco.Web/Editors/UserGroupsController.cs
+++ b/src/Umbraco.Web/Editors/UserGroupsController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web.Http;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Services;
@@ -60,7 +61,7 @@ namespace Umbraco.Web.Editors
 
             //remove ones that have been removed
             var existing = Services.UserService.GetPermissions(userGroupSave.PersistedUserGroup, true)
-                .ToDictionary(x => x.EntityId, x => x);
+                .ToFastDictionary(x => x.EntityId, x => x);
             var toRemove = existing.Keys.Except(userGroupSave.AssignedPermissions.Select(x => x.Key));
             foreach (var contentId in toRemove)
             {

--- a/src/Umbraco.Web/Macros/PartialViewMacroController.cs
+++ b/src/Umbraco.Web/Macros/PartialViewMacroController.cs
@@ -4,6 +4,7 @@ using Umbraco.Web.Mvc;
 using System.Linq;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core;
 
 namespace Umbraco.Web.Macros
 {
@@ -35,7 +36,7 @@ namespace Umbraco.Web.Macros
                 _macro.Id,
                 _macro.Alias,
                 _macro.Name,
-                _macro.Properties.ToDictionary(x => x.Key, x => (object)x.Value));
+                _macro.Properties.ToFastDictionary(x => x.Key, x => (object)x.Value));
             return PartialView(_macro.MacroSource, model);
         }
     }

--- a/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/UserMapDefinition.cs
@@ -226,7 +226,7 @@ namespace Umbraco.Web.Models.Mapping
             //Deal with assigned permissions:
 
             var allContentPermissions = _userService.GetPermissions(source, true)
-                .ToDictionary(x => x.EntityId, x => x);
+                .ToFastDictionary(x => x.EntityId, x => x);
 
             IEntitySlim[] contentEntities;
             if (allContentPermissions.Keys.Count == 0)

--- a/src/Umbraco.Web/PropertyEditors/DropDownFlexibleConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/DropDownFlexibleConfigurationEditor.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Web.PropertyEditors
         {
             // map to what the editor expects
             var i = 1;
-            var items = configuration?.Items.ToDictionary(x => x.Id.ToString(), x => new { value = x.Value, sortOrder = i++ }) ?? new object();
+            var items = configuration?.Items.ToFastDictionary(x => x.Id.ToString(), x => new { value = x.Value, sortOrder = i++ }) ?? new object();
             
             var multiple = configuration?.Multiple ?? false;
 

--- a/src/Umbraco.Web/PropertyEditors/ValueListConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueListConfigurationEditor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core.Services;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -58,7 +59,7 @@ namespace Umbraco.Web.PropertyEditors
             var i = 1;
             return new Dictionary<string, object>
             {
-                { "items", configuration.Items.ToDictionary(x => x.Id.ToString(), x => new { value = x.Value, sortOrder = i++ }) }
+                { "items", configuration.Items.ToFastDictionary(x => x.Id.ToString(), x => new { value = x.Value, sortOrder = i++ }) }
             };
         }
 

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -200,7 +200,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     throw new PanicException("_contentDate.CultureInfos is null.");
 
                 return _cultures = ContentData.CultureInfos
-                    .ToDictionary(x => x.Key, x => new PublishedCultureInfo(x.Key, x.Value.Name, x.Value.UrlSegment, x.Value.Date), StringComparer.OrdinalIgnoreCase);
+                    .ToFastDictionary(x => x.Key, x => new PublishedCultureInfo(x.Key, x.Value.Name, x.Value.UrlSegment, x.Value.Date), StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/Umbraco.Web/Routing/SiteDomainHelper.cs
+++ b/src/Umbraco.Web/Routing/SiteDomainHelper.cs
@@ -264,7 +264,7 @@ namespace Umbraco.Web.Routing
             // convert sites into authority sites based upon current scheme
             // because some domains in the sites might not have a scheme -- and cache
             return _qualifiedSites[current.Scheme] = _sites
-                .ToDictionary(
+                .ToFastDictionary(
                     kvp => kvp.Key,
                     kvp => kvp.Value.Select(d => new Uri(UriUtility.StartWithScheme(d, current.Scheme)).GetLeftPart(UriPartial.Authority)).ToArray()
                 );


### PR DESCRIPTION
Based on a discussion about ToDictionary usages here https://github.com/umbraco/Umbraco-CMS/pull/7910/files#r409689045

I decided to just have a look to see where we could micro optimize some things and created a new ToFastDictionary ext method and another CopyToDictionary ext method. I also realized we are using GroupBy/ToDictionary in many places which in most cases can be better resolved and is much better for performance to use ToLookup so have changed a few of those (though there are more that could be done too).

