### PR TITLE
V8/feature/block list hide contentin overlay v2

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.controller.js
@@ -13,9 +13,11 @@
                 $scope.$broadcast("formSubmitting", { scope: $scope });
                 // Some property editors need to performe an action after all property editors have reacted to the formSubmitting.
                 $scope.$broadcast("postFormSubmitting", { scope: $scope });
+                
+                block.active = false;
+            } else {
+                $scope.api.activateBlock(block);
             }
-
-            block.active = !block.active;
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn-reset umb-outline blockelement-labelblock-editor blockelement__draggable-element" ng-click="api.editBlock(block)" ng-focus="block.focus" ng-class="{'--active':block.active}">
+<button type="button" class="btn-reset umb-outline blockelement-labelblock-editor blockelement__draggable-element" ng-click="api.editBlock(block, block.hideContentInOverlay)" ng-focus="block.focus" ng-class="{'--active':block.active}">
     <i class="icon {{block.content.icon}}"></i>
     <span>{{block.label}}</span>
 </button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -196,6 +196,28 @@
 
                     </div>
 
+                    <div class="umb-group-panel">
+
+                        <div class="umb-group-panel__header">
+                            <localize key="blockEditor_headlineAdvanced">Advanced</localize>
+                        </div>
+
+                        <div class="umb-group-panel__content">
+
+                            <!-- forceHideContentEditorInOverlay -->
+                            <div class="control-group umb-control-group -no-border">
+                                <div class="umb-el-wrap">
+                                    <label class="control-label" for="forceHideContentEditorInOverlay"><localize key="blockEditor_forceHideContentEditor">Force hide content editor</localize></label>
+                                    <div class="controls">
+                                        <umb-toggle checked="vm.block.forceHideContentEditorInOverlay" on-click="vm.block.forceHideContentEditorInOverlay = vm.block.forceHideContentEditorInOverlay != true"></umb-toggle>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+
                 </div>
             </umb-editor-container>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -254,8 +254,6 @@
             if (blockObject.config.settingsElementTypeKey) {
                 blockSettingsClone = Utilities.copy(blockObject.settings);
             }
-
-            var hideContent = (openSettings === true && inlineEditing === true);
             
             var blockEditorModel = {
                 hideContent: blockObject.hideContentInOverlay,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -237,8 +237,7 @@
             var wasNotActiveBefore = blockObject.active !== true;
             activateBlock(blockObject);
 
-
-            if (inlineEditing === true && openSettings !== true) {	            // dont open the editor overlay if block has hidden its content editor in overlays and we are requesting to open content, not settings.
+	        // dont open the editor overlay if block has hidden its content editor in overlays and we are requesting to open content, not settings.
             if (openSettings !== true && blockObject.hideContentInOverlay === true) {
                 return;
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -235,7 +235,6 @@
         function editBlock(blockObject, openSettings) {
 
             var wasNotActiveBefore = blockObject.active !== true;
-            activateBlock(blockObject);
 
 	        // dont open the editor overlay if block has hidden its content editor in overlays and we are requesting to open content, not settings.
             if (openSettings !== true && blockObject.hideContentInOverlay === true) {
@@ -243,9 +242,11 @@
             }
 
             // if requesting to open settings but we dont have settings then return.
-            if (openSettings === true && blockObject.config.settingsElementTypeKey) {
+            if (openSettings === true && !blockObject.config.settingsElementTypeKey) {
                 return;
             }
+
+            activateBlock(blockObject);
 
             // make a clone to avoid editing model directly.
             var blockContentClone = Utilities.copy(blockObject.content);
@@ -341,7 +342,11 @@
                     if(!(mouseEvent.ctrlKey || mouseEvent.metaKey)) {
                         editorService.close();
                         if (added && vm.layout.length > createIndex) {
-                            editBlock(vm.layout[createIndex].$block);
+                            if (inlineEditing === true) {
+                                activateBlock(vm.layout[createIndex].$block);
+                            } else if (inlineEditing === false && vm.layout[createIndex].$block.hideContentInOverlay !== true) {
+                                editBlock(vm.layout[createIndex].$block);
+                            }
                         }
                     }
                 },

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -242,6 +242,11 @@
                 return;
             }
 
+            // if requesting to open settings but we dont have settings then return.
+            if (openSettings === true && blockObject.config.settingsElementTypeKey) {
+                return;
+            }
+
             // make a clone to avoid editing model directly.
             var blockContentClone = Utilities.copy(blockObject.content);
             var blockSettingsClone = null;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -172,6 +172,7 @@
 
             block.view = (block.config.view ? "/" + block.config.view : getDefaultViewForBlock(block));
 
+            block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true || inlineEditing === true;
             block.showSettings = block.config.settingsElementTypeKey != null;
             block.showCopy = vm.supportCopy && block.config.contentTypeKey != null;// if we have content, otherwise it dosnt make sense to copy.
 
@@ -226,13 +227,19 @@
                 deleteBlock(entry.$block);
             });
         }
