### PR TITLE
Prevent property previews from having focus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -240,7 +240,7 @@
 
                                 </div>
 
-                                <ng-form inert class="umb-group-builder__property-preview-form" name="propertyEditorPreviewForm" umb-disable-form-validation ng-click="editPropertyTypeSettings(property, tab)">
+                                <ng-form inert class="umb-group-builder__property-preview-form" name="propertyEditorPreviewForm" umb-disable-form-validation ng-click="editPropertyTypeSettings(property, tab)" tabindex="-1">
                                     <umb-property-editor
                                         ng-if="property.view !== undefined"
                                         model="property"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When tabbing through the content type editor, inputs/buttons/etc. within the property previews can receive focus:

![property-preview-catches-focus-before](https://user-images.githubusercontent.com/7405322/81853481-bede7000-955c-11ea-9498-eb44e803009f.gif)

You can't actually interact with the focused elements within the property previews. If you hit enter with one of them is in a focused state, the "edit property" dialog opens up (as you'd expect it to), so the applied focus within the preview doesn't break things as such. It just feels weird when navigating. 

Anyway. This PR fixes it:

![property-preview-catches-focus-after](https://user-images.githubusercontent.com/7405322/81853500-c7cf4180-955c-11ea-8cce-930cb753acd1.gif)

