### PR TITLE
PropertyValueConverterBase cleanup: fix IsValue, obsolete HasValue, add documentation

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Core.PropertyEditors
             }
         }
 
-        [Obsolete("This method is not part of the IPropertyValueConverter contract and therefore not used, use IsValue instead.")]
+        [Obsolete("This method is not part of the IPropertyValueConverter contract, therefore not used and will be removed in future versions; use IsValue instead.")]
         public virtual bool HasValue(IPublishedProperty property, string culture, string segment)
         {
             var value = property.GetSourceValue(culture, segment);

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
@@ -17,6 +17,10 @@ namespace Umbraco.Core.PropertyEditors
             {
                 case PropertyValueLevel.Source:
                     return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string) value) == false);
+                case PropertyValueLevel.Inter:
+                    return null;
+                case PropertyValueLevel.Object:
+                    return null;
                 default:
                     throw new NotSupportedException($"Invalid level: {level}.");
             }

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
@@ -4,13 +4,16 @@ using Umbraco.Core.Models.PublishedContent;
 namespace Umbraco.Core.PropertyEditors
 {
     /// <summary>
-    /// Provides a default overridable implementation for <see cref="IPropertyValueConverter"/> that does nothing.
+    /// Provides a default implementation for <see cref="IPropertyValueConverter" />.
     /// </summary>
+    /// <seealso cref="Umbraco.Core.PropertyEditors.IPropertyValueConverter" />
     public abstract class PropertyValueConverterBase : IPropertyValueConverter
     {
+        /// <inheritdoc />
         public virtual bool IsConverter(IPublishedPropertyType propertyType)
             => false;
 
+        /// <inheritdoc />
         public virtual bool? IsValue(object value, PropertyValueLevel level)
         {
             switch (level)
@@ -35,18 +38,23 @@ namespace Umbraco.Core.PropertyEditors
             return value != null && (!(value is string stringValue) || !string.IsNullOrWhiteSpace(stringValue));
         }
 
+        /// <inheritdoc />
         public virtual Type GetPropertyValueType(IPublishedPropertyType propertyType)
             => typeof(object);
 
+        /// <inheritdoc />
         public virtual PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
             => PropertyCacheLevel.Snapshot;
 
+        /// <inheritdoc />
         public virtual object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
             => source;
 
+        /// <inheritdoc />
         public virtual object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
             => inter;
 
+        /// <inheritdoc />
         public virtual object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
             => inter?.ToString() ?? string.Empty;
     }

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Core.PropertyEditors
                 case PropertyValueLevel.Source:
                     // the default implementation uses the old magic null & string comparisons,
                     // other implementations may be more clever, and/or test the final converted object values
-                    return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string)value) == false);
+                    return value != null && (!(value is string stringValue) || !string.IsNullOrWhiteSpace(stringValue));
                 case PropertyValueLevel.Inter:
                     return null;
                 case PropertyValueLevel.Object:
@@ -32,7 +32,7 @@ namespace Umbraco.Core.PropertyEditors
         public virtual bool HasValue(IPublishedProperty property, string culture, string segment)
         {
             var value = property.GetSourceValue(culture, segment);
-            return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string)value) == false);
+            return value != null && (!(value is string stringValue) || !string.IsNullOrWhiteSpace(stringValue));
         }
 
         public virtual Type GetPropertyValueType(IPublishedPropertyType propertyType)

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
@@ -16,7 +16,9 @@ namespace Umbraco.Core.PropertyEditors
             switch (level)
             {
                 case PropertyValueLevel.Source:
-                    return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string) value) == false);
+                    // the default implementation uses the old magic null & string comparisons,
+                    // other implementations may be more clever, and/or test the final converted object values
+                    return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string)value) == false);
                 case PropertyValueLevel.Inter:
                     return null;
                 case PropertyValueLevel.Object:
@@ -26,16 +28,15 @@ namespace Umbraco.Core.PropertyEditors
             }
         }
 
+        [Obsolete("This method is not part of the IPropertyValueConverter contract and therefore not used, use IsValue instead.")]
         public virtual bool HasValue(IPublishedProperty property, string culture, string segment)
         {
-            // the default implementation uses the old magic null & string comparisons,
-            // other implementations may be more clever, and/or test the final converted object values
             var value = property.GetSourceValue(culture, segment);
-            return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string) value) == false);
+            return value != null && (!(value is string) || string.IsNullOrWhiteSpace((string)value) == false);
         }
 
         public virtual Type GetPropertyValueType(IPublishedPropertyType propertyType)
-            => typeof (object);
+            => typeof(object);
 
         public virtual PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
             => PropertyCacheLevel.Snapshot;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8259.

### Description
This PR cleans up the `PropertyValueConverterBase` by:
- Fixing `IsValue`, so it doesn't throw `NotSupportedException` for valid enum values, but returns `null` when it can't determine whether it's an actual value;
- Obsoleting `HasValue`, as it's not included in the `IPropertyValueConverter` contract and might confuse developers overriding this unused method;
- Simplifying the value check using type pattern matching (`value is string stringValue`);
- Adding XML documentation