### PR TITLE
Hide action button in tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
@@ -1,7 +1,7 @@
 .umb-button-ellipsis{
     padding: 0 5px;
     text-align: center;
-    margin: 0 10px 0 auto;
+    margin: 0 auto;
     cursor: pointer;
     border-radius: @baseBorderRadius;
     color: black;
@@ -9,7 +9,7 @@
     opacity: 0.8;
     transition: opacity .3s ease-out;
 
-    &.show-text{
+    &.show-text {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -86,7 +86,7 @@ body.touch .umb-tree {
             width: auto;
             height: auto;
             margin: 0 5px 0 auto;
-            padding: 9px 5px;
+            padding: 7px 5px;
             overflow: visible;
             clip: auto;
         }
@@ -175,7 +175,7 @@ body.touch .umb-tree {
     display: flex;
     flex: 0 0 auto;
     justify-content: flex-end;
-    padding: 9px 5px;
+    padding: 7px 5px;
     text-align: center;
     margin: 0 5px 0 auto;
     cursor: pointer;
@@ -209,7 +209,7 @@ body.touch .umb-tree {
         display: flex;
         flex: 0 0 auto;
         justify-content: flex-end;
-        padding: 9px 5px;
+        padding: 7px 5px;
         text-align: center;
         margin: 0 auto;
         cursor: pointer;

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -75,8 +75,8 @@ body.touch .umb-tree {
     
     &:hover {
         background: @ui-option-hover;
-        
         color: @ui-option-type-hover;
+
         a {
             color: @ui-option-type-hover;
         }
@@ -85,7 +85,7 @@ body.touch .umb-tree {
             position: relative;
             width: auto;
             height: auto;
-            margin: 0 10px 0 auto;
+            margin: 0 5px 0 auto;
             padding: 9px 5px;
             overflow: visible;
             clip: auto;
@@ -177,7 +177,7 @@ body.touch .umb-tree {
     justify-content: flex-end;
     padding: 9px 5px;
     text-align: center;
-    margin: 0 10px 0 auto;
+    margin: 0 5px 0 auto;
     cursor: pointer;
     border-radius: @baseBorderRadius;
 
@@ -188,18 +188,20 @@ body.touch .umb-tree {
         display: inline-block;
         margin: 0 2px 0 0;
         background: @ui-active-type;
-        
+
         &:last-child {
             margin: 0;
         }
     }
+
     &:hover {
         background: rgba(255, 255, 255, .5);
+
         i {
             background: @ui-active-type-hover;
         }
     }
-    
+
     // NOTE - We're having to repeat ourselves here due to an .sr-only class appearing in umbraco/lib/font-awesome/css/font-awesome.min.css
     &.sr-only--hoverable:hover,
     &.sr-only--focusable:focus {
@@ -209,7 +211,7 @@ body.touch .umb-tree {
         justify-content: flex-end;
         padding: 9px 5px;
         text-align: center;
-        margin: 0 10px 0 auto;
+        margin: 0 auto;
         cursor: pointer;
         border-radius: 3px;
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -20,7 +20,7 @@
             action="options(node, $event)"
             text="{{optionsText}} {{node.name}}"
             state="hidden"
-            >
+            class="umb-options">
         </umb-button-ellipsis>
 
         <umb-loader ng-show="node.loading" position="bottom" class="umb-tree-item__loader"></umb-loader>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -13,7 +13,7 @@
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 
-        <!-- NOTE: These are the 'option' elipses -->
+        <!-- NOTE: These are the 'option' ellipsis -->
         <umb-button-ellipsis
             ng-if="::node.menuUrl"
             element="tree-item-options"

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
@@ -1,6 +1,6 @@
 <div class="form-search">
-    <i class="icon icon-search" ng-if="showSearch == 'false'"></i>
-    <a class="icon icon-arrow-left" ng-if="showSearch == 'true'" title="Back" ng-click="hideSearch()"></a>
+    <i class="icon icon-search" ng-if="showSearch == 'false'" aria-hidden="true"></i>
+    <button type="button" class="btn-reset icon icon-arrow-left" ng-if="showSearch == 'true'" title="Back" ng-click="hideSearch()"></button>
     <input type="text"
            ng-model="term"
            class="umb-search-field search-query -full-width-input"

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
@@ -1,6 +1,6 @@
 <div class="form-search">
     <i class="icon icon-search" ng-if="showSearch == 'false'" aria-hidden="true"></i>
-    <button type="button" class="btn-reset icon icon-arrow-left" ng-if="showSearch == 'true'" title="Back" ng-click="hideSearch()"></button>
+    <button type="button" class="btn-reset icon icon-arrow-left" ng-if="showSearch == 'true'" localize="title" title="@general_back" ng-click="hideSearch()"></button>
     <input type="text"
            ng-model="term"
            class="umb-search-field search-query -full-width-input"

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -14,9 +14,9 @@
                 action="options(tree.root, $event)"
                 text="Open context node for {{tree.name}}"
                 state="hidden"
+                class="umb-options"
                 ng-hide="tree.root.isContainer || !tree.root.menuUrl"
-                ng-swipe-right="options(tree.root, $event)"
-                >
+                ng-swipe-right="options(tree.root, $event)">
             </umb-button-ellipsis>
 
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -48,9 +48,9 @@
                 action="options(group, $event)"
                 text="Open context node for {{group.name}}"
                 state="hidden"
+                class="umb-options"
                 ng-hide="group.isContainer || !group.menuUrl"
-                ng-swipe-right="options(group, $event)"
-                >
+                ng-swipe-right="options(group, $event)">
             </umb-button-ellipsis>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -11,10 +11,10 @@
 
         <div class="umb-mini-list-view__breadcrumb">
 
-            <a ng-if="showBackButton()" href="" class="umb-mini-list-view__back" ng-click="exitMiniListView()">
+            <button type="button" ng-if="showBackButton()" class="btn-reset umb-mini-list-view__back" ng-click="exitMiniListView()">
                 <i class="icon-arrow-left umb-mini-list-view__back-icon" aria-hidden="true"></i>
                 <span class="umb-mini-list-view__back-text"><localize key="general_back">Back</localize></span> /
-            </a>
+            </button>
 
             <umb-breadcrumbs
                 ng-if="breadcrumb && breadcrumb.length > 0"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This previous PR https://github.com/umbraco/Umbraco-CMS/pull/8132 introduced a `umb-button-ellipsis` components and replaced with this various placed with "ellipsis" button. One of these placed is the action button in tree.

However `umb-tree` has an options to `hideoptions` which set a class `hide-options` and the following styling which hide the button with class `umb-options`: https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less#L217-L219

The new button in tree does however no longer has this class, so it is always shown on hover (e.g. in macro partial view picker) even `hideoptions` is set. Note this is used quite many places: https://github.com/umbraco/Umbraco-CMS/search?q=hideoptions&unscoped_q=hideoptions where this is the one when using treepicker infinite editor https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html#L59

This PR add this class to the component here (because we might not want to use this class on all `umb-button-ellipsis` components and furthermore it make it easier to target some specific styling to this inside tree.

**Before**

![image](https://user-images.githubusercontent.com/2919859/88474759-ffc60e00-cf29-11ea-834d-7f5f14ef3343.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/88474740-d1483300-cf29-11ea-849b-faa0e31d0360.png)