### PR TITLE
v8.7: Removes "undefined" from the title when the user is editing content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
@@ -26,8 +26,8 @@
                 scope.a11yName = data[1];
                 var title = data[2] + ": ";
                 if (!scope.isNew) {
-                    scope.a11yMessage += " " + scope.editor.content.name;
-                    title += scope.content.name;
+                    scope.a11yMessage += " " + editorState.current.contentTypeName;
+                    title += scope.editor.content.name;
                 } else {
                     var name = editorState.current.contentTypeName;
                     scope.a11yMessage += " " + name;


### PR DESCRIPTION
When editing content the title displays undefined:
![image](https://user-images.githubusercontent.com/10153922/83329996-5db8db00-a284-11ea-8f42-9151813ee52a.png)
This has been changed to display the name of the page.
The hidden accessibility text now contents the name of the content being edited.