### PR TITLE
Fix overlapping centered content in umb-empty-state directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -36,8 +36,7 @@
                     </div>
                         
                     <umb-empty-state 
-                        ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes <= 1"
-                        position="center">
+                        ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes <= 1">
                         <localize key="contentTypeEditor_noAvailableCompositions"></localize>
                     </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -17,24 +17,9 @@
                 <umb-box-content>
 
                     <div class="umb-control-group">
-                        <div class="form-search">
-                            <i class="icon-search"></i>
-                            <input 
-                                type="text"
-                                style="width: 100%"
-                                ng-model="searchTerm"
-                                class="umb-search-field search-query input-block-level"
-                                localize="placeholder"
-                                placeholder="@placeholders_filter"
-                                umb-auto-focus
-                                no-dirty-check />
-                        </div>
-                    </div>
-                        
-                    <div class="umb-control-group">
                         <localize key="contentTypeEditor_compositionsDescription"></localize>
                     </div>
-                        
+
                     <umb-empty-state 
                         ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes <= 1">
                         <localize key="contentTypeEditor_noAvailableCompositions"></localize>
@@ -48,19 +33,32 @@
                     <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1 && model.whereCompositionUsed.length > 0">
                         <h5><localize key="contentTypeEditor_compositionUsageHeading"></localize></h5>
                         <p><localize key="contentTypeEditor_compositionUsageSpecification"></localize></p>
-                        <ul class="umb-checkbox-list">
-                            <li class="umb-checkbox-list__item" 
-                                ng-repeat="contentTypeEntity in model.whereCompositionUsed">
-                                <a ng-click="vm.openContentType(contentTypeEntity.contentType, model.section)">
-                                    <i class="{{contentTypeEntity.contentType.icon}}"></i>
-                                    &nbsp;{{contentTypeEntity.contentType.name}}
-                                </a>
-                            </li>
-                        </ul>
+                        <umb-node-preview ng-repeat="contentTypeEntity in model.whereCompositionUsed"
+                            icon="contentTypeEntity.contentType.icon"
+                            name="contentTypeEntity.contentType.name"
+                            alias="contentTypeEntity.contentType.alias"
+                            allow-open="true"
+                            on-open="vm.openContentType(contentTypeEntity.contentType, model.section)">
+                        </umb-node-preview>
+                    </div>
+
+                    <div class="umb-control-group" ng-show="vm.availableGroups.length > 0">
+                        <div class="form-search">
+                            <i class="icon-search"></i>
+                            <input 
+                                type="text"
+                                style="width: 100%"
+                                ng-model="searchTerm"
+                                class="umb-search-field search-query input-block-level"
+                                localize="placeholder"
+                                placeholder="@placeholders_filter"
+                                umb-auto-focus
+                                no-dirty-check />
+                        </div>
                     </div>
 
                     <div class="umb-control-group -no-border" ng-if="vm.availableGroups.length > 0">
-                        <ul class="umb-checkbox-list" ng-repeat="group in vm.availableGroups | filter:searchTerm">
+                        <ul class="umb-checkbox-list" ng-repeat="group in filtered = (vm.availableGroups | filter:searchTerm)">
                             <li ng-show="vm.availableGroups.length > 1">
                                 <i class="icon-folder umb-checkbox-list__item-icon"></i>
                                 {{group.containerPath}}
@@ -76,7 +74,7 @@
                                            checklist-model="model.compositeContentTypes"
                                            checklist-value="compositeContentType.contentType.alias"
                                            ng-change="model.selectCompositeContentType(compositeContentType.contentType)"
-                                           ng-disabled="compositeContentType.allowed===false || compositeContentType.inherited" />                                  
+                                           ng-disabled="compositeContentType.allowed===false || compositeContentType.inherited" />
 
                                 </div>
 
@@ -88,6 +86,11 @@
 
                             </li>
                         </ul>
+
+                        <umb-empty-state
+                            ng-if="filtered.length === 0">
+                            <localize key="general_searchNoResult"></localize>
+                        </umb-empty-state>
                     </div>
 
                 </umb-box-content>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -54,9 +54,7 @@
                     </ul>
                 </div>
 
-                <umb-empty-state
-                    ng-if="filtered.length === 0"
-                    position="center">
+                <umb-empty-state ng-if="filtered.length === 0">
                     <localize key="defaultdialogs_noIconsFound">No icons were found.</localize>
                 </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -16,6 +16,15 @@
     <umb-editor-container>
         <umb-box>
             <umb-box-content>
+                <div class="umb-control-group">
+                    <umb-color-swatches
+                        use-color-class="true"
+                        colors="vm.colors"
+                        selected-color="vm.color"
+                        size="s"
+                        on-select="vm.selectColor(color)">
+                    </umb-color-swatches>
+                </div>
 
                 <div class="umb-control-group">
                     <div class="form-search">
@@ -31,19 +40,9 @@
                     </div>
                 </div>
 
-                <div class="umb-control-group">
-                    <umb-color-swatches
-                        use-color-class="true"
-                        colors="vm.colors"
-                        selected-color="vm.color"
-                        size="s"
-                        on-select="vm.selectColor(color)">
-                    </umb-color-swatches>
-                </div>
-
                 <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
