### PR TITLE
Grid media picker doesn't enable select (at all)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -347,23 +347,11 @@ angular.module("umbraco")
 
             function openDetailsDialog() {
                 localizationService.localize("defaultdialogs_editSelectedMedia").then(function (data) {
+                    $scope.model.selection.push($scope.target);
                     vm.mediaPickerDetailsOverlay = {
                         show: true,
                         title: data,
-                        disableFocalPoint: $scope.disableFocalPoint,
-                        submit: function (model) {
-                            $scope.model.selection.push($scope.target);
-                            $scope.model.submit($scope.model);
-
-                            vm.mediaPickerDetailsOverlay.show = false;
-                            vm.mediaPickerDetailsOverlay = null;
-                        },
-                        close: function (oldModel) {
-                            vm.mediaPickerDetailsOverlay.show = false;
-                            vm.mediaPickerDetailsOverlay = null;
-
-                            close();
-                        }
+                        disableFocalPoint: $scope.disableFocalPoint
                     };
                 });
             };


### PR DESCRIPTION
When adding images to the grid using the built-in media grid-editor, the select button is never enabled. When adding `config.size`, the details dialog shows, but no longer in its own dialog, so the submit/close methods aren't used.  
I've moved the selection statement up to enable selection.  
Historically, the crop-mechanism here works rather bad as well, so hope to have a quick look at it, but this can be merged as-is to make the editor work at all.

Dropping a mention to @bjarnef and @kjac since their names are all over the blame for these files. 😉  
Would appreciate feedback/thoughts/hidden knowledge.