### PR TITLE
no more 401 when trying to create content where no permitted types exist

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -28,7 +28,9 @@ function contentCreateController($scope,
         
         $q.all([contentTypeResource.getAllowedTypes($scope.currentNode.id), authResource.getCurrentUser()])
             .then(resolvedPromises => {
-                [let types, let currentUser] = resolvedPromises;
+                let types;
+                let currentUser;
+                [types, currentUser] = resolvedPromises;
             
                 $scope.allowedTypes = iconHelper.formatContentTypeIcons(types);                
             

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -34,7 +34,7 @@ function contentCreateController($scope,
             
                 $scope.allowedTypes = iconHelper.formatContentTypeIcons(types);                
             
-                if (currentUser.allowedSections.includes('settings')) {
+                if (currentUser.allowedSections.indexOf('settings') !== -1) {
                     $scope.hasSettingsAccess = true;
 
                     if ($scope.allowedTypes.length === 0) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8062

### Description
Issue here was caused by calling `getCount` on `contentTypeResource` as the API method is restricted to users with access to the document types tree, so returns the 401 for editor/writer user types.

I've fixed it by refactoring `Umbraco.Editors.Content.CreateController` to make better use of `$q.all` - we now wait for all promises to resolve, which gives us access to the currentUser object, so can check the user's permissions before calling getCount. Users without appropriate permissions see the basic message "The selected page in the content tree doesn't allow for any pages to be created below it.".

Verify by first logging in as an admin and ensuring no doc types are permitted at root. Log in as writer/editor, and attempt to create at the root (ie click ... next to content). Should not be logged out, but should see the text message re no permitted content.

Because I can't help myself, I cleaned up the `createOrSelectBlueprintIfAny` method in the same controller - removes the underscore dependency in favor of boring old vanilla javascript and removes some nesting by returning early when no blueprints exist for the doctype.
