### PR TITLE
Fixes #7148 - ensures we only check for SurfaceController routes

### DIFF
--- a/src/Umbraco.Web/Mvc/RenderRouteHandler.cs
+++ b/src/Umbraco.Web/Mvc/RenderRouteHandler.cs
@@ -178,43 +178,28 @@ namespace Umbraco.Web.Mvc
             using (RouteTable.Routes.GetReadLock())
             {
                 Route surfaceRoute;
-                if (postedInfo.Area.IsNullOrWhiteSpace())
+
+                //find the controller in the route table
+                var surfaceRoutes = RouteTable.Routes.OfType<Route>()
+                                        .Where(x => x.Defaults != null &&
+                                                    x.Defaults.ContainsKey("controller") &&
+                                                    x.Defaults["controller"].ToString().InvariantEquals(postedInfo.ControllerName) &&
+                                                    // Only return surface controllers
+                                                    x.DataTokens["umbraco"].ToString().InvariantEquals("surface") &&
+                                                    // Check for area token if the area is supplied
+                                                    (postedInfo.Area.IsNullOrWhiteSpace() ? !x.DataTokens.ContainsKey("area") : x.DataTokens["area"].ToString().InvariantEquals(postedInfo.Area)))
+                                        .ToList();
+
+                // If more than one route is found, find one with a matching action
+                if (surfaceRoutes.Count > 1)
                 {
-                    //find the controller in the route table without an area
-                    var surfaceRoutes = RouteTable.Routes.OfType<Route>()
-                                                  .Where(x => x.Defaults != null &&
-                                                              x.Defaults.ContainsKey("controller") &&
-                                                              x.Defaults["controller"].ToString().InvariantEquals(postedInfo.ControllerName) &&
-                                                              x.DataTokens.ContainsKey("area") == false).ToList();
-
-                    // If more than one route is found, find one with a matching action
-                    if (surfaceRoutes.Count > 1)
-                    {
-                        surfaceRoute = surfaceRoutes.FirstOrDefault(x =>
-                            x.Defaults["action"] != null &&
-                            x.Defaults["action"].ToString().InvariantEquals(postedInfo.ActionName));
-
-                        if (surfaceRoute == null)
-                        {
-                            // we found n possibilities, but no exact matches in the Route Table.
-                            // is one of these a generic SurfaceController route?
-                            surfaceRoute = surfaceRoutes.Where(x => x.DataTokens["umbraco"].ToString().InvariantEquals("surface")).FirstOrDefault();
-                        }
-                    }
-                    else
-                    {
-                        surfaceRoute = surfaceRoutes.SingleOrDefault();
-                    }
+                    surfaceRoute = surfaceRoutes.FirstOrDefault(x =>
+                        x.Defaults["action"] != null &&
+                        x.Defaults["action"].ToString().InvariantEquals(postedInfo.ActionName));
                 }
                 else
                 {
-                    //find the controller in the route table with the specified area
-                    surfaceRoute = RouteTable.Routes.OfType<Route>()
-                                             .SingleOrDefault(x => x.Defaults != null &&
-                                                                   x.Defaults.ContainsKey("controller") &&
-                                                                   x.Defaults["controller"].ToString().InvariantEquals(postedInfo.ControllerName) &&
-                                                                   x.DataTokens.ContainsKey("area") &&
-                                                                   x.DataTokens["area"].ToString().InvariantEquals(postedInfo.Area));
+                    surfaceRoute = surfaceRoutes.FirstOrDefault();
                 }
 
                 if (surfaceRoute == null)


### PR DESCRIPTION
Fixes #7148

When finding the SurfaceController to post back to when using BeginUmbracoForm we weren't specifically checking for only SurfaceControllers routes since we just assumed it would be a SurfaceController route. This is problematic if using a SurfaceController simultaneously as an IRenderController with a custom front-end route since it will fail to find that controller to post back to. This is fixed by further filtering the controllers looked up to only include SurfaceControllers.

## Changes:

* Includes original changes from community PR https://github.com/umbraco/Umbraco-CMS/pull/7149/files
* Refactored to be changed according to comments in the PR
* Removes additional checks for `if (postedInfo.Area.IsNullOrWhiteSpace())` and simplifies the whole linq query so it's just one query that takes into account if the Area is set or not

## Testing

* Create more than one surface controller and create a couple forms with BeginUmbracoForm for each one and verify they work
* Ensure Umbraco Forms works
* Run through these steps to reproduce original bug https://github.com/umbraco/Umbraco-CMS/issues/7148 which requires creating a custom route for one of your surface controllers and also ensuring that SurfaceController implements IRenderController or IRenderMvcController and then using BeginUmbracoForm to post to that controller