### PR TITLE
Ensure SVG image is shown in preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
@@ -1,7 +1,7 @@
 ﻿.umb-property-file-upload {
+    .umb-property-editor--limit-width();
 
     .umb-upload-button-big {
-        max-width: (@propertyEditorLimitedWidth - 40);
         display: block;
         padding: 20px;
         opacity: 1;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -724,6 +724,7 @@
 // --------------------------------------------------
 .umb-fileupload {
     display: flex;
+    flex-direction: column;
 }
 
 .umb-fileupload .preview {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This previous PR https://github.com/umbraco/Umbraco-CMS/pull/6962 added the following css:

```
.umb-fileupload {
    display: flex;
}
```

Unfortunately it has a side-effect that SVG image preview is no longer is shown on the media edit page.

**Before**

![image](https://user-images.githubusercontent.com/2919859/80120205-f1fb9800-858a-11ea-886e-006c68a7c35a.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/80120145-e0b28b80-858a-11ea-8802-b8fb7c2128e5.png)
