### PR TITLE
In Nucache when we are loading in all data that we page over the data as to not cause an SQL timeout

### DIFF
--- a/src/Umbraco.Core/Persistence/NPocoDatabaseExtensions.cs
+++ b/src/Umbraco.Core/Persistence/NPocoDatabaseExtensions.cs
@@ -18,6 +18,48 @@ namespace Umbraco.Core.Persistence
     /// </summary>
     public static partial class NPocoDatabaseExtensions
     {
+        /// <summary>
+        /// Iterates over the result of a paged data set with a db reader
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="database"></param>
+        /// <param name="pageSize">
+        /// The number of rows to load per page
+        /// </param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// NPoco's normal Page returns a List{T} but sometimes we don't want all that in memory and instead want to
+        /// iterate over each row with a reader using Query vs Fetch.
+        /// </remarks>
+        internal static IEnumerable<T> QueryPaged<T>(this IDatabase database, long pageSize, Sql sql)
+        {
+            var sqlString = sql.SQL;
+            var sqlArgs = sql.Arguments;
+
+            int? itemCount = null;
+            long pageIndex = 0;
+            do
+            {
+                // Get the paged queries
+                database.BuildPageQueries<T>(pageIndex * pageSize, pageSize, sqlString, ref sqlArgs, out var sqlCount, out var sqlPage);
+
+                // get the item count once
+                if (itemCount == null)
+                {
+                    itemCount = database.ExecuteScalar<int>(sqlCount, sqlArgs);
+                }
+                pageIndex++;
+
+                // iterate over rows without allocating all items to memory (Query vs Fetch)
+                foreach (var row in database.Query<T>(sqlPage, sqlArgs))
+                {
+                    yield return row;
+                }
+
+            } while ((pageIndex * pageSize) < itemCount);
+        }
+
         // NOTE
         //
         // proper way to do it with TSQL and SQLCE


### PR DESCRIPTION
This is similar to the problem mentioned in v7 preview here https://github.com/umbraco/Umbraco-CMS/issues/7574

When a site cold boots or rebuilds nucache from scratch by querying the DB, if there's a ton of data in the database this could lead to an Sql timeout exception. When we read this data in we use a db reader (cursor) so we don't load all of the data into memory at once (to preserve memory) but this means the connection may stay open longer. Because of that, we should be paging over the data using a db reader. This PR updates this behavior to read in by pages of size 500. 

When in PureLive and a content type is changed, the content/media nucache needs to rebuild from the database data which is also a factor in when sql timeouts can occur. This paging will alleviate that issue but i've also added a Parellel call to process both the content and the media in parallel if the user's machine supports it which could go a little quicker as well.

## Testing

These queries will execute in various circumstances - like a cold boot when nucache files don't exist, or when content types are changed.  So to test just have PureLive mode on (default) and add a property to a doc type, this will rebuild all of nucache, both media and content with these queries.