### PR TITLE
Lock core relation types

### DIFF
--- a/src/Umbraco.Core/Models/RelationTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/RelationTypeExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace Umbraco.Core.Models
+{
+    internal static class RelationTypeExtensions
+    {
+        internal static bool IsSystemRelationType(this IRelationType relationType) =>
+            relationType.Alias == Constants.Conventions.RelationTypes.RelatedDocumentAlias
+            || relationType.Alias == Constants.Conventions.RelationTypes.RelatedMediaAlias;
+    }
+}

--- a/src/Umbraco.Core/Models/RelationTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/RelationTypeExtensions.cs
@@ -4,6 +4,9 @@
     {
         internal static bool IsSystemRelationType(this IRelationType relationType) =>
             relationType.Alias == Constants.Conventions.RelationTypes.RelatedDocumentAlias
-            || relationType.Alias == Constants.Conventions.RelationTypes.RelatedMediaAlias;
+            || relationType.Alias == Constants.Conventions.RelationTypes.RelatedMediaAlias
+            || relationType.Alias == Constants.Conventions.RelationTypes.RelateDocumentOnCopyAlias
+            || relationType.Alias == Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias
+            || relationType.Alias == Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias;
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Models\ContentDataIntegrityReportEntry.cs" />
     <Compile Include="Models\ContentDataIntegrityReportOptions.cs" />
     <Compile Include="Models\InstallLog.cs" />
+    <Compile Include="Models\RelationTypeExtensions.cs" />
     <Compile Include="Persistence\Repositories\IInstallationRepository.cs" />
     <Compile Include="Persistence\Repositories\Implement\InstallationRepository.cs" />
     <Compile Include="Services\Implement\InstallationService.cs" />

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.html
@@ -6,6 +6,7 @@
             <umb-editor-header
                 name="vm.relationType.name"
                 alias="vm.relationType.alias"
+                alias-locked="vm.relationType.isSystemRelationType"
                 hide-description="true"
                 hide-icon="true"
                 navigation="vm.page.navigation"

--- a/src/Umbraco.Web/Models/ContentEditing/RelationTypeDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/RelationTypeDisplay.cs
@@ -13,6 +13,9 @@ namespace Umbraco.Web.Models.ContentEditing
             Notifications = new List<Notification>();
         }
 
+        [DataMember(Name = "isSystemRelationType")]
+        public bool IsSystemRelationType { get; set; }
+
         /// <summary>
         /// Gets or sets a boolean indicating whether the RelationType is Bidirectional (true) or Parent to Child (false)
         /// </summary>

--- a/src/Umbraco.Web/Models/Mapping/RelationMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/RelationMapDefinition.cs
@@ -39,6 +39,8 @@ namespace Umbraco.Web.Models.Mapping
             target.Udi = Udi.Create(Constants.UdiEntityType.RelationType, source.Key);
             target.Path = "-1," + source.Id;
 
+            target.IsSystemRelationType = source.IsSystemRelationType();
+
             // Set the "friendly" and entity names for the parent and child object types
             if (source.ParentObjectType.HasValue)
             {

--- a/src/Umbraco.Web/Trees/RelationTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/RelationTypeTreeController.cs
@@ -17,8 +17,6 @@ namespace Umbraco.Web.Trees
     {
         protected override MenuItemCollection GetMenuForNode(string id, FormDataCollection queryStrings)
         {
-            //TODO: Do not allow deleting built in types
-
             var menu = new MenuItemCollection();
 
             if (id == Constants.System.RootString)

--- a/src/Umbraco.Web/Trees/RelationTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/RelationTypeTreeController.cs
@@ -5,6 +5,7 @@ using Umbraco.Web.WebApi.Filters;
 using Umbraco.Core;
 using Umbraco.Core.Services;
 using Umbraco.Web.Actions;
+using Umbraco.Core.Models;
 
 namespace Umbraco.Web.Trees
 {
@@ -34,7 +35,10 @@ namespace Umbraco.Web.Trees
             var relationType = Services.RelationService.GetRelationTypeById(int.Parse(id));
             if (relationType == null) return new MenuItemCollection();
 
-            menu.Items.Add<ActionDelete>(Services.TextService.Localize("actions", ActionDelete.ActionAlias));
+            if (relationType.IsSystemRelationType() == false)
+            {
+                menu.Items.Add<ActionDelete>(Services.TextService.Localize("actions", ActionDelete.ActionAlias));
+            }
 
             return menu;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8021

### Description
This PR lock the core relation types to track content and media, so alias of these relation types is locked and delete action is not available for these. This works similar to the changes in https://github.com/umbraco/Umbraco-CMS/pull/6943

![2020-04-27_16-01-14](https://user-images.githubusercontent.com/2919859/80381007-938f2c00-88a0-11ea-821e-5c505f36b3d6.gif)
