### PR TITLE
Sort on y-axis in sort dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
@@ -11,6 +11,8 @@
         vm.saveButtonState = "init";
         vm.sortOrder = {};
         vm.sortableOptions = {
+            axis: "y",
+            containment: "parent",
             distance: 10,
             tolerance: "pointer",
             opacity: 0.7,
@@ -68,7 +70,7 @@
 
         function sort(column) {
             // reverse if it is already ordered by that column
-            if(vm.sortOrder.column === column) {
+            if (vm.sortOrder.column === column) {
                 vm.sortOrder.reverse = !vm.sortOrder.reverse
             } else {
                 vm.sortOrder.column = column;
@@ -82,7 +84,6 @@
         }
 
         onInit();
-
     }
 
     angular.module("umbraco").controller("Umbraco.Editors.Content.SortController", ContentSortController);

--- a/src/Umbraco.Web.UI.Client/src/views/content/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/sort.html
@@ -33,7 +33,7 @@
                                             <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                             <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
                                         </span>
-                                    </a>
+                                    </button>
                                 </th>
                             </tr>
                         </thead>

--- a/src/Umbraco.Web.UI.Client/src/views/content/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/sort.html
@@ -21,8 +21,7 @@
                                     <button type="button" class="btn-reset" ng-click="vm.sort('name')">
                                         <strong><localize key="general_name">Name</localize></strong>
                                         <span ng-if="vm.sortOrder.column === 'name'" aria-hidden="true">
-                                            <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
-                                            <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
+                                            <i ng-class="{ 'icon-navigation-up': vm.sortOrder.reverse, 'icon-navigation-down': !vm.sortOrder.reverse }"></i>
                                         </span>
                                     </button>
                                 </th>
@@ -30,8 +29,7 @@
                                     <button type="button" class="btn-reset" ng-click="vm.sort('createDate')">
                                         <strong><localize key="sort_sortCreationDate">Creation date</localize></strong>
                                         <span ng-if="vm.sortOrder.column === 'createDate'" aria-hidden="true">
-                                            <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
-                                            <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
+                                            <i ng-class="{ 'icon-navigation-up': vm.sortOrder.reverse, 'icon-navigation-down': !vm.sortOrder.reverse }"></i>
                                         </span>
                                     </button>
                                 </th>

--- a/src/Umbraco.Web.UI.Client/src/views/content/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/sort.html
@@ -19,7 +19,7 @@
                             <tr>
                                 <th colspan="2">
                                     <button type="button" class="btn-reset" ng-click="vm.sort('name')">
-                                        <b><localize key="general_name">Name</localize></b>
+                                        <strong><localize key="general_name">Name</localize></strong>
                                         <span ng-if="vm.sortOrder.column === 'name'" aria-hidden="true">
                                             <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                             <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
@@ -28,7 +28,7 @@
                                 </th>
                                 <th>
                                     <button type="button" class="btn-reset" ng-click="vm.sort('createDate')">
-                                        <b><localize key="sort_sortCreationDate">Creation date</localize></b>
+                                        <strong><localize key="sort_sortCreationDate">Creation date</localize></strong>
                                         <span ng-if="vm.sortOrder.column === 'createDate'" aria-hidden="true">
                                             <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                             <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR restrict the sorting to y-axis in sort dialog and within parent element.
Furthermore if remove unnecessary use of `ng-if` and use `ng-class` to toggle asc/desc sort icon instead.

One of the button elements also had a wrong end-closing tag, so fixed that as well.

![2020-07-11_12-27-49](https://user-images.githubusercontent.com/2919859/87222179-05d8be00-c372-11ea-83bb-9e6934d9a7f7.gif)
