### PR TITLE
Improve dictionary dashboard performance significantly

### DIFF
--- a/src/Umbraco.Web/Editors/DictionaryController.cs
+++ b/src/Umbraco.Web/Editors/DictionaryController.cs
@@ -207,44 +207,31 @@ namespace Umbraco.Web.Editors
         /// </returns>
         public IEnumerable<DictionaryOverviewDisplay> GetList()
         {
-            var list = new List<DictionaryOverviewDisplay>();
+            var items = Services.LocalizationService.GetDictionaryItemDescendants(null).ToArray();
+            var list = new List<DictionaryOverviewDisplay>(items.Length);
 
-            const int level = 0;
-
-            foreach (var dictionaryItem in Services.LocalizationService.GetRootDictionaryItems().OrderBy(ItemSort()))
+            // recursive method to build a tree structure from the flat structure returned above
+            void BuildTree(int level = 0, Guid? parentId = null)
             {
-                var item = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(dictionaryItem);
-                item.Level = 0;
-                list.Add(item);
+                var children = items.Where(t => t.ParentId == parentId).ToArray();
+                if(children.Any() == false)
+                {
+                    return;
+                }
 
-                GetChildItemsForList(dictionaryItem, level + 1, list);
+                foreach(var child in children.OrderBy(ItemSort()))
+                {
+                    var display = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(child);
+                    display.Level = level;
+                    list.Add(display);
+
+                    BuildTree(level + 1, child.Key);
+                }                
             }
 
-            return list;
-        }
+            BuildTree();
 
-        /// <summary>
-        /// Get child items for list.
-        /// </summary>
-        /// <param name="dictionaryItem">
-        /// The dictionary item.
-        /// </param>
-        /// <param name="level">
-        /// The level.
-        /// </param>
-        /// <param name="list">
-        /// The list.
-        /// </param>
-        private void GetChildItemsForList(IDictionaryItem dictionaryItem, int level, ICollection<DictionaryOverviewDisplay> list)
-        {
-            foreach (var childItem in Services.LocalizationService.GetDictionaryItemChildren(dictionaryItem.Key).OrderBy(ItemSort()))
-            {
-                var item = Mapper.Map<IDictionaryItem, DictionaryOverviewDisplay>(childItem);
-                item.Level = level;
-                list.Add(item);
-
-                GetChildItemsForList(childItem, level + 1, list);
-            }
+            return list;            
         }
 
         private static Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As the dictionary grows larger, the dictionary dashboard turns slower. When you have a somewhat sizable dictionary, the dashboard takes ages to load.

This PR improves the dashboard load speed significantly... in my test scenario about 75 times - load time is cut from ~30s to ~400ms on average:

![Measurements](https://user-images.githubusercontent.com/7405322/83100137-7623cc80-a0af-11ea-8560-fe05c32510c0.png)

Those ~30s can mainly be credited to recursive operations on the database whereas this PR fetches all dictionary items in one go. So there is a significant performance improvement towards the database as well.

### Testing this PR

First and foremost you must have a somewhat large dictionary to test this. You can use the following SQL to generate one (do backup your database first, though!).

[Add dictionary items.txt](https://github.com/umbraco/Umbraco-CMS/files/4693318/Add.dictionary.items.txt)

The SQL generates the dictionary structure used in the performance measurements above:

![image](https://user-images.githubusercontent.com/7405322/83100259-bc792b80-a0af-11ea-88a1-d5f1659bc9e5.png)

Now load the dashboard a few times. Without this PR applied it'll take a loooong time to load. With this PR applied it is pretty darn fast 😄 

I have compared the output of the `GetList()` API call and it remains unchanged (the size on the measurements above also indicate this).
