### PR TITLE
7731 bye bye underscore => _.each

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsearch.directive.js
@@ -160,7 +160,8 @@
                 searchService.searchAll(search).then(function (result) {
                     //result is a dictionary of group Title and it's results
                     var filtered = {};
-                    _.each(result, function (value, key) {
+                    Object.keys(result).forEach(key => {
+                        let value = result[key];
                         if (value.results.length > 0) {
                             filtered[key] = value;
                         }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -88,9 +88,8 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
             /** Helper function to emit tree events */
             function emitEvent(eventName, args) {
                 if (registeredCallbacks[eventName] && Utilities.isArray(registeredCallbacks[eventName])) {
-                    _.each(registeredCallbacks[eventName], function (c) {
-                        c(args);//call it
-                    });
+                    // call it
+                    registeredCallbacks[eventName].forEach(c => c(args));
                 }
             }
 
@@ -342,26 +341,17 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
 
                 var css = [];
                 if (node.cssClasses) {
-                    _.each(node.cssClasses, function (c) {
-                        css.push(c);
-                    });
+                    node.cssClasses.forEach(c => css.push(c));
                 }
 
                 return css.join(" ");
             };
 
-            $scope.selectEnabledNodeClass = function (node) {
-                return node ?
-                    node.selected ?
-                        'icon umb-tree-icon sprTree icon-check green temporary' :
-                        '' :
-                    '';
-            };
+            $scope.selectEnabledNodeClass = node =>
+                node && node.selected ? 'icon umb-tree-icon sprTree icon-check green temporary' : '';            
 
             /* helper to force reloading children of a tree node */
-            $scope.loadChildren = function (node, forceReload) {
-                return loadChildren(node, forceReload);
-            };
+            $scope.loadChildren = (node, forceReload) => loadChildren(node, forceReload);
 
             /**
               Method called when the options button next to the root node is called.

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -70,9 +70,7 @@ angular.module("umbraco.directives")
                 
                 var css = [];                
                 if (node.cssClasses) {
-                    _.each(node.cssClasses, function(c) {
-                        css.push(c);
-                    });
+                    node.cssClasses.forEach(c => css.push(c));
                 }
                 if (node.selected) {
                     css.push("umb-tree-node-checked");

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -161,19 +161,17 @@
                 var resourceLookup = scope.contentType === "documentType" ? contentTypeResource.getAvailableCompositeContentTypes : mediaTypeResource.getAvailableCompositeContentTypes;
 
                 return resourceLookup(scope.model.id, selectedContentTypeAliases, propAliasesExisting).then(function (filteredAvailableCompositeTypes) {
-                    _.each(scope.compositionsDialogModel.availableCompositeContentTypes, function (current) {
+                    scope.compositionsDialogModel.availableCompositeContentTypes.forEach(current => {
                         //reset first
                         current.allowed = true;
                         //see if this list item is found in the response (allowed) list
-                        var found = _.find(filteredAvailableCompositeTypes, function (f) {
-                            return current.contentType.alias === f.contentType.alias;
-                        });
+                        var found = filteredAvailableCompositeTypes.find(f => current.contentType.alias === f.contentType.alias);
 
                         //allow if the item was  found in the response (allowed) list -
                         // and ensure its set to allowed if it is currently checked,
                         // DO not allow if it's a locked content type.
-                        current.allowed = scope.model.lockedCompositeContentTypes.indexOf(current.contentType.alias) === -1 &&
-                            (selectedContentTypeAliases.indexOf(current.contentType.alias) !== -1) || ((found !== null && found !== undefined) ? found.allowed : false);
+                        current.allowed = scope.model.lockedCompositeContentTypes.includes(current.contentType.alias) &&
+                            (selectedContentTypeAliases.includes(current.contentType.alias)) || (found ? found.allowed : false);
 
                     });
                 });
@@ -192,15 +190,15 @@
             function setupAvailableContentTypesModel(result) {
                 scope.compositionsDialogModel.availableCompositeContentTypes = result;
                 //iterate each one and set it up
-                _.each(scope.compositionsDialogModel.availableCompositeContentTypes, function (c) {
+                scope.compositionsDialogModel.availableCompositeContentTypes.forEach(c => {
                     //enable it if it's part of the selected model
-                    if (scope.compositionsDialogModel.compositeContentTypes.indexOf(c.contentType.alias) !== -1) {
+                    if (scope.compositionsDialogModel.compositeContentTypes.includes(c.contentType.alias)) {
                         c.allowed = true;
                     }
 
                     //set the inherited flags
                     c.inherited = false;
-                    if (scope.model.lockedCompositeContentTypes.indexOf(c.contentType.alias) > -1) {
+                    if (scope.model.lockedCompositeContentTypes.includes(c.contentType.alias)) {
                         c.inherited = true;
                     }
                     // convert icons for composite content types

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
@@ -63,7 +63,7 @@
                         }
                         // update children
                         miniListView.children = data.items;
-                        _.each(miniListView.children, function(c) {
+                        miniListView.children.forEach(c => {
                             // child allowed by default
                             c.allowed = true;
  
@@ -95,7 +95,8 @@
                             var filtered = angular.isFunction(scope.entityTypeFilter.filter)
                                 ? _.filter(miniListView.children, scope.entityTypeFilter.filter)
                                 : _.where(miniListView.children, scope.entityTypeFilter.filter);
-                            _.each(filtered, (node) => node.allowed = false);
+                            
+                            filtered.forEach(node => node.allowed = false);
                         }
 
                         // update pagination

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -190,7 +190,7 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
                                 var parts = nextPath.split("?");
                                 var query = {};
                                 if (parts.length > 1) {
-                                    _.each(parts[1].split("&"), function(q) {
+                                    parts[1].split("&").forEach(q => {
                                         var keyVal = q.split("=");
                                         query[keyVal[0]] = keyVal[1];
                                     });

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/media.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/media.mocks.js
@@ -11,9 +11,7 @@ angular.module('umbraco.mocks').
         var ids = mocksUtils.getParameterByName(data, "ids") || "1234,1234,4234";
         var items = [];
         
-        _.each(ids, function(id){
-          items.push(_getNode( parseInt( id, 10 )) );
-        });
+        ids.forEach(id => items.push(_getNode(parseInt(id, 10))));
 
         return [200, items, null];
       }
@@ -26,8 +24,6 @@ angular.module('umbraco.mocks').
 
           var id = mocksUtils.getParameterByName(data, "id") || 1234;
           id = parseInt(id, 10);
-
-
           
           return [200, _getNode(id), null];
       }

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/media.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/media.mocks.js
@@ -8,10 +8,12 @@ angular.module('umbraco.mocks').
       }
 
       function returnNodebyIds(status, data, headers) {
-        var ids = mocksUtils.getParameterByName(data, "ids") || "1234,1234,4234";
+        var ids = mocksUtils.getParameterByName(data, "ids") || ['1234','1234','4234'];
         var items = [];
         
-        ids.forEach(id => items.push(_getNode(parseInt(id, 10))));
+        for (var i = 0; i < ids.length; i += 1) {
+          items.push(_getNode(parseInt(ids[i], 10)));
+        }
 
         return [200, items, null];
       }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -442,9 +442,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
         getByIds: function (ids) {
 
             var idQuery = "";
-            _.each(ids, function (item) {
-                idQuery += "ids=" + item + "&";
-            });
+            ids.forEach(id => idQuery += `ids=${id}&`);
 
             return umbRequestHelper.resourcePromise(
                 $http.get(
@@ -455,9 +453,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 'Failed to retrieve data for content with multiple ids')
                 .then(function (result) {
                     //each item needs to be re-formatted
-                    _.each(result, function (r) {
-                        umbDataFormatter.formatContentGetData(r)
-                    });
+                    result.forEach(r => umbDataFormatter.formatContentGetData(r));
                     return $q.when(result);
                 });
         },

--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -226,9 +226,7 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
         getByIds: function (ids) {
 
             var idQuery = "";
-            _.each(ids, function (item) {
-                idQuery += "ids=" + item + "&";
-            });
+            ids.forEach(id => idQuery += `ids=${id}&`);
 
             return umbRequestHelper.resourcePromise(
                 $http.get(

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membergroup.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membergroup.resource.js
@@ -32,9 +32,7 @@ function memberGroupResource($q, $http, umbRequestHelper) {
         getByIds: function (ids) {
 
             var idQuery = "";
-            _.each(ids, function (item) {
-                idQuery += "ids=" + item + "&";
-            });
+            ids.forEach(id => idQuery += `ids=${id}&`);
 
             return umbRequestHelper.resourcePromise(
                 $http.get(

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -16,16 +16,15 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
             }
 
             var query = "";
-            _.each(filterContentTypes, function (item) {
-                query += "filterContentTypes=" + item + "&";
-            });
+            filterContentTypes.forEach(fct => query += `filterContentTypes=${fct}&`);
+
             // if filterContentTypes array is empty we need a empty variable in the querystring otherwise the service returns a error
             if (filterContentTypes.length === 0) {
                 query += "filterContentTypes=&";
             }
-            _.each(filterPropertyTypes, function (item) {
-                query += "filterPropertyTypes=" + item + "&";
-            });
+
+            filterPropertyTypes.forEach(fpt => query += `filterPropertyTypes=${fpt}&`);
+
             // if filterPropertyTypes array is empty we need a empty variable in the querystring otherwise the service returns a error
             if (filterPropertyTypes.length === 0) {
                 query += "filterPropertyTypes=&";

--- a/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
@@ -276,7 +276,7 @@ angular.module('umbraco.services')
                 //blocking
                 var promises = [];
                 var assets = [];
-                _.each(nonEmpty, function (path) {
+                nonEmpty.forEach(path => {
                     path = convertVirtualPath(path);
                     var asset = service._getAssetPromise(path);
                     //if not previously loaded, add to list of promises
@@ -325,19 +325,17 @@ angular.module('umbraco.services')
                         scope = $rootScope;
                     }
                     angularHelper.safeApply(scope,
-                        function () {
-                            asset.deferred.resolve(true);
-                        });
+                        () => asset.deferred.resolve(true));
                 }
 
                 if (cssAssets.length > 0) {
-                    var cssPaths = _.map(cssAssets, function (asset) { return appendRnd(asset.path) });
-                    LazyLoad.css(cssPaths, function () { _.each(cssAssets, assetLoaded); });
+                    var cssPaths = cssAssets.map(css => appendRnd(css.path));
+                    LazyLoad.css(cssPaths, () => cssAssets.forEach(assetLoaded));
                 }
 
                 if (jsAssets.length > 0) {
-                    var jsPaths = _.map(jsAssets, function (asset) { return appendRnd(asset.path) });
-                    LazyLoad.js(jsPaths, function () { _.each(jsAssets, assetLoaded); });
+                    var jsPaths = jsAssets.map(js => appendRnd(js.path));
+                    LazyLoad.js(jsPaths, () => jsAssets.forEach(assetLoaded));
                 }
 
                 return promise;

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -169,7 +169,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             //if the routing parameter keys are the same, we'll compare their values to see if any have changed and if so then the routing will be allowed.
             if (diff1.length === 0 && diff2.length === 0) {
                 var partsChanged = 0;
-                _.each(currRoutingKeys, function (k) {
+                currRoutingKeys.forEach(k => {
                     if (currUrlParams[k] != nextUrlParams[k]) {
                         partsChanged++;
                     }
@@ -206,7 +206,8 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             var toRetain = _.union(retainedQueryStrings, toRetain);
             var currentSearch = $location.search();
             $location.search('');
-            _.each(toRetain, function (k) {
+
+            toRetain.forEach(k => {
                 if (currentSearch[k]) {
                     $location.search(k, currentSearch[k]);
                 }
@@ -240,7 +241,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             var toRetain = Utilities.copy(nextRouteParams);
             var updated = false;
 
-            _.each(retainedQueryStrings, function (r) {
+            retainedQueryStrings.forEach(r => {
                 // if mculture is set to null in nextRouteParams, the value will be undefined and we will not retain any query string that has a value of "null"
                 if (currRouteParams[r] && nextRouteParams[r] !== undefined && !nextRouteParams[r]) {
                     toRetain[r] = currRouteParams[r];

--- a/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
@@ -43,9 +43,7 @@ angular.module('umbraco.services')
                 }
 
                 return entityResource.search(args.term, "Member", args.searchFrom).then(function (data) {
-                    _.each(data, function (item) {
-                        searchResultFormatter.configureMemberResult(item);
-                    });
+                    data.forEach(item => searchResultFormatter.configureMemberResult(item));
                     return data;
                 });
             },
@@ -68,9 +66,7 @@ angular.module('umbraco.services')
                 }
 
                 return entityResource.search(args.term, "Document", args.searchFrom, args.canceler, args.dataTypeKey).then(function (data) {
-                    _.each(data, function (item) {
-                        searchResultFormatter.configureContentResult(item);
-                    });
+                    data.forEach(item => searchResultFormatter.configureContentResult(item));
                     return data;
                 });
             },
@@ -93,9 +89,7 @@ angular.module('umbraco.services')
                 }
 
                 return entityResource.search(args.term, "Media", args.searchFrom, args.canceler, args.dataTypeKey).then(function (data) {
-                    _.each(data, function (item) {
-                        searchResultFormatter.configureMediaResult(item);
-                    });
+                    data.forEach(item => searchResultFormatter.configureMediaResult(item));
                     return data;
                 });
             },
@@ -119,7 +113,7 @@ angular.module('umbraco.services')
 
                 return entityResource.searchAll(args.term, args.canceler).then(function (data) {
 
-                    _.each(data, function (resultByType) {
+                    data.forEach(resultByType => {
 
                         //we need to format the search result data to include things like the subtitle, urls, etc...
                         // this is done with registered angular services as part of the SearchableTreeAttribute, if that
@@ -140,7 +134,7 @@ angular.module('umbraco.services')
                             }
                         }
                         //now apply the formatter for each result
-                        _.each(resultByType.results, function (item) {
+                        resultByType.results.forEach(item => {
                             formatterMethod.apply(this, [item, resultByType.treeAlias, resultByType.appAlias]);
                         });
 
@@ -148,12 +142,10 @@ angular.module('umbraco.services')
 
                     return data;
                 });
-
             },
 
             // TODO: This doesn't do anything!
             setCurrent: function (sectionAlias) {
-
                 var currentSection = sectionAlias;
             }
         };

--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -54,7 +54,7 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
             //take the last child
             var childPath = this.getPath(node.children[node.children.length - 1]).join(",");
             //check if this already exists, if so exit
-            if (expandedPaths.indexOf(childPath) !== -1) {
+            if (expandedPaths.includes(childPath)) {
                 return;
             }
 
@@ -65,18 +65,18 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
 
             var clonedPaths = expandedPaths.slice(0); //make a copy to iterate over so we can modify the original in the iteration
 
-            _.each(clonedPaths, function (p) {
+            clonedPaths.forEach(p => {
                 if (childPath.startsWith(p + ",")) {
                     //this means that the node's path supercedes this path stored so we can remove the current 'p' and replace it with node.path
                     expandedPaths.splice(expandedPaths.indexOf(p), 1); //remove it
-                    if (expandedPaths.indexOf(childPath) === -1) {
+                    if (expandedPaths.includes(childPath) === false) {
                         expandedPaths.push(childPath); //replace it
                     }
                 }
                 else if (p.startsWith(childPath + ",")) {
                     //this means we've already tracked a deeper node so we shouldn't track this one
                 }
-                else if (expandedPaths.indexOf(childPath) === -1) {
+                else if (expandedPaths.includes(childPath) === false) {
                     expandedPaths.push(childPath); //track it
                 }
             });

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -265,9 +265,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
 
                     //reset the tabs and set the active one
                     if (response.data.tabs && response.data.tabs.length > 0) {
-                        _.each(response.data.tabs, function (item) {
-                            item.active = false;
-                        });
+                        response.data.tabs.forEach(item => item.active = false);
                         response.data.tabs[activeTabIndex].active = true;
                     }
 
@@ -324,7 +322,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
             if (!jsonData) { throw "jsonData cannot be null"; }
 
             if (Utilities.isArray(jsonData)) {
-                _.each(jsonData, function (item) {
+                jsonData.forEach(item => {
                     if (!item.key || !item.value) { throw "jsonData array item must have both a key and a value property"; }
                 });
             }
@@ -342,7 +340,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                     var formData = new FormData();
                     //add the json data
                     if (Utilities.isArray(data)) {
-                        _.each(data, function(item) {
+                        data.forEach(item => {
                             formData.append(item.key, !Utilities.isString(item.value) ? Utilities.toJson(item.value) : item.value);
                         });
                     }

--- a/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
@@ -12,36 +12,23 @@
             { "value": 4, "name": "Inactive", "key": "Inactive", "color": "warning" }
         ];
 
-        localizationService.localizeMany(_.map(userStates, function (userState) {
-            return "user_state" + userState.key;
-        })).then(function (data) {
-            var reg = /^\[[\S\s]*]$/g;
-            _.each(data, function (value, index) {
-                if (!reg.test(value)) {
-                    // Only translate if key exists
-                    userStates[index].name = value;
-                }
+        localizationService.localizeMany(userStates.map(userState => "user_state" + userState.key))
+            .then(data => {
+                var reg = /^\[[\S\s]*]$/g;
+                data.forEach((value, index) => {
+                    if (!reg.test(value)) {
+                        // Only translate if key exists
+                        userStates[index].name = value;
+                    }
+                });
             });
-        });
 
-        function getUserStateFromValue(value) {
-            var foundUserState;
-            angular.forEach(userStates, function (userState) {
-                if(userState.value === value) {
-                    foundUserState = userState;
-                }
-            });
-            return foundUserState;
+        function getUserStateFromValue(value) {        
+            return userStates.find(userState => userState.value === value);
         }
 
         function getUserStateByKey(key) {
-            var foundUserState;
-            angular.forEach(userStates, function (userState) {
-                if(userState.key === key) {
-                    foundUserState = userState;
-                }
-            });
-            return foundUserState;
+            return userStates.find(userState => userState.key === key);           
         }
 
         function getUserStatesFilter(userStatesObject) {
@@ -49,7 +36,7 @@
             var userStatesFilter = [];
 
             for (var key in userStatesObject) {
-                if (userStatesObject.hasOwnProperty(key)) {
+                if (hasOwnProperty.call(userStatesObject, key)) {
                     var userState = getUserStateByKey(key);
                     if(userState) {
                         userState.count = userStatesObject[key];
@@ -59,7 +46,6 @@
             }
 
             return userStatesFilter;
-
         }
 
         ////////////
@@ -71,10 +57,7 @@
         };
 
         return service;
-
     }
 
     angular.module('umbraco.services').factory('usersHelper', usersHelperService);
-
-
 })();

--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -173,9 +173,9 @@ function umbModelMapper() {
         /** This converts the source model to a basic entity model, it will throw an exception if there isn't enough data to create the model */
         convertToEntityBasic: function (source) {
             var required = ["id", "name", "icon", "parentId", "path"];
-            _.each(required, function (k) {
-                if (!_.has(source, k)) {
-                    throw "The source object does not contain the property " + k;
+            required.forEach(k => {
+                if (!hasOwnProperty.call(source, k)) {
+                    throw `The source object does not contain the property ${k}`;
                 }
             });
             var optional = ["metaData", "key", "alias"];

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypeconfigurationpicker/datatypeconfigurationpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypeconfigurationpicker/datatypeconfigurationpicker.controller.js
@@ -42,15 +42,14 @@
                 
                 var filteredConfigs = [];
                 
-                _.each(configs, function(configGroup) {
-                        for(var i = 0; i<configGroup.length; i++) {
-                            if (configGroup[i].alias === $scope.model.editor.alias) {
-                                filteredConfigs.push(configGroup[i]);
-                            }
+                Object.values(configs).forEach(configGroup => {
+                    for(var i = 0; i < configGroup.length; i++) {
+                        if (configGroup[i].alias === $scope.model.editor.alias) {
+                            filteredConfigs.push(configGroup[i]);
                         }
                     }
-                );
-                
+                });
+            
                 vm.configs = filteredConfigs;
                 vm.loading = false;
             });

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -303,9 +303,7 @@ angular.module("umbraco")
                     $timeout(function () {
                         if ($scope.multiPicker) {
                             var images = _.rest($scope.images, $scope.images.length - files.length);
-                            _.each(images, function (image) {
-                                selectMedia(image);
-                            });
+                            images.forEach(image => selectMedia(image));
                         } else {
                             var image = $scope.images[$scope.images.length - 1];
                             clickHandler(image);

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -283,19 +283,14 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             if (Utilities.isArray(args.children)) {
 
                 //iterate children
-                _.each(args.children,
-                    function (child) {
-
-                        //now we need to look in the already selected search results and
-                        // toggle the check boxes for those ones that are listed
-                        var exists = _.find(vm.searchInfo.selectedSearchResults,
-                            function (selected) {
-                                return child.id == selected.id;
-                            });
-                        if (exists) {
-                            child.selected = true;
-                        }
-                    });
+                args.children.forEach(child => {
+                    //now we need to look in the already selected search results and
+                    // toggle the check boxes for those ones that are listed
+                    var exists = vm.searchInfo.selectedSearchResults.find(selected => child.id === selected.id);
+                    if (exists) {
+                        child.selected = true;
+                    }
+                });
 
                 //check filter
                 performFiltering(args.children);
@@ -550,77 +545,65 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                 //we need to ensure that any currently displayed nodes that get selected
                 // from the search get updated to have a check box!
                 function checkChildren(children) {
-                    _.each(children,
-                        function (child) {
-                            //check if the id is in the selection, if so ensure it's flagged as selected
-                            var exists = _.find(vm.searchInfo.selectedSearchResults,
-                                function (selected) {
-                                    return child.id == selected.id;
+                    children.forEach(child => {
+                        //check if the id is in the selection, if so ensure it's flagged as selected
+                        var exists = vm.searchInfo.selectedSearchResults.find(selected => child.id === selected.id);
+                        //if the curr node exists in selected search results, ensure it's checked
+                        if (exists) {
+                            child.selected = true;
+                        }
+                        //if the curr node does not exist in the selected search result, and the curr node is a child of a list view search result
+                        else if (child.metaData.isSearchResult) {
+                            //if this tree node is under a list view it means that the node was added
+                            // to the tree dynamically under the list view that was searched, so we actually want to remove
+                            // it all together from the tree
+                            var listView = child.parent();
+                            listView.children = _.reject(listView.children,
+                                function (c) {
+                                    return c.id == child.id;
                                 });
-                            //if the curr node exists in selected search results, ensure it's checked
-                            if (exists) {
-                                child.selected = true;
-                            }
-                            //if the curr node does not exist in the selected search result, and the curr node is a child of a list view search result
-                            else if (child.metaData.isSearchResult) {
-                                //if this tree node is under a list view it means that the node was added
-                                // to the tree dynamically under the list view that was searched, so we actually want to remove
-                                // it all together from the tree
-                                var listView = child.parent();
-                                listView.children = _.reject(listView.children,
-                                    function (c) {
-                                        return c.id == child.id;
-                                    });
-                            }
+                        }
 
-                            //check if the current node is a list view and if so, check if there's any new results
-                            // that need to be added as child nodes to it based on search results selected
-                            if (child.metaData.isContainer) {
+                        //check if the current node is a list view and if so, check if there's any new results
+                        // that need to be added as child nodes to it based on search results selected
+                        if (child.metaData.isContainer) {
 
-                                child.cssClasses = _.reject(child.cssClasses,
-                                    function (c) {
-                                        return c === 'tree-node-slide-up-hide-active';
-                                    });
+                            child.cssClasses = _.reject(child.cssClasses,
+                                function (c) {
+                                    return c === 'tree-node-slide-up-hide-active';
+                                });
 
-                                var listViewResults = _.filter(vm.searchInfo.selectedSearchResults,
-                                    function (i) {
-                                        return i.parentId == child.id;
-                                    });
-                                _.each(listViewResults,
-                                    function (item) {
-                                        var childExists = _.find(child.children,
-                                            function (c) {
-                                                return c.id == item.id;
-                                            });
-                                        if (!childExists) {
-                                            var parent = child;
-                                            child.children.unshift({
-                                                id: item.id,
-                                                name: item.name,
-                                                cssClass: "icon umb-tree-icon sprTree " + item.icon,
-                                                level: child.level + 1,
-                                                metaData: {
-                                                    isSearchResult: true
-                                                },
-                                                hasChildren: false,
-                                                parent: function () {
-                                                    return parent;
-                                                }
-                                            });
-                                        }
-                                    });
-                            }
+                            var listViewResults = vm.searchInfo.selectedSearchResults.filter(i => i.parentId === child.id);
 
-                            //recurse
-                            if (child.children && child.children.length > 0) {
-                                checkChildren(child.children);
-                            }
-                        });
+                            listViewResults.forEach(item => {
+                                var childExists = child.children.find(c => c.id === item.id);
+
+                                if (!childExists) {
+                                    var parent = child;
+                                    child.children.unshift({
+                                        id: item.id,
+                                        name: item.name,
+                                        cssClass: "icon umb-tree-icon sprTree " + item.icon,
+                                        level: child.level + 1,
+                                        metaData: {
+                                            isSearchResult: true
+                                        },
+                                        hasChildren: false,
+                                        parent: () => parent                                        
+                                    });
+                                }
+                            });
+                        }
+
+                        //recurse
+                        if (child.children && child.children.length > 0) {
+                            checkChildren(child.children);
+                        }
+                    });
                 }
 
                 checkChildren(tree.root.children);
             }
-
 
             vm.searchInfo.showSearch = false;
             vm.searchInfo.searchFromId = vm.startNodeId;
@@ -634,24 +617,16 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             performFiltering(results);
 
             //now actually remove all filtered items so they are not even displayed
-            results = _.filter(results,
-                function (item) {
-                    return !item.filtered;
-                });
-
+            results = results.filter(item => !item.filtered);          
             vm.searchInfo.results = results;
 
             //sync with the curr selected results
-            _.each(vm.searchInfo.results,
-                function (result) {
-                    var exists = _.find($scope.model.selection,
-                        function (item) {
-                            return result.id == item.id;
-                        });
-                    if (exists) {
-                        result.selected = true;
-                    }
-                });
+            vm.searchInfo.results.forEach(result => {
+                var exists = $scope.model.selection.find(item => result.id === item.id);               
+                if (exists) {
+                    result.selected = true;
+                }
+            });
 
             vm.searchInfo.showSearch = true;
         }
@@ -673,12 +648,8 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
         }
 
         function listViewItemsLoaded(items) {
-            var selectedIds = _.pluck($scope.model.selection, "id");
-            _.each(items, function (item) {
-                if (_.contains(selectedIds, item.id)) {
-                    item.selected = true;
-                }
-            });
+            var selectedIds = $scope.model.selection.map(x => x.id);
+            items.forEach(item => item.selected = selectedIds.includes(item.id));
         }
 
         function submit(model) {


### PR DESCRIPTION
Changes replace `_.each` with native `.forEach` in directives (components) and resources - I've sanity checked these locally, all seems to be fine. This is related to #7731 but does not yet complete the _.each removal (figured it's better to have multiple smaller PRs rather than one big one with 50 files modified).

Most are like-for-like replacements, with the exception of some like the changes in umbsearch.directive.js where the value is a dictionary not an array, so uses `Object.keys().forEach()` because the value is not directly iterable.

Made related syntax changes to replace some indexOf calls with includes (easier to read `x.includes(y)` compared to `x.indexOf(y) !== -1`), and converted a few functions to single-line fat-arrows where it made sense to be terser.