### PR TITLE
Adding ng-trim="false" attribute to textarea property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.PropertyEditors.textAreaController">
     <ng-form name="textareaFieldForm">
-        <textarea ng-model="model.value" id="{{model.alias}}" name="textarea" rows="{{model.config.rows || 10}}" class="umb-property-editor umb-textarea textstring" val-server="value" ng-keyup="model.change()" ng-required="model.validation.mandatory" aria-required="{{model.validation.mandatory}}"></textarea>
+        <textarea ng-model="model.value" id="{{model.alias}}" name="textarea" rows="{{model.config.rows || 10}}" class="umb-property-editor umb-textarea textstring" val-server="value" ng-keyup="model.change()" ng-trim="false" ng-required="model.validation.mandatory" aria-required="{{model.validation.mandatory}}"></textarea>
 
         <span ng-messages="textareaFieldForm.textarea.$error" show-validation-on-submit >
             <span class="help-inline" ng-message="required">{{mandatoryMessage}}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR addresses issue #8082 

### Description
Adds an `ng-trim="false"` attribute to the textarea property editor so that character count functionality updates when the last character of the input is a space. This attribute is present on the textstring property editor which works as expected. 

This can be tested by creating a textarea property with a character limit and entering a number of spaces once the character count appears and observing that it updates with each new character entered.

Newbie PR here, so please shout if I've done something wrong or put something in the wrong place! 👍