### PR TITLE
Shorter JSON property names for nucache

### DIFF
--- a/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
@@ -88,8 +88,8 @@ namespace Umbraco.Tests.Services
         private void AssertJsonStartsWith(int id, string expected)
         {
             var json = GetJson(id).Replace('"', '\'');
-            var pos = json.IndexOf("'cultureData':", StringComparison.InvariantCultureIgnoreCase);
-            json = json.Substring(0, pos + "'cultureData':".Length);
+            var pos = json.IndexOf("'cd':", StringComparison.InvariantCultureIgnoreCase);
+            json = json.Substring(0, pos + "'cd':".Length);
             Assert.AreEqual(expected, json);
         }
 
@@ -595,7 +595,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'en','seg':'','val':'v1en'},{'culture':'fr','seg':'','val':'v1fr'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'c':'en','v':'v1en'},{'c':'fr','v':'v1fr'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch content type to Nothing
             contentType.Variations = ContentVariation.Nothing;
@@ -612,7 +612,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'','seg':'','val':'v1en'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'v':'v1en'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch content back to Culture
             contentType.Variations = ContentVariation.Culture;
@@ -629,7 +629,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'','seg':'','val':'v1en'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'v':'v1en'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch property back to Culture
             contentType.PropertyTypes.First(x => x.Alias == "value1").Variations = ContentVariation.Culture;
@@ -645,7 +645,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'en','seg':'','val':'v1en'},{'culture':'fr','seg':'','val':'v1fr'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'c':'en','v':'v1en'},{'c':'fr','v':'v1fr'}],'value2':[{'v':'v2'}]},'cd':");
         }
 
         [Test]
@@ -686,7 +686,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'','seg':'','val':'v1'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'v':'v1'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch content type to Culture
             contentType.Variations = ContentVariation.Culture;
@@ -702,7 +702,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'','seg':'','val':'v1'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'v':'v1'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch property to Culture
             contentType.PropertyTypes.First(x => x.Alias == "value1").Variations = ContentVariation.Culture;
@@ -717,7 +717,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'en','seg':'','val':'v1'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'c':'en','v':'v1'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch content back to Nothing
             contentType.Variations = ContentVariation.Nothing;
@@ -734,7 +734,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'','seg':'','val':'v1'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'v':'v1'}],'value2':[{'v':'v2'}]},'cd':");
         }
 
         [Test]
@@ -772,7 +772,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'en','seg':'','val':'v1en'},{'culture':'fr','seg':'','val':'v1fr'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'c':'en','v':'v1en'},{'c':'fr','v':'v1fr'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch property type to Nothing
             contentType.PropertyTypes.First(x => x.Alias == "value1").Variations = ContentVariation.Nothing;
@@ -789,7 +789,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'','seg':'','val':'v1en'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'v':'v1en'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch property back to Culture
             contentType.PropertyTypes.First(x => x.Alias == "value1").Variations = ContentVariation.Culture;
@@ -805,7 +805,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'en','seg':'','val':'v1en'},{'culture':'fr','seg':'','val':'v1fr'}],'value2':[{'culture':'','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'c':'en','v':'v1en'},{'c':'fr','v':'v1fr'}],'value2':[{'v':'v2'}]},'cd':");
 
             // switch other property to Culture
             contentType.PropertyTypes.First(x => x.Alias == "value2").Variations = ContentVariation.Culture;
@@ -823,7 +823,7 @@ namespace Umbraco.Tests.Services
 
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value1':[{'culture':'en','seg':'','val':'v1en'},{'culture':'fr','seg':'','val':'v1fr'}],'value2':[{'culture':'en','seg':'','val':'v2'}]},'cultureData':");
+                "{'pd':{'value1':[{'c':'en','v':'v1en'},{'c':'fr','v':'v1fr'}],'value2':[{'c':'en','v':'v2'}]},'cd':");
         }
 
         [TestCase(ContentVariation.Culture, ContentVariation.Nothing)]
