### PR TITLE
If content type is deleted and other document types have a reference to it, raise an event

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -511,6 +511,16 @@ namespace Umbraco.Core.Services.Implement
 
                 // delete content
                 DeleteItemsOfTypes(descendantsAndSelf.Select(x => x.Id));
+                
+                // Next find all other document types that have a reference to this content type
+                var referenceToAllowedContentTypes = GetAll().Where(q => q.AllowedContentTypes.Any(p=>p.Id.Value==item.Id));
+                foreach (var reference in referenceToAllowedContentTypes)
+                {                                        
+                    reference.AllowedContentTypes = reference.AllowedContentTypes.Where(p => p.Id.Value != item.Id);                   
+                    var changedRef = new List<ContentTypeChange<TItem>>() { new ContentTypeChange<TItem>(reference, ContentTypeChangeTypes.RefreshMain) };
+                    // Fire change event
+                    OnChanged(scope, changedRef.ToEventArgs());                  
+                }
 
                 // finally delete the content type
                 // - recursively deletes all descendants
@@ -518,7 +528,7 @@ namespace Umbraco.Core.Services.Implement
                 //  (contents of any descendant type have been deleted but
                 //   contents of any composed (impacted) type remain but
                 //   need to have their property data cleared)
-                Repository.Delete(item);
+                Repository.Delete(item);                               
 
                 //...
                 var changes = descendantsAndSelf.Select(x => new ContentTypeChange<TItem>(x, ContentTypeChangeTypes.Remove))


### PR DESCRIPTION
Fixes umbraco/Umbraco-CMS#8256

When a document type is being deleted, all document types are being iterated to lookup if they have a reference to the document type. If it has, simply update the AllowedContentTypes to reflect the change.

To test:
- Compile the CMS and copy the DLL's from deploy project.
- Run the solution
- Add three document types (dta, dtb, dtc)
- Let the third document types (dtc) be Allowed as child for each of the other two (dta and dtb)
- Locate the uda files and verify that for both dta and dtb, that there is a reference to dtc
- Delete dtc
- Locate the uda files and verify that for both dta and dtb, that the reference to dtc has been deleted.