### PR TITLE
Use property editor width limit for slider property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -707,8 +707,9 @@
             margin-top: 0;
         }
     }
+
 //
-// folder-browser
+// Folder browser
 // --------------------------------------------------
 .umb-folderbrowser .add-link {
   display: inline-block;
@@ -804,6 +805,13 @@
     border-bottom: 1px solid @tableBorder;
 }
 
+
+//
+// Slider
+// --------------------------------------------------
+.umb-slider {
+    .umb-property-editor--limit-width();
+}
 
 //
 // Tags

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.html
@@ -1,6 +1,6 @@
-﻿<div ng-controller="Umbraco.PropertyEditors.SliderController">
+﻿<div class="umb-property-editor umb-slider" ng-controller="Umbraco.PropertyEditors.SliderController">
 
-    <div style="padding-top: 50px; padding-bottom: 40px; width: 66.6%">
+    <div style="padding-top: 50px; padding-bottom: 40px;">
         <umb-range-slider 
             ng-model="sliderValue"
             options="sliderOptions"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR re-use the `umb-property-editor--limit-width` mixin to set the max width and not specific to `66.6%` width also mean it in overlay use more of the width instead only 2/3 of the width in overlays.

**Before**

![image](https://user-images.githubusercontent.com/2919859/84061924-0bcc2f80-a9bf-11ea-9e9e-6bef2e139fb6.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/84060868-387f4780-a9bd-11ea-91f6-5303116f86ae.png)
