### PR TITLE
Add the current culture to the cache key  for the CachedPartial Html Helper

### DIFF
--- a/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
@@ -83,6 +83,12 @@ namespace Umbraco.Web
             Func<object, ViewDataDictionary, string> contextualKeyBuilder = null)
         {
             var cacheKey = new StringBuilder(partialViewName);
+             //let's always cache by the current culture to allow variants to have different cache results
+            var cultureName = System.Threading.Thread.CurrentThread.CurrentUICulture.Name;
+            if (!String.IsNullOrEmpty(cultureName))
+            {
+                cacheKey.AppendFormat("{0}-", cultureName);
+            }
             if (cacheByPage)
             {
                 if (Current.UmbracoContext == null)


### PR DESCRIPTION
When using variants it's unlikely to need the same Html.Partial result to be cached across all language variations, if we always add the current culture name to the cache key, we ensure this doesn't accidentally happen, and when not using variants, no harm to have the current culture name for the single site included in the key.

We made a very similar change for Macro caching here:
https://github.com/umbraco/Umbraco-CMS/pull/7555/files

I'm not sure why at the time, I didn't think to check whether Html.CachePartial would have the same issue.