### PR TITLE
8245 allow string templates in overlays

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -189,7 +189,7 @@ Opens an overlay to show a custom YSOD. </br>
 </table>
 
 @param {object} model Overlay options.
-@param {string} view Path to view or one of the default view names.
+@param {string} view Path to view, one of the default view names or an HTML string.
 @param {string} position The overlay position ("left", "right", "center": "target").
 **/
 
@@ -262,9 +262,8 @@ Opens an overlay to show a custom YSOD. </br>
             function setView() {
                 if (scope.view) {
 
-                    // if the view value has a space, treat it as an inline value
-                    // since setting the view by alias will not have a space
-                    if (scope.view.indexOf(' ') > -1) {
+                    // an inline template must be HTML, so must start and end with < and > respectively
+                    if (scope.view.startsWith('<') && scope.view.endsWith('>')) {
                         // reuse the existing scoped-view element, and compile our view into it
                         const element = el.find('.scoped-view');
                         element.html(scope.view);
@@ -274,7 +273,7 @@ Opens an overlay to show a custom YSOD. </br>
                         // ensure the ng-include view isn't rendered 
                         scope.viewIsLiteral = true;
                     }
-                    
+                    // when passed a view alias eg confirm, ysod
                     else if (scope.view.indexOf(".html") === -1) {
                         var viewAlias = scope.view.toLowerCase();
                         scope.view = "views/common/overlays/" + viewAlias + "/" + viewAlias + ".html";

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -260,10 +260,22 @@ Opens an overlay to show a custom YSOD. </br>
             }
 
             function setView() {
-
                 if (scope.view) {
 
-                    if (scope.view.indexOf(".html") === -1) {
+                    // if the view value has a space, treat it as an inline value
+                    // since setting the view by alias will not have a space
+                    if (scope.view.indexOf(' ') > -1) {
+                        // reuse the existing scoped-view element, and compile our view into it
+                        const element = el.find('.scoped-view');
+                        element.html(scope.view);
+                        element.show();
+                        $compile(element.contents())(scope);
+                        
+                        // ensure the ng-include view isn't rendered 
+                        scope.viewIsLiteral = true;
+                    }
+                    
+                    else if (scope.view.indexOf(".html") === -1) {
                         var viewAlias = scope.view.toLowerCase();
                         scope.view = "views/common/overlays/" + viewAlias + "/" + viewAlias + ".html";
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/overlays/umb-overlay.html
@@ -7,7 +7,7 @@
 
         <div data-element="overlay-content" class="umb-overlay-container form-horizontal">
             <ng-transclude></ng-transclude>
-            <div ng-if="view && !parentScope" ng-include="view"></div>
+            <div ng-if="view && !viewIsLiteral && !parentScope" ng-include="view"></div>
             <div class="scoped-view"></div>
         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8245 

### Description

Changes allow passing an HTML string as the overlay view as an alternate to a view path - means that for simple overlays there's no need to add an additional HTML file to hold that content. 

Testing requires a couple of changes to existing content, given this is a new thing. Doesn't need to be these files, I just grabbed something existing to save spinning up a new dashboard/view.

- edit Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html, adding the below (anywhere, it's just a button to trigger our overlay): 

`<button ng-click="vm.overlay()" type="button">Overlay</button>`

- edit Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js, adding the following (also doesn't matter where, just smoosh it into the controller):

```javascript
    vm.overlay = overlay;
    function overlay() { 
        overlayService.open({
            view: '<div>value can be localized <localize key="general_delete"></localize> or include other <b>html</b></div>',
            submitButtonLabelKey: 'general_delete',
            submitButtonStyle: 'danger',
            submit: () => overlayService.close(),
            close: () => overlayService.close()
        });
    }
```

To note here is the string being passed as the view - it contains HTML and an AngularJs directive, both of which will be compiled and rendered into our overlay. Save both files, navigate to the Examine management dashboard in settings, click your button and whammo, overlay from a string.

