### PR TITLE
Store Image Cropper media files in specific culture folders

### DIFF
--- a/src/Umbraco.Core/IO/IMediaFileSystem.cs
+++ b/src/Umbraco.Core/IO/IMediaFileSystem.cs
@@ -22,9 +22,10 @@ namespace Umbraco.Core.IO
         /// <param name="filename">The file name.</param>
         /// <param name="cuid">The unique identifier of the content/media owning the file.</param>
         /// <param name="puid">The unique identifier of the property type owning the file.</param>
+        /// <param name="culture">The culture to save the file against.</param>
         /// <returns>The filesystem-relative path to the media file.</returns>
         /// <remarks>With the old media path scheme, this CREATES a new media path each time it is invoked.</remarks>
-        string GetMediaPath(string filename, Guid cuid, Guid puid);
+        string GetMediaPath(string filename, Guid cuid, Guid puid, string culture = null);
 
         /// <summary>
         /// Gets the file path of a media file.
@@ -33,10 +34,11 @@ namespace Umbraco.Core.IO
         /// <param name="prevpath">A previous file path.</param>
         /// <param name="cuid">The unique identifier of the content/media owning the file.</param>
         /// <param name="puid">The unique identifier of the property type owning the file.</param>
+        /// <param name="culture">The culture to save the file against.</param>
         /// <returns>The filesystem-relative path to the media file.</returns>
         /// <remarks>In the old, legacy, number-based scheme, we try to re-use the media folder
         /// specified by <paramref name="prevpath"/>. Else, we CREATE a new one. Each time we are invoked.</remarks>
-        string GetMediaPath(string filename, string prevpath, Guid cuid, Guid puid);
+        string GetMediaPath(string filename, string prevpath, Guid cuid, Guid puid, string culture = null);
 
         /// <summary>
         /// Stores a media file associated to a property of a content item.
@@ -46,13 +48,14 @@ namespace Umbraco.Core.IO
         /// <param name="filename">The media file name.</param>
         /// <param name="filestream">A stream containing the media bytes.</param>
         /// <param name="oldpath">An optional filesystem-relative filepath to the previous media file.</param>
+        /// <param name="culture">The culture to save the file against.</param>
         /// <returns>The filesystem-relative filepath to the media file.</returns>
         /// <remarks>
         /// <para>The file is considered "owned" by the content/propertyType.</para>
         /// <para>If an <paramref name="oldpath"/> is provided then that file (and associated thumbnails if any) is deleted
         /// before the new file is saved, and depending on the media path scheme, the folder may be reused for the new file.</para>
         /// </remarks>
-        string StoreFile(IContentBase content, PropertyType propertyType, string filename, Stream filestream, string oldpath);
+        string StoreFile(IContentBase content, PropertyType propertyType, string filename, Stream filestream, string oldpath, string culture = null);
 
         /// <summary>
         /// Copies a media file as a new media file, associated to a property of a content item.
@@ -60,7 +63,8 @@ namespace Umbraco.Core.IO
         /// <param name="content">The content item owning the copy of the media file.</param>
         /// <param name="propertyType">The property type owning the copy of the media file.</param>
         /// <param name="sourcepath">The filesystem-relative path to the source media file.</param>
+        /// <param name="culture">The culture to save the file against.</param>
         /// <returns>The filesystem-relative path to the copy of the media file.</returns>
-        string CopyFile(IContentBase content, PropertyType propertyType, string sourcepath);
+        string CopyFile(IContentBase content, PropertyType propertyType, string sourcepath, string culture = null);
     }
 }

--- a/src/Umbraco.Core/IO/IMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/IMediaPathScheme.cs
@@ -15,8 +15,9 @@ namespace Umbraco.Core.IO
         /// <param name="propertyGuid">The property type unique identifier.</param>
         /// <param name="filename">The file name.</param>
         /// <param name="previous">A previous filename.</param>
+        /// <param name="culture">The culture to include in the path..</param>
         /// <returns>The filesystem-relative complete file path.</returns>
-        string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null);
+        string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null, string culture = null);
 
         /// <summary>
         /// Gets the directory that can be deleted when the file is deleted.

--- a/src/Umbraco.Core/IO/MediaFileSystem.cs
+++ b/src/Umbraco.Core/IO/MediaFileSystem.cs
@@ -59,23 +59,23 @@ namespace Umbraco.Core.IO
         #region Media Path
 
         /// <inheritoc />
