### PR TITLE
Streamline umb-checkbox and umb-radiobutton components

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -31,8 +31,9 @@
 @param {boolean} disabled Set the checkbox to be disabled.
 @param {boolean} required Set the checkbox to be required.
 @param {callback} onChange Callback when the value of the checkbox change by interaction.
-@param {string} cssClass Set a css class modifier
-@param {boolean} disableDirtyCheck Disable checking if the model is dirty
+@param {string} cssClass Set a css class modifier.
+@param {string} iconClass Set an icon next to checkbox.
+@param {boolean} disableDirtyCheck Disable checking if the model is dirty.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -33,6 +33,7 @@
 @param {callback} onChange Callback when the value of the radiobutton change by interaction.
 @param {string} cssClass Set a css class modifier.
 @param {string} iconClass Set an icon next to radiobutton.
+@param {boolean} disableDirtyCheck Disable checking if the model is dirty.
 
 **/
 
@@ -85,7 +86,8 @@
             required: "<",
             onChange: "&?",
             cssClass: "@?",
-            iconClass: "@?"
+            iconClass: "@?",
+            disableDirtyCheck: "=?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -26,11 +26,12 @@
 @param {string} value Set the value of the radiobutton.
 @param {string} name Set the name of the radiobutton.
 @param {string} text Set the text for the radiobutton label.
-@param {string} labelKey Set a dictinary/localization string for the checkbox label
+@param {string} labelKey Set a dictinary/localization string for the checkbox label.
 @param {boolean} disabled Set the radiobutton to be disabled.
 @param {boolean} required Set the radiobutton to be required.
 @param {callback} onChange Callback when the value of the radiobutton change by interaction.
-@param {string} cssClass Set a css class modifier
+@param {string} cssClass Set a css class modifier.
+@param {string} iconClass Set an icon next to radiobutton.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -79,7 +79,8 @@
             labelKey: "@?",
             disabled: "<",
             required: "<",
-            onChange: "&?"
+            onChange: "&?",
+            iconClass: "@?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -27,6 +27,7 @@
 @param {string} name Set the name of the radiobutton.
 @param {string} text Set the text for the radiobutton label.
 @param {string} labelKey Set a dictinary/localization string for the checkbox label.
+@param {string} serverValidationField Set the <code>val-server-field</code> of the radiobutton.
 @param {boolean} disabled Set the radiobutton to be disabled.
 @param {boolean} required Set the radiobutton to be required.
 @param {callback} onChange Callback when the value of the radiobutton change by interaction.
@@ -79,6 +80,7 @@
             name: "@",
             text: "@",
             labelKey: "@?",
+            serverValidationField: "@",
             disabled: "<",
             required: "<",
             onChange: "&?",

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -30,6 +30,7 @@
 @param {boolean} disabled Set the radiobutton to be disabled.
 @param {boolean} required Set the radiobutton to be required.
 @param {callback} onChange Callback when the value of the radiobutton change by interaction.
+@param {string} cssClass Set a css class modifier
 
 **/
 
@@ -80,6 +81,7 @@
             disabled: "<",
             required: "<",
             onChange: "&?",
+            cssClass: "@?",
             iconClass: "@?"
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -32,10 +32,7 @@
         </span>
     </span>
     <span class="umb-form-check__info" ng-transclude>
-
         <i ng-if="vm.iconClass.length" class="{{vm.iconClass}}" aria-hidden="true"></i>
-
         <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
-
     </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -1,4 +1,4 @@
-<label class="radio umb-form-check umb-form-check--radiobutton" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
+<label class="radio umb-form-check umb-form-check--radiobutton {{vm.cssClass}}" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
     <span class="umb-form-check__symbol">
         <input type="radio"
             id="{{vm.inputId}}"

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -1,6 +1,20 @@
 <label class="radio umb-form-check umb-form-check--radiobutton {{vm.cssClass}}" ng-class="{ 'umb-form-check--disabled': vm.disabled }">
     <span class="umb-form-check__symbol">
-        <input type="radio"
+        <input ng-if="vm.disableDirtyCheck"
+            type="radio"
+            id="{{vm.inputId}}"
+            name="{{vm.name}}"
+            value="{{vm.value}}"
+            class="umb-form-check__input"
+            val-server-field="{{vm.serverValidationField}}"
+            ng-model="vm.model"
+            ng-disabled="vm.disabled"
+            ng-required="vm.required"
+            ng-change="vm.change()"
+            no-dirty-check />
+
+        <input ng-if="!vm.disableDirtyCheck"
+            type="radio"
             id="{{vm.inputId}}"
             name="{{vm.name}}"
             value="{{vm.value}}"

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -15,6 +15,7 @@
         </span>
     </span>
     <span class="umb-form-check__info" ng-transclude>
-        <span class="umb-form-check__text">{{vm.text}}</span>
+        <i ng-if="vm.iconClass.length" class="{{vm.iconClass}}" aria-hidden="true"></i>
+        <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
     </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -5,6 +5,7 @@
             name="{{vm.name}}"
             value="{{vm.value}}"
             class="umb-form-check__input"
+            val-server-field="{{vm.serverValidationField}}"
             ng-model="vm.model"
             ng-disabled="vm.disabled"
             ng-required="vm.required"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Recently features has been added to `umb-checkbox`, but not to `umb-radiobutton`.
I think these two components should be as consistent as possible. If new features are added to one of them, it should probably also been included on the other one.
