### PR TITLE
Blocklist repeatable textstrings

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -50,6 +52,17 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
                 var value = sourceString.Substring(pos, npos - pos);
                 values.Add(value);
                 pos = sourceString.IndexOf("<value>", pos, StringComparison.Ordinal);
+            }
+
+            // WB: MultipleTextStringPropertyEditor stores this as JSON now - will keep XML above stuff for legacy in case?!
+            if (sourceString.DetectIsJson())
+            {
+                var json = sourceString.ConvertToJsonIfPossible();
+                if(json is JArray)
+                {
+                    var jsonArray = (JArray)json;
+                    return jsonArray.Where(x => x["value"] != null).Select(x => x["value"].Value<string>());
+                }                
             }
 
             // fall back on normal behaviour


### PR DESCRIPTION
## Note this targets v8/8.7

This PR fixes a bug with the yet to be released v8.7 with the block list editor, see screenshot below to see that it renders a JSON object on each new line as opposed to the values stored inside the repeatable textstring property editor.

![image](https://user-images.githubusercontent.com/1389894/88035143-9a44dc80-cb39-11ea-9a5c-395959cd46cd.png)



## Test Notes
* Test before & after PR applied
* Use block list editor
* Create a new element type for use in block editor
* Add a Repeatable TextString property to element type
* Add example content
* Render results with Razor
* Verify output on frontend of site

## Example Razor Template
```chstml
@inherits Umbraco.Web.Mvc.UmbracoViewPage<ContentModels.Home>
@using ContentModels = Umbraco.Web.PublishedModels;
@{
	Layout = null;
}

<h3>@Model.Header</h3>
<h4>Normal Repeatable Textstring</h4>
<ul>
    @foreach(var item in Model.Features) {
        <li>@item</li>
    }
</ul>


@foreach(var block in Model.Widgets.Layout) {
    var blockEl = (ContentModels.Product)block.Data;
    <h3>Product Name: @blockEl.ProductName</h3>
    <ul>
        @foreach (var feature in blockEl.Features)
        {
            <li>@feature</li>
        }
    </ul>
}

```