### PR TITLE
Allows unpublished content to render a macro HTML in the RTE

### DIFF
--- a/src/Umbraco.Web/Editors/MacroRenderingController.cs
+++ b/src/Umbraco.Web/Editors/MacroRenderingController.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Web.Editors
                 //need to create a specific content result formatted as HTML since this controller has been configured
                 //with only json formatters.
                 result.Content = new StringContent(
-                    _componentRenderer.RenderMacro(pageId, m.Alias, macroParams).ToString(),
+                    _componentRenderer.RenderMacroForContent(publishedContent, m.Alias, macroParams).ToString(),
                     Encoding.UTF8,
                     "text/html");
 

--- a/src/Umbraco.Web/IUmbracoComponentRenderer.cs
+++ b/src/Umbraco.Web/IUmbracoComponentRenderer.cs
@@ -42,5 +42,18 @@ namespace Umbraco.Web
         /// <param name="parameters">The parameters.</param>
         /// <returns></returns>
         IHtmlString RenderMacro(int contentId, string alias, IDictionary<string, object> parameters);
+
+        /// <summary>
+        /// Renders the macro with the specified alias, passing in the specified parameters.
+        /// </summary>
+        /// <param name="content">An IPublishedContent to use for the context for the macro rendering</param>
+        /// <param name="alias">The alias.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <returns>A raw HTML string of the macro output</returns>
+        /// <remarks>
+        /// Currently only used when the node is unpublished and unable to get the contentId item from the
+        /// content cache as its unpublished. This deals with taking in a preview/draft version of the content node
+        /// </remarks>
+        IHtmlString RenderMacroForContent(IPublishedContent content, string alias, IDictionary<string, object> parameters);
     }
 }

--- a/src/Umbraco.Web/UmbracoComponentRenderer.cs
+++ b/src/Umbraco.Web/UmbracoComponentRenderer.cs
@@ -102,6 +102,15 @@ namespace Umbraco.Web
             return RenderMacro(content, alias, parameters);
         }
 
+
+        public IHtmlString RenderMacroForContent(IPublishedContent content, string alias, IDictionary<string, object> parameters)
+        {
+            if(content == null)
+                throw new InvalidOperationException("Cannot render a macro, IPublishedContent is null");
+
+            return RenderMacro(content, alias, parameters);
+        }
+
         /// <summary>
         /// Renders the macro with the specified alias, passing in the specified parameters.
         /// </summary>


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco.Forms.Issues/issues/354
However, this is a core CMS issue as opposed to a Forms issue

## Test Notes
* Test before & after PR applied to verify it works
* Have Umbraco Forms installed
* Create a doctype with one property that is a RTE that allows macros to be inserted
* Create new content node and use the Forms Macro in the RTE (Do NOT publish it. only save it)
* Reload/come back to the node & see the error or verify its gone all OK & the macro can render in the RTE