### PR TITLE
Listview columns grouping

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -1,10 +1,12 @@
 ﻿<div class="umb-property-editor" ng-controller="Umbraco.PrevalueEditors.IncludePropertiesListViewController">
     <div class="control-group">
-
         <select ng-model="selectedField" ng-change="changeField()" val-highlight="{{hasError}}">
-            <option ng-repeat="field in systemFields" value="_system_{{field.value}}" ng-bind="field.name"></option>
-            <option class="select-dash" disabled="disabled">----</option>
-            <option ng-repeat="alias in propertyAliases" value="{{alias}}" ng-bind="alias"></option>
+            <optgroup label="System Fields">
+                <option ng-repeat="field in systemFields" value="_system_{{field.value}}" ng-bind="field.name"></option>
+            </optgroup>
+            <optgroup label="Custom Fields">
+                <option ng-repeat="alias in propertyAliases" value="{{alias}}" ng-bind="alias"></option>
+            </optgroup>
         </select>
         <button type="button" class="btn" ng-click="addField()">
             <localize key="general_add">Add</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.html
@@ -31,8 +31,7 @@
                     </td>
                     <td>
                        <div class="list-view-layout__name flex-column content-start">
-                            <span class="list-view-layout__name-text" ng-if="!val.isSystem" ng-bind="val.alias"></span>
-                            <span class="list-view-layout__name-text" ng-if="val.isSystem == 1" ng-bind="val.alias"></span>
+                            <span class="list-view-layout__name-text" ng-bind="val.alias"></span>
                             <span class="list-view-layout__system" ng-show="val.isSystem == 1">(system field)</span>
                        </div>
                     </td>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR use `<optgroup>` to group fields for listview columns in two groups: "System Fields" and "Custom Fields".

Furthermore is remove unnecessary use of `ng-if`.
The following part:

```
<span class="list-view-layout__name-text" ng-if="!val.isSystem" ng-bind="val.alias"></span>
<span class="list-view-layout__name-text" ng-if="val.isSystem == 1" ng-bind="val.alias"></span>
```

can be simplified to:

```
<span class="list-view-layout__name-text" ng-bind="val.alias"></span>
```

![image](https://user-images.githubusercontent.com/2919859/87228443-95e22c00-c3a1-11ea-8ddb-be22b1fa7ee6.png)
