### PR TITLE
Replace anchor elements with button elements in public access overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/protect.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/protect.html
@@ -47,9 +47,9 @@
                                               allow-remove="true"
                                               on-remove="vm.removeMember(member)">
                             </umb-node-preview>
-                            <a href ng-click="vm.pickMember()" class="umb-node-preview-add" prevent-default>
+                            <button type="button" ng-click="vm.pickMember()" class="umb-node-preview-add">
                                 <localize key="general_add">Add</localize>
-                            </a>
+                            </button>
                         </div>
                     </div>
 
@@ -66,9 +66,9 @@
                                               allow-remove="true"
                                               on-remove="vm.removeGroup(group)">
                             </umb-node-preview>
-                            <a href ng-click="vm.pickGroup()" class="umb-node-preview-add" prevent-default>
+                            <button type="button" ng-click="vm.pickGroup()" class="umb-node-preview-add">
                                 <localize key="general_add">Add</localize>
-                            </a>
+                            </button>
                         </div>
                     </div>
 
@@ -81,15 +81,15 @@
                                         <strong><localize key="publicAccess_paLoginPage">Login Page</localize></strong>
                                         <small><localize key="publicAccess_paLoginPageHelp">Choose the page that contains the login form</localize></small>
                                     </label>
-                                    <a href ng-show="!vm.loginPage" ng-click="vm.pickLoginPage()" class="umb-node-preview-add" prevent-default>
-                                        <localize key="general_add">Add</localize>
-                                    </a>
                                     <umb-node-preview ng-show="vm.loginPage"
                                                       icon="vm.loginPage.icon"
                                                       name="vm.loginPage.name"
                                                       allow-remove="true"
                                                       on-remove="vm.loginPage = null">
                                     </umb-node-preview>
+                                    <button type="button" ng-show="!vm.loginPage" ng-click="vm.pickLoginPage()" class="umb-node-preview-add">
+                                        <localize key="general_add">Add</localize>
+                                    </button>
                                 </div>
                             </div>
                             <div class="control-group umb-control-group">
@@ -98,15 +98,15 @@
                                         <strong><localize key="publicAccess_paErrorPage">Error Page</localize></strong>
                                         <small><localize key="publicAccess_paErrorPageHelp">Used when people are logged on, but do not have access</localize></small>
                                     </label>
-                                    <a href ng-show="!vm.errorPage" ng-click="vm.pickErrorPage()" class="umb-node-preview-add" prevent-default>
-                                        <localize key="general_add">Add</localize>
-                                    </a>
                                     <umb-node-preview ng-show="vm.errorPage"
                                                       icon="vm.errorPage.icon"
                                                       name="vm.errorPage.name"
                                                       allow-remove="true"
                                                       on-remove="vm.errorPage = null">
                                     </umb-node-preview>
+                                    <button type="button" ng-show="!vm.errorPage" ng-click="vm.pickErrorPage()" class="umb-node-preview-add">
+                                        <localize key="general_add">Add</localize>
+                                    </button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Replacing anchor element with `<button>` element in public access overlay/dialog.

![chrome_2020-06-21_19-47-21](https://user-images.githubusercontent.com/2919859/85234124-8491a980-b40b-11ea-9c0a-585792a91015.png)
