### PR TITLE
Adjustments for SqlMainDomLock and others to make azure operations more resilient

### DIFF
--- a/src/Umbraco.Core/Persistence/FaultHandling/Strategies/SqlAzureTransientErrorDetectionStrategy.cs
+++ b/src/Umbraco.Core/Persistence/FaultHandling/Strategies/SqlAzureTransientErrorDetectionStrategy.cs
@@ -4,6 +4,10 @@ using System.Data.SqlClient;
 
 namespace Umbraco.Core.Persistence.FaultHandling.Strategies
 {
+    // See https://docs.microsoft.com/en-us/azure/azure-sql/database/troubleshoot-common-connectivity-issues
+    // Also we could just use the nuget package instead https://www.nuget.org/packages/EnterpriseLibrary.TransientFaultHandling/ ?
+    // but i guess that's not netcore so we'll just leave it.
+
     /// <summary>
     /// Provides the transient error detection logic for transient faults that are specific to SQL Azure.
     /// </summary>
@@ -71,7 +75,7 @@ namespace Umbraco.Core.Persistence.FaultHandling.Strategies
         /// Determines whether the specified exception represents a transient failure that can be compensated by a retry.
         /// </summary>
         /// <param name="ex">The exception object to be verified.</param>
-        /// <returns>True if the specified exception is considered as transient, otherwise false.</returns>
+        /// <returns>true if the specified exception is considered as transient; otherwise, false.</returns>
         public bool IsTransient(Exception ex)
         {
             if (ex != null)
@@ -97,40 +101,50 @@ namespace Umbraco.Core.Persistence.FaultHandling.Strategies
 
                                 return true;
 
-                            // SQL Error Code: 40197
-                            // The service has encountered an error processing your request. Please try again.
-                            case 40197:
+                            // SQL Error Code: 10928
+                            // Resource ID: %d. The %s limit for the database is %d and has been reached.
+                            case 10928:
+                            // SQL Error Code: 10929
+                            // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d. 
+                            // However, the server is currently too busy to support requests greater than %d for this database.
+                            case 10929:
                             // SQL Error Code: 10053
                             // A transport-level error has occurred when receiving results from the server.
                             // An established connection was aborted by the software in your host machine.
                             case 10053:
                             // SQL Error Code: 10054
-                            // A transport-level error has occurred when sending the request to the server.
+                            // A transport-level error has occurred when sending the request to the server. 
                             // (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by the remote host.)
                             case 10054:
                             // SQL Error Code: 10060
-                            // A network-related or instance-specific error occurred while establishing a connection to SQL Server.
-                            // The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server
-                            // is configured to allow remote connections. (provider: TCP Provider, error: 0 - A connection attempt failed
-                            // because the connected party did not properly respond after a period of time, or established connection failed
+                            // A network-related or instance-specific error occurred while establishing a connection to SQL Server. 
+                            // The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server 
+                            // is configured to allow remote connections. (provider: TCP Provider, error: 0 - A connection attempt failed 
+                            // because the connected party did not properly respond after a period of time, or established connection failed 
                             // because connected host has failed to respond.)"}
                             case 10060:
+                            // SQL Error Code: 40197
+                            // The service has encountered an error processing your request. Please try again.
+                            case 40197:
+                            // SQL Error Code: 40540
+                            // The service has encountered an error processing your request. Please try again.
+                            case 40540:
                             // SQL Error Code: 40613
-                            // Database XXXX on server YYYY is not currently available. Please retry the connection later. If the problem persists, contact customer
+                            // Database XXXX on server YYYY is not currently available. Please retry the connection later. If the problem persists, contact customer 
                             // support, and provide them the session tracing ID of ZZZZZ.
                             case 40613:
                             // SQL Error Code: 40143
                             // The service has encountered an error processing your request. Please try again.
                             case 40143:
                             // SQL Error Code: 233
-                            // The client was unable to establish a connection because of an error during connection initialization process before login.
-                            // Possible causes include the following: the client tried to connect to an unsupported version of SQL Server; the server was too busy
-                            // to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server.
+                            // The client was unable to establish a connection because of an error during connection initialization process before login. 
+                            // Possible causes include the following: the client tried to connect to an unsupported version of SQL Server; the server was too busy 
+                            // to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server. 
                             // (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by the remote host.)
                             case 233:
                             // SQL Error Code: 64
-                            // A connection was successfully established with the server, but then an error occurred during the login process.
-                            // (provider: TCP Provider, error: 0 - The specified network name is no longer available.)
+                            // A connection was successfully established with the server, but then an error occurred during the login process. 
+                            // (provider: TCP Provider, error: 0 - The specified network name is no longer available.) 
                             case 64:
                             // DBNETLIB Error Code: 20
                             // The instance of SQL Server you attempted to connect to does not support encryption.

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
@@ -12,6 +12,11 @@ namespace Umbraco.Core.Persistence.Repositories
         /// </summary>
         void ClearSchedule(DateTime date);
 
+        void ClearSchedule(DateTime date, ContentScheduleAction action);
+
+        bool HasContentForExpiration(DateTime date);
+        bool HasContentForRelease(DateTime date);
+
         /// <summary>
         /// Gets <see cref="IContent"/> objects having an expiration date before (lower than, or equal to) a specified date.
         /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1001,6 +1001,37 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         }
 
         /// <inheritdoc />
+        public void ClearSchedule(DateTime date, ContentScheduleAction action)
+        {
+            var a = action.ToString();
+            var sql = Sql().Delete<ContentScheduleDto>().Where<ContentScheduleDto>(x => x.Date <= date && x.Action == a);
+            Database.Execute(sql);
+        }
+
+        private Sql GetSqlForHasScheduling(ContentScheduleAction action, DateTime date)
+        {
+            var template = SqlContext.Templates.Get("Umbraco.Core.DocumentRepository.GetSqlForHasScheduling", tsql => tsql
+                .SelectCount()
+                    .From<ContentScheduleDto>()
+                    .Where<ContentScheduleDto>(x => x.Action == SqlTemplate.Arg<string>("action") && x.Date <= SqlTemplate.Arg<DateTime>("date")));
+
+            var sql = template.Sql(action.ToString(), date);
+            return sql;
+        }
+
+        public bool HasContentForExpiration(DateTime date)
+        {
+            var sql = GetSqlForHasScheduling(ContentScheduleAction.Expire, date);
+            return Database.ExecuteScalar<int>(sql) > 0;
+        }
+
+        public bool HasContentForRelease(DateTime date)
+        {
+            var sql = GetSqlForHasScheduling(ContentScheduleAction.Release, date);
+            return Database.ExecuteScalar<int>(sql) > 0;
+        }
+
+        /// <inheritdoc />
         public IEnumerable<IContent> GetContentForRelease(DateTime date)
         {
             var action = ContentScheduleAction.Release.ToString();

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Core.Runtime
         {
             while (true)
             {
-                // poll every 1.5 second
+                // poll every couple of seconds
                 // local testing shows the actual query to be executed from client/server is approx 300ms but would change depending on environment/IO
                 Thread.Sleep(2000);
 

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -201,7 +201,7 @@ namespace Umbraco.Core.Runtime
 
             return Task.Run(() =>
             {
-                // ensure this is disposed when this thread ends
+
                 using var db = _dbFactory.CreateDatabase();
 
                 var watch = new Stopwatch();
@@ -356,7 +356,6 @@ namespace Umbraco.Core.Runtime
 
                         if (_dbFactory.Configured)
                         {
-                            // ensure this is disposed when this thread ends
                             using var db = _dbFactory.CreateDatabase();
                             using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
 

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -172,7 +172,6 @@ namespace Umbraco.Core.Runtime
                     }
                     catch (Exception ex)
                     {
-                        // unexpected, if this occurs MainDom will be shutdown!
                         _logger.Error<SqlMainDomLock>(ex, "Unexpected error during listening.");
 
                         // We need to keep on listening unless we've been notified by our own AppDomain to shutdown since

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1359,13 +1359,7 @@ namespace Umbraco.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public IEnumerable<PublishResult> PerformScheduledPublish(DateTime date)
-            => PerformScheduledPublishInternal(date).ToList();
-
-        // beware! this method yields results, so the returned IEnumerable *must* be
-        // enumerated for anything to happen - dangerous, so private + exposed via
-        // the public method above, which forces ToList().
-        private IEnumerable<PublishResult> PerformScheduledPublishInternal(DateTime date)
+        public IEnumerable<PublishResult> PerformScheduledPublish(DateTime date)            
         {
             var evtMsgs = EventMessagesFactory.Get();
 

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1392,7 +1392,7 @@ namespace Umbraco.Core.Services.Implement
                             .ToList();
 
                         if (pendingCultures.Count == 0)
-                            continue; //shouldn't happen but no point in continuing if there's nothing there
+                            continue; //shouldn't happen but no point in processing this document if there's nothing there
 
                         var saveEventArgs = new ContentSavingEventArgs(d, evtMsgs);
                         if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
@@ -1453,7 +1453,7 @@ namespace Umbraco.Core.Services.Implement
                             .ToList();
 
                         if (pendingCultures.Count == 0)
-                            continue; //shouldn't happen but no point in continuing if there's nothing there
+                            continue; //shouldn't happen but no point in processing this document if there's nothing there
 
                         var saveEventArgs = new ContentSavingEventArgs(d, evtMsgs);
                         if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs, nameof(Saving)))
@@ -1479,7 +1479,7 @@ namespace Umbraco.Core.Services.Implement
                                     d.Id, culture, string.Join(",", invalidProperties.Select(x => x.Alias)));
 
                             publishing &= tryPublish; //set the culture to be published
-                            if (!publishing) continue; // no point continuing
+                            if (!publishing) continue; // move to next document
                         }
 
                         PublishResult result;

--- a/src/Umbraco.Examine/IndexRebuilder.cs
+++ b/src/Umbraco.Examine/IndexRebuilder.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Examine;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Logging;
 
 namespace Umbraco.Examine
 {   
@@ -12,12 +14,20 @@ namespace Umbraco.Examine
     /// </summary>
     public class IndexRebuilder
     {
+        private readonly IProfilingLogger _logger;
         private readonly IEnumerable<IIndexPopulator> _populators;
         public IExamineManager ExamineManager { get; }
 
+        [Obsolete("Use constructor with all dependencies")]
         public IndexRebuilder(IExamineManager examineManager, IEnumerable<IIndexPopulator> populators)
+            : this(Current.ProfilingLogger, examineManager, populators)
+        {
+        }
+
+        public IndexRebuilder(IProfilingLogger logger, IExamineManager examineManager, IEnumerable<IIndexPopulator> populators)
         {
             _populators = populators;
+            _logger = logger;
             ExamineManager = examineManager;
         }
 
@@ -53,7 +63,14 @@ namespace Umbraco.Examine
             // run each populator over the indexes
             foreach(var populator in _populators)
             {
-                populator.Populate(indexes);
+                try
+                {
+                    populator.Populate(indexes);
+                }
+                catch (Exception e)
+                {
+                    _logger.Error<IndexRebuilder>(e, "Index populating failed for populator {Populator}", populator.GetType());                    
+                }
             }
         }
 

--- a/src/Umbraco.TestData/LoadTestController.cs
+++ b/src/Umbraco.TestData/LoadTestController.cs
@@ -1,0 +1,371 @@
+﻿using System;
+using System.Threading;
+using System.Linq;
+using System.Web.Mvc;
+using Umbraco.Core.Services;
+using Umbraco.Core.Models;
+using System.Web;
+using System.Web.Hosting;
+using System.Web.Routing;
+using System.Diagnostics;
+using Umbraco.Core.Composing;
+using System.Configuration;
+
+// see https://github.com/Shazwazza/UmbracoScripts/tree/master/src/LoadTesting
+
+namespace Umbraco.TestData
+{
+    public class LoadTestController : Controller
+    {
+        public LoadTestController(ServiceContext serviceContext)
+        {
+            _serviceContext = serviceContext;
+        }
+
+        private static readonly Random _random = new Random();
+        private static readonly object _locko = new object();
+
+        private static volatile int _containerId = -1;
+
+        private const string _containerAlias = "LoadTestContainer";
+        private const string _contentAlias = "LoadTestContent";
+        private const int _textboxDefinitionId = -88;
+        private const int _maxCreate = 1000;
+
+        private static readonly string HeadHtml = @"<html>
+<head>
+  <title>LoadTest</title>
+  <style>
+    body { font-family: arial; }
+    a,a:visited { color: blue; }
+    h1 { margin: 0; padding: 0; font-size: 120%; font-weight: bold; }
+    h1 a { text-decoration: none; }
+    div.block { margin: 20px 0; }
+    ul { margin:0; }
+    div.ver { font-size: 80%; }
+    div.head { padding:0 0 10px 0; margin: 0 0 20px 0; border-bottom: 1px solid #cccccc; }
+  </style>
+</head>
+<body>
+  <div class=""head"">
+  <h1><a href=""/LoadTest"">LoadTest</a></h1>
+  <div class=""ver"">" + System.Configuration.ConfigurationManager.AppSettings["umbracoConfigurationStatus"] + @"</div>
+  </div>
+";
+
+        private const string FootHtml = @"</body>
+</html>";
+
+        private static readonly string _containerTemplateText = @"
+@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@{
+    Layout = null;
+    var container = Umbraco.ContentAtRoot().OfTypes(""" + _containerAlias + @""").FirstOrDefault();
+    var contents = container.Children().ToArray();
+    var groups = contents.GroupBy(x => x.Value<string>(""origin""));
+    var id = contents.Length > 0 ? contents[0].Id : -1;
+    var wurl = Request.QueryString[""u""] == ""1"";
+    var missing = contents.Length > 0 && contents[contents.Length - 1].Id - contents[0].Id >= contents.Length;
+}
+" + HeadHtml + @"
+<div class=""block"">
+<span @Html.Raw(missing ? ""style=\""color:red;\"""" : """")>@contents.Length items</span>
+<ul>
+@foreach (var group in groups)
+{
+    <li>@group.Key: @group.Count()</li>
+}
+</ul></div>
+<div class=""block"">
+@foreach (var content in contents)
+{
+	while (content.Id > id)
+	{
+		<div style=""color:red;"">@id :: MISSING</div>
+		id++;
+	}
+    if (wurl)
+    {
+        <div>@content.Id :: @content.Name :: @content.Url</div>
+    }
+    else
+    {
+        <div>@content.Id :: @content.Name</div>
+    }	id++;
+}
+</div>
+" + FootHtml;
+        private readonly ServiceContext _serviceContext;
+
+        private ActionResult ContentHtml(string s)
+        {
+            return Content(HeadHtml + s + FootHtml);
+        }
+
+        public ActionResult Index()
+        {
+            var res = EnsureInitialize();
+            if (res != null) return res;
+
+            var html = @"Welcome. You can:
+<ul>
+    <li><a href=""/LoadTestContainer"">List existing contents</a> (u:url)</li>
+    <li><a href=""/LoadTest/Create?o=browser"">Create a content</a> (o:origin, r:restart, n:number)</li>
+    <li><a href=""/LoadTest/Clear"">Clear all contents</a></li>
+    <li><a href=""/LoadTest/Domains"">List the current domains in w3wp.exe</a></li>
+    <li><a href=""/LoadTest/Restart"">Restart the current AppDomain</a></li>
+    <li><a href=""/LoadTest/Recycle"">Recycle the AppPool</a></li>
+    <li><a href=""/LoadTest/Die"">Cause w3wp.exe to die</a></li>
+</ul>
+";
+
+            return ContentHtml(html);
+        }
+
+        private ActionResult EnsureInitialize()
+        {
+            if (_containerId > 0) return null;
+
+            lock (_locko)
+            {
+                if (_containerId > 0) return null;
+
+                var contentTypeService = _serviceContext.ContentTypeService;
+                var contentType = contentTypeService.Get(_contentAlias);
+                if (contentType == null)
+                    return ContentHtml("Not installed, first you must <a href=\"/LoadTest/Install\">install</a>.");
+
+                var containerType = contentTypeService.Get(_containerAlias);
+                if (containerType == null)
+                    return ContentHtml("Panic! Container type is missing.");
+
+                var contentService = _serviceContext.ContentService;
+                var container = contentService.GetPagedOfType(containerType.Id, 0, 100, out _, null).FirstOrDefault();
+                if (container == null)
+                    return ContentHtml("Panic! Container is missing.");
+
+                _containerId = container.Id;
+                return null;
+            }
+        }
+
+        public ActionResult Install()
+        {
+            var dataTypeService = _serviceContext.DataTypeService;
+
+            //var dataType = dataTypeService.GetAll(Constants.DataTypes.DefaultContentListView);
+
+
+            //if (!dict.ContainsKey("pageSize")) dict["pageSize"] = new PreValue("10");
+            //dict["pageSize"].Value = "200";
+            //dataTypeService.SavePreValues(dataType, dict);
+
+            var contentTypeService = _serviceContext.ContentTypeService;
+
+            var contentType = new ContentType(-1)
+            {
+                Alias = _contentAlias,
+                Name = "LoadTest Content",
+                Description = "Content for LoadTest",
+                Icon = "icon-document"
+            };
+            var def = _serviceContext.DataTypeService.GetDataType(_textboxDefinitionId);
+            contentType.AddPropertyType(new PropertyType(def)
+            {
+                Name = "Origin",
+                Alias = "origin",
+                Description = "The origin of the content.",
+            });
+            contentTypeService.Save(contentType);
+
+            var containerTemplate = ImportTemplate(_serviceContext,
+                 "LoadTestContainer", "LoadTestContainer", _containerTemplateText);
+
+            var containerType = new ContentType(-1)
+            {
+                Alias = _containerAlias,
+                Name = "LoadTest Container",
+                Description = "Container for LoadTest content",
+                Icon = "icon-document",
+                AllowedAsRoot = true,
+                IsContainer = true
+            };
+            containerType.AllowedContentTypes = containerType.AllowedContentTypes.Union(new[]
+            {
+                new ContentTypeSort(new Lazy<int>(() => contentType.Id), 0, contentType.Alias),
+            });
+            containerType.AllowedTemplates = containerType.AllowedTemplates.Union(new[] { containerTemplate });
+            containerType.SetDefaultTemplate(containerTemplate);
+            contentTypeService.Save(containerType);
+
+            var contentService = _serviceContext.ContentService;
+            var content = contentService.Create("LoadTestContainer", -1, _containerAlias);
+            contentService.SaveAndPublish(content);
+
+            return ContentHtml("Installed.");
+        }
+
+        public ActionResult Create(int n = 1, int r = 0, string o = null)
+        {
+            var res = EnsureInitialize();
+            if (res != null) return res;
+
+            if (r < 0) r = 0;
+            if (r > 100) r = 100;
+            var restart = GetRandom(0, 100) > (100 - r);
+
+            var contentService = _serviceContext.ContentService;
+
+            if (n < 1) n = 1;
+            if (n > _maxCreate) n = _maxCreate;
+            for (int i = 0; i < n; i++)
+            {
+                var name = Guid.NewGuid().ToString("N").ToUpper() + "-" + (restart ? "R" : "X") + "-" + o;
+                var content = contentService.Create(name, _containerId, _contentAlias);
+                content.SetValue("origin", o);
+                contentService.SaveAndPublish(content);
+            }
+
+            if (restart)
+                DoRestart();
+
+            return ContentHtml("Created " + n + " content"
+                + (restart ? ", and restarted" : "")
+                + ".");
+        }
+
+        private int GetRandom(int minValue, int maxValue)
+        {
+            lock (_locko)
+            {
+                return _random.Next(minValue, maxValue);
+            }
+        }
+
+        public ActionResult Clear()
+        {
+            var res = EnsureInitialize();
+            if (res != null) return res;
+
+            var contentType = _serviceContext.ContentTypeService.Get(_contentAlias);
+            _serviceContext.ContentService.DeleteOfType(contentType.Id);
+
+            return ContentHtml("Cleared.");
+        }
+
+        private void DoRestart()
+        {
+            HttpContext.User = null;
+            System.Web.HttpContext.Current.User = null;
+            Thread.CurrentPrincipal = null;
+            HttpRuntime.UnloadAppDomain();
+        }
+
+        public ActionResult Restart()
+        {
+            DoRestart();
+
+            return ContentHtml("Restarted.");
+        }
+
+        public ActionResult Die()
+        {
+            var timer = new System.Threading.Timer(_ =>
+            {
+                throw new Exception("die!");
+            });
+            timer.Change(100, 0);
+
+            return ContentHtml("Dying.");
+        }
+
+        public ActionResult Domains()
+        {
+            var currentDomain = AppDomain.CurrentDomain;
+            var currentName = currentDomain.FriendlyName;
+            var pos = currentName.IndexOf('-');
+            if (pos > 0) currentName = currentName.Substring(0, pos);
+
+            var text = new System.Text.StringBuilder();
+            text.Append("<div class=\"block\">Process ID: " + Process.GetCurrentProcess().Id + "</div>");
+            text.Append("<div class=\"block\">");
+            text.Append("<div>IIS Site: " + HostingEnvironment.ApplicationHost.GetSiteName() + "</div>");
+            text.Append("<div>App ID: " + currentName + "</div>");
+            //text.Append("<div>AppPool: " + Zbu.WebManagement.AppPoolHelper.GetCurrentApplicationPoolName() + "</div>");
+            text.Append("</div>");
+
+            text.Append("<div class=\"block\">Domains:<ul>");
+            text.Append("<li>Not implemented.</li>");
+            /*
+            foreach (var domain in Zbu.WebManagement.AppDomainHelper.GetAppDomains().OrderBy(x => x.Id))
+            {
+                var name = domain.FriendlyName;
+                pos = name.IndexOf('-');
+                if (pos > 0) name = name.Substring(0, pos);
+                text.Append("<li style=\""
+                    + (name != currentName ? "color: #cccccc;" : "")
+                    //+ (domain.Id == currentDomain.Id ? "" : "")
+                    + "\">"
+                    +"[" + domain.Id + "] " + name 
+                    + (domain.IsDefaultAppDomain() ? " (default)" : "") 
+                    + (domain.Id == currentDomain.Id ? " (current)" : "")
+                    + "</li>");
+            }
+            */
+            text.Append("</ul></div>");
+
+            return ContentHtml(text.ToString());
+        }
+
+        public ActionResult Recycle()
+        {
+            return ContentHtml("Not implemented&mdash;please use IIS console.");
+        }
+
+        private static Template ImportTemplate(ServiceContext svces, string name, string alias, string text, ITemplate master = null)
+        {
+            var t = new Template(name, alias) { Content = text };
+            if (master != null)
+                t.SetMasterTemplate(master);
+            svces.FileService.SaveTemplate(t);
+            return t;
+        }
+    }
+
+    public class TestComponent : IComponent
+    {
+        public void Initialize()
+        {
+            if (ConfigurationManager.AppSettings["Umbraco.TestData.Enabled"] != "true")
+                return;
+
+            RouteTable.Routes.MapRoute(
+               name: "LoadTest",
+               url: "LoadTest/{action}",
+               defaults: new
+               {
+                   controller = "LoadTest",
+                   action = "Index"
+               },
+               namespaces: new[] { "Umbraco.TestData" }
+           );
+        }
+
+        public void Terminate()
+        {
+        }
+    }
+
+    public class TestComposer : ComponentComposer<TestComponent>, IUserComposer
+    {
+        public override void Compose(Composition composition)
+        {
+            base.Compose(composition);
+
+            if (ConfigurationManager.AppSettings["Umbraco.TestData.Enabled"] != "true")
+                return;
+
+            composition.Register(typeof(LoadTestController), Lifetime.Request);
+        }
+    }
+}

--- a/src/Umbraco.TestData/Umbraco.TestData.csproj
+++ b/src/Umbraco.TestData/Umbraco.TestData.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LoadTestController.cs" />
     <Compile Include="SegmentTestController.cs" />
     <Compile Include="UmbracoTestDataController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -12,8 +12,7 @@
     <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <UseIISExpress>true</UseIISExpress>
-    <IISExpressSSLPort>
-    </IISExpressSSLPort>
+    <IISExpressSSLPort>44331</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
     <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -12,7 +12,8 @@
     <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <UseIISExpress>true</UseIISExpress>
-    <IISExpressSSLPort>44331</IISExpressSSLPort>
+    <IISExpressSSLPort>
+    </IISExpressSSLPort>
     <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
     <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
@@ -125,6 +126,10 @@
     <ProjectReference Include="..\Umbraco.ModelsBuilder.Embedded\Umbraco.ModelsBuilder.Embedded.csproj">
       <Project>{52ac0ba8-a60e-4e36-897b-e8b97a54ed1c}</Project>
       <Name>Umbraco.ModelsBuilder.Embedded</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Umbraco.TestData\Umbraco.TestData.csproj">
+      <Project>{fb5676ed-7a69-492c-b802-e7b24144c0fc}</Project>
+      <Name>Umbraco.TestData</Name>
     </ProjectReference>
     <ProjectReference Include="..\Umbraco.Web\Umbraco.Web.csproj">
       <Project>{651e1350-91b6-44b7-bd60-7207006d7003}</Project>

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -218,7 +218,7 @@ namespace Umbraco.Web.Compose
                 }
                 catch (Exception e)
                 {
-                    _logger.Error<InstructionProcessTask>("Failed (will repeat).", e);
+                    _logger.Error<InstructionProcessTask>(e, "Failed (will repeat).");
                 }
                 return true; // repeat
             }

--- a/src/Umbraco.Web/Scheduling/LogScrubber.cs
+++ b/src/Umbraco.Web/Scheduling/LogScrubber.cs
@@ -70,8 +70,7 @@ namespace Umbraco.Web.Scheduling
                 return false; // do NOT repeat, going down
             }
 
-            // running on a background task, and Log.CleanLogs uses the old SqlHelper,
-            // better wrap in a scope and ensure it's all cleaned up and nothing leaks
+            // Ensure we use an explicit scope since we are running on a background thread.
             using (var scope = _scopeProvider.CreateScope())
             using (_logger.DebugDuration<LogScrubber>("Log scrubbing executing", "Log scrubbing complete"))
             {

--- a/src/Umbraco.Web/Scheduling/ScheduledPublishing.cs
+++ b/src/Umbraco.Web/Scheduling/ScheduledPublishing.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Sync;
 
@@ -55,30 +56,24 @@ namespace Umbraco.Web.Scheduling
 
             try
             {
-                // ensure we run with an UmbracoContext, because this may run in a background task,
-                // yet developers may be using the 'current' UmbracoContext in the event handlers
-                //
-                // TODO: or maybe not, CacheRefresherComponent already ensures a context when handling events
-                // - UmbracoContext 'current' needs to be refactored and cleaned up
-                // - batched messenger should not depend on a current HttpContext
-                //    but then what should be its "scope"? could we attach it to scopes?
-                // - and we should definitively *not* have to flush it here (should be auto)
-                //
-                using (var contextReference = _umbracoContextFactory.EnsureUmbracoContext())
+                // We don't need an explicit scope here because PerformScheduledPublish creates it's own scope
+                // so it's safe as it will create it's own ambient scope.
+                // Ensure we run with an UmbracoContext, because this will run in a background task,
+                // and developers may be using the UmbracoContext in the event handlers.
+
+                using var contextReference = _umbracoContextFactory.EnsureUmbracoContext();
+                try
                 {
-                    try
-                    {
-                        // run
-                        var result = _contentService.PerformScheduledPublish(DateTime.Now);
-                        foreach (var grouped in result.GroupBy(x => x.Result))
-                            _logger.Info<ScheduledPublishing>("Scheduled publishing result: '{StatusCount}' items with status {Status}", grouped.Count(), grouped.Key);
-                    }
-                    finally
-                    {
-                        // if running on a temp context, we have to flush the messenger
-                        if (contextReference.IsRoot && Composing.Current.ServerMessenger is BatchedDatabaseServerMessenger m)
-                            m.FlushBatch();
-                    }
+                    // run
+                    var result = _contentService.PerformScheduledPublish(DateTime.Now);
+                    foreach (var grouped in result.GroupBy(x => x.Result))
+                        _logger.Info<ScheduledPublishing>("Scheduled publishing result: '{StatusCount}' items with status {Status}", grouped.Count(), grouped.Key);
+                }
+                finally
+                {
+                    // if running on a temp context, we have to flush the messenger
+                    if (contextReference.IsRoot && Composing.Current.ServerMessenger is BatchedDatabaseServerMessenger m)
+                        m.FlushBatch();
                 }
             }
             catch (Exception ex)

--- a/src/Umbraco.Web/Scheduling/SchedulerComponent.cs
+++ b/src/Umbraco.Web/Scheduling/SchedulerComponent.cs
@@ -155,7 +155,7 @@ namespace Umbraco.Web.Scheduling
             }
 
             var periodInMilliseconds = healthCheckConfig.NotificationSettings.PeriodInHours * 60 * 60 * 1000;
-            var task = new HealthCheckNotifier(_healthCheckRunner, delayInMilliseconds, periodInMilliseconds, healthChecks, notifications, _runtime, logger);
+            var task = new HealthCheckNotifier(_healthCheckRunner, delayInMilliseconds, periodInMilliseconds, healthChecks, notifications, _scopeProvider, _runtime, logger);
             _healthCheckRunner.TryAdd(task);
             return task;
         }


### PR DESCRIPTION
Details are here: https://github.com/umbraco/Umbraco-CMS/issues/8215

This should also resolve https://github.com/umbraco/Umbraco-CMS/issues/8392

* Improvements to SqlMainDomLock
  * Better management of db instances and transactions - previously this was trying to manage a single database instances which isn't what should be done, db instances should exist for a short period of time and disposed of. Changed to more explicit code for managing transactions
  * Increase polling times - though according to logs this wasn't causing problems but is still too aggressive for what it's doing
  * Don't stop listening (shut down maindom) if there are SQL exceptions, only if the appdomain has actually triggered a shutdown. We cannot just stop listening even if there are errors since it will lead to premature MainDom shutdown when the app is not actually being shutdown. This means it will just retry on the next poll. 
* Investigation into scheduled publishing lock request timeouts (also reported here #8392) which occurs around the same time as when SqlMainDomLock fails
  * The PerformScheduledPublishInternal was using yield returns with a wrapped Scope/IDisposable which is a bit hard to follow along. One issue is that we were yield returning when the Saving event was canceled for an individual item but not continuing so the logic would have proceeded anyways for that item even if that event was canceled and found other similar issues where it would actually break out of the entire process instead of skip to the next record
  * I believe one of the main issues seen with the lock request timeouts like those in #8392 and in the logs for #8215 is because the PerformScheduledPublishInternal takes a WriteLock at the very beginning of the method. This is the write lock that times out according to the stack traces. This is probably because scheduled publishing runs every minute which is actually a bit crazy to think we lock the whole content tree every minute even if we aren't writing anything. And because of that I think this may also be one of the other main suspects as to why we saw SqlMainDomLock error around the same time we see the sql lock timeout error for scheduled publishing. To fix this:
    * We need a new and much faster method: DocumentRepository.HasContentForRelease instead of only relying on the potentially expensive DocumentRepository.GetContentForRelease, similarly for GetContentForExpiration we should also have HasContentForExpiration. Then we separate the job of PerformScheduledPublishInternal into 2 parts: First, without any read or write locks just check if either HasContentForRelease or GetContentForExpiration  is true, then we can take a write lock and proceed as we are today. This will mean that there isn't a writelock on all content attempted to be made every minute.
* Don't short circuit index rebuilding if one of the populators throws an exception, continue with the other populators
* Brings our sql transient fault handling in-line with the latest specs from MS
