### PR TITLE
Adjust border radius of button in button group if having sub buttons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-group.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-group.less
@@ -14,7 +14,7 @@
     display: flex;
 }
 
-.umb-button-group {
+.umb-button-group.-with-button-group-toggle {
 
     .umb-button__button {
         border-radius: @baseBorderRadius 0 0 @baseBorderRadius;

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -1,4 +1,4 @@
-<div class="btn-group umb-button-group" ng-class="{'dropup': direction === 'up'}">
+<div class="btn-group umb-button-group" ng-class="{ 'dropup': direction === 'up', '-with-button-group-toggle': subButtons.length > 0 }">
 
    <umb-button
       ng-if="defaultButton"
@@ -32,12 +32,11 @@
    </button>
 
     <umb-dropdown
-         ng-show="subButtons.length > 0 && dropdown.isOpen"
+         ng-if="subButtons.length > 0 && dropdown.isOpen"
          class="umb-button-group__sub-buttons"
          on-close="closeDropdown()"
          deep-blur="closeDropdown()"
-         ng-class="{'-align-right': float === 'right'}"
-         >
+         ng-class="{'-align-right': float === 'right'}">
       <umb-dropdown-item ng-repeat="subButton in subButtons">
          <button
             data-element="{{subButton.alias ? 'button-' + subButton.alias : 'button-group-secondary-' + $index }}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When SMTP mail settings has been configurated in web.config the "Invite user" button is shown with a "Create user" subbutton.
However when this isn't configurated only "Create user" button is show, where the button has rounded corners on the left, but no border radius on the right.

**Before**

![image](https://user-images.githubusercontent.com/2919859/86246220-ef30ab00-bbaa-11ea-83e9-dec6aac63131.png)

![image](https://user-images.githubusercontent.com/2919859/86246325-18e9d200-bbab-11ea-93bc-1620239469a9.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/86246425-4171cc00-bbab-11ea-9868-268083874a6f.png)

![image](https://user-images.githubusercontent.com/2919859/86245947-8cd7aa80-bbaa-11ea-8455-bb4da87e433e.png)
