### PR TITLE
Added content apps for document types

### DIFF
--- a/src/Umbraco.Core/Manifest/ManifestContentAppFactory.cs
+++ b/src/Umbraco.Core/Manifest/ManifestContentAppFactory.cs
@@ -62,6 +62,10 @@ namespace Umbraco.Core.Manifest
                     partA = "member";
                     partB = member.ContentType.Alias;
                     break;
+                case IContentType contentType:
+                    partA = "contentType";
+                    partB = contentType.Alias;
+                    break;
 
                 default:
                     return null;

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -92,33 +92,6 @@
             vm.labels.addTemplate = values[13];
             vm.labels.allowCultureVariants = values[14];
 
-            var buttons = [
-                {
-                    "name": vm.labels.design,
-                    "alias": "design",
-                    "icon": "icon-document-dashed-line",
-                    "view": "views/documenttypes/views/design/design.html"
-                },
-                {
-                    "name": vm.labels.listview,
-                    "alias": "listView",
-                    "icon": "icon-list",
-                    "view": "views/documenttypes/views/listview/listview.html"
-                },
-                {
-                    "name": vm.labels.permissions,
-                    "alias": "permissions",
-                    "icon": "icon-keychain",
-                    "view": "views/documenttypes/views/permissions/permissions.html"
-                },
-                {
-                    "name": vm.labels.templates,
-                    "alias": "templates",
-                    "icon": "icon-layout",
-                    "view": "views/documenttypes/views/templates/templates.html"
-                }
-            ];
-
             vm.page.keyboardShortcutsOverview = [
                 {
                     "name": vm.labels.sections,
@@ -187,9 +160,6 @@
                     ]
                 }
             ];
-
-            loadButtons(buttons);
-
         });
 
         contentTypeHelper.checkModelsBuilderStatus().then(function (result) {
@@ -286,18 +256,16 @@
             });
         }
 
-        function loadButtons(buttons) {
-
-            angular.forEach(buttons,
+        function loadButtons() {
+			vm.page.navigation = vm.contentType.apps;
+			
+			angular.forEach(vm.contentType.apps,
                 function (val, index) {
-
                     if (disableTemplates === true && val.alias === "templates") {
-                        buttons.splice(index, 1);
+                        vm.page.navigation.splice(index, 1);
                     }
-
                 });
-
-            vm.page.navigation = buttons;
+			
             initializeActiveNavigationPanel();
         }
 
@@ -307,17 +275,15 @@
             var initialViewSetFromRouteParams = false;
             var view = $routeParams.view;
             if (view) {
-                var viewPath = "views/documenttypes/views/" + view + "/" + view + ".html";
                 for (var i = 0; i < vm.page.navigation.length; i++) {
-                    if (vm.page.navigation[i].view === viewPath) {
+                    if (vm.page.navigation[i].alias.toLowerCase() === view.toLowerCase()) {
                         vm.page.navigation[i].active = true;
                         initialViewSetFromRouteParams = true;
                         break;
                     }
                 }
             }
-
-            if (initialViewSetFromRouteParams === false) {
+			if (initialViewSetFromRouteParams === false) {
                 vm.page.navigation[0].active = true;
             }
         }
@@ -446,10 +412,12 @@
             // convert icons for content type
             convertLegacyIcons(contentType);
 
-            //set a shared state
-            editorState.set(contentType);
-
             vm.contentType = contentType;
+
+			//set a shared state
+            editorState.set(vm.contentType);
+			
+			loadButtons();
         }
 
         /** Syncs the template alias for new doc types before saving if a template is to be created */
@@ -536,7 +504,7 @@
         evts.push(eventsService.on("editors.groupsBuilder.changed", function(name, args) {
             angularHelper.getCurrentForm($scope).$setDirty();
         }));
-
+		
         //ensure to unregister from all events!
         $scope.$on('$destroy', function () {
             for (var e in evts) {

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -259,12 +259,14 @@
         function loadButtons() {
             vm.page.navigation = vm.contentType.apps;
 
-            Utilies.forEach(vm.contentType.apps,
-                function (val, index) {
-                    if (disableTemplates === true && val.alias === "templates") {
-                        vm.page.navigation.splice(index, 1);
-                    }
-                });
+            if (disableTemplates === true) {
+                Utilities.forEach(vm.contentType.apps,
+                    (app, index) => {
+                        if (app.alias === "templates") {
+                            vm.page.navigation.splice(index, 1);
+                        }
+                    });
+            }
 
             initializeActiveNavigationPanel();
         }
@@ -493,9 +495,8 @@
                     if (treeExists) {
                         navigationService.syncTree({ tree: "templates", path: [], forceReload: true })
                             .then(function (syncArgs) {
-                                navigationService.reloadNode(syncArgs.node)
-                            }
-                            );
+                                navigationService.reloadNode(syncArgs.node);
+                            });
                     }
                 });
             }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -38,7 +38,7 @@
         vm.page.loading = false;
         vm.page.saveButtonState = "init";
         vm.page.navigation = [];
