### PR TITLE
Richtext rules adjustments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-stylesheet.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-stylesheet.less
@@ -41,6 +41,7 @@ textarea.umb-stylesheet-rule-styles {
     width: 300px;
     height: 100px;
     resize: none;
+    font-family: @monoFontFamily;
 }
 
 .umb-stylesheet-rule-preview {

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -131,7 +131,7 @@
 
         pre {
             display: inline-flex;
-            font-family: monospace;
+            font-family: @monoFontFamily;
             margin-left: 15px;
             margin-right: 15px;
             white-space: nowrap;
@@ -168,7 +168,7 @@
     label {
         border: 1px solid @white;
         padding: 6px 10px;
-        font-family: monospace;
+        font-family: @monoFontFamily;
         border: 1px solid @gray-8;
         background: @gray-11;
         margin: 0 15px 0 3px;

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.html
@@ -4,7 +4,7 @@
             <input overlay-submit-on-enter="false" name="newItem" focus-when="{{focusOnNew}}" ng-keydown="createNew($event)" type="text" ng-model="newItem" val-highlight="{{hasError}}" />
         </div>
         <div class="umb-prevalues-multivalues__right">
-            <button class="btn btn-info" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button type="button" class="btn btn-info" ng-click="add($event)"><localize key="general_add">Add</localize></button>
         </div>
     </div>
     <div ui-sortable="sortableOptions">
@@ -14,7 +14,7 @@
                 <input type="text" ng-model="item.value" val-server="item_{{$index}}" required />
             </div>
             <div class="umb-prevalues-multivalues__right">
-                <button class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></button>
+                <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></button>
             </div>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/infiniteeditors/richtextrule/richtextrule.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/infiniteeditors/richtextrule/richtextrule.html
@@ -2,7 +2,7 @@
     
     <form novalidate name="richTextRuleForm" val-form-manager>
 
-    <umb-editor-view>
+        <umb-editor-view>
 
             <umb-editor-header
                 name="model.title"
@@ -64,9 +64,8 @@
                         action="vm.submit(model)">
                     </umb-button>
                 </umb-editor-footer-content-right>
-            </umb-editor-footer>
-            '        
-    </umb-editor-view>
+            </umb-editor-footer>     
+        </umb-editor-view>
 
     </form>
 

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/views/rules/rules.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/views/rules/rules.controller.js
@@ -59,7 +59,6 @@ angular.module("umbraco").controller("Umbraco.Editors.StyleSheets.RulesControlle
             };
 
             editorService.open(ruleDialog);
-
         }
 
         function setDirty() {

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/views/rules/rules.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/views/rules/rules.html
@@ -9,10 +9,8 @@
                 <div class="umb-property-editor umb-stylesheet-rules form-horizontal" ng-controller="Umbraco.Editors.StyleSheets.RulesController">
                     <div ui-sortable="sortableOptions" ng-model="model.stylesheet.rules">
                         <div class="umb-stylesheet-rules__listitem" ng-repeat="rule in model.stylesheet.rules track by $id(rule)">
-                            <i class="icon icon-navigation handle"></i>
-                            <div class="umb-stylesheet-rules__left">
-                                {{rule.name}}
-                            </div>
+                            <i class="icon icon-navigation handle" aria-hidden="true"></i>
+                            <div class="umb-stylesheet-rules__left">{{rule.name}}</div>
                             <div class="umb-stylesheet-rules__right">
                                 <a class="umb-node-preview__action" ng-click="edit(rule, $event)"><localize key="general_edit">Edit</localize></a>
                                 <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(rule, $event)"><localize key="general_remove">Remove</localize></a>

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/views/rules/rules.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/views/rules/rules.html
@@ -12,8 +12,8 @@
                             <i class="icon icon-navigation handle" aria-hidden="true"></i>
                             <div class="umb-stylesheet-rules__left">{{rule.name}}</div>
                             <div class="umb-stylesheet-rules__right">
-                                <a class="umb-node-preview__action" ng-click="edit(rule, $event)"><localize key="general_edit">Edit</localize></a>
-                                <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(rule, $event)"><localize key="general_remove">Remove</localize></a>
+                                <button type="button" class="umb-node-preview__action" ng-click="edit(rule, $event)"><localize key="general_edit">Edit</localize></button>
+                                <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(rule, $event)"><localize key="general_remove">Remove</localize></button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
A few adjustments to richtext styles editor using `<button>` elements instead of `<a>` elements.
Furthermore is replace a few fonts using `@monoFontFamily` variable, where it makes the textarea look more like an css editor.

![image](https://user-images.githubusercontent.com/2919859/88467032-e2198a00-ced2-11ea-95aa-2e0fee829f59.png)

I considered it ace editor code be used here as well, but I think it need to include the selector as readonly line. https://stackoverflow.com/a/39640987/1693918
Might be possible, but a bit more complex and would require another PR.
