### PR TITLE
Preserve sort order when copying content

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2174,7 +2174,7 @@ namespace Umbraco.Core.Services.Implement
                     var total = long.MaxValue;
                     while (page * pageSize < total)
                     {
-                        var descendants = GetPagedDescendants(content.Id, page++, pageSize, out total);
+                        var descendants = GetPagedDescendants(content.Id, page++, pageSize, out total, ordering: Ordering.By("sortOrder"));
                         foreach (var descendant in descendants)
                         {
                             // if parent has not been copied, skip, else gets its copy id

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -1959,6 +1959,33 @@ namespace Umbraco.Tests.Services
             Assert.AreNotEqual(childCopy.Key, child.Key);
         }
 
+        
+        [Test]
+        public void Copy_Recursive_Preserves_Sort_Order()
+        {
+            // Arrange
+            var contentService = ServiceContext.ContentService;
+            var temp = contentService.GetById(NodeDto.NodeIdSeed + 2);
+            Assert.AreEqual("Home", temp.Name);
+            Assert.AreEqual(2, contentService.CountChildren(temp.Id));
+            var reversedChildren = contentService.GetPagedChildren(temp.Id, 0, 10, out var total1).Reverse().ToArray();
+            contentService.Sort(reversedChildren);
+
+            // Act
+            var copy = contentService.Copy(temp, temp.ParentId, false, true, Constants.Security.SuperUserId);
+            var content = contentService.GetById(NodeDto.NodeIdSeed + 2);
+
+            // Assert
+            Assert.That(copy, Is.Not.Null);
+            Assert.That(copy.Id, Is.Not.EqualTo(content.Id));
+            Assert.AreNotSame(content, copy);
+            Assert.AreEqual(2, contentService.CountChildren(copy.Id));
+
+            var copiedChildren = contentService.GetPagedChildren(copy.Id, 0, 10, out var total2).OrderBy(c => c.SortOrder).ToArray();
+            Assert.AreEqual(reversedChildren.First().Name, copiedChildren.First().Name);
+            Assert.AreEqual(reversedChildren.Last().Name, copiedChildren.Last().Name);
+        }
+
         [Test]
         public void Can_Copy_NonRecursive()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7199 8033

### Description

As described in #8033, the sort order isn't preserved when copying content; instead the copied content is sorted by creation order of the original content:

![copy-descendants-before](https://user-images.githubusercontent.com/7405322/82761507-4b115280-9dfb-11ea-8dfb-b7b3595e7f3a.gif)

This PR ensures that we copy descendants by order of their original sort order. Here's the same operation with this PR applied:

![copy-descendants-after](https://user-images.githubusercontent.com/7405322/82761528-73994c80-9dfb-11ea-8c92-d69826d51acc.gif)
