### PR TITLE
Listview "Order by" should not contain removed columns

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
@@ -53,10 +53,9 @@ function includePropsPreValsController($rootScope, $scope, localizationService, 
         $scope.errorMsg = "";
     }
 
-    $scope.removeField = function(e) {
-        $scope.model.value = _.reject($scope.model.value, function (x) {
-            return x.alias === e.alias;
-        }); 
+    $scope.removeField = function (e) {
+        var index = $scope.model.value.indexOf(e);
+        $scope.model.value.splice(index, 1);
     }
 
     //now we'll localize these strings, for some reason the directive doesn't work inside of the select group with an ng-model declared


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "Order by" selector does not update when removing listview columns:

![listview-sortby-removed-properties-before](https://user-images.githubusercontent.com/7405322/82815632-d4776200-9e99-11ea-9e5a-5eecc117dd6f.gif)

This PR fixes it:

![listview-sortby-removed-properties-after](https://user-images.githubusercontent.com/7405322/82815639-d7725280-9e99-11ea-94e1-a5a8ec5a0e7d.gif)
