### PR TITLE
Add Fallback.ToDefaultLanguage

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/Fallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/Fallback.cs
@@ -60,6 +60,16 @@ namespace Umbraco.Core.Models.PublishedContent
         /// </summary>
         public static Fallback ToAncestors => new Fallback(new[] { Ancestors });
 
+        /// <summary>
+        /// Fallback to the default language.
+        /// </summary>
+        public const int DefaultLanguage = 4;
+
+        /// <summary>
+        /// Gets the fallback to default language policy.
+        /// </summary>
+        public static Fallback ToDefaultLanguage => new Fallback(new[] { DefaultLanguage });
+
         /// <inheritdoc />
         public IEnumerator<int> GetEnumerator()
         {

--- a/src/Umbraco.Web/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Web/Models/PublishedContent/PublishedValueFallback.cs
@@ -48,6 +48,14 @@ namespace Umbraco.Web.Models.PublishedContent
                         if (TryGetValueWithLanguageFallback(property, culture, segment, out value))
                             return true;
                         break;
+                    case Fallback.DefaultLanguage:
+                        var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();
+                        if (property.HasValue(defaultCulture, segment))
+                        {
+                            value = property.Value<T>(defaultCulture, segment);
+                            return true;
+                        }
+                        break;
                     default:
                         throw NotSupportedFallbackMethod(f, "property");
                 }
@@ -87,6 +95,14 @@ namespace Umbraco.Web.Models.PublishedContent
                     case Fallback.Language:
                         if (TryGetValueWithLanguageFallback(content, alias, culture, segment, out value))
                             return true;
+                        break;
+                    case Fallback.DefaultLanguage:
+                        var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();
+                        if (content.HasValue(alias, defaultCulture, segment))
+                        {
+                            value = content.Value<T>(alias, defaultCulture, segment);
+                            return true;
+                        }
                         break;
                     default:
                         throw NotSupportedFallbackMethod(f, "element");
@@ -137,6 +153,14 @@ namespace Umbraco.Web.Models.PublishedContent
                     case Fallback.Ancestors:
                         if (TryGetValueWithAncestorsFallback(content, alias, culture, segment, out value, ref noValueProperty))
                             return true;
+                        break;
+                    case Fallback.DefaultLanguage:
+                        var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();
+                        if (content.HasValue(alias, defaultCulture, segment))
+                        {
+                            value = content.Value<T>(alias, defaultCulture, segment);
+                            return true;
+                        }
                         break;
                     default:
                         throw NotSupportedFallbackMethod(f, "content");


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8349.

### Description
This add a new fallback value (4) to get the content/property value from the default language, instead of the configured language fallback chain.

This is currently a draft, as it needs some unit tests to verify the functionality and additional documentation about why this a much needed addition/feature.