### PR TITLE
UmbSessionStorage: Make sure key exists before using it as a JSON string

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -206,7 +206,11 @@ function umbSessionStorage($window) {
     return {
 
         get: function (key) {
-            return JSON.parse(storage["umb_" + key]);
+            if (storage["umb_" + key]) {
+                return JSON.parse(storage["umb_" + key]);
+            } else {
+                return null;
+            }
         },
 
         set: function (key, value) {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/8035