### PR TITLE
BlockEditor Fix - Parse on contentType key

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -359,6 +359,7 @@
 
                     if (infiniteMode && $scope.model.submit) {
                         $scope.model.documentTypeAlias = vm.contentType.alias;
+                        $scope.model.documentTypeKey = vm.contentType.key;
                         $scope.model.submit($scope.model);
                     }
 


### PR DESCRIPTION
Fixes issue mentioned in the Block List PR, https://github.com/umbraco/Umbraco-CMS/pull/8273#issuecomment-651624122

We never parsed on the documentTypeKey so fixing this.