### PR TITLE
Added support for segments to File Uploads

### DIFF
--- a/src/Umbraco.Core/Models/Editors/ContentPropertyFile.cs
+++ b/src/Umbraco.Core/Models/Editors/ContentPropertyFile.cs
@@ -17,6 +17,11 @@
         public string Culture { get; set; }
 
         /// <summary>
+        /// When dealing with content variants, this is the segment for the variant
+        /// </summary>
+        public string Segment { get; set; }
+
+        /// <summary>
         /// An array of metadata that is parsed out from the file info posted to the server which is set on the client. 
         /// </summary>
         /// <remarks>

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
@@ -26,6 +26,7 @@
             fileManager.setFiles({
                 propertyAlias: vm.propertyAlias,
                 culture: vm.culture,
+                segment: vm.segment,
                 files: []
             });
             //clear the current files
@@ -92,6 +93,11 @@
                 vm.culture = null;
             }
 
+            //normalize segment to null if it's not there
+            if (!vm.segment) {
+                vm.segment = null;
+            }
+
             // TODO: need to figure out what we can do for things like Nested Content
 
             var existingClientFiles = checkPendingClientFiles();
@@ -134,11 +140,16 @@
                 vm.culture = null;
             }
 
+            //normalize segment to null if it's not there
+            if (!vm.segment) {
+                vm.segment = null;
+            }
+
             //check the file manager to see if there's already local files pending for this editor
             var existingClientFiles = _.map(
                 _.filter(fileManager.getFiles(),
                     function (f) {
-                        return f.alias === vm.propertyAlias && f.culture === vm.culture;
+                        return f.alias === vm.propertyAlias && f.culture === vm.culture && f.segment === vm.segment;
                     }),
                 function (f) {
                     return f.file;
@@ -264,7 +275,8 @@
                 fileManager.setFiles({
                     propertyAlias: vm.propertyAlias,
                     files: args.files,
-                    culture: vm.culture
+                    culture: vm.culture,
+                    segment: vm.segment
                 });
 
                 updateModelFromSelectedFiles(args.files).then(function(newVal) {
@@ -287,6 +299,7 @@
         templateUrl: 'views/components/upload/umb-property-file-upload.html',
         bindings: {
             culture: "@?",
+            segment: "@?",
             propertyAlias: "@",
             value: "<",
             hideSelection: "<",

--- a/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/filemanager.service.js
@@ -39,18 +39,22 @@ function fileManager($rootScope) {
                 args.culture = null;
             }
 
+            if (!args.segment) {
+                args.segment = null;
+            }
+
             var metaData = [];
             if (Utilities.isArray(args.metaData)) {
                 metaData = args.metaData;
             }
 
-            //this will clear the files for the current property/culture and then add the new ones for the current property
+            //this will clear the files for the current property/culture/segment and then add the new ones for the current property
             fileCollection = _.reject(fileCollection, function (item) {
-                return item.alias === args.propertyAlias && (!args.culture || args.culture === item.culture);
+                return item.alias === args.propertyAlias && (!args.culture || args.culture === item.culture) && (!args.segment || args.segment === item.segment);
             });
             for (var i = 0; i < args.files.length; i++) {
                 //save the file object to the files collection
-                fileCollection.push({ alias: args.propertyAlias, file: args.files[i], culture: args.culture, metaData: metaData });
+                fileCollection.push({ alias: args.propertyAlias, file: args.files[i], culture: args.culture, segment: args.segment, metaData: metaData });
             }
         },
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -252,12 +252,13 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                     for (var f in args.files) {
                         //each item has a property alias and the file object, we'll ensure that the alias is suffixed to the key
                         // so we know which property it belongs to on the server side
-                        var fileKey = "file_" + args.files[f].alias + "_" + (args.files[f].culture ? args.files[f].culture : "");
+                        var file = args.files[f];
+                        var fileKey = "file_" + file.alias + "_" + (file.culture ? file.culture : "") + "_" + (file.segment ? file.segment : "");
 
-                        if (Utilities.isArray(args.files[f].metaData) && args.files[f].metaData.length > 0) {
-                            fileKey += ("_" + args.files[f].metaData.join("_"));
+                        if (Utilities.isArray(file.metaData) && file.metaData.length > 0) {
+                            fileKey += ("_" + file.metaData.join("_"));
                         }
-                        formData.append(fileKey, args.files[f].file);
+                        formData.append(fileKey, file.file);
                     }
                 }).then(function (response) {
                     //success callback

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -34,6 +34,7 @@
             fileManager.setFiles({
                 propertyAlias: $scope.model.alias,
                 culture: $scope.model.culture,
+                segment: $scope.model.segment,
                 files: []
             });
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -1,5 +1,6 @@
 ﻿<div ng-controller="Umbraco.PropertyEditors.FileUploadController">
     <umb-property-file-upload culture="{{model.culture}}"
+                              segment="{{model.segment}}"
                               property-alias="{{model.alias}}"
                               value="model.value"
                               required="model.validation.mandatory"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -55,6 +55,7 @@ angular.module('umbraco')
                 fileManager.setFiles({
                     propertyAlias: $scope.model.alias,
                     culture: $scope.model.culture,
+                    segment: $scope.model.segment,
                     files: []
                 });
             }
@@ -189,6 +190,7 @@ angular.module('umbraco')
                 fileManager.setFiles({
                     propertyAlias: $scope.model.alias,
                     culture: $scope.model.culture,
+                    segment: $scope.model.segment,
                     files: []
                 });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -3,6 +3,7 @@
 
     <ng-form name="imageCropperForm">
         <umb-property-file-upload culture="{{model.culture}}"
+                                  segment="{{model.segment}}"
                                   property-alias="{{model.alias}}"
                                   value="model.value.src"
                                   required="model.validation.mandatory"

--- a/src/Umbraco.Web/Editors/Binders/ContentModelBinderHelper.cs
+++ b/src/Umbraco.Web/Editors/Binders/ContentModelBinderHelper.cs
@@ -50,7 +50,19 @@ namespace Umbraco.Web.Editors.Binders
                     }
                 }
 
-                // TODO: anything after 3 parts we can put in metadata
+                //if there are 4 parts part 4 is always segment
+                string segment = null;
+                if (parts.Length > 3)
+                {
+                    segment = parts[3];
+                    //normalize to null if empty
+                    if (segment.IsNullOrWhiteSpace())
+                    {
+                        segment = null;
+                    }
+                }
+
+                // TODO: anything after 4 parts we can put in metadata
 
                 var fileName = file.Headers.ContentDisposition.FileName.Trim('\"');
 
@@ -59,6 +71,7 @@ namespace Umbraco.Web.Editors.Binders
                     TempFilePath = file.LocalFileName,
                     PropertyAlias = propAlias,
                     Culture = culture,
+                    Segment = segment,
                     FileName = fileName
                 });
             }

