### PR TITLE
Remove the usage of Parallel to run the populators

### DIFF
--- a/src/Umbraco.Examine/IndexRebuilder.cs
+++ b/src/Umbraco.Examine/IndexRebuilder.cs
@@ -50,8 +50,11 @@ namespace Umbraco.Examine
                 index.CreateIndex(); // clear the index
             }
 
-            //run the populators in parallel against all indexes
-            Parallel.ForEach(_populators, populator => populator.Populate(indexes));
+            // run each populator over the indexes
+            foreach(var populator in _populators)
+            {
+                populator.Populate(indexes);
+            }
         }
 
     }


### PR DESCRIPTION
During some investigations of Examine indexes becoming locked there was a report of this stack trace when Umbraco is populating the indexes (https://github.com/umbraco/Umbraco-CMS/issues/8215#issuecomment-652354745)

```
System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: This SqlTransaction has completed; it is no longer usable.
   at System.Data.SqlClient.SqlTransaction.ZombieCheck()
   at System.Data.SqlClient.SqlTransaction.Commit()
   at NPoco.Database.CompleteTransaction()
   at Umbraco.Core.Scoping.Scope.DisposeLastScope() in d:\a\1\s\src\Umbraco.Core\Scoping\Scope.cs:line 388
   at Umbraco.Core.Scoping.Scope.Dispose() in d:\a\1\s\src\Umbraco.Core\Scoping\Scope.cs:line 365
   at Umbraco.Core.Services.Implement.ContentService.GetPagedDescendants(Int32 id, Int64 pageIndex, Int32 pageSize, Int64& totalChildren, IQuery`1 filter, Ordering ordering) in d:\a\1\s\src\Umbraco.Core\Services\Implement\ContentService.cs:line 606
   at Umbraco.Examine.ContentIndexPopulator.PopulateIndexes(IReadOnlyList`1 indexes) in d:\a\1\s\src\Umbraco.Examine\ContentIndexPopulator.cs:line 77
   at System.Threading.Tasks.Parallel.<>c__DisplayClass17_0`1.<ForWorker>b__1()
   at System.Threading.Tasks.Task.InnerInvokeWithArg(Task childTask)
   at System.Threading.Tasks.Task.<>c__DisplayClass176_0.<ExecuteSelfReplicating>b__0(Object )
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Parallel.ForWorker[TLocal](Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.ForEach[TSource](IEnumerable`1 source, Action`1 body)
   at Umbraco.Examine.IndexRebuilder.RebuildIndexes(Boolean onlyEmptyIndexes) in d:\a\1\s\src\Umbraco.Examine\IndexRebuilder.cs:line 55
   at Umbraco.Web.Search.BackgroundIndexRebuilder.RebuildOnStartupTask.Run() in d:\a\1\s\src\Umbraco.Web\Search\BackgroundIndexRebuilder.cs:line 93
---> (Inner Exception #0) System.InvalidOperationException: This SqlTransaction has completed; it is no longer usable.
   at System.Data.SqlClient.SqlTransaction.ZombieCheck()
   at System.Data.SqlClient.SqlTransaction.Commit()
   at NPoco.Database.CompleteTransaction()
   at Umbraco.Core.Scoping.Scope.DisposeLastScope() in d:\a\1\s\src\Umbraco.Core\Scoping\Scope.cs:line 388
   at Umbraco.Core.Scoping.Scope.Dispose() in d:\a\1\s\src\Umbraco.Core\Scoping\Scope.cs:line 365
   at Umbraco.Core.Services.Implement.ContentService.GetPagedDescendants(Int32 id, Int64 pageIndex, Int32 pageSize, Int64& totalChildren, IQuery`1 filter, Ordering ordering) in d:\a\1\s\src\Umbraco.Core\Services\Implement\ContentService.cs:line 606
   at Umbraco.Examine.ContentIndexPopulator.PopulateIndexes(IReadOnlyList`1 indexes) in d:\a\1\s\src\Umbraco.Examine\ContentIndexPopulator.cs:line 77
   at System.Threading.Tasks.Parallel.<>c__DisplayClass17_0`1.<ForWorker>b__1()
   at System.Threading.Tasks.Task.InnerInvokeWithArg(Task childTask)
   at System.Threading.Tasks.Task.<>c__DisplayClass176_0.<ExecuteSelfReplicating>b__0(Object )<---
```

There have been a couple of other cases where we've found running things in Parallel have caused some issues. In this case it looks like perhaps some Scopes aren't being used correctly when using Parallel which in some cases may cause this zombie transaction. 

This PR removes the Parallel call and just iterates over the populators. The slight increase in potential performance with Parallel here isn't worth the potential side affects and unknowns of working in Parallel with Scopes since a user may be executing custom code inside of these populators too which could have adverse affects with Scopes. So safer to not be Parallel.