### PR TITLE
Fix glitch in umb-checkbox background

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -45,6 +45,7 @@ label.umb-form-check--checkbox{
         }
         &:checked ~ .umb-form-check__state .umb-form-check__check {
             border-color: @ui-option-type;
+            background-color: @ui-option-type;
         }
         &:checked:hover ~ .umb-form-check__state .umb-form-check__check {
             &::before {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_Note: This is a regression, it was also fixed in #4981_

On some screens I'm seeing a white border in some usages of `umb-checkbox`. It might be a screen resolution/interpolation thing that sets it off. Curiously enough it's on every other checked checkbox on the RTE configuration:

![image](https://user-images.githubusercontent.com/7405322/82890788-0269ae80-9f4d-11ea-9eac-c49bdad0b597.png)

Anyway... the fix is quite harmless - it's adding a background color to the checked state of the checkbox. It looks like this:

![image](https://user-images.githubusercontent.com/7405322/82890972-52487580-9f4d-11ea-8218-2c89e1339960.png)
