### PR TITLE
fix: remove auto focus from package search box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -17,7 +17,7 @@
                     id="package-query"
                     localize="placeholder"
                     placeholder="@packager_packageSearch"
-                    umb-auto-focus ng-model="vm.searchQuery"
+                    ng-model="vm.searchQuery"
                     ng-change="vm.search()"
                     no-dirty-check>
             </div>


### PR DESCRIPTION
This PR removes the auto-focus on the package search box. 

![image](https://user-images.githubusercontent.com/6573613/83290000-d6189100-a1dd-11ea-8499-fed784fc0d7e.png)

This issue was identified in the  Accessibility audit for version 8.4

**Rational**
> The search field receives focus on page load.
> 
> This differs from other pages within the menu as their focus remains within the menu when the page loads.
> 
> It is good that the focus goes into the page when the menu item is activated, but because of the focus it misses the secondary nav (Packages, Installed etc.)

This PR makes the experience consistent with the rest of the pages in the backoffice.