### PR TITLE
Angular Divorce: Utilities.equals implementation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -66,7 +66,7 @@
 
         /** Allows us to deep watch whatever we want - executes on every digest cycle */
         function doCheck() {
-            if (!angular.equals(vm.content.updateDate, prevContentDateUpdated)) {
+            if (!Utilities.equals(vm.content.updateDate, prevContentDateUpdated)) {
                 setActiveCulture();
                 prevContentDateUpdated = Utilities.copy(vm.content.updateDate);
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/checklistmodel.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/checklistmodel.directive.js
@@ -11,7 +11,7 @@ angular.module('umbraco.directives')
   function contains(arr, item) {
     if (Utilities.isArray(arr)) {
       for (var i = 0; i < arr.length; i++) {
-        if (angular.equals(arr[i], item)) {
+        if (Utilities.equals(arr[i], item)) {
           return true;
         }
       }
@@ -23,7 +23,7 @@ angular.module('umbraco.directives')
   function add(arr, item) {
     arr = Utilities.isArray(arr) ? arr : [];
     for (var i = 0; i < arr.length; i++) {
-      if (angular.equals(arr[i], item)) {
+      if (Utilities.equals(arr[i], item)) {
         return arr;
       }
     }    
@@ -35,7 +35,7 @@ angular.module('umbraco.directives')
   function remove(arr, item) {
     if (Utilities.isArray(arr)) {
       for (var i = 0; i < arr.length; i++) {
-        if (angular.equals(arr[i], item)) {
+        if (Utilities.equals(arr[i], item)) {
           arr.splice(i, 1);
           break;
         }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
@@ -160,7 +160,7 @@
         function onChanges(changes) {
             if (changes.center && !changes.center.isFirstChange()
                 && changes.center.currentValue
-                && !angular.equals(changes.center.currentValue, changes.center.previousValue)) {
+                && !Utilities.equals(changes.center.currentValue, changes.center.previousValue)) {
                 //when center changes update the dimensions
                 setDimensions();
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
@@ -94,7 +94,7 @@ function valPropertyMsg(serverValidationManager, localizationService) {
                 if (!watcher) {
                     watcher = scope.$watch("currentProperty.value",
                         function (newValue, oldValue) {
-                            if (angular.equals(newValue, oldValue)) {
+                            if (Utilities.equals(newValue, oldValue)) {
                                 return;
                             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valserver.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valserver.directive.js
@@ -68,7 +68,7 @@ function valServer(serverValidationManager) {
                         return modelCtrl.$modelValue;
                     }, function (newValue, oldValue) {
 
-                        if (!newValue || angular.equals(newValue, oldValue)) {
+                        if (!newValue || Utilities.equals(newValue, oldValue)) {
                             return;
                         }
 

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -28,41 +28,41 @@
   /**
    * Equivalent to angular.equals
    */
-  const equals = (a, b) => {
-    if (o1 === o2) return true;
-    if (o1 === null || o2 === null) return false;
+  const equals = (a, b) => { 
+    if (a === b) return true; 
+    if (a === null || b === null) return false; 
     // eslint-disable-next-line no-self-compare
-    if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
-    var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
+    if (a !== a && b !== b) return true; // NaN === NaN
+    var t1 = typeof a, t2 = typeof b, length, key, keySet;
     if (t1 === t2 && t1 === 'object') {
-      if (isArray(o1)) {
-        if (!isArray(o2)) return false;
-        if ((length = o1.length) === o2.length) {
+      if (isArray(a)) {
+        if (!isArray(b)) return false;
+        if ((length = a.length) === b.length) {
           for (key = 0; key < length; key++) {
-            if (!equals(o1[key], o2[key])) return false;
+            if (!equals(a[key], b[key])) return false;
           }
           return true;
         }
-      } else if (isDate(o1)) {
-        if (!isDate(o2)) return false;
-        return simpleCompare(o1.getTime(), o2.getTime());
-      } else if (isRegExp(o1)) {
-        if (!isRegExp(o2)) return false;
-        return o1.toString() === o2.toString();
+      } else if (isDate(a)) {
+        if (!isDate(b)) return false;
+        return simpleCompare(a.getTime(), b.getTime());
+      } else if (isRegExp(a)) {
+        if (!isRegExp(b)) return false;
+        return a.toString() === b.toString();
       } else {
-        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) ||
-          isArray(o2) || isDate(o2) || isRegExp(o2)) return false;
+        if (isScope(a) || isScope(b) || isWindow(a) || isWindow(b) ||
+          isArray(b) || isDate(b) || isRegExp(b)) return false;
         keySet = createMap();
-        for (key in o1) {
-          if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
-          if (!equals(o1[key], o2[key])) return false;
+        for (key in a) {
+          if (key.charAt(0) === '$' || isFunction(a[key])) continue;
+          if (!equals(a[key], b[key])) return false;
           keySet[key] = true;
         }
-        for (key in o2) {
+        for (key in b) {
           if (!(key in keySet) &&
             key.charAt(0) !== '$' &&
-            isDefined(o2[key]) &&
-            !isFunction(o2[key])) return false;
+            isDefined(b[key]) &&
+            !isFunction(b[key])) return false;
         }
         return true;
       }
@@ -74,7 +74,7 @@
   /** 
    * Equivalent to angular.isDate
    */
-  const isDate = val => {
+  const isDate = value => {
     return toString.call(value) === '[object Date]';
   }
 

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -20,21 +20,15 @@
    */
   const copy = val => angular.copy(val);
 
-
-
   /**
    * Equivalent to angular.isArray
    */
   const isArray = val => Array.isArray(val) || val instanceof Array;
 
-
-
   /**
-   * Facade to angular.equals
+   * Equivalent to angular.equals
    */
   const equals = (a, b) => {
-    // angular.equals(a, b);
-
     if (o1 === o2) return true;
     if (o1 === null || o2 === null) return false;
     // eslint-disable-next-line no-self-compare
@@ -77,27 +71,25 @@
 
   }
 
-
   /** 
-   * equivalent to angular.isDate
+   * Equivalent to angular.isDate
    */
   const isDate = val => {
     return toString.call(value) === '[object Date]';
   }
 
   /**
-   * equivalent to angular.isRegExp
+   * Equivalent to angular.isRegExp
    */
   const isRegExp = val => {
     return toString.call(val) === '[object RegExp]';
   }
 
-
   /** 
-   * equivalent to angular.simpleCompare
+   * Equivalent to angular.simpleCompare
    */
   const simpleCompare = (a, b) => {
-      return a === b || (a !== a && b !== b); 
+    return a === b || (a !== a && b !== b);
   }
 
   /**

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -10,106 +10,179 @@
  */
 (function (window) {
 
-    /**
-     * Equivalent to angular.noop
-     */
-    const noop = () => { };
+  /**
+   * Equivalent to angular.noop
+   */
+  const noop = () => { };
 
-    /**
-     * Facade to angular.copy
-     */
-    const copy = val => angular.copy(val);
+  /**
+   * Facade to angular.copy
+   */
+  const copy = val => angular.copy(val);
 
-    /**
-     * Equivalent to angular.isArray
-     */
-    const isArray = val => Array.isArray(val) || val instanceof Array;
 
-    /**
-     * Facade to angular.equals
-     */
-    const equals = (a, b) => angular.equals(a, b);
-    
-    /**
-     * Facade to angular.extend
-     * Use this with Angular objects, for vanilla JS objects, use Object.assign()
-     */
-    const extend = (dst, src) => angular.extend(dst, src);
 
-    /**
-     * Equivalent to angular.isFunction
-     */
-    const isFunction = val => typeof val === 'function';
+  /**
+   * Equivalent to angular.isArray
+   */
+  const isArray = val => Array.isArray(val) || val instanceof Array;
 
-    /**
-     * Equivalent to angular.isUndefined
-     */
-    const isUndefined = val => typeof val === 'undefined';
 
-    /**
-     * Equivalent to angular.isDefined. Inverts result of const isUndefined
-     */
-    const isDefined = val => !isUndefined(val);
 
-    /**
-     * Equivalent to angular.isString
-     */
-    const isString = val => typeof val === 'string';
+  /**
+   * Facade to angular.equals
+   */
+  const equals = (a, b) => {
+    // angular.equals(a, b);
 
-    /**
-     * Equivalent to angular.isNumber
-     */
-    const isNumber = val => typeof val === 'number';
-
-    /**
-     * Equivalent to angular.isObject
-     */
-    const isObject = val => val !== null && typeof val === 'object';
-
-    const isWindow = obj => obj && obj.window === obj;
-
-    const isScope = obj => obj && obj.$evalAsync && obj.$watch;
-
-    const toJsonReplacer = (key, value) => {
-        var val = value;      
-        if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
-          val = undefined;
-        } else if (isWindow(value)) {
-          val = '$WINDOW';
-        } else if (value &&  window.document === value) {
-          val = '$DOCUMENT';
-        } else if (isScope(value)) {
-          val = '$SCOPE';
-        }      
-        return val;
-      }
-    /**
-     * Equivalent to angular.toJson
-     */
-    const toJson = (obj, pretty) => {
-        if (isUndefined(obj)) return undefined;
-        if (!isNumber(pretty)) {
-          pretty = pretty ? 2 : null;
+    if (o1 === o2) return true;
+    if (o1 === null || o2 === null) return false;
+    // eslint-disable-next-line no-self-compare
+    if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
+    var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
+    if (t1 === t2 && t1 === 'object') {
+      if (isArray(o1)) {
+        if (!isArray(o2)) return false;
+        if ((length = o1.length) === o2.length) {
+          for (key = 0; key < length; key++) {
+            if (!equals(o1[key], o2[key])) return false;
+          }
+          return true;
         }
-        return JSON.stringify(obj, toJsonReplacer, pretty);
+      } else if (isDate(o1)) {
+        if (!isDate(o2)) return false;
+        return simpleCompare(o1.getTime(), o2.getTime());
+      } else if (isRegExp(o1)) {
+        if (!isRegExp(o2)) return false;
+        return o1.toString() === o2.toString();
+      } else {
+        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) ||
+          isArray(o2) || isDate(o2) || isRegExp(o2)) return false;
+        keySet = createMap();
+        for (key in o1) {
+          if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
+          if (!equals(o1[key], o2[key])) return false;
+          keySet[key] = true;
+        }
+        for (key in o2) {
+          if (!(key in keySet) &&
+            key.charAt(0) !== '$' &&
+            isDefined(o2[key]) &&
+            !isFunction(o2[key])) return false;
+        }
+        return true;
+      }
     }
+    return false;
 
-    let _utilities = {
-        noop: noop,
-        copy: copy,
-        isArray: isArray,
-        equals: equals,
-        extend: extend,
-        isFunction: isFunction,
-        isUndefined: isUndefined,
-        isDefined: isDefined,
-        isString: isString,
-        isNumber: isNumber,
-        isObject: isObject,
-        toJson: toJson
-    };
+  }
 
-    if (typeof (window.Utilities) === 'undefined') {
-        window.Utilities = _utilities;
+
+  /** 
+   * equivalent to angular.isDate
+   */
+  const isDate = val => {
+    return toString.call(value) === '[object Date]';
+  }
+
+  /**
+   * equivalent to angular.isRegExp
+   */
+  const isRegExp = val => {
+    return toString.call(val) === '[object RegExp]';
+  }
+
+
+  /** 
+   * equivalent to angular.simpleCompare
+   */
+  const simpleCompare = (a, b) => {
+      return a === b || (a !== a && b !== b); 
+  }
+
+  /**
+   * Facade to angular.extend
+   * Use this with Angular objects, for vanilla JS objects, use Object.assign()
+   */
+  const extend = (dst, src) => angular.extend(dst, src);
+
+  /**
+   * Equivalent to angular.isFunction
+   */
+  const isFunction = val => typeof val === 'function';
+
+  /**
+   * Equivalent to angular.isUndefined
+   */
+  const isUndefined = val => typeof val === 'undefined';
+
+  /**
+   * Equivalent to angular.isDefined. Inverts result of const isUndefined
+   */
+  const isDefined = val => !isUndefined(val);
+
+  /**
+   * Equivalent to angular.isString
+   */
+  const isString = val => typeof val === 'string';
+
+  /**
+   * Equivalent to angular.isNumber
+   */
+  const isNumber = val => typeof val === 'number';
+
+  /**
+   * Equivalent to angular.isObject
+   */
+  const isObject = val => val !== null && typeof val === 'object';
+
+  const isWindow = obj => obj && obj.window === obj;
+
+  const isScope = obj => obj && obj.$evalAsync && obj.$watch;
+
+  const toJsonReplacer = (key, value) => {
+    var val = value;
+    if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
+      val = undefined;
+    } else if (isWindow(value)) {
+      val = '$WINDOW';
+    } else if (value && window.document === value) {
+      val = '$DOCUMENT';
+    } else if (isScope(value)) {
+      val = '$SCOPE';
     }
+    return val;
+  }
+  /**
+   * Equivalent to angular.toJson
+   */
+  const toJson = (obj, pretty) => {
+    if (isUndefined(obj)) return undefined;
+    if (!isNumber(pretty)) {
+      pretty = pretty ? 2 : null;
+    }
+    return JSON.stringify(obj, toJsonReplacer, pretty);
+  }
+
+  let _utilities = {
+    noop: noop,
+    copy: copy,
+    isDate: isDate,
+    isRegExp: isRegExp,
+    simpleCompare: simpleCompare,
+    isArray: isArray,
+    equals: equals,
+    extend: extend,
+    isFunction: isFunction,
+    isUndefined: isUndefined,
+    isDefined: isDefined,
+    isString: isString,
+    isNumber: isNumber,
+    isObject: isObject,
+    toJson: toJson
+  };
+
+  if (typeof (window.Utilities) === 'undefined') {
+    window.Utilities = _utilities;
+  }
 })(window);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -53,7 +53,7 @@ angular.module("umbraco")
         };
         
         $scope.$watch('control.value', function(newValue, oldValue) {
-            if(angular.equals(newValue, oldValue)){
+            if(Utilities.equals(newValue, oldValue)){
                 return; // simply skip that
             }
             

--- a/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
@@ -1,5 +1,53 @@
 (function () {
     describe('Utilities', function () {
+        describe('equals', function () {
+            var dateA = new Date('December 25, 1995 03:24:00');
+            var dateB = new Date('1995-12-25T03:24:00');
+            var dateC = new Date('2020-11-26T15:21:10');
+
+            it('should be true for identical objects', function () {
+                expect(Utilities.equals('john', 'john')).toEqual(true);
+                expect(Utilities.equals(['john', 'doe'], ['john', 'doe'])).toEqual(true);
+                expect(Utilities.equals(dateA, dateA)).toEqual(true);
+                expect(Utilities.equals(['john', 'doe', [0, 1]], ['john', 'doe', [0, 1]])).toEqual(true);
+            });
+            it('should be false for none-identical objects of the same type', function () {
+                expect(Utilities.equals('john', 'doe')).toEqual(false);
+                expect(Utilities.equals(['john', 'doe'], ['jane', 'doe'])).toEqual(false);
+                expect(Utilities.equals(dateB, dateC)).toEqual(false);
+            });
+
+            it('should be false for different types of objects', function () {
+                expect(Utilities.equals(dateA, ['john', 'doe'])).toEqual(false);
+                expect(Utilities.equals(1, ['john', 'doe'])).toEqual(false);
+                expect(Utilities.equals(false, ['john', 'doe'])).toEqual(false);
+            });
+        });
+
+        describe('isDate', function () {
+
+            it('should be true if the object is a Date', function () {
+                expect(angular.isDate(dateA)).toEqual(true);
+                expect(Utilities.isDate(dateA)).toEqual(true); 
+            });
+
+            it('should be false if the object is not a Date', function () {
+                expect(Utilities.isDate('Not a date')).toEqual(false);
+            });
+        });
+
+        describe('isRegExp', function () {
+            var regex = new RegExp('');
+            it('should be true if the object is a RegExp', function () {
+                expect(Utilities.isRegExp(regex)).toEqual(true);
+            });
+
+            it('should be false if the object is not a RegExp', function () {
+                expect(Utilities.isRegExp('Not a RegExp')).toEqual(false);
+            });
+        });
+
+
         describe('toJson', function () {
             it('should delegate to JSON.stringify', function () {
                 var spy = spyOn(JSON, 'stringify').and.callThrough();

--- a/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
@@ -1,14 +1,14 @@
 (function () {
-    describe("Utilities", function () {
-        describe("toJson", function () {
-            it("should delegate to JSON.stringify", function () {
-                var spy = spyOn(JSON, "stringify").and.callThrough();
+    describe('Utilities', function () {
+        describe('toJson', function () {
+            it('should delegate to JSON.stringify', function () {
+                var spy = spyOn(JSON, 'stringify').and.callThrough();
 
-                expect(Utilities.toJson({})).toEqual("{}");
+                expect(Utilities.toJson({})).toEqual('{}');
                 expect(spy).toHaveBeenCalled();
             });
 
-            it("should format objects pretty", function () {
+            it('should format objects pretty', function () {
                 expect(Utilities.toJson({ a: 1, b: 2 }, true)).toBe(
                     '{\n  "a": 1,\n  "b": 2\n}'
                 );
@@ -25,29 +25,29 @@
                 );
             });
 
-            it("should not serialize properties starting with $$", function () {
-                expect(Utilities.toJson({ $$some: "value" }, false)).toEqual("{}");
+            it('should not serialize properties starting with $$', function () {
+                expect(Utilities.toJson({ $$some: 'value' }, false)).toEqual('{}');
             });
 
-            it("should serialize properties starting with $", function () {
-                expect(Utilities.toJson({ $few: "v" }, false)).toEqual('{"$few":"v"}');
+            it('should serialize properties starting with $', function () {
+                expect(Utilities.toJson({ $few: 'v' }, false)).toEqual('{"$few":"v"}');
             });
 
-            it("should not serialize $window object", function () {
+            it('should not serialize $window object', function () {
                 expect(Utilities.toJson(window)).toEqual('"$WINDOW"');
             });
 
-            it("should not serialize $document object", function () {
+            it('should not serialize $document object', function () {
                 expect(Utilities.toJson(document)).toEqual('"$DOCUMENT"');
             });
 
-            it("should not serialize scope instances", inject(function (
+            it('should not serialize scope instances', inject(function (
                 $rootScope
             ) {
                 expect(Utilities.toJson({ key: $rootScope })).toEqual('{"key":"$SCOPE"}');
             }));
 
-            it("should serialize undefined as undefined", function () {
+            it('should serialize undefined as undefined', function () {
                 expect(Utilities.toJson(undefined)).toEqual(undefined);
             });
         });

--- a/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
@@ -1,10 +1,10 @@
 (function () {
     describe('Utilities', function () {
+        var dateA = new Date('December 25, 1995 03:24:00');
+        var dateB = new Date('1995-12-25T03:24:00');
+        var dateC = new Date('2020-11-26T15:21:10');
+        
         describe('equals', function () {
-            var dateA = new Date('December 25, 1995 03:24:00');
-            var dateB = new Date('1995-12-25T03:24:00');
-            var dateC = new Date('2020-11-26T15:21:10');
-
             it('should be true for identical objects', function () {
                 expect(Utilities.equals('john', 'john')).toEqual(true);
                 expect(Utilities.equals(['john', 'doe'], ['john', 'doe'])).toEqual(true);
@@ -28,7 +28,7 @@
 
             it('should be true if the object is a Date', function () {
                 expect(angular.isDate(dateA)).toEqual(true);
-                expect(Utilities.isDate(dateA)).toEqual(true); 
+                expect(Utilities.isDate(dateA)).toEqual(true);
             });
 
             it('should be false if the object is not a Date', function () {


### PR DESCRIPTION
@harry-gordon  and I have made some changes for the Angular Divorce issue #7718 

### Prerequisites

-  ✅  I have added steps to test this contribution in the description below (added unit tests)

### Description

**Replaced** facade with implementation for
- Utilities.equals

**Added** the functions to support Utilities.equals
- Utilities.isDate
- Utilities.isRegexp
- Utilities.simpleCompare

**Added unit tests** for 
- Utilities.equals
- Utilities.isDate
- Utilities.isRegExp (although not lots)
