### PR TITLE
Adjust property settings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -509,7 +509,7 @@ input.umb-group-builder__group-sort-value {
             width: 60px;
             height: 60px;
             text-align: center;
-            line-height: 60px;
+            line-height: 58px;
             border-radius: 5px;
             float: left;
             margin-right: 20px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -511,7 +511,11 @@ input.umb-group-builder__group-sort-value {
             line-height: 58px;
             border-radius: 5px;
             float: left;
-            margin-right: 20px;
+            margin-right: 5px;
+
+            &:hover, &:focus {
+                border-color: @gray-6;
+            }
 
             .icon {
                 font-size: 26px;
@@ -520,7 +524,7 @@ input.umb-group-builder__group-sort-value {
 
         .editor-details {
             float: left;
-            margin-top: 10px;
+            margin-top: 0;
 
             .editor-name {
                 display: block;
@@ -536,6 +540,7 @@ input.umb-group-builder__group-sort-value {
         .editor-settings-icon {
             font-size: 18px;
             margin-top: 8px;
+            margin-left: 5px;
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -486,7 +486,6 @@ input.umb-group-builder__group-sort-value {
         border: 1px dashed @ui-action-border;
         width: 100%;
         height: 80px;
-        line-height: 80px;
         text-align: center;
         display: block;
         border-radius: 5px;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -103,8 +103,7 @@
                                    placeholder="@validation_mandatoryMessage"
                                    ng-model="model.property.validation.mandatoryMessage"
                                    ng-if="model.property.validation.mandatory"
-                                   ng-keypress="vm.submitOnEnter($event)">
-                            </input>
+                                   ng-keypress="vm.submitOnEnter($event)" />
 
                             <label class="mt3">
                                 <localize key="validation_customValidation"></localize>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -49,7 +49,7 @@
                                     placeholder="@placeholders_enterDescription"
                                     ng-keypress="vm.submitOnEnter($event)"
                                     umb-auto-resize>
-                        </textarea>
+                            </textarea>
                         </div>
                     
                         <div class="editor-wrapper umb-control-group control-group" ng-model="model.property.editor" val-require-component ng-if="!model.property.locked">
@@ -139,8 +139,7 @@
                              
                                     <umb-toggle data-element="permissions-allow-culture-variant"
                                                 checked="model.property.allowCultureVariant"
-                                                on-click="vm.toggleAllowCultureVariants()"
-                                    >
+                                                on-click="vm.toggleAllowCultureVariants()">
                                     </umb-toggle>
 
                         </div>
@@ -177,8 +176,7 @@
                             <umb-toggle ng-if="vm.showSensitiveData" data-element="settings_is_sensitive_data"
                                         checked="model.property.isSensitiveData"
                                         on-click="vm.toggleIsSensitiveData()">
-                            </umb-toggle>
-                                                      
+                            </umb-toggle>            
 
                         </div>
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -54,24 +54,26 @@
                     
                         <div class="editor-wrapper umb-control-group control-group" ng-model="model.property.editor" val-require-component ng-if="!model.property.locked">
                     
-                            <button type="button" data-element="editor-add" ng-if="!model.property.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openDataTypePicker(model.property)">
+                            <button type="button" class="btn btn-link editor-placeholder" data-element="editor-add" ng-if="!model.property.editor" hotkey="alt+shift+e" ng-click="vm.openDataTypePicker(model.property)">
                                 <localize key="shortcuts_addEditor"></localize>
                             </button>
                     
-                            <div class="editor clearfix" ng-if="model.property.editor">
+                            <div class="editor flex clearfix" ng-if="model.property.editor">
                     
-                                <button type="button" class="editor-icon-wrapper" ng-click="vm.openDataTypePicker(model.property)">
+                                <button type="button" class="flex-none editor-icon-wrapper" ng-click="vm.openDataTypePicker(model.property)">
                                     <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}" aria-hidden="true"></i>
                                 </button>
                     
-                                <div class="editor-details">
-                                    <button type="button" ng-click="vm.openDataTypePicker(model.property)">
-                                        <span class="editor-name">{{ model.property.dataTypeName }}</span>
-                                        <span class="editor-editor">{{ model.property.editor }}</span>
+                                <div class="editor-details flex-auto">
+                                    <button type="button" class="btn btn-link" ng-click="vm.openDataTypePicker(model.property)">
+                                        <span class="flex flex-column">
+                                            <span class="editor-name">{{ model.property.dataTypeName }}</span>
+                                            <span class="editor-editor">{{ model.property.editor }}</span>
+                                        </span>
                                     </button>
                                 </div>
                     
-                                <button type="button" class="editor-settings-icon pull-right"
+                                <button type="button" class="btn btn-link editor-settings-icon pull-right"
                                         ng-click="vm.openDataTypeSettings(model.property)"
                                         hotkey="alt+shift+d"
                                         ng-if="model.property.editor">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -60,20 +60,20 @@
                     
                             <div class="editor flex clearfix" ng-if="model.property.editor">
                     
-                                <button type="button" class="flex-none editor-icon-wrapper" ng-click="vm.openDataTypePicker(model.property)">
+                                <button type="button" class="btn-reset flex-none editor-icon-wrapper" ng-click="vm.openDataTypePicker(model.property)">
                                     <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}" aria-hidden="true"></i>
                                 </button>
                     
                                 <div class="editor-details flex-auto">
                                     <button type="button" class="btn btn-link" ng-click="vm.openDataTypePicker(model.property)">
-                                        <span class="flex flex-column">
+                                        <span class="flex flex-column text-left">
                                             <span class="editor-name">{{ model.property.dataTypeName }}</span>
                                             <span class="editor-editor">{{ model.property.editor }}</span>
                                         </span>
                                     </button>
                                 </div>
                     
-                                <button type="button" class="btn btn-link editor-settings-icon pull-right"
+                                <button type="button" class="btn-reset editor-settings-icon self-start"
                                         ng-click="vm.openDataTypeSettings(model.property)"
                                         hotkey="alt+shift+d"
                                         ng-if="model.property.editor">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -54,27 +54,29 @@
                     
                         <div class="editor-wrapper umb-control-group control-group" ng-model="model.property.editor" val-require-component ng-if="!model.property.locked">
                     
-                            <a data-element="editor-add" href="" ng-if="!model.property.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openDataTypePicker(model.property)">
+                            <button type="button" data-element="editor-add" ng-if="!model.property.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openDataTypePicker(model.property)">
                                 <localize key="shortcuts_addEditor"></localize>
-                            </a>
+                            </button>
                     
                             <div class="editor clearfix" ng-if="model.property.editor">
                     
-                                <a href="" class="editor-icon-wrapper" ng-click="vm.openDataTypePicker(model.property)">
-                                    <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}"></i>
-                                </a>
+                                <button type="button" class="editor-icon-wrapper" ng-click="vm.openDataTypePicker(model.property)">
+                                    <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}" aria-hidden="true"></i>
+                                </button>
                     
                                 <div class="editor-details">
-                                    <a href="" class="editor-name" ng-click="vm.openDataTypePicker(model.property)">{{ model.property.dataTypeName }}</a>
-                                    <a href="" class="editor-editor" ng-click="vm.openDataTypePicker(model.property)">{{ model.property.editor }}</a>
+                                    <button type="button" ng-click="vm.openDataTypePicker(model.property)">
+                                        <span class="editor-name">{{ model.property.dataTypeName }}</span>
+                                        <span class="editor-editor">{{ model.property.editor }}</span>
+                                    </button>
                                 </div>
                     
-                                <a href class="editor-settings-icon pull-right"
-                                ng-click="vm.openDataTypeSettings(model.property)"
-                                hotkey="alt+shift+d"
-                                ng-if="model.property.editor">
-                                    <i class="icon icon-settings"></i>
-                                </a>
+                                <button type="button" class="editor-settings-icon pull-right"
+                                        ng-click="vm.openDataTypeSettings(model.property)"
+                                        hotkey="alt+shift+d"
+                                        ng-if="model.property.editor">
+                                    <i class="icon icon-settings" aria-hidden="true"></i>
+                                </button>
                     
                             </div>
                     

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -55,7 +55,7 @@
 
                     <ng-form name="groupNameForm" data-element="group-name">
                         <div class="umb-group-builder__group-title control-group -no-margin" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited}">
-                            <i class="umb-group-builder__group-title-icon icon-navigation" ng-if="sortingMode && !tab.inherited"></i>
+                            <i class="umb-group-builder__group-title-icon icon-navigation" aria-hidden="true" ng-if="sortingMode && !tab.inherited"></i>
                             <input data-element="group-name-field"
                                    class="umb-group-builder__group-title-input"
                                    type="text"
@@ -80,7 +80,7 @@
                     </ng-form>
 
                     <div class="umb-group-builder__group-inherited-label" ng-if="tab.inherited">
-                        <i class="icon icon-merge"></i>
+                        <i class="icon icon-merge" aria-hidden="true"></i>
                         <localize key="contentTypeEditor_inheritedFrom"></localize>: {{ tab.inheritedFromName }}
                         <span ng-repeat="contentTypeName in tab.parentTabContentTypeNames">
                             <button type="button" class="btn-link btn-small p0" ng-click="openDocumentType(tab.parentTabContentTypes[$index])">{{ contentTypeName }}</button>
@@ -101,7 +101,7 @@
                     </ng-form>
 
                     <div class="umb-group-builder__group-remove" ng-if="!sortingMode && canRemoveGroup(tab)">
-                        <i class="icon-trash" ng-click="togglePrompt(tab)"></i>
+                        <i class="icon-trash" aria-hidden="true" ng-click="togglePrompt(tab)"></i>
                         <umb-confirm-action
                             ng-if="tab.deletePrompt"
                             direction="left"
@@ -175,7 +175,7 @@
                                 </ng-form>
 
                                 <div ng-if="sortingMode" class="flex items-center">
-                                    <i class="icon icon-navigation" ng-if="!property.inherited" style="margin-right: 10px;"></i>
+                                    <i class="icon icon-navigation" aria-hidden="true" ng-if="!property.inherited" style="margin-right: 10px;"></i>
                                     <span class="umb-group-builder__property-meta-label">{{ property.label }}</span>
                                     <span class="umb-group-builder__property-meta-alias" style="margin-bottom: 0; margin-left: 5px; margin-top: 1px;">({{ property.alias }})</span>
                                     <input name="propertySortOrder" type="number" class="umb-group-builder__group-sort-value umb-property-editor-tiny" ng-model="property.sortOrder" ng-disabled="property.inherited" />
@@ -223,13 +223,13 @@
                                 <div class="umb-group-builder__property-tags -right">
 
                                     <div class="umb-group-builder__property-tag" ng-if="property.inherited">
-                                        <i class="icon icon-merge"></i>
+                                        <i class="icon icon-merge" aria-hidden="true"></i>
                                         <span style="margin-right: 3px"><localize key="contentTypeEditor_inheritedFrom"></localize></span>
                                         {{property.contentTypeName}}
                                     </div>
 
                                     <div class="umb-group-builder__property-tag" ng-if="property.locked">
-                                        <i class="icon icon-lock"></i>
+                                        <i class="icon icon-lock" aria-hidden="true"></i>
                                         <localize key="general_locked"></localize>
                                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -44,9 +44,9 @@
         <li ng-repeat="tab in model.groups" ng-class="{'umb-group-builder__group-sortable': sortingMode}" data-element="group-{{tab.name}}">
 
             <!-- TAB INIT STATE -->
-            <a href="" class="umb-group-builder__group -placeholder" hotkey="alt+shift+g" ng-click="addGroup(tab)" ng-if="tab.tabState=='init' && !sortingMode" data-element="group-add">
+            <button type="button" class="umb-group-builder__group -placeholder" hotkey="alt+shift+g" ng-click="addGroup(tab)" ng-if="tab.tabState=='init' && !sortingMode" data-element="group-add">
                 <localize key="contentTypeEditor_addGroup"></localize>
-            </a>
+            </button>
 
             <!-- TAB ACTIVE OR INACTIVE STATE -->
             <div class="umb-group-builder__group" ng-if="tab.tabState !== 'init'" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited, 'umb-group-builder__group-handle -sortable': sortingMode && !tab.inherited}" tabindex="0" ng-focus="activateGroup(tab)">
@@ -182,7 +182,6 @@
                                 </div>
 
                             </div>
-
 
                             <div tabindex="-1" class="umb-group-builder__property-preview" ng-if="!sortingMode" ng-class="{'-not-clickable': !sortingMode && (property.inherited || property.locked)}">
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -194,27 +194,27 @@
                                     </span>
 
                                     <div class="umb-group-builder__property-tag -white" ng-if="property.validation.mandatory">
-                                        <i class="umb-group-builder__property-tag-icon">*</i>
+                                        <i class="umb-group-builder__property-tag-icon" aria-hidden="true">*</i>
                                         <localize key="general_mandatory"></localize>
                                     </div>
 
                                     <div class="umb-group-builder__property-tag -white" ng-if="property.showOnMemberProfile">
-                                        <i class="icon-eye umb-group-builder__property-tag-icon"></i>
+                                        <i class="icon-eye umb-group-builder__property-tag-icon" aria-hidden="true"></i>
                                         <localize key="contentTypeEditor_showOnMemberProfile"></localize>
                                     </div>
 
                                     <div class="umb-group-builder__property-tag -white" ng-if="property.memberCanEdit">
-                                        <i class="icon-edit umb-group-builder__property-tag-icon"></i>
+                                        <i class="icon-edit umb-group-builder__property-tag-icon" aria-hidden="true"></i>
                                         <localize key="contentTypeEditor_memberCanEdit"></localize>
                                     </div>
 
                                     <div class="umb-group-builder__property-tag -white" ng-if="property.isSensitiveData">
-                                        <i class="icon-lock umb-group-builder__property-tag-icon"></i>
+                                        <i class="icon-lock umb-group-builder__property-tag-icon" aria-hidden="true"></i>
                                         <localize key="contentTypeEditor_isSensitiveData"></localize>
                                     </div>
 
                                     <div class="umb-group-builder__property-tag -white" ng-if="property.allowCultureVariant">
-                                        <i class="icon-shuffle umb-group-builder__property-tag-icon"></i>
+                                        <i class="icon-shuffle umb-group-builder__property-tag-icon" aria-hidden="true"></i>
                                         <localize key="contentTypeEditor_variantsHeading"></localize>
                                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -44,9 +44,13 @@
         <li ng-repeat="tab in model.groups" ng-class="{'umb-group-builder__group-sortable': sortingMode}" data-element="group-{{tab.name}}">
 
             <!-- TAB INIT STATE -->
-            <button type="button" class="umb-group-builder__group -placeholder" hotkey="alt+shift+g" ng-click="addGroup(tab)" ng-if="tab.tabState=='init' && !sortingMode" data-element="group-add">
+            <a href="" class="umb-group-builder__group -placeholder"
+                ng-if="tab.tabState=='init' && !sortingMode"
+                data-element="group-add"
+                hotkey="alt+shift+g"
+                ng-click="addGroup(tab)">
                 <localize key="contentTypeEditor_addGroup"></localize>
-            </button>
+            </a>
 
             <!-- TAB ACTIVE OR INACTIVE STATE -->
             <div class="umb-group-builder__group" ng-if="tab.tabState !== 'init'" ng-class="{'-active':tab.tabState=='active', '-inherited': tab.inherited, 'umb-group-builder__group-handle -sortable': sortingMode && !tab.inherited}" tabindex="0" ng-focus="activateGroup(tab)">
@@ -117,15 +121,14 @@
                     <li data-element="property-{{property.alias}}" ng-class="{'umb-group-builder__property-sortable': sortingMode && !property.inherited}" ng-repeat="property in tab.properties">
 
                         <!-- Add new property -->
-                        <button type="button"
-                            data-element="property-add"
-                            class="umb-group-builder__group-add-property"
+                        <a href="" class="umb-group-builder__group-add-property"
                             ng-if="property.propertyState=='init' && !sortingMode"
+                            data-element="property-add"
                             ng-click="addProperty(property, tab)"
                             ng-focus="activateGroup(tab)"
                             focus-when="{{property.focus}}">
                             <localize key="contentTypeEditor_addProperty"></localize>
-                        </button>
+                        </a>
 
                         <div class="umb-group-builder__property" ng-if="property.propertyState!=='init'" ng-class="{'-active': property.dialogIsOpen, '-active': property.propertyState=='active', '-inherited': property.inherited, '-locked': property.locked, 'umb-group-builder__property-handle -sortable': sortingMode && !property.inherited, '-sortable-locked': sortingMode && property.inherited}">
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -117,7 +117,7 @@
                     <li data-element="property-{{property.alias}}" ng-class="{'umb-group-builder__property-sortable': sortingMode && !property.inherited}" ng-repeat="property in tab.properties">
 
                         <!-- Add new property -->
-                        <a href=""
+                        <button type="button"
                             data-element="property-add"
                             class="umb-group-builder__group-add-property"
                             ng-if="property.propertyState=='init' && !sortingMode"
@@ -125,7 +125,7 @@
                             ng-focus="activateGroup(tab)"
                             focus-when="{{property.focus}}">
                             <localize key="contentTypeEditor_addProperty"></localize>
-                        </a>
+                        </button>
 
                         <div class="umb-group-builder__property" ng-if="property.propertyState!=='init'" ng-class="{'-active': property.dialogIsOpen, '-active': property.propertyState=='active', '-inherited': property.inherited, '-locked': property.locked, 'umb-group-builder__property-handle -sortable': sortingMode && !property.inherited, '-sortable-locked': sortingMode && property.inherited}">
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -101,7 +101,7 @@
                     </ng-form>
 
                     <div class="umb-group-builder__group-remove" ng-if="!sortingMode && canRemoveGroup(tab)">
-                        <i class="icon-trash" aria-hidden="true" ng-click="togglePrompt(tab)"></i>
+                        <button type="button" class="umb-control-tool-icon icon-trash btn-reset" ng-click="togglePrompt(tab)"></button>
                         <umb-confirm-action
                             ng-if="tab.deletePrompt"
                             direction="left"

--- a/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
@@ -41,19 +41,19 @@
                             </div>
                         </div>
 
-                        <a data-element="editor-add" href="" ng-if="!model.parameter.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                        <button type="button" data-element="editor-add" ng-if="!model.parameter.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
                             <localize key="shortcuts_addEditor"></localize>
-                        </a>
+                        </button>
 
                         <div class="editor clearfix" ng-if="model.parameter.editor">
 
-                            <a href="" class="editor-icon-wrapper" ng-click="vm.openMacroParameterPicker(model.parameter)">
-                                <i class="icon {{model.parameter.dataTypeIcon}}" ng-class="{'icon-autofill': model.parameter.dataTypeIcon == null}"></i>
-                            </a>
+                            <button type="button" class="editor-icon-wrapper" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                                <i class="icon {{model.parameter.dataTypeIcon}}" ng-class="{'icon-autofill': model.parameter.dataTypeIcon == null}" aria-hidden="true"></i>
+                            </button>
 
                             <div class="editor-details">
-                                <a href="" class="editor-name" ng-click="vm.openMacroParameterPicker(model.parameter)">{{model.parameter.dataTypeName}}</a>
-                                <a href="" class="editor-editor" ng-click="vm.openMacroParameterPicker(model.parameter)">{{model.parameter.editor}}</a>
+                                <button type="button" class="editor-name" ng-click="vm.openMacroParameterPicker(model.parameter)">{{model.parameter.dataTypeName}}</button>
+                                <button type="button" class="editor-editor" ng-click="vm.openMacroParameterPicker(model.parameter)">{{model.parameter.editor}}</button>
                             </div>
 
                         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
@@ -45,15 +45,15 @@
                             <localize key="shortcuts_addEditor"></localize>
                         </button>
 
-                        <div class="editor clearfix" ng-if="model.parameter.editor">
+                        <div class="editor flex clearfix" ng-if="model.parameter.editor">
 
-                            <button type="button" class="btn btn-link editor-icon-wrapper" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                            <button type="button" class="btn-reset flex-none editor-icon-wrapper" ng-click="vm.openMacroParameterPicker(model.parameter)">
                                 <i class="icon {{model.parameter.dataTypeIcon}}" ng-class="{'icon-autofill': model.parameter.dataTypeIcon == null}" aria-hidden="true"></i>
                             </button>
 
-                            <div class="editor-details">
+                            <div class="editor-details flex-auto">
                                 <button type="button" class="btn btn-link" ng-click="vm.openMacroParameterPicker(model.parameter)">
-                                    <span class="flex flex-column">
+                                    <span class="flex flex-column text-left">
                                         <span class="editor-name">{{ model.parameter.dataTypeName }}</span>
                                         <span class="editor-editor">{{ model.parameter.editor }}</span>
                                     </span>

--- a/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
@@ -41,19 +41,23 @@
                             </div>
                         </div>
 
-                        <button type="button" data-element="editor-add" ng-if="!model.parameter.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                        <button type="button" class="btn btn-link editor-placeholder" data-element="editor-add" ng-if="!model.parameter.editor" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
                             <localize key="shortcuts_addEditor"></localize>
                         </button>
 
                         <div class="editor clearfix" ng-if="model.parameter.editor">
 
-                            <button type="button" class="editor-icon-wrapper" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                            <button type="button" class="btn btn-link editor-icon-wrapper" ng-click="vm.openMacroParameterPicker(model.parameter)">
                                 <i class="icon {{model.parameter.dataTypeIcon}}" ng-class="{'icon-autofill': model.parameter.dataTypeIcon == null}" aria-hidden="true"></i>
                             </button>
 
                             <div class="editor-details">
-                                <button type="button" class="editor-name" ng-click="vm.openMacroParameterPicker(model.parameter)">{{model.parameter.dataTypeName}}</button>
-                                <button type="button" class="editor-editor" ng-click="vm.openMacroParameterPicker(model.parameter)">{{model.parameter.editor}}</button>
+                                <button type="button" class="btn btn-link" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                                    <span class="flex flex-column">
+                                        <span class="editor-name">{{ model.parameter.dataTypeName }}</span>
+                                        <span class="editor-editor">{{ model.parameter.editor }}</span>
+                                    </span>
+                                </button>
                             </div>
 
                         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -95,7 +95,7 @@
                                    </div>
 
                                     <div class="cell-tools-remove row-tool">
-                                        <button class="icon-trash btn-reset" ng-click="togglePrompt(row)" type="button"></button>
+                                        <button type="button" class="umb-control-tool-icon icon-trash btn-reset" ng-click="togglePrompt(row)"></button>
                                         <umb-confirm-action
                                             ng-if="row.deletePrompt"
                                             direction="left"
@@ -200,7 +200,7 @@
                                                                           </div>
 
                                                                           <div class="umb-control-tool">
-                                                                              <button class="umb-control-tool-icon icon-trash btn-reset" ng-click="togglePrompt(control)" type="button"></button>
+                                                                              <button type="button" class="umb-control-tool-icon icon-trash btn-reset" ng-click="togglePrompt(control)"></button>
                                                                               <umb-confirm-action ng-if="control.deletePrompt"
                                                                                                   direction="left"
                                                                                                   on-confirm="removeControl(area, $index)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This adjust property settings for datatypes and macro parameter settings to use `<button>` elements instead and furthermore ensure the settings icon on datatype property editor always is in top-right corner, when name is a longer value.

**Before**

![2020-05-06_22-34-37](https://user-images.githubusercontent.com/2919859/81225713-f80d6200-8fe9-11ea-9a14-e87f1e952284.gif)

**After**

![2020-05-06_22-29-16](https://user-images.githubusercontent.com/2919859/81225251-335b6100-8fe9-11ea-85bb-f090593f1ade.gif)
