### PR TITLE
Use code snippet component for insert field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-code-snippet.less
@@ -18,6 +18,7 @@
             justify-content: flex-start;
             flex-grow: 1;
             padding: 2px 10px;
+            text-transform: uppercase;
         }
 
         button {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertfield/insertfield.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertfield/insertfield.html
@@ -71,7 +71,7 @@
                         <div class="umb-el-wrap">
                             <div class="controls">
                                 <label class="control-label"><localize key="templateEditor_outputSample">Output sample</localize></label>
-                                <pre>{{ vm.generateOutputSample() }}</pre>
+                                <umb-code-snippet language="'cshtml'">{{ vm.generateOutputSample() }}</umb-code-snippet>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR re-use the `umb-code-snippet` component which is also used in querybuilder to show the code snippet when inserting af field value to make it a bit more consistent.

![2020-06-09_16-12-44](https://user-images.githubusercontent.com/2919859/84158446-2c05f800-aa6c-11ea-8766-a1e841ba5409.gif)