-     
+
         var labelKeys = [
             "general_design",
             "general_listView",
@@ -249,7 +249,7 @@
             contentTypeResource.getById(documentTypeId).then(function (dt) {
                 init(dt);
                 // we don't need to sync the tree in infinite mode
-                if(!infiniteMode) { 
+                if (!infiniteMode) {
                     syncTreeNode(vm.contentType, dt.path, true);
                 }
                 vm.page.loading = false;
@@ -257,15 +257,15 @@
         }
 
         function loadButtons() {
-			vm.page.navigation = vm.contentType.apps;
-			
-			angular.forEach(vm.contentType.apps,
+            vm.page.navigation = vm.contentType.apps;
+
+            Utilies.forEach(vm.contentType.apps,
                 function (val, index) {
                     if (disableTemplates === true && val.alias === "templates") {
                         vm.page.navigation.splice(index, 1);
                     }
                 });
-			
+
             initializeActiveNavigationPanel();
         }
 
@@ -283,7 +283,7 @@
                     }
                 }
             }
-			if (initialViewSetFromRouteParams === false) {
+            if (initialViewSetFromRouteParams === false) {
                 vm.page.navigation[0].active = true;
             }
         }
@@ -345,17 +345,17 @@
                 }).then(function (data) {
                     //success
                     // we don't need to sync the tree in infinite mode
-                    if(!infiniteMode) {
+                    if (!infiniteMode) {
                         syncTreeNode(vm.contentType, data.path);
                     }
 
                     // emit event
                     var args = { documentType: vm.contentType };
                     eventsService.emit("editors.documentType.saved", args);
-                    
+
                     vm.page.saveButtonState = "success";
 
-                    if(infiniteMode && $scope.model.submit) {
+                    if (infiniteMode && $scope.model.submit) {
                         $scope.model.documentTypeAlias = vm.contentType.alias;
                         $scope.model.submit($scope.model);
                     }
@@ -414,10 +414,10 @@
 
             vm.contentType = contentType;
 
-			//set a shared state
+            //set a shared state
             editorState.set(vm.contentType);
-			
-			loadButtons();
+
+            loadButtons();
         }
 
         /** Syncs the template alias for new doc types before saving if a template is to be created */
@@ -495,16 +495,16 @@
                             .then(function (syncArgs) {
                                 navigationService.reloadNode(syncArgs.node)
                             }
-                        );
+                            );
                     }
-                }); 
+                });
             }
         }));
 
         evts.push(eventsService.on("editors.groupsBuilder.changed", function(name, args) {
             angularHelper.getCurrentForm($scope).$setDirty();
         }));
