### PR TITLE
Show custom label properties on members

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
@@ -5,6 +5,14 @@
 
         var vm = this;
 
+        vm.hideSystemProperties = function (property) {
+            // hide some specific, known properties by alias
+            if (property.alias === "_umb_id" || property.alias === "_umb_doctype") {
+                return false;
+            }
+            // hide all label properties with the alias prefix "umbracoMember" (e.g. "umbracoMemberFailedPasswordAttempts")
+            return property.view !== "readonlyvalue" || property.alias.indexOf("umbracoMember") !== 0;
+        }
     }
 
     angular.module("umbraco").controller("Umbraco.Editors.Member.Apps.ContentController", MemberAppContentController);

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
@@ -11,7 +11,7 @@
                 return false;
             }
             // hide all label properties with the alias prefix "umbracoMember" (e.g. "umbracoMemberFailedPasswordAttempts")
-            return property.view !== "readonlyvalue" || property.alias.indexOf("umbracoMember") !== 0;
+            return property.view !== "readonlyvalue" || property.alias.startsWith('umbracoMember') === false;
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
@@ -7,7 +7,7 @@
         </div>
 
         <div class="umb-group-panel__content">
-            <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties | filter: {view:'!readonlyvalue'} | filter: {alias:'!_umb_id'} | filter: {alias:'!_umb_doctype'} track by property.alias" property="property">
+            <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties | filter:vm.hideSystemProperties track by property.alias" property="property">
                 <umb-property-editor model="property"></umb-property-editor>
             </umb-property>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8342

### Description

As described in #8342 ... custom label properties on a member type are not rendered when editing a member of said type.

For example this member type:

![image](https://user-images.githubusercontent.com/7405322/85859964-4bb45480-b7be-11ea-81d0-b5b9503ce137.png)

...renders like this in the editor (note the missing label property):

![image](https://user-images.githubusercontent.com/7405322/85860286-d301c800-b7be-11ea-9026-ea032a93399f.png)

This happens because we don't want to show the system label properties (prefixed with "umbracoMember", e.g. "umbracoMemberFailedPasswordAttempts") when editing the member. So we filter out all label properties. Bit harsh, really.

This PR adds a custom filter which only filters out label properties if they're carrying the "umbracoMember" prefix. When the PR is applied, the custom label property renders in the editor as expected:

![image](https://user-images.githubusercontent.com/7405322/85860064-71415e00-b7be-11ea-913b-12cf5c6780f1.png)


