### PR TITLE
Datatype configuration: Improve accessibility and UX

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypeconfigurationpicker/datatypeconfigurationpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypeconfigurationpicker/datatypeconfigurationpicker.html
@@ -18,29 +18,28 @@
                     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
                     <div ng-if="!vm.loading">
-                        <a href="" tabindex="0" umb-auto-focus></a>
                         <ul class="umb-card-grid -three-in-row">
-                            <li ng-repeat="dataTypeConfig in vm.configs | orderBy:'name'"
+                            <li ng-repeat="dataTypeConfig in vm.configs | orderBy:'name' track by $index"
                                 data-element="datatypeconfig-{{dataTypeConfig.name}}">
                                 <div ng-if="dataTypeConfig.loading" class="umb-card-grid-item__loading">
                                     <div class="umb-button__progress"></div>
                                 </div>
-                                <a class="umb-card-grid-item" href="" ng-click="vm.pickDataType(dataTypeConfig)" title="{{ dataTypeConfig.name }}">
+                                <button umb-auto-focus="{{$index === 0}}" class="btn-reset umb-card-grid-item" type="button" ng-click="vm.pickDataType(dataTypeConfig)" title="Select {{ dataTypeConfig.name }}">
                                     <span>
-                                        <i class="{{ dataTypeConfig.icon }}" ng-class="{'icon-autofill': dataTypeConfig.icon == null}"></i>
-                                        {{ dataTypeConfig.name }}
+                                        <i class="{{ dataTypeConfig.icon }}" ng-class="{'icon-autofill': dataTypeConfig.icon == null}" aria-hidden="true"></i>
+                                        <span class="sr-only">Select</span> {{ dataTypeConfig.name }}
                                     </span>
-                                </a>
+                                </button>
                             </li>
                         </ul>
                         <ul class="umb-card-grid -three-in-row">
                             <li>
-                                <a class="umb-card-grid-item-slot" href="" ng-click="vm.newDataType()" title="Create a new configuration of {{ model.editor.name }}">
+                                <button umb-auto-focus="{{vm.configs.length === 0}}" class="btn-reset umb-card-grid-item-slot" type="button" ng-click="vm.newDataType()" title="Create a new configuration of {{ model.editor.name }}">
                                     <span>
-                                        <i class="icon icon-add"></i>
-                                        Create new
+                                        <i class="icon icon-add" aria-hidden="true"></i>
+                                        Create new <span class="sr-only">configuration of {{ model.editor.name }}</span>
                                     </span>
-                                </a>
+                                </button>
                             </li>
                         </ul>
 


### PR DESCRIPTION
### Prerequisites

✔️  I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
In this PR the following has been done
- Convert `<a>` to `<button>` since the `href` was empty
- Hide the icon by setting `aria-hidden="true"` on it
- Add some visuallyhidden texts to improve the screen reader experience
- Add the umb-auto-focus directive on the button and set the first button to be focused when the overlay opens instead of relying on an empty anchor tag - If no editor exists to configure then the "Add new" button will be focused instead - Below you can see the before and after effect.

I hope you like it and look forward to receive any feedback you might have as usual 😃 

**Before**
![datatype-config-before](https://user-images.githubusercontent.com/1932158/82765153-82402d80-9e14-11ea-9886-969797c42ded.gif)


**After**
![datatype-config-after](https://user-images.githubusercontent.com/1932158/82764982-507a9700-9e13-11ea-9f82-b90a3b5b01d4.gif)
