### PR TITLE
Added initial Cypress test for BackOffice tour.

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
@@ -1,0 +1,49 @@
+/// <reference types="Cypress" />
+context('Backoffice Tour', () => {
+
+  beforeEach(() => {
+    cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'));
+  });
+
+  it('Backoffice introduction tour should run', () => {
+    //arrange
+    cy.umbracoGlobalHelp().should("be.visible");
+    
+    //act
+    cy.umbracoGlobalHelp().click()
+    //assert
+    cy.get('[data-element="help-tours"]').should("be.visible");
+    //act
+    cy.get('[data-element="help-tours"]').click();
+    //assert
+    cy.get('[data-element="tour-umbIntroIntroduction"] .umb-button').should("be.visible");
+    //act
+    cy.get('[data-element="tour-umbIntroIntroduction"] .umb-button').click();
+    //assert
+    cy.get('.umb-tour-step', { timeout: 60000 }).should('be.visible');
+    cy.get('.umb-tour-step__footer').should('be.visible'); 
+    cy.get('.umb-tour-step__counter').should('be.visible');
+
+    for(let i=1;i<7;i++){
+      cy.get('.umb-tour-step__counter').contains(i + '/12');
+      cy.get('.umb-tour-step__footer .umb-button').should('be.visible').click();
+    }
+    cy.umbracoGlobalUser().click()
+    cy.get('.umb-tour-step__counter').contains('8/12');
+    cy.get('.umb-tour-step__footer .umb-button').should('be.visible').click();
+    cy.get('.umb-tour-step__counter').contains('9/12');
+    cy.get('.umb-overlay-drawer__align-right .umb-button').should('be.visible').click();
+    cy.get('.umb-tour-step__counter').contains('10/12');
+    cy.umbracoGlobalHelp().click()
+
+    for(let i=11;i<13;i++){
+      cy.get('.umb-tour-step__counter').contains(i + '/12');
+      cy.get('.umb-tour-step__footer .umb-button').should('be.visible').click();
+    }
+    cy.get('.umb-tour-step__footer .umb-button').should('be.visible').click();
+
+    //assert
+    cy.umbracoGlobalHelp().should("be.visible");
+    cy.get('[data-element="help-tours"] .umb-progress-circle').contains('17%');
+   });
+});


### PR DESCRIPTION
### Prerequisites

- [x ] I have added steps to test this contribution in the description below

This is part of the overall project to extend Cypress tests for the Umbraco back-office in v8 (and will be able to also merged into .NET Core)

### Description

I've done a first pass at a Cypress test for the back-office tour Introduction step, which runs through each step (17% of the overall back-office tour)

- I tried to use the existing extension methods. I couldn't find the Umbraco button by label key though. 
- I don't check Cypress against actual language content, in case that changes - except the tour index indicator 3/12 etc
- There is scope for this to be refactored especially as we add the extra tour steps
- Not sure I'm always targeting the right things, but have tried to follow the existing pattern. 
- I have an act, assert thing going on, and also in some places I check if it is visible then immediately click. Not sure the preference
- The remaining tours can be added to this once I'm comfortable I'm writing the right pattern
- This should also work in the .NET Core back-office as I believe tours run the same way

NB: If the tour steps ever change order or if a new step is added, this test will need to be amended