### PR TITLE
Reload property preview when changing property type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
@@ -33,8 +33,15 @@ function umbPropEditor(umbPropEditorHelper) {
                    scope.model.alias = Math.random().toString(36).slice(2);
                 }
 
-                scope.propertyEditorView = umbPropEditorHelper.getViewPath(scope.model.view, scope.isPreValue);
-                
+                var unbindWatcher = scope.$watch("model.view",
+                    function() {
+                        scope.propertyEditorView = umbPropEditorHelper.getViewPath(scope.model.view, scope.isPreValue);
+                    }
+                );
+
+                scope.$on("$destroy", function () {
+                    unbindWatcher();
+                });
             }
         };
     };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8068

### Description

When changing a property type on an existing property, the property preview doesn't reload in the content type builder (like it does in V7):

![groups-builder-preview-reload-before](https://user-images.githubusercontent.com/7405322/81850221-fd256080-9557-11ea-8074-cc3c00732919.gif)

This PR ensures that we watch for changes and update the property preview accordingly:

![groups-builder-preview-reload-after](https://user-images.githubusercontent.com/7405322/81850696-a2403900-9558-11ea-991e-7b2f4d40ba98.gif)

