### PR TITLE
Fix folder uploads when existing image names clash with the uploaded folder name

### DIFF
--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -774,10 +774,13 @@ namespace Umbraco.Web.Editors
             var total = long.MaxValue;
             while (page * pageSize < total)
             {
-                var children = Services.MediaService.GetPagedChildren(mediaId, page, pageSize, out total,
+                var children = Services.MediaService.GetPagedChildren(mediaId, page++, pageSize, out total,
                     SqlContext.Query<IMedia>().Where(x => x.Name == nameToFind));
-                foreach (var c in children)
-                    return c; //return first one if any are found
+                var match = children.FirstOrDefault(c => c.ContentType.Alias == contentTypeAlias);
+                if (match != null)
+                {
+                    return match;
+                }
             }
             return null;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8325

### Description

See #8325 for steps to reproduce.

When this PR is applied, the uploaded folder is created correctly with the "(1)" suffix, and the uploaded images are created inside the folder as one would expect:

![folder-upload-name-clash](https://user-images.githubusercontent.com/7405322/85853985-cf1c7880-b7b3-11ea-8066-9220e2196e18.gif)
