### PR TITLE
Media picker folder icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.html
@@ -19,15 +19,14 @@
                 </div>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-
-                    <button aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="remove()">
+                    <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="remove()">
                         <i class="icon icon-delete" aria-hidden="true"></i>
                     </button>
                 </div>
             </li>
 
             <li style="border: none;" class="add-wrapper unsortable" ng-hide="model.value">
-                <button aria-label="Open media picker" data-element="sortable-thumbnails-add" class="add-link add-link-square btn-reset umb-outline umb-outline--surrounding" ng-click="add()" prevent-default>
+                <button type="button" aria-label="Open media picker" data-element="sortable-thumbnails-add" class="add-link add-link-square btn-reset umb-outline umb-outline--surrounding" ng-click="add()">
                     <i class="icon icon-add large" aria-hidden="true"></i>
                 </button>
             </li>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.html
@@ -10,13 +10,12 @@
                 </p>
 
                 <!-- FILE -->
-                <div ng-class="{'trashed': media.trashed}" class="umb-icon-holder" ng-hide="media.thumbnail">
-                    <span class="file-icon">
-                        <i class="icon {{media.icon}}"></i>
-                        <span ng-if="media.extension">.{{media.extension}}</span>
-                    </span>
-                    <small>{{media.name}}</small>
-                </div>
+                <umb-file-icon ng-hide="media.thumbnail" ng-class="{'trashed': media.trashed}"
+                               extension="{{media.extension}}"
+                               icon="{{media.icon}}"
+                               size="s"
+                               text="{{media.name}}">
+                </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
                     <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="remove()">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -31,6 +31,7 @@
                 <!-- FILE -->
                 <umb-file-icon ng-hide="media.thumbnail" ng-class="{'trashed': media.trashed}"
                                extension="{{media.extension}}"
+                               icon="{{media.icon}}"
                                size="s"
                                text="{{media.name}}">
                 </umb-file-icon>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed when picking a folder from media picker and media folder picker in richtext editor datatype configuration, it was showing the default `icon-document` icon instead of `icon-folder`.
This PR fixes this. Furthermore I have updated the `<button>` elements in media folder picker to use `type="button"` like added in this PR https://github.com/umbraco/Umbraco-CMS/pull/7651 (and recommended since browsers may have different default behaviour). Finally it also re-use the `umb-file-icon` component here.

![image](https://user-images.githubusercontent.com/2919859/84952241-01621200-b0f2-11ea-80fb-f7128e61f73f.png)

![image](https://user-images.githubusercontent.com/2919859/84952321-1b9bf000-b0f2-11ea-9919-e8c209495518.png)
