### PR TITLE
Add backdrop when menu items are opened

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbcontextmenu.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbcontextmenu.directive.js
@@ -1,5 +1,5 @@
 angular.module("umbraco.directives")
-.directive('umbContextMenu', function (navigationService, keyboardService) {
+.directive('umbContextMenu', function (navigationService, keyboardService, backdropService) {
     return {
         scope: {
             menuDialogTitle: "@",
@@ -20,10 +20,12 @@ angular.module("umbraco.directives")
 
             scope.outSideClick = function() {
                 navigationService.hideNavigation();
+                closeBackdrop();
             };
 
             keyboardService.bind("esc", function() {
                 navigationService.hideNavigation();
+                closeBackdrop();
             });
 
             //ensure to unregister from all events!
@@ -31,6 +33,16 @@ angular.module("umbraco.directives")
                 keyboardService.unbind("esc");
             });
 
+            function closeBackdrop() {
+                var onTopClass = 'on-top-of-backdrop';
+                var leftColumn = $('#leftcolumn');
+                var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
+
+                if(isLeftColumnOnTop){
+                    backdropService.close();
+                    leftColumn.removeClass(onTopClass);
+                }
+            }
         }
     };
 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbcontextmenu.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbcontextmenu.directive.js
@@ -20,29 +20,16 @@ angular.module("umbraco.directives")
 
             scope.outSideClick = function() {
                 navigationService.hideNavigation();
-                closeBackdrop();
             };
 
             keyboardService.bind("esc", function() {
                 navigationService.hideNavigation();
-                closeBackdrop();
             });
 
             //ensure to unregister from all events!
             scope.$on('$destroy', function () {
                 keyboardService.unbind("esc");
             });
-
-            function closeBackdrop() {
-                var onTopClass = 'on-top-of-backdrop';
-                var leftColumn = $('#leftcolumn');
-                var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
-
-                if(isLeftColumnOnTop){
-                    backdropService.close();
-                    leftColumn.removeClass(onTopClass);
-                }
-            }
         }
     };
 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
@@ -9,7 +9,7 @@
             var allowedNumberOfVisibleEditors = 3;
             var aboveBackDropCssClass = 'above-backdrop';
             var sectionId = '#leftcolumn';
