### PR TITLE
#8412 Set ng-maxlength and maxlength attributes on the tag input 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
@@ -26,6 +26,8 @@
                    ng-model="vm.tagToAdd"
                    ng-keydown="vm.addTagOnEnter($event)"
                    ng-blur="vm.addTag()"
+                   ng-maxlength="200"
+                   maxlength="200"
                    localize="placeholder"
                    placeholder="@placeholders_enterTags" />
 


### PR DESCRIPTION
...on umb-tags-editor.html to avoid a string or binary data would be truncated error when the entered tag exceeds the database column length

This fixes https://github.com/umbraco/Umbraco-CMS/issues/8412

### Description

Sets max length on the tag input
To test this, set up a blank site, paste a tag longer than 200 characters in the tag picker
It will be truncated in the UI
Prior to this fix it would throw a server error on save & publish


<!-- Thanks for contributing to Umbraco CMS! -->
