### PR TITLE
Add GetMainDom method to UmbracoApplication

### DIFF
--- a/src/Umbraco.Web/UmbracoApplication.cs
+++ b/src/Umbraco.Web/UmbracoApplication.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Web;
 using Umbraco.Core;
+using Umbraco.Core.Logging;
 using Umbraco.Core.Logging.Serilog;
 using Umbraco.Core.Runtime;
 using Umbraco.Web.Runtime;
@@ -17,16 +18,24 @@ namespace Umbraco.Web
         {
             var logger = SerilogLogger.CreateWithDefaultConfiguration();
 
+            var runtime = new WebRuntime(this, logger, GetMainDom(logger));
+
+            return runtime;
+        }
+
+        /// <summary>
+        /// Returns a new MainDom
+        /// </summary>
+        public static IMainDom GetMainDom(ILogger logger)
+        {
             // Determine if we should use the sql main dom or the default
             var appSettingMainDomLock = ConfigurationManager.AppSettings[Constants.AppSettings.MainDomLock];
 
             var mainDomLock = appSettingMainDomLock == "SqlMainDomLock"
                 ? (IMainDomLock)new SqlMainDomLock(logger)
                 : new MainDomSemaphoreLock(logger);
-            
-            var runtime = new WebRuntime(this, logger, new MainDom(logger, mainDomLock));
 
-            return runtime;
+            return new MainDom(logger, mainDomLock);
         }
 
         /// <summary>


### PR DESCRIPTION
Add GetMainDom method to UmbracoApplication so GetRuntime can be overridden.

Prior to v8.6 you could implement a custom web runtime (see https://github.com/umbraco/UmbracoDocs/blob/master/Getting-Started/Code/Debugging/Logging/index.md#advanced) however since changes to allow swapping of the MainDom in v8.6 you can no longer do this, so this PR returns this ability.

That example in the docs would become

```csharp
        protected override IRuntime GetRuntime()
        {
            var logLevelSetting = ConfigurationManager.AppSettings["YourMinimumLoggingLevel"]; //Warning, Debug, Information, etc

            const bool ignoreCase = true; //this is to clarify the function of the boolean second parameter in the TryParse
            if (!Enum.TryParse(logLevelSetting, ignoreCase, out LogEventLevel minimumLevel))
            {
                minimumLevel = LogEventLevel.Information;//set to this level if the config setting is missing or doesn't match a valid enumeration
            }

            var levelSwitch = new LoggingLevelSwitch { MinimumLevel = minimumLevel };

            var loggerConfig = new LoggerConfiguration()
                .MinimalConfiguration()
                .ReadFromConfigFile()
                .ReadFromUserConfigFile()
                .MinimumLevel.ControlledBy(levelSwitch);

            var logger = new SerilogLogger(loggerConfig);

            var runtime = new WebRuntime(this, logger, GetMainDom(logger));

            return runtime;
        }
```

---
_This item has been added to our backlog [AB#6437](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/6437)_