### PR TITLE
Fix HasValue and IsValue for Dropdown Property Types with no Values

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -16,12 +16,13 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
         //ensure this is a bool, old data could store zeros/ones or string versions
         $scope.model.config.multiple = Object.toBoolean($scope.model.config.multiple);
         
-    //ensure when form is saved that we don't store [] or [null] as string values in the database when no items are selected
+        //ensure when form is saved that we don't store [] or [null] as string values in the database when no items are selected
         $scope.$on("formSubmitting", function () {
             if ($scope.model.value.length === 0 || $scope.model.value[0] === null) {
                 $scope.model.value = null;
             }
         });
+        
         function convertArrayToDictionaryArray(model){
             //now we need to format the items in the dictionary because we always want to have an array
             var newItems = [];

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -15,7 +15,13 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
 
         //ensure this is a bool, old data could store zeros/ones or string versions
         $scope.model.config.multiple = Object.toBoolean($scope.model.config.multiple);
-
+        
+    //ensure when form is saved that we don't store [] or [null] as string values in the database when no items are selected
+        $scope.$on("formSubmitting", function () {
+            if ($scope.model.value.length === 0 || $scope.model.value[0] === null) {
+                $scope.model.value = null;
+            }
+        });
         function convertArrayToDictionaryArray(model){
             //now we need to format the items in the dictionary because we always want to have an array
             var newItems = [];

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/FlexibleDropdownPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/FlexibleDropdownPropertyValueConverter.cs
@@ -49,5 +49,22 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                ? typeof(IEnumerable<string>)
                : typeof(string);
         }
+        
+        //an empty dropdown will also store a value as a string in the format '[]' or '[null]'
+        public override bool HasValue(IPublishedProperty property, string culture, string segment)
+        {
+            var value = property.GetSourceValue(culture, segment);
+            return value != null && (!(value is string) || (string.IsNullOrWhiteSpace((string)value) == false && !string.Equals((string)value, "[]") && !string.Equals((string)value, "[null]", StringComparison.CurrentCultureIgnoreCase)));
+        }
+        public override bool? IsValue(object value, PropertyValueLevel level)
+        {
+            switch (level)
+            {
+                case PropertyValueLevel.Source:
+                    return value != null && (!(value is string) || (string.IsNullOrWhiteSpace((string)value) == false && !string.Equals((string)value, "[]") && !string.Equals((string)value, "[null]", StringComparison.CurrentCultureIgnoreCase)));
+                default:
+                    throw new NotSupportedException($"Invalid level: {level}.");
+            }
+        }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/FlexibleDropdownPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/FlexibleDropdownPropertyValueConverter.cs
@@ -48,6 +48,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             return propertyType.DataType.ConfigurationAs<DropDownFlexibleConfiguration>().Multiple
                ? typeof(IEnumerable<string>)
                : typeof(string);
-        }      
+        }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/FlexibleDropdownPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/FlexibleDropdownPropertyValueConverter.cs
@@ -48,23 +48,6 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             return propertyType.DataType.ConfigurationAs<DropDownFlexibleConfiguration>().Multiple
                ? typeof(IEnumerable<string>)
                : typeof(string);
-        }
-        
-        //an empty dropdown will also store a value as a string in the format '[]' or '[null]'
-        public override bool HasValue(IPublishedProperty property, string culture, string segment)
-        {
-            var value = property.GetSourceValue(culture, segment);
-            return value != null && (!(value is string) || (string.IsNullOrWhiteSpace((string)value) == false && !string.Equals((string)value, "[]") && !string.Equals((string)value, "[null]", StringComparison.CurrentCultureIgnoreCase)));
-        }
-        public override bool? IsValue(object value, PropertyValueLevel level)
-        {
-            switch (level)
-            {
-                case PropertyValueLevel.Source:
-                    return value != null && (!(value is string) || (string.IsNullOrWhiteSpace((string)value) == false && !string.Equals((string)value, "[]") && !string.Equals((string)value, "[null]", StringComparison.CurrentCultureIgnoreCase)));
-                default:
-                    throw new NotSupportedException($"Invalid level: {level}.");
-            }
-        }
+        }      
     }
 }


### PR DESCRIPTION
### Prerequisites

- [yep] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/8153

### Description
An 'empty' dropdown (Umbraco.Dropdown.Flexible) property -  will store a value as a string in the database in the format '[]' or '[null]' when actually 'nothing is selected'- this is after first selecting an item in the dropdown, saving, then unselecting the selected item reverting back to the state where nothing is selected... 

this breaks IsValue and HasValue in 'PropertyValueConverterBase' because they are only determining whether something has a value on the basis of whether it is a string and isn't whitespace... so this also breaks ToAncestors() on a recursive property that uses the dropdown.

~Hopefully this PR illustrates the problem, I'm not saying this is the only way or best way to fix it... eg you could look from the property editor perspective and try to ensure that [] && [null] is never actually saved to the database, or you could move this fix into the 'PropertyValueConverterBase' if it's a common issue across other similar property editors - for now, I've added the check for [] and [null] in the specific converter for the dropdown: `FlexibleDropdownPropertyValueConverter`~

To test the solution, create a property with a dropdown with alias 'searchEngineChangeFrequency', give it several values add it to a document type, in the template for that document type write out:

`<h2>@Model.HasValue("searchEngineChangeFrequency") - @Model.Value("searchEngineChangeFrequency")</h2>`

In the backoffice 'save and publish' a page featuring the dropdown editor 
Initially have no value selected.

With this PR in place you should see
False - 
Now select a value in the list and save and publish you should see
True - daily
Now return and unselect the value in the dropdown, you should see
False - 
again... without the PR you will see 
True - 



<!-- Thanks for contributing to Umbraco CMS! -->
