### PR TITLE
Fixing Nasty Exception with Scope/Provider #5151 - when indexing data

### DIFF
--- a/src/Umbraco.Core/Services/UserServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/UserServiceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Security;
 using Umbraco.Core.Models.Membership;
@@ -115,6 +116,18 @@ namespace Umbraco.Core.Services
         {
             var permissionCollection = userService.GetPermissions(user, nodeId);
             return permissionCollection.SelectMany(c => c.AssignedPermissions).Distinct().ToArray();
+        }
+
+        internal static IEnumerable<IProfile> GetProfilesById(this IUserService userService, params int[] ids)
+        {
+            var fullUsers = userService.GetUsersById(ids);
+
+            return fullUsers.Select(user =>
+            {
+                var asProfile = user as IProfile;
+                return asProfile ?? new UserProfile(user.Id, user.Name);
+            });
+
         }
     }
 }

--- a/src/Umbraco.Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Examine/ContentValueSetBuilder.cs
@@ -53,9 +53,9 @@ namespace Umbraco.Examine
             // processing below instead of one by one.
             using (var scope = _scopeProvider.CreateScope())
             {
-                creatorIds = content.Select(x => x.CreatorId).Distinct().Select(x => _userService.GetProfileById(x))
+                creatorIds = _userService.GetProfilesById(content.Select(x => x.CreatorId).ToArray())
                     .ToDictionary(x => x.Id, x => x);
-                writerIds = content.Select(x => x.WriterId).Distinct().Select(x => _userService.GetProfileById(x))
+                writerIds = _userService.GetProfilesById(content.Select(x => x.WriterId).ToArray())
                     .ToDictionary(x => x.Id, x => x);
                 scope.Complete();
             }

--- a/src/Umbraco.Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Examine/ContentValueSetBuilder.cs
@@ -1,9 +1,13 @@
 ﻿using Examine;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.Membership;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 