-        public string GetMediaPath(string filename, Guid cuid, Guid puid)
+        public string GetMediaPath(string filename, Guid cuid, Guid puid, string culture = null)
         {
             filename = Path.GetFileName(filename);
             if (filename == null) throw new ArgumentException("Cannot become a safe filename.", nameof(filename));
             filename = IOHelper.SafeFileName(filename.ToLowerInvariant());
 
-            return _mediaPathScheme.GetFilePath(this, cuid, puid, filename);
+            return _mediaPathScheme.GetFilePath(this, cuid, puid, filename, null, culture);
         }
 
         /// <inheritoc />
-        public string GetMediaPath(string filename, string prevpath, Guid cuid, Guid puid)
+        public string GetMediaPath(string filename, string prevpath, Guid cuid, Guid puid, string culture = null)
         {
             filename = Path.GetFileName(filename);
             if (filename == null) throw new ArgumentException("Cannot become a safe filename.", nameof(filename));
             filename = IOHelper.SafeFileName(filename.ToLowerInvariant());
 
-            return _mediaPathScheme.GetFilePath(this, cuid, puid, filename, prevpath);
+            return _mediaPathScheme.GetFilePath(this, cuid, puid, filename, prevpath, culture);
         }
 
         #endregion
@@ -83,7 +83,7 @@ namespace Umbraco.Core.IO
         #region Associated Media Files
 
         /// <inheritoc />
-        public string StoreFile(IContentBase content, PropertyType propertyType, string filename, Stream filestream, string oldpath)
+        public string StoreFile(IContentBase content, PropertyType propertyType, string filename, Stream filestream, string oldpath, string culture = null)
         {
             if (content == null) throw new ArgumentNullException(nameof(content));
             if (propertyType == null) throw new ArgumentNullException(nameof(propertyType));
@@ -97,13 +97,13 @@ namespace Umbraco.Core.IO
 
             // get the filepath, store the data
             // use oldpath as "prevpath" to try and reuse the folder, in original number-based scheme
-            var filepath = GetMediaPath(filename, oldpath, content.Key, propertyType.Key);
+            var filepath = GetMediaPath(filename, oldpath, content.Key, propertyType.Key, culture);
             AddFile(filepath, filestream);
             return filepath;
         }
 
         /// <inheritoc />
-        public string CopyFile(IContentBase content, PropertyType propertyType, string sourcepath)
+        public string CopyFile(IContentBase content, PropertyType propertyType, string sourcepath, string culture = null)
         {
             if (content == null) throw new ArgumentNullException(nameof(content));
             if (propertyType == null) throw new ArgumentNullException(nameof(propertyType));
@@ -115,7 +115,7 @@ namespace Umbraco.Core.IO
 
             // get the filepath
             var filename = Path.GetFileName(sourcepath);
-            var filepath = GetMediaPath(filename, content.Key, propertyType.Key);
+            var filepath = GetMediaPath(filename, content.Key, propertyType.Key, culture);
             this.CopyFile(sourcepath, filepath);
             return filepath;
         }

