### PR TITLE
Improving umb-button link docs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -55,8 +55,8 @@ Use this directive to render an umbraco button. The directive can be used to gen
 </pre>
 
 @param {callback} action The button action which should be performed when the button is clicked.
-@param {string=} href Url/Path to navigato to.
-@param {string=} type Set the button type ("button" or "submit").
+@param {string=} href Url/Path to navigato to. (requires "type" to be set to "link")
+@param {string=} type Set the button type ("button", "link", "submit").
 @param {string=} buttonStyle Set the style of the button. The directive uses the default bootstrap styles ("primary", "info", "success", "warning", "danger", "inverse", "link", "block"). Pass in array to add multple styles [success,block].
 @param {string=} state Set a progress state on the button ("init", "busy", "success", "error").
 @param {string=} shortcut Set a keyboard shortcut for the button ("ctrl+c").


### PR DESCRIPTION
While implementing a new backoffice UI I found the docs for the `umb-button` to be inaccurate.

In order for the `href` attribute to work the `type` attribute must be set to "link", else you end up with a button that doesn't do anything on click...

This was missing from the docs, it now isn't! 🎉