### PR TITLE
Add missing esc shortcut to close examine result field values overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
@@ -33,6 +33,7 @@
                     type="button"
                     button-style="link"
                     label-key="general_close"
+                    shortcut="esc"
                     action="model.close()">
                 </umb-button>
             </umb-editor-footer-content-right>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When opening member search result overlay with title "Field values" from MembersIndex it isn't possible to close this overlay via `esc` shortcut.

![2020-07-24_20-14-58](https://user-images.githubusercontent.com/2919859/88422396-7a880f80-cdea-11ea-9721-deafd0faa803.gif)