-		
+
         //ensure to unregister from all events!
         $scope.$on('$destroy', function () {
             for (var e in evts) {

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -278,7 +278,7 @@
             var view = $routeParams.view;
             if (view) {
                 for (var i = 0; i < vm.page.navigation.length; i++) {
-                    if (vm.page.navigation[i].alias.toLowerCase() === view.toLowerCase()) {
+                    if (vm.page.navigation[i].alias.localeCompare(view, undefined, { sensitivity: 'accent' }) === 0) {
                         vm.page.navigation[i].active = true;
                         initialViewSetFromRouteParams = true;
                         break;

--- a/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
@@ -30,9 +30,6 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
 
-                case IContent _:
-                    return null;
-
                 case IMedia media when !media.ContentType.IsContainer || media.Properties.Count > 0:
                     return _mediaApp ?? (_mediaApp = new ContentApp
                     {
@@ -42,9 +39,6 @@ namespace Umbraco.Web.ContentApps
                         View = "views/media/apps/content/content.html",
                         Weight = Weight
                     });
-
-                case IMedia _:
-                    return null;
 
                 case IMember _:
                     return _memberApp ?? (_memberApp = new ContentApp
@@ -56,11 +50,8 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
 
-                case IContentType _:
-                    return null;
-
                 default:
-                    throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");
+                    return null;
             }
         }
     }

--- a/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentEditorContentAppFactory.cs
@@ -56,6 +56,9 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
 
+                case IContentType _:
+                    return null;
+
                 default:
                     throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");
             }

--- a/src/Umbraco.Web/ContentApps/ContentInfoContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentInfoContentAppFactory.cs
@@ -48,6 +48,9 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
 
+                case IContentType _:
+                    return null;
+
                 default:
                     throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");
             }

--- a/src/Umbraco.Web/ContentApps/ContentInfoContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentInfoContentAppFactory.cs
@@ -48,11 +48,8 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
 
-                case IContentType _:
-                    return null;
-
                 default:
-                    throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");
+                    return null;
             }
         }
     }

--- a/src/Umbraco.Web/ContentApps/ContentTypeDesignContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypeDesignContentAppFactory.cs
@@ -16,12 +16,6 @@ namespace Umbraco.Web.ContentApps
         {
             switch (source)
             {
-                case IContent _:
-                    return null;
-                case IMedia _:
-                    return null;
-                case IMember _:
-                    return null;
                 case IContentType _:
                     return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
                     {
@@ -32,7 +26,7 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
                 default:
-                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+                    return null;
             }
         }
     }

