### PR TITLE
Netcore: Removing UmbracoContext.Security usages

### DIFF
--- a/src/Umbraco.Infrastructure/Install/InstallSteps/StarterKitDownloadStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/StarterKitDownloadStep.cs
@@ -7,6 +7,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.Models.Packaging;
 using Umbraco.Net;
 using Umbraco.Web.Install.Models;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Install.InstallSteps
 {
@@ -16,16 +17,16 @@ namespace Umbraco.Web.Install.InstallSteps
     internal class StarterKitDownloadStep : InstallSetupStep<Guid?>
     {
         private readonly InstallHelper _installHelper;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly IUmbracoVersion _umbracoVersion;
         private readonly IUmbracoApplicationLifetime _umbracoApplicationLifetime;
         private readonly IContentService _contentService;
         private readonly IPackagingService _packageService;
 
-        public StarterKitDownloadStep(IContentService contentService, IPackagingService packageService, InstallHelper installHelper, IUmbracoContextAccessor umbracoContextAccessor, IUmbracoVersion umbracoVersion, IUmbracoApplicationLifetime umbracoApplicationLifetime)
+        public StarterKitDownloadStep(IContentService contentService, IPackagingService packageService, InstallHelper installHelper, IWebSecurity webSecurity, IUmbracoVersion umbracoVersion, IUmbracoApplicationLifetime umbracoApplicationLifetime)
         {
             _installHelper = installHelper;
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _webSecurity = webSecurity;
             _umbracoVersion = umbracoVersion;
             _umbracoApplicationLifetime = umbracoApplicationLifetime;
             _contentService = contentService;
@@ -66,7 +67,7 @@ namespace Umbraco.Web.Install.InstallSteps
         private async Task<(string packageFile, int packageId)> DownloadPackageFilesAsync(Guid kitGuid)
         {
             //Go get the package file from the package repo
-            var packageFile = await _packageService.FetchPackageFileAsync(kitGuid, _umbracoVersion.Current, _umbracoContextAccessor.UmbracoContext.Security.GetUserId().ResultOr(0));
+            var packageFile = await _packageService.FetchPackageFileAsync(kitGuid, _umbracoVersion.Current, _webSecurity.GetUserId().ResultOr(0));
             if (packageFile == null) throw new InvalidOperationException("Could not fetch package file " + kitGuid);
 
             //add an entry to the installedPackages.config
@@ -76,7 +77,7 @@ namespace Umbraco.Web.Install.InstallSteps
 
             _packageService.SaveInstalledPackage(packageDefinition);
 
-            _packageService.InstallCompiledPackageFiles(packageDefinition, packageFile, _umbracoContextAccessor.UmbracoContext.Security.GetUserId().ResultOr(-1));
+            _packageService.InstallCompiledPackageFiles(packageDefinition, packageFile, _webSecurity.GetUserId().ResultOr(-1));
 
             return (compiledPackage.PackageFile.Name, packageDefinition.Id);
         }

--- a/src/Umbraco.Infrastructure/Install/InstallSteps/StarterKitInstallStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/StarterKitInstallStep.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Umbraco.Net;
 using Umbraco.Core.Services;
 using Umbraco.Web.Install.Models;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Install.InstallSteps
 {
@@ -14,13 +15,13 @@ namespace Umbraco.Web.Install.InstallSteps
     internal class StarterKitInstallStep : InstallSetupStep<object>
     {
         private readonly IUmbracoApplicationLifetime _umbracoApplicationLifetime;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly IPackagingService _packagingService;
 
-        public StarterKitInstallStep(IUmbracoApplicationLifetime umbracoApplicationLifetime, IUmbracoContextAccessor umbracoContextAccessor, IPackagingService packagingService)
+        public StarterKitInstallStep(IUmbracoApplicationLifetime umbracoApplicationLifetime, IWebSecurity webSecurity, IPackagingService packagingService)
         {
             _umbracoApplicationLifetime = umbracoApplicationLifetime;
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _webSecurity = webSecurity;
             _packagingService = packagingService;
         }
 
@@ -47,7 +48,7 @@ namespace Umbraco.Web.Install.InstallSteps
 
             var packageFile = new FileInfo(definition.PackagePath);
 
-            _packagingService.InstallCompiledPackageData(definition, packageFile, _umbracoContextAccessor.UmbracoContext.Security.GetUserId().ResultOr(-1));
+            _packagingService.InstallCompiledPackageData(definition, packageFile, _webSecurity.GetUserId().ResultOr(-1));
         }
 
         public override bool RequiresExecution(object model)

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttributeTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttributeTests.cs
@@ -96,20 +96,11 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.BackOffice.Filters
                 .SetupGet(x => x.CurrentUser)
                 .Returns(currentUserMock.Object);
 
-            var umbracoContextMock = new Mock<IUmbracoContext>();
-            umbracoContextMock
-                .SetupGet(x => x.Security)
-                .Returns(webSecurityMock.Object);
-
-            var umbracoContextAccessorMock = new Mock<IUmbracoContextAccessor>();
-            umbracoContextAccessorMock
-                .SetupGet(x => x.UmbracoContext)
-                .Returns(umbracoContextMock.Object);
 
             var serviceProviderMock = new Mock<IServiceProvider>();
             serviceProviderMock
-                .Setup(x => x.GetService(typeof(IUmbracoContextAccessor)))
-                .Returns(umbracoContextAccessorMock.Object);
+                .Setup(x => x.GetService(typeof(IWebSecurity)))
+                .Returns(webSecurityMock.Object);
 
             httpContext.RequestServices = serviceProviderMock.Object;
 

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -313,6 +313,7 @@ namespace Umbraco.Tests.Testing
             Composition.RegisterUnique<ISectionService, SectionService>();
 
             Composition.RegisterUnique<HtmlLocalLinkParser>();
+            Composition.RegisterUnique<IWebSecurity, WebSecurity>();
             Composition.RegisterUnique<IEmailSender, EmailSender>();
             Composition.RegisterUnique<HtmlUrlParser>();
             Composition.RegisterUnique<HtmlImageSourceParser>();

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Net;
-using System.Security.Claims;
-using System.Security.Principal;
 using System.Threading.Tasks;
-using Umbraco.Core;
 using Umbraco.Core.BackOffice;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Mapping;
@@ -29,7 +26,7 @@ namespace Umbraco.Web.BackOffice.Controllers
     [IsBackOffice] // TODO: This could be applied with our Application Model conventions
     public class AuthenticationController : UmbracoApiControllerBase
     {
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly BackOfficeUserManager _userManager;
         private readonly BackOfficeSignInManager _signInManager;
         private readonly IUserService _userService;
@@ -40,14 +37,14 @@ namespace Umbraco.Web.BackOffice.Controllers
         // TODO: We need to review all _userManager.Raise calls since many/most should be on the usermanager or signinmanager, very few should be here
 
         public AuthenticationController(
-            IUmbracoContextAccessor umbracoContextAccessor,
+            IWebSecurity webSecurity,
             BackOfficeUserManager backOfficeUserManager,
             BackOfficeSignInManager signInManager,
             IUserService userService,
             UmbracoMapper umbracoMapper,
             IGlobalSettings globalSettings)
         {
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _webSecurity = webSecurity;
             _userManager = backOfficeUserManager;
             _signInManager = signInManager;
             _userService = userService;
@@ -62,8 +59,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         [HttpGet]
         public bool IsAuthenticated()
         {
-            var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-            var attempt = umbracoContext.Security.AuthorizeRequest();
+            var attempt = _webSecurity.AuthorizeRequest();
             if (attempt == ValidateRequestAttempt.Success)
             {
                 return true;

--- a/src/Umbraco.Web.BackOffice/Controllers/PackageController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PackageController.cs
@@ -10,13 +10,12 @@ using Microsoft.Net.Http.Headers;
 using Semver;
 using Umbraco.Core;
 using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
 using Umbraco.Core.Models.Packaging;
 using Umbraco.Core.Services;
 using Umbraco.Web.BackOffice.Filters;
 using Umbraco.Web.Common.Attributes;
 using Umbraco.Web.Common.Exceptions;
-using Umbraco.Web.Editors;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.BackOffice.Controllers
 {
@@ -29,16 +28,16 @@ namespace Umbraco.Web.BackOffice.Controllers
     {
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IPackagingService _packagingService;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
 
         public PackageController(
             IHostingEnvironment hostingEnvironment,
             IPackagingService packagingService,
-            IUmbracoContextAccessor umbracoContextAccessor)
+            IWebSecurity webSecurity)
         {
             _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
             _packagingService = packagingService ?? throw new ArgumentNullException(nameof(packagingService));
-            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
         }
 
         public IEnumerable<PackageDefinition> GetCreatedPackages()
@@ -92,8 +91,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         [HttpDelete]
         public IActionResult DeleteCreatedPackage(int packageId)
         {
-            var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-            _packagingService.DeleteCreatedPackage(packageId, umbracoContext.Security.GetUserId().ResultOr(0));
+            _packagingService.DeleteCreatedPackage(packageId, _webSecurity.GetUserId().ResultOr(0));
 
             return Ok();
         }

--- a/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
@@ -15,7 +15,7 @@ using Umbraco.Web.Common.Filters;
 using Umbraco.Web.Editors;
 using Umbraco.Web.Features;
 using Umbraco.Web.PublishedCache;
-using Umbraco.Web.Trees;
+using Umbraco.Web.Security;
 using Umbraco.Web.WebAssets;
 using Constants = Umbraco.Core.Constants;
 
@@ -28,7 +28,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         private readonly UmbracoFeatures _features;
         private readonly IGlobalSettings _globalSettings;
         private readonly IPublishedSnapshotService _publishedSnapshotService;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly ILocalizationService _localizationService;
         private readonly IUmbracoVersion _umbracoVersion;
         private readonly IContentSettings _contentSettings;
@@ -44,7 +44,7 @@ namespace Umbraco.Web.BackOffice.Controllers
             UmbracoFeatures features,
             IGlobalSettings globalSettings,
             IPublishedSnapshotService publishedSnapshotService,
-            IUmbracoContextAccessor umbracoContextAccessor,
+            IWebSecurity webSecurity,
             ILocalizationService localizationService,
             IUmbracoVersion umbracoVersion,
             IContentSettings contentSettings,
@@ -59,7 +59,7 @@ namespace Umbraco.Web.BackOffice.Controllers
             _features = features;
             _globalSettings = globalSettings;
             _publishedSnapshotService = publishedSnapshotService;
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _webSecurity = webSecurity;
             _localizationService = localizationService;
             _umbracoVersion = umbracoVersion;
             _contentSettings = contentSettings ?? throw new ArgumentNullException(nameof(contentSettings));
@@ -112,7 +112,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         [UmbracoAuthorize]
         public ActionResult Frame(int id, string culture)
         {
-            var user = _umbracoContextAccessor.UmbracoContext.Security.CurrentUser;
+            var user = _webSecurity.CurrentUser;
 
             var previewToken = _publishedSnapshotService.EnterPreview(user, id);
 

--- a/src/Umbraco.Web.BackOffice/Controllers/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/RedirectUrlManagementController.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Hosting;
 using Umbraco.Core.Mapping;
 using Umbraco.Core.Services;
 using Umbraco.Web.Common.Attributes;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.BackOffice.Controllers
 {
@@ -19,21 +20,21 @@ namespace Umbraco.Web.BackOffice.Controllers
     {
         private readonly ILogger _logger;
         private readonly IWebRoutingSettings _webRoutingSettings;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly IRedirectUrlService _redirectUrlService;
         private readonly UmbracoMapper _umbracoMapper;
         private readonly IHostingEnvironment _hostingEnvironment;
 
         public RedirectUrlManagementController(ILogger logger,
             IWebRoutingSettings webRoutingSettings,
-            IUmbracoContextAccessor umbracoContextAccessor,
+            IWebSecurity webSecurity,
             IRedirectUrlService redirectUrlService,
             UmbracoMapper umbracoMapper,
             IHostingEnvironment hostingEnvironment)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _webRoutingSettings = webRoutingSettings ?? throw new ArgumentNullException(nameof(webRoutingSettings));
-            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
             _redirectUrlService = redirectUrlService ?? throw new ArgumentNullException(nameof(redirectUrlService));
             _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));
             _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
@@ -47,8 +48,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         public IActionResult GetEnableState()
         {
             var enabled = _webRoutingSettings.DisableRedirectUrlTracking == false;
-            var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-            var userIsAdmin = umbracoContext.Security.CurrentUser.IsAdmin();
+            var userIsAdmin = _webSecurity.CurrentUser.IsAdmin();
             return Ok(new { enabled, userIsAdmin });
         }
 
@@ -104,8 +104,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         [HttpPost]
         public IActionResult ToggleUrlTracker(bool disable)
         {
-            var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-            var userIsAdmin = umbracoContext.Security.CurrentUser.IsAdmin();
+            var userIsAdmin = _webSecurity.CurrentUser.IsAdmin();
             if (userIsAdmin == false)
             {
                 var errorMessage = "User is not a member of the administrators group and so is not allowed to toggle the URL tracker";

--- a/src/Umbraco.Web.BackOffice/Controllers/TourController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TourController.cs
@@ -8,6 +8,7 @@ using Umbraco.Core.Hosting;
 using Umbraco.Core.Services;
 using Umbraco.Web.Common.Attributes;
 using Umbraco.Web.Models;
+using Umbraco.Web.Security;
 using Umbraco.Web.Tour;
 
 namespace Umbraco.Web.BackOffice.Controllers
@@ -18,21 +19,21 @@ namespace Umbraco.Web.BackOffice.Controllers
         private readonly TourFilterCollection _filters;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ITourSettings _tourSettings;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly IContentTypeService _contentTypeService;
 
         public TourController(
             TourFilterCollection filters,
             IHostingEnvironment hostingEnvironment,
             ITourSettings tourSettings,
-            IUmbracoContextAccessor umbracoContextAccessor,
+            IWebSecurity webSecurity,
             IContentTypeService contentTypeService)
         {
             _filters = filters;
             _hostingEnvironment = hostingEnvironment;
 
             _tourSettings = tourSettings;
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _webSecurity = webSecurity;
             _contentTypeService = contentTypeService;
         }
 
@@ -43,7 +44,7 @@ namespace Umbraco.Web.BackOffice.Controllers
             if (_tourSettings.EnableTours == false)
                 return result;
 
-            var user = _umbracoContextAccessor.UmbracoContext.Security.CurrentUser;
+            var user = _webSecurity.CurrentUser;
             if (user == null)
                 return result;
 
@@ -185,7 +186,7 @@ namespace Umbraco.Web.BackOffice.Controllers
                 var backOfficeTours = tours.Where(x =>
                     aliasFilters.Count == 0 || aliasFilters.All(filter => filter.IsMatch(x.Alias)) == false);
 
-                var user = _umbracoContextAccessor.UmbracoContext.Security.CurrentUser;
+                var user = _webSecurity.CurrentUser;
 
                 var localizedTours = backOfficeTours.Where(x =>
                     string.IsNullOrWhiteSpace(x.Culture) || x.Culture.Equals(user.Language,

--- a/src/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttribute.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Web.BackOffice.Filters
                 }
 
                 var webSecurity = context.HttpContext.RequestServices.GetService<IWebSecurity>();
-                var user = webSecurity.CurrentUser;
+                var user = webSecurity?.CurrentUser;
                 if (user == null)
                 {
                     return;

--- a/src/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttribute.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Core;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.BackOffice.Filters
 {
@@ -42,8 +43,8 @@ namespace Umbraco.Web.BackOffice.Filters
                     throw new InvalidOperationException($"No argument found for the current action with the name: {_userIdParameter}");
                 }
 
-                var umbracoContextAccessor = context.HttpContext.RequestServices.GetService<IUmbracoContextAccessor>();
-                var user = umbracoContextAccessor.UmbracoContext.Security.CurrentUser;
+                var webSecurity = context.HttpContext.RequestServices.GetService<IWebSecurity>();
+                var user = webSecurity.CurrentUser;
                 if (user == null)
                 {
                     return;

--- a/src/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/AppendUserModifiedHeaderAttribute.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Web.BackOffice.Filters
                 }
 
                 var webSecurity = context.HttpContext.RequestServices.GetService<IWebSecurity>();
-                var user = webSecurity?.CurrentUser;
+                var user = webSecurity.CurrentUser;
                 if (user == null)
                 {
                     return;

--- a/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Umbraco.Core;
 using Umbraco.Web.Editors;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.WebApi.Filters
 {
@@ -11,10 +13,12 @@ namespace Umbraco.Web.WebApi.Filters
     internal sealed class OutgoingEditorModelEventAttribute : ActionFilterAttribute
     {
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
 
-        public OutgoingEditorModelEventAttribute(IUmbracoContextAccessor umbracoContextAccessor)
+        public OutgoingEditorModelEventAttribute(IUmbracoContextAccessor umbracoContextAccessor, IWebSecurity webSecurity)
         {
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
         }
 
         public override void OnActionExecuted(ActionExecutedContext context)
@@ -22,7 +26,7 @@ namespace Umbraco.Web.WebApi.Filters
             if (context.Result == null) return;
 
             var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-            var user = umbracoContext.Security.CurrentUser;
+            var user = _webSecurity.CurrentUser;
             if (user == null) return;
 
             if (context.Result is ObjectResult objectContent)
@@ -41,6 +45,5 @@ namespace Umbraco.Web.WebApi.Filters
 
             base.OnActionExecuted(context);
         }
-
     }
 }

--- a/src/Umbraco.Web.BackOffice/Filters/UmbracoApplicationAuthorizeAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/UmbracoApplicationAuthorizeAttribute.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Core;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.BackOffice.Filters
 {
@@ -24,18 +22,19 @@ namespace Umbraco.Web.BackOffice.Filters
             /// </summary>
             internal static bool Enable = true;
 
-            private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+            private readonly IWebSecurity _webSecurity;
             private readonly string[] _appNames;
 
             /// <summary>
             /// Constructor to set any number of applications that the user needs access to be authorized
             /// </summary>
+            /// <param name="webSecurity"></param>
             /// <param name="appName">
             /// If the user has access to any of the specified apps, they will be authorized.
             /// </param>
-            public UmbracoApplicationAuthorizeFilter(IUmbracoContextAccessor umbracoContextAccessor, params string[] appName)
+            public UmbracoApplicationAuthorizeFilter(IWebSecurity webSecurity, params string[] appName)
             {
-                _umbracoContextAccessor = umbracoContextAccessor;
+                _webSecurity = webSecurity;
                 _appNames = appName;
             }
 
@@ -55,10 +54,9 @@ namespace Umbraco.Web.BackOffice.Filters
                     return true;
                 }
 
-                var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-                var authorized = umbracoContext.Security.CurrentUser != null
-                                 && _appNames.Any(app => umbracoContext.Security.UserHasSectionAccess(
-                                     app, umbracoContext.Security.CurrentUser));
+                var authorized = _webSecurity.CurrentUser != null
+                                 && _appNames.Any(app => _webSecurity.UserHasSectionAccess(
+                                     app, _webSecurity.CurrentUser));
 
                 return authorized;
             }

--- a/src/Umbraco.Web.Common/Install/InstallController.cs
+++ b/src/Umbraco.Web.Common/Install/InstallController.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Web.Common.Install
     [Area(Umbraco.Core.Constants.Web.Mvc.InstallArea)]
     public class InstallController : Controller
     {
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly InstallHelper _installHelper;
         private readonly IRuntimeState _runtime;
         private readonly IGlobalSettings _globalSettings;
@@ -33,7 +33,7 @@ namespace Umbraco.Web.Common.Install
         private readonly IRuntimeMinifier _runtimeMinifier;
 
         public InstallController(
-            IUmbracoContextAccessor umbracoContextAccessor,
+            IWebSecurity webSecurity,
             InstallHelper installHelper,
             IRuntimeState runtime,
             IGlobalSettings globalSettings,
@@ -43,7 +43,7 @@ namespace Umbraco.Web.Common.Install
             ILogger logger,
             LinkGenerator linkGenerator)
         {
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _webSecurity = webSecurity;
             _installHelper = installHelper;
             _runtime = runtime;
             _globalSettings = globalSettings;
@@ -69,7 +69,7 @@ namespace Umbraco.Web.Common.Install
                 // Update ClientDependency version and delete its temp directories to make sure we get fresh caches
                 _runtimeMinifier.Reset();
 
-                var result = _umbracoContextAccessor.UmbracoContext.Security.ValidateCurrentUser(false);
+                var result = _webSecurity.ValidateCurrentUser(false);
 
                 switch (result)
                 {

--- a/src/Umbraco.Web/Editors/AuthenticationController.cs
+++ b/src/Umbraco.Web/Editors/AuthenticationController.cs
@@ -88,7 +88,7 @@ namespace Umbraco.Web.Editors
         [WebApi.UmbracoAuthorize(requireApproval: false)]
         public IDictionary<string, object> GetPasswordConfig(int userId)
         {
-            return _passwordConfiguration.GetConfiguration(userId != UmbracoContext.Security.CurrentUser.Id);
+            return _passwordConfiguration.GetConfiguration(userId != Security.CurrentUser.Id);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Umbraco.Web.Editors
         [CheckIfUserTicketDataIsStale]
         public UserDetail GetCurrentUser()
         {
-            var user = UmbracoContext.Security.CurrentUser;
+            var user = Security.CurrentUser;
             var result = Mapper.Map<UserDetail>(user);
             var httpContextAttempt = TryGetHttpContext();
             if (httpContextAttempt.Success)
@@ -195,7 +195,7 @@ namespace Umbraco.Web.Editors
         [SetAngularAntiForgeryTokens]
         public UserDetail GetCurrentInvitedUser()
         {
-            var user = UmbracoContext.Security.CurrentUser;
+            var user = Security.CurrentUser;
 
             if (user.IsApproved)
             {
@@ -219,7 +219,7 @@ namespace Umbraco.Web.Editors
         [ValidateAngularAntiForgeryToken]
         public async Task<Dictionary<string, string>> GetCurrentUserLinkedLogins()
         {
-            var identityUser = await UserManager.FindByIdAsync(UmbracoContext.Security.GetUserId().ResultOr(0).ToString());
+            var identityUser = await UserManager.FindByIdAsync(Security.GetUserId().ResultOr(0).ToString());
             return identityUser.Logins.ToDictionary(x => x.LoginProvider, x => x.ProviderKey);
         }
 

--- a/src/Umbraco.Web/Editors/Filters/ContentModelValidator.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentModelValidator.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Editors.Filters
 {
@@ -18,13 +19,13 @@ namespace Umbraco.Web.Editors.Filters
     /// </summary>
     internal abstract class ContentModelValidator
     {
-        protected IUmbracoContextAccessor UmbracoContextAccessor { get; }
+        protected IWebSecurity WebSecurity { get; }
         protected ILogger Logger { get; }
 
-        protected ContentModelValidator(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor)
+        protected ContentModelValidator(ILogger logger, IWebSecurity webSecurity)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            UmbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            WebSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
         }
     }
 
@@ -45,7 +46,7 @@ namespace Umbraco.Web.Editors.Filters
     {
         private readonly ILocalizedTextService _textService;
 
-        protected ContentModelValidator(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, ILocalizedTextService textService) : base(logger, umbracoContextAccessor)
+        protected ContentModelValidator(ILogger logger, IWebSecurity webSecurity, ILocalizedTextService textService) : base(logger, webSecurity)
         {
             _textService = textService ?? throw new ArgumentNullException(nameof(textService));
         }

--- a/src/Umbraco.Web/Editors/Filters/ContentSaveModelValidator.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentSaveModelValidator.cs
@@ -2,6 +2,7 @@
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Editors.Filters
 {
@@ -10,7 +11,7 @@ namespace Umbraco.Web.Editors.Filters
     /// </summary>
     internal class ContentSaveModelValidator : ContentModelValidator<IContent, ContentItemSave, ContentVariantSave>
     {
-        public ContentSaveModelValidator(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, ILocalizedTextService textService) : base(logger, umbracoContextAccessor, textService)
+        public ContentSaveModelValidator(ILogger logger, IWebSecurity webSecurity, ILocalizedTextService textService) : base(logger, webSecurity, textService)
         {
         }
     }

--- a/src/Umbraco.Web/Editors/Filters/MediaItemSaveValidationAttribute.cs
+++ b/src/Umbraco.Web/Editors/Filters/MediaItemSaveValidationAttribute.cs
@@ -9,6 +9,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Composing;
 using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Security;
 using Umbraco.Web.WebApi;
 
 namespace Umbraco.Web.Editors.Filters
@@ -19,19 +20,19 @@ namespace Umbraco.Web.Editors.Filters
     internal class MediaItemSaveValidationAttribute : ActionFilterAttribute
     {
         private readonly ILogger _logger;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly ILocalizedTextService _textService;
         private readonly IMediaService _mediaService;
         private readonly IEntityService _entityService;
 
-        public MediaItemSaveValidationAttribute() : this(Current.Logger, Current.UmbracoContextAccessor, Current.Services.TextService, Current.Services.MediaService, Current.Services.EntityService)
+        public MediaItemSaveValidationAttribute() : this(Current.Logger, Current.UmbracoContextAccessor.UmbracoContext.Security, Current.Services.TextService, Current.Services.MediaService, Current.Services.EntityService)
         {
         }
 
-        public MediaItemSaveValidationAttribute(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, ILocalizedTextService textService, IMediaService mediaService, IEntityService entityService)
+        public MediaItemSaveValidationAttribute(ILogger logger, IWebSecurity webSecurity, ILocalizedTextService textService, IMediaService mediaService, IEntityService entityService)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
             _textService = textService ?? throw new ArgumentNullException(nameof(textService));
             _mediaService = mediaService ?? throw new ArgumentNullException(nameof(mediaService));
             _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
@@ -40,7 +41,7 @@ namespace Umbraco.Web.Editors.Filters
         public override void OnActionExecuting(HttpActionContext actionContext)
         {
             var model = (MediaItemSave)actionContext.ActionArguments["contentItem"];
-            var contentItemValidator = new MediaSaveModelValidator(_logger, _umbracoContextAccessor, _textService);
+            var contentItemValidator = new MediaSaveModelValidator(_logger, _webSecurity, _textService);
 
             if (ValidateUserAccess(model, actionContext))
             {
@@ -90,7 +91,7 @@ namespace Umbraco.Web.Editors.Filters
 
             if (MediaController.CheckPermissions(
                     actionContext.Request.Properties,
-                    _umbracoContextAccessor.UmbracoContext.Security.CurrentUser,
+                    _webSecurity.CurrentUser,
                     _mediaService, _entityService,
                     contentIdToCheck, contentToCheck) == false)
             {

--- a/src/Umbraco.Web/Editors/Filters/MediaSaveModelValidator.cs
+++ b/src/Umbraco.Web/Editors/Filters/MediaSaveModelValidator.cs
@@ -2,6 +2,7 @@
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Editors.Filters
 {
@@ -10,7 +11,7 @@ namespace Umbraco.Web.Editors.Filters
     /// </summary>
     internal class MediaSaveModelValidator : ContentModelValidator<IMedia, MediaItemSave, IContentProperties<ContentPropertyBasic>>
     {
-        public MediaSaveModelValidator(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, ILocalizedTextService textService) : base(logger, umbracoContextAccessor, textService)
+        public MediaSaveModelValidator(ILogger logger, IWebSecurity webSecurity, ILocalizedTextService textService) : base(logger, webSecurity, textService)
         {
         }
     }

--- a/src/Umbraco.Web/Editors/Filters/MemberSaveModelValidator.cs
+++ b/src/Umbraco.Web/Editors/Filters/MemberSaveModelValidator.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Editors.Filters
 {
@@ -25,12 +26,12 @@ namespace Umbraco.Web.Editors.Filters
 
         public MemberSaveModelValidator(
             ILogger logger,
-            IUmbracoContextAccessor umbracoContextAccessor,
+            IWebSecurity webSecurity,
             ILocalizedTextService textService,
             IMemberTypeService memberTypeService,
             IMemberService memberService,
             IShortStringHelper shortStringHelper)
-            : base(logger, umbracoContextAccessor, textService)
+            : base(logger, webSecurity, textService)
         {
             _memberTypeService = memberTypeService ?? throw new ArgumentNullException(nameof(memberTypeService));
             _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
@@ -101,7 +102,7 @@ namespace Umbraco.Web.Editors.Filters
 
             //if the user doesn't have access to sensitive values, then we need to validate the incoming properties to check
             //if a sensitive value is being submitted.
-            if (UmbracoContextAccessor.UmbracoContext.Security.CurrentUser.HasAccessToSensitiveData() == false)
+            if (WebSecurity.CurrentUser.HasAccessToSensitiveData() == false)
             {
                 var contentType = _memberTypeService.Get(model.PersistedContent.ContentTypeId);
                 var sensitiveProperties = contentType

--- a/src/Umbraco.Web/Editors/Filters/MemberSaveValidationAttribute.cs
+++ b/src/Umbraco.Web/Editors/Filters/MemberSaveValidationAttribute.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Web.Composing;
 using Umbraco.Web.Models.ContentEditing;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Editors.Filters
 {
@@ -15,20 +16,20 @@ namespace Umbraco.Web.Editors.Filters
     internal class MemberSaveValidationAttribute : ActionFilterAttribute
     {
         private readonly ILogger _logger;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IWebSecurity _webSecurity;
         private readonly ILocalizedTextService _textService;
         private readonly IMemberTypeService _memberTypeService;
         private readonly IMemberService _memberService;
         private readonly IShortStringHelper _shortStringHelper;
 
         public MemberSaveValidationAttribute()
-            : this(Current.Logger, Current.UmbracoContextAccessor, Current.Services.TextService, Current.Services.MemberTypeService, Current.Services.MemberService, Current.ShortStringHelper)
+            : this(Current.Logger, Current.UmbracoContextAccessor.UmbracoContext.Security, Current.Services.TextService, Current.Services.MemberTypeService, Current.Services.MemberService, Current.ShortStringHelper)
         { }
 
-        public MemberSaveValidationAttribute(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, ILocalizedTextService textService, IMemberTypeService memberTypeService, IMemberService memberService, IShortStringHelper shortStringHelper)
+        public MemberSaveValidationAttribute(ILogger logger, IWebSecurity webSecurity, ILocalizedTextService textService, IMemberTypeService memberTypeService, IMemberService memberService, IShortStringHelper shortStringHelper)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
             _textService = textService ?? throw new ArgumentNullException(nameof(textService));
             _memberTypeService = memberTypeService ?? throw new ArgumentNullException(nameof(memberTypeService));
             _memberService = memberService  ?? throw new ArgumentNullException(nameof(memberService));
@@ -38,7 +39,7 @@ namespace Umbraco.Web.Editors.Filters
         public override void OnActionExecuting(HttpActionContext actionContext)
         {
             var model = (MemberSave)actionContext.ActionArguments["contentItem"];
-            var contentItemValidator = new MemberSaveModelValidator(_logger, _umbracoContextAccessor,_textService, _memberTypeService, _memberService, _shortStringHelper);
+            var contentItemValidator = new MemberSaveModelValidator(_logger, _webSecurity, _textService, _memberTypeService, _memberService, _shortStringHelper);
             //now do each validation step
             if (contentItemValidator.ValidateExistingContent(model, actionContext))
                 if (contentItemValidator.ValidateProperties(model, model, actionContext))

--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Web.Editors
             var ctId = Convert.ToInt32(contentTypeSave.Id);
             var ct = ctId > 0 ? Services.MemberTypeService.Get(ctId) : null;
 
-            if (UmbracoContext.Security.CurrentUser.HasAccessToSensitiveData() == false)
+            if (Security.CurrentUser.HasAccessToSensitiveData() == false)
             {
                 //We need to validate if any properties on the contentTypeSave have had their IsSensitiveValue changed,
                 //and if so, we need to check if the current user has access to sensitive values. If not, we have to return an error

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         public string[] GetCurrentUserAvatarUrls()
         {
-            var urls = UmbracoContext.Security.CurrentUser.GetUserAvatarUrls(AppCaches.RuntimeCache, _mediaFileSystem, _imageUrlGenerator);
+            var urls = Security.CurrentUser.GetUserAvatarUrls(AppCaches.RuntimeCache, _mediaFileSystem, _imageUrlGenerator);
             if (urls == null)
                 throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, "Could not access Gravatar endpoint"));
 

--- a/src/Umbraco.Web/Mvc/UmbracoAuthorizeAttribute.cs
+++ b/src/Umbraco.Web/Mvc/UmbracoAuthorizeAttribute.cs
@@ -4,6 +4,7 @@ using System.Web.Mvc;
 using Umbraco.Core;
 using Umbraco.Web.Composing;
 using Umbraco.Core.Configuration;
+using Umbraco.Web.Security;
 
 namespace Umbraco.Web.Mvc
 {
@@ -12,25 +13,23 @@ namespace Umbraco.Web.Mvc
     public sealed class UmbracoAuthorizeAttribute : AuthorizeAttribute
     {
         // see note in HttpInstallAuthorizeAttribute
-        private readonly IUmbracoContext _umbracoContext;
+        private readonly IWebSecurity _webSecurity;
         private readonly IRuntimeState _runtimeState;
         private readonly string _redirectUrl;
 
         private IRuntimeState RuntimeState => _runtimeState ?? Current.RuntimeState;
 
-        private IUmbracoContext UmbracoContext => _umbracoContext ?? Current.UmbracoContext;
+        private IWebSecurity WebSecurity => _webSecurity ?? Current.UmbracoContext.Security;
 
         /// <summary>
         /// THIS SHOULD BE ONLY USED FOR UNIT TESTS
         /// </summary>
-        /// <param name="umbracoContext"></param>
+        /// <param name="webSecurity"></param>
         /// <param name="runtimeState"></param>
-        public UmbracoAuthorizeAttribute(IUmbracoContext umbracoContext, IRuntimeState runtimeState)
+        public UmbracoAuthorizeAttribute(IWebSecurity webSecurity, IRuntimeState runtimeState)
         {
-            if (umbracoContext == null) throw new ArgumentNullException(nameof(umbracoContext));
-            if (runtimeState == null) throw new ArgumentNullException(nameof(runtimeState));
-            _umbracoContext = umbracoContext;
-            _runtimeState = runtimeState;
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
+            _runtimeState = runtimeState ?? throw new ArgumentNullException(nameof(runtimeState));
         }
 
         /// <summary>
@@ -75,7 +74,7 @@ namespace Umbraco.Web.Mvc
                 // otherwise we need to ensure that a user is logged in
                 return RuntimeState.Level == RuntimeLevel.Install
                     || RuntimeState.Level == RuntimeLevel.Upgrade
-                    || UmbracoContext.Security.ValidateCurrentUser();
+                    || WebSecurity.ValidateCurrentUser();
             }
             catch (Exception)
             {

--- a/src/Umbraco.Web/WebApi/UmbracoAuthorizeAttribute.cs
+++ b/src/Umbraco.Web/WebApi/UmbracoAuthorizeAttribute.cs
@@ -19,24 +19,22 @@ namespace Umbraco.Web.WebApi
         internal static bool Enable = true;
 
         // TODO: inject!
-        private readonly IUmbracoContext _umbracoContext;
+        private readonly IWebSecurity _webSecurity;
         private readonly IRuntimeState _runtimeState;
 
         private IRuntimeState RuntimeState => _runtimeState ?? Current.RuntimeState;
 
-        private IUmbracoContext UmbracoContext => _umbracoContext ?? Current.UmbracoContext;
+        private IWebSecurity WebSecurity => _webSecurity ?? Current.UmbracoContext.Security;
 
         /// <summary>
         /// THIS SHOULD BE ONLY USED FOR UNIT TESTS
         /// </summary>
-        /// <param name="umbracoContext"></param>
+        /// <param name="webSecurity"></param>
         /// <param name="runtimeState"></param>
-        public UmbracoAuthorizeAttribute(IUmbracoContext umbracoContext, IRuntimeState runtimeState)
+        public UmbracoAuthorizeAttribute(IWebSecurity webSecurity, IRuntimeState runtimeState)
         {
-            if (umbracoContext == null) throw new ArgumentNullException(nameof(umbracoContext));
-            if (runtimeState == null) throw new ArgumentNullException(nameof(runtimeState));
-            _umbracoContext = umbracoContext;
-            _runtimeState = runtimeState;
+            _webSecurity = webSecurity ?? throw new ArgumentNullException(nameof(webSecurity));
+            _runtimeState = runtimeState ?? throw new ArgumentNullException(nameof(runtimeState));
         }
 
         public UmbracoAuthorizeAttribute() : this(true)
@@ -60,7 +58,7 @@ namespace Umbraco.Web.WebApi
                 // otherwise we need to ensure that a user is logged in
                 return RuntimeState.Level == RuntimeLevel.Install
                     || RuntimeState.Level == RuntimeLevel.Upgrade
-                    || UmbracoContext.Security.ValidateCurrentUser(false, _requireApproval) == ValidateRequestAttempt.Success;
+                    || WebSecurity.ValidateCurrentUser(false, _requireApproval) == ValidateRequestAttempt.Success;
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Notes:

Once `IWebSecurity` was added to the DI Container (#8220) we can now directly inject `IWebSecurity` and eliminate the usages of `UmbracoContext.Security`.