### PR TITLE
Use primary button style for save-button in content template

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -270,9 +270,15 @@
          * @param {any} app the active content app
          */
         function createButtons(content) {
+            
+            var isBlueprint = content.isBlueprint;
+
+            if ($scope.page.isNew && $location.path().search(/contentBlueprints/i) !== -1) {
+               isBlueprint = true;
+            }
 
             // for trashed and element type items, the save button is the primary action - otherwise it's a secondary action
-            $scope.page.saveButtonStyle = content.trashed || content.isElement || content.isBlueprint ? "primary" : "info";
+            $scope.page.saveButtonStyle = content.trashed || content.isElement || isBlueprint ? "primary" : "info";
             // only create the save/publish/preview buttons if the
             // content app is "Conent"
             if ($scope.activeApp && $scope.activeApp.alias !== "umbContent" && $scope.activeApp.alias !== "umbInfo" && $scope.activeApp.alias !== "umbListView") {

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
@@ -14,8 +14,7 @@
                 on-select-app="appChanged(app)"
                 on-select-app-anchor="appAnchorChanged(app, anchor)"
                 on-back="onBack()"
-                show-back="!(infiniteModel && infiniteModel.infiniteMode)"
-                >
+                show-back="!(infiniteModel && infiniteModel.infiniteMode)">
             </umb-variant-content-editors>
 
             <umb-editor-footer>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed when creating a new content template (blueprint) the save-button in the edit view (new) is a bit inconsistent from other parts of the UI where only a save-button (green button) is displayed, e.g. in datatype edit view or for an existing created content template.

**Before**

![image](https://user-images.githubusercontent.com/2919859/84077895-45f5fb00-a9d8-11ea-9b8d-d3100394bdfc.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/84077679-0202f600-a9d8-11ea-9a2d-593f78d15e77.png)

![image](https://user-images.githubusercontent.com/2919859/84077609-eb5c9f00-a9d7-11ea-9681-519bfd470ad5.png)
