### PR TITLE
Make icon property for checkbox and radiobutton consistent with other components

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbcheckbox.directive.js
@@ -32,7 +32,8 @@
 @param {boolean} required Set the checkbox to be required.
 @param {callback} onChange Callback when the value of the checkbox change by interaction.
 @param {string} cssClass Set a css class modifier.
-@param {string} iconClass Set an icon next to checkbox.
+@deprecated @param {string} iconClass Set an icon next to checkbox. Use "icon" parameter instead.
+@param {string} icon Set an icon next to checkbox.
 @param {boolean} disableDirtyCheck Disable checking if the model is dirty.
 
 **/
@@ -49,6 +50,8 @@
 
         function onInit() {
             vm.inputId = vm.inputId || "umb-check_" + String.CreateGuid();
+
+            vm.icon = vm.icon || vm.iconClass || null;
 
             // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
             if (vm.labelKey) {
@@ -86,7 +89,8 @@
             required: "<",
             onChange: "&?",
             cssClass: "@?",
-            iconClass: "@?",
+            iconClass: "@?", // deprecated
+            icon: "@?",
             disableDirtyCheck: "=?"
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbradiobutton.directive.js
@@ -50,6 +50,8 @@
         function onInit() {
             vm.inputId = vm.inputId || "umb-radio_" + String.CreateGuid();
 
+            vm.icon = vm.icon || vm.iconClass || null;
+
             // If a labelKey is passed let's update the returned text if it's does not contain an opening square bracket [
             if (vm.labelKey) {
                  localizationService.localize(vm.labelKey).then(function (data) {
@@ -86,7 +88,8 @@
             required: "<",
             onChange: "&?",
             cssClass: "@?",
-            iconClass: "@?",
+            iconClass: "@?", // deprecated
+            icon: "@?",
             disableDirtyCheck: "=?"
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-checkbox.html
@@ -32,7 +32,7 @@
         </span>
     </span>
     <span class="umb-form-check__info" ng-transclude>
-        <i ng-if="vm.iconClass.length" class="{{vm.iconClass}}" aria-hidden="true"></i>
+        <i ng-if="vm.icon.length" class="{{vm.icon}}" aria-hidden="true"></i>
         <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
     </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-radiobutton.html
@@ -30,7 +30,7 @@
         </span>
     </span>
     <span class="umb-form-check__info" ng-transclude>
-        <i ng-if="vm.iconClass.length" class="{{vm.iconClass}}" aria-hidden="true"></i>
+        <i ng-if="vm.icon.length" class="{{vm.icon}}" aria-hidden="true"></i>
         <span ng-if="vm.text.length" class="umb-form-check__text">{{vm.text}}</span>
     </span>
 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -29,11 +29,15 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             // extend commands with properties for font-icon and if it is a custom command
             $scope.tinyMceConfig.commands = _.map($scope.tinyMceConfig.commands, function (obj) {
                 var icon = getFontIcon(obj.alias);
-                return angular.extend(obj, {
+
+                var objCmd = angular.extend(obj, {
                     fontIcon: icon.name,
                     isCustom: icon.isCustom,
-                    selected: $scope.model.value.toolbar.indexOf(obj.alias) >= 0
+                    selected: $scope.model.value.toolbar.indexOf(obj.alias) >= 0,
+                    icon: "mce-ico " + (icon.isCustom ? ' mce-i-custom ' : ' mce-i-') + icon.name
                 });
+
+                return objCmd;
             });
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -30,7 +30,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             $scope.tinyMceConfig.commands = _.map($scope.tinyMceConfig.commands, function (obj) {
                 var icon = getFontIcon(obj.alias);
 
-                var objCmd = angular.extend(obj, {
+                var objCmd = Utilities.extend(obj, {
                     fontIcon: icon.name,
                     isCustom: icon.isCustom,
                     selected: $scope.model.value.toolbar.indexOf(obj.alias) >= 0,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -5,7 +5,7 @@
                 <umb-checkbox
                     model="cmd.selected"
                     on-change="selectCommand(cmd)"
-                    icon-class="mce-ico {{(cmd.isCustom ? ' mce-i-custom ' : ' mce-i-') + cmd.fontIcon}}"
+                    icon="{{cmd.icon}}"
                     text="{{cmd.name}}"
                     class="mce-cmd" />
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
It would have been great if the `umb-checkbox` and `umb-radiobutton` just used `icon` instead of `icon-class` attribute to be consistent with other components in core using icons as well. This was introduced in https://github.com/umbraco/Umbraco-CMS/pull/6979

At the moment this is only used for icons in richtext editor configuration in core.

![image](https://user-images.githubusercontent.com/2919859/88305187-7e903080-cd09-11ea-9af2-cb6d6487ba99.png)


This PR add an `icon` parameter as other components and and mark `iconClass` as deprecated. Maybe this can be removed in a minor version. Note sure if the `@deprecated` in `ngdoc` is entirely correct.

**umbButton**
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js#L65

**umbFileIcon**
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/common/directives/components/umbfileicon.directive.js#L41

**umbNodePreview**
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnodepreview.directive.js#L79