### PR TITLE
Add a bit of spacing in infinite listview editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -200,10 +200,16 @@ h5.-black {
         clear: both;
     }
 }
+
+.umb-editor--infiniteMode .umb-control-group .control-header {
+    padding-bottom: 5px;
+}
+
 .form-horizontal .umb-control-group .control-header {
     float: left;
     width: 160px;
     padding-top: 5px;
+    padding-bottom: 0;
     text-align: left;
 
     .control-label {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When editing a listview in infinite editing, the UI looks a tad cramped:

![image](https://user-images.githubusercontent.com/7405322/82797352-3d99ae00-9e77-11ea-99f3-436d434ceb91.png)

This PR adds some spacing (targeting only controls in infinite editing):

![image](https://user-images.githubusercontent.com/7405322/82797215-1216c380-9e77-11ea-92a0-0ed4f07ea8bf.png)
