### PR TITLE
Return Image only type when datatype is configured as such

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
@@ -79,8 +79,8 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             PropertyCacheLevel cacheLevel, object source, bool preview)
         {
             var config = GetConfiguration(propertyType.DataType);
-            var isMultiple = config.Multiple;
-            var isImagesOnly = config.OnlyImages;
+            var isMultiple = IsMultipleDataType(config);
+            var isImagesOnly = IsImagesOnlyDataType(config);
 
             var udis = (Udi[])source;
             var mediaItems = isImagesOnly


### PR DESCRIPTION
Currently when you have a media data type with "Images only" enabled, the result will still be IPublishedContent, even though everything is an Image object. We can easily return the data as IEnumerable<Image> or Image when the option is turned on.

Took most of the code from the nested content property value converter:
https://github.com/umbraco/Umbraco-CMS/blob/df8f28114160271ed4ab5db4519b4d13c3acccfc/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
https://github.com/umbraco/Umbraco-CMS/blob/df8f28114160271ed4ab5db4519b4d13c3acccfc/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs

Way to test:
Create a model with modelsbuilder that has a mediapicker with the option to only choose images. It should come out as an Image object now instead of IPublishedContent. If the media picker has multiple enabled, it'll return an IEnumerable<Image> 