### PR TITLE
Add missing focus style in .buttonbackground mixin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -448,9 +448,11 @@
   }
 
   // in these cases the gradient won't cover the background, so we override
+  &:focus,
   &:hover {
     color: @textColorHover;
     background-color: @hoverColor;
+    text-decoration: none;
   }
 
   &.disabled, &[disabled] {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While I was working on #8141 I noticed some issues with the focus styling in the user dialog overlay for instance - Turns out it was missing the :focus pseudo class, which I have now added.

**Before**
![edit-focus-before](https://user-images.githubusercontent.com/1932158/82713196-6b6dcf80-9c8a-11ea-832e-767b08b5b3c0.gif)


**After**
![edit-focus-after](https://user-images.githubusercontent.com/1932158/82713208-74f73780-9c8a-11ea-940e-604e041e2871.gif)
