### PR TITLE
Add utility function equivalent to angular.fromJson

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbrawmodel.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbrawmodel.directive.js
@@ -39,7 +39,7 @@ angular.module("umbraco.directives")
 
                 function stringToJson(text) {
                     try {
-                        return JSON.parse(text);
+                        return Utilities.fromJson(text);
                     } catch (err) {
                         setInvalid();
                         return text;
@@ -55,7 +55,7 @@ angular.module("umbraco.directives")
                 function isValidJson(model) {
                     var flag = true;
                     try {
-                        JSON.parse(model)
+                        Utilities.fromJson(model)
                     } catch (err) {
                         flag = false;
                     }

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/_utils.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/_utils.js
@@ -90,7 +90,7 @@ angular.module('umbraco.mocks').
                                             name: "1 column layout",
                                             sections: [
                                                 {
-                                                    grid: 12,
+                                                    grid: 12
                                                 }
                                             ]
                                         },
@@ -98,7 +98,7 @@ angular.module('umbraco.mocks').
                                             name: "2 column layout",
                                             sections: [
                                                 {
-                                                    grid: 4,
+                                                    grid: 4
                                                 },
                                                 {
                                                     grid: 8
@@ -139,7 +139,7 @@ angular.module('umbraco.mocks').
                                     }
 
                                 }
-                            },
+                            }
                         ]
                     },
                     {

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -206,7 +206,7 @@ function umbSessionStorage($window) {
     return {
 
         get: function (key) {
-            return JSON.parse(storage["umb_" + key]);
+            return Utilities.fromJson(storage["umb_" + key]);
         },
 
         set: function (key, value) {

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -94,6 +94,16 @@
         return JSON.stringify(obj, toJsonReplacer, pretty);
     }
 
+    /**
+     * Equivalent to angular.fromJson
+     */
+    const fromJson = (val) => {
+        if (!isString(val)) {
+            return val;
+        }
+        return JSON.parse(val);
+    }
+
     let _utilities = {
         noop: noop,
         copy: copy,
@@ -106,6 +116,7 @@
         isString: isString,
         isNumber: isNumber,
         isObject: isObject,
+        fromJson: fromJson,
         toJson: toJson
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.controller.js
@@ -70,8 +70,8 @@ function MacroPickerController($scope, entityResource, macroResource, umbPropEdi
                                     //detect if it is a json string
                                     if (val.detectIsJson()) {
                                         try {
-                                            //Parse it to json
-                                            prop.value = JSON.parse(val);
+                                            //Parse it from json
+                                            prop.value = Utilities.fromJson(val);
                                         }
                                         catch (e) {
                                             // not json

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -189,7 +189,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                     if ($scope.model.filter.startsWith("{")) {
                         $scope.model.filterAdvanced = true;
                         //convert to object
-                        $scope.model.filter = JSON.parse($scope.model.filter);
+                        $scope.model.filter = Utilities.fromJson($scope.model.filter);
                     }
                 }
             }

--- a/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/utilities.spec.js
@@ -1,5 +1,13 @@
 (function () {
     describe("Utilities", function () {
+        describe("fromJson", function () {
+            it("should deserialize json as object", function () {
+                expect(Utilities.fromJson('{"a":1,"b":2}')).toEqual({ a: 1, b: 2 });
+            });
+            it("should return object as object", function () {
+                expect(Utilities.fromJson({ a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
+            });
+        }),
         describe("toJson", function () {
             it("should delegate to JSON.stringify", function () {
                 var spy = spyOn(JSON, "stringify").and.callThrough();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
This previous PR https://github.com/umbraco/Umbraco-CMS/pull/7952 replacing `angular.fromJson` from `JSON.parse` seems to fail as `angular.fromJson` also checked in the value passed in was equal to an string value.
https://github.com/angular/angular.js/blob/master/src/Angular.js#L1335-L1339

E.g. when inserting an image editor in grid content it is causing an console error, when session storage is empty.

Furthermore we now have a `Utilities.toJson()` function https://github.com/umbraco/Umbraco-CMS/pull/7924 so I think we should have an `Utilities.fromJson` as well.

You can of course always use the traditional `JSON.parse` inside a `try/catch` block in e.g, but this method (similar to the `angular.fromJson()` only try to parse the value if it is an string value).

```
try {
    var obj = JSON.parse(value);
}
catch { 

}
```