### PR TITLE
Fix checkbox and radio label alignment

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -1,25 +1,18 @@
 @checkboxWidth: 18px;
 @checkboxHeight: 18px;
-label.umb-form-check--checkbox{
-    margin:3px 0;
-}
 
 .umb-form-check {
     display: flex;
+    align-items: center;
     position: relative;
-    padding-left: 0px;
-    margin: 0;
-    min-height: 22px;
+    padding-left: 0;
+    margin: 5px 0;
+    min-height: 20px;
     cursor: pointer !important;
 
-    .umb-form-check__symbol {
-        margin-top: 4px;
-        margin-right: 10px;
-    }
     .umb-form-check__info {
-        margin-left:20px;
+        margin-left: 30px;
         position: relative;
-        top: 3px;
     }
     
 
@@ -81,7 +74,6 @@ label.umb-form-check--checkbox{
     }
 
     .tabbing-active &.umb-form-check--radiobutton &__input:focus ~ .umb-form-check__state .umb-form-check__check {
-        //outline: 2px solid @inputBorderTabFocus;
         border: 2px solid @inputBorderTabFocus;
         margin: -1px;
     }
@@ -99,11 +91,10 @@ label.umb-form-check--checkbox{
 
     &__state {
         display: flex;
-        height: 18px;
+        height: 20px;
+        width: 20px;
         position: absolute;
-        margin-top: 2px;
-        top: 0;
-        left: -1px;
+        top: -1px;
     }
 
     &__check {

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -29,7 +29,7 @@ label.control-label, .control-label {
   }
 
 
-.controls-row label{padding: 0 10px 0 10px; vertical-align: middle;}
+.controls-row label:not(.umb-form-check){padding: 0 10px 0 10px; vertical-align: middle;}
 
 
 

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -267,7 +267,7 @@ label:not([for]) {
     margin-left: 0;
 }
 
-.controls-row label {
+.controls-row label:not(.umb-form-check) {
   display: inline-block;
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As pointed out by @bjarnef in #8119 I did unfortunately not get to the root of the problem with the proposed PR, which affected the display of radio buttons making them look worse and the rich text editor settings did not look to good either - They did not look good before but looked worse after, which was not the intent 😅 

With this PR I managed to address the root of the problem and there were several issues that needed to be fixed styling wise. Now both radio buttons and checkboxes look good 👍 

### Before
_Relation types_
![radio-relate-before](https://user-images.githubusercontent.com/1932158/84081475-4f826180-a9de-11ea-9e72-986d9ce3d204.png)

_Rich text editor_
![rte-before](https://user-images.githubusercontent.com/1932158/84081463-45f8f980-a9de-11ea-9f17-05b005278546.png)

_Radio- and checkboxes_
![radio-checkboxes-before](https://user-images.githubusercontent.com/1932158/84081449-41344580-a9de-11ea-9202-3cf0b44ced63.png)


### After
_Relation types_
![radio-relate-after](https://user-images.githubusercontent.com/1932158/84080961-5eb4df80-a9dd-11ea-930b-96da5ae8d128.png)

_Rich text editor_
![rte-after](https://user-images.githubusercontent.com/1932158/84080965-5f4d7600-a9dd-11ea-8739-81ea8eac4a70.png)

_Radio- and checkboxes_
![radio-checkboxes-after](https://user-images.githubusercontent.com/1932158/84080967-607ea300-a9dd-11ea-925f-8d096a21ace1.png)
