### PR TITLE
V8/tmplogin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -274,6 +274,7 @@
             vm.showEmailResetConfirmation = false;
 
             if (vm.requestPasswordResetForm.$invalid) {
+                vm.errorMsg = 'Email address cannot be empty';
                 return;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -247,7 +247,7 @@
 
                 <div ng-show="vm.view == 'password-reset-code-expired'">
                     <div class="text-error" ng-repeat="error in vm.resetPasswordCodeInfo.errors">
-                        <p>{{error}}</p>
+                        <p class="text-error">{{error}}</p>
                     </div>
 
                     <div class="switch-view">

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -23,7 +23,7 @@
                             <small style="font-size: 13px;">{{vm.invitedUserPasswordModel.passwordPolicyText}}</small>
                         </label>
                         <input type="password" ng-model="vm.invitedUserPasswordModel.password" name="password" id="umb-passwordOne" class="-full-width-input" umb-auto-focus required val-server-field="value" ng-minlength="{{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}}" />
-                        <span ng-messages="inviteUserPasswordForm.password.$error" show-validation-on-submit >
+                        <span ng-messages="inviteUserPasswordForm.password.$error" show-validation-on-submit>
                             <span class="help-inline" ng-message="required"><localize key="user_passwordIsBlank">Your new password cannot be blank!</localize></span>
                             <span class="help-inline" ng-message="minlength">Minimum {{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}} characters</span>
                             <span class="help-inline" ng-message="valServerField">{{inviteUserPasswordForm.password.errorMsg}}</span>
@@ -33,7 +33,7 @@
                     <div class="control-group" ng-class="{error: vm.setPasswordForm.confirmPassword.$invalid}">
                         <label for="umb-confirmPasswordOne"><localize key="user_confirmNewPassword">Confirm new password</localize></label>
                         <input type="password" ng-model="vm.invitedUserPasswordModel.confirmPassword" name="confirmPassword" id="umb-confirmPasswordOne" class="-full-width-input" required val-compare="password" />
-                        <span ng-messages="inviteUserPasswordForm.confirmPassword.$error" show-validation-on-submit >
+                        <span ng-messages="inviteUserPasswordForm.confirmPassword.$error" show-validation-on-submit>
                             <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
                             <span class="help-inline" ng-message="valCompare"><localize key="user_passwordMismatch">The confirmed password doesn't match the new password!</localize></span>
                         </span>
@@ -41,11 +41,10 @@
                     </div>
 
                     <div class="flex justify-between items-center">
-                        <umb-button
-                            type="submit"
-                            button-style="success"
-                            state="vm.invitedUserPasswordModel.buttonState"
-                            label="Save password">
+                        <umb-button type="submit"
+                                    button-style="success"
+                                    state="vm.invitedUserPasswordModel.buttonState"
+                                    label="Save password">
                         </umb-button>
                     </div>
 
@@ -58,11 +57,10 @@
 
                     <ng-form name="vm.avatarForm">
 
-                        <umb-progress-bar
-                            style="max-width: 100px; margin-bottom: 5px;"
-                            ng-show="vm.avatarFile.uploadStatus === 'uploading'"
-                            progress="{{ vm.avatarFile.uploadProgress }}"
-                            size="s">
+                        <umb-progress-bar style="max-width: 100px; margin-bottom: 5px;"
+                                          ng-show="vm.avatarFile.uploadStatus === 'uploading'"
+                                          progress="{{ vm.avatarFile.uploadProgress }}"
+                                          size="s">
                         </umb-progress-bar>
 
                         <div class="umb-info-local-item text-error mt3" ng-if="vm.avatarFile.uploadStatus === 'error'">
@@ -70,19 +68,18 @@
                         </div>
 
                         <a class="umb-avatar-btn"
-                            ngf-select
-                            ng-model="vm.avatarFile.filesHolder"
-                            ngf-change="vm.changeAvatar($files, $event)"
-                            ngf-multiple="false"
-                            ngf-pattern="{{vm.avatarFile.acceptedFileTypes}}"
-                            ngf-max-size="{{ vm.avatarFile.maxFileSize }}">
+                           ngf-select
+                           ng-model="vm.avatarFile.filesHolder"
+                           ngf-change="vm.changeAvatar($files, $event)"
+                           ngf-multiple="false"
+                           ngf-pattern="{{vm.avatarFile.acceptedFileTypes}}"
+                           ngf-max-size="{{ vm.avatarFile.maxFileSize }}">
 
-                            <umb-avatar
-                                color="gray"
-                                size="xl"
-                                unknown-char="+"
-                                img-src="{{vm.invitedUser.avatars[3]}}"
-                                img-srcset="{{vm.invitedUser.avatars[4]}} 2x, {{invitedUser.avatars[4]}} 3x">
+                            <umb-avatar color="gray"
+                                        size="xl"
+                                        unknown-char="+"
+                                        img-src="{{vm.invitedUser.avatars[3]}}"
+                                        img-srcset="{{vm.invitedUser.avatars[4]}} 2x, {{invitedUser.avatars[4]}} 3x">
                             </umb-avatar>
                         </a>
 
@@ -94,11 +91,10 @@
                     <localize key="user_userinviteAvatarMessage"></localize>
                 </p>
                 <div class="flex justify-center items-center">
-                    <umb-button
-                        type="button"
-                        button-style="success"
-                        label="Done"
-                        action="vm.getStarted()">
+                    <umb-button type="button"
+                                button-style="success"
+                                label="Done"
+                                action="vm.getStarted()">
                     </umb-button>
                 </div>
             </div>
@@ -153,7 +149,7 @@
                         </div>
                         <div class="control-group" ng-class="{error: vm.loginForm.username.$invalid}">
                             <label for="umb-username">{{vm.labels.usernameLabel}}</label>
-                            <input type="text" ng-model="vm.login" name="username" id="umb-username" class="-full-width-input" placeholder="{{vm.labels.usernamePlaceholder}}" focus-when="{{vm.view === 'login'}}" aria-required="true"/>
+                            <input type="text" ng-model="vm.login" name="username" id="umb-username" class="-full-width-input" placeholder="{{vm.labels.usernamePlaceholder}}" focus-when="{{vm.view === 'login'}}" aria-required="true" />
                         </div>
 
                         <div class="control-group" ng-class="{error: vm.loginForm.password.$invalid}">
@@ -188,21 +184,21 @@
                     </p>
 
                     <form method="POST" name="vm.requestPasswordResetForm" ng-submit="vm.requestPasswordResetSubmit(email)">
-                        <div class="control-group" ng-class="{error: requestPasswordResetForm.email.$invalid}">
+                        <div class="control-group" ng-class="{error: vm.requestPasswordResetForm.email.$invalid}">
                             <label for="umb-email"><localize key="general_email">Email</localize></label>
                             <input type="email" val-email ng-model="email" name="email" id="umb-email" class="-full-width-input" localize="placeholder" placeholder="@placeholders_email" focus-when="{{vm.view === 'request-password-reset'}}" />
                         </div>
 
-                        <div class="control-group" ng-show="requestPasswordResetForm.$invalid">
-                            <div class="text-error">{{errorMsg}}</div>
+                        <div ng-messages="vm.requestPasswordResetForm.$error" class="control-group" ng-show="vm.requestPasswordResetForm.$invalid">
+                            <p ng-message="auth" class="text-error" role="alert" tabindex="0">{{vm.errorMsg}}</p>
                         </div>
 
                         <div class="control-group" ng-show="vm.showEmailResetConfirmation">
                             <div class="text-info" role="alert">
                                 <p tabindex="0">
-                                <localize key="login_requestPasswordResetConfirmation">An email with password reset instructions will be sent to the specified address if it matched our records</localize>
-                                    </p>
-                                </div>
+                                    <localize key="login_requestPasswordResetConfirmation">An email with password reset instructions will be sent to the specified address if it matched our records</localize>
+                                </p>
+                            </div>
                         </div>
 
                         <div class="flex justify-between items-center">
@@ -231,16 +227,16 @@
                             <input type="password" ng-model="vm.confirmPassword" name="confirmPassword" id="umb-confirmPasswordThree" class="-full-width-input" localize="placeholder" placeholder="@placeholders_confirmPassword" />
                         </div>
 
-                        <div ng-hide="vm.resetComplete" class="control-group" ng-show="vm.setPasswordForm.$invalid">
-                            <div class="text-error">{{vm.errorMsg}}</div>
+                        <div ng-messages="vm.setPasswordForm.$error" class="control-group" ng-show="vm.setPasswordForm.$invalid">
+                            <p ng-message="auth" class="text-error" role="alert" tabindex="0">{{vm.errorMsg}}</p>
                         </div>
-
                         <div class="control-group" ng-show="vm.showSetPasswordConfirmation">
                             <div class="text-info">
+                                <p tabindex="0">
                                 <localize key="login_setPasswordConfirmation">Your new password has been set and you may now use it to log in.</localize>
+                                </p>
                             </div>
                         </div>
-
                         <div class="flex justify-between items-center">
                             <button ng-hide="vm.resetComplete" type="submit" class="btn btn-success" val-trigger-change="#login .form input"><localize key="general_submit">Submit</localize></button>
                             <a class="muted" href="#" prevent-default ng-click="vm.showLogin()"><localize key="login_returnToLogin">Return to login form</localize></a>
@@ -251,7 +247,7 @@
 
                 <div ng-show="vm.view == 'password-reset-code-expired'">
                     <div class="text-error" ng-repeat="error in vm.resetPasswordCodeInfo.errors">
-                        <span>{{error}}</span>
+                        <p>{{error}}</p>
                     </div>
 
                     <div class="switch-view">


### PR DESCRIPTION
When the email address is empty on a password reset there is no message displayed to the user to indicate that the email address is empty.  This has been fixed.

I've also added alerts for the error messages on the password reset and the confirm password screen so that screen readers can be alerted on the errors.

And finally I've added tabindexs so that screen readers can tab into them