### PR TITLE
Adjust property editor settings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -527,7 +527,6 @@ input.umb-group-builder__group-sort-value {
         text-align: left;
         display: flex;
         align-items: center;
-        max-width: calc(100% - 48px);
         min-height: 80px;
         color: @ui-action-discreet-type;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -54,12 +54,12 @@
 
                         <div class="editor-wrapper umb-control-group control-group" ng-model="model.property.editor" val-require-component ng-if="!model.property.locked">
 
-                            <a data-element="editor-add" href="" ng-if="!model.property.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openDataTypePicker(model.property)">
+                            <button type="button" class="btn-reset editor-placeholder" data-element="editor-add" ng-if="!model.property.editor" hotkey="alt+shift+e" ng-click="vm.openDataTypePicker(model.property)">
                                 <localize key="defaultdialogs_selectEditor"></localize>
                                 <div ng-messages="model.property.editor" show-validation-on-submit>
                                     <span class="umb-validation-label" ng-message="required">Required editor</span>
                                 </div>
-                            </a>
+                            </button>
 
                             <div class="editor clearfix" ng-if="model.property.editor">
 
@@ -141,8 +141,7 @@
                             <h5><localize key="contentTypeEditor_cultureVariantHeading" /></h5>
                             <umb-toggle data-element="permissions-allow-culture-variant"
                                         checked="model.property.allowCultureVariant"
-                                        on-click="vm.toggleAllowCultureVariants()"
-                            >
+                                        on-click="vm.toggleAllowCultureVariants()">
                             </umb-toggle>
 
                         </div>
@@ -152,8 +151,7 @@
 
                             <umb-toggle data-element="permissions-allow-segment-variant"
                                         checked="model.property.allowSegmentVariant"
-                                        on-click="vm.toggleAllowSegmentVariants()"
-                            >
+                                        on-click="vm.toggleAllowSegmentVariants()">
                             </umb-toggle>
 
                         </div>
@@ -191,7 +189,6 @@
                                         checked="model.property.isSensitiveData"
                                         on-click="vm.toggleIsSensitiveData()">
                             </umb-toggle>
-
 
                         </div>
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -63,7 +63,7 @@
 
                             <div class="editor clearfix" ng-if="model.property.editor">
 
-                                <button class="btn-reset editor-info" ng-click="vm.openDataTypeSettings(model.property)">
+                                <button type="button" class="btn-reset editor-info" ng-click="vm.openDataTypeSettings(model.property)">
                                     <div class="editor-icon-wrapper">
                                         <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}"></i>
                                     </div>
@@ -75,7 +75,7 @@
 
                                 </button>
 
-                                <button class="editor-remove-icon btn-reset pull-right"
+                                <button type="button" class="editor-remove-icon btn-reset pull-right"
                                     ng-click="vm.openDataTypePicker(model.property)"
                                     hotkey="alt+shift+d"
                                     localize="title"

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -65,23 +65,21 @@
 
                                 <button type="button" class="btn-reset editor-info" ng-click="vm.openDataTypeSettings(model.property)">
                                     <div class="editor-icon-wrapper">
-                                        <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}"></i>
+                                        <i class="icon {{ model.property.dataTypeIcon }}" ng-class="{'icon-autofill': model.property.dataTypeIcon == null}" aria-hidden="true"></i>
                                     </div>
 
                                     <div class="editor-details">
                                         <span class="editor-name">{{ model.property.dataTypeName }}</span>
                                         <span class="editor-editor">{{ model.property.editor }}</span>
                                     </div>
-
                                 </button>
 
                                 <button type="button" class="editor-remove-icon btn-reset pull-right"
                                     ng-click="vm.openDataTypePicker(model.property)"
                                     hotkey="alt+shift+d"
                                     localize="title"
-                                    title="@actions_changeDataType"
-                                >
-                                    <i class="icon icon-wrong"></i>
+                                    title="@actions_changeDataType">
+                                    <i class="icon icon-wrong" aria-hidden="true"></i>
                                 </button>
                             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -108,8 +108,7 @@
                                    placeholder="@validation_mandatoryMessage"
                                    ng-model="model.property.validation.mandatoryMessage"
                                    ng-if="model.property.validation.mandatory"
-                                   ng-keypress="vm.submitOnEnter($event)">
-                            </input>
+                                   ng-keypress="vm.submitOnEnter($event)" />
 
                             <label class="mt3">
                                 <localize key="validation_customValidation"></localize>

--- a/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
@@ -47,19 +47,16 @@
 
                         <div class="editor clearfix" ng-if="model.parameter.editor">
 
-                            <div class="editor-details">
-                                <button class="btn-reset editor-info" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                            <button type="button" class="btn-reset editor-info" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                                <div class="editor-icon-wrapper">
+                                    <i class="icon {{ model.parameter.dataTypeIcon }}" ng-class="{'icon-autofill': model.parameter.dataTypeIcon == null}" aria-hidden="true"></i>
+                                </div>
 
-                                    <div class="editor-icon-wrapper">
-                                        <i class="icon {{model.parameter.dataTypeIcon}}" ng-class="{'icon-autofill': model.parameter.dataTypeIcon == null}"></i>
-                                    </div>
-
-                                    <div class="editor-details">
-                                        <a href="" class="editor-name">{{model.parameter.dataTypeName}}</a>
-                                        <a href="" class="editor-editor">{{model.parameter.editor}}</a>
-                                    </div>
-                                </button>
-                            </div>
+                                <div class="editor-details">
+                                    <span class="editor-name">{{ model.parameter.dataTypeName }}</span>
+                                    <span class="editor-editor">{{ model.parameter.editor }}</span>
+                                </div>
+                            </button>
 
                         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
@@ -41,9 +41,9 @@
                             </div>
                         </div>
 
-                        <a data-element="editor-add" href="" ng-if="!model.parameter.editor" class="editor-placeholder" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
+                        <button type="button" class="btn-reset editor-placeholder" data-element="editor-add" ng-if="!model.parameter.editor" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
                             <localize key="shortcuts_addEditor"></localize>
-                        </a>
+                        </button>
 
                         <div class="editor clearfix" ng-if="model.parameter.editor">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The property editor settings via datatype on a document type has now changed a bit in this PR https://github.com/umbraco/Umbraco-CMS/pull/5677

However this PR didn't take into account the look and feel of macro parameter editors and furthermore my previous PR https://github.com/umbraco/Umbraco-CMS/pull/8071 wasn't merged in time before these changes was made.

I have added a few changes to make it more consistent again and made some accessibility enhancements.

![2020-06-08_20-34-51](https://user-images.githubusercontent.com/2919859/84067438-b2b4c980-a9c7-11ea-9fc6-30d4c8e7e24c.gif)
