### PR TITLE
Random fixes for nested content "add" button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -201,7 +201,7 @@
 .umb-nested-content__add-content.--disabled:hover {
     color: @gray-7;
     border-color: @gray-7;
-    cursor: default;
+    cursor: not-allowed;
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -36,13 +36,17 @@
 
         <div ng-hide="vm.hasContentTypes">
             <div class="umb-nested-content__help-text">
-                <localize key="content_nestedContentNoContentTypes"></localize>
+                <localize key="content_nestedContentNoContentTypes">No content types are configured for this property.</localize>
             </div>
         </div>
-
         <div class="umb-nested-content__footer-bar" ng-hide="!vm.inited || vm.hasContentTypes === false || vm.singleMode === true">
-            <button type="button" class="btn-reset umb-nested-content__add-content umb-focus" ng-class="{ '--disabled': (!vm.scaffolds.length || vm.nodes.length >= vm.maxItems) }" ng-click="vm.openNodeTypePicker($event)" prevent-default>
-                <localize key="grid_addElement"></localize>
+            <button
+                type="button"
+                class="btn-reset umb-nested-content__add-content umb-focus"
+                ng-class="{ '--disabled': (!vm.scaffolds.length || vm.nodes.length >= vm.maxItems) }"
+                ng-click="vm.openNodeTypePicker($event)"
+                aria-disabled="{{!vm.scaffolds.length || vm.nodes.length >= vm.maxItems}}">
+                <localize key="grid_addElement">Add element</localize>
             </button>
         </div>
 


### PR DESCRIPTION
### Prerequisites

✔️ I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
I noticed some fallback texts were missing if the dictionary labels for certain language don't exists so I added some fallback texts.

Apart from that I made a tiny accessibility improvement adding the `aria-disabled` attribute and whenever the max limit of allowed blocks in nested content screen readers will announce either "disabled" or "dimmed" letting screen reader users know the button won't be doing anything.

In order to disable it totally from being clicked we would need to set `disabled="true"` but screen readers currently have varying support for this, so it works inconsistently and could leave some users in the dark. So click events will still be fired but since there is a limit no new blocks will be added anyway 👍 