### PR TITLE
Bugfix: Adds new confirmation email marketing step

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/tours/umbEmailMarketing/confirm/confirm.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/tours/umbEmailMarketing/confirm/confirm.controller.js
@@ -1,0 +1,15 @@
+(function () {
+    "use strict";
+
+    function ConfirmController($scope, userService) {
+
+        var vm = this;
+        vm.userEmailAddress = "";
+
+        userService.getCurrentUser().then(function(user){
+            vm.userEmailAddress = user.email;
+        });
+    }
+
+    angular.module("umbraco").controller("Umbraco.Tours.UmbEmailMarketing.ConfirmController", ConfirmController);
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/common/tours/umbEmailMarketing/confirm/confirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/tours/umbEmailMarketing/confirm/confirm.html
@@ -1,0 +1,15 @@
+<div ng-controller="Umbraco.Tours.UmbEmailMarketing.ConfirmController as vm">
+
+    <umb-tour-step-header title="model.currentStep.title"></umb-tour-step-header>
+
+    <umb-tour-step on-close="model.completeTour()">
+        <p>We have sent a welcome email to your email address <strong>{{ vm.userEmailAddress }}</strong></p>
+    </umb-tour-step>
+
+    <umb-tour-step-footer>
+        <div class="flex justify-end">
+            <umb-button type="button" button-style="link" action="model.completeTour()" label-key="general_close" shortcut="esc"></umb-button>
+        </div>
+    </umb-tour-step-footer>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/tours/umbEmailMarketing/emails/emails.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/tours/umbEmailMarketing/emails/emails.controller.js
@@ -13,10 +13,7 @@
                 userService.addUserToEmailMarketing(user);
             });
 
-            // Mark Tour as complete
-            // This is also can help us indicate that the user accepted
-            // Where disabled is set if user closes modal or chooses NO
-            $scope.model.completeTour();
+            $scope.model.nextStep();
         }
     }
 

--- a/src/Umbraco.Web.UI/config/BackOfficeTours/getting-started.json
+++ b/src/Umbraco.Web.UI/config/BackOfficeTours/getting-started.json
@@ -14,6 +14,10 @@
                 "content": "<p>Thank you for using Umbraco! Would you like to stay up-to-date with Umbraco product updates, security advisories, community news and special offers? Sign up for our newsletter and never miss out on the latest Umbraco news.</p> <p class='notice'>By signing up, you agree that we can use your info according to our <a href='https://umbraco.com/about-us/privacy/'>privacy policy</a>.</p>",
                 "view": "emails",
                 "type": "promotion"
+            },
+            {
+                "title": "Thank you for subscribing to our mailing list",
+                "view": "confirm"
             }
         ]
     },


### PR DESCRIPTION
Adds a new confirmation email marketing step to email marketing tour for more visual confirmation.

## Test Notes
* Log out of the Umbraco backoffice
* Open DB table `UmbracoUsers`
* Find your user and remove the JSON for email marketing tour
* Log back into backoffice
* Opt into emails & confirm you see a second step with your email address listed

**Before**
```
[{"alias":"umbIntroIntroduction","completed":false,"disabled":true},{"alias":"umbEmailMarketing","completed":true,"disabled":false}]
```

**After**
```
[{"alias":"umbIntroIntroduction","completed":false,"disabled":true}]
```

![image](https://user-images.githubusercontent.com/1389894/81574047-31085680-939d-11ea-8ccf-80f81a4348f4.png)
