### PR TITLE
umb-notifications.html - refactored switch logic

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
@@ -7,13 +7,14 @@
             <div ng-if="notification.view">
                 <div ng-include="notification.view"></div>
             </div>
-            <div ng-if="notification.headline" ng-switch on="{{notification}}">
-                <a ng-href="{{notification.url}}" ng-switch-when="{{notification.url && notification.url.trim() != ''}}" target="_blank">
-                    <strong>{{notification.headline}}</strong>
+
+            <div ng-if="notification.headline">
+                <a ng-if="notification.url" ng-href="{{notification.url}}" href="" target="_blank">
+                    <strong ng-bind="notification.headline"></strong>
                     <span ng-bind-html="notification.message"></span>
                 </a>
-                <div ng-switch-default>
-                    <strong>{{notification.headline}}</strong>
+                <div ng-if="!notification.url">
+                    <strong ng-bind="notification.headline"></strong>
                     <span ng-bind-html="notification.message"></span>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
@@ -19,7 +19,7 @@
                 </div>
             </div>
 
-            <button type="button" class='close -align-right' ng-click="removeNotification($index)" aria-hidden="true">
+            <button type="button" class="close -align-right" ng-click="removeNotification($index)" aria-hidden="true">
                 <span aria-hidden="true">&times;</span>
             </button>
         </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A while ago I was trying to figure out why I couldn't get the `url` property to render in the `umb-notifications.html` view.

I commented about it here: https://github.com/umbraco/Umbraco-CMS/pull/2965#discussion_r401619104

I couldn't see how the `ng-switch` statement worked, (as it's intended to work with literal values, not objects).  So I swapped out the `ng-switch` statement with a couple of `ng-if` conditions.

In terms of testing, I made a test dashboard harness...

**package.manifest**

```json
{
    "javascript": [
        "~/App_Plugins/LeeTest/dashboard.js"
    ],
    "dashboards": [{
            "alias": "leeTestDashboard",
            "view": "/App_Plugins/LeeTest/dashboard.html",
            "sections": ["content"],
        }
    ]
}
```

**dashboard.html**

```html
<div ng-controller="LeeTest.Controller as vm">
    <button type="button" ng-click="vm.click()">Click me</button>
</div>
```

**dashboard.js**

```js
angular.module("umbraco").controller("LeeTest.Controller",[
    "$scope",
    "notificationsService",
    function ($scope, notificationsService) {

        var vm = this;

        vm.types = ["success", "warning", "error", "info"];

        vm.click = function() {

            vm.types.forEach(function(type) {

                notificationsService.add({
                    headline: type,
                    message: "This a message.",
                    url: "/umbraco/#/settings",
                    type: type,
                    sticky: false
                });

            });

        };
    }
]);
```

---
I've added an additional commit to change couple of quotes from single to double, for consistency.
