### PR TITLE
Update boolean/toggle/checkbox label prevalues

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -87,22 +87,28 @@
             }
 
             function setLabelText() {
-
-                // set default label for "on"
+                
                 if (scope.labelOn) {
                     scope.displayLabelOn = scope.labelOn;
-                } else {
-                    localizationService.localize("general_on").then(function (value) {
-                        scope.displayLabelOn = value;
-                    });
                 }
-
-                // set default label for "Off"
+                
                 if (scope.labelOff) {
                     scope.displayLabelOff = scope.labelOff;
-                } else {
-                    localizationService.localize("general_off").then(function (value) {
-                        scope.displayLabelOff = value;
+                }
+
+                if (scope.displayLabelOn.length === 0 && scope.displayLabelOff.length === 0)
+                {
+                    var labelKeys = [
+                        "general_on",
+                        "general_off"
+                    ];
+
+                    localizationService.localizeMany(labelKeys).then(function (data) {
+                        // set default label for "On"
+                        scope.displayLabelOn = data[0];
+
+                        // set default label for "Off"
+                        scope.displayLabelOff = data[1];
                     });
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -79,7 +79,7 @@
 
                 setLabelText();
 
-                // must wait until the current digest cycle is finished before we emit this event on init, 
+                // Must wait until the current digest cycle is finished before we emit this event on init, 
                 // otherwise other property editors might not yet be ready to receive the event
                 $timeout(function () {
                     eventsService.emit("toggleValue", { value: scope.checked });
@@ -104,10 +104,10 @@
                     ];
 
                     localizationService.localizeMany(labelKeys).then(function (data) {
-                        // set default label for "On"
+                        // Set default label for "On"
                         scope.displayLabelOn = data[0];
 
-                        // set default label for "Off"
+                        // Set default label for "Off"
                         scope.displayLabelOff = data[1];
                     });
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -7,8 +7,13 @@ function booleanEditorController($scope, angularHelper) {
     // Maybe sometime later we can make it support "Yes/No" or "On/Off" as well similar to ng-true-value and ng-false-value in Angular.
     var config = {
         truevalue: "1",
-        falsevalue: "0"
+        falsevalue: "0",
+        showLabels: false
     };
+
+    if ($scope.model.config && $scope.model.config.showLabels && Object.toBoolean($scope.model.config.showLabels)) {
+        config.showLabels = true;
+    }
 
     // Map the user config
     Utilities.extend(config, $scope.model.config);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
@@ -6,6 +6,6 @@
         show-labels="{{model.config.labelOn ? 'true': 'false'}}"
         label-position="right"
         label-on="{{model.config.labelOn}}"
-        label-off="{{model.config.labelOn}}">
+        label-off="{{model.config.labelOff}}">
     </umb-toggle>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
@@ -3,7 +3,7 @@
         input-id="{{model.alias}}"
         checked="renderModel.value"
         on-click="toggle()"
-        show-labels="{{model.config.labelOn ? 'true': 'false'}}"
+        show-labels="{{model.config.showLabels}}"
         label-position="right"
         label-on="{{model.config.labelOn}}"
         label-off="{{model.config.labelOff}}">

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -10,10 +10,10 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("default", "Initial State", "boolean", Description = "The initial state for the toggle, when it is displayed for the first time in the backoffice, eg. for a new content item.")]
         public bool Default { get; set; }
 
-        [ConfigurationField("labelOn", "Label text when enabled", "textstring")]
+        [ConfigurationField("labelOn", "Label On", "textstring", Description = "Label text when checked.")]
         public string LabelOn { get; set; }
 
-        [ConfigurationField("labelOff", "Label text when disabled", "textstring")]
+        [ConfigurationField("labelOff", "Label Off", "textstring", Description = "Label text unchecked.")]
         public string LabelOff { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -7,8 +7,8 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class TrueFalseConfiguration
     {
-        [ConfigurationField("default","Initial State", "boolean",Description = "The initial state for this checkbox, when it is displayed for the first time in the backoffice, eg. for a new content item.")]
-        public string Default { get; set; } // TODO: well, true or false?!
+        [ConfigurationField("default", "Initial State", "boolean", Description = "The initial state for the toggle, when it is displayed for the first time in the backoffice, eg. for a new content item.")]
+        public bool Default { get; set; }
 
         [ConfigurationField("labelOn", "Label text when enabled", "textstring")]
         public string LabelOn { get; set; }

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -10,7 +10,10 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("default","Initial State", "boolean",Description = "The initial state for this checkbox, when it is displayed for the first time in the backoffice, eg. for a new content item.")]
         public string Default { get; set; } // TODO: well, true or false?!
 
-        [ConfigurationField("labelOn", "Write a label text", "textstring")]
-        public string Label { get; set; }
+        [ConfigurationField("labelOn", "Label text when enabled", "textstring")]
+        public string LabelOn { get; set; }
+
+        [ConfigurationField("labelOff", "Label text when disabled", "textstring")]
+        public string LabelOff { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("labelOn", "Label On", "textstring", Description = "Label text when checked.")]
         public string LabelOn { get; set; }
 
-        [ConfigurationField("labelOff", "Label Off", "textstring", Description = "Label text unchecked.")]
+        [ConfigurationField("labelOff", "Label Off", "textstring", Description = "Label text when unchecked.")]
         public string LabelOff { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -10,6 +10,9 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("default", "Initial State", "boolean", Description = "The initial state for the toggle, when it is displayed for the first time in the backoffice, eg. for a new content item.")]
         public bool Default { get; set; }
 
+        [ConfigurationField("showLabels", "Show toggle labels", "boolean", Description = "Show labels next to toggle button.")]
+        public bool ShowLabels { get; set; }
+
         [ConfigurationField("labelOn", "Label On", "textstring", Description = "Label text when checked.")]
         public string LabelOn { get; set; }
 

--- a/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalseConfiguration.cs
@@ -13,10 +13,10 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("showLabels", "Show toggle labels", "boolean", Description = "Show labels next to toggle button.")]
         public bool ShowLabels { get; set; }
 
-        [ConfigurationField("labelOn", "Label On", "textstring", Description = "Label text when checked.")]
+        [ConfigurationField("labelOn", "Label On", "textstring", Description = "Label text when enabled.")]
         public string LabelOn { get; set; }
 
-        [ConfigurationField("labelOff", "Label Off", "textstring", Description = "Label text when unchecked.")]
+        [ConfigurationField("labelOff", "Label Off", "textstring", Description = "Label text when disabled.")]
         public string LabelOff { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Web.PropertyEditors
     [DataEditor(
         Constants.PropertyEditors.Aliases.Boolean,
         EditorType.PropertyValue | EditorType.MacroParameter,
-        "Checkbox",
+        "Toggle",
         "boolean",
         ValueType = ValueTypes.Integer,
         Group = Constants.PropertyEditors.Groups.Common,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The True/False property editor aka Checkbox has at the moment a prevalue in the configuration to set a label text, but "Write a label text" is not very informative. Furthermore it both used this for "label-on" and "label-off".

Instead it now has two prevalues to set text for "Label On" and "Label Off". If the developer want the same text whether the toggle is checked or not, is it quite easy to set same label text in both prevalues.

Maybe some even prefer it only show a specific label when the toggle in checked of not checked?

At the moment it would only show labels if the toggle has a "labelOn" value and not if "labelOff" actual has a value:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html#L6
So the configuration now has a property "Show labels" to active decide whether labels should be shown or not.
Furthermore if either labelOn or labelOff didn't had a value `umb-toggle` has fallback to `On` and `Off`. I have changed this so it only use this fallback if both fields are empty - or if both `label-on` and `label-off` in the `umb-toggle` component are empty. With this you can e.g. show a label text only if the toggle is checked or unchecked. e.g. if you specify a custom label on text "Day" a no value for label off text (Night), it shouldn't default to "Off" right? Better only use the default values is none label text has been filled.

I have already updated the property editor name from "Checkbox" to "Toggle" since it hasn't much to do with a checkbox anymore. If replacing the font icons with SVG icons as in this PR https://github.com/umbraco/Umbraco-CMS/pull/5606 we might even use something like `icon-toggle` or `icon-switch` instead of `icon-checkbox` sometime later.

![2020-07-25_18-01-37](https://user-images.githubusercontent.com/2919859/88461071-09576380-cea1-11ea-802b-e299c92d6726.gif)