@@ -1054,7 +1054,7 @@ namespace Umbraco.Tests.Services
             // both value11 and value21 are variant
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             composed.Variations = ContentVariation.Nothing;
             ServiceContext.ContentTypeService.Save(composed);
@@ -1062,7 +1062,7 @@ namespace Umbraco.Tests.Services
             // both value11 and value21 are invariant
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11en'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'','seg':'','val':'v21en'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11en'}],'value12':[{'v':'v12'}],'value21':[{'v':'v21en'}],'value22':[{'v':'v22'}]},'cd':");
 
             composed.Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composed);
@@ -1070,7 +1070,7 @@ namespace Umbraco.Tests.Services
             // value11 is variant again, but value21 is still invariant
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'','seg':'','val':'v21en'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'v':'v21en'}],'value22':[{'v':'v22'}]},'cd':");
 
             composed.PropertyTypes.First(x => x.Alias == "value21").Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composed);
@@ -1078,7 +1078,7 @@ namespace Umbraco.Tests.Services
             // we can make it variant again
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             composing.Variations = ContentVariation.Nothing;
             ServiceContext.ContentTypeService.Save(composing);
@@ -1086,7 +1086,7 @@ namespace Umbraco.Tests.Services
             // value11 is invariant
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11en'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11en'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             composing.Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composing);
@@ -1094,7 +1094,7 @@ namespace Umbraco.Tests.Services
             // value11 is still invariant
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11en'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11en'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             composing.PropertyTypes.First(x => x.Alias == "value11").Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composing);
@@ -1102,7 +1102,7 @@ namespace Umbraco.Tests.Services
             // we can make it variant again
             Console.WriteLine(GetJson(document.Id));
             AssertJsonStartsWith(document.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
         }
 
         [Test]
@@ -1167,11 +1167,11 @@ namespace Umbraco.Tests.Services
             // both value11 and value21 are variant
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
 
             composed1.Variations = ContentVariation.Nothing;
             ServiceContext.ContentTypeService.Save(composed1);
@@ -1179,11 +1179,11 @@ namespace Umbraco.Tests.Services
             // both value11 and value21 are invariant
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11en'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'','seg':'','val':'v21en'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11en'}],'value12':[{'v':'v12'}],'value21':[{'v':'v21en'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
 
             composed1.Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composed1);
@@ -1191,11 +1191,11 @@ namespace Umbraco.Tests.Services
             // value11 is variant again, but value21 is still invariant
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'','seg':'','val':'v21en'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'v':'v21en'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
 
             composed1.PropertyTypes.First(x => x.Alias == "value21").Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composed1);
@@ -1203,11 +1203,11 @@ namespace Umbraco.Tests.Services
             // we can make it variant again
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
 
             composing.Variations = ContentVariation.Nothing;
             ServiceContext.ContentTypeService.Save(composing);
@@ -1215,11 +1215,11 @@ namespace Umbraco.Tests.Services
             // value11 is invariant
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11en'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11en'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
 
             composing.Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composing);
@@ -1227,11 +1227,11 @@ namespace Umbraco.Tests.Services
             // value11 is still invariant
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11en'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11en'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
 
             composing.PropertyTypes.First(x => x.Alias == "value11").Variations = ContentVariation.Culture;
             ServiceContext.ContentTypeService.Save(composing);
