### PR TITLE
Don't re-create indexes twice when rebuilding in the back office

### DIFF
--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -141,9 +141,6 @@ namespace Umbraco.Web.Editors
 
             try
             {
-                //clear and replace
-                index.CreateIndex();
-
                 var cacheKey = "temp_indexing_op_" + index.Name;
                 //put temp val in cache which is used as a rudimentary way to know when the indexing is done
                 AppCaches.RuntimeCache.Insert(cacheKey, () => "tempValue", TimeSpan.FromMinutes(5));


### PR DESCRIPTION
when we rebuild indexes in the back office we are actually calling index.CreateIndex() 2 times before populating.

This code is simple, don't call `index.CreateIndex();` because it is called inside `_indexRebuilder.RebuildIndex(indexName);`

