### PR TITLE
Sort on y-axis in listview config layouts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -1,5 +1,5 @@
 <label class="checkbox umb-form-check umb-form-check--checkbox {{vm.cssClass}}" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
-    <div class="umb-form-check__symbol">
+    <span class="umb-form-check__symbol">
         <input ng-if="vm.disableDirtyCheck"
             type="checkbox"
             id="{{vm.inputId}}"
@@ -13,29 +13,29 @@
             ng-change="vm.change()"
             no-dirty-check />
 
-            <input ng-if="!vm.disableDirtyCheck"
-                type="checkbox"
-                id="{{vm.inputId}}"
-                name="{{vm.name}}"
-                value="{{vm.value}}"
-                class="umb-form-check__input"
-                val-server-field="{{vm.serverValidationField}}"
-                ng-model="vm.model"
-                ng-disabled="vm.disabled"
-                ng-required="vm.required"
-                ng-change="vm.change()"/>
+        <input ng-if="!vm.disableDirtyCheck"
+            type="checkbox"
+            id="{{vm.inputId}}"
+            name="{{vm.name}}"
+            value="{{vm.value}}"
+            class="umb-form-check__input"
+            val-server-field="{{vm.serverValidationField}}"
+            ng-model="vm.model"
+            ng-disabled="vm.disabled"
+            ng-required="vm.required"
+            ng-change="vm.change()"/>
 
         <span class="umb-form-check__state" aria-hidden="true">
             <span class="umb-form-check__check">
                 <i class="umb-form-check__icon icon-check"></i>
             </span>
         </span>
-    </div>
-    <div class="umb-form-check__info" ng-transclude>
+    </span>
+    <span class="umb-form-check__info" ng-transclude>
 
         <i ng-if="vm.iconClass.length" class="{{vm.iconClass}}" aria-hidden="true"></i>
 
         <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
 
-    </div>
+    </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -1,5 +1,5 @@
 <label class="radio umb-form-check umb-form-check--radiobutton" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
-    <div class="umb-form-check__symbol">
+    <span class="umb-form-check__symbol">
         <input type="radio"
             id="{{vm.inputId}}"
             name="{{vm.name}}"
@@ -13,8 +13,8 @@
         <span class="umb-form-check__state" aria-hidden="true">
             <span class="umb-form-check__check"></span>
         </span>
-    </div>
-    <div class="umb-form-check__info" ng-transclude>
+    </span>
+    <span class="umb-form-check__info" ng-transclude>
         <span class="umb-form-check__text">{{vm.text}}</span>
-    </div>
+    </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -52,7 +52,9 @@
                         </ng-form>
                     </td>
                     <td>
-                        <button type="button" class="btn-icon icon-trash" ng-click="removeField(val)" aria-label="Remove"></button>
+                        <button type="button" class="btn-icon" ng-click="removeField(val)" aria-label="Remove">
+                            <i class="icon-trash" aria-hidden="true"></i>
+                        </button>
                     </td>
                 </tr>
             </tbody>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -25,7 +25,7 @@
             <tbody ui-sortable="sortableOptions" ng-model="model.value">
                 <tr ng-repeat="val in model.value">
                     <td>
-                        <i class="icon icon-navigation handle"></i>
+                        <i class="icon icon-navigation handle" aria-hidden="true" aria-label="Sort"></i>
                     </td>
                     <td>
                        <div class="list-view-layout__name flex-column content-start">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.controller.js
@@ -15,6 +15,8 @@
       vm.focusLayoutName = false;
 
       vm.layoutsSortableOptions = {
+         axis: "y",
+         containment: "parent",
          distance: 10,
          tolerance: "pointer",
          opacity: 0.7,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.controller.js
@@ -43,7 +43,6 @@
          };
 
          $scope.model.value.push(layout);
-
       }
 
       function showPrompt(layout) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -31,7 +31,8 @@
                </div>
 
                <div>
-                   <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected" />
+                   <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected"></umb-checkbox>
+
                    <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
                        <i class="icon-trash" ng-click="vm.showPrompt(layout)" aria-hidden="true"></i>
                        <umb-confirm-action ng-if="layout.deletePrompt"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -4,16 +4,16 @@
 
       <div class="list-view-layout" ng-repeat="layout in model.value">
 
-         <i class="icon-navigation list-view-layout__sort-handle" aria-label="Sort"></i>
+         <i class="icon-navigation list-view-layout__sort-handle" aria-hidden="true" aria-label="Sort"></i>
 
          <div>
 
             <button ng-if="layout.isSystem !== 1" type="button" ng-click="vm.openIconPicker(layout)" class="list-view-layout__icon" umb-auto-focus>
-               <i class="{{ layout.icon }}"></i>
+               <i class="{{ layout.icon }}" aria-hidden="true"></i>
             </button>
 
             <div ng-if="layout.isSystem === 1" class="list-view-layout__icon">
-               <i class="{{ layout.icon }}"></i>
+               <i class="{{ layout.icon }}" aria-hidden="true"></i>
             </div>
 
          </div>
@@ -31,7 +31,7 @@
          <div>
            <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected" /> 
             <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
-                <i class="icon-trash" ng-click="vm.showPrompt(layout)"></i>
+                <i class="icon-trash" ng-click="vm.showPrompt(layout)" aria-hidden="true"></i>
                 <umb-confirm-action
                     ng-if="layout.deletePrompt"
                     direction="left"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -34,7 +34,9 @@
                    <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected"></umb-checkbox>
 
                    <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