@@ -1239,11 +1239,11 @@ namespace Umbraco.Tests.Services
             // we can make it variant again
             Console.WriteLine(GetJson(document1.Id));
             AssertJsonStartsWith(document1.Id,
-                "{'properties':{'value11':[{'culture':'en','seg':'','val':'v11en'},{'culture':'fr','seg':'','val':'v11fr'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value21':[{'culture':'en','seg':'','val':'v21en'},{'culture':'fr','seg':'','val':'v21fr'}],'value22':[{'culture':'','seg':'','val':'v22'}]},'cultureData':");
+                "{'pd':{'value11':[{'c':'en','v':'v11en'},{'c':'fr','v':'v11fr'}],'value12':[{'v':'v12'}],'value21':[{'c':'en','v':'v21en'},{'c':'fr','v':'v21fr'}],'value22':[{'v':'v22'}]},'cd':");
 
             Console.WriteLine(GetJson(document2.Id));
             AssertJsonStartsWith(document2.Id,
-                "{'properties':{'value11':[{'culture':'','seg':'','val':'v11'}],'value12':[{'culture':'','seg':'','val':'v12'}],'value31':[{'culture':'','seg':'','val':'v31'}],'value32':[{'culture':'','seg':'','val':'v32'}]},'cultureData':");
+                "{'pd':{'value11':[{'v':'v11'}],'value12':[{'v':'v12'}],'value31':[{'v':'v31'}],'value32':[{'v':'v32'}]},'cd':");
         }
 
         private void CreateFrenchAndEnglishLangs()

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/ContentNestedData.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/ContentNestedData.cs
@@ -9,15 +9,28 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
     /// </summary>
     internal class ContentNestedData
     {
-        [JsonProperty("properties")]
+        //dont serialize empty properties
+        [JsonProperty("pd")]
         [JsonConverter(typeof(CaseInsensitiveDictionaryConverter<PropertyData[]>))]
         public Dictionary<string, PropertyData[]> PropertyData { get; set; }
 
-        [JsonProperty("cultureData")]
+        [JsonProperty("cd")]
         [JsonConverter(typeof(CaseInsensitiveDictionaryConverter<CultureVariation>))]
         public Dictionary<string, CultureVariation> CultureData { get; set; }
 
-        [JsonProperty("urlSegment")]
+        [JsonProperty("us")]
         public string UrlSegment { get; set; }
+
+        //Legacy properties used to deserialize existing nucache db entries
+        [JsonProperty("properties")]
+        [JsonConverter(typeof(CaseInsensitiveDictionaryConverter<PropertyData[]>))]
+        private Dictionary<string, PropertyData[]> LegacyPropertyData { set { PropertyData = value; } }
+
+        [JsonProperty("cultureData")]
+        [JsonConverter(typeof(CaseInsensitiveDictionaryConverter<CultureVariation>))]
+        private Dictionary<string, CultureVariation> LegacyCultureData { set { CultureData = value; } }
+
+        [JsonProperty("urlSegment")]
+        private string LegacyUrlSegment { set { UrlSegment = value; } }
     }
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/CultureVariation.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/CultureVariation.cs
@@ -8,16 +8,29 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
     /// </summary>
     internal class CultureVariation
     {
-        [JsonProperty("name")]
+        [JsonProperty("nm")]
         public string Name { get; set; }
 
-        [JsonProperty("urlSegment")]
+        [JsonProperty("us")]
         public string UrlSegment { get; set; }
 
-        [JsonProperty("date")]
+        [JsonProperty("dt")]
         public DateTime Date { get; set; }
 
-        [JsonProperty("isDraft")]
+        [JsonProperty("isd")]
         public bool IsDraft { get; set; }
+
+        //Legacy properties used to deserialize existing nucache db entries
+        [JsonProperty("name")]
+        private string LegacyName { set { Name = value; } }
+
+        [JsonProperty("urlSegment")]
+        private string LegacyUrlSegment { set { UrlSegment = value; } }
+
+        [JsonProperty("date")]
+        private DateTime LegacyDate { set { Date = value; } }
+
+        [JsonProperty("isDraft")]
+        private bool LegacyIsDraft { set { IsDraft = value; } }
     }
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/PropertyData.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/PropertyData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Newtonsoft.Json;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
@@ -8,21 +9,43 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         private string _culture;
         private string _segment;
 
-        [JsonProperty("culture")]
+        [DefaultValue("")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, PropertyName = "c")]
         public string Culture
         {
             get => _culture;
             set => _culture = value ?? throw new ArgumentNullException(nameof(value)); // TODO: or fallback to string.Empty? CANNOT be null
         }
 
-        [JsonProperty("seg")]
+        [DefaultValue("")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, PropertyName = "s")]
         public string Segment
         {
             get => _segment;
             set => _segment = value ?? throw new ArgumentNullException(nameof(value)); // TODO: or fallback to string.Empty? CANNOT be null
         }
 