-                <div class="umb-control-group" ng-show="!vm.loading && filtered.length > 0 ">
+                <div class="umb-control-group" ng-show="!vm.loading && filtered.length > 0">
                     <ul class="umb-iconpicker" ng-class="vm.color.value" ng-show="vm.icons">
                         <li class="umb-iconpicker-item" ng-class="{'-selected': icon == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: searchTerm) track by $id(icon)">
                             <button type="button" title="{{icon}}" ng-click="vm.selectIcon(icon, vm.color.value)" prevent-default>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
@@ -17,7 +17,7 @@
                 <umb-box-content>
 
                     <!-- FILTER -->
-                    <div class="umb-control-group -no-border">
+                    <div class="umb-control-group">
                         <div class="form-search">
                             <i class="icon-search"></i>
                             <input type="text"

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
@@ -78,7 +78,7 @@
                             </div>
                         </div>
 
-                        <umb-empty-state position="center" ng-if="vm.filterResult.totalResults === 0">
+                        <umb-empty-state ng-if="vm.filterResult.totalResults === 0">
                             <localize key="general_searchNoResult"></localize>
                         </umb-empty-state>
                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.html
@@ -41,11 +41,8 @@
                                 </li>
                             </ul>
 
-                            <umb-empty-state ng-if="nomacros"
-                                                position="center">
-                                <localize key="defaultdialogs_noMacros">
-                                    There are no macros available to insert
-                                </localize>
+                            <umb-empty-state ng-if="nomacros">
+                                <localize key="defaultdialogs_noMacros">There are no macros available to insert</localize>
                             </umb-empty-state>
                         </div>
 
@@ -65,8 +62,7 @@
                                 </li>
                             </ul>
 
-                            <umb-empty-state ng-if="noMacroParams"
-                                                position="center">
+                            <umb-empty-state ng-if="noMacroParams">
                                 <localize key="defaultdialogs_noMacroParams">There are no parameters for this macro</localize>
                             </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -1,5 +1,5 @@
 <div ng-controller="Umbraco.Editors.MediaPickerController as vm">
-    <umb-editor-view >
+    <umb-editor-view>
 
         <umb-editor-header
             name="model.title"
@@ -130,7 +130,7 @@
                         </umb-pagination>
                     </div>
 
-                    <umb-empty-state ng-if="vm.searchOptions.filter && images.length === 0 && !vm.loading && !activeDrag" position="center">
+                    <umb-empty-state ng-if="vm.searchOptions.filter && images.length === 0 && !vm.loading && !activeDrag">
                         <localize key="general_searchNoResult"></localize>
                     </umb-empty-state>
 
@@ -170,7 +170,7 @@
                         <div ng-if="target.url">
                             <umb-image-gravity src="target.url"
                             center="target.focalPoint"
-							on-value-changed="vm.focalPointChanged(left, top)">
+                            on-value-changed="vm.focalPointChanged(left, top)">
                             </umb-image-gravity>
                         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
@@ -47,7 +47,7 @@
                                                             select-result-callback="vm.selectResult">
                                 </umb-tree-search-results>
 
-                                <umb-empty-state ng-if="!vm.hasItems && vm.emptyStateMessage" position="center">
+                                <umb-empty-state ng-if="!vm.hasItems && vm.emptyStateMessage">
                                     {{ vm.emptyStateMessage }}
                                 </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
@@ -73,8 +73,7 @@
                     </div>
 
                     <umb-empty-state
-                        ng-if="vm.userGroups.length === 0 && !vm.loading"
-                        position="center">
+                        ng-if="vm.userGroups.length === 0 && !vm.loading">
                         <localize key="user_noUserGroupsAdded">No user groups have been added</localize>
                     </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -1,5 +1,5 @@
 <div>
-  <umb-empty-state ng-if="results.length === 0" position="center">
+  <umb-empty-state ng-if="results.length === 0">
     <localize key="general_searchNoResult"></localize>
   </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/sort.html
@@ -49,8 +49,7 @@
                     </table>
 
                     <umb-empty-state
-                        ng-if="!vm.children"
-                        position="center">
+                        ng-if="!vm.children">
                         <localize key="sort_sortEmptyState"></localize>
                     </umb-empty-state>
                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/sort.html
@@ -49,8 +49,7 @@
                 </table>
 
                 <umb-empty-state
-                    ng-if="!vm.children"
-                    position="center">
+                    ng-if="!vm.children">
                     <localize key="sort_sortEmptyState"></localize>
                 </umb-empty-state>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8293.

### Description
This fixes the overlapping text when using the `umb-empty-state` with `position="center"` in size constraint places (e.g. dialogs). The following views should be checked:
- Compositions (on document type): no available compositions, no search results
- Icon picker: no search results
- Macro parameter picker: no search results
- Macro picker: no macros
- Media picker: no search results
- Tree picker: no search results
- User group picker: no user groups
- Tree search results directive (used in content/URL pickers): no search results
- Content sort: no children
- Media sort: no children

I've also cleaned up the compositions view, so the description is shown on top, the search input only if there are items available and when no results are found, a nice message is displayed:

![compositions-search](https://user-images.githubusercontent.com/1051287/84827000-1d977d80-b024-11ea-8072-65a1c8b2f7c0.png)

The used document/content types now also use the `umb-node-preview` directive:
![compositions](https://user-images.githubusercontent.com/1051287/84826878-ea54ee80-b023-11ea-89c2-934acec4edc9.png)

I've also moved the color swatches in the icon picker to the top, above the search field, as you can only search on icons (not colors):
![iconpicker](https://user-images.githubusercontent.com/1051287/84826881-ecb74880-b023-11ea-8c5f-04f19bbba2fd.png)
