### PR TITLE
Fix "Edit: undefined" in content editor title

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
@@ -27,7 +27,7 @@
                 var title = data[2] + ": ";
                 if (!scope.isNew) {
                     scope.a11yMessage += " " + scope.editor.content.name;
-                    title += scope.content.name;
+                    title += scope.editor.content.name;
                 } else {
                     var name = editorState.current.contentTypeName;
                     scope.a11yMessage += " " + name;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The content editor title seems broken; it reads "Edit: undefined" when editing an existing content item:

![image](https://user-images.githubusercontent.com/7405322/81852339-2693bb80-955b-11ea-83c3-203d02d3be26.png)

This happens for both culture variant and invariant content. But still works fine when creating a new content item:

![image](https://user-images.githubusercontent.com/7405322/81852388-3b704f00-955b-11ea-9d69-345be5d1c91c.png)

With this PR, the title goes back to "Edit: [name of content item]" like it used to be:

![content-editor-title-undefined-name](https://user-images.githubusercontent.com/7405322/81852544-7b373680-955b-11ea-9dde-4b250c9c1cef.gif)

