### PR TITLE
ModelsBuilder enabled flag not respected

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/ILivePublishedModelFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/ILivePublishedModelFactory.cs
@@ -3,6 +3,17 @@
     /// <summary>
     /// Provides a live published model creation service.
     /// </summary>
+    public interface ILivePublishedModelFactory2 : ILivePublishedModelFactory
+    {
+        /// <summary>
+        /// Tells the factory that it should build a new generation of models
+        /// </summary>
+        void Reset();
+    }
+
+    /// <summary>
+    /// Provides a live published model creation service.
+    /// </summary>
     public interface ILivePublishedModelFactory : IPublishedModelFactory
     {
         /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/ILivePublishedModelFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/ILivePublishedModelFactory.cs
@@ -9,6 +9,11 @@
         /// Tells the factory that it should build a new generation of models
         /// </summary>
         void Reset();
+
+        /// <summary>
+        /// If the live model factory 
+        /// </summary>
+        bool Enabled { get; }
     }
 
     /// <summary>

--- a/src/Umbraco.Core/PublishedModelFactoryExtensions.cs
+++ b/src/Umbraco.Core/PublishedModelFactoryExtensions.cs
@@ -17,6 +17,20 @@ namespace Umbraco.Core
         /// <returns></returns>
         public static bool IsLiveFactory(this IPublishedModelFactory factory) => factory is ILivePublishedModelFactory;
 
+        /// <summary>
+        /// Returns true if the current <see cref="IPublishedModelFactory"/> is an implementation of <see cref="ILivePublishedModelFactory2"/> and is enabled
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <returns></returns>
+        public static bool IsLiveFactoryEnabled(this IPublishedModelFactory factory)
+        {
+            if (factory is ILivePublishedModelFactory2 liveFactory2)
+                return liveFactory2.Enabled;
+
+            // if it's not ILivePublishedModelFactory2 we can't determine if it's enabled or not so return true
+            return factory is ILivePublishedModelFactory;
+        }
+
         [Obsolete("This method is no longer used or necessary and will be removed from future")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void WithSafeLiveFactory(this IPublishedModelFactory factory, Action action)
@@ -61,7 +75,6 @@ namespace Umbraco.Core
                         if (resetMethod != null)
                             resetMethod.Invoke(liveFactory, null);
                     }
-
                     action();
                 }
             }

