### PR TITLE
`IP` null when `GetCurrentRequestIpAddress` called from spoofed context

### DIFF
--- a/src/Umbraco.Core/Compose/AuditEventsComponent.cs
+++ b/src/Umbraco.Core/Compose/AuditEventsComponent.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Core.Compose
             {
                 var httpContext = HttpContext.Current == null ? (HttpContextBase) null : new HttpContextWrapper(HttpContext.Current);
                 var ip = httpContext.GetCurrentRequestIpAddress();
-                if (ip.ToLowerInvariant().StartsWith("unknown")) ip = "";
+                if (ip == null || ip.ToLowerInvariant().StartsWith("unknown")) ip = "";
                 return ip;
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes issue [8090](https://github.com/umbraco/Umbraco-CMS/issues/8090).

### Description
When calling `httpContext.GetCurrentRequestIpAddress()` from a spoofed HTTP context then the returned IP is `null`. A use case for this would be calling the MemberService.Save from a Hangfire scheduled task.

Testing is tricky; the way I tested was to make these changes locally then reference the DLL in a project where I had this error. Using the current Core DLL I receive the `NullReference` on line 71, using the updated DLL with this patch completes the MemberService.Save completely.

Since IP can return an empty string anyway this won't have any adverse affect.

<!-- Thanks for contributing to Umbraco CMS! -->
