### PR TITLE
Preventive check that will enable sections load for users with no dashboards

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs
@@ -322,8 +322,10 @@ namespace Umbraco.Web.Trees
 
                 var nodes = GetTreeNodesInternal(id, queryStrings);
 
-                //only render the recycle bin if we are not in dialog and the start id id still the root
-                if (IsDialog(queryStrings) == false && id == Constants.System.RootString)
+                //only render the recycle bin if we are not in dialog and the start id is still the root
+                //we need to check for the "application" key in the queryString because its value is required here,
+                //and for some reason when there are no dashboards, this parameter is missing  
+                if (IsDialog(queryStrings) == false && id == Constants.System.RootString && queryStrings.HasKey("application"))
                 {
                     nodes.Add(CreateTreeNode(
                         RecycleBinId.ToInvariantString(),


### PR DESCRIPTION
Fix for #7758 

Description about the problem and steps to reproduce/test can be found in #7758!

The error that a user with no dashboards was getting when logging in, was that we were trying to get a missing required value parameter (`application`) from the query string -> [code ref](https://github.com/umbraco/Umbraco-CMS/blob/d7469e6576fbe4bf4d23f9046399b3899c0ff58c/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs#L335). 

I suspect that passing `null` as the value of the `queryString` when `hasDashboards` is **false** (in `GetSections()` in the [SectionController.cs](https://github.com/umbraco/Umbraco-CMS/blob/d7469e6576fbe4bf4d23f9046399b3899c0ff58c/src/Umbraco.Web/Editors/SectionController.cs#L60)) might not be the right approach but just to be sure we now check if the `queryString` has the key `application` before we try to get its value.