### PR TITLE
Allow editor info to shrink for longer datatype names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -523,7 +523,7 @@ input.umb-group-builder__group-sort-value {
     }
 
     .editor-info {
-        flex: 1 0 auto;
+        flex: 1 1 auto;
         text-align: left;
         display: flex;
         align-items: center;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In property settings overlay when datatype has a longer name the editor info need to shrink, so it doesn't push the remove button out of screen real estate.

**Before**

![image](https://user-images.githubusercontent.com/2919859/87097363-51417e00-c245-11ea-92df-c4c37d061985.png)


After

![image](https://user-images.githubusercontent.com/2919859/87097215-f7d94f00-c244-11ea-80c7-f19a28e01eaf.png)
