### PR TITLE
Fixes SqlMainDomLock setting for Azure does not work in Load Balancing #8038

### DIFF
--- a/build/NuSpecs/tools/Views.Web.config.install.xdt
+++ b/build/NuSpecs/tools/Views.Web.config.install.xdt
@@ -11,7 +11,7 @@
         <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" xdt:Locator="Match(factoryType)" xdt:Transform="SetAttributes(factoryType)" />
         <pages pageBaseType="System.Web.Mvc.WebViewPage">
             <namespaces>
-                <add namespace="Umbraco.Web.PublishedContentModels" xdt:Transform="InsertIfMissing" />
+                <add namespace="Umbraco.Web.PublishedModels" xdt:Transform="InsertIfMissing" />
             </namespaces>
         </pages>
     </system.web.webPages.razor>

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Dtos;
@@ -16,7 +17,7 @@ namespace Umbraco.Core.Runtime
     internal class SqlMainDomLock : IMainDomLock
     {
         private string _lockId;
-        private const string MainDomKey = "Umbraco.Core.Runtime.SqlMainDom";
+        private const string MainDomKeyPrefix = "Umbraco.Core.Runtime.SqlMainDom";
         private const string UpdatedSuffix = "_updated";
         private readonly ILogger _logger;
         private IUmbracoDatabase _db;
@@ -125,6 +126,14 @@ namespace Umbraco.Core.Runtime
             return Task.Factory.StartNew(ListeningLoop, _cancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
         }
+
+        /// <summary>
+        /// Returns the keyvalue table key for the current server/app
+        /// </summary>
+        private string MainDomKey { get; } = MainDomKeyPrefix + "-"
+                                                + (NetworkHelper.MachineName    // eg DOMAIN\SERVER
+                                                + HttpRuntime.AppDomainAppId)   // eg /LM/S3SVC/11/ROOT
+                                            .GenerateHash(); 
 
         private void ListeningLoop()
         {

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -130,10 +131,12 @@ namespace Umbraco.Core.Runtime
         /// <summary>
         /// Returns the keyvalue table key for the current server/app
         /// </summary>
-        private string MainDomKey { get; } = MainDomKeyPrefix + "-"
-                                                + (NetworkHelper.MachineName    // eg DOMAIN\SERVER
-                                                + HttpRuntime.AppDomainAppId)   // eg /LM/S3SVC/11/ROOT
-                                            .GenerateHash(); 
+        /// <remarks>
+        /// The key is the the normal MainDomId which takes into account the AppDomainAppId and the physical file path of the app and this is
+        /// combined with the current machine name. The machine name is required because the default semaphore lock is machine wide so it implicitly
+        /// takes into account machine name whereas this needs to be explicitly per machine.
+        /// </remarks>
+        private string MainDomKey { get; } = MainDomKeyPrefix + "-" + (NetworkHelper.MachineName + MainDom.GetMainDomId()).GenerateHash<SHA1>();
 
         private void ListeningLoop()
         {

--- a/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Tests.PublishedContent
             _snapshotService?.Dispose();
         }
 
-        private void Init(IEnumerable<ContentNodeKit> kits)
+        private void Init(Func<IEnumerable<ContentNodeKit>> kits)
         {
             Current.Reset();
 
@@ -133,7 +133,7 @@ namespace Umbraco.Tests.PublishedContent
             _snapshotAccessor = new TestPublishedSnapshotAccessor();
 
             // create a data source for NuCache
-            _source = new TestDataSource(kits);
+            _source = new TestDataSource(kits());
 
             // at last, create the complete NuCache snapshot service!
             var options = new PublishedSnapshotServiceOptions { IgnoreLocalDb = true };
@@ -371,7 +371,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void EmptyTest()
         {
-            Init(Enumerable.Empty<ContentNodeKit>());
+            Init(() => Enumerable.Empty<ContentNodeKit>());
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -383,7 +383,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void ChildrenTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -410,7 +410,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void ParentTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -436,7 +436,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void MoveToRootTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             // get snapshot
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
@@ -478,7 +478,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void MoveFromRootTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             // get snapshot
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
@@ -520,7 +520,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void ReOrderTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             // get snapshot
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
@@ -595,7 +595,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void MoveTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             // get snapshot
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
@@ -697,10 +697,60 @@ namespace Umbraco.Tests.PublishedContent
         }
 
         [Test]
+        public void Clear_Branch_Locked()
+        {
+            // This test replicates an issue we saw here https://github.com/umbraco/Umbraco-CMS/pull/7907#issuecomment-610259393
+            // The data was sent to me and this replicates it's structure
+
+            var paths = new Dictionary<int, string> { { -1, "-1" } };
+
+            Init(() => new List<ContentNodeKit>
+            {
+                CreateInvariantKit(1, -1, 1, paths),    // first level
+                CreateInvariantKit(2, 1, 1, paths),     // second level
+                CreateInvariantKit(3, 2, 1, paths),     // third level
+
+                CreateInvariantKit(4, 3, 1, paths),     // fourth level (we'll copy this one to the same level)
+
+                CreateInvariantKit(5, 4, 1, paths),     // 6th level
+
+                CreateInvariantKit(6, 5, 2, paths),     // 7th level
+                CreateInvariantKit(7, 5, 3, paths),
+                CreateInvariantKit(8, 5, 4, paths),
+                CreateInvariantKit(9, 5, 5, paths),
+                CreateInvariantKit(10, 5, 6, paths)
+            });
+
+            // get snapshot
+            var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
+            _snapshotAccessor.PublishedSnapshot = snapshot;
+
+            var snapshotService = (PublishedSnapshotService)_snapshotService;
+            var contentStore = snapshotService.GetContentStore();
+            //This will set a flag to force creating a new Gen next time the store is locked (i.e. In Notify)
+            contentStore.CreateSnapshot();
+
+            // notify - which ensures there are 2 generations in the cache meaning each LinkedNode has a Next value.
+            _snapshotService.Notify(new[]
+            {
+                new ContentCacheRefresher.JsonPayload(4, Guid.Empty, TreeChangeTypes.RefreshBranch)
+            }, out _, out _);
+
+            // refresh the branch again, this used to show the issue where a null ref exception would occur
+            // because in the ClearBranchLocked logic, when SetValueLocked was called within a recursive call
+            // to a child, we null out the .Value of the LinkedNode within the while loop because we didn't capture
+            // this value before recursing.
+            Assert.DoesNotThrow(() =>
+                _snapshotService.Notify(new[]
+                {
+                    new ContentCacheRefresher.JsonPayload(4, Guid.Empty, TreeChangeTypes.RefreshBranch)
+                }, out _, out _));
+        }
+
+        [Test]
         public void NestedVariationChildrenTest()
         {
-            var mixedKits = GetNestedVariantKits();
-            Init(mixedKits);
+            Init(GetNestedVariantKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -789,7 +839,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void VariantChildrenTest()
         {
-            Init(GetVariantKits());
+            Init(GetVariantKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -861,7 +911,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void RemoveTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -910,7 +960,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void UpdateTest()
         {
-            Init(GetInvariantKits());
+            Init(GetInvariantKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -957,13 +1007,13 @@ namespace Umbraco.Tests.PublishedContent
             documents = snapshot.Content.GetById(2).Children().ToArray();
             AssertDocuments(documents, "N9", "N8", "N7");
 
-            
+
         }
 
         [Test]
         public void AtRootTest()
         {
-            Init(GetVariantWithDraftKits());
+            Init(GetVariantWithDraftKits);
 
             var snapshot = _snapshotService.CreatePublishedSnapshot(previewToken: null);
             _snapshotAccessor.PublishedSnapshot = snapshot;
@@ -992,7 +1042,7 @@ namespace Umbraco.Tests.PublishedContent
                 yield return CreateInvariantKit(2, 1, 1, paths);
             }
 
-            Init(GetKits());
+            Init(GetKits);
 
             var snapshotService = (PublishedSnapshotService)_snapshotService;
             var contentStore = snapshotService.GetContentStore();
@@ -1031,7 +1081,7 @@ namespace Umbraco.Tests.PublishedContent
                 yield return CreateInvariantKit(4, 1, 3, paths);
             }
 
-            Init(GetKits());
+            Init(GetKits);
 
             var snapshotService = (PublishedSnapshotService)_snapshotService;
             var contentStore = snapshotService.GetContentStore();
@@ -1111,7 +1161,7 @@ namespace Umbraco.Tests.PublishedContent
                 yield return CreateInvariantKit(40, 1, 3, paths);
             }
 
-            Init(GetKits());
+            Init(GetKits);
 
             var snapshotService = (PublishedSnapshotService)_snapshotService;
             var contentStore = snapshotService.GetContentStore();
@@ -1130,7 +1180,7 @@ namespace Umbraco.Tests.PublishedContent
 
             _snapshotService.Notify(new[]
             {
-                new ContentCacheRefresher.JsonPayload(1, Guid.Empty, TreeChangeTypes.RefreshNode) 
+                new ContentCacheRefresher.JsonPayload(1, Guid.Empty, TreeChangeTypes.RefreshNode)
             }, out _, out _);
 
             Assert.AreEqual(2, contentStore.Test.LiveGen);
@@ -1178,12 +1228,12 @@ namespace Umbraco.Tests.PublishedContent
 
                 //children of 1
                 yield return CreateInvariantKit(20, 1, 1, paths);
-                yield return CreateInvariantKit(30, 1, 2, paths); 
+                yield return CreateInvariantKit(30, 1, 2, paths);
                 yield return CreateInvariantKit(40, 1, 3, paths);
             }
 
             //init with all published
-            Init(GetKits());
+            Init(GetKits);
 
             var snapshotService = (PublishedSnapshotService)_snapshotService;
             var contentStore = snapshotService.GetContentStore();
@@ -1200,7 +1250,7 @@ namespace Umbraco.Tests.PublishedContent
                 //Change the root publish flag
                 var kit = rootKit.Clone();
                 kit.DraftData = published ? null : kit.PublishedData;
-                kit.PublishedData = published? kit.PublishedData : null;
+                kit.PublishedData = published ? kit.PublishedData : null;
                 _source.Kits[1] = kit;
 
                 _snapshotService.Notify(new[]
@@ -1215,12 +1265,12 @@ namespace Umbraco.Tests.PublishedContent
                 var (gen, contentNode) = contentStore.Test.GetValues(1)[0];
                 Assert.AreEqual(assertGen, gen);
                 //even when unpublishing/re-publishing/etc... the linked list is always maintained
-                AssertLinkedNode(contentNode, 100, 2, 3, 20, 40); 
+                AssertLinkedNode(contentNode, 100, 2, 3, 20, 40);
             }
 
             //unpublish the root
             ChangePublishFlagOfRoot(false, 2, TreeChangeTypes.RefreshBranch);
-            
+
             //publish the root (since it's not published, it will cause a RefreshBranch)
             ChangePublishFlagOfRoot(true, 3, TreeChangeTypes.RefreshBranch);
 
@@ -1253,7 +1303,7 @@ namespace Umbraco.Tests.PublishedContent
                 yield return CreateInvariantKit(4, 1, 3, paths);
             }
 
-            Init(GetKits());
+            Init(GetKits);
 
             var snapshotService = (PublishedSnapshotService)_snapshotService;
             var contentStore = snapshotService.GetContentStore();
@@ -1313,9 +1363,9 @@ namespace Umbraco.Tests.PublishedContent
         public void MultipleCacheIteration()
         {
             //see https://github.com/umbraco/Umbraco-CMS/issues/7798
-            this.Init(this.GetInvariantKits());
+            Init(GetInvariantKits);
             var snapshot = this._snapshotService.CreatePublishedSnapshot(previewToken: null);
-            this._snapshotAccessor.PublishedSnapshot = snapshot;
+            _snapshotAccessor.PublishedSnapshot = snapshot;
 
             var items = snapshot.Content.GetByXPath("/root/itype");
             Assert.AreEqual(items.Count(), items.Count());

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/subheader/umb-editor-sub-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/subheader/umb-editor-sub-header.less
@@ -5,7 +5,7 @@
    border-right: 5px solid @brownGrayLight;
    display: flex;
    justify-content: space-between;
-   margin: -10px -5px 10px;
+   margin: -10px -1px 10px;
    position: relative;
    top: 0;
    box-sizing: border-box;
@@ -34,6 +34,7 @@
     transition: box-shadow 240ms;
     position:sticky;
     z-index: 30;
+    width: calc(100% + 2px);
 
     &.umb-sticky-bar--active {
         box-shadow: 0 6px 3px -3px rgba(0,0,0,.16);

--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -141,9 +141,6 @@ namespace Umbraco.Web.Editors
 
             try
             {
-                //clear and replace
-                index.CreateIndex();
-
                 var cacheKey = "temp_indexing_op_" + index.Name;
                 //put temp val in cache which is used as a rudimentary way to know when the indexing is done
                 AppCaches.RuntimeCache.Insert(cacheKey, () => "tempValue", TimeSpan.FromMinutes(5));

--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -873,9 +873,11 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var id = content.FirstChildContentId;
             while (id > 0)
             {
+                // get the required link node, this ensures that both `link` and `link.Value` are not null
                 var link = GetRequiredLinkedNode(id, "child", null);
-                ClearBranchLocked(link.Value);
-                id = link.Value.NextSiblingContentId;
+                var linkValue = link.Value; // capture local since clearing in recurse can clear it
+                ClearBranchLocked(linkValue); // recurse
+                id = linkValue.NextSiblingContentId;
             }
         }
 


### PR DESCRIPTION
Fixes: SqlMainDomLock setting for Azure does not work in Load Balancing #8038

The reason this doesn't work in LB is because there is only a single 'key' for the database table `umbracoKeyValue` to use for this lock which means only a single server/app can be registered for this distributed lock. 

The purpose of MainDom is to synchronize access to certain resources between concurrent AppDomains. This means that the lock needs to be specific to one web application on one web server. This is exactly what the original MainDom did with it's system wide semaphore lock. This would work in load balancing (outside of azure) because implicitly a system-wide semaphore lock is machine specific. This Sql lock needs to take into account this same uniqueness.

So now it does, the key in the DB is a combination of the original MainDom's semaphore lock Id (which takes into account the web app's Id and physical path) and the current server's name.

The changes are minimal but should make sense.

For testing, use the SqlMainDomLock config:

```xml
<add
    key="Umbraco.Core.MainDom.Lock"
    value="SqlMainDomLock" />
```

when you run the site have a look at the data in the table `[umbracoKeyValue]` and you'll see an entry for: `Umbraco.Core.Runtime.SqlMainDom-****` which is the lock for your current machine/app. If you bump the web.config and refresh you'll notice the value for this row changes. Rows do not keep getting added to the table because the hash is always consistent. If you only have the front-end of your app open (not the back office since that polls), then bump the web.config, that will shut down the app and you'll see that row be removed. That is exactly how SqlMainDomLock works and that's what should be happening. When the app shutsdown (without restarting with new requests), the row will be removed, when a new request comes in it will be re-added. When the app restarts the value will be changed. (though that is all just testing the original SqlMainDomLock stuff which we know works, for this we just want to test that it's not creating more than one row per machine/app)


