### PR TITLE
Umb-confirm-directive: Hide icons and add missing screen reader friendly texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
@@ -7,10 +7,16 @@
      on-outside-click="clickCancel()">
 
         <button class="umb_confirm-action__overlay-action -confirm btn-reset" ng-click="clickConfirm()" localize="title" title="@buttons_confirmActionConfirm" type="button">
-            <i class="icon-check"></i>
+            <i class="icon-check" aria-hidden="true"></i>
+            <span class="sr-only">
+                <localize key="buttons_confirmActionConfirm">Confirm</localize>
+            </span>
         </button>
 
         <button class="umb_confirm-action__overlay-action -cancel btn-reset"  ng-click="clickCancel()" localize="title" title="@buttons_confirmActionCancel" type="button">
-            <i class="icon-delete"></i>
+            <i class="icon-delete" aria-hidden="true"></i>
+            <span class="sr-only">
+                <localize key="buttons_confirmActionCancel">Cancel</localize>
+            </span>
         </button>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have added screen reader friendly texts on the buttons and added `aria-hidden="true"` on the `<i>` element ensuring no screen reader announces them.