--- a/src/Umbraco.Core/IO/MediaPathSchemes/CombinedGuidsMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/CombinedGuidsMediaPathScheme.cs
@@ -12,14 +12,14 @@ namespace Umbraco.Core.IO.MediaPathSchemes
     public class CombinedGuidsMediaPathScheme : IMediaPathScheme
     {
         /// <inheritdoc />
-        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null)
+        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null, string culture = null)
         {
             // assumes that cuid and puid keys can be trusted - and that a single property type
             // for a single content cannot store two different files with the same name
 
             var combinedGuid = GuidUtils.Combine(itemGuid, propertyGuid);
             var directory = HexEncoder.Encode(combinedGuid.ToByteArray()/*'/', 2, 4*/); // could use ext to fragment path eg 12/e4/f2/...
-            return Path.Combine(directory, filename).Replace('\\', '/');
+            return Path.Combine(directory, culture ?? "", filename).Replace('\\', '/');
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/IO/MediaPathSchemes/OriginalMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/OriginalMediaPathScheme.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Core.IO.MediaPathSchemes
         private bool _folderCounterInitialized;
 
         /// <inheritdoc />
-        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null)
+        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null, string culture = null)
         {
             string directory;
             if (previous != null)
@@ -45,7 +45,7 @@ namespace Umbraco.Core.IO.MediaPathSchemes
             if (directory == null)
                 throw new InvalidOperationException("Cannot use a null directory.");
 
-            return Path.Combine(directory, filename).Replace('\\', '/');
+            return Path.Combine(directory, culture ?? "", filename).Replace('\\', '/');
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/IO/MediaPathSchemes/TwoGuidsMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/TwoGuidsMediaPathScheme.cs
@@ -12,9 +12,9 @@ namespace Umbraco.Core.IO.MediaPathSchemes
     public class TwoGuidsMediaPathScheme : IMediaPathScheme
     {
         /// <inheritdoc />
-        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null)
+        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null, string culture = null)
         {
-            return Path.Combine(itemGuid.ToString("N"), propertyGuid.ToString("N"), filename).Replace('\\', '/');
+            return Path.Combine(itemGuid.ToString("N"), propertyGuid.ToString("N"), culture ?? "", filename).Replace('\\', '/');
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
@@ -14,12 +14,12 @@ namespace Umbraco.Core.IO.MediaPathSchemes
         private const int DirectoryLength = 8;
 
         /// <inheritdoc />
-        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null)
+        public string GetFilePath(IMediaFileSystem fileSystem, Guid itemGuid, Guid propertyGuid, string filename, string previous = null, string culture = null)
         {
             var combinedGuid = GuidUtils.Combine(itemGuid, propertyGuid);
             var directory = GuidUtils.ToBase32String(combinedGuid, DirectoryLength);
 
-            return Path.Combine(directory, filename).Replace('\\', '/');
+            return Path.Combine(directory, culture ?? "", filename).Replace('\\', '/');
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -168,7 +168,7 @@ namespace Umbraco.Web.PropertyEditors
                     var src = GetFileSrcFromPropertyValue(propVal, out var jo);
                     if (src == null) continue;
                     var sourcePath = _mediaFileSystem.GetRelativePath(src);
-                    var copyPath = _mediaFileSystem.CopyFile(args.Copy, property.PropertyType, sourcePath);
+                    var copyPath = _mediaFileSystem.CopyFile(args.Copy, property.PropertyType, sourcePath, propertyValue.Culture);
                     jo["src"] = _mediaFileSystem.GetUrl(copyPath);
                     args.Copy.SetValue(property.Alias, jo.ToString(), propertyValue.Culture, propertyValue.Segment);
                     isUpdated = true;

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -120,7 +120,6 @@ namespace Umbraco.Web.PropertyEditors
 
                 return editorJson?.ToString(); // unchanged
             }
-
             // process the file
             var filepath = editorJson == null ? null : ProcessFile(editorValue, file, currentPath, cuid, puid);
 
@@ -147,7 +146,7 @@ namespace Umbraco.Web.PropertyEditors
 
             // get the filepath
             // in case we are using the old path scheme, try to re-use numbers (bah...)
-            var filepath = _mediaFileSystem.GetMediaPath(file.FileName, currentPath, cuid, puid); // fs-relative path
+            var filepath = _mediaFileSystem.GetMediaPath(file.FileName, currentPath, cuid, puid, file.Culture); // fs-relative path
 
             using (var filestream = File.OpenRead(file.TempFilePath))
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This is linked to the PR [8165](https://github.com/umbraco/Umbraco-CMS/issues/8165)

### Description

The change passes through the culture of the property down to the IMediaPathScheme to store files in culture specific folders. An example would be `/media/hsudhsie/un-UK/image.jpg`. This will only happen if the site has been setup to be multi-lingual.

Steps to test:

1. Create an Umbraco site with at least 2 different cultures
2. Add an Image Cropper property
3. Make the Image Cropper to vary by culture
4. Upload the same image file in multiple cultures
5. Observe on disk the file is created within a folder named with the culture
6. In Umbraco, clear the image for 1 culture.
7. Observe the media file has been removed from disk for that culture only
8. Observe the other cultures still have their file

![cultured_image](https://user-images.githubusercontent.com/5808078/83328292-eb42fd80-a279-11ea-891a-fb2888f56761.gif)

Other tests included uploading an image via the Image Cropper when the property is not vary by culture. This stores the image in the usual media folder, e.g. `/media/gagdhd/test.png`.

Switching to multi-cultured after uploading an image has also been tested. This stores the image in the usual media folder, still visible as the path has already been saved. If another image is uploaded it puts it into the culture specific folder.

<!-- Thanks for contributing to Umbraco CMS! -->
