### PR TITLE
WIP Option C - Compress custom properties for nucache to reduce memory consumption

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/AppSettingsNucachePropertyMapFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/AppSettingsNucachePropertyMapFactory.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    public class AppSettingsNucachePropertyMapFactory : INucachePropertyOptionsFactory
+    {
+        public NucachePropertyOptions GetNucachePropertyOptions()
+        {
+            NucachePropertyOptions options = new NucachePropertyOptions
+            {
+                PropertyMap = GetPropertyMap(),
+                LZ4CompressionLevel = K4os.Compression.LZ4.LZ4Level.L10_OPT,
+                MinimumCompressibleStringLength = null
+            };
+            return options;
+        }
+
+        public IReadOnlyDictionary<string, (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias)> GetPropertyMap()
+        {
+            var propertyMap = new Dictionary<string, (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias)>();
+            // TODO: Use xml/json/c# to define map
+            var propertyDictionarySerializerMap = ConfigurationManager.AppSettings["Umbraco.Web.PublishedCache.NuCache.PropertySerializationMap"];
+            if (!string.IsNullOrWhiteSpace(propertyDictionarySerializerMap))
+            {
+                //propertyAlias,CompressionLevel,DecompressionLevel,mappedAlias;
+                propertyDictionarySerializerMap.Split(';')
+                    .Select(x =>
+                    {
+                        var y = x.Split(',');
+                        (string alias, NucachePropertyCompressionLevel compressionLevel, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias) v = (y[0],
+                        (NucachePropertyCompressionLevel)System.Enum.Parse(typeof(NucachePropertyCompressionLevel), y[1]),
+                        (NucachePropertyDecompressionLevel)System.Enum.Parse(typeof(NucachePropertyDecompressionLevel), y[2]),
+                        y[3]
+                        );
+                        return v;
+                    })
+                    .ToList().ForEach(x => propertyMap.Add(x.alias, (x.compressionLevel, x.decompressionLevel, x.mappedAlias)));
+            }
+            return propertyMap;
+        }
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/AppSettingsNucachePropertyMapFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/AppSettingsNucachePropertyMapFactory.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    public class AppSettingsNucachePropertyMapFactory : INucachePropertyOptionsFactory
+    public class AppSettingsNuCachePropertyMapFactory : INuCachePropertyOptionsFactory
     {
-        public NucachePropertyOptions GetNucachePropertyOptions()
+        public NucachePropertyOptions GetNuCachePropertyOptions()
         {
             NucachePropertyOptions options = new NucachePropertyOptions
             {

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/AppSettingsNucachePropertyMapFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/AppSettingsNucachePropertyMapFactory.cs
@@ -9,9 +9,9 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
     public class AppSettingsNuCachePropertyMapFactory : INuCachePropertyOptionsFactory
     {
-        public NucachePropertyOptions GetNuCachePropertyOptions()
+        public NuCachePropertyOptions GetNuCachePropertyOptions()
         {
-            NucachePropertyOptions options = new NucachePropertyOptions
+            NuCachePropertyOptions options = new NuCachePropertyOptions
             {
                 PropertyMap = GetPropertyMap(),
                 LZ4CompressionLevel = K4os.Compression.LZ4.LZ4Level.L10_OPT,

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.ContentDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.ContentDataSerializer.cs
@@ -5,8 +5,17 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
     class ContentDataSerializer : ISerializer<ContentData>
     {
+        public ContentDataSerializer(IDictionaryOfPropertyDataSerializer dictionaryOfPropertyDataSerializer = null)
+        {
+            _dictionaryOfPropertyDataSerializer = dictionaryOfPropertyDataSerializer;
+            if(_dictionaryOfPropertyDataSerializer == null)
+            {
+                _dictionaryOfPropertyDataSerializer = PropertiesSerializer;
+            }
+        }
         private static readonly DictionaryOfPropertyDataSerializer PropertiesSerializer = new DictionaryOfPropertyDataSerializer();
         private static readonly DictionaryOfCultureVariationSerializer CultureVariationsSerializer = new DictionaryOfCultureVariationSerializer();
+        private readonly IDictionaryOfPropertyDataSerializer _dictionaryOfPropertyDataSerializer;
 
         public ContentData ReadFrom(Stream stream)
         {
@@ -19,7 +28,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                 VersionDate = PrimitiveSerializer.DateTime.ReadFrom(stream),
                 WriterId = PrimitiveSerializer.Int32.ReadFrom(stream),
                 TemplateId = PrimitiveSerializer.Int32.ReadFrom(stream),
-                Properties = PropertiesSerializer.ReadFrom(stream), // TODO: We don't want to allocate empty arrays
+                Properties = _dictionaryOfPropertyDataSerializer.ReadFrom(stream), // TODO: We don't want to allocate empty arrays
                 CultureInfos = CultureVariationsSerializer.ReadFrom(stream) // TODO: We don't want to allocate empty arrays
             };
         }
@@ -36,7 +45,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             {
                 PrimitiveSerializer.Int32.WriteTo(value.TemplateId.Value, stream);
             }
-            PropertiesSerializer.WriteTo(value.Properties, stream);
+            _dictionaryOfPropertyDataSerializer.WriteTo(value.Properties, stream);
             CultureVariationsSerializer.WriteTo(value.CultureInfos, stream);
         }
     }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.ContentNodeKitSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.ContentNodeKitSerializer.cs
@@ -5,7 +5,17 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
     internal class ContentNodeKitSerializer : ISerializer<ContentNodeKit>
     {
-        static readonly ContentDataSerializer DataSerializer = new ContentDataSerializer();
+        public ContentNodeKitSerializer(ContentDataSerializer contentDataSerializer = null)
+        {
+            _contentDataSerializer = contentDataSerializer;
+            if(_contentDataSerializer == null)
+            {
+                _contentDataSerializer = DefaultDataSerializer;
+            }
+        }
+        static readonly ContentDataSerializer DefaultDataSerializer = new ContentDataSerializer();
+        private readonly ContentDataSerializer _contentDataSerializer;
+
         //static readonly ListOfIntSerializer ChildContentIdsSerializer = new ListOfIntSerializer();
 
         public ContentNodeKit ReadFrom(Stream stream)
@@ -26,10 +36,10 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             };
             var hasDraft = PrimitiveSerializer.Boolean.ReadFrom(stream);
             if (hasDraft)
-                kit.DraftData = DataSerializer.ReadFrom(stream);
+                kit.DraftData = _contentDataSerializer.ReadFrom(stream);
             var hasPublished = PrimitiveSerializer.Boolean.ReadFrom(stream);
             if (hasPublished)
-                kit.PublishedData = DataSerializer.ReadFrom(stream);
+                kit.PublishedData = _contentDataSerializer.ReadFrom(stream);
             return kit;
         }
 
@@ -47,11 +57,11 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 
             PrimitiveSerializer.Boolean.WriteTo(value.DraftData != null, stream);
             if (value.DraftData != null)
-                DataSerializer.WriteTo(value.DraftData, stream);
+                _contentDataSerializer.WriteTo(value.DraftData, stream);
 
             PrimitiveSerializer.Boolean.WriteTo(value.PublishedData != null, stream);
             if (value.PublishedData != null)
-                DataSerializer.WriteTo(value.PublishedData, stream);
+                _contentDataSerializer.WriteTo(value.PublishedData, stream);
         }
     }
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.DictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.DictionaryOfPropertyDataSerializer.cs
@@ -6,7 +6,7 @@ using Umbraco.Core;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    internal class DictionaryOfPropertyDataSerializer : SerializerBase, ISerializer<IDictionary<string, PropertyData[]>>
+    internal class DictionaryOfPropertyDataSerializer : SerializerBase, ISerializer<IDictionary<string, PropertyData[]>>, IDictionaryOfPropertyDataSerializer
     {
         public IDictionary<string, PropertyData[]> ReadFrom(Stream stream)
         {

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.cs
@@ -6,10 +6,10 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
     internal class BTree
     {
-        public static BPlusTree<int, ContentNodeKit> GetTree(string filepath, bool exists)
+        public static BPlusTree<int, ContentNodeKit> GetTree(string filepath, bool exists, ContentDataSerializer contentDataSerializer = null)
         {
             var keySerializer = new PrimitiveSerializer();
-            var valueSerializer = new ContentNodeKitSerializer();
+            var valueSerializer = new ContentNodeKitSerializer(contentDataSerializer);
             var options = new BPlusTree<int, ContentNodeKit>.OptionsV2(keySerializer, valueSerializer)
             {
                 CreateFile = exists ? CreatePolicy.IfNeeded : CreatePolicy.Always,

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/IDictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/IDictionaryOfPropertyDataSerializer.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    internal interface IDictionaryOfPropertyDataSerializer
+    {
+        IDictionary<string, PropertyData[]> ReadFrom(Stream stream);
+        void WriteTo(IDictionary<string, PropertyData[]> value, Stream stream);
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/INucachePropertyOptionsFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/INucachePropertyOptionsFactory.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    public interface INucachePropertyOptionsFactory
+    public interface INuCachePropertyOptionsFactory
     {
-        NucachePropertyOptions GetNucachePropertyOptions();
+        NucachePropertyOptions GetNuCachePropertyOptions();
     }
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/INucachePropertyOptionsFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/INucachePropertyOptionsFactory.cs
@@ -8,6 +8,6 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
     public interface INuCachePropertyOptionsFactory
     {
-        NucachePropertyOptions GetNuCachePropertyOptions();
+        NuCachePropertyOptions GetNuCachePropertyOptions();
     }
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/INucachePropertyOptionsFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/INucachePropertyOptionsFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    public interface INucachePropertyOptionsFactory
+    {
+        NucachePropertyOptions GetNucachePropertyOptions();
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
@@ -8,15 +8,23 @@ using System.Threading.Tasks;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    public class LazyCompressedString
+    /// <summary>
+    /// Lazily decompresses a LZ4 Pickler compressed UTF8 string
+    /// </summary>
+    internal class LazyCompressedString
     {
         private byte[] _bytes;
         private string _str;
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="bytes">LZ4 Pickle compressed UTF8 String</param>
         public LazyCompressedString(byte[] bytes)
         {
             _bytes = bytes;
         }
+
         public override string ToString()
         {
             return LazyInitializer.EnsureInitialized(ref _str, () =>

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
@@ -1,0 +1,31 @@
+﻿using K4os.Compression.LZ4;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    public class LazyCompressedString
+    {
+        private byte[] _bytes;
+        private string _str;
+
+        public LazyCompressedString(byte[] bytes)
+        {
+            _bytes = bytes;
+        }
+        public override string ToString()
+        {
+            return LazyInitializer.EnsureInitialized(ref _str, () =>
+            {
+                var str = Encoding.UTF8.GetString(LZ4Pickler.Unpickle(_bytes));
+                _bytes = null;
+                return str;
+            });
+        }
+    }
+
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/Lz4DictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/Lz4DictionaryOfPropertyDataSerializer.cs
@@ -146,7 +146,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             }
         }
         private readonly (NucachePropertyCompressionLevel Compress, NucachePropertyDecompressionLevel decompressionLevel, string MappedAlias) DEFAULT_MAP =(NucachePropertyCompressionLevel.None, NucachePropertyDecompressionLevel.NotCompressed, null);
-        private readonly NucachePropertyOptions _nucachePropertyOptions;
+        private readonly NuCachePropertyOptions _nucachePropertyOptions;
 
         public (NucachePropertyCompressionLevel Compress, NucachePropertyDecompressionLevel decompressionLevel, string MappedAlias) GetSerializationMap(string propertyAlias)
         {

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/Lz4DictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/Lz4DictionaryOfPropertyDataSerializer.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CSharpTest.Net.Serialization;
+using Umbraco.Core;
+using System.Text;
+using K4os.Compression.LZ4;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    /// <summary>
+    /// If/where to compress custom properties for nucache
+    /// </summary>
+    public enum NucachePropertyCompressionLevel
+    {
+        None = 0,
+        SQLDatabase = 1,
+        NucacheDatabase = 2
+    }
+    /// <summary>
+    /// If/where to decompress custom properties for nucache
+    /// </summary>
+    public enum NucachePropertyDecompressionLevel
+    {
+        NotCompressed = 0,
+        Immediate = 1,
+        Lazy = 2
+    }
+
+    
+    internal class Lz4DictionaryOfPropertyDataSerializer : SerializerBase, ISerializer<IDictionary<string, PropertyData[]>>, IDictionaryOfPropertyDataSerializer
+    {
+        private readonly IReadOnlyDictionary<string, (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias)> _compressProperties;
+        private readonly LZ4Level _compressionLevel;
+        private readonly long? _minimumStringLengthForCompression;
+        private readonly IReadOnlyDictionary<string, (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias)> _uncompressProperties;
+
+
+        public Lz4DictionaryOfPropertyDataSerializer(NucachePropertyOptions nucachePropertyOptions)
+        {
+            _compressProperties = nucachePropertyOptions.PropertyMap.ToList().ToDictionary(x => string.Intern(x.Value.mappedAlias), x => (x.Value.compress,x.Value.decompressionLevel, string.Intern(x.Value.mappedAlias)));
+            _minimumStringLengthForCompression = nucachePropertyOptions.MinimumCompressibleStringLength;
+            _uncompressProperties = _compressProperties.ToList().ToDictionary(x => x.Value.mappedAlias, x => (x.Value.compress, x.Value.decompressionLevel, x.Value.mappedAlias));
+
+            _compressionLevel = nucachePropertyOptions.LZ4CompressionLevel;
+        }
+       
+
+        public IDictionary<string, PropertyData[]> ReadFrom(Stream stream)
+        {
+            var dict = new Dictionary<string, PropertyData[]>(StringComparer.InvariantCultureIgnoreCase);
+
+            // read properties count
+            var pcount = PrimitiveSerializer.Int32.ReadFrom(stream);
+
+            // read each property
+            for (var i = 0; i < pcount; i++)
+            {
+
+                // read property alias
+                var alias = PrimitiveSerializer.String.ReadFrom(stream);
+                var map = GetDeSerializationMap(alias);
+                var key = string.Intern(map.MappedAlias ?? alias);
+
+                // read values count
+                var vcount = PrimitiveSerializer.Int32.ReadFrom(stream);
+
+                // create pdata and add to the dictionary
+                var pdatas = new List<PropertyData>();
+
+                // for each value, read and add to pdata
+                for (var j = 0; j < vcount; j++)
+                {
+                    var pdata = new PropertyData();
+                    pdatas.Add(pdata);
+
+                    // everything that can be null is read/written as object
+                    //  even though - culture and segment should never be null here, as 'null' represents
+                    //  the 'current' value, and string.Empty should be used to represent the invariant or
+                    //  neutral values - PropertyData throws when getting nulls, so falling back to
+                    //  string.Empty here - what else?
+                    pdata.Culture = ReadStringObject(stream, true) ?? string.Empty;
+                    pdata.Segment = ReadStringObject(stream, true) ?? string.Empty;
+                    pdata.Value = ReadObject(stream);
+
+                    var decompressionLevel = NucachePropertyDecompressionLevel.Immediate;
+                    if ((map.Compress.Equals(NucachePropertyCompressionLevel.NucacheDatabase) || map.Compress.Equals(NucachePropertyCompressionLevel.SQLDatabase))
+                        && pdata.Value != null && pdata.Value is byte[] byteArrayValue)
+                    {
+                        //Compressed string
+                        switch (decompressionLevel)
+                        {
+                            case NucachePropertyDecompressionLevel.Lazy:
+                                pdata.Value = new LazyCompressedString(byteArrayValue);
+                                break;
+                            case NucachePropertyDecompressionLevel.NotCompressed:
+                                break;//Shouldn't be any not compressed
+                            case NucachePropertyDecompressionLevel.Immediate:
+                            default:
+                                pdata.Value = Encoding.UTF8.GetString(LZ4Pickler.Unpickle(byteArrayValue));
+                                break;
+                        }
+                    }
+                }
+
+                dict[key] = pdatas.ToArray();
+            }
+            return dict;
+        }
+
+        public void WriteTo(IDictionary<string, PropertyData[]> value, Stream stream)
+        {
+            // write properties count
+            PrimitiveSerializer.Int32.WriteTo(value.Count, stream);
+
+            // write each property
+            foreach (var (alias, values) in value)
+            {
+                var map = GetSerializationMap(alias);
+
+                // write alias
+                PrimitiveSerializer.String.WriteTo(map.MappedAlias ?? alias, stream);
+
+                // write values count
+                PrimitiveSerializer.Int32.WriteTo(values.Length, stream);
+
+                // write each value
+                foreach (var pdata in values)
+                {
+                    // everything that can be null is read/written as object
+                    //  even though - culture and segment should never be null here,
+                    //  see note in ReadFrom() method above
+                    WriteObject(pdata.Culture ?? string.Empty, stream);
+                    WriteObject(pdata.Segment ?? string.Empty, stream);
+
+                    //Only compress strings
+                    if (pdata.Value is string stringValue && pdata.Value != null && map.Compress.Equals(NucachePropertyCompressionLevel.NucacheDatabase)
+                        && (_minimumStringLengthForCompression == null
+                        || !_minimumStringLengthForCompression.HasValue
+                        || stringValue.Length > _minimumStringLengthForCompression.Value))
+                    {
+                        var stringBytes = Encoding.UTF8.GetBytes(stringValue);
+                        var compressedBytes = LZ4Pickler.Pickle(stringBytes, _compressionLevel);
+                        WriteObject(compressedBytes, stream);
+                    }
+                    WriteObject(pdata.Value, stream);
+                }
+            }
+        }
+        private readonly (NucachePropertyCompressionLevel Compress, NucachePropertyDecompressionLevel decompressionLevel, string MappedAlias) DEFAULT_MAP =(NucachePropertyCompressionLevel.None, NucachePropertyDecompressionLevel.NotCompressed, null);
+        public (NucachePropertyCompressionLevel Compress, NucachePropertyDecompressionLevel decompressionLevel, string MappedAlias) GetSerializationMap(string propertyAlias)
+        {
+            if (_compressProperties == null)
+            {
+                return DEFAULT_MAP;
+            }
+            if (_compressProperties.TryGetValue(propertyAlias, out (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias) map))
+            {
+                return map;
+            }
+
+            return DEFAULT_MAP;
+        }
+        public (NucachePropertyCompressionLevel Compress, NucachePropertyDecompressionLevel decompressionLevel, string MappedAlias) GetDeSerializationMap(string propertyAlias)
+        {
+            if (_uncompressProperties == null)
+            {
+                return DEFAULT_MAP;
+            }
+            if (_uncompressProperties.TryGetValue(propertyAlias, out (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias) map))
+            {
+                return map;
+            }
+            return DEFAULT_MAP;
+        }
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/Lz4DictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/Lz4DictionaryOfPropertyDataSerializer.cs
@@ -39,9 +39,9 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 
         public Lz4DictionaryOfPropertyDataSerializer(NucachePropertyOptions nucachePropertyOptions)
         {
-            _compressProperties = nucachePropertyOptions.PropertyMap.ToList().ToDictionary(x => string.Intern(x.Value.mappedAlias), x => (x.Value.compress,x.Value.decompressionLevel, string.Intern(x.Value.mappedAlias)));
+            _compressProperties = nucachePropertyOptions.PropertyMap.ToList().ToDictionary(x => string.Intern(x.Key), x => (x.Value.compress,x.Value.decompressionLevel, string.Intern(x.Value.mappedAlias)));
             _minimumStringLengthForCompression = nucachePropertyOptions.MinimumCompressibleStringLength;
-            _uncompressProperties = _compressProperties.ToList().ToDictionary(x => x.Value.mappedAlias, x => (x.Value.compress, x.Value.decompressionLevel, x.Value.mappedAlias));
+            _uncompressProperties = _compressProperties.ToList().ToDictionary(x => x.Value.mappedAlias, x => (x.Value.compress, x.Value.decompressionLevel, x.Key));
 
             _compressionLevel = nucachePropertyOptions.LZ4CompressionLevel;
         }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         private MessagePackSerializerOptions _options;
         private readonly NucachePropertyOptions _propertyOptions;
 
-        public MsgPackContentNestedDataSerializer(NucachePropertyOptions propertyOptions = null)
+        public MsgPackContentNestedDataSerializer(INuCachePropertyOptionsFactory propertyOptionsFactory = null)
         {
             var defaultOptions = ContractlessStandardResolver.Options;
 
@@ -34,7 +34,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             _options = defaultOptions
                 .WithResolver(resolver)
                 .WithCompression(MessagePackCompression.Lz4BlockArray);
-            _propertyOptions = propertyOptions ?? new NucachePropertyOptions();
+            _propertyOptions = propertyOptionsFactory?.GetNuCachePropertyOptions() ?? new NucachePropertyOptions();
         }
 
         public string ToJson(string serialized)

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
     internal class MsgPackContentNestedDataSerializer : IContentNestedDataByteSerializer
     {
         private MessagePackSerializerOptions _options;
-        private readonly NucachePropertyOptions _propertyOptions;
+        private readonly NuCachePropertyOptions _propertyOptions;
 
         public MsgPackContentNestedDataSerializer(INuCachePropertyOptionsFactory propertyOptionsFactory = null)
         {
@@ -34,7 +34,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             _options = defaultOptions
                 .WithResolver(resolver)
                 .WithCompression(MessagePackCompression.Lz4BlockArray);
-            _propertyOptions = propertyOptionsFactory?.GetNuCachePropertyOptions() ?? new NucachePropertyOptions();
+            _propertyOptions = propertyOptionsFactory?.GetNuCachePropertyOptions() ?? new NuCachePropertyOptions();
         }
 
         public string ToJson(string serialized)

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/NucachePropertyOptions.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/NucachePropertyOptions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    public class NucachePropertyOptions
+    public class NuCachePropertyOptions
     {
         public IReadOnlyDictionary<string, (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel,
             string mappedAlias)> PropertyMap

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/NucachePropertyOptions.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/NucachePropertyOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    public class NucachePropertyOptions
+    {
+        public IReadOnlyDictionary<string, (NucachePropertyCompressionLevel compress, NucachePropertyDecompressionLevel decompressionLevel,
+            string mappedAlias)> PropertyMap
+        { get; set; } = new Dictionary<string, (NucachePropertyCompressionLevel compress,
+                NucachePropertyDecompressionLevel decompressionLevel, string mappedAlias)>();
+
+        public K4os.Compression.LZ4.LZ4Level LZ4CompressionLevel { get; set; } = K4os.Compression.LZ4.LZ4Level.L00_FAST;
+
+        public long? MinimumCompressibleStringLength { get; set; }
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
@@ -14,13 +14,14 @@ namespace Umbraco.Web.PublishedCache.NuCache
             base.Compose(composition);
 
             var serializer = ConfigurationManager.AppSettings["Umbraco.Web.PublishedCache.NuCache.Serializer"];
-
+            composition.Register<INuCachePropertyOptionsFactory, AppSettingsNuCachePropertyMapFactory>();
+            composition.Register<Lz4DictionaryOfPropertyDataSerializer, Lz4DictionaryOfPropertyDataSerializer>();
             if (serializer == "MsgPack")
             {
                 var propertyDictionarySerializer = ConfigurationManager.AppSettings["Umbraco.Web.PublishedCache.NuCache.DictionaryOfPropertiesSerializer"];
                 if (propertyDictionarySerializer == "LZ4Map")
                 {
-                    composition.Register<INucachePropertyOptionsFactory, AppSettingsNucachePropertyMapFactory>();
+                    
                     composition.Register(factory =>
                     {
                         var lz4Serializer = factory.GetInstance<Lz4DictionaryOfPropertyDataSerializer>();

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         private readonly IDefaultCultureAccessor _defaultCultureAccessor;
         private readonly UrlSegmentProviderCollection _urlSegmentProviders;
         private readonly IContentNestedDataSerializer _contentNestedDataSerializer;
+        private readonly ContentDataSerializer _contentDataSerializer;
 
         // volatile because we read it with no lock
         private volatile bool _isReady;
@@ -83,7 +84,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             IDataSource dataSource, IGlobalSettings globalSettings,
             IEntityXmlSerializer entitySerializer,
             IPublishedModelFactory publishedModelFactory,
-            UrlSegmentProviderCollection urlSegmentProviders, IContentNestedDataSerializer contentNestedDataSerializer)
+            UrlSegmentProviderCollection urlSegmentProviders, IContentNestedDataSerializer contentNestedDataSerializer, ContentDataSerializer contentDataSerializer = null)
             : base(publishedSnapshotAccessor, variationContextAccessor)
         {
             //if (Interlocked.Increment(ref _singletonCheck) > 1)
@@ -101,6 +102,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             _globalSettings = globalSettings;
             _urlSegmentProviders = urlSegmentProviders;
             _contentNestedDataSerializer = contentNestedDataSerializer;
+            _contentDataSerializer = contentDataSerializer;
 
             // we need an Xml serializer here so that the member cache can support XPath,
             // for members this is done by navigating the serialized-to-xml member
@@ -182,8 +184,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
             _localMediaDbExists = File.Exists(localMediaDbPath);
 
             // if both local databases exist then GetTree will open them, else new databases will be created
-            _localContentDb = BTree.GetTree(localContentDbPath, _localContentDbExists);
-            _localMediaDb = BTree.GetTree(localMediaDbPath, _localMediaDbExists);
+            _localContentDb = BTree.GetTree(localContentDbPath, _localContentDbExists, _contentDataSerializer);
+            _localMediaDb = BTree.GetTree(localMediaDbPath, _localMediaDbExists, _contentDataSerializer);
 
             _logger.Info<PublishedSnapshotService>("Registered with MainDom, localContentDbExists? {LocalContentDbExists}, localMediaDbExists? {LocalMediaDbExists}", _localContentDbExists, _localMediaDbExists);
         }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -254,12 +254,12 @@
     <Compile Include="PublishedCache\NuCache\DataSource\AppSettingsNuCachePropertyMapFactory.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\IContentNestedDataSerializer.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\IDictionaryOfPropertyDataSerializer.cs" />
-    <Compile Include="PublishedCache\NuCache\DataSource\INucachePropertyOptionsFactory.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\INuCachePropertyOptionsFactory.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\JsonContentNestedDataSerializer.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\LazyCompressedString.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\MsgPackContentNestedDataSerializer.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\Lz4DictionaryOfPropertyDataSerializer.cs" />
-    <Compile Include="PublishedCache\NuCache\DataSource\NucachePropertyOptions.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\NuCachePropertyOptions.cs" />
     <Compile Include="PublishedCache\NuCache\PublishedSnapshotServiceOptions.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenObj.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenRef.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -251,7 +251,7 @@
     <Compile Include="Compose\NestedContentPropertyComposer.cs" />
     <Compile Include="PropertyEditors\ParameterEditors\MultipleMediaPickerParameterEditor.cs" />
     <Compile Include="PropertyEditors\RichTextEditorPastedImages.cs" />
-    <Compile Include="PublishedCache\NuCache\DataSource\AppSettingsNucachePropertyMapFactory.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\AppSettingsNuCachePropertyMapFactory.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\IContentNestedDataSerializer.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\IDictionaryOfPropertyDataSerializer.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\INucachePropertyOptionsFactory.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -68,6 +68,9 @@
     <PackageReference Include="ImageProcessor">
       <Version>2.7.0.100</Version>
     </PackageReference>
+    <PackageReference Include="K4os.Compression.LZ4">
+      <Version>1.1.11</Version>
+    </PackageReference>
     <PackageReference Include="LightInject" Version="5.4.0" />
     <PackageReference Include="LightInject.Annotation" Version="1.1.0" />
     <PackageReference Include="LightInject.Mvc" Version="2.0.0" />
@@ -248,9 +251,15 @@
     <Compile Include="Compose\NestedContentPropertyComposer.cs" />
     <Compile Include="PropertyEditors\ParameterEditors\MultipleMediaPickerParameterEditor.cs" />
     <Compile Include="PropertyEditors\RichTextEditorPastedImages.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\AppSettingsNucachePropertyMapFactory.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\IContentNestedDataSerializer.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\IDictionaryOfPropertyDataSerializer.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\INucachePropertyOptionsFactory.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\JsonContentNestedDataSerializer.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\LazyCompressedString.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\MsgPackContentNestedDataSerializer.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\Lz4DictionaryOfPropertyDataSerializer.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\NucachePropertyOptions.cs" />
     <Compile Include="PublishedCache\NuCache\PublishedSnapshotServiceOptions.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenObj.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenRef.cs" />

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -58,8 +58,24 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web.UI.Client", "ht
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest\", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
 	ProjectSection(WebsiteProperties) = preProject
+		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
+		Debug.AspNetCompiler.VirtualPath = "/localhost_49800"
+		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
+		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
+		Debug.AspNetCompiler.Updateable = "true"
+		Debug.AspNetCompiler.ForceOverwrite = "true"
+		Debug.AspNetCompiler.FixedNames = "false"
+		Debug.AspNetCompiler.Debug = "True"
+		Release.AspNetCompiler.VirtualPath = "/localhost_49800"
+		Release.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
+		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
+		Release.AspNetCompiler.Updateable = "true"
+		Release.AspNetCompiler.ForceOverwrite = "true"
+		Release.AspNetCompiler.FixedNames = "false"
+		Release.AspNetCompiler.Debug = "False"
+		VWDPort = "49800"
 		SlnRelativePath = "Umbraco.Tests.AcceptanceTest\"
 	EndProjectSection
 EndProject
@@ -123,6 +139,10 @@ Global
 		{4C4C194C-B5E4-4991-8F87-4373E24CC19F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -157,6 +177,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{227C3B55-80E5-4E7E-A802-BE16C5128B9D} = {2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{5D3B8245-ADA6-453F-A008-50ED04BFE770} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{E3F9F378-AFE1-40A5-90BD-82833375DBFE} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
 		{5B03EF4E-E0AC-4905-861B-8C3EC1A0D458} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
@@ -164,7 +185,6 @@ Global
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -58,24 +58,8 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web.UI.Client", "ht
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest\", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
 	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_49800"
-		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_49800"
-		Release.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_49800\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "49800"
 		SlnRelativePath = "Umbraco.Tests.AcceptanceTest\"
 	EndProjectSection
 EndProject
@@ -139,10 +123,6 @@ Global
 		{4C4C194C-B5E4-4991-8F87-4373E24CC19F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -177,7 +157,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{227C3B55-80E5-4E7E-A802-BE16C5128B9D} = {2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{5D3B8245-ADA6-453F-A008-50ED04BFE770} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{E3F9F378-AFE1-40A5-90BD-82833375DBFE} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
 		{5B03EF4E-E0AC-4905-861B-8C3EC1A0D458} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
@@ -185,6 +164,7 @@ Global
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}


### PR DESCRIPTION
### Prerequisites

- [x ] I have added steps to test this contribution in the description below

RE: https://github.com/umbraco/Umbraco-CMS/pull/8365

### Description
What?
Compress custom properties at cmsContentNu table level or nucache.db level.
Decompress properties when reading the property from nucache.db or lazily when the property is read / converted.
Map property alias to a shorter key in nucache

Why?
Reduce memory consumption by keeping large string / rich text properties compressed till read.

TODO: Update propertyconverterbase logic for IsValue and HasValue as these check for strings which may not work with lazy decompression.
TODO: Configuration per property editor / per property.

How to test:
Enable MessagePack Nucache Serializer
`<add key="Umbraco.Web.PublishedCache.NuCache.Serializer" value="MsgPack"/>
`
Enable LZ4 DictionaryOfPropertiesSerializer
`<add key="Umbraco.Web.PublishedCache.NuCache.DictionaryOfPropertiesSerializer" value="LZ4Map"/>`

Configure Map
Format:
`<add key="Umbraco.Web.PublishedCache.NuCache.PropertySerializationMap" value="{propertyAlias},{NucachePropertyCompressionLevel},{NucachePropertyDecompressionLevel},{shorterPropertyAlias};{propertyAlias2},{NucachePropertyCompressionLevel2},{NucachePropertyDecompressionLevel2}{shorterPropertyAlias2};"/>`

Example:
Compress richText1 in cmsContentNu table, Lazy decompression when property read, shorten property key to rte1.
Compress textString2 in nuCache.db, Immediately decompress property when deserialized, don't change property key.
Don't compress/decompress umbracoNaviHide, shorten property key to unh.

`<add key="Umbraco.Web.PublishedCache.NuCache.PropertySerializationMap" value="richText1,SQLDatabase,Lazy,rte1;textString2,NucacheDatabase,Immediate,textString2;umbracoNaviHide,None,NotCompressed,unh"/>`

Rebuild nucache

