### PR TITLE
fix null point exceptions and use Context factory 

### DIFF
--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -73,7 +73,17 @@ namespace Umbraco.Tests.Scoping
         protected override IPublishedSnapshotService CreatePublishedSnapshotService()
         {
             var options = new PublishedSnapshotServiceOptions { IgnoreLocalDb = true };
-            var publishedSnapshotAccessor = new UmbracoContextPublishedSnapshotAccessor(Umbraco.Web.Composing.Current.UmbracoContextAccessor);
+            var umbracoContextFactory = new UmbracoContextFactory(
+                new TestUmbracoContextAccessor(),
+                Mock.Of<IPublishedSnapshotService>(),
+                new TestVariationContextAccessor(),
+                new TestDefaultCultureAccessor(),
+                TestObjects.GetUmbracoSettings(),
+                TestObjects.GetGlobalSettings(),
+                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
+                Mock.Of<IUserService>());
+            var publishedSnapshotAccessor = new UmbracoContextPublishedSnapshotAccessor(umbracoContextFactory);
             var runtimeStateMock = new Mock<IRuntimeState>();
             runtimeStateMock.Setup(x => x.Level).Returns(() => RuntimeLevel.Run);
 

--- a/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
@@ -256,8 +256,17 @@ namespace Umbraco.Tests.TestHelpers
                 Logger);
 
             // testing=true so XmlStore will not use the file nor the database
-
-            var publishedSnapshotAccessor = new UmbracoContextPublishedSnapshotAccessor(Umbraco.Web.Composing.Current.UmbracoContextAccessor);
+            var umbracoContextFactory = new UmbracoContextFactory(
+                new TestUmbracoContextAccessor(),
+                Mock.Of<IPublishedSnapshotService>(),
+                new TestVariationContextAccessor(),
+                new TestDefaultCultureAccessor(),
+                TestObjects.GetUmbracoSettings(),
+                TestObjects.GetGlobalSettings(),
+                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
+                Mock.Of<IUserService>());
+            var publishedSnapshotAccessor = new UmbracoContextPublishedSnapshotAccessor(umbracoContextFactory);
             var variationContextAccessor = new TestVariationContextAccessor();
             var service = new XmlPublishedSnapshotService(
                 ServiceContext,

--- a/src/Umbraco.Web/PublishedCache/UmbracoContextPublishedSnapshotAccessor.cs
+++ b/src/Umbraco.Web/PublishedCache/UmbracoContextPublishedSnapshotAccessor.cs
@@ -4,19 +4,21 @@ namespace Umbraco.Web.PublishedCache
 {
     public class UmbracoContextPublishedSnapshotAccessor : IPublishedSnapshotAccessor
     {
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
 
-        public UmbracoContextPublishedSnapshotAccessor(IUmbracoContextAccessor umbracoContextAccessor)
+        public UmbracoContextPublishedSnapshotAccessor(IUmbracoContextFactory umbracoContextFactory)
         {
-            _umbracoContextAccessor = umbracoContextAccessor;
+            _umbracoContextFactory = umbracoContextFactory;
         }
 
         public IPublishedSnapshot PublishedSnapshot
         {
             get
             {
-                var umbracoContext = _umbracoContextAccessor.UmbracoContext;
-                return umbracoContext?.PublishedSnapshot;
+                using (var context = _umbracoContextFactory.EnsureUmbracoContext())
+                {
+                    return context.UmbracoContext?.PublishedSnapshot;
+                }
             }
 
             set => throw new NotSupportedException(); // not ok to set

--- a/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
@@ -96,11 +96,11 @@ namespace Umbraco.Web.Routing
 
         private void StoreOldRoute(IContent entity, OldRoutesDictionary oldRoutes)
         {
-            var contentCache = _publishedSnapshotAccessor.PublishedSnapshot.Content;
-            var entityContent = contentCache.GetById(entity.Id);
-            if (entityContent == null) return;            
+            var contentCache = _publishedSnapshotAccessor.PublishedSnapshot?.Content;
+            var entityContent = contentCache?.GetById(entity.Id);
+            if (entityContent == null) return;
 
-            // get the default affected cultures by going up the tree until we find the first culture variant entity (default to no cultures) 
+            // get the default affected cultures by going up the tree until we find the first culture variant entity (default to no cultures)
             var defaultCultures = entityContent.AncestorsOrSelf()?.FirstOrDefault(a => a.Cultures.Any())?.Cultures.Keys.ToArray()
                 ?? new[] { (string)null };
             foreach (var x in entityContent.DescendantsOrSelf())


### PR DESCRIPTION
Hi all,
on time of writing my module I notice one thing if I am saving content on boot time it will fail because of null point exception in  private void StoreOldRoute(IContent entity, OldRoutesDictionary oldRoutes) and here is my quick fix for that and also I think in UmbracoContextPublishedSnapshotAccessor should use context factory instead of accessor. 
