### PR TITLE
Ensure that "sort" is available as "order by" for custom listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
@@ -12,16 +12,18 @@
 
             /* ---------- INIT ---------- */ 
 
+            const setDataType = (dataType) => {
+                scope.dataType = dataType;
+                listViewPrevalueHelper.setPrevalues(dataType.preValues);
+            }
+
             const activate = () => {
 
                 if (scope.enableListView) {
 
                     dataTypeResource.getByName(scope.listViewName)
                         .then(dataType => {
-
-                            scope.dataType = dataType;
-
-                            listViewPrevalueHelper.setPrevalues(dataType.preValues);
+                            setDataType(dataType);
                             scope.customListViewCreated = checkForCustomListView();
                         });
 
@@ -64,7 +66,7 @@
                 dataTypeResource.createCustomListView(scope.modelAlias).then(dataType => {
 
                     // store data type
-                    scope.dataType = dataType;
+                    setDataType(dataType);
 
                     // set list view name on scope
                     scope.listViewName = dataType.name;
@@ -95,7 +97,7 @@
                         .then(defaultDataType => {
 
                             // store data type
-                            scope.dataType = defaultDataType;
+                            setDataType(defaultDataType);
 
                             // change state to default list view
                             scope.customListViewCreated = false;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7340

### Description

See #7340 for a detailed issue description. 

TL;DR: When creating a custom listview for a content type, "Sort" is not available as an "Order By" option. It only becomes available after saving and reloading the browser window:

![create-listview-orderby-missing-sortorder-before](https://user-images.githubusercontent.com/7405322/82808495-624b5100-9e8a-11ea-8afb-4af264dffe2d.gif)

This happens because the listview editor reverts to the built-in listview configuration (formerly known as prevalues) when creating a new custom listview, instead of adhering to the default configuration as dictated by Umbraco. Since the built-in listview configuration is missing "Sort", it appears to be missing when creating the new custom listview. 

This PR fixes it; here's the PR applied in action:

![create-listview-orderby-missing-sortorder-after](https://user-images.githubusercontent.com/7405322/82808725-d259d700-9e8a-11ea-8026-6d5a73e66a2f.gif)

As you can tell, the listview editor reverts back to the built-in listview configuration again after removing the custom listview.
