### PR TITLE
Netcore: Implemented DisableBrowserCacheAttribute in .Net core.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Filters/DisableBrowserCacheAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DisableBrowserCacheAttribute.cs
@@ -10,19 +10,12 @@ namespace Umbraco.Web.BackOffice.Filters
     {
         public override async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
         {
-            if (context.HttpContext == null || context.HttpContext.Response == null)
+            if (context.HttpContext?.Response?.StatusCode == 200)
             {
-                await next();
+                context.HttpContext.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+                context.HttpContext.Response.Headers["Expires"] = "-1";
+                context.HttpContext.Response.Headers["Pragma"] = "no-cache";
             }
-
-            if (context.HttpContext.Response.StatusCode != 200)
-            {
-                await next();
-            }
-
-            context.HttpContext.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
-            context.HttpContext.Response.Headers["Expires"] = "-1";
-            context.HttpContext.Response.Headers["Pragma"] = "no-cache";
 
             await next();
         }

--- a/src/Umbraco.Web.BackOffice/Filters/DisableBrowserCacheAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DisableBrowserCacheAttribute.cs
@@ -8,16 +8,16 @@ namespace Umbraco.Web.BackOffice.Filters
     /// </summary>
     public class DisableBrowserCacheAttribute : ActionFilterAttribute
     {
-        public override async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        public override void OnResultExecuting(ResultExecutingContext context)
         {
-            if (context.HttpContext?.Response?.StatusCode == 200)
+            if (context.HttpContext?.Response?.StatusCode != 200)
             {
-                context.HttpContext.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
-                context.HttpContext.Response.Headers["Expires"] = "-1";
-                context.HttpContext.Response.Headers["Pragma"] = "no-cache";
+                return;
             }
 
-            await next();
+            context.HttpContext.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+            context.HttpContext.Response.Headers["Expires"] = "-1";
+            context.HttpContext.Response.Headers["Pragma"] = "no-cache";
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Filters/DisableBrowserCacheAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DisableBrowserCacheAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Umbraco.Web.BackOffice.Filters
+{
+    /// <summary>
+    /// Ensures that the request is not cached by the browser
+    /// </summary>
+    public class DisableBrowserCacheAttribute : ActionFilterAttribute
+    {
+        public override async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            if (context.HttpContext == null || context.HttpContext.Response == null)
+            {
+                await next();
+            }
+
+            if (context.HttpContext.Response.StatusCode != 200)
+            {
+                await next();
+            }
+
+            context.HttpContext.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+            context.HttpContext.Response.Headers["Expires"] = "-1";
+            context.HttpContext.Response.Headers["Pragma"] = "no-cache";
+
+            await next();
+        }
+    }
+}


### PR DESCRIPTION
Towards #7991.

In this PR I've taken a copy of `DisableBrowserCacheAttribute` into `Umbraco.Web.BackOffice` and re-implemented using .Net Core.

I suspect we might actually be able to get rid of this and use the built-in `ResponseCache`, but we may want it for more control and is at least useful at the moment as a simple example reference for other migrations. 