### PR TITLE
UI: Corrected validation indication in variant-picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
@@ -68,8 +68,7 @@
             function onVariantValidation(valid, errors, allErrors, culture, segment) {
 
                 // only want to react to property errors:
-            if(errors.findIndex(error => {console.log("reject this", error, error.propertyAlias !== null); return error.propertyAlias !== null;}) === -1) {
-                    console.log("rejected", errors)
+            if(errors.findIndex(error => {return error.propertyAlias !== null;}) === -1) {
                     // we dont have any errors for properties, meaning we will back out.
                     return;
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/servervalidationmgr.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/servervalidationmgr.service.js
@@ -356,7 +356,7 @@ function serverValidationManager($timeout) {
             var cbs = this.getFieldCallbacks(fieldName);
             //call each callback for this error
             for (var cb in cbs) {
-                executeCallback(this, errorsForCallback, cbs[cb].callback, null);
+                executeCallback(this, errorsForCallback, cbs[cb].callback, null, null);
             }
         },
 
@@ -456,7 +456,10 @@ function serverValidationManager($timeout) {
                 callbacks[cb].callback.apply(this, [
                         true,       //pass in a value indicating it is VALID
                         [],         //pass in empty collection
-                        []]);       //pass in empty collection
+                        [],
+                        null,
+                        null]
+                    );
             }
         },
         

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -53,7 +53,7 @@
                         <umb-dropdown-item
                             ng-repeat-start="entry in vm.variantMenu track by entry.key"
                             class="umb-variant-switcher__item"
-                            ng-class="{'--current': entry.variant === editor.content, '--active': entry.variant.active && vm.dropdownOpen, '--error': variantHasError(entry.variant), '--state-notCreated':entry.variant.state==='NotCreated' && entry.variant.name == null, '--state-draft':entry.variant.state==='Draft' || (entry.variant.state==='NotCreated' && entry.variant.name != null)}"
+                            ng-class="{'--current': entry.variant === editor.content, '--active': entry.variant.active && vm.dropdownOpen, '--error': entry.variant.active !== true && entry.variant.hasError, '--state-notCreated':entry.variant.state==='NotCreated' && entry.variant.name == null, '--state-draft':entry.variant.state==='Draft' || (entry.variant.state==='NotCreated' && entry.variant.name != null)}"
                         >
                             <button type="button" ng-if="entry.subVariants && entry.subVariants.length > 0" class="umb-variant-switcher__item-expand-button umb-outline" ng-click="entry.open = !entry.open">
                                 <i class="icon icon-navigation-down" ng-if="entry.open"></i>
@@ -73,7 +73,7 @@
                             <umb-dropdown-item
                                 ng-repeat="subVariant in entry.subVariants track by $index"
                                 class="umb-variant-switcher__item"
-                                ng-class="{'--current': subVariant === editor.content, '--active': subVariant.active && vm.dropdownOpen, '--error': variantHasError(subVariant), '--state-notCreated':subVariant.state==='NotCreated', '--state-draft':subVariant.state==='Draft'}"
+                                ng-class="{'--current': subVariant === editor.content, '--active': subVariant.active && vm.dropdownOpen, '--error': subVariant.active !== true && subVariant.hasError, '--state-notCreated':subVariant.state==='NotCreated', '--state-draft':subVariant.state==='Draft'}"
                             >
                                 <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, subVariant)" prevent-default>
                                     <span class="umb-variant-switcher__name" ng-bind="subVariant.segment"></span>


### PR DESCRIPTION
This PR makes sure that validation indication in variant-picker only stays as long as an error is present. Plus avoid displaying field-errors, we only want to use property errors for this indication.

This PR is an addition to the work for Segments, the reason for this PR to target this is that Segments will soon be merged and include a ton of changes to variant-picker. This way we minimize merge errors.

fixes https://github.com/umbraco/Umbraco-CMS/issues/7964

---
_This item has been added to our backlog [AB#6512](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/6512)_