### PR TITLE
Fix translations files including icon HTML

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -4,10 +4,6 @@
     <name>The Umbraco community</name>
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
-  <!--???-->
-  <!-- = unklar-->
-  <!--!!!-->
-  <!-- = ToDo-->
   <area alias="actions">
     <key alias="assignDomain">Kulturen und Hostnamen</key>
     <key alias="auditTrail">Protokoll</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -923,7 +923,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="insertControl">Item toevoegen</key>
     <key alias="chooseLayout">Kies de indeling</key>
     <key alias="addRows">Kies een indeling voor deze pagina om content toe te kunnen voegen</key>
-    <key alias="addElement"><![CDATA[<i class="icon icon-add blue"></i> Plaats een (extra) content blok]]></key>
+    <key alias="addElement">Plaats een (extra) content blok</key>
     <key alias="dropElement">Drop content</key>
     <key alias="settingsApplied">Instellingen toegepast</key>
     <key alias="contentNotAllowed">Deze content is hier niet toegestaan</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -796,7 +796,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="macro">Macro</key>
     <key alias="insertControl">Insert control</key>
     <key alias="addRows">Choose a layout for the page</key>
-    <key alias="addElement"><![CDATA[To start, click the <i class="icon icon-add blue"></i> below and add your first element]]></key>
+    <key alias="addElement">Add content</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
     <key alias="placeholderImageCaption">Image caption...</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8405

### Description
A few translation files included icon HTML for a translation key using for Nested Content add button and also in overlay title. No other languages than `nl` and `tr` did include this.

In general I think HTML should be avoided when possible in translations, since we just want the raw translation and when people contribute with translations they often only make changes to a few languages - not all of them.

This should probably be cherry picked in `v8/8.6`