### PR TITLE
umb-button.html - missing closing bracket

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -52,7 +52,7 @@
             {{vm.buttonLabel}}
             <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
-    </button
+    </button>
 
 
 </div>


### PR DESCRIPTION
Super quick PR, no tests nor reproduction steps, just a small markup fix.

I noticed in "umb-button.html" that the last the `<button>` was missing its closing bracket.

