### PR TITLE
Adjust toggle styling when checked and disabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -78,6 +78,7 @@
                 scope.inputId = scope.inputId || "umb-toggle_" + String.CreateGuid();
 
                 setLabelText();
+
                 // must wait until the current digest cycle is finished before we emit this event on init, 
                 // otherwise other property editors might not yet be ready to receive the event
                 $timeout(function () {
@@ -115,7 +116,6 @@
             };
 
             onInit();
-
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -111,8 +111,8 @@
 
     &:not(.umb-toggle--checked) {
         .umb-toggle__toggle {
-            background-color: @gray-9;
-            border-color: @gray-9;
+            background-color: @gray-8;
+            border-color: @gray-8;
         }
 
         .umb-toggle__icon--left,

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle.less
@@ -41,9 +41,6 @@
     }
 }
 
-
-
-
 .umb-toggle__handler {
     position: absolute;
     top: 1px;
@@ -59,9 +56,7 @@
         transform: translateX(20px);
         background-color: @white;
     }
-
 }
-
 
 /* Icons */
 
@@ -78,9 +73,7 @@
     color:@white;
     transition: opacity 120ms;
     opacity: 0;
-    // .umb-toggle:hover & {
-    //     color: @ui-btn-hover;
-    // }
+
     .umb-toggle--checked & {
         opacity: 1;
     }
@@ -93,6 +86,7 @@
     right: 5px;
     color: @ui-btn;
     transition: opacity 120ms;
+
     .umb-toggle--checked & {
         opacity: 0;
     }
@@ -101,23 +95,41 @@
     }
 }
 
-
-
-.umb-toggle.umb-toggle--disabled.umb-toggle--checked,
 .umb-toggle.umb-toggle--disabled {
     .umb-toggle__toggle {
         cursor: not-allowed;
-        background-color: @gray-9;
-        border-color: @gray-9;
     }
-    .umb-toggle__icon--left {
-        color: @gray-6;
+
+    &, &.umb-toggle--checked {
+
+        .umb-toggle__toggle {
+            .umb-toggle__handler {
+                background-color: @gray-10;
+            }
+        }
     }
-    .umb-toggle__icon--right {
-        color: @gray-6;
+
+    &:not(.umb-toggle--checked) {
+        .umb-toggle__toggle {
+            background-color: @gray-9;
+            border-color: @gray-9;
+        }
+
+        .umb-toggle__icon--left,
+        .umb-toggle__icon--right {
+            color: @gray-6;
+        }
     }
-    .umb-toggle__handler {
-        background-color: @gray-10;
+
+    &.umb-toggle--checked {
+        .umb-toggle__toggle {
+            background-color: lighten(@ui-btn, 50%);
+            border-color: lighten(@ui-btn, 50%);
+        }
+        .umb-toggle__icon--left,
+        .umb-toggle__icon--right {
+            color: @gray-9;
+        }
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
@@ -1,8 +1,7 @@
 <button role="checkbox" aria-checked="{{checked}}" ng-click="click()" type="button" class="umb-toggle" ng-disabled="disabled" ng-class="{'umb-toggle--checked': checked, 'umb-toggle--disabled': disabled}" id="{{inputId}}">
     
     <span ng-if="!labelPosition && showLabels === 'true' || labelPosition === 'left' && showLabels === 'true'">
-        <span ng-if="!checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOff }}</span>
-        <span ng-if="checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOn }}</span>
+        <span ng-if="checked" class="umb-toggle__label umb-toggle__label--left">{{ checked ? displayLabelOn : displayLabelOff }}</span>
     </span>
 
     <div class="umb-toggle__toggle">
@@ -12,8 +11,7 @@
     </div>
 
     <span ng-if="labelPosition === 'right' && showLabels === 'true'">
-        <span ng-if="!checked" class="umb-toggle__label umb-toggle__label--right">{{ displayLabelOff }}</span>
-        <span ng-if="checked" class="umb-toggle__label umb-toggle__label--right">{{ displayLabelOn }}</span>
+        <span class="umb-toggle__label umb-toggle__label--right">{{ checked ? displayLabelOn : displayLabelOff }}</span>
     </span>
 
 </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
@@ -1,7 +1,7 @@
 <button role="checkbox" aria-checked="{{checked}}" ng-click="click()" type="button" class="umb-toggle" ng-disabled="disabled" ng-class="{'umb-toggle--checked': checked, 'umb-toggle--disabled': disabled}" id="{{inputId}}">
     
     <span ng-if="!labelPosition && showLabels === 'true' || labelPosition === 'left' && showLabels === 'true'">
-        <span ng-if="checked" class="umb-toggle__label umb-toggle__label--left">{{ checked ? displayLabelOn : displayLabelOff }}</span>
+        <span class="umb-toggle__label umb-toggle__label--left">{{ checked ? displayLabelOn : displayLabelOff }}</span>
     </span>
 
     <div class="umb-toggle__toggle">

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle.html
@@ -1,5 +1,5 @@
 <button role="checkbox" aria-checked="{{checked}}" ng-click="click()" type="button" class="umb-toggle" ng-disabled="disabled" ng-class="{'umb-toggle--checked': checked, 'umb-toggle--disabled': disabled}" id="{{inputId}}">
-
+    
     <span ng-if="!labelPosition && showLabels === 'true' || labelPosition === 'left' && showLabels === 'true'">
         <span ng-if="!checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOff }}</span>
         <span ng-if="checked" class="umb-toggle__label umb-toggle__label--left">{{ displayLabelOn }}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment when `umb-toggle` is checked and disabled, it is not clear the toggle is checked. This was changed in PR https://github.com/umbraco/Umbraco-CMS/pull/7626

For example in languages where default language here is checked and disabled.

![chrome_2020-07-15_18-57-29](https://user-images.githubusercontent.com/2919859/87588485-0bbcff00-c6e4-11ea-8ee8-9288a9b667a2.png)

I have adjusted the toggle background color, so it looks more look the active checked state and a bit dimmed, which is a common pattern used accross different web interfaces, e.g https://css-tricks.com/custom-styling-form-inputs-with-modern-css-features/

![2020-07-15_21-42-59](https://user-images.githubusercontent.com/2919859/87588796-89810a80-c6e4-11ea-8ef7-9960eb046984.gif)

![image](https://user-images.githubusercontent.com/2919859/87594382-28116980-c6ed-11ea-9b8e-fb9d81977854.png)

Finally it removes unneccessary use of `ng-if`.