--- a/src/Umbraco.Core/PublishedModelFactoryExtensions.cs
+++ b/src/Umbraco.Core/PublishedModelFactoryExtensions.cs
@@ -50,14 +50,17 @@ namespace Umbraco.Core
             {
                 lock (liveFactory.SyncRoot)
                 {
-                    // TODO: Fix this in 8.3! - We need to change the ILivePublishedModelFactory interface to have a Reset method and then when we have an embedded MB
-                    // version we will publicize the ResetModels (and change the name to Reset).
-                    // For now, this will suffice and we'll use reflection, there should be no other implementation of ILivePublishedModelFactory.
-                    // Calling ResetModels resets the MB flag so that the next time EnsureModels is called (which is called when nucache lazily calls CreateModel) it will
-                    // trigger the recompiling of pure live models.
-                    var resetMethod = liveFactory.GetType().GetMethod("ResetModels", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-                    if (resetMethod != null)
-                        resetMethod.Invoke(liveFactory, null);
+                    if (liveFactory is ILivePublishedModelFactory2 liveFactory2)
+                    {
+                        liveFactory2.Reset();
+                    }
+                    else
+                    {
+                        // This is purely here for backwards compat and to avoid breaking changes but this code will probably never get executed
+                        var resetMethod = liveFactory.GetType().GetMethod("ResetModels", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                        if (resetMethod != null)
+                            resetMethod.Invoke(liveFactory, null);
+                    }
 
                     action();
                 }

--- a/src/Umbraco.ModelsBuilder.Embedded/PureLiveModelFactory.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/PureLiveModelFactory.cs
@@ -135,6 +135,9 @@ namespace Umbraco.ModelsBuilder.Embedded
         }
 
         /// <inheritdoc />
+        public bool Enabled => _config.Enable;
+
+        /// <inheritdoc />
         public void Reset()
         {
             if (_config.Enable)

--- a/src/Umbraco.ModelsBuilder.Embedded/PureLiveModelFactory.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/PureLiveModelFactory.cs
@@ -21,7 +21,7 @@ using File = System.IO.File;
 
 namespace Umbraco.ModelsBuilder.Embedded
 {
-    internal class PureLiveModelFactory : ILivePublishedModelFactory, IRegisteredObject
+    internal class PureLiveModelFactory : ILivePublishedModelFactory2, IRegisteredObject
     {
         private Assembly _modelsAssembly;
         private Infos _infos = new Infos { ModelInfos = null, ModelTypeMap = new Dictionary<string, Type>() };
@@ -132,6 +132,13 @@ namespace Umbraco.ModelsBuilder.Embedded
             var listType = typeof(List<>).MakeGenericType(modelInfo.ModelType);
             ctor = modelInfo.ListCtor = ReflectionUtilities.EmitConstructor<Func<IList>>(declaring: listType);
             return ctor();
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            if (_config.Enable)
+                ResetModels();
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -858,6 +858,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
             Notify<IContentType>(_contentStore, payloads, RefreshContentTypesLocked);
             Notify<IMediaType>(_mediaStore, payloads, RefreshMediaTypesLocked);
 
+            OnNotified(new NotifiedEventArgs<ContentTypeCacheRefresher.JsonPayload>(payloads));
+
             if (_publishedModelFactory.IsLiveFactory())
             {
                 //In the case of Pure Live - we actually need to refresh all of the content and the media

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -859,9 +859,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             Notify<IContentType>(_contentStore, payloads, RefreshContentTypesLocked);
             Notify<IMediaType>(_mediaStore, payloads, RefreshMediaTypesLocked);
 
-            OnNotified(new NotifiedEventArgs<ContentTypeCacheRefresher.JsonPayload>(payloads));
-
-            if (_publishedModelFactory.IsLiveFactory())
+            if (_publishedModelFactory.IsLiveFactoryEnabled())
             {
                 //In the case of Pure Live - we actually need to refresh all of the content and the media
                 //see https://github.com/umbraco/Umbraco-CMS/issues/5671

--- a/src/Umbraco.Web/PublishedCache/PublishedSnapshotServiceBase.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedSnapshotServiceBase.cs
@@ -6,16 +6,6 @@ using Umbraco.Web.Cache;
 
 namespace Umbraco.Web.PublishedCache
 {
-    internal class NotifiedEventArgs<T> : EventArgs
-    {
-        public NotifiedEventArgs(T[] payloads)
-        {
-            Payloads = payloads;
-        }
-
-        public T[] Payloads { get; }
-    }
-
     internal abstract class PublishedSnapshotServiceBase : IPublishedSnapshotService
     {
         protected PublishedSnapshotServiceBase(IPublishedSnapshotAccessor publishedSnapshotAccessor, IVariationContextAccessor variationContextAccessor)

--- a/src/Umbraco.Web/PublishedCache/PublishedSnapshotServiceBase.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedSnapshotServiceBase.cs
@@ -49,8 +49,5 @@ namespace Umbraco.Web.PublishedCache
 
         public virtual void Dispose()
         { }
-
-        protected void OnNotified(NotifiedEventArgs<ContentTypeCacheRefresher.JsonPayload> args) => Notified?.Invoke(this, args);
-        public event EventHandler<NotifiedEventArgs<ContentTypeCacheRefresher.JsonPayload>> Notified;
     }
 }

--- a/src/Umbraco.Web/PublishedCache/PublishedSnapshotServiceBase.cs
+++ b/src/Umbraco.Web/PublishedCache/PublishedSnapshotServiceBase.cs
@@ -1,11 +1,22 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web.Cache;
 
 namespace Umbraco.Web.PublishedCache
 {
-    abstract class PublishedSnapshotServiceBase : IPublishedSnapshotService
+    internal class NotifiedEventArgs<T> : EventArgs
+    {
+        public NotifiedEventArgs(T[] payloads)
+        {
+            Payloads = payloads;
+        }
+
+        public T[] Payloads { get; }
+    }
+
+    internal abstract class PublishedSnapshotServiceBase : IPublishedSnapshotService
     {
         protected PublishedSnapshotServiceBase(IPublishedSnapshotAccessor publishedSnapshotAccessor, IVariationContextAccessor variationContextAccessor)
         {
@@ -38,5 +49,8 @@ namespace Umbraco.Web.PublishedCache
 
         public virtual void Dispose()
         { }
+
+        protected void OnNotified(NotifiedEventArgs<ContentTypeCacheRefresher.JsonPayload> args) => Notified?.Invoke(this, args);
+        public event EventHandler<NotifiedEventArgs<ContentTypeCacheRefresher.JsonPayload>> Notified;
     }
 }


### PR DESCRIPTION
When MB is disabled we were still rebuilding all of nucache linked list data when schema changes are made which is a requirement of PureLive models, but if MB is disabled then PureLive models don't matter. This was causing unnecessary performance and db overhead when modifying document types when mb is disabled.

This is all done with no breaking changes by adding an additive interface: `ILivePublishedModelFactory2` which fixes a TODO that should have been cleared in 8.3 but we are getting to it now and also allows for us to know if the ILivePublishedModelFactory is enabled or not.