### PR TITLE
Replace anchor elements with button elements in treepicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.html
@@ -15,12 +15,11 @@
 		</umb-node-preview>
 	</div>
 
-	<a ng-show="model.config.multiPicker === true || renderModel.length === 0"
-		class="umb-node-preview-add"
-		href=""
-		ng-click="openContentPicker()"
-		prevent-default>
+	<button type="button"
+		    class="umb-node-preview-add"
+            ng-show="model.config.multiPicker === true || renderModel.length === 0"
+		    ng-click="openContentPicker()">
 		<localize key="general_add">Add</localize>
-	</a>
+	</button>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -22,12 +22,10 @@
 
     <div ng-if="!node && model.value.type !== 'member'" class="mt2">
         <span ng-hide="showSearch || model.value.query">
-            <a class="umb-node-preview-add"
-               href=""
-               ng-click="openContentPicker()"
-               prevent-default>
+            <button type="button" class="umb-node-preview-add"
+               ng-click="openContentPicker()">
                 <localize key="general_choose">Choose a root node</localize>
-            </a>
+            </button>
             <div class="mt2" ng-show="model.value.type == 'content'">
                 <i class="icon icon-search"></i>
                 <a href ng-click="showSearch = true">Query for root node with xpath</a>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -38,7 +38,7 @@
                    class="umb-property-editor umb-textstring"
                    placeholder="Enter xpath query">
 
-            <ul class="unstyled list-icons" style="margin-top: 15px">
+            <ul class="unstyled list-icons mt3">
                 <li style="max-width: 600px">
                     <i class="icon icon-help-alt" aria-hidden="true"></i>
                     <button type="button" class="btn-link" ng-click="showHelp = 1">Show xpath query help</button>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -6,7 +6,6 @@
 		<option value="member">Members</option>
 	</select>
 
-
     <umb-node-preview
 		ng-show="node"
         class="mt1"
@@ -21,7 +20,7 @@
 	</umb-node-preview>
 
     <div ng-if="!node && model.value.type !== 'member'" class="mt2">
-        <span ng-hide="showSearch || model.value.query">
+        <div ng-hide="showSearch || model.value.query">
             <button type="button" class="umb-node-preview-add"
                     ng-click="openContentPicker()">
                 <localize key="general_choose">Choose a root node</localize>
@@ -30,9 +29,9 @@
                 <i class="icon icon-search" aria-hidden="true"></i>
                 <button type="button" class="btn-link" ng-click="showSearch = true">Query for root node with xpath</button>
             </div>
-        </span>
+        </div>
 
-        <span ng-show="showSearch || model.value.query">
+        <div ng-show="showSearch || model.value.query">
 
             <input type="text"
                    ng-model="model.value.query"
@@ -44,7 +43,7 @@
                     <i class="icon icon-help-alt" aria-hidden="true"></i>
                     <button type="button" class="btn-link" ng-click="showHelp = 1">Show xpath query help</button>
 
-                    <small ng-if="showHelp">
+                    <div class="small" ng-if="showHelp">
                         <p>
                             Use Xpath query to set a root node on the tree, either based on a search from the root of the content tree, or by using a context-aware placeholder.
                         </p>
@@ -64,14 +63,14 @@
                             <code>$root</code>: root of the content tree<br/>
                             <code>$site</code>: Ancestor node at level 1 <br/>
                         </p>
-                    </small>
+                    </div>
                 </li>
                 <li>
                     <i class="icon icon-delete red" aria-hidden="true"></i>
                     <button type="button" class="btn-link" ng-click="showSearch = false; model.value.query = ''"> Cancel and clear query</button>
                 </li>
             </ul>
-        </span>
+        </div>
     </div>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -49,7 +49,7 @@
                         </p>
 
                         <p>
-                            Placeholders finds the nearest published ID and runs its query from there. so for instance:
+                            Placeholders finds the nearest published ID and runs its query from there, so for instance:
 
                             <pre>$parent/newsArticle</pre>
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -23,12 +23,12 @@
     <div ng-if="!node && model.value.type !== 'member'" class="mt2">
         <span ng-hide="showSearch || model.value.query">
             <button type="button" class="umb-node-preview-add"
-               ng-click="openContentPicker()">
+                    ng-click="openContentPicker()">
                 <localize key="general_choose">Choose a root node</localize>
             </button>
             <div class="mt2" ng-show="model.value.type == 'content'">
-                <i class="icon icon-search"></i>
-                <a href ng-click="showSearch = true">Query for root node with xpath</a>
+                <i class="icon icon-search" aria-hidden="true"></i>
+                <button type="button" class="btn-link" ng-click="showSearch = true">Query for root node with xpath</button>
             </div>
         </span>
 
@@ -41,10 +41,8 @@
 
             <ul class="unstyled list-icons" style="margin-top: 15px">
                 <li style="max-width: 600px">
-                    <i class="icon icon-help-alt"></i>
-                    <a href ng-click="showHelp = 1" prevent-default>
-                        Show xpath query help
-                    </a>
+                    <i class="icon icon-help-alt" aria-hidden="true"></i>
+                    <button type="button" class="btn-link" ng-click="showHelp = 1">Show xpath query help</button>
 
                     <small ng-if="showHelp">
                         <p>
@@ -69,8 +67,8 @@
                     </small>
                 </li>
                 <li>
-                    <i class="icon icon-delete red"></i>
-                    <a href ng-click="showSearch = false; model.value.query = ''"> Cancel and clear query</a>
+                    <i class="icon icon-delete red" aria-hidden="true"></i>
+                    <button type="button" class="btn-link" ng-click="showSearch = false; model.value.query = ''"> Cancel and clear query</button>
                 </li>
             </ul>
         </span>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.html
@@ -12,12 +12,11 @@
                           on-remove="vm.remove(itemType)">
         </umb-node-preview>
 
-        <a class="umb-node-preview-add"
-           href=""
-           ng-click="vm.add()"
-           prevent-default>
+        <button type="button"
+                class="umb-node-preview-add"
+                ng-click="vm.add()">
             <localize key="general_add">Add</localize>
-        </a>
+        </button>
     </div>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Replace anchor elements with `<button>` elements in treepicker and treesource picker.

![chrome_2020-06-21_19-47-21](https://user-images.githubusercontent.com/2919859/85234769-1b606500-b410-11ea-85bc-e0748f856953.png)