### PR TITLE
V8 - Update multi media picker macro parameter to store Udis

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleMediaPickerParameterEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ParameterEditors/MultipleMediaPickerParameterEditor.cs
@@ -22,6 +22,7 @@ namespace Umbraco.Web.PropertyEditors.ParameterEditors
             : base(logger)
         {
             DefaultConfiguration.Add("multiPicker", "1");
+            DefaultConfiguration.Add("idType", "udi");
         }
     }
 }

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -573,6 +573,16 @@ namespace Umbraco.Web
             switch (id)
             {
                 case string s:
+                    //could be a Udi string and not a pure Guid
+                    if (Udi.TryParse(s, out Udi udi))
+                    {
+                        var guidUdi = udi as GuidUdi;
+                        if (guidUdi != null)
+                        {
+                            guidId = guidUdi.Guid;
+                            return true;
+                        }
+                    }               
                     return Guid.TryParse(s, out guidId);
 
                 case Guid g:


### PR DESCRIPTION
This has come up as part of my investigation into making Media picked in a Macro - tracked using the new Media Tracking features - see https://github.com/umbraco/Umbraco-CMS/issues/8131

Essentially I've found a weird anomaly, which might have a perfectly good reason for why it is like this or it might have just been missed in the switch to udis, I'm illustrating it in this PR, but this might be a 'breaking change' - so would need some thought.

The anomaly is a Single Media Picker used as a 'Macro Parameter' stores it's picked value as a Udi, but the Multiple Media Picker Macro Parameter stores it's picked values in the old way as integers.

eg:

`<div class="umb-macro-holder mceNonEditable loading"><!-- <?UMBRACO_MACRO macroAlias="latestBlogposts" numberOfPosts="4" startNodeId="umb://document/1d770f10d1ca4a269d68071e2c9f7ac1" multipleMediaPicker="1141,1142,1143" singleMediaPicker="umb://media/90ba0d3dba6e4c9fa1953db78352ba73" /> --> <ins>Macro alias: <strong>latestBlogposts</strong></ins></div>`

(now I want to parse this using regexes for the Media Tracking, but that will be much easier if the references are stores as Udis, and much more performant, not having to convert ids to udis)

The Multiple Media Picker is based on the same underlying property editor for picking Media as the Single Media Picker. But there is a configuration option to tell it to store udis or not - so to make it do the Udis I want, I just add the following to the ParameterEditor configuration:

`    DefaultConfiguration.Add("idType", "udi");`

And we get Udis!!

`<div class="umb-macro-holder mceNonEditable"><!-- <?UMBRACO_MACRO macroAlias="latestBlogposts" numberOfPosts="4" startNodeId="umb://document/1d770f10d1ca4a269d68071e2c9f7ac1" multipleMediaPicker="umb://media/eee91c05b2e84031a056dcd7f28eff89,umb://media/fa763e0d0ceb408c8720365d57e06e32,umb://media/c0969cab13ab4de9819a848619ac2b5d" singleMediaPicker="umb://media/90ba0d3dba6e4c9fa1953db78352ba73" /> --> <ins>`

But is it set to be integer ids for a reason? - eg length of parameter string could get quite long? is it purposeful to use ints here?

Then I was thinking, we won't 'just be able to change this' - it will break people's site on upgrade, or will it be so bad? Won't the code to read in the string of picked ids, 'just work' - will people be parsing the picked items as integers?

We don't have ValueConverters for Macro Parameter reading, so something like this:

   var pickedMediaParameter = Model.GetParameterValue<string>
    ("multipleMediaPicker");
    var pickedMediaIds  = pickedMediaParameter.Split(new char[]{','},StringSplitOptions.RemoveEmptyEntries);
    var pickedMedia = Umbraco.Media(pickedMediaIds);

Would work for both "1141,1142,1143" AND "umb://media/eee91c05b2e84031a056dcd7f28eff89,umb://media/fa763e0d0ceb408c8720365d57e06e32,umb://media/c0969cab13ab4de9819a848619ac2b5d" 

So I tried it... and found that it didn't! so I dug into it a little bit to find out why...

... and I found that the problem was in the UmbracoHelper Media method that takes in an array of objects...

`public IEnumerable<IPublishedContent> Media(params object[] ids)`

This first tries to parse the array as integers, and then falls back to parse the array as Guids...

... but I have a string array of Udis...

and the act of parsing these as Guids, returned nothing and broke the Macro...

... if I add the option of parsing the id as a Udi before falling through to try to parse as a Guid, all was ok:

```
   internal static bool ConvertIdObjectToGuid(object id, out Guid guidId)
        {
            switch (id)
            {
                case string s:
                    //could be a Udi string and not a pure Guid
                    if (Udi.TryParse(s, out Udi udi))
                    {
                        var guidUdi = udi as GuidUdi;
                        if (guidUdi != null)
                        {
                            guidId = guidUdi.Guid;
                            return true;
                        }
                    }               
                    return Guid.TryParse(s, out guidId);

                case Guid g:
                    guidId = g;
                    return true;

                default:
                    guidId = default;
                    return false;
            }
        }
```
But I'm aware that this is in a much-used part of Umbraco and so wonder if instead I've gotten confused and missing something obvious. I've added the update to UmbracoHelper in this PR too.

So with this in place, IF people were reading and using multiple media picker parameters this way in their macros then it wouldn't be MUCH of a breaking change? or do we add a new Multi Media Picker 2, macro parameter and make the existing version obsolete? or is it ints for a good reason and we should leave alone?

### Prerequisites

- [ y] I have added steps to test this contribution in the description below

To Test this contribution, Spin up a version of the site with a starter kit, create a new macro that has two macro parameters, one a multi media picker parameter, another a single media picker - implement the macro to write out any media images picked by the macro, and insert the macro into a page and pick some images. You'll see the anomaly with the multi media picker storing as ids, and the single picker storing as udi. Then pull this branch, and point at the same site - you should find without updating anything content wise the page will still render the macro, even though it's still got the integer ids picked, and this fix is in place. Then in the backoffice open the macro inside the rich text area, and submit and save. The picked ids will switched to udis (but the important thing is the items that were 'picked' are still displayed as 'picked' you don't need to repick them as part of the udi storage change. Now publish the page, and your Macro should still render the images.

 Thanks for considering this contribution to Umbraco CMS! 
