### PR TITLE
Add generic PropertyValueConverterBase classes

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterBase.cs
@@ -45,4 +45,61 @@ namespace Umbraco.Core.PropertyEditors
         public virtual object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
             => inter?.ToString() ?? string.Empty;
     }
+
+    public abstract class PropertyValueConverterBase<TIntermediate, TObject> : PropertyValueConverterBase
+    {
+        public sealed override bool? IsValue(object value, PropertyValueLevel level)
+        {
+            switch (level)
+            {
+                case PropertyValueLevel.Source:
+                    return IsSourceValue(value);
+                case PropertyValueLevel.Inter:
+                    return IsIntermediateValue((TIntermediate)value);
+                case PropertyValueLevel.Object:
+                    return IsObjectValue((TObject)value);
+                default:
+                    return base.IsValue(value, level);
+            }
+        }
+
+        protected virtual bool? IsSourceValue(object value)
+            => base.IsValue(value, PropertyValueLevel.Source);
+
+        protected virtual bool? IsIntermediateValue(TIntermediate value)
+            => base.IsValue(value, PropertyValueLevel.Inter);
+
+        protected virtual bool? IsObjectValue(TObject value)
+            => base.IsValue(value, PropertyValueLevel.Object);
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+            => typeof(TObject);
+
+        public sealed override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+            => this.ConvertSourceToIntermediate<object>(owner, propertyType, source, preview);
+
+        protected abstract TIntermediate ConvertSourceToIntermediate<T>(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview);
+
+        public sealed override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+            => this.ConvertIntermediateToObject<TIntermediate>(owner, propertyType, referenceCacheLevel, (TIntermediate)inter, preview);
+
+        protected abstract TObject ConvertIntermediateToObject<T>(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, TIntermediate inter, bool preview)
+            where T : TIntermediate;
+
+        public sealed override object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+            => this.ConvertIntermediateToXPath<TIntermediate>(owner, propertyType, referenceCacheLevel, (TIntermediate)inter, preview);
+
+        protected virtual object ConvertIntermediateToXPath<T>(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, TIntermediate inter, bool preview)
+            where T : TIntermediate
+            => base.ConvertIntermediateToXPath(owner, propertyType, referenceCacheLevel, inter, preview);
+    }
+
+    public abstract class PropertyValueConverterBase<TValue> : PropertyValueConverterBase<TValue, TValue>
+    {
+        protected override TValue ConvertIntermediateToObject<T>(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, TValue inter, bool preview)
+            => inter;
+
+        protected override bool? IsObjectValue(TValue value)
+            => IsIntermediateValue(value);
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is currently WIP and I'm creating a draft PR to discuss whether adding generic versions of `PropertyValueConverterBase` might help with creating custom PVCs and add some more type checking between source, intermediate and object values.

These generic base classes can be used as follows:

```c#
public class YesNoValueConverter : PropertyValueConverterBase<bool>
{
    public override bool IsConverter(IPublishedPropertyType propertyType)
        => propertyType.EditorAlias == Constants.PropertyEditors.Aliases.Boolean;

    public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
        => PropertyCacheLevel.Element;

    protected override bool ConvertSourceToIntermediate<T>(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
    {
        if (source is string s)
        {
            if (s.Length == 0 || s == "0")
                return false;

            if (s == "1")
                return true;

            return bool.TryParse(s, out var result) && result;
        }

        if (source is int i)
            return i == 1;

        if (source is long l)
            return l == 1;

        if (source is bool b)
            return b;

        return false;
    }

    protected override object ConvertIntermediateToXPath<T>(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, bool inter, bool preview)
        => inter ? "1" : "0";
```

As you can see, there's no need to specify the value type (as that's already set to the generic type parameter) and the intermediate value doesn't need casting to a boolean.

This is a very simple PVC (and thus a very small code reduction compared to https://github.com/umbraco/Umbraco-CMS/blob/3bfd9b71e290354744d677440983ecd06c5c0788/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs), but having the type safety/enforcement on more complex PVCs will ensure the correct values/types are returned!

If the intermediate and object values are different, `PropertyValueConverterBase<TIntermediate, TObject>` can be used as base class and will ensure the correct types are available on the `ConvertIntermediateToObject<T>()` method.