--- a/src/Umbraco.Web/ContentApps/ContentTypeDesignContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypeDesignContentAppFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Web.ContentApps
+{
+    internal class ContentTypeDesignContentAppFactory : IContentAppFactory
+    {
+        private const int Weight = -200;
+
+        private ContentApp _contentTypeApp;
+
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+            switch (source)
+            {
+                case IContent _:
+                    return null;
+                case IMedia _:
+                    return null;
+                case IMember _:
+                    return null;
+                case IContentType _:
+                    return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
+                    {
+                        Alias = "design",
+                        Name = "Design",
+                        Icon = "icon-document-dashed-line",
+                        View = "views/documenttypes/views/design/design.html",
+                        Weight = Weight
+                    });
+                default:
+                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/ContentApps/ContentTypeListViewContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypeListViewContentAppFactory.cs
@@ -16,12 +16,6 @@ namespace Umbraco.Web.ContentApps
         {
             switch (source)
             {
-                case IContent _:
-                    return null;
-                case IMedia _:
-                    return null;
-                case IMember _:
-                    return null;
                 case IContentType _:
                     return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
                     {
@@ -32,7 +26,7 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
                 default:
-                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+                    return null;
             }
         }
     }

--- a/src/Umbraco.Web/ContentApps/ContentTypeListViewContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypeListViewContentAppFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Web.ContentApps
+{
+    internal class ContentTypeListViewContentAppFactory : IContentAppFactory
+    {
+        private const int Weight = -180;
+
+        private ContentApp _contentTypeApp;
+
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+            switch (source)
+            {
+                case IContent _:
+                    return null;
+                case IMedia _:
+                    return null;
+                case IMember _:
+                    return null;
+                case IContentType _:
+                    return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
+                    {
+                        Alias = "listView",
+                        Name = "List view",
+                        Icon = "icon-list",
+                        View = "views/documenttypes/views/listview/listview.html",
+                        Weight = Weight
+                    });
+                default:
+                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/ContentApps/ContentTypePermissionsContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypePermissionsContentAppFactory.cs
@@ -16,12 +16,6 @@ namespace Umbraco.Web.ContentApps
         {
             switch (source)
             {
-                case IContent _:
-                    return null;
-                case IMedia _:
-                    return null;
-                case IMember _:
-                    return null;
                 case IContentType _:
                     return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
                     {
@@ -32,7 +26,7 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
                 default:
-                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+                    return null;
             }
         }
     }

--- a/src/Umbraco.Web/ContentApps/ContentTypePermissionsContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypePermissionsContentAppFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Web.ContentApps
+{
+    internal class ContentTypePermissionsContentAppFactory : IContentAppFactory
+    {
+        private const int Weight = -160;
+
+        private ContentApp _contentTypeApp;
+
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+            switch (source)
+            {
+                case IContent _:
+                    return null;
+                case IMedia _:
+                    return null;
+                case IMember _:
+                    return null;
+                case IContentType _:
+                    return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
+                    {
+                        Alias = "permissions",
+                        Name = "Permissions",
+                        Icon = "icon-keychain",
+                        View = "views/documenttypes/views/permissions/permissions.html",
+                        Weight = Weight
+                    });
+                default:
+                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/ContentApps/ContentTypeTemplatesContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypeTemplatesContentAppFactory.cs
@@ -16,12 +16,6 @@ namespace Umbraco.Web.ContentApps
         {
             switch (source)
             {
-                case IContent _:
-                    return null;
-                case IMedia _:
-                    return null;
-                case IMember _:
-                    return null;
                 case IContentType _:
                     return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
                     {
@@ -32,7 +26,7 @@ namespace Umbraco.Web.ContentApps
                         Weight = Weight
                     });
                 default:
-                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+                    return null;
             }
         }
     }

--- a/src/Umbraco.Web/ContentApps/ContentTypeTemplatesContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ContentTypeTemplatesContentAppFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Web.ContentApps
+{
+    internal class ContentTypeTemplatesContentAppFactory : IContentAppFactory
+    {
+        private const int Weight = -140;
+
+        private ContentApp _contentTypeApp;
+
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+            switch (source)
+            {
+                case IContent _:
+                    return null;
+                case IMedia _:
+                    return null;
+                case IMember _:
+                    return null;
+                case IContentType _:
+                    return _contentTypeApp ?? (_contentTypeApp = new ContentApp()
+                    {
+                        Alias = "templates",
+                        Name = "Templates",
+                        Icon = "icon-layout",
+                        View = "views/documenttypes/views/templates/templates.html",
+                        Weight = Weight
+                    });
+                default:
+                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/ContentApps/ListViewContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ListViewContentAppFactory.cs
@@ -45,12 +45,8 @@ namespace Umbraco.Web.ContentApps
                     entityType = "media";
                     dtdId = Core.Constants.DataTypes.DefaultMediaListView;
                     break;
-                case IMember _:
-                    return null;
-                case IContentType _:
-                    return null;
                 default:
-                    throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");
+                    return null;
             }
 
             return CreateContentApp(_dataTypeService, _propertyEditors, entityType, contentTypeAlias, dtdId);

--- a/src/Umbraco.Web/ContentApps/ListViewContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/ListViewContentAppFactory.cs
@@ -45,7 +45,9 @@ namespace Umbraco.Web.ContentApps
                     entityType = "media";
                     dtdId = Core.Constants.DataTypes.DefaultMediaListView;
                     break;
-                case IMember member:
+                case IMember _:
+                    return null;
+                case IContentType _:
                     return null;
                 default:
                     throw new NotSupportedException($"Object type {o.GetType()} is not supported here.");

--- a/src/Umbraco.Web/Models/ContentEditing/DocumentTypeDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/DocumentTypeDisplay.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Umbraco.Core.Models.ContentEditing;
 
 namespace Umbraco.Web.Models.ContentEditing
 {
@@ -26,6 +27,9 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "allowSegmentVariant")]
         public bool AllowSegmentVariant { get; set; }
+
+        [DataMember(Name = "apps")]
+        public IEnumerable<ContentApp> ContentApps { get; set; }
 
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/CommonMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/CommonMapper.cs
@@ -7,6 +7,7 @@ using Umbraco.Core;
 using Umbraco.Core.Mapping;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Entities;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Services;
 using Umbraco.Web.ContentApps;
@@ -81,7 +82,7 @@ namespace Umbraco.Web.Models.Mapping
             return urlHelper.GetUmbracoApiService<MemberTreeController>(controller => controller.GetTreeNode(source.Key.ToString("N"), null));
         }
 
-        public IEnumerable<ContentApp> GetContentApps(IContentBase source)
+        public IEnumerable<ContentApp> GetContentApps(IUmbracoEntity source)
         {
             var apps = _contentAppDefinitions.GetContentAppsFor(source).ToArray();
 

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Web.Models.Mapping
     /// </summary>
     internal class ContentTypeMapDefinition : IMapDefinition
     {
+        private readonly CommonMapper _commonMapper;
         private readonly PropertyEditorCollection _propertyEditors;
         private readonly IDataTypeService _dataTypeService;
         private readonly IFileService _fileService;
@@ -25,10 +26,11 @@ namespace Umbraco.Web.Models.Mapping
         private readonly IMemberTypeService _memberTypeService;
         private readonly ILogger _logger;
 
-        public ContentTypeMapDefinition(PropertyEditorCollection propertyEditors, IDataTypeService dataTypeService, IFileService fileService,
+        public ContentTypeMapDefinition(CommonMapper commonMapper, PropertyEditorCollection propertyEditors, IDataTypeService dataTypeService, IFileService fileService,
             IContentTypeService contentTypeService, IMediaTypeService mediaTypeService, IMemberTypeService memberTypeService,
             ILogger logger)
         {
+            _commonMapper = commonMapper;
             _propertyEditors = propertyEditors;
             _dataTypeService = dataTypeService;
             _fileService = fileService;
@@ -122,6 +124,7 @@ namespace Umbraco.Web.Models.Mapping
 
             target.AllowCultureVariant = source.VariesByCulture();
             target.AllowSegmentVariant = source.VariesBySegment();
+            target.ContentApps = _commonMapper.GetContentApps(source);
 
             //sync templates
             target.AllowedTemplates = context.MapEnumerable<ITemplate, EntityBasic>(source.AllowedTemplates);

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -238,7 +238,11 @@ namespace Umbraco.Web.Runtime
             composition.ContentApps()
                 .Append<ListViewContentAppFactory>()
                 .Append<ContentEditorContentAppFactory>()
-                .Append<ContentInfoContentAppFactory>();
+                .Append<ContentInfoContentAppFactory>()
+                .Append<ContentTypeDesignContentAppFactory>()
+                .Append<ContentTypeListViewContentAppFactory>()
+                .Append<ContentTypePermissionsContentAppFactory>()
+                .Append<ContentTypeTemplatesContentAppFactory>();
 
             // register back office sections in the order we want them rendered
             composition.Sections()

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -134,6 +134,10 @@
     <Compile Include="Composing\CompositionExtensions\Installer.cs" />
     <Compile Include="Composing\LightInject\LightInjectContainer.cs" />
     <Compile Include="Compose\BackOfficeUserAuditEventsComponent.cs" />
+    <Compile Include="ContentApps\ContentTypeTemplatesContentAppFactory.cs" />
+    <Compile Include="ContentApps\ContentTypePermissionsContentAppFactory.cs" />
+    <Compile Include="ContentApps\ContentTypeListViewContentAppFactory.cs" />
+    <Compile Include="ContentApps\ContentTypeDesignContentAppFactory.cs" />
     <Compile Include="ContentApps\ListViewContentAppFactory.cs" />
     <Compile Include="Dashboards\ContentDashboard.cs" />
     <Compile Include="Dashboards\DashboardCollection.cs" />


### PR DESCRIPTION
This PR adds the ability to add content apps to document types.

I updated the tabs that are currently used (design, list view, permissions and templates) to be using the new content apps. 

Why would you want content apps for document types? I think it's always good to have the possibility to extend the backoffice on all spots, but I actually had an idea I couldn't do because this wasn't possible. I want to be able to set SEO settings for all pages that have a certain document type. 

I am not too familiar with the Umbraco code, so I hope everything that I changed is alright! Please let me know if it isn't and I can change it around.

Doc type with 1 custom C# content app
![docTypeWithCustomApp](https://user-images.githubusercontent.com/11466511/83022600-0ddfd700-a02c-11ea-9eea-8e488fa8df06.PNG)

Doc type with 2 custom content apps (1x C# and 1x manifest)
![docTypeWithCustomApps](https://user-images.githubusercontent.com/11466511/83022622-189a6c00-a02c-11ea-8eee-88eabdd7ac75.PNG)
