### PR TITLE
Remove button for custom listview layouts isn't rendered

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -30,18 +30,18 @@
                    <input ng-if="layout.isSystem !== 1" type="text" ng-model="layout.path" placeholder="Layout path..." class="-full-width-input" />
                </div>
 
-         <div>
-           <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected" />
-            <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
-                <umb-confirm-action
-                    show="layout.deletePrompt"
-                    direction="left"
-                    on-delete="vm.showPrompt(layout)"
-                    on-confirm="vm.removeLayout($index, layout)"
-                    on-cancel="vm.hidePrompt(layout)">
-                </umb-confirm-action>
-            </div>
-         </div>
+               <div>
+                   <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected"></umb-checkbox>
+
+                   <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
+                       <umb-confirm-action show="layout.deletePrompt"
+                                           direction="left"
+                                           on-delete="vm.showPrompt(layout)"
+                                           on-confirm="vm.removeLayout($index, layout)"
+                                           on-cancel="vm.hidePrompt(layout)">
+                       </umb-confirm-action>
+                   </div>
+               </div>
 
            </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Custom angular element directives/components can't be self-closing elements like navtive elements, e.g. `<input type="checkbox value="" />`:
https://stackoverflow.com/a/25012451/1693918

This was previous fixed in https://github.com/umbraco/Umbraco-CMS/pull/8422 but overwritten in https://github.com/umbraco/Umbraco-CMS/commit/1cd79d81af821470de2123e1c6febe2980d98111#diff-c84512d9cc059db603911cd477e1d82e

**Before**

![image](https://user-images.githubusercontent.com/2919859/88463961-0c5d4e80-ceb7-11ea-9171-c6b65e405f89.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/88463927-c99b7680-ceb6-11ea-9c75-0f1974cb64f5.png)
