### PR TITLE
Added translation of property name for nested content property editors.

### DIFF
--- a/src/Umbraco.Tests/Published/NestedContentTests.cs
+++ b/src/Umbraco.Tests/Published/NestedContentTests.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Tests.Published
             var proflog = new ProfilingLogger(logger, profiler);
 
             PropertyEditorCollection editors = null;
-            var editor = new NestedContentPropertyEditor(logger, new Lazy<PropertyEditorCollection>(() => editors), Mock.Of<IDataTypeService>(), Mock.Of<IContentTypeService>());
+            var editor = new NestedContentPropertyEditor(logger, new Lazy<PropertyEditorCollection>(() => editors), Mock.Of<IDataTypeService>(), Mock.Of<IContentTypeService>(), Mock.Of<ILocalizedTextService>());
             editors = new PropertyEditorCollection(new DataEditorCollection(new DataEditor[] { editor }));
 
             var dataType1 = new DataType(editor)

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -290,7 +290,7 @@ namespace Umbraco.Web.PropertyEditors
                     {
                         foreach (var result in validator.Validate(row.JsonRowValue[row.PropKey], propertyEditor.GetValueEditor().ValueType, config))
                         {
-                            result.ErrorMessage = "Item " + (row.RowIndex + 1) + " '" + row.PropType.Name + "' " + result.ErrorMessage;
+                            result.ErrorMessage = "Item " + (row.RowIndex + 1) + " '" + _textService.UmbracoDictionaryTranslate(row.PropType.Name) + "' " + result.ErrorMessage;
                             validationResults.Add(result);
                         }
                     }
@@ -301,7 +301,7 @@ namespace Umbraco.Web.PropertyEditors
                         if (row.JsonRowValue[row.PropKey] == null)
                         {
                             var message = string.IsNullOrWhiteSpace(row.PropType.MandatoryMessage)
-                                                      ? $"'{row.PropType.Name}' cannot be null"
+                                                      ? $"'{_textService.UmbracoDictionaryTranslate(row.PropType.Name)}' cannot be null"
                                                       : row.PropType.MandatoryMessage;
                             validationResults.Add(new ValidationResult($"Item {(row.RowIndex + 1)}: {message}", new[] { row.PropKey }));
                         }                            
@@ -322,7 +322,7 @@ namespace Umbraco.Web.PropertyEditors
                         if (!regex.IsMatch(row.JsonRowValue[row.PropKey].ToString()))
                         {
                             var message = string.IsNullOrWhiteSpace(row.PropType.ValidationRegExpMessage)
-                                                      ? $"'{row.PropType.Name}' is invalid, it does not match the correct pattern"
+                                                      ? $"'{_textService.UmbracoDictionaryTranslate(row.PropType.Name)}' is invalid, it does not match the correct pattern"
                                                       : row.PropType.ValidationRegExpMessage;
                            validationResults.Add(new ValidationResult($"Item {(row.RowIndex + 1)}: {message}", new[] { row.PropKey }));
                         }


### PR DESCRIPTION
Mandatory messages are not changed and the text "Cannot be empty" remains untranslated which seems wrong? But this fixes the issue reported by 8081

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8081

### Description
The issue described in 8081 needed the LocalizedTextService passed in through to the mapper so we can map the "label" of the property name in the same way it works for the vanilla property editor.  

I didn't attempt to translate ".... cannot be empty" though it seems like this would be a good addition to the Umbraco dictionary. 

To test:
1) Create two users, EN / DK
2) Create a Nested Content Doc type with a mandatory field name as per the instructions in the issue (namely named #p_NameTest and create corresponding dictionary item "p_NameTest" with EN and DK translations. 
3) Attempt to save and publish a new NC item without filling in the mandatory field. 
4) Check that the warning has the translated field name instead of #p_NameTest rendered. 

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