+        
+        function activateBlock(blockObject) {
+            blockObject.active = true;
+        }
 
         function editBlock(blockObject, openSettings) {
 
             var wasNotActiveBefore = blockObject.active !== true;
-            blockObject.active = true;
+            activateBlock(blockObject);
 
-            if (inlineEditing === true && openSettings !== true) {
+
+            if (inlineEditing === true && openSettings !== true) {	            // dont open the editor overlay if block has hidden its content editor in overlays and we are requesting to open content, not settings.
+            if (openSettings !== true && blockObject.hideContentInOverlay === true) {
                 return;
             }
 
@@ -247,7 +254,7 @@
             var hideContent = (openSettings === true && inlineEditing === true);
             
             var blockEditorModel = {
-                hideContent: hideContent,
+                hideContent: blockObject.hideContentInOverlay,
                 openSettings: openSettings === true,
                 liveEditing: liveEditing,
                 title: blockObject.label,
@@ -481,6 +488,7 @@
 
 
         vm.blockEditorApi = {
+            activateBlock: activateBlock,
             editBlock: editBlock,
             copyBlock: copyBlock,
             requestDeleteBlock: requestDeleteBlock,

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1849,6 +1849,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="tabCreateEmpty">Opret ny</key>
     <key alias="tabClipboard">Udklipsholder</key>
     <key alias="tabBlockSettings">Indstillinger</key>
+    <key alias="headlineAdvanced">Avanceret</key>
+    <key alias="forceHideContentEditor">Skjuld indholds editoren</key>
   </area>
 
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2465,6 +2465,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="tabCreateEmpty">Create empty</key>
     <key alias="tabClipboard">Clipboard</key>
     <key alias="tabBlockSettings">Settings</key>
+    <key alias="headlineAdvanced">Advanced</key>
+    <key alias="forceHideContentEditor">Force hide content editor</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2485,6 +2485,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="tabCreateEmpty">Create empty</key>
     <key alias="tabClipboard">Clipboard</key>
     <key alias="tabBlockSettings">Settings</key>
+    <key alias="headlineAdvanced">Advanced</key>
+    <key alias="forceHideContentEditor">Force hide content editor</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs
@@ -44,6 +44,9 @@ namespace Umbraco.Web.PropertyEditors
 
             [JsonProperty("editorSize")]
             public string EditorSize { get; set; }
+
+            [JsonProperty("forceHideContentEditorInOverlay")]
+            public bool ForceHideContentEditorInOverlay { get; set; }
         }
 
         [ConfigurationField("validationLimit", "Amount", "numberrange", Description = "Set a required range of blocks")]


### PR DESCRIPTION
(New PR to avoid dragging old stuff with us.)

This PR is adding the ability to hide the content editor from the infinite editing overlay in the Block List property editor.
The content editor is already hidden if the editor is set to inline mode. But for the default mode, this enables the specific block type to force the content editor to be hidden. This is preferred if the custom view for the given block type delivers a UI that provides editing of the content.