### PR TITLE
fix for 8192 make call to add missing bits to userdto

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -151,7 +151,7 @@ SELECT '4CountOfLockedOut' AS colName, COUNT(id) AS num FROM umbracoUser WHERE u
 UNION
 SELECT '5CountOfInvited' AS colName, COUNT(id) AS num FROM umbracoUser WHERE lastLoginDate IS NULL AND userDisabled = 1 AND invitedDate IS NOT NULL
 UNION
-SELECT '6CountOfDisabled' AS colName, COUNT(id) AS num FROM umbracoUser WHERE userDisabled = 0 AND userNoConsole = 0 AND lastLoginDate IS NULL 
+SELECT '6CountOfDisabled' AS colName, COUNT(id) AS num FROM umbracoUser WHERE userDisabled = 0 AND userNoConsole = 0 AND lastLoginDate IS NULL
 ORDER BY colName";
 
             var result = Database.Fetch<dynamic>(sql);
@@ -562,9 +562,9 @@ ORDER BY colName";
             {
                 userDto.EmailConfirmedDate = null;
                 userDto.SecurityStampToken = entity.SecurityStamp = Guid.NewGuid().ToString();
-                
+
                 changedCols.Add("emailConfirmedDate");
-                changedCols.Add("securityStampToken");  
+                changedCols.Add("securityStampToken");
             }
 
             //only update the changed cols
@@ -693,7 +693,13 @@ ORDER BY colName";
             else
                 sql.WhereNotIn<UserDto>(x => x.Id, inSql);
 
-            return ConvertFromDtos(Database.Fetch<UserDto>(sql));
+
+            var dtos = Database.Fetch<UserDto>(sql);
+
+            //adds missing bits like content and media start nodes
+            PerformGetReferencedDtos(dtos);
+
+            return ConvertFromDtos(dtos);
         }
 
         /// <summary>


### PR DESCRIPTION
Existing issue https://github.com/umbraco/Umbraco-CMS/issues/8192

### Description
Create bunch of users in umbraco and add them a group, ensure that each user is given any number of start nodes.

Then in template run following:

```
IUserService us2 = Services.UserService;

                        <ul>
                            @foreach (IUser user in us2.GetAllInGroup(3))
                            {
                                <li>@user.Name  - @user.StartContentIds.Count()</li>
                            }
                       </ul>
```

For each user the startContentIds count will be 0.  This is because the UserDto is not being hydrated with this data.  I have added extra call to hydrate, its the same call made by GetUsersById in UserService which does give correct counts for StartContentIds

This PR fixes this issue.