@@ -16,20 +20,46 @@ namespace Umbraco.Examine
     {
         private readonly UrlSegmentProviderCollection _urlSegmentProviders;
         private readonly IUserService _userService;
+        private readonly IScopeProvider _scopeProvider;
+
+        [Obsolete("Use the other ctor instead")]
+        public ContentValueSetBuilder(PropertyEditorCollection propertyEditors,
+            UrlSegmentProviderCollection urlSegmentProviders,
+            IUserService userService,
+            bool publishedValuesOnly)
+            : this(propertyEditors, urlSegmentProviders, userService, Current.ScopeProvider, publishedValuesOnly)
+        {
+        }
 
         public ContentValueSetBuilder(PropertyEditorCollection propertyEditors,
             UrlSegmentProviderCollection urlSegmentProviders,
             IUserService userService,
+            IScopeProvider scopeProvider,
             bool publishedValuesOnly)
             : base(propertyEditors, publishedValuesOnly)
         {
             _urlSegmentProviders = urlSegmentProviders;
             _userService = userService;
+            _scopeProvider = scopeProvider;
         }
 
         /// <inheritdoc />
         public override IEnumerable<ValueSet> GetValueSets(params IContent[] content)
         {
+            Dictionary<int, IProfile> creatorIds;
+            Dictionary<int, IProfile> writerIds;
+
+            // We can lookup all of the creator/writer names at once which can save some
+            // processing below instead of one by one.
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                creatorIds = content.Select(x => x.CreatorId).Distinct().Select(x => _userService.GetProfileById(x))
+                    .ToDictionary(x => x.Id, x => x);
+                writerIds = content.Select(x => x.WriterId).Distinct().Select(x => _userService.GetProfileById(x))
+                    .ToDictionary(x => x.Id, x => x);
+                scope.Complete();
+            }
+
             // TODO: There is a lot of boxing going on here and ultimately all values will be boxed by Lucene anyways
             // but I wonder if there's a way to reduce the boxing that we have to do or if it will matter in the end since
             // Lucene will do it no matter what? One idea was to create a `FieldValue` struct which would contain `object`, `object[]`, `ValueType` and `ValueType[]`
@@ -58,8 +88,8 @@ namespace Umbraco.Examine
                     {"urlName", urlValue?.Yield() ?? Enumerable.Empty<string>()},                  //Always add invariant urlName
                     {"path", c.Path?.Yield() ?? Enumerable.Empty<string>()},
                     {"nodeType", c.ContentType.Id.ToString().Yield() ?? Enumerable.Empty<string>()},
-                    {"creatorName", (c.GetCreatorProfile(_userService)?.Name ?? "??").Yield() },
-                    {"writerName",(c.GetWriterProfile(_userService)?.Name ?? "??").Yield() },
+                    {"creatorName", (creatorIds.TryGetValue(c.CreatorId, out var creatorProfile) ? creatorProfile.Name : "??").Yield() },
+                    {"writerName", (writerIds.TryGetValue(c.CreatorId, out var writerProfile) ? writerProfile.Name : "??").Yield() },
                     {"writerID", new object[] {c.WriterId}},
                     {"templateID", new object[] {c.TemplateId ?? 0}},
                     {UmbracoContentIndex.VariesByCultureFieldName, new object[] {"n"}},

--- a/src/Umbraco.Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Examine/ContentValueSetBuilder.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Examine
                     {"path", c.Path?.Yield() ?? Enumerable.Empty<string>()},
                     {"nodeType", c.ContentType.Id.ToString().Yield() ?? Enumerable.Empty<string>()},
                     {"creatorName", (creatorIds.TryGetValue(c.CreatorId, out var creatorProfile) ? creatorProfile.Name : "??").Yield() },
-                    {"writerName", (writerIds.TryGetValue(c.CreatorId, out var writerProfile) ? writerProfile.Name : "??").Yield() },
+                    {"writerName", (writerIds.TryGetValue(c.WriterId, out var writerProfile) ? writerProfile.Name : "??").Yield() },
                     {"writerID", new object[] {c.WriterId}},
                     {"templateID", new object[] {c.TemplateId ?? 0}},
                     {UmbracoContentIndex.VariesByCultureFieldName, new object[] {"n"}},

--- a/src/Umbraco.Tests/Services/UserServiceTests.cs
+++ b/src/Umbraco.Tests/Services/UserServiceTests.cs
@@ -925,6 +925,24 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Get_By_Profile_Id_Must_return_null_if_user_not_exists()
+        {
+            var profile = ServiceContext.UserService.GetProfileById(42);
+
+            // Assert
+            Assert.IsNull(profile);
+        }
+
+        [Test]
+        public void GetProfilesById_Must_empty_if_users_not_exists()
+        {
+            var profiles = ServiceContext.UserService.GetProfilesById(42);
+
+            // Assert
+            CollectionAssert.IsEmpty(profiles);
+        }
+
+        [Test]
         public void Get_User_By_Username()
         {
             // Arrange

--- a/src/Umbraco.Tests/UmbracoExamine/IndexInitializer.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/IndexInitializer.cs
@@ -30,16 +30,22 @@ namespace Umbraco.Tests.UmbracoExamine
     /// </summary>
     internal static class IndexInitializer
     {
-        public static ContentValueSetBuilder GetContentValueSetBuilder(PropertyEditorCollection propertyEditors, bool publishedValuesOnly)
+        public static ContentValueSetBuilder GetContentValueSetBuilder(PropertyEditorCollection propertyEditors, IScopeProvider scopeProvider, bool publishedValuesOnly)
         {
-            var contentValueSetBuilder = new ContentValueSetBuilder(propertyEditors, new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }), GetMockUserService(), publishedValuesOnly);
+            var contentValueSetBuilder = new ContentValueSetBuilder(
+                propertyEditors,
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                GetMockUserService(),
+                scopeProvider,
+                publishedValuesOnly);
+
             return contentValueSetBuilder;
         }
 
-        public static ContentIndexPopulator GetContentIndexRebuilder(PropertyEditorCollection propertyEditors, IContentService contentService, ISqlContext sqlContext, bool publishedValuesOnly)
+        public static ContentIndexPopulator GetContentIndexRebuilder(PropertyEditorCollection propertyEditors, IContentService contentService, IScopeProvider scopeProvider, bool publishedValuesOnly)
         {
-            var contentValueSetBuilder = GetContentValueSetBuilder(propertyEditors, publishedValuesOnly);
-            var contentIndexDataSource = new ContentIndexPopulator(true, null, contentService, sqlContext, contentValueSetBuilder);
+            var contentValueSetBuilder = GetContentValueSetBuilder(propertyEditors, scopeProvider, publishedValuesOnly);
+            var contentIndexDataSource = new ContentIndexPopulator(true, null, contentService, scopeProvider.SqlContext, contentValueSetBuilder);
             return contentIndexDataSource;
         }
 

--- a/src/Umbraco.Tests/UmbracoExamine/IndexTest.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/IndexTest.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Tests.UmbracoExamine
         [Test]
         public void Index_Property_Data_With_Value_Indexer()
         {
-            var contentValueSetBuilder = IndexInitializer.GetContentValueSetBuilder(Factory.GetInstance<PropertyEditorCollection>(), false);
+            var contentValueSetBuilder = IndexInitializer.GetContentValueSetBuilder(Factory.GetInstance<PropertyEditorCollection>(), ScopeProvider, false);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
@@ -121,7 +121,7 @@ namespace Umbraco.Tests.UmbracoExamine
         [Test]
         public void Rebuild_Index()
         {
-            var contentRebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider.SqlContext, false);
+            var contentRebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider, false);
             var mediaRebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
 
             using (var luceneDir = new RandomIdRamDirectory())
@@ -149,7 +149,7 @@ namespace Umbraco.Tests.UmbracoExamine
         [Test]
         public void Index_Protected_Content_Not_Indexed()
         {
-            var rebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider.SqlContext, false);
+            var rebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider, false);
 
 
             using (var luceneDir = new RandomIdRamDirectory())
