### PR TITLE
Removing references to legacy Examine config

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.Debug.config
+++ b/src/Umbraco.Web.UI/web.Template.Debug.config
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-
     
-    <!--
+  <!--
     Defines transforms that apply to web.Template.config when creating the Debug web.config.
 
     This file should contain changes that need to go into the Debug config (the one that everybody
@@ -12,14 +11,6 @@
     One can edit web.config, it will not be overritten, but it WILL be altered by this transform
     file everytime Umbraco builds.
   -->
-
-    <configSections>
-        <section name="Examine" xdt:Transform="Remove" xdt:Locator="Match(name)" />
-        <section name="ExamineLuceneIndexSets" xdt:Transform="Remove" xdt:Locator="Match(name)" />
-    </configSections>
-
-    <Examine xdt:Transform="Remove"  />
-    <ExamineLuceneIndexSets xdt:Transform="Remove"  />
 
     <appSettings>
         <add key="Umbraco.TestData.Enabled" xdt:Transform="Remove" xdt:Locator="Match(key)"/>


### PR DESCRIPTION
This removes the last remaining reference to the legacy Examine config sections.

I encountered some problems while testing my package against for configuring Examine against the Umbraco source as I have a config section named the same thing 🤪