### PR TITLE
Adds in NC Property Component to deal with keys that were duplicated

### DIFF
--- a/src/Umbraco.Web/Compose/NestedContentPropertyComponent.cs
+++ b/src/Umbraco.Web/Compose/NestedContentPropertyComponent.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Events;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
+using Umbraco.Web.PropertyEditors;
+
+namespace Umbraco.Web.Compose
+{
+    public class NestedContentPropertyComponent : IComponent
+    {
+        public void Initialize()
+        {
+            ContentService.Copying += ContentService_Copying;
+            ContentService.Saving += ContentService_Saving;
+            ContentService.Publishing += ContentService_Publishing;
+        }
+
+        private void ContentService_Copying(IContentService sender, CopyEventArgs<IContent> e)
+        {
+            // When a content node contains nested content property
+            // Check if the copied node contains a nested content
+            var nestedContentProps = e.Copy.Properties.Where(x => x.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.NestedContent);
+
+            // Each NC Property on a doctype
+            foreach (var nestedContentProp in nestedContentProps)
+            {
+                // A NC Prop may have one or more values due to cultures
+                var propVals = nestedContentProp.Values;
+                foreach (var cultureVal in propVals)
+                {
+                    // Remove keys from published value & any nested NC's
+                    var updatedPublishedVal = CreateNewNestedContentKeys(cultureVal.PublishedValue.ToString());
+                    cultureVal.PublishedValue = updatedPublishedVal;
+
+                    // Remove keys from edited/draft value & any nested NC's
+                    var updatedEditedVal = CreateNewNestedContentKeys(cultureVal.EditedValue.ToString());
+                    cultureVal.EditedValue = updatedEditedVal;
+                }
+            }
+        }
+
+        private void ContentService_Saving(IContentService sender, ContentSavingEventArgs e)
+        {
+            // One or more content nodes could be saved in a bulk publish
+            foreach(var entity in e.SavedEntities)
+            {
+                // When a content node contains nested content property
+                // Check if the copied node contains a nested content
+                var nestedContentProps = entity.Properties.Where(x => x.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.NestedContent);
+
+                // Each NC Property on a doctype
+                foreach (var nestedContentProp in nestedContentProps)
+                {
+                    // A NC Prop may have one or more values due to cultures
+                    var propVals = nestedContentProp.Values;
+                    foreach (var cultureVal in propVals)
+                    {
+                        // Remove keys from published value & any nested NC's
+                        var updatedPublishedVal = CreateMissingNestedContentKeys(cultureVal.PublishedValue.ToString());
+                        cultureVal.PublishedValue = updatedPublishedVal;
+
+                        // Remove keys from edited/draft value & any nested NC's
+                        var updatedEditedVal = CreateMissingNestedContentKeys(cultureVal.EditedValue.ToString());
+                        cultureVal.EditedValue = updatedEditedVal;
+                    }
+                }
+            }
+        }
+
+        private void ContentService_Publishing(IContentService sender, ContentPublishingEventArgs e)
+        {
+            // One or more content nodes could be saved in a bulk publish
+            foreach (var entity in e.PublishedEntities)
+            {
+                // When a content node contains nested content property
+                // Check if the copied node contains a nested content
+                var nestedContentProps = entity.Properties.Where(x => x.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.NestedContent);
+
+                // Each NC Property on a doctype
+                foreach (var nestedContentProp in nestedContentProps)
+                {
+                    // A NC Prop may have one or more values due to cultures
+                    var propVals = nestedContentProp.Values;
+                    foreach (var cultureVal in propVals)
+                    {
+                        // Remove keys from published value & any nested NC's
+                        var updatedPublishedVal = CreateMissingNestedContentKeys(cultureVal.PublishedValue.ToString());
+                        cultureVal.PublishedValue = updatedPublishedVal;
+
+                        // Remove keys from edited/draft value & any nested NC's
+                        var updatedEditedVal = CreateMissingNestedContentKeys(cultureVal.EditedValue.ToString());
+                        cultureVal.EditedValue = updatedEditedVal;
+                    }
+                }
+            }
+        }
+
+        public void Terminate()
+        {
+            ContentService.Copying -= ContentService_Copying;
+            ContentService.Saving -= ContentService_Saving;
+            ContentService.Publishing -= ContentService_Publishing;
+        }
+
+        private string CreateNewNestedContentKeys(string ncJson)
+        {
+            // Try & convert JSON to JArray (two props we will know should exist are key & ncContentTypeAlias)
+            var ncItems = JArray.Parse(ncJson);
+
+            // NC prop contains one or more items/rows of things
+            foreach (var nestedContentItem in ncItems.Children<JObject>())
+            {
+                foreach (var ncItemProp in nestedContentItem.Properties())
+                {
+                    if(ncItemProp.Name.ToLowerInvariant() == "key")
+                        ncItemProp.Value = Guid.NewGuid().ToString();
+
+                    // No need to check this property for JSON - as this is a JSON prop we know
+                    // That onyl contains the string of the doctype alias used as the NC item
+                    if (ncItemProp.Name == NestedContentPropertyEditor.ContentTypeAliasPropertyKey)
+                        continue;
+
+                    // As we don't know what properties in the JSON may contain the nested NC
+                    // We are detecting if its value stores JSON to help filter the list AND that in its JSON it has ncContentTypeAlias prop
+                    if (ncItemProp.Value.ToString().DetectIsJson() && ncItemProp.Value.ToString().Contains(NestedContentPropertyEditor.ContentTypeAliasPropertyKey))
+                    {
+                        // Recurse & update this JSON property
+                        ncItemProp.Value = CreateNewNestedContentKeys(ncItemProp.Value.ToString());
+                    }
+                }
+            }
+
+            return ncItems.ToString();
+        }
+
+        private string CreateMissingNestedContentKeys(string ncJson)
+        {
+            // Try & convert JSON to JArray (two props we will know should exist are key & ncContentTypeAlias)
+            var ncItems = JArray.Parse(ncJson);
+
+            // NC prop contains one or more items/rows of things
+            foreach (var nestedContentItem in ncItems.Children<JObject>())
+            {
+                var ncKeyProp = nestedContentItem.Properties().SingleOrDefault(x => x.Name.ToLowerInvariant() == "key");
+                if(ncKeyProp == null)
+                {
+                    nestedContentItem.Properties().Append(new JProperty("key", Guid.NewGuid().ToString()));
+                }
+
+                foreach (var ncItemProp in nestedContentItem.Properties())
+                {
+                    // No need to check this property for JSON (Its the key OR ncContentTypeAlias) which has no JSON
+                    if (ncItemProp.Name == NestedContentPropertyEditor.ContentTypeAliasPropertyKey || ncItemProp.Name.ToLowerInvariant() == "key")
+                        continue;
+
+                    // As we don't know what properties in the JSON may contain the nested NC
+                    // We are detecting if its value stores JSON to help filter the list AND that in its JSON it has ncContentTypeAlias prop
+                    if (ncItemProp.Value.ToString().DetectIsJson() && ncItemProp.Value.ToString().Contains(NestedContentPropertyEditor.ContentTypeAliasPropertyKey))
+                    {
+                        // Recurse & update this JSON property
+                        ncItemProp.Value = CreateMissingNestedContentKeys(ncItemProp.Value.ToString());
+                    }
+                }
+            }
+
+            return ncItems.ToString();
+        }
+    }
+}