-        [JsonProperty("val")]
+        [JsonProperty("v")]
         public object Value { get; set; }
+
+
+        //Legacy properties used to deserialize existing nucache db entries
+        [JsonProperty("culture")]
+        private string LegacyCulture
+        {
+            set => Culture = value;
+        }
+
+        [JsonProperty("seg")]
+        private string LegacySegment
+        {
+            set => Segment = value;
+        }
+
+        [JsonProperty("val")]
+        private object LegacyValue
+        {
+            set => Value = value;
+        }
     }
 }

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -58,8 +58,24 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web.UI.Client", "ht
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest\", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
 	ProjectSection(WebsiteProperties) = preProject
+		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
+		Debug.AspNetCompiler.VirtualPath = "/localhost_49800"
+		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
+		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
+		Debug.AspNetCompiler.Updateable = "true"
+		Debug.AspNetCompiler.ForceOverwrite = "true"
+		Debug.AspNetCompiler.FixedNames = "false"
+		Debug.AspNetCompiler.Debug = "True"
+		Release.AspNetCompiler.VirtualPath = "/localhost_49800"
+		Release.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
+		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
+		Release.AspNetCompiler.Updateable = "true"
+		Release.AspNetCompiler.ForceOverwrite = "true"
+		Release.AspNetCompiler.FixedNames = "false"
+		Release.AspNetCompiler.Debug = "False"
+		VWDPort = "49800"
 		SlnRelativePath = "Umbraco.Tests.AcceptanceTest\"
 	EndProjectSection
 EndProject
@@ -123,6 +139,10 @@ Global
 		{4C4C194C-B5E4-4991-8F87-4373E24CC19F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -157,6 +177,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{227C3B55-80E5-4E7E-A802-BE16C5128B9D} = {2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{5D3B8245-ADA6-453F-A008-50ED04BFE770} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{E3F9F378-AFE1-40A5-90BD-82833375DBFE} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
 		{5B03EF4E-E0AC-4905-861B-8C3EC1A0D458} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
@@ -164,7 +185,6 @@ Global
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -58,24 +58,8 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web.UI.Client", "ht
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest\", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
 	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_49800"
-		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_49800"
-		Release.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "49800"
 		SlnRelativePath = "Umbraco.Tests.AcceptanceTest\"
 	EndProjectSection
 EndProject
@@ -139,10 +123,6 @@ Global
 		{4C4C194C-B5E4-4991-8F87-4373E24CC19F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -177,7 +157,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{227C3B55-80E5-4E7E-A802-BE16C5128B9D} = {2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{5D3B8245-ADA6-453F-A008-50ED04BFE770} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{E3F9F378-AFE1-40A5-90BD-82833375DBFE} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
 		{5B03EF4E-E0AC-4905-861B-8C3EC1A0D458} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
@@ -185,6 +164,7 @@ Global
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A

### Description

What:
Changes the property names in json for properties on ContentNestedData, CultureVariation and PropertyData types to shorter names.
Also  changes Culture and Segment on PropertyData to not be serialized to json when the value is an empty string, these properties will still deserialize to an empty string.

Why?:
When you have a large number of content/media items with several properties on them, cold boot up time (no NuCache.*.db files on disk) can be very slow. By shortening the json you reduce the number of bytes that need to be read from the data base into memory and then to the nucache.db files on disk. For ~26,000 published content and ~110,000 media items this saved ~2 mins of time for cold boots and reduced NuCache.Content.db from 114mb to 98mb for my scenario.

How to test?
Create a large number of media and published content items with 10+ properties. 

1. Delete the local nucache files (Nucache.*.db and Nucache.*.tlog).
2. Start the website, time how long it takes to boot
3. Website should load existing nucache serialization format successfully.
4. Rebuild the cmsContentNu table using the backoffice. The cmsContentNu.data column should be in the more compact representation
5. Stop the site.
6.  Delete the local nucache files (Nucache.*.db and Nucache.*.tlog).
7. Start the website, time how long it takes to boot
8. Website should load existing nucache serialization format successfully.


