### PR TITLE
Fix for issue #7461 ("Inserting a macro in the rich test editor (RTE) in the Grid makes it disappear on Save & Publish")

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -87,7 +87,9 @@ angular.module("umbraco.directives")
                         tinyMceService.initializeEditor({
                             editor: editor,
                             model: scope,
-                            currentForm: angularHelper.getCurrentForm(scope)
+                            // Form is found in the scope of the grid controller above us, not in our isolated scope
+                            // https://github.com/umbraco/Umbraco-CMS/issues/7461
+                            currentForm: angularHelper.getCurrentForm(scope.$parent)
                         });
 
                         //custom initialization for this editor within the grid

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1504,6 +1504,8 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             });
 
             args.editor.on('Dirty', function (e) {
+            	syncContent(); // Set model.value to the RTE's content
+
                 //make the form dirty manually so that the track changes works, setting our model doesn't trigger
                 // the angular bits because tinymce replaces the textarea.
                 if (args.currentForm) {


### PR DESCRIPTION
### Description
Fixes #7461

This PR contains two changes to grid RTE editor code;
a) GridRteDirective now finds the `currentForm` using the parent scope from the GridController above the GridRte directive. The GridRte directive creates its own isolated scope and therefore we need to search for the form in `$scope.parent` and not the isolated `$scope`. This does NOT fix the issue mentioned but fixes the dirty event handler in the RTE so that `form.$setDirty()` is called correctly.
b) `syncContent()` is now called on TinyMCE Dirty events so that model.value is set to the RTE's contents whenever a macro is edited or inserted. This fixes the issue mentioned above.


GIF before where the text isn't saved after saving and publishing content:
![2020-07-14T14-41-06--18](https://user-images.githubusercontent.com/5199871/87432743-4b9abe00-c5e0-11ea-85fd-175ecc743595.gif)

GIF after the fix:
![2020-07-14T14-42-15--20](https://user-images.githubusercontent.com/5199871/87432757-51909f00-c5e0-11ea-9afe-c432a03b9eda.gif)