### PR TITLE
Improve the accessibility of the cog icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -153,9 +153,10 @@
                                                       </div>
 
                                                       <div class="cell-tools" ng-if="(area === active || area === currentCellWithActiveChild) && !sortMode">
-                                                         <div class="cell-tool" ng-click="editGridItemSettings(area, 'cell')">
-                                                            <i class="icon-settings"></i>
-                                                         </div>
+                                                         <button type="button" aria-haspopup="true" class="btn-reset cell-tool" ng-click="editGridItemSettings(area, 'cell')">
+                                                            <i class="icon-settings" aria-hidden></i>
+                                                            <span class="sr-only">Open column settings</span>
+                                                         </button>
                                                       </div>
 
                                                       <div class="umb-cell-inner" ui-sortable="sortableOptionsCell" umb-grid-hack-scope ng-model="area.controls">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -22,7 +22,7 @@
         <div class="templates-preview"
              ng-show="!model.value || model.value == ''">
 
-             <p><strong><localize key="grid_chooseLayout" /></strong></p>
+             <p><strong><localize key="grid_chooseLayout">Choose a layout</localize></strong></p>
 
             <div class="preview-rows layout"
                  ng-repeat="template in model.config.items.templates"
@@ -83,7 +83,7 @@
                                     <div class="umb-row-title">{{row.label || row.name}}</div>
 
                                     <div class="umb-grid-has-config" ng-if="row.hasConfig && !sortMode">
-                                            <localize key="grid_settingsApplied" />
+                                            <p><localize key="grid_settingsApplied">Settings applied</localize></p>
                                     </div>
                                 </div>
 
@@ -138,18 +138,20 @@
 
                                                       <!-- disable drop overlay -->
                                                       <div class="drop-overlay -disable" ng-if="area.dropNotAllowed">
-                                                          <i class="icon-delete drop-icon"></i>
-                                                          <localize key="grid_contentNotAllowed" />
+                                                          <i class="icon-delete drop-icon" aria-hidden="true"></i>
+                                                          <p><localize key="grid_contentNotAllowed">This content is not allowed here</localize></p>
                                                       </div>
 
                                                       <!-- allow drop overlay -->
                                                       <div class="drop-overlay -allow" ng-if="area.dropOnEmpty">
-                                                          <i class="icon-download drop-icon"></i>
-                                                          <localize key="grid_contentAllowed" />
+                                                          <i class="icon-download drop-icon" aria-hidden="true"></i>
+                                                          <p><localize key="grid_contentAllowed">This content is allowed here</localize></p>
                                                       </div>
 
                                                       <div class="umb-grid-has-config" ng-if="area.hasConfig && !sortMode">
-                                                         <localize key="grid_settingsApplied" />
+                                                         <p>
+                                                            <localize key="grid_settingsApplied">Settings applied</localize>
+                                                         </p>
                                                       </div>
 
                                                       <div class="cell-tools" ng-if="(area === active || area === currentCellWithActiveChild) && !sortMode">
@@ -164,8 +166,10 @@
                                                           <!-- Control placeholder -->
                                                           <button class="umb-cell-placeholder btn-reset" type="button" ng-if="area.controls.length === 0" ng-click="openEditorOverlay($event, area, 0, area.$uniqueId);">
                                                                <div class="cell-tools-add -center">
-                                                                   <localize ng-if="!sortMode" key="grid_addElement" />
-                                                                   <localize ng-if="sortMode" key="grid_dropElement" />
+                                                                   <p>
+                                                                        <localize ng-if="!sortMode" key="grid_addElement">Add content</localize>
+                                                                        <localize ng-if="sortMode" key="grid_dropElement">Drop element</localize>
+                                                                   </p>
                                                                </div>
                                                           </button>
 
@@ -227,7 +231,7 @@
 
                                                       <!-- if area is empty tools -->
                                                       <div class="umb-grid-add-more-content" ng-if="area.controls.length > 0 && !sortMode && (area.maxItems == undefined || area.maxItems == '' || area.maxItems == 0 || area.maxItems > area.controls.length)">
-                                                          <button class="cell-tools-add -bar newbtn btn-reset" type="button" ng-click="openEditorOverlay($event, area, 0, area.$uniqueId);"><localize key="grid_addElement" /></button>
+                                                          <button class="cell-tools-add -bar newbtn btn-reset" type="button" ng-click="openEditorOverlay($event, area, 0, area.$uniqueId);"><localize key="grid_addElement">Add element</localize></button>
                                                       </div>
 
                                                  </div>
@@ -265,7 +269,7 @@
 
                     <div class="templates-preview" ng-if="showRowConfigurations">
 
-                        <p ng-hide="section.rows.length > 0"><strong><localize key="grid_addRows" /></strong></p>
+                        <p ng-hide="section.rows.length > 0"><strong><localize key="grid_addRows">Add row</localize></strong></p>
 
                         <button class="preview-rows columns btn-reset"
                              ng-repeat="layout in  section.$allowedLayouts"


### PR DESCRIPTION
### Prerequisites

✔️ I have added steps to test this contribution in the description below

### Description
Currently the settings cog icon in the grid is wrapped in a div and has no screen reader friendly text, which this PR aims to fix.

- I have wrapped the icon in a `<button>` and hidden the icon using `aria-hidden="true"`
- I have also added a generic text for screen readers announcing "Open column settings" - At a later stage we need to make this a tad more specific towards the context of the cog's placement. But baby steps! 👶 😃 
- I have also added some fallback texts and wrapped them in `<p></p>` in case dictionary items have not been added for some reason while I was at it 👍 