### PR TITLE
V8: add root LESS partial for exposing useful colors/variables

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -17,6 +17,7 @@
 @import "../../lib/bootstrap/less/type.less";
 @import "../../lib/bootstrap/less/code.less";
 @import "tables.less";
+@import "root.less";
 
 
 // Components: common

--- a/src/Umbraco.Web.UI.Client/src/less/root.less
+++ b/src/Umbraco.Web.UI.Client/src/less/root.less
@@ -1,0 +1,49 @@
+/* contains variables to make available on the :root pseudo element - ie colors, base sizing/padding units 
+   makes package developers happy :)
+*/
+
+:root {
+    --brandPrimary: @blueExtraDark; // brandPrimary-400
+    --brandSecondary: @pinkLight; // brandSecondary-400
+    
+    --brandPrimary-50: @blueLight;
+    --brandPrimary-100: @blue;
+    --brandPrimary-200: @blueMid;
+    --brandPrimary-300: @blueDark;
+    --brandPrimary-400: @blueExtraDark;
+    --brandPrimary-500: @blueNight;
+    
+    --brandSecondary-400: @pinkLight;
+    --brandSecondary-500: @pinkRedLight;
+    --brandSecondary-600: @pink;
+    
+    --brandAccent: @brown;
+    
+    // build the gray palette with a loop
+    // grays are 100 - 1100, light to dark
+    @iterations: 11;
+    .grays(@i: 11, @weight: 100) when (@i > 0) {
+        --gray-@{weight}: ~"@{gray-@{i}}";
+        
+        .grays(@i - 1, @weight + 100);
+    }
+    
+    .grays(@iterations, 100);
+        
+    --error: @red;    
+    --warning: @orange;
+    --success: @green;
+    
+    --paddingMini: @paddingMini;
+    --paddingSmall: @paddingSmall;
+    --paddingLarge: @paddingLarge;
+
+    --fontSizeLarge: @fontSizeLarge;
+    --fontSizeMedium: @fontSizeMedium;
+    --fontSizeSmall: @fontSizeSmall;
+    --fontSizeMini: @fontSizeMini;    
+    
+    --baseFontFamily: @sansFontFamily;
+    --altFontFamily: @serifFontFamily;
+    --monoFontFamily: @monoFontFamily;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This revives changes/discussion from #6915 where I deleted my old branch so can't modify the PR...

After some chat around how to best approach this, I've revised the naming to use brandPrimary, brandSecondary and brandAccent. I have though kept a grayscale palette, since gray will always be gray. Could maybe call it monochrome, but the implication is the same.

I've intentionally kept this to a small set of colors (compared to what's available in _variables.less) as many of those are very specific use-cases, eg If a dev wants to use @sand-5, they can always look it up in the LESS source.

There's probably scope too to review the depth of colors in _variables.less - eg there are 19 gray variants (22 if we include three named browns which are actually gray, even more if we include some of the sand variants, which are essentially gray 😄).

