### PR TITLE
Search the entire subtree in media pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -126,20 +126,6 @@ Use this directive to generate a thumbnail grid of media items.
                         scope.items.splice(i, 1);
                         i--;
                     }
-
-                    // If subfolder search is not enabled remove the media items that's not needed
-                    // Make sure that includeSubFolder is not undefined since the directive is used
-                    // in contexts where it should not be used. Currently only used when we trigger
-                    // a media picker
-                    if (scope.includeSubFolders !== undefined) {
-                        if (scope.includeSubFolders !== 'true') {
-                            if (item.parentId !== parseInt(scope.currentFolderId)) {
-                                scope.items.splice(i, 1);
-                                i--;
-                            }
-                        }
-                    }
-
                 }
                 
                 if (scope.items.length > 0) {
@@ -344,7 +330,6 @@ Use this directive to generate a thumbnail grid of media items.
                 disableFolderSelect: "@",
                 onlyImages: "@",
                 onlyFolders: "@",
-                includeSubFolders: "@",
                 currentFolderId: "@"
             },
             link: link

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -40,7 +40,7 @@ angular.module("umbraco")
             $scope.allowMediaEdit = dialogOptions.allowMediaEdit ? dialogOptions.allowMediaEdit : false;
 
             $scope.filterOptions = {
-                excludeSubFolders: umbSessionStorage.get("mediaPickerExcludeSubFolders") || false
+                searchOnlyThisFolder: umbSessionStorage.get("mediaPickerSearchOnlyThisFolder") || false
             };
 
             var userStartNodes = [];
@@ -395,7 +395,7 @@ angular.module("umbraco")
             }
 
             function toggle() {
-                umbSessionStorage.set("mediaPickerExcludeSubFolders", $scope.filterOptions.excludeSubFolders);
+                umbSessionStorage.set("mediaPickerSearchOnlyThisFolder", $scope.filterOptions.searchOnlyThisFolder);
                 // Make sure to activate the changeSearch function everytime the toggle is clicked
                 changeSearch();
             }
@@ -408,7 +408,7 @@ angular.module("umbraco")
 
             function searchMedia() {
                 vm.loading = true;
-                entityResource.getPagedDescendants($scope.filterOptions.excludeSubFolders ? $scope.currentFolder.id : $scope.startNodeId, "Media", vm.searchOptions)
+                entityResource.getPagedDescendants($scope.filterOptions.searchOnlyThisFolder ? $scope.currentFolder.id : $scope.startNodeId, "Media", vm.searchOptions)
                     .then(function (data) {
                         // update image data to work with image grid
                         if (data.items) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -32,10 +32,10 @@
 
                                 <div class="form-search__toggle">
                                     <umb-checkbox
-                                        model="filterOptions.excludeSubFolders"
+                                        model="filterOptions.searchOnlyThisFolder"
                                         on-change="vm.toggle()"
                                         text="Include subfolders in search"
-                                        label-key="general_excludeFromSubFolders">
+                                        label-key="general_searchOnlyThisFolder">
                                     </umb-checkbox>
                                 </div>
                             </div>
@@ -112,7 +112,6 @@
                             disable-folder-select={{disableFolderSelect}}
                             only-images={{onlyImages}}
                             only-folders={{onlyFolders}}
-                            include-sub-folders={{!filterOptions.excludeSubFolders}}
                             current-folder-id="{{currentFolder.id}}">
                     </umb-media-grid>
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -663,7 +663,7 @@
     <key alias="icon">Ikon</key>
     <key alias="id">Id</key>
     <key alias="import">Importer</key>
-    <key alias="excludeFromSubFolders">Søg kun i denne mappe</key>
+    <key alias="searchOnlyThisFolder">Søg kun i denne mappe</key>
     <key alias="info">Info</key>
     <key alias="innerMargin">Indre margen</key>
     <key alias="insert">Indsæt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -686,7 +686,7 @@
     <key alias="icon">Icon</key>
     <key alias="id">Id</key>
     <key alias="import">Import</key>
-    <key alias="excludeFromSubFolders">Search only this folder</key>
+    <key alias="searchOnlyThisFolder">Search only this folder</key>
     <key alias="info">Info</key>
     <key alias="innerMargin">Inner margin</key>
     <key alias="insert">Insert</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -690,7 +690,7 @@
     <key alias="icon">Icon</key>
     <key alias="id">Id</key>
     <key alias="import">Import</key>
-    <key alias="excludeFromSubFolders">Search only this folder</key>
+    <key alias="searchOnlyThisFolder">Search only this folder</key>
     <key alias="info">Info</key>
     <key alias="innerMargin">Inner margin</key>
     <key alias="insert">Insert</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As discussed [here](https://github.com/umbraco/Umbraco-CMS/pull/4720#issuecomment-635301456) the "Search only this folder" option in the media picker should search the current folder _and_ all sub folders:

![image](https://user-images.githubusercontent.com/7405322/83144962-582c8b00-a0f4-11ea-9456-53e739d361ae.png)

As-is it _only_ searches the current folder - all sub folders are omitted from the search results.

With this PR applied, the media picker lists search results form the entire subtree below the current folder:
 
![media-picker-search-subtree](https://user-images.githubusercontent.com/7405322/83145337-ef91de00-a0f4-11ea-86eb-636c7380f0e6.gif)

I have taken the opportunity to clean up a bit, as some of the variable/label naming around this feature doesn't make sense right now. Also it turns out that the removal of sub folder results is actually performed clientside (!) in `<umb-media-grid />`, and since media picker is the only one currently using that feature in the entire codebase, I have removed the feature altogether.