### PR TITLE
Update 'default value' title + description of CheckBox Configuration

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class TrueFalseConfiguration
     {
-        [ConfigurationField("default","Initial State", "boolean",Description = "The initial state for the checkbox, when this is displayed in the backoffice for the first time. NB changing this initial value does not alter the value on existing published content items.")]
+        [ConfigurationField("default","Initial State", "boolean",Description = "The initial state for this checkbox, when it is displayed for the first time in the backoffice, eg. for a new content item.")]
         public string Default { get; set; } // TODO: well, true or false?!
 
         [ConfigurationField("labelOn", "Write a label text", "textstring")]

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class TrueFalseConfiguration
     {
-        [ConfigurationField("default", "Default Value", "boolean")]
+        [ConfigurationField("default","Initial State", "boolean",Description = "The initial state for the checkbox, when this is displayed in the backoffice for the first time. NB changing this initial value does not alter the value on existing published content items.")]
         public string Default { get; set; } // TODO: well, true or false?!
 
         [ConfigurationField("labelOn", "Write a label text", "textstring")]


### PR DESCRIPTION
See Issue: https://github.com/umbraco/Umbraco-CMS/issues/8420 for the explanation of the misconception.

This PR just updates the text of the Checkbox Configuration option to change 'Default Value' To 'Initial State' to try to avoid misconceptions that this option is some kind of 'fall back default value' in code.

![image](https://user-images.githubusercontent.com/260802/87222768-9c0ae500-c36e-11ea-84ee-690670996ccb.png)

Thanks for considering this contribution to Umbraco CMS!
