### PR TITLE
Clone properties before manipulating them in the rollback window

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
@@ -116,6 +116,11 @@
             // extract all properties from the tabs and create new object for the diff
             currentVersion.tabs.forEach((tab, tabIndex) => {
                 tab.properties.forEach((property, propertyIndex) => {
+
+                    // this is a reference to the property being displayed in the editor - we need to clone it before
+                    // manipulating it here, so any changes made to the property value won't be reflected in the editor
+                    property = _.clone(property);
+
                     var oldProperty = previousVersion.tabs[tabIndex].properties[propertyIndex];
 
                     // we have to make properties storing values as object into strings (Grid, nested content, etc.)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8146

### Description

#8146 describes how the rollback window causes the Repeatable Textstrings property editor to go bananas. The same thing happens to Nested Content (although not nearly as bad) and likely a bunch of other editors too.

Specifically this happens when doing a diff compare in the rollback window. Here's a GIF of the issue:

![rollback-clone-before](https://user-images.githubusercontent.com/7405322/82783167-3f0aac80-9e5e-11ea-8e11-682e96b03301.gif)

This PR ensures that the rollback window performs diff compares on clones of the content properties, thus ensuring that any property manipulation performed for the sake of the diff does not affect the content editor. 

Here's the same operation with this PR applied:

![rollback-clone-after](https://user-images.githubusercontent.com/7405322/82783313-7d07d080-9e5e-11ea-826b-7f64fffff306.gif)

