### PR TITLE
Upload media and select media type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -104,11 +104,4 @@
 
 </ng-form>
 
-<umb-overlay
-		ng-if="mediatypepickerOverlay.show"
-		model="mediatypepickerOverlay"
-        view="mediatypepickerOverlay.view"
-		position="right">
-</umb-overlay>
-
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -318,25 +318,26 @@ angular.module("umbraco")
             // Add items overlay menu
             // *********************************************
             $scope.openEditorOverlay = function (event, area, index, key) {
-                var title = "";
-                localizationService.localize("grid_insertControl").then(function (value) {
-                    title = value;
-                    overlayService.open({
-                        view: "itempicker",
-                        filter: area.$allowedEditors.length > 15,
-                        title: title,
-                        availableItems: area.$allowedEditors,
-                        event: event,
-                        submit: function (model) {
-                            if (model.selectedItem) {
-                                $scope.addControl(model.selectedItem, area, index);
-                                overlayService.close();
-                            }
-                        },
-                        close: function () {
+
+                const dialog = {
+                    view: "itempicker",
+                    filter: area.$allowedEditors.length > 15,
+                    availableItems: area.$allowedEditors,
+                    event: event,
+                    submit: function (model) {
+                        if (model.selectedItem) {
+                            $scope.addControl(model.selectedItem, area, index);
                             overlayService.close();
                         }
-                    });
+                    },
+                    close: function () {
+                        overlayService.close();
+                    }
+                };
+
+                localizationService.localize("grid_insertControl").then(value => {
+                    dialog.title = value;
+                    overlayService.open(dialog);
                 });
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When having multiple allowed media types (e.g. default "Image" and a "Special Image" under e.g. "Folder" media type) and dragging files/images to dropzone, it shows an overlay to select media type. This is however the older/legacy `umb-overlay` instead of using `overlayService` or `editorService`.

In this case we could use `editorService.mediaTypePicker()` however I have chosen to use `overlayService` using `itempicker` view, because this is used when inserting grid editors (where you choose which editor to use).
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js#L320-L341

This is how it looks at the moment:

![chrome_2020-05-01_12-32-21](https://user-images.githubusercontent.com/2919859/80802617-1c171080-8bb0-11ea-92ea-b1d6e7f1c0e2.png)

and when inserting an item in grid:

![image](https://user-images.githubusercontent.com/2919859/80802639-2e914a00-8bb0-11ea-9679-a8169e61f2ef.png)

With these changes after uploading files to dropzone in e.g. "Folder" with "Image" and "Special Image" allowed. For this case "Special Image" (alias: specialImage) has just a single property Upload image (umbracoFile) using Image Cropper - just like the default "Image" media type.

![image](https://user-images.githubusercontent.com/2919859/80802766-921b7780-8bb0-11ea-9152-af7bbebed0ba.png)






