### PR TITLE
umb-button directive: Change binding type for autoFocus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -99,7 +99,7 @@ Use this directive to render an umbraco button. The directive can be used to gen
                 alias: "@?",
                 addEllipsis: "@?",
                 showCaret: "@?",
-                autoFocus: "@?",
+                autoFocus: "<?",
                 hasPopup: "@?",
                 isExpanded: "<?"
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Working on #8141 I noticed this bug.

I have changes the binding time from @ to < in order to pass the dynamic expression. Currently setting `umb-auto-focus="false"` explicitly will actually evaluate the expression where it's being used to true as well since the check just expects any kind of string not a boolean. However I can't think of an instance currently where you would want to the value to false initially but I think it should be changed for good measure and who knows, there might be scenarios where the current situation would break something, so we better do it this way instead 😅 