### PR TITLE
Add disable-dirty-check option

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -32,6 +32,7 @@
 @param {boolean} required Set the checkbox to be required.
 @param {callback} onChange Callback when the value of the checkbox change by interaction.
 @param {string} cssClass Set a css class modifier
+@param {boolean} disableDirtyCheck Disable checking if the model is dirty
 
 **/
 
@@ -84,7 +85,8 @@
             required: "<",
             onChange: "&?",
             cssClass: "@?",
-            iconClass: "@?"
+            iconClass: "@?",
+            disableDirtyCheck: "=?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,7 +1,7 @@
 <label class="checkbox umb-form-check umb-form-check--checkbox {{vm.cssClass}}" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
-
     <div class="umb-form-check__symbol">
-        <input type="checkbox"
+        <input ng-if="vm.disableDirtyCheck"
+            type="checkbox"
             id="{{vm.inputId}}"
             name="{{vm.name}}"
             value="{{vm.value}}"
@@ -10,7 +10,20 @@
             ng-model="vm.model"
             ng-disabled="vm.disabled"
             ng-required="vm.required"
-            ng-change="vm.change()"/>
+            ng-change="vm.change()"
+            no-dirty-check />
+
+            <input ng-if="!vm.disableDirtyCheck"
+                type="checkbox"
+                id="{{vm.inputId}}"
+                name="{{vm.name}}"
+                value="{{vm.value}}"
+                class="umb-form-check__input"
+                val-server-field="{{vm.serverValidationField}}"
+                ng-model="vm.model"
+                ng-disabled="vm.disabled"
+                ng-required="vm.required"
+                ng-change="vm.change()"/>
 
         <span class="umb-form-check__state" aria-hidden="true">
             <span class="umb-form-check__check">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have extended the `<umb-checkbox>` directive with a `disable-dirty-check` parameter since I have recently worked on a custom content app where I reused the directive and we wanted to be able to disable the dirty check. But it's not possible to do currently out of the box. I'm reusing the already build in `no-dirty-check` directive if the `disable-dirty-check` is set to true, which will help out others too if they need an easy way to prevent the model from becoming dirty and therefore trigger the "unsaved data overlay" in scenarios where it does not make sense 😃 

I used the "checkboxlist" datatype for demo purposes only and it's not part of this PR.

**Default directive behavior**
![disable-dirty-check-false-default](https://user-images.githubusercontent.com/1932158/82128208-ac14a700-97b9-11ea-8a44-a2592417988a.gif)


**Directive behavior when `disable-cdirty-check="true"` is set**
![disable-dirty-check-true](https://user-images.githubusercontent.com/1932158/82128214-b2a31e80-97b9-11ea-9663-dff6ac6f9229.gif)
