### PR TITLE
Fix nested content clipboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
@@ -67,7 +67,7 @@ function clipboardService(notificationsService, eventsService, localStorageServi
 
     var prepareEntryForStorage = function(entryData, firstLevelClearupMethod) {
 
-        var cloneData = Utilities.copy(entryData);
+        var cloneData = angular.copy(entryData);
         if (firstLevelClearupMethod != undefined) {
             firstLevelClearupMethod(cloneData);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8223

### Description
The `copy` code is relying on the `Utilities` class to be there, but this (js) class was added for 8.7 only. So while cherry picking to 8.6 worked (there were no merge conflicts), it's unfortunately relying on a file from 8.7.

I searched for any other mentions of `Utilities.` in the client files and could only find this one.

To test, run this build and check that you can copy and paste a nested content item (each product in the starter kit has "features" which are NC items).
