### PR TITLE
Add varchar(max) support in DTO attributes

### DIFF
--- a/src/Umbraco.Core/Persistence/DatabaseAnnotations/SpecialDbTypes.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseAnnotations/SpecialDbTypes.cs
@@ -7,6 +7,7 @@
     public enum SpecialDbTypes
     {
         NTEXT,
-        NCHAR
+        NCHAR,
+        NVARCHARMAX
     }
 }

--- a/src/Umbraco.Core/Persistence/PocoDataDataReader.cs
+++ b/src/Umbraco.Core/Persistence/PocoDataDataReader.cs
@@ -79,6 +79,9 @@ namespace Umbraco.Core.Persistence
                         case SpecialDbTypes.NCHAR:
                             sqlDbType = SqlDbType.NChar;
                             break;
+                        case SpecialDbTypes.NVARCHARMAX:
+                            sqlDbType = SqlDbType.NVarChar;
+                            break;
                         default:
                             throw new ArgumentOutOfRangeException();
                     }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -231,5 +231,11 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
 
         public override string DropIndex { get { return "DROP INDEX {1}.{0}"; } }
 
+        public override string GetSpecialDbType(SpecialDbTypes dbTypes)
+        {
+            if (dbTypes == SpecialDbTypes.NVARCHARMAX) // SqlCE does not have nvarchar(max) for now
+                return "NTEXT";
+            return base.GetSpecialDbType(dbTypes);
+        }
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -196,7 +196,13 @@ namespace Umbraco.Core.Persistence.SqlSyntax
                 return "NCHAR";
             }
             else if (dbTypes == SpecialDbTypes.NTEXT)
+            {
                 return "NTEXT";
+            }
+            else if (dbTypes == SpecialDbTypes.NVARCHARMAX)
+            {
+                return "NVARCHAR(MAX)";
+            }
 
             return "NVARCHAR";
         }


### PR DESCRIPTION


This fixes #5204

### Description

A `SpecialDbTypes.NVARCHARMAX` has been added to the enum in order to allow the definition of nvarchar(max) fields in Migration schemas:
```
[SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
public string Body {get; set;}
```

The implementation for this new enum member has been added in `SqlSyntaxProviderBase`, and overriden in `SqlCeSyntaxProvider`  because SqlCE does not implement nvarchar(max) - ntext should be used instead.

<!-- Thanks for contributing to Umbraco CMS! -->