--- a/src/Umbraco.Web/Compose/NestedContentPropertyComposer.cs
+++ b/src/Umbraco.Web/Compose/NestedContentPropertyComposer.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Composing;
+
+namespace Umbraco.Web.Compose
+{
+    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
+    public class NestedContentPropertyComposer : ComponentComposer<NestedContentPropertyComponent>, ICoreComposer
+    { }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Cache\UserGroupCacheRefresher.cs" />
     <Compile Include="Cache\UserGroupPermissionsCacheRefresher.cs" />
     <Compile Include="Compose\BackOfficeUserAuditEventsComposer.cs" />
+    <Compile Include="Compose\NestedContentPropertyComponent.cs" />
     <Compile Include="Compose\NotificationsComposer.cs" />
     <Compile Include="Compose\PublicAccessComposer.cs" />
     <Compile Include="Composing\CompositionExtensions\Installer.cs" />
@@ -237,6 +238,7 @@
     <Compile Include="Mvc\SurfaceControllerTypeCollectionBuilder.cs" />
     <Compile Include="Mvc\ValidateUmbracoFormRouteStringAttribute.cs" />
     <Compile Include="Profiling\WebProfilingController.cs" />
+    <Compile Include="Compose\NestedContentPropertyComposer.cs" />
     <Compile Include="PropertyEditors\ParameterEditors\MultipleMediaPickerParameterEditor.cs" />
     <Compile Include="PropertyEditors\RichTextEditorPastedImages.cs" />
     <Compile Include="PublishedCache\NuCache\PublishedSnapshotServiceOptions.cs" />


### PR DESCRIPTION
When copying a node only the Copying & Copied events are emitted and not the Saving & Saved events that were assumed would fire.

When copying a content node, it will create new GUID string keys for all nested content items, including a recursive if one of the JSON properties of the nested content, included another nested content item, as opposed to removing/clearing the keys as originally suggested for the solution.

Saving & Publishing nodes will only add new keys if they are missing, which requires @nielslyngsoe #7166 JS PR as he removes the key property & further nested content inside nested content key properties from the clientside code when a nested content item/s are copied & used.


## Note
This PR is built upon @nielslyngsoe JS changes needed to deal with copying nested content items, so be mindful that this PR targets his PR as opposed to V8/dev - https://github.com/umbraco/Umbraco-CMS/pull/7166

## Test Notes
* Use a package such as Igloo which uses Nested Content alot
* Create a page with a hero and add buttons to it (which is also another nested content)
* Ensure all keys are unique
* Copy the hero inside the nested content UI
* Create a new copy with slightly different content
* Save or Save & Publish Node
* Reload node in backoffice & verify XHR request in DevTools for node that the NC property items all have unique keys

* Copy the entire content node with the right click context menu
* Ensure all NC items have new/unique keys different from the original content item (please compare)

## Other Tests

* Verify this works OK with segments/culture variants and each language variant of the nested content gets unique keys as well.


Fixes AB#6684