### PR TITLE
update date-format matching for formats with am/pm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -55,7 +55,9 @@ function dateTimePickerController($scope, angularHelper, dateHelper, validationM
         };
 
         // Don't show calendar if date format has been set to only time
-        if ($scope.model.config.format === "HH:mm:ss" || $scope.model.config.format === "HH:mm" || $scope.model.config.format === "HH") {
+        const timeFormat = $scope.model.config.format.toLowerCase();
+        const timeFormatPattern = /^h{1,2}:m{1,2}:s{1,2}\s?a?$/gmi;
+        if (timeFormat.match(timeFormatPattern)) {            
             $scope.datePickerConfig.enableTime = true;
             $scope.datePickerConfig.noCalendar = true;
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
@@ -25,7 +25,7 @@
                         <span class="sr-only"><localize key="content_removeDate">Clear date</localize></span>
                     </button>
                     <span class="add-on" aria-hidden="true">
-                        <i class="icon-calendar"></i>
+                        <i class="icon-{{ datePickerConfig.noCalendar ? 'time' : 'calendar' }}"></i>
                     </span>
                 </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8241 

### Description
I've updated the date-format string check to catch all (most) time variants, replacing the old string comparisons with a regex match to catch lots more for less effort. Also updated the view to show clock icon when the picker is time-only, rather than the calendar. This won't catch absolutely every time format, but it's a lot broader than the previous solution which forced 24-hour formatting with a leading 0

Verify by updating the date picker config to `h:mm:ss a` or any combination of 1-2 `H/h`, 1-2 `m`, 1/2 `s`, all colon-separated, with or without a trailing `a`, with or without a leading space (aka any valid [momentjs time format](https://momentjs.com/docs/#/displaying/format/)). Picker will not display the calendar, and will reformat times with respect to am/pm when the format starts with `h`.