--- a/src/Umbraco.Web/Editors/ContentControllerBase.cs
+++ b/src/Umbraco.Web/Editors/ContentControllerBase.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Web.Editors
 
                 // prepare files, if any matching property and culture
                 var files = contentItem.UploadedFiles
-                    .Where(x => x.PropertyAlias == propertyDto.Alias && x.Culture == propertyDto.Culture)
+                    .Where(x => x.PropertyAlias == propertyDto.Alias && x.Culture == propertyDto.Culture && x.Segment == propertyDto.Segment)
                     .ToArray();
 
                 foreach (var file in files)


### PR DESCRIPTION
As per @nielslyngsoe's [comment](https://github.com/umbraco/Umbraco-CMS/pull/8065#issuecomment-624531758) I'm targeting this to `v8/dev`. 

This adds a "segment" parameter to posted file data, so you can post files for multiple variants (segmented / non segmented) at the same time. I did not completely test all upload related editors yet, but I tested with "File Upload" and "ImageCropper" and it looked good.

As an aside, it seems there is a bug in Umbraco stable when uploading the same file for the same property of different cultures that leads to only 1 file being generated on disk.  The filename of a media file seems determined only based on the content id + property id + sanitized filename, so if I upload `some-image.jpg` for the `image` property of a doctype for cultures `nl-NL` and `en-US` there will only be 1 file total. Which means if I delete it for `nl-NL` it will also be gone for `en-US` and gives a 404 in Umbraco... 

At least that's something I saw when testing this, and I'm pretty sure this was due to code already shipped in a public release. `UniqueMediaPathScheme.GetFilePath`. I can look into that later, I have not filed a bug report for that because I haven't checked this in a released version yet.

---
_This item has been added to our backlog [AB#6523](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/6523)_