### PR TITLE
Adjust target overlay position using hotkey

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -438,8 +438,9 @@ Opens an overlay to show a custom YSOD. </br>
                 elementWidth = el[0].clientWidth;
 
                 // move element to this position
-                position.left = mousePositionClickX - (elementWidth / 2);
-                position.top = mousePositionClickY - (elementHeight / 2);
+                // when using hotkey it fallback to center of container
+                position.left = mousePositionClickX ? mousePositionClickX - (elementWidth / 2) : (containerLeft + containerRight) / 2 - (elementWidth / 2);
+                position.top = mousePositionClickY ? mousePositionClickY - (elementHeight / 2) : (containerTop + containerBottom) / 2 - (elementHeight / 2);
 
                 // check to see if element is outside screen
                 // outside right

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -407,11 +407,15 @@ Opens an overlay to show a custom YSOD. </br>
 
             function setTargetPosition() {
 
-                var container = $("#contentwrapper");
-                var containerLeft = container[0].offsetLeft;
-                var containerRight = containerLeft + container[0].offsetWidth;
-                var containerTop = container[0].offsetTop;
-                var containerBottom = containerTop + container[0].offsetHeight;
+                var overlay = $(scope.model.event.target).closest('.umb-overlay');
+                var container = overlay.length > 0 ? overlay : $("#contentwrapper");
+
+                let rect = container[0].getBoundingClientRect();
+
+                var containerLeft = rect.left;
+                var containerRight = containerLeft + rect.width;
+                var containerTop = rect.top;
+                var containerBottom = containerTop + rect.height;
 
                 var mousePositionClickX = null;
                 var mousePositionClickY = null;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/overlays/umboverlay.directive.js
@@ -468,6 +468,7 @@ Opens an overlay to show a custom YSOD. </br>
                 }
 
                 el.css(position);
+                el.css("visibility", "visible");
             }
 
             scope.submitForm = function (model) {

--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -106,7 +106,6 @@
     height: auto;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, 0);
     transform: translate(-50%, -50%);
     border-radius: @baseBorderRadius;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/overlays.less
@@ -127,6 +127,7 @@
     width: 400px;
     max-height: 100vh;
     box-sizing: border-box;
+    visibility: hidden;
     border-radius: @baseBorderRadius;
 
     &.umb-overlay--medium {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8424

### Description
This PR use similar to this other PR https://github.com/umbraco/Umbraco-CMS/pull/8416 `getBoundingClientRect()` which get the "real" position, when e.g. uisng transform styles via css.

In this case `setTargetPosition()` is only using for overlays having position set to `target`.

When using hotkey the `mousePositionClickX` and `mousePositionClickY` was undefined/null, so in this case it fallback to center of container element.

Furthermore the position was calculate based on container `#contentwrapper`, but like `umb-tooltip` in https://github.com/umbraco/Umbraco-CMS/pull/8416, this would probably be positioned wrong if opening an `target` overlay from an existing overlay.

![2020-07-13_13-55-00](https://user-images.githubusercontent.com/2919859/87302077-052a5e00-c511-11ea-9fb2-82dd7df480b9.gif)