### PR TITLE
Replace traditional checkbox with umb-checkbox component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -350,18 +350,16 @@
                             </div>
 
                             <div class="umb-info-local-item mt4 flex items-center flex-column" ng-if="vm.installState.status == '' && vm.localPackage.isCompatible">
-                                <label for="license-accept" class="umb-package-installer-label">
-                                    <input type="checkbox" id="license-accept" ng-model="vm.localPackage.packageLicenseAccept" required no-dirty-check>
-                                    <strong class="label-text"><localize key="packager_accept">I accept</localize> <a href="{{ vm.localPackage.licenseUrl }}" target="_blank"><localize key="packager_termsOfUse">terms of use</localize></a></strong>
-                                </label>
-                                <umb-button
-                                    ng-if="vm.installState.type !== 'error'"
-                                    class="mt3"
-                                    type="button"
-                                    button-style="success"
-                                    disabled="localPackageForm.$invalid"
-                                    action="vm.installPackage(vm.localPackage)"
-                                    label-key="packager_packageInstall">
+                                <umb-checkbox model="vm.localPackage.packageLicenseAccept" required="true">
+                                    <strong class="label-text"><localize key="packager_accept">I accept</localize> <a href="#" ng-href="{{vm.localPackage.licenseUrl}}" target="_blank"><localize key="packager_termsOfUse">terms of use</localize></a></strong>
+                                </umb-checkbox>
+                                <umb-button ng-if="vm.installState.type !== 'error'"
+                                            class="mt3"
+                                            type="button"
+                                            button-style="success"
+                                            disabled="localPackageForm.$invalid"
+                                            action="vm.installPackage(vm.localPackage)"
+                                            label-key="packager_packageInstall">
                                 </umb-button>
                             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I just noticed when installing a package, the accept terms checkbox was a traditional checkbox. I have replaced this with `umb-checkbox` component to make it consistent with the rest of the backoffice UI.

**Before**

![chrome_2020-04-27_14-00-17](https://user-images.githubusercontent.com/2919859/80371360-11980680-8892-11ea-9fa2-b81dfb7f24be.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/80371385-1eb4f580-8892-11ea-9328-98695ef66c52.png)

![image](https://user-images.githubusercontent.com/2919859/80371400-25436d00-8892-11ea-9a99-e6029f914196.png)