@@ -274,7 +274,7 @@ namespace Umbraco.Tests.UmbracoExamine
         [Test]
         public void Index_Reindex_Content()
         {
-            var rebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider.SqlContext, false);
+            var rebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider, false);
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
                 validator: new ContentValueSetValidator(false)))
@@ -315,7 +315,7 @@ namespace Umbraco.Tests.UmbracoExamine
         public void Index_Delete_Index_Item_Ensure_Heirarchy_Removed()
         {
 
-            var rebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider.SqlContext, false);
+            var rebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider, false);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir))

--- a/src/Umbraco.Tests/UmbracoExamine/SearchTests.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/SearchTests.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Tests.UmbracoExamine
                     allRecs);
 
             var propertyEditors = Factory.GetInstance<PropertyEditorCollection>();
-            var rebuilder = IndexInitializer.GetContentIndexRebuilder(propertyEditors, contentService, ScopeProvider.SqlContext, true);
+            var rebuilder = IndexInitializer.GetContentIndexRebuilder(propertyEditors, contentService, ScopeProvider, true);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir))

--- a/src/Umbraco.Web/Search/ExamineComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineComposer.cs
@@ -4,6 +4,7 @@ using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Examine;
@@ -36,12 +37,14 @@ namespace Umbraco.Web.Search
                     factory.GetInstance<PropertyEditorCollection>(),
                     factory.GetInstance<UrlSegmentProviderCollection>(),
                     factory.GetInstance<IUserService>(),
+                    factory.GetInstance<IScopeProvider>(),
                     true));
             composition.RegisterUnique<IContentValueSetBuilder>(factory =>
                 new ContentValueSetBuilder(
                     factory.GetInstance<PropertyEditorCollection>(),
                     factory.GetInstance<UrlSegmentProviderCollection>(),
                     factory.GetInstance<IUserService>(),
+                    factory.GetInstance<IScopeProvider>(),
                     false));
             composition.RegisterUnique<IValueSetBuilder<IMedia>, MediaValueSetBuilder>();
             composition.RegisterUnique<IValueSetBuilder<IMember>, MemberValueSetBuilder>();


