### PR TITLE
Update listviews after sorting children

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function ContentSortController($scope, $filter, $routeParams, contentResource, navigationService) {
+    function ContentSortController($scope, $filter, $routeParams, contentResource, navigationService, eventsService) {
 
         var vm = this;
         var id = $scope.currentNode.id;
@@ -50,6 +50,7 @@
                     navigationService.syncTree({ tree: "content", path: $scope.currentNode.path, forceReload: true })
                         .then(() => navigationService.reloadNode($scope.currentNode));
 
+                    eventsService.emit("sortCompleted", { id: id });
                     vm.saveButtonState = "success";
                 }, function(error) {
                     vm.error = error;

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function MediaSortController($scope, $filter, mediaResource, navigationService) {
+    function MediaSortController($scope, $filter, mediaResource, navigationService, eventsService) {
 
         var vm = this;
         var id = $scope.currentNode.id;
@@ -50,6 +50,7 @@
                     navigationService.syncTree({ tree: "media", path: $scope.currentNode.path, forceReload: true })
                         .then(() => navigationService.reloadNode($scope.currentNode));
 
+                    eventsService.emit("sortCompleted", { id: id });
                     vm.saveButtonState = "success";
                 }, function(error) {
                     vm.error = error;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -1,4 +1,4 @@
-function listViewController($scope, $interpolate, $routeParams, $injector, $timeout, currentUserResource, notificationsService, iconHelper, editorState, localizationService, appState, $location, listViewHelper, navigationService, editorService, overlayService, languageResource, mediaHelper) {
+function listViewController($scope, $interpolate, $routeParams, $injector, $timeout, currentUserResource, notificationsService, iconHelper, editorState, localizationService, appState, $location, listViewHelper, navigationService, editorService, overlayService, languageResource, mediaHelper, eventsService) {
 
     //this is a quick check to see if we're in create mode, if so just exit - we cannot show children for content
     // that isn't created yet, if we continue this will use the parent id in the route params which isn't what
@@ -837,6 +837,19 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     $scope.createFromBlueprint = createFromBlueprint;
     $scope.toggleDropdown = toggleDropdown;
     $scope.leaveDropdown = leaveDropdown;
+
+    // if this listview has sort order in it, make sure it is updated when sorting is performed on the current content
+    if (_.find($scope.options.includeProperties, property => property.alias === "sortOrder")) {
+        var eventSubscription = eventsService.on("sortCompleted", function (e, args) {
+            if (parseInt(args.id) === parseInt($scope.contentId)) {
+                $scope.reloadView($scope.contentId);
+            }
+        });
+
+        $scope.$on('$destroy', function () {
+            eventsService.unsubscribe(eventSubscription);
+        });
+    }
 
     //GO!
     initView();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7995

### Description

As discussed in #7995, the listviews do not update after performing a sort of the children displayed, leaving them somewhat out of sync.

This PR ensures that listviews are updated after a sort is performed on the children of the currently displayed content item. This applies to content and media listviews alike.

Since the sort order column is not part of the default listview, I have opted to only update the listviews after sorting if the sort column is indeed part of the listview. Thus the behavior for default listviews remain unchanged, and any performance penalty introduced by this PR will only affect those listviews where sort order is explicitly added as a column.

Here's a quick demo of this PR:

![listview-reload-after-sort](https://user-images.githubusercontent.com/7405322/82764049-6a64ab80-9e0c-11ea-81a2-651740c7b426.gif)
