### PR TITLE
umb-notifications.html - added option for setting the target attribute

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/notifications.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/notifications.service.js
@@ -52,6 +52,7 @@ angular.module('umbraco.services')
 		* @param {String} item.message longer text for the notication, trimmed after 200 characters, which can then be exanded
 		* @param {String} item.type Notification type, can be: "success","warning","error" or "info" 
 		* @param {String} item.url url to open when notification is clicked
+		* @param {String} item.target the target used together with `url`. Empty if not specified.
 		* @param {String} item.view path to custom view to load into the notification box
 		* @param {Array} item.actions Collection of button actions to append (label, func, cssClass)
 		* @param {Boolean} item.sticky if set to true, the notification will not auto-close

--- a/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
@@ -9,7 +9,7 @@
             </div>
 
             <div ng-if="notification.headline">
-                <a ng-if="notification.url" ng-href="{{notification.url}}" href="" target="_blank">
+                <a ng-if="notification.url" ng-href="{{notification.url}}" href="" target="{{notification.target}}" rel="noreferrer">
                     <strong ng-bind="notification.headline"></strong>
                     <span ng-bind-html="notification.message"></span>
                 </a>


### PR DESCRIPTION
Following the discussion in https://github.com/umbraco/Umbraco-CMS/pull/8207, I've now added a `target` property to control the corresponding target attribute of the `<a/>` element of the notification.

With this PR, the target will no longer be `_blank` by default, but instead leaves it up to the developer to set so if needed.

The PR also adds `rel="noreferrer"` to the `<a/>` element for security and privacy reasons. While this is primarily for when the link opens in a new window/tab, I don't see a problem always having it on the link.