### PR TITLE
Use element type description as tooltip in the Nested Content "Add content" dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.controller.js
@@ -19,6 +19,31 @@ function ItemPickerOverlay($scope, localizationService) {
         $scope.submitForm($scope.model);
     };
 
+    $scope.tooltip = {
+        show: false,
+        event: null
+    };
+
+    $scope.showTooltip = function(item, $event) {
+        if (!item.tooltip) {
+            $scope.mouseLeave();
+            return;
+        }
+        $scope.tooltip = {
+            show: true,
+            event: $event,
+            text: item.tooltip
+        };
+    }
+
+    $scope.hideTooltip = function () {
+        $scope.tooltip = {
+            show: false,
+            event: null,
+            text: null
+        };
+    }
+
     onInit();
 
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -38,9 +38,13 @@
             <button class="umb-card-grid-item btn-reset" ng-click="selectItem(availableItem)">
                 <span>
                     <i class="{{ availableItem.icon }}"></i>
-                    {{ availableItem.name }}
+                    <span ng-mouseover="showTooltip(availableItem, $event)" ng-mouseleave="hideTooltip()">{{ availableItem.name }}</span>                    
                 </span>
             </button>
         </li>
     </ul>
+
+    <umb-tooltip ng-if="tooltip.show" event="tooltip.event">
+        {{ tooltip.text }}
+    </umb-tooltip>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -176,7 +176,8 @@
                 vm.overlayMenu.availableItems.push({
                     alias: scaffold.contentTypeAlias,
                     name: scaffold.contentTypeName,
-                    icon: iconHelper.convertFromLegacyIcon(scaffold.icon)
+                    icon: iconHelper.convertFromLegacyIcon(scaffold.icon),
+                    tooltip: scaffold.documentType.description
                 });
             });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8073

### Description

As discussed in #8073 it makes sense to use the element type descriptions in the Nested Content "Add content" dialog.

This PR shows the element type descriptions as tooltips on hover. I have opted to only show the tooltips when hovering the element type names, as it got too aggressive otherwise.

Obviously no tooltip is displayed if the element type does not have a description. 

Here's a GIF that shows the feature in action (only some of the element types have descriptions):

![element-type-description-as-tooltip](https://user-images.githubusercontent.com/7405322/82753552-bf7dce80-9dc6-11ea-9c4c-19dc55afd5a0.gif)