### PR DESCRIPTION
Fixing Nasty Exception with Scope/Provider #5151

To replicate this problem it seems that you would need to individually re-index a lot of documents in one operation (i.e. like transferring a lot with Deploy). 

This is actually only a guess at the problem/solution but I think it's correct. The underlying exception is: 

```
System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at Umbraco.Core.Scoping.ScopeProvider.SetCallContextObject(String key, IInstanceIdentifiable value)
   at Umbraco.Core.Scoping.ScopeProvider.SetAmbient(Scope scope, ScopeContext context)
   at Umbraco.Core.Scoping.ScopeProvider.CreateScope(IsolationLevel isolationLevel, RepositoryCacheMode repositoryCacheMode, IEventDispatcher eventDispatcher, Nullable`1 scopeFileSystems, Boolean callContext, Boolean autoComplete)
   at Umbraco.Core.Services.Implement.UserService.GetUserById(Int32 id)
   at Umbraco.Core.Services.Implement.UserService.GetProfileById(Int32 id)
   at Umbraco.Core.ContentExtensions.GetCreatorProfile(IContentBase content, IUserService userService)
   at Umbraco.Examine.ContentValueSetBuilder.<GetValueSets>d__3.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at Examine.LuceneEngine.Providers.LuceneIndex.ForceProcessQueueItems(Boolean block) in C:\projects\examine\src\Examine\LuceneEngine\Providers\LuceneIndex.cs:line 879
```

and 

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Umbraco.Core.Scoping.Scope.<>c__DisplayClass72_0.<RobustExit>b__2()
   at Umbraco.Core.Scoping.Scope.TryFinally(Int32 index, Action[] actions)
   at Umbraco.Core.Scoping.Scope.TryFinally(Int32 index, Action[] actions)
   at Umbraco.Core.Scoping.Scope.TryFinally(Int32 index, Action[] actions)
   at Umbraco.Core.Scoping.Scope.RobustExit(Boolean completed, Boolean onException)
   at Umbraco.Core.Scoping.Scope.DisposeLastScope()
   at Umbraco.Core.Scoping.Scope.Dispose()
   at Umbraco.Core.Services.Implement.UserService.GetUserById(Int32 id)
   at Umbraco.Core.Services.Implement.UserService.GetProfileById(Int32 id)
   at Umbraco.Core.ContentExtensions.GetCreatorProfile(IContentBase content, IUserService userService)
   at Umbraco.Examine.ContentValueSetBuilder.<GetValueSets>d__3.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at Examine.LuceneEngine.Providers.LuceneIndex.ForceProcessQueueItems(Boolean block) in C:\projects\examine\src\Examine\LuceneEngine\Providers\LuceneIndex.cs:line 879
```

But i think the null ref is caused by the first one probably on a second pass of indexing another document.

I 'think' what is happening here is that when a user object hasn't been cached, then a call during a document indexing operation will be made to the IUserService to get the user profile information for that user which will cause a DB query and then it's cached. But when `ForceProcessQueueItems` is called, this is occurring on a background thread and we are not explicitly creating a Scope which means it will try to use an ambient scope but since this isn't in a request this will use a CallContext ambient scope and I think because one doesn't exist on each call during the indexing operation it will try to create one by calling `StaticCallContextObjects` which fwill use the same, which is always the static key of "Umbraco.Core.Scoping.ScopeContext". This is because it's assuming that only one thread would access this same CallContext at once so when the call to `SetAmbient` it first nullifies the CallContext Scope and then adds it. I suspect however that there are multiple threads using this same CallContext at once and when the user isn't cached it needs to make a DB call so it needs to create an Ambient Scope and this happens concurrently, then the null exception will occur because another thread has set the Ambient Scope to null while trying to create it meanwhile another thread is trying to complete the scope.

To avoid this problem, the rule of thumb is that an explicit Scope needs to be used when accessing the database, via services, or whatever when running on a background (non-request) thread else it will try to create an Ambient Scope in the CallContext which in some cases will work fine but in cases like this where somehow multiple threads are accessing the same CallContext it will not work.

... at least that is my theory here.

