### PR TITLE
Importing a doctype leaves behind temp files

### DIFF
--- a/src/Umbraco.Web/Models/ContentTypeImportModel.cs
+++ b/src/Umbraco.Web/Models/ContentTypeImportModel.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Umbraco.Core.Models.Editors;
 using Umbraco.Web.Models.ContentEditing;
 
 namespace Umbraco.Web.Models
 {
     [DataContract(Name = "contentTypeImportModel")]
-    public class ContentTypeImportModel : INotificationModel, IHaveUploadedFiles
+    public class ContentTypeImportModel : INotificationModel
     {
         [DataMember(Name = "alias")]
         public string Alias { get; set; }
@@ -19,7 +18,5 @@ namespace Umbraco.Web.Models
 
         [DataMember(Name = "tempFileName")]
         public string TempFileName { get; set; }
-
-        public List<ContentPropertyFile> UploadedFiles => new List<ContentPropertyFile>();
     }
 }


### PR DESCRIPTION
Importing a doctype would never assign a value to UploadedFiles, turns out we don't need UploadedFiles on the model

Additionally added a check to see if temp files were left behind and delete them to prevent errors when the same file has just been uploaded
