### PR TITLE
Stabilising acceptance tests + Bugfix for hanging saves of media.

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress.json
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress.json
@@ -6,5 +6,6 @@
         "username": "<insert username/email in cypress.env.json>",
         "password": "<insert password in cypress.env.json>"
     },
-    "supportFile": "cypress/support/index.ts"
+    "supportFile": "cypress/support/index.ts",
+    "videoUploadOnPasses" : false
 }

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -6,28 +6,28 @@ context('Templates', () => {
   });
 
   it('Create template', () => {
-    const name = "Test template";
+        const name = "Test template";
 
-   cy.umbracoEnsureTemplateNameNotExists(name);
+        cy.umbracoEnsureTemplateNameNotExists(name);
 
-    cy.umbracoSection('settings');
-    cy.get('li .umb-tree-root:contains("Settings")').should("be.visible");
+        cy.umbracoSection('settings');
+        cy.get('li .umb-tree-root:contains("Settings")').should("be.visible");
 
-    cy.umbracoTreeItem("settings", ["Templates"]).rightclick();
+        cy.umbracoTreeItem("settings", ["Templates"]).rightclick();
 
-    cy.umbracoContextMenuAction("action-create").click();
+        cy.umbracoContextMenuAction("action-create").click();
 
-    //Type name
-    cy.umbracoEditorHeaderName(name);
+        //Type name
+        cy.umbracoEditorHeaderName(name);
 
-    //Save
-    cy.get('.btn-success').click();
+        //Save
+        cy.get("form[name='contentForm']").submit();
 
-    //Assert
-    cy.umbracoSuccessNotification().should('be.visible');
+        //Assert
+        cy.umbracoSuccessNotification().should('be.visible');
 
-    //Clean up
-    cy.umbracoEnsureTemplateNameNotExists(name);
+        //Clean up
+        cy.umbracoEnsureTemplateNameNotExists(name);
    });
 
 });

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -1,4 +1,6 @@
 /// <reference types="Cypress" />
+import {DocumentTypeBuilder, TemplateBuilder} from "umbraco-cypress-testhelpers";
+
 context('Templates', () => {
 
   beforeEach(() => {
@@ -30,4 +32,26 @@ context('Templates', () => {
         cy.umbracoEnsureTemplateNameNotExists(name);
    });
 
+    it('Delete template', () => {
+        const name = "Test template";
+        cy.umbracoEnsureTemplateNameNotExists(name);
+
+        const template = new TemplateBuilder()
+            .withName(name)
+            .build();
+
+        cy.saveTemplate(template);
+
+        cy.umbracoSection('settings');
+        cy.get('li .umb-tree-root:contains("Settings")').should("be.visible");
+
+        cy.umbracoTreeItem("settings", ["Templates", name]).rightclick();
+        cy.umbracoContextMenuAction("action-delete").click();
+
+        cy.umbracoButtonByLabelKey("general_ok").click();
+
+        cy.contains(name).should('not.exist');
+
+        cy.umbracoEnsureTemplateNameNotExists(name);
+    });
 });

--- a/src/Umbraco.Tests.AcceptanceTest/package.json
+++ b/src/Umbraco.Tests.AcceptanceTest/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "cross-env": "^7.0.2",
     "ncp": "^2.0.0",
-    "cypress": "^4.5.0",
+    "cypress": "^4.6.0",
     "umbraco-cypress-testhelpers": "1.0.0-beta-38"
   },
   "dependencies": {

--- a/src/Umbraco.Tests.AcceptanceTest/package.json
+++ b/src/Umbraco.Tests.AcceptanceTest/package.json
@@ -7,7 +7,7 @@
     "cross-env": "^7.0.2",
     "ncp": "^2.0.0",
     "cypress": "^4.6.0",
-    "umbraco-cypress-testhelpers": "1.0.0-beta-38"
+    "umbraco-cypress-testhelpers": "1.0.0-beta-39"
   },
   "dependencies": {
     "typescript": "^3.9.2"

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -882,22 +882,15 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 // they require.
 
                 // These can be run side by side in parallel.
+                using (_contentStore.GetScopedWriteLock(_scopeProvider))
+                {
+                    NotifyLocked(new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _, out _);
+                }
 
-                Parallel.Invoke(
-                    () =>
-                    {
-                        using (_contentStore.GetScopedWriteLock(_scopeProvider))
-                        {
-                            NotifyLocked(new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _, out _);
-                        }
-                    },
-                    () =>
-                    {
-                        using (_mediaStore.GetScopedWriteLock(_scopeProvider))
-                        {
-                            NotifyLocked(new[] { new MediaCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _);
-                        }
-                    });
+                using (_mediaStore.GetScopedWriteLock(_scopeProvider))
+                {
+                    NotifyLocked(new[] { new MediaCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _);
+                }
             }
 
             ((PublishedSnapshot)CurrentPublishedSnapshot)?.Resync();


### PR DESCRIPTION
## Notes
- Fixed bug with parallel execution of the cache refreshers

- Fixed issue in template test that called postSave twice.

- Updated Cypress to latest + Updated Umbraco Test helpers with longer timeout on close tours modal.

- Added new acceptance test for delete templates