### PR TITLE
Remove "double tabbing" in the datatype picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
@@ -37,9 +37,8 @@
                             <h5>{{key | umbCmsTitleCase}}</h5>
                             <ul class="umb-card-grid -six-in-row">
                                 <li ng-repeat="dataType in value | orderBy:'name'"
-                                    data-element="datatype-{{dataType.name}}"
-                                    ng-click="vm.viewOptionsForEditor(dataType)">
-                                    <a class="umb-card-grid-item" href="" title="{{ dataType.name }}">
+                                    data-element="datatype-{{dataType.name}}">
+                                    <a class="umb-card-grid-item" href="" ng-click="vm.viewOptionsForEditor(dataType)" title="{{ dataType.name }}">
                                         <span>
                                             <i class="{{ dataType.icon }}" ng-class="{'icon-autofill': dataType.icon == null}"></i>
                                             {{ dataType.name }}
@@ -58,12 +57,11 @@
                                 <h5>{{result.group | umbCmsTitleCase}}</h5>
                                 <ul class="umb-card-grid -six-in-row">
                                     <li ng-repeat="dataType in result.entries | orderBy:'name'"
-                                        ng-mouseover="vm.showDetailsOverlay(dataType)"
-                                        ng-click="vm.pickDataType(dataType)">
+                                        ng-mouseover="vm.showDetailsOverlay(dataType)">
                                         <div ng-if="dataType.loading" class="umb-card-grid-item__loading">
                                             <div class="umb-button__progress"></div>
                                         </div>
-                                        <a class="umb-card-grid-item" href="" title="{{ dataType.name }}">
+                                        <a class="umb-card-grid-item" href="" ng-click="vm.pickDataType(dataType)" title="{{ dataType.name }}">
                                             <span>
                                                 <i class="{{ dataType.icon }}" ng-class="{'icon-autofill': dataType.icon == null}"></i>
                                                 {{ dataType.name }}
@@ -78,9 +76,8 @@
                             <div ng-if="result.entries.length > 0">
                                 <h5>{{result.group | umbCmsTitleCase}}</h5>
                                 <ul class="umb-card-grid -six-in-row">
-                                    <li ng-repeat="dataType in result.entries | orderBy:'name'"
-                                        ng-click="vm.pickEditor(dataType)">
-                                        <a class="umb-card-grid-item" href="" title="{{ dataType.name }}">
+                                    <li ng-repeat="dataType in result.entries | orderBy:'name'">
+                                        <a class="umb-card-grid-item" href="" ng-click="vm.pickEditor(dataType)" title="{{ dataType.name }}">
                                             <span>
                                                 <i class="{{ dataType.icon }}" ng-class="{'icon-autofill': dataType.icon == null}"></i>
                                                 {{ dataType.name }}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The (very nicely) revamped data type picker suffers from "double tabbing" when you tab your way through the available datatypes:

![double-tab-datatype-picker-before](https://user-images.githubusercontent.com/7405322/81833592-33ef7c80-9540-11ea-9ca8-14bac0c715d9.gif)

And if you happen to hit enter on the innermost focused element of a datatype, you'll get duplicate "Select configuration" dialogs:

![image](https://user-images.githubusercontent.com/7405322/81833665-48cc1000-9540-11ea-8db8-eceaf27f5502.png)

This PR shuffles some click handlers around, ensuring that only the innermost elements (the `a` tags) can receive keyboard focus. When applied it's much easier to tab your way through the datatype picker:

![double-tab-datatype-picker-after](https://user-images.githubusercontent.com/7405322/81833784-6d27ec80-9540-11ea-91ca-f07e5dd88571.gif)
