### PR TITLE
Using IOHelper for Log files

### DIFF
--- a/src/Umbraco.Core/IO/SystemDirectories.cs
+++ b/src/Umbraco.Core/IO/SystemDirectories.cs
@@ -11,6 +11,8 @@ namespace Umbraco.Core.IO
 
         public static string Data => "~/App_Data";
 
+        public static string LogFiles => Data + "/Logs";
+
         public static string TempData => Data + "/TEMP";
 
         public static string TempFileUploads => TempData + "/FileUploads";

--- a/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
+++ b/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using Serilog.Events;
 using Serilog.Formatting.Compact.Reader;
+using Umbraco.Core.IO;
 
 namespace Umbraco.Core.Logging.Viewer
 {
@@ -16,7 +17,7 @@ namespace Umbraco.Core.Logging.Viewer
         public JsonLogViewer(ILogger logger, string logsPath = "", string searchPath = "") : base(searchPath)
         {
             if (string.IsNullOrEmpty(logsPath))
-                logsPath = $@"{AppDomain.CurrentDomain.BaseDirectory}\App_Data\Logs\";
+                logsPath = IOHelper.MapPath(SystemDirectories.LogFiles);
 
             _logsPath = logsPath;
             _logger = logger;
@@ -62,7 +63,7 @@ namespace Umbraco.Core.Logging.Viewer
             var logs = new List<LogEvent>();
 
             //Log Directory
-            var logDirectory = $@"{AppDomain.CurrentDomain.BaseDirectory}\App_Data\Logs\";
+            var logDirectory = _logsPath;
 
             var count = 0;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

#8280

### Description
Adjusted code around logging to use IOHelper over hardcoded paths with AppDomain.CurrentDomain.BaseDirectory ie. to support virtual directories for log files.

I've adjusted the environment variable called "BASEDIR" to also use the IOHelper, I had to trim the string in the end since the IOHelper return a trailing slash but the configuration in serilog.config does not expect this. So the Trim is to keep backwards compatibility for sites that is upgrading.

Also added a property for the LogFiles in the SystemDirectories-class to avoid having it hardcoded in lots of places. 

Since the JsonLogViewer reads this setting we still have an "issue" if someone wants to store log files in a custom folder (ie out of the root), we could address this by making SystemDirectories.LogFile simular to the SystemDirectories.Media where one could also configure this in web.config app settings.

Let me know if that is something that we want to do?
