### PR TITLE
Register dragover state of file upload

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
@@ -19,6 +19,17 @@ function umbFileUpload() {
                 //clear the element value - this allows us to pick the same file again and again
                 el.val('');
             });
+
+            el.on('drag dragstart dragend dragover dragenter dragleave drop', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+            })
+            .on('dragover dragenter', function () {
+                scope.$emit("isDragover", { value: true });
+            })
+            .on('dragleave dragend drop', function () {
+                scope.$emit("isDragover", { value: false });
+            });
         }
     };
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
@@ -78,6 +78,8 @@
         /** Called when the component initializes */
         function onInit() {
             $scope.$on("filesSelected", onFilesSelected);
+            $scope.$on("isDragover", isDragover);
+
             initialize();
         }
 
@@ -293,6 +295,11 @@
             }
         }
 
+        function isDragover(e, args) {
+            vm.dragover = args.value;
+            angularHelper.safeApply($scope);
+        }
+
     };
 
     var umbPropertyFileUploadComponent = {
@@ -303,6 +310,7 @@
             propertyAlias: "@",
             value: "<",
             hideSelection: "<",
+            dragover: "<",
             /**
              * Called when a file is selected on this instance
              */

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
@@ -26,4 +26,10 @@
             width: 100%;
         }
     }
+
+    .drag-over {
+        .umb-upload-button-big {
+            border-color: @gray-1;
+        }
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-property-file-upload">
 
-    <ng-form name="vm.fileUploadForm">
+    <ng-form name="vm.fileUploadForm" ng-class="{ 'drag-over': vm.dragover }">
         <input type="hidden" ng-model="mandatoryValidator" ng-required="vm.required && !vm.files.length" />
 
         <div class="fileinput-button umb-upload-button-big"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment when dragging file over dropzone in e.g. image cropper a `drag-over` class is added and return feedback to the user. However when dragging a file over a single file upload field on a File media type the user get no feedback on drag over.

I was a bit inspired from this article https://css-tricks.com/drag-and-drop-file-uploading/ and have for a while noticed the file upload in Umbraco didn't provide any feeback to user on dragover.

This is how the dragover change look for the image cropper dropzone:

![2020-07-06_16-42-16](https://user-images.githubusercontent.com/2919859/86606076-d3147b80-bfa7-11ea-8ad0-8c21cb1fd846.gif)

This PR add a `drag-over` class here as well, which style the upload button with a border color as in the image cropper dropzone.

**Before**

![2020-07-06_17-02-05](https://user-images.githubusercontent.com/2919859/86608279-972ee580-bfaa-11ea-9b04-51b73cad16bb.gif)


**After**

![2020-07-06_16-40-36](https://user-images.githubusercontent.com/2919859/86605853-85980e80-bfa7-11ea-8a5a-6834903daaa1.gif)

