### PR TITLE
Parse complex RTE styles rules correctly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -133,7 +133,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                         else if (rule.selector[0] !== "." && rule.selector.indexOf(".") > -1) {
                             var split = rule.selector.split(".");
                             r.block = split[0];
-                            r.classes = rule.selector.substring(rule.selector.indexOf(".") + 1).replace(".", " ");
+                            r.classes = rule.selector.substring(rule.selector.indexOf(".") + 1).replace(/\./g, " ");
                         }
                         else if (rule.selector[0] != "#" && rule.selector.indexOf("#") > -1) {
                             var split = rule.selector.split("#");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7976

### Description

See #7976 for an issue description.

To test this PR:

1. Create an RTE style rule with a selector in this format: `[HTML tag].[CSS class].[CSS class].[CSS class]` - e.g. `p.some.complex.rule`. You can make it as complex as you want, but it must contain a HTML tag and at least two CSS classes separated by a period:

![image](https://user-images.githubusercontent.com/7405322/82786195-72503a00-9e64-11ea-9915-fd987822137a.png)

2. Verify that the RTE picks up this style rule and renders it correctly - both in the style selector and when the style rule is applied to content:

![image](https://user-images.githubusercontent.com/7405322/82786160-61072d80-9e64-11ea-8cdd-912f0f171085.png)
