### PR TITLE
Show custom EventMessage when cancelling ContentService.Moving event

### DIFF
--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -290,7 +290,12 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Moves a document under a new parent.
         /// </summary>
-        OperationResult Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId);
+        void Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Moves a document under a new parent and shows event messages (if any).
+        /// </summary>
+        OperationResult MoveWithResult(IContent content, int parentId, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
         /// Copies a document.

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -290,7 +290,7 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Moves a document under a new parent.
         /// </summary>
-        void Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId);
+        OperationResult Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
         /// Copies a document.

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1585,7 +1585,12 @@ namespace Umbraco.Web.Editors
         {
             var toMove = ValidateMoveOrCopy(move);
 
-            Services.ContentService.Move(toMove, move.ParentId, Security.GetUserId().ResultOr(0));
+            var moveResult = Services.ContentService.Move(toMove, move.ParentId, Security.GetUserId().ResultOr(0));
+
+            if (moveResult.Success == false)
+            {
+                return Request.CreateValidationErrorResponse(new SimpleNotificationModel());
+            }
 
             var response = Request.CreateResponse(HttpStatusCode.OK);
             response.Content = new StringContent(toMove.Path, Encoding.UTF8, "text/plain");

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -1585,7 +1585,7 @@ namespace Umbraco.Web.Editors
         {
             var toMove = ValidateMoveOrCopy(move);
 
-            var moveResult = Services.ContentService.Move(toMove, move.ParentId, Security.GetUserId().ResultOr(0));
+            var moveResult = Services.ContentService.MoveWithResult(toMove, move.ParentId, Security.GetUserId().ResultOr(0));
 
             if (moveResult.Success == false)
             {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

https://github.com/umbraco/Umbraco-CMS/issues/8372

### Description

This PR fixes an issue where the `ContentService.Moving` event does not show a custom `EventMessage` to the user when the event is cancelled using the `e.CancelOperation(new EventMessage(...))` method. The user would always see the default success message even if the Moving event was cancelled.

I have basically just copied pieces of logic from the `ContentService.Trashing` event which is almost identical to the Moving event. You can use the following code to test the fix, just add the code to a PublishedContentEvents.cs file in the src/Umbraco.Web.UI/App_Code/ folder:

```
using System;
using Umbraco.Core;
using Umbraco.Core.Composing;
using Umbraco.Core.Events;
using Umbraco.Core.Models;
using Umbraco.Core.Services;
using Umbraco.Core.Services.Implement;

namespace Application.Core.Composing
{
    public class PublishedContentEventsComposer : IUserComposer
    {
        public void Compose(Composition composition)
        {
            composition.Components().Append<PublishedContentEventsComponent>();
        }
    }

    public class PublishedContentEventsComponent : IComponent
    {
        public PublishedContentEventsComponent()
        {
        }

        public void Initialize()
        {
            ContentService.Moving += ContentService_Moving;
        }

        private void ContentService_Moving(IContentService sender, MoveEventArgs<IContent> e)
        {
            foreach (var moveInfo in e.MoveInfoCollection)
            {
                e.CancelOperation(new EventMessage("Unauthorized", "This document type can't be moved", EventMessageType.Error));
            }
        }
        public void Terminate()
        {
        }
    }
}
```

![Video_2020-07-02_152157](https://user-images.githubusercontent.com/161342/86363983-e3f78100-bc77-11ea-9b6e-2123c1dd8888.gif)