### PR TITLE
Fix a few localization glitches in the listview "Order by" selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/sortby.prevalues.controller.js
@@ -46,7 +46,7 @@ function sortByPreValsController($rootScope, $scope, localizationService, editor
         var systemFields = [
             { value: "SortOrder", key: "general_sort" },
             { value: "Name", key: "general_name" },
-            { value: "VersionDate", key: "content_updateDate" },
+            { value: "UpdateDate", key: "content_updateDate" },
             { value: "Updater", key: "content_updatedBy" },
             { value: "CreateDate", key: "content_createDate" },
             { value: "Owner", key: "content_createBy" },
@@ -57,26 +57,17 @@ function sortByPreValsController($rootScope, $scope, localizationService, editor
         ];
         _.each(systemFields, function (e) {
             localizationService.localize(e.key).then(function (v) {
-
                 var sortByListValue = findFromSortByFields(e.value);
                 if (sortByListValue) {
                     sortByListValue.name = v;
-                    switch (e.value) {
-                        case "Updater":
-                            e.name += " (Content only)";
-                            break;
-                        case "Published":
-                            e.name += " (Content only)";
-                            break;
-                        case "Email":
-                            e.name += " (Members only)";
-                            break;
-                        case "Username":
-                            e.name += " (Members only)";
-                            break;
-                    }
                 }
             });
+        });
+
+        _.each($scope.sortByFields, function (sortByField) {
+            if (!sortByField.name) {
+                sortByField.name = "(" + sortByField.value + ")";
+            }
         });
 
         // Check existing model value is available in list and ensure a value is set


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There are a few issues in the "Order by" selector when editing listviews:

1. If you remove and add the "Last edited" column, its name won't get translated like the rest of the system fields - it shows as `undefined`.
2. Non-system fields also show as `undefined` until you fill out a heading for them.

![listview-orderby-localization-before](https://user-images.githubusercontent.com/7405322/82821327-2fae5200-9ea4-11ea-9937-5e7d6e0e3b4b.gif)

I also found some unused code that could be deleted while I was at it. Here's a GIF of the same operations with this PR applied:

![listview-orderby-localization-after](https://user-images.githubusercontent.com/7405322/82821370-4785d600-9ea4-11ea-8fcf-aac2aee1d2a5.gif)
