### PR TITLE
Use eventsService to tell everyone the current culture has changed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -20,7 +20,7 @@
         controller: umbVariantContentEditorsController
     };
 
-    function umbVariantContentEditorsController($scope, $location, contentEditingHelper) {
+    function umbVariantContentEditorsController($scope, $location, eventsService) {
 
         var prevContentDateUpdated = null;
 
@@ -36,6 +36,7 @@
         vm.selectVariant = selectVariant;
         vm.selectApp = selectApp;
         vm.selectAppAnchor = selectAppAnchor;
+        vm.requestSplitView = requestSplitView;
 
         //Used to track how many content views there are (for split view there will be 2, it could support more in theory)
         vm.editors = [];
@@ -66,7 +67,7 @@
 
         /** Allows us to deep watch whatever we want - executes on every digest cycle */
         function doCheck() {
-            if (!angular.equals(vm.content.updateDate, prevContentDateUpdated)) {
+            if (!Utilities.equals(vm.content.updateDate, prevContentDateUpdated)) {
                 setActiveVariant();
                 prevContentDateUpdated = Utilities.copy(vm.content.updateDate);
             }
@@ -84,11 +85,12 @@
         function setActiveVariant() {
             // set the active variant
             var activeVariant = null;
-            _.each(vm.content.variants, function (v) {
+            vm.content.variants.forEach(v => {
                 if ((vm.culture === "invariant" || v.language && v.language.culture === vm.culture) && v.segment === vm.segment) {
                     activeVariant = v;
                 }
             });
+
             if (!activeVariant) {
                 // Set the first variant to active if we can't find it.
                 // If the content item is invariant, then only one item exists in the array.
@@ -101,13 +103,14 @@
                 //now re-sync any other editor content (i.e. if split view is open)
                 for (var s = 1; s < vm.editors.length; s++) {
                     //get the variant from the scope model
-                    var variant = _.find(vm.content.variants, function (v) {
-                        return (!v.language || v.language.culture === vm.editors[s].content.language.culture) && v.segment === vm.editors[s].content.segment;
-                    });
+                    var variant = vm.content.variants.find(v =>
+                        (!v.language || v.language.culture === vm.editors[s].content.language.culture) && v.segment === vm.editors[s].content.segment);
+
                     vm.editors[s].content = variant;
                 }
             }
 
+            eventsService.emit('editors.content.cultureChanged', activeVariant.language.culture);
         }
 
         /**
@@ -158,31 +161,29 @@
          */
         function openSplitView(selectedVariant) {
             // enforce content contentApp in splitview.
-            var contentApp = vm.content.apps.find((app) => app.alias === "umbContent");
+            var contentApp = vm.content.apps.find(app => app.alias === "umbContent");
             if(contentApp) {
                 selectApp(contentApp);
             }
             
             insertVariantEditor(vm.editors.length, selectedVariant);
             
-            splitViewChanged();
-            
+            splitViewChanged();            
         }
-
-        $scope.$on("editors.content.splitViewRequest", function(event, args) {requestSplitView(args);});
-        vm.requestSplitView = requestSplitView;
+        
         function requestSplitView(args) {
             var culture = args.culture;
             var segment = args.segment;
 
-            var variant = _.find(vm.content.variants, function (v) {
-                return (!v.language || v.language.culture === culture) && v.segment === segment;
-            });
+            var variant = vm.content.variants.find(v =>
+                (!v.language || v.language.culture === culture) && v.segment === segment);
 
             if (variant != null) {
                 openSplitView(variant);
             }
         }
+
+        eventsService.on("editors.content.splitViewRequest", (_, args) => requestSplitView(args));
 
         /** Closes the split view */
         function closeSplitView(editorIndex) {
@@ -192,8 +193,9 @@
             editor.content.active = false;
             
             //update the current culture to reflect the last open variant (closing the split view corresponds to selecting the other variant)
-            
-            $location.search({"cculture": vm.editors[0].content.language ? vm.editors[0].content.language.culture : null, "csegment": vm.editors[0].content.segment});
+            const culture = vm.editors[0].content.language ? vm.editors[0].content.language.culture : null;
+
+            $location.search({"cculture": culture, "csegment": vm.editors[0].content.segment});
             splitViewChanged();
         }
 
@@ -220,11 +222,9 @@
                 $location.search("cculture", variantCulture).search("csegment", variantSegment);
             }
             else {
-
                 //update the editors collection
-                insertVariantEditor(editorIndex, variant);
-                
-            }
+                insertVariantEditor(editorIndex, variant);                
+            }            
         }
 
         /**
@@ -242,7 +242,6 @@
                 vm.onSelectAppAnchor({"app": app, "anchor": anchor});
             }
         }
-
     }
 
     angular.module('umbraco.directives').component('umbVariantContentEditors', umbVariantContentEditors);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

To save having to manually track the current variant (`$watch` === 👿), this PR uses the events service to broadcast the update of the selected content variant. How that event is used is up the subscribing code, but will be useful in variant-aware content apps, and can be used when working on #8345 (by triggering Nested Content's sync method when the variant changes). Event is raised when the culture changes and when returning from split view. It does not fire on initial load, as the active variant is already available from editorState.

To test, unzip [CultureClub.zip](https://github.com/umbraco/Umbraco-CMS/files/4849928/CultureClub.zip) into App_plugins. It adds a quick content app, displaying the current culture. Switch cultures, app updates 🍾 

For those playing along at home and not wanting to install my beautiful app, this is the important bit:

```javascript
angular.module("umbraco")
    .controller("CultureClubController", function ($scope, eventsService, editorState) {
        // changing the culture in the header emits 'editors.content.cultureChanged'
        const cultureChanged = eventsService.on('editors.content.cultureChanged', 
            (_, args) => this.culture = args);
    
        this.culture = editorState.current.variants.find(x => x.active).language.culture;
    
        // MUST be disposed otherwise ever culture change adds a new listener which is horrible if you're responding to the 
        // change by sending a request - suddenly you have lots of requests instead of 1.
        $scope.$on('$destroy', () => cultureChanged());
});
```

Used `editors.content.cultureChanged` to be consistent with existing events `editors.content.splitViewChanged` and `editors.content.splitViewRequest`