### PR TITLE
Update dependencies.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -44,7 +44,8 @@ function dependencies() {
         },
         {
             "name": "angular-aria",
-            "src":  ["./node_modules/angular-aria/angular-aria.min.js"],
+            "src":  ["./node_modules/angular-aria/angular-aria.min.js",
+                    "./node_modules/angular-aria/angular-aria.min.js.map"],
             "base": "./node_modules/angular-aria"
         },
         {


### PR DESCRIPTION
DevTools failed to load SourceMap: Could not load content for https://localhost:44313/umbraco/lib/angular-aria/angular-aria.min.js.map: HTTP error: status code 404, net::ERR_HTTP_RESPONSE_CODE_FAILURE

### Description
Add source map for angular-aria, to avoid console warning from the 
```//# sourceMappingURL=angular-aria.min.js.map``` in umbraco/lib/angular-aria/angular-aria.min.js


<!-- Thanks for contributing to Umbraco CMS! -->
