### PR TITLE
Align group builder property actions to top

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -347,12 +347,11 @@ input.umb-group-builder__group-title-input:disabled:hover {
 .umb-group-builder__property-actions {
     flex: 0 0 44px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: flex-end;
 }
 
 .umb-group-builder__property-action {
-    
     position: relative;
     margin: 5px 0;
     


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR align the property actions to top in the group builder instead of centered. In might work okay with these centered, but if adding a longer description, it push down these actions.
It seems nicer to have these at same position next to the property editor preview.

**Before**

![image](https://user-images.githubusercontent.com/2919859/87098024-aa5de180-c246-11ea-8f46-2ef5418f63de.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/87097744-26a3f500-c246-11ea-85aa-bd28cf7f06d1.png)

