### PR TITLE
Logging content template save in back office to log table

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2985,6 +2985,8 @@ namespace Umbraco.Core.Services.Implement
 
                 _documentBlueprintRepository.Save(content);
 
+                Audit(AuditType.Save, Constants.Security.SuperUserId, content.Id, $"Saved content template: {content.Name}");
+
                 scope.Events.Dispatch(SavedBlueprint, this, new SaveEventArgs<IContent>(content), "SavedBlueprint");
 
                 scope.Complete();


### PR DESCRIPTION
Similar to #8140 I am trying to log the saving of a content template into the `umbracoLog` table. Currently it does not save into the `umbracoLog` table.

with this PR applied, when a content template is saved the following SQL query should bring back results on content template as well.

SELECT TOP (10) [id]
      ,[userId]
      ,[NodeId]
      ,[entityType]
      ,[Datestamp]
      ,[logHeader]
      ,[logComment]
      ,[parameters]
  FROM [dbo].[umbracoLog]
  order by Datestamp desc