### PR TITLE
Fix HTML markup of includeproperties.prevalues.html

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -9,7 +9,7 @@
         <button type="button" class="btn" ng-click="addField()">
             <localize key="general_add">Add</localize>
         </button>
-        <span class="help-inline" ng-bind="errorMsg"</span>
+        <span class="help-inline" ng-bind="errorMsg"></span>
     </div>
     <div class="control-group">
         <table class="table" ng-show="model.value.length > 0">


### PR DESCRIPTION
I've noticed this span was missing a closing >, so I added it.