### PR TITLE
Grid: adds row immediately if only one layout is allowed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -251,7 +251,9 @@
 
                        <button
                           class="iconBox btn-reset"
-                          ng-click="toggleAddRow()"
+                          type="button"
+                          title="{{ section.$allowedLayouts.length == 1 ? section.$allowedLayouts[0].label || section.$allowedLayouts[0].name : '' }}"
+                          ng-click="section.$allowedLayouts.length == 1 ? addRow(section, section.$allowedLayouts[0]) : toggleAddRow()"
                           ng-if="!showRowConfigurations">
 
                           <i class="icon icon-add" ></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8039

### Description
This changes the +-button in grids, if you only have one allowed layout to choose from. If you only have one allowed layout, the row gets inserted on the first click of the + button. In addition to that, a tooltip is added with the name of the layout.

How it looks for one allowed layout:
![rRdAGIsTwb](https://user-images.githubusercontent.com/3726467/82677073-c0d4bd00-9c47-11ea-98bb-76794339b7d0.gif)

How it looks for more than one allowed layout:
![OIoUuAgkmq](https://user-images.githubusercontent.com/3726467/82677095-ca5e2500-9c47-11ea-9fbb-937734127c87.gif)