-            scope.isLeftColumnAbove = false;
+            var isLeftColumnAbove = false;
             scope.editors = [];
             
             function addEditor(editor) {
@@ -22,9 +22,9 @@
                 scope.editors.push(editor);
 
                 if(scope.editors.length === 1){
-                    scope.isLeftColumnAbove = $(sectionId).hasClass(aboveBackDropCssClass);
+                    isLeftColumnAbove = $(sectionId).hasClass(aboveBackDropCssClass);
 
-                    if(scope.isLeftColumnAbove){
+                    if(isLeftColumnAbove){
                         $(sectionId).removeClass(aboveBackDropCssClass);
                     }
                 }
@@ -49,11 +49,11 @@
                 updateEditors(-1);
 
                 if(scope.editors.length === 1){
-                    if(scope.isLeftColumnAbove){
+                    if(isLeftColumnAbove){
                         $('#leftcolumn').addClass(aboveBackDropCssClass);
                     }
 
-                    scope.isLeftColumnAbove = false;
+                    isLeftColumnAbove = false;
                 }
             }
             

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
@@ -7,11 +7,12 @@
 
             var evts = [];
             var allowedNumberOfVisibleEditors = 3;
-            
+            var aboveBackDropCssClass = 'above-backdrop';
+            var sectionId = '#leftcolumn';
+            scope.isLeftColumnAbove = false;
             scope.editors = [];
             
             function addEditor(editor) {
-                
                 editor.inFront = true;
                 editor.moveRight = true;
                 editor.level = 0;
@@ -19,6 +20,14 @@
                                 
                 // push the new editor to the dom
                 scope.editors.push(editor);
+
+                if(scope.editors.length === 1){
+                    scope.isLeftColumnAbove = $(sectionId).hasClass(aboveBackDropCssClass);
+
+                    if(scope.isLeftColumnAbove){
+                        $(sectionId).removeClass(aboveBackDropCssClass);
+                    }
+                }
                 
                 $timeout(() => {
                     editor.moveRight = false;
@@ -32,14 +41,20 @@
             }
             
             function removeEditor(editor) {
-                
                 editor.moveRight = true;
                 
                 editor.animating = true;
                 setTimeout(removeEditorFromDOM.bind(this, editor), 400);
                 
                 updateEditors(-1);
-                
+
+                if(scope.editors.length === 1){
+                    if(scope.isLeftColumnAbove){
+                        $('#leftcolumn').addClass(aboveBackDropCssClass);
+                    }
+
+                    scope.isLeftColumnAbove = false;
+                }
             }
             
             function revealEditorContent(editor) {
@@ -57,7 +72,7 @@
                 if (index !== -1) {
                     scope.editors.splice(index, 1);
                 }
-                
+ 
                 updateEditors();
                 
                 scope.$digest();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
@@ -22,21 +22,8 @@
                 keyboardService.unbind("esc");
             });
 
-            // Close any potential backdrop and remove the #leftcolumn modifier class
-            function closeBackdrop() {
-                var onTopClass = 'on-top-of-backdrop';
-                var leftColumn = $('#leftcolumn');
-                var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
-
-                if(isLeftColumnOnTop){
-                    backdropService.close();
-                    leftColumn.removeClass(onTopClass);
-                }
-            }
-
             function hide() {
-                closeBackdrop()
-                
+
                 if ($scope.dialog.confirmDiscardChanges) {
                     localizationService.localizeMany(["prompt_unsavedChanges", "prompt_unsavedChangesWarning", "prompt_discardChanges", "prompt_stay"]).then(
                         function (values) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbcontextdialog/umbcontextdialog.directive.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    function UmbContextDialog(navigationService, keyboardService, localizationService, overlayService) {
+    function UmbContextDialog(navigationService, keyboardService, localizationService, overlayService, backdropService) {
 
         function link($scope) {
 
@@ -22,7 +22,21 @@
                 keyboardService.unbind("esc");
             });
 
+            // Close any potential backdrop and remove the #leftcolumn modifier class
+            function closeBackdrop() {
+                var onTopClass = 'on-top-of-backdrop';
+                var leftColumn = $('#leftcolumn');
+                var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
+
+                if(isLeftColumnOnTop){
+                    backdropService.close();
+                    leftColumn.removeClass(onTopClass);
+                }
+            }
+
             function hide() {
+                closeBackdrop()
+                
                 if ($scope.dialog.confirmDiscardChanges) {
                     localizationService.localizeMany(["prompt_unsavedChanges", "prompt_unsavedChangesWarning", "prompt_discardChanges", "prompt_stay"]).then(
                         function (values) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -321,13 +321,13 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
 
             // Close any potential backdrop and remove the #leftcolumn modifier class
             function closeBackdrop() {
-                var onTopClass = 'on-top-of-backdrop';
+                var aboveClass = 'above-backdrop';
                 var leftColumn = $('#leftcolumn');
-                var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
+                var isLeftColumnOnTop = leftColumn.hasClass(aboveClass);
 
                 if(isLeftColumnOnTop){
                     backdropService.close();
-                    leftColumn.removeClass(onTopClass);
+                    leftColumn.removeClass(aboveClass);
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -3,7 +3,7 @@
 * @name umbraco.directives.directive:umbTree
 * @restrict E
 **/
-function umbTreeDirective($q, $rootScope, treeService, notificationsService, userService) {
+function umbTreeDirective($q, $rootScope, treeService, notificationsService, userService, backdropService) {
 
     return {
         restrict: 'E',
@@ -319,6 +319,18 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
                 }
             }
 
+            // Close any potential backdrop and remove the #leftcolumn modifier class
+            function closeBackdrop() {
+                var onTopClass = 'on-top-of-backdrop';
+                var leftColumn = $('#leftcolumn');
+                var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
+
+                if(isLeftColumnOnTop){
+                    backdropService.close();
+                    leftColumn.removeClass(onTopClass);
+                }
+            }
+
             /** Returns the css classses assigned to the node (div element) */
             $scope.getNodeCssClass = function (node) {
                 if (!node) {
@@ -368,6 +380,8 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
             */
             $scope.select = function (n, ev) {
 
+                closeBackdrop()
+                
                 if (n.metaData && n.metaData.noAccess === true) {
                     ev.preventDefault();
                     return;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -124,7 +124,6 @@ angular.module("umbraco.directives")
             */
             scope.options = function (n, ev) {
                 umbTreeCtrl.emitEvent("treeOptionsClick", { element: element, tree: scope.tree, node: n, event: ev });
-                navigationService.hideDialog();
             };
 
             /**
@@ -148,7 +147,6 @@ angular.module("umbraco.directives")
                 }
 
                 umbTreeCtrl.emitEvent("treeNodeSelect", { element: element, tree: scope.tree, node: n, event: ev });
-                navigationService.hideDialog();
                 ev.preventDefault();
             };
 
@@ -176,8 +174,6 @@ angular.module("umbraco.directives")
                 else {
                     scope.loadChildren(node, false);
                 }
-
-                navigationService.hideDialog();
             };
 
             /* helper to force reloading children of a tree node */

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -18,7 +18,7 @@
    </example>
  */
 angular.module("umbraco.directives")
-    .directive('umbTreeItem', function(treeService, $timeout, localizationService, eventsService, appState) {
+    .directive('umbTreeItem', function(treeService, $timeout, localizationService, eventsService, appState, navigationService) {
     return {
         restrict: 'E',
         replace: true,
@@ -124,6 +124,7 @@ angular.module("umbraco.directives")
             */
             scope.options = function (n, ev) {
                 umbTreeCtrl.emitEvent("treeOptionsClick", { element: element, tree: scope.tree, node: n, event: ev });
+                navigationService.hideDialog();
             };
 
             /**
@@ -147,6 +148,7 @@ angular.module("umbraco.directives")
                 }
 
                 umbTreeCtrl.emitEvent("treeNodeSelect", { element: element, tree: scope.tree, node: n, event: ev });
+                navigationService.hideDialog();
                 ev.preventDefault();
             };
 
@@ -174,6 +176,8 @@ angular.module("umbraco.directives")
                 else {
                     scope.loadChildren(node, false);
                 }
+
+                navigationService.hideDialog();
             };
 
             /* helper to force reloading children of a tree node */

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -116,6 +116,17 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
         }
     }
 
+    function closeBackdrop() {
+        var onTopClass = 'on-top-of-backdrop';
+        var leftColumn = $('#leftcolumn');
+        var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
+
+        if(isLeftColumnOnTop){
+            backdropService.close();
+            leftColumn.removeClass(onTopClass);
+        }
+    }
+
     var service = {
 
         /**
@@ -472,6 +483,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             appState.setMenuState("currentNode", null);
             appState.setMenuState("menuActions", []);
             setMode("tree");
+            closeBackdrop();
         },
 
         /** Executes a given menu action */
@@ -656,6 +668,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             if (showMenu) {
                 this.showMenu({ skipDefault: true, node: appState.getMenuState("currentNode") });
             } else {
+                closeBackdrop();
                 setMode("default");
             }
         },

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -704,6 +704,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
           */
         hideNavigation: function () {
             appState.setMenuState("menuActions", []);
+            closeBackdrop();
             setMode("default");
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -28,7 +28,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
 
     eventsService.on('appState.backdrop', function(e, args){
         var element = $(args.element);
-        element.addClass('on-top-of-backdrop');
+        element.addClass('above-backdrop');
     });
 
     //A list of query strings defined that when changed will not cause a reload of the route
@@ -117,13 +117,13 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
     }
 
     function closeBackdrop() {
-        var onTopClass = 'on-top-of-backdrop';
+        var aboveClass = 'above-backdrop';
         var leftColumn = $('#leftcolumn');
-        var isLeftColumnOnTop = leftColumn.hasClass(onTopClass);
+        var isLeftColumnOnTop = leftColumn.hasClass(aboveClass);
 
         if(isLeftColumnOnTop){
             backdropService.close();
-            leftColumn.removeClass(onTopClass);
+            leftColumn.removeClass(aboveClass);
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -13,7 +13,7 @@
  * Section navigation and search, and maintain their state for the entire application lifetime
  *
  */
-function navigationService($routeParams, $location, $q, $injector, eventsService, umbModelMapper, treeService, appState) {
+function navigationService($routeParams, $location, $q, $injector, eventsService, umbModelMapper, treeService, appState, backdropService) {
 
     //the promise that will be resolved when the navigation is ready
     var navReadyPromise = $q.defer();
@@ -26,7 +26,10 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
         navReadyPromise.resolve(mainTreeApi);
     });
 
-
+    eventsService.on('appState.backdrop', function(e, args){
+        var element = $(args.element);
+        element.addClass('on-top-of-backdrop');
+    });
 
     //A list of query strings defined that when changed will not cause a reload of the route
     var nonRoutingQueryStrings = ["mculture", "cculture", "csegment", "lq", "sr"];
@@ -410,12 +413,15 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
          * @param {Event} event the click event triggering the method, passed from the DOM element
          */
         showMenu: function (args) {
-
             var self = this;
+
+            var backDropOptions = {
+                'element': $('#leftcolumn')[0]
+            };
 
             return treeService.getMenu({ treeNode: args.node })
                 .then(function (data) {
-
+                    backdropService.open(backDropOptions);
                     //check for a default
                     //NOTE: event will be undefined when a call to hideDialog is made so it won't re-load the default again.
                     // but perhaps there's a better way to deal with with an additional parameter in the args ? it works though.

--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -81,7 +81,7 @@ body.umb-drawer-is-visible #mainwrapper{
   position: absolute;
   top: 0;
 
-  &.on-top-of-backdrop{
+  &.above-backdrop{
       z-index: 7501;
   }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -80,6 +80,10 @@ body.umb-drawer-is-visible #mainwrapper{
   float: left;
   position: absolute;
   top: 0;
+
+  &.on-top-of-backdrop{
+      z-index: 7501;
+  }
 }
 
 #navigation {

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -92,6 +92,8 @@ function contentCreateController($scope,
         } else {
             createBlank(docType);
         }
+
+        navigationService.hideDialog();
     }
 
     function createFromBlueprint(blueprintId) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR a backdrop is added whenever we open a menu - I have done this to align the UI behavior throughout the entire backoffice. Should this PR end up being accepted I will do a follow up PR where I refactor the "closeBackdrop" function I have added in 3 files so the close method of the backdrop service can handle the removal of the class based on a parameter instead so it's handled by the service instead of the places where it's called.

I hope you like it 😃 

~~**EDIT**: Ok, so I appear to have missed some spots where the backdrop does is not removed using the context menu - I'm looking into and will update this PR when it's ready for review again 👍~~

**EDIT:** Ok, this is good to go again! 😄 - Ensure to test it thourougly though - I think I covered all the edge cases now and I have tested that it acts like you would expect when interacting with the various context menu dialogs, methods etc. 👍  

**Before**
![without-backdrop](https://user-images.githubusercontent.com/1932158/82130284-4a106d80-97ca-11ea-98b0-d47013aec705.gif)


**After**
![with-backdrop](https://user-images.githubusercontent.com/1932158/82130288-50064e80-97ca-11ea-8cf2-39982a8ebaa6.gif)
