### PR TITLE
v7: Revert previous changes, force writer in update of cache

### DIFF
--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -306,6 +306,10 @@ namespace umbraco
             // note that some threads could read from it while we hold the lock, though
             using (var safeXml = GetSafeXmlWriter())
             {
+                if (!safeXml.IsWriter)
+                {
+                    safeXml.UpgradeToWriter();
+                }
                 safeXml.Xml = PublishNodeDo(d, safeXml.Xml, true);
                 safeXml.AcceptChanges();
             }

--- a/src/Umbraco.Web/umbraco.presentation/content.cs
+++ b/src/Umbraco.Web/umbraco.presentation/content.cs
@@ -306,10 +306,9 @@ namespace umbraco
             // note that some threads could read from it while we hold the lock, though
             using (var safeXml = GetSafeXmlWriter())
             {
-                if (!safeXml.IsWriter)
-                {
+                if (safeXml.IsWriter == false)
                     safeXml.UpgradeToWriter();
-                }
+
                 safeXml.Xml = PublishNodeDo(d, safeXml.Xml, true);
                 safeXml.AcceptChanges();
             }


### PR DESCRIPTION
### Description
In previous PR #8455 , we fixed issue which was occurring but in time of QA for client we find out that change is actually causing more issues in different places, it is why I continue to research on issue. and find out it is enough to force Xml writer to be writer and all issues are solved.
@nul800sebastiaan  I am doing PR to check again unit tests results as I already notice they could be different on local and CI env (not sure why)
