### PR TITLE
Theme backoffice docs for v8 to clearly differentiate it from the v7 docs

### DIFF
--- a/src/Umbraco.Web.UI.Docs/gulpfile.js
+++ b/src/Umbraco.Web.UI.Docs/gulpfile.js
@@ -16,7 +16,7 @@ gulp.task('docs', [], function (cb) {
     var options = {
         html5Mode: false,
         startPage: '/api',
-        title: "Umbraco Backoffice UI API Documentation",
+        title: "Umbraco 8 Backoffice UI API Documentation",
         dest: './api',
         styles: ['./umb-docs.css'],
         image: "https://our.umbraco.com/assets/images/logo.svg"

--- a/src/Umbraco.Web.UI.Docs/umb-docs.css
+++ b/src/Umbraco.Web.UI.Docs/umb-docs.css
@@ -4,7 +4,7 @@ html {
 }
 body {
     font-family: 'Segoe UI', Tahoma, Helvetica, sans-serif;
-    
+
 }
 
 .container, .navbar-static-top .container, .navbar-fixed-top .container, .navbar-fixed-bottom .container {
@@ -33,37 +33,43 @@ body {
     font-family: inherit;
 }
 
+.navbar .container{
+    min-height: inherit;
+    display: flex;
+    align-items: center;
+}
+
 .navbar .brand {
     display: block;
-    float: left;
-    padding: 10px 20px 10px;
-    margin-left: -20px;
-    font-size: 20px;
-    font-weight: 200;
-    color: rgba(0,0,0,.8);
+    color: white;
     text-shadow: none;
 }
 
 .navbar-fixed-top .navbar-inner {
     min-height: 50px;
-    background: #a3db78;
+    background: #3544b1;
 }
 
 .form-search .well {
-    background-color: #f5fbf1;
+    background-color: #f7f7f7;
 }
 
 .form-search > ul.nav > li.module {
-    background-color: #daf0c9;
+    background-color: #3544b1;
 }
 
-.breadcrumb {    
-    background-color: #f5fbf1;
+.form-search > ul.nav > li.module a {
+    color: white;
 }
 
-a {
-    color: #f36f21;
+.form-search > ul.nav > li.section {
+    background-color: #ccc;
 }
+
+.breadcrumb {
+    background-color: #f7f7f7;
+}
+
 a:hover {
     text-decoration: none;
     color: rgba(0,0,0,.8);
@@ -87,9 +93,12 @@ a:hover {
     color: #000;
 }
 
+.form-search > ul.nav > li.module > a:hover{
+    color: #fff;
+}
+
 .header img {
     width: 50px;
-    margin-top: 5px;
 }
 
 .content .methods code {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have caught myself needing to double check the url for the v8 backoffice documentation to make sure I was not looking at the v7 docs since they currently share the same theme and both headlines are identical saying "Umbraco Backoffice UI API Documentation".

Therefore I have changed the headline to say "Umbraco 8 Backoffice UI API Documentation" and then I have themed it so the styles differentiate from the v7 version as well making it very explicit what version the documentation is for - The colors etc. are reused from our.umbraco.com.

I'm of course open for suggestions for changes 😃 

Oh, and btw - It would be nice if the docs could be updated as well since for instance the umbDateTimePicker is still displayed as umbFlatPicker https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbFlatpickr even though the documentation for it has changed - There might be other directives etc. that would be nice to have updated as well 😃 
**Before**
![backoffice-docs-before](https://user-images.githubusercontent.com/1932158/80306153-d0382600-87c1-11ea-92df-878aa22426a5.png)

**After**
![backoffice-docs-after](https://user-images.githubusercontent.com/1932158/80306159-d75f3400-87c1-11ea-8b28-6b53d045039c.png)
