### PR TITLE
Fix HTML markup of umb-list-view-settings.html

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -44,6 +44,6 @@
                 aria-label="Edit"></button>
         </div>
     </div>
-    
+  </div>
 
 </div>


### PR DESCRIPTION
I've noticed this file was missing a closing div tag, so I added it.