### PR TITLE
Sort dialog: Accessibility optimizations

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -347,8 +347,14 @@ label:not([for]) {
   border: none !important;
 }
 
-table thead a {
+table thead a,
+table thead button {
   color: @gray-2;
+}
+
+table thead button:hover,
+table thead button:focus{
+    text-decoration: underline;
 }
 
 /* UI interactions */

--- a/src/Umbraco.Web.UI.Client/src/views/content/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/sort.html
@@ -1,37 +1,35 @@
 <div ng-controller="Umbraco.Editors.Content.SortController as vm" ng-cloak>
-    
+
         <div class="umb-dialog-body with-footer sort-order">
-            
+
             <div class="umb-pane">
 
-                <div ng-if="vm.error">
-                    <div class="alert alert-error">
-                        <div>{{vm.error.errorMsg}}</div>
-                    </div>
+                <div ng-if="vm.error" class="alert alert-error">
+                    <p>{{vm.error.errorMsg}}</p>
                 </div>
-    
+
                 <umb-load-indicator
                     ng-show="vm.loading">
                 </umb-load-indicator>
-    
+
                 <div ng-if="!vm.loading">
-                    <p class="abstract"><localize key="sort_sortHelp"></localize></p>
+                    <p class="abstract"><localize key="sort_sortHelp">Drag the different items up or down below to set how they should be arranged. Or click the column headers to sort the entire collection of items</localize></p>
                     <table class="table table-condensed table-sortable" ng-if="vm.children">
                         <thead>
                             <tr>
                                 <th colspan="2">
-                                    <a ng-href="#" ng-click="vm.sort('name')" prevent-default>
-                                        <localize key="general_name"></localize>
-                                        <span ng-if="vm.sortOrder.column === 'name'">
+                                    <button type="button" class="btn-reset" ng-click="vm.sort('name')">
+                                        <b><localize key="general_name">Name</localize></b>
+                                        <span ng-if="vm.sortOrder.column === 'name'" aria-hidden="true">
                                             <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                             <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
                                         </span>
-                                    </a>
+                                    </button>
                                 </th>
                                 <th>
-                                    <a ng-href="#" ng-click="vm.sort('createDate')" prevent-default>
-                                        <localize key="sort_sortCreationDate"></localize>
-                                        <span ng-if="vm.sortOrder.column === 'createDate'">
+                                    <button type="button" class="btn-reset" ng-click="vm.sort('createDate')">
+                                        <b><localize key="sort_sortCreationDate">Creation date</localize></b>
+                                        <span ng-if="vm.sortOrder.column === 'createDate'" aria-hidden="true">
                                             <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                             <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
                                         </span>
@@ -51,14 +49,14 @@
                     <umb-empty-state
                         ng-if="!vm.children"
                         position="center">
-                        <localize key="sort_sortEmptyState"></localize>
+                        <localize key="sort_sortEmptyState">This node has no child nodes to sort</localize>
                     </umb-empty-state>
                 </div>
-    
+
             </div>
-    
+
         </div>
-    
+
         <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
             <umb-button
                 type="button"
@@ -68,12 +66,12 @@
             </umb-button>
             <umb-button
                 ng-if="vm.children"
-                type="button" 
+                type="button"
                 action="vm.save()"
                 state="vm.saveButtonState"
                 button-style="success"
                 label-key="buttons_save">
             </umb-button>
         </div>
-    
+
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/sort.html
@@ -1,13 +1,11 @@
 <div ng-controller="Umbraco.Editors.Media.SortController as vm" ng-cloak>
-    
+
     <div class="umb-dialog-body with-footer sort-order">
-        
+
         <div class="umb-pane">
 
-            <div ng-if="vm.error">
-                <div class="alert alert-error">
-                    <div>{{vm.error.errorMsg}}</div>
-                </div>
+            <div ng-if="vm.error" class="alert alert-error">
+                <p>{{vm.error.errorMsg}}</p>
             </div>
 
             <umb-load-indicator
@@ -15,27 +13,27 @@
             </umb-load-indicator>
 
             <div ng-if="!vm.loading">
-                <p class="abstract"><localize key="sort_sortHelp"></localize></p>
+                <p class="abstract"><localize key="sort_sortHelp">Drag the different items up or down below to set how they should be arranged. Or click the column headers to sort the entire collection of items</localize></p>
                 <table class="table table-condensed table-sortable" ng-if="vm.children">
                     <thead>
                         <tr>
                             <th colspan="2">
-                                <a ng-href="#" ng-click="vm.sort('name')" prevent-default>
-                                    <localize key="general_name"></localize>
-                                    <span ng-if="vm.sortOrder.column === 'name'">
+                                <button type="button" class="btn-reset" ng-click="vm.sort('name')">
+                                    <b><localize key="general_name">Name</localize></b>
+                                    <span ng-if="vm.sortOrder.column === 'name'" aria-hidden="true">
                                         <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                         <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
                                     </span>
-                                </a>
+                                </button>
                             </th>
                             <th>
-                                <a ng-href="#" ng-click="vm.sort('createDate')" prevent-default>
-                                    <localize key="sort_sortCreationDate"></localize>
-                                    <span ng-if="vm.sortOrder.column === 'createDate'">
+                                <button type="button" class="btn-reset" ng-click="vm.sort('createDate')">
+                                    <b><localize key="sort_sortCreationDate">Creation date</localize></b>
+                                    <span ng-if="vm.sortOrder.column === 'createDate'" aria-hidden="true">
                                         <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                         <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
                                     </span>
-                                </a>
+                                </button>
                             </th>
                         </tr>
                     </thead>
@@ -68,7 +66,7 @@
         </umb-button>
         <umb-button
             ng-if="vm.children"
-            type="button" 
+            type="button"
             action="vm.save()"
             state="vm.saveButtonState"
             button-style="success"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Within this PR the following has been changed

- `<a>` is converted to `<button>` since they don't contain any `href` values
- `aria-hidden="true"` has been added to the section containing the arrow icons
- Fallback texts have been added in case localization of the dictionary key has not been added for a certain culture
- Also changed the error display to render the text within a `<p>` and moved the `ng-if` onto the wrapping `<div>`, meaning I removed the outer `<div>`, which is not needed