### PR TITLE
Add id attribute so click on property label focus in input

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
@@ -7,6 +7,7 @@
                ng-model="model.value"
                ng-required="model.validation.mandatory"
                aria-required="{{model.validation.mandatory}}"
+               id="{{model.alias}}"
                val-server="value"
                fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8077

### Description
This PR add the `id` attribute as on most other property editors, so clicking property label set focus in the input field.

![2020-05-08_10-59-11](https://user-images.githubusercontent.com/2919859/81390182-4c642f00-911b-11ea-8788-b198c4516b6a.gif)
