### PR TITLE
Enable navigating datatype configuration picker by keyboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypeconfigurationpicker/datatypeconfigurationpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypeconfigurationpicker/datatypeconfigurationpicker.html
@@ -18,15 +18,14 @@
                     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
                     <div ng-if="!vm.loading">
-
+                        <a href="" tabindex="0" umb-auto-focus></a>
                         <ul class="umb-card-grid -three-in-row">
                             <li ng-repeat="dataTypeConfig in vm.configs | orderBy:'name'"
-                                data-element="datatypeconfig-{{dataTypeConfig.name}}"
-                                ng-click="vm.pickDataType(dataTypeConfig)">
+                                data-element="datatypeconfig-{{dataTypeConfig.name}}">
                                 <div ng-if="dataTypeConfig.loading" class="umb-card-grid-item__loading">
                                     <div class="umb-button__progress"></div>
                                 </div>
-                                <a class="umb-card-grid-item" href="" title="{{ dataTypeConfig.name }}">
+                                <a class="umb-card-grid-item" href="" ng-click="vm.pickDataType(dataTypeConfig)" title="{{ dataTypeConfig.name }}">
                                     <span>
                                         <i class="{{ dataTypeConfig.icon }}" ng-class="{'icon-autofill': dataTypeConfig.icon == null}"></i>
                                         {{ dataTypeConfig.name }}
@@ -35,8 +34,8 @@
                             </li>
                         </ul>
                         <ul class="umb-card-grid -three-in-row">
-                            <li ng-click="vm.newDataType()">
-                                <a class="umb-card-grid-item-slot" href="" title="Create a new configuration of {{ model.dataType.name }}">
+                            <li>
+                                <a class="umb-card-grid-item-slot" href="" ng-click="vm.newDataType()" title="Create a new configuration of {{ model.editor.name }}">
                                     <span>
                                         <i class="icon icon-add"></i>
                                         Create new


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The datatype configuration picker has a few minor issues:

1. When the datatype configuration picker opens, it does not apply focus to itself. Thus if you use tab to navigate through the available datatype configurations, you're tabbing around behind the overlay. 

2. If you manually set focus in the dialog, it suffers from the same "double tabbing" issues as the datatype picker (see #8102).

3. Lastly the create button hover title is "Create a new configuration of" - it's missing the name of the data type editor.

![double-tab-datatype-configuration-picker-before](https://user-images.githubusercontent.com/7405322/81834924-ed9b1d00-9541-11ea-8b51-5c0cd0458db6.gif)

This PR ensures that the dialog captures focus on load, and fixes the other small issues as well:

![double-tab-datatype-configuration-picker-after](https://user-images.githubusercontent.com/7405322/81835292-613d2a00-9542-11ea-8e83-ad4fb6d1303c.gif)
