### PR TITLE
Remove unnecessary translation to removed variable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
@@ -34,10 +34,6 @@
 
         function init() {
 
-            localizationService.localize("contentTypeEditor_chooseChildNode").then(function(value){
-                childNodeSelectorOverlayTitle = value;
-            });
-
             contentTypeResource.getAll().then(function(contentTypes){
                 vm.contentTypes = _.where(contentTypes, {isElement: false});
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment in `v8/contrib` branch there a console error when navigating to a document type.

![chrome_2020-07-10_00-01-09](https://user-images.githubusercontent.com/2919859/87095577-4389f980-c241-11ea-8433-00edb95b60bb.png)

It happens because it assign a translated value to a undefined variable and when merging PR https://github.com/umbraco/Umbraco-CMS/pull/8045

and merging with latest changes in this commit: https://github.com/umbraco/Umbraco-CMS/pull/8045/commits/2e0504e00c4ca0da81996d043646a6d76a97c57c

However PR https://github.com/umbraco/Umbraco-CMS/pull/8045 removed the variable `childNodeSelectorOverlayTitle` since it isn't necessary and the translation happens here https://github.com/umbraco/Umbraco-CMS/pull/8045/files#diff-87fde30a6a97c0d78ed91c4470bc78cdR84-R87