### PR TITLE
Fix LogScrubber exception when cleaning up temp files

### DIFF
--- a/src/Umbraco.Web/Scheduling/SchedulerComponent.cs
+++ b/src/Umbraco.Web/Scheduling/SchedulerComponent.cs
@@ -177,7 +177,7 @@ namespace Umbraco.Web.Scheduling
                 new[] { new DirectoryInfo(IOHelper.MapPath(SystemDirectories.TempFileUploads)) },
                 TimeSpan.FromDays(1), //files that are over a day old
                 _runtime, _logger);
-            _scrubberRunner.TryAdd(task);
+            _fileCleanupRunner.TryAdd(task);
             return task;
         }
     }

--- a/src/Umbraco.Web/Scheduling/TempFileCleanup.cs
+++ b/src/Umbraco.Web/Scheduling/TempFileCleanup.cs
@@ -51,6 +51,7 @@ namespace Umbraco.Web.Scheduling
             if (!dir.Exists)
             {
                 _logger.Debug<TempFileCleanup>("The cleanup folder doesn't exist {Folder}", dir.FullName);
+                return;
             }
 
             var files = dir.GetFiles("*.*", SearchOption.AllDirectories);

--- a/src/Umbraco.Web/Scheduling/TempFileCleanup.cs
+++ b/src/Umbraco.Web/Scheduling/TempFileCleanup.cs
@@ -61,6 +61,7 @@ namespace Umbraco.Web.Scheduling
                 {
                     try
                     {
+                        file.IsReadOnly = false;
                         file.Delete();
                     }
                     catch (Exception ex)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7675.

### Description
This adds the `TempFileCleanup` task to the right background runner, skips nonexistent directories and also allows read-only files to be deleted (by removing this flag before deletion).

Testing can be done by ensuring the `~\App_Data\TEMP\FileUploads` directory doesn't exist, optionally set the logging level to debug (so you can see the `The cleanup folder doesn't exist...` message), wait for the background task to run (default 3 minutes delay) and check whether the exception/error isn't logged anymore.