### PR TITLE
#8345  - Nested content not remembering value on variant switch

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -98,6 +98,8 @@
         vm.wideMode = Object.toBoolean(model.config.hideLabel);
         vm.hasContentTypes = model.config.contentTypes.length > 0;
 
+        var cultureChanged = eventsService.on('editors.content.cultureChanged', (_, args) => updateModel());
+
         var labels = {};
         vm.labels = labels;
         localizationService.localizeMany(["grid_addElement", "content_createEmpty", "actions_copy"]).then(function (data) {
@@ -696,6 +698,7 @@
 
         $scope.$on("$destroy", function () {
             unsubscribe();
+            cultureChanged();
             watcher();
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -98,7 +98,7 @@
         vm.wideMode = Object.toBoolean(model.config.hideLabel);
         vm.hasContentTypes = model.config.contentTypes.length > 0;
 
-        var cultureChanged = eventsService.on('editors.content.cultureChanged', (_, args) => updateModel());
+        var cultureChanged = eventsService.on('editors.content.cultureChanged', (name, args) => updateModel());
 
         var labels = {};
         vm.labels = labels;


### PR DESCRIPTION
This fixes #8345

### Description
Thanks to the steps by @snedled and @nathanwoulfe (including the work done for emitting an event when changing variant, and the example code in #8355, this should now work as the nestedcontent controller listens for the now emitted editors.content.cultureChanged event, and when destroyed updates the editor model prior to the language variant changing.

I've been able to test this by:
- Create a content type with a nested content field, and set it to use 2 language variants.
- Add some example content to the nested content field - leave the nested content item expanded and don't save the node.
- Swap the language variant on the node itself, this will reload the editor.
- Swap back to the original language variant - the nested content editor will be minimized, but expanding will show the original content prior to swapping variant.
- Previously, the new nested content item was created, but the content within the item was wiped.

Let me know if this works for you!

Thanks
Rick