### PR TITLE
GetControllerTypeInternal should release the controller instance if it creates one

### DIFF
--- a/src/Umbraco.Web/Mvc/ControllerFactoryExtensions.cs
+++ b/src/Umbraco.Web/Mvc/ControllerFactoryExtensions.cs
@@ -25,7 +25,10 @@ namespace Umbraco.Web.Mvc
 
             //we have no choice but to instantiate the controller
             var instance = factory.CreateController(requestContext, controllerName);
-            return instance?.GetType();
+            var controllerType = instance?.GetType();
+            factory.ReleaseController(instance);
+
+            return controllerType;
         }
     }
 }

--- a/src/Umbraco.Web/Mvc/MasterControllerFactory.cs
+++ b/src/Umbraco.Web/Mvc/MasterControllerFactory.cs
@@ -81,7 +81,10 @@ namespace Umbraco.Web.Mvc
 
                 //we have no choice but to instantiate the controller
                 var instance = factory.CreateController(requestContext, controllerName);
-                return instance?.GetType();
+                var controllerType = instance?.GetType();
+                factory.ReleaseController(instance);
+
+                return controllerType;
             }
 
             return GetControllerType(requestContext, controllerName);


### PR DESCRIPTION


### Prerequisites

- [ ] I have added steps to test this contribution in the description below

### Description
`ControllerFactoryExtensions.GetControllerTypeInternal` and `MasterControllerFactory.GetControllerTypeInternal` will fall back to calling `CreateController` if a custom controller factory is being used.

In this case, it should then call `ReleaseController`. The factory may have retained a reference to the instance, leading to a memory leak if the instance is never released.