-                       <i class="icon-trash" ng-click="vm.showPrompt(layout)" aria-hidden="true"></i>
+                       <button type="button" class="btn-icon" ng-click="vm.showPrompt(layout)" aria-label="Remove">
+                           <i class="icon-trash" aria-hidden="true"></i>
+                       </button>
                        <umb-confirm-action ng-if="layout.deletePrompt"
                                            direction="left"
                                            on-confirm="vm.removeLayout($index, layout)"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -1,47 +1,50 @@
 <div ng-controller="Umbraco.PrevalueEditors.ListViewLayoutsPreValsController as vm">
 
-   <div class="list-view-layouts" ui-sortable="vm.layoutsSortableOptions" ng-model="model.value">
+   <div class="list-view-layouts">
 
-      <div class="list-view-layout" ng-repeat="layout in model.value">
+       <div ui-sortable="vm.layoutsSortableOptions" ng-model="model.value">
 
-         <i class="icon-navigation list-view-layout__sort-handle" aria-hidden="true" aria-label="Sort"></i>
+           <div class="list-view-layout" ng-repeat="layout in model.value">
 
-         <div>
+               <i class="icon-navigation list-view-layout__sort-handle" aria-hidden="true" aria-label="Sort"></i>
 
-            <button ng-if="layout.isSystem !== 1" type="button" ng-click="vm.openIconPicker(layout)" class="list-view-layout__icon" umb-auto-focus>
-               <i class="{{ layout.icon }}" aria-hidden="true"></i>
-            </button>
+               <div>
 
-            <div ng-if="layout.isSystem === 1" class="list-view-layout__icon">
-               <i class="{{ layout.icon }}" aria-hidden="true"></i>
-            </div>
+                   <button ng-if="layout.isSystem !== 1" type="button" ng-click="vm.openIconPicker(layout)" class="list-view-layout__icon" umb-auto-focus>
+                       <i class="{{ layout.icon }}" aria-hidden="true"></i>
+                   </button>
 
-         </div>
+                   <div ng-if="layout.isSystem === 1" class="list-view-layout__icon">
+                       <i class="{{ layout.icon }}" aria-hidden="true"></i>
+                   </div>
 
-         <div class="list-view-layout__name">
-            <input ng-if="layout.isSystem !== 1" type="text" ng-model="layout.name" placeholder="Name..." class="-full-width-input" focus-when="{{ vm.focusLayoutName }}" />
-            <span ng-if="layout.isSystem === 1" class="list-view-layout__name-text">{{ layout.name }}</span>
-            <span ng-if="layout.isSystem === 1" class="list-view-layout__system">(system layout)</span>
-         </div>
+               </div>
 
-         <div class="list-view-layout__path">
-            <input ng-if="layout.isSystem !== 1" type="text" ng-model="layout.path" placeholder="Layout path..." class="-full-width-input" />
-         </div>
+               <div class="list-view-layout__name">
+                   <input ng-if="layout.isSystem !== 1" type="text" ng-model="layout.name" placeholder="Name..." class="-full-width-input" focus-when="{{ vm.focusLayoutName }}" />
+                   <span ng-if="layout.isSystem === 1" class="list-view-layout__name-text">{{ layout.name }}</span>
+                   <span ng-if="layout.isSystem === 1" class="list-view-layout__system">(system layout)</span>
+               </div>
 
-         <div>
-           <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected" /> 
-            <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
-                <i class="icon-trash" ng-click="vm.showPrompt(layout)" aria-hidden="true"></i>
-                <umb-confirm-action
-                    ng-if="layout.deletePrompt"
-                    direction="left"
-                    on-confirm="vm.removeLayout($index, layout)"
-                    on-cancel="vm.hidePrompt(layout)">
-                </umb-confirm-action>
-            </div>
-         </div>
+               <div class="list-view-layout__path">
+                   <input ng-if="layout.isSystem !== 1" type="text" ng-model="layout.path" placeholder="Layout path..." class="-full-width-input" />
+               </div>
 
-      </div>
+               <div>
+                   <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected" />
+                   <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
+                       <i class="icon-trash" ng-click="vm.showPrompt(layout)" aria-hidden="true"></i>
+                       <umb-confirm-action ng-if="layout.deletePrompt"
+                                           direction="left"
+                                           on-confirm="vm.removeLayout($index, layout)"
+                                           on-cancel="vm.hidePrompt(layout)">
+                       </umb-confirm-action>
+                   </div>
+               </div>
+
+           </div>
+
+       </div>
 
       <button type="button" class="list-view-add-layout" ng-click="vm.addLayout()">Add layout</button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -1,8 +1,8 @@
 <div ng-controller="Umbraco.PrevalueEditors.ListViewLayoutsPreValsController as vm">
 
-   <div class="list-view-layouts">
+   <div class="list-view-layouts-container">
 
-       <div ui-sortable="vm.layoutsSortableOptions" ng-model="model.value">
+       <div class="list-view-layouts" ui-sortable="vm.layoutsSortableOptions" ng-model="model.value">
 
            <div class="list-view-layout" ng-repeat="layout in model.value">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR restrict sorting on y-axis and within parent element. I also noticed the remove button no longer was rendered for custom listviews, because of the self-closing `<umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected" />`. Changing this to `<umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected"></umb-checkbox>` fixes this issue.

![chrome_2020-07-11_17-33-01](https://user-images.githubusercontent.com/2919859/87228074-1fdcc580-c39f-11ea-8dcb-7536498fe29a.png)

Previous it looked like this as the GIF in this PR:
https://github.com/umbraco/Umbraco-CMS/pull/5405

In both `umb-checkbox` and `umb-radiobutton` I noticed the label had child `<div>` elements, which isn't valid for `<label>`, so changing this to `<span>` instead.

Finally the "Add layout" button is also removed outside the sortable placeholder, so it isn't part of the sortable area.

![2020-07-11_17-52-08](https://user-images.githubusercontent.com/2919859/87228129-69c5ab80-c39f-11ea-9abd-c33a00f54be8.gif)
