### PR TITLE
Change button style for redirect delete confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js
@@ -107,6 +107,7 @@
                 view: "views/dashboard/content/overlays/delete.html",
                 redirect: redirect,
                 submitButtonLabelKey: "contentTypeEditor_yesDelete",
+                submitButtonStyle: "danger",
                 submit: function (model) {
                     performDelete(model.redirect);
                     overlayService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -38,8 +38,7 @@
                             label-key="general_typeToSearch"
                             text="Type to search"
                             on-change="vm.filter()"
-                            prevent-submit-on-enter="true"
-                        >
+                            prevent-submit-on-enter="true">
                         </umb-search-filter>
                     </div>
                 </ng-form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR change the button style to `danger` in redirect delete confirm to be consistent with other delete confirm overlays, e.g. in language delete confirm.

![image](https://user-images.githubusercontent.com/2919859/88477616-ea5cde00-cf41-11ea-9a95-935581aa246d.png)

**Before**

![image](https://user-images.githubusercontent.com/2919859/88477654-28f29880-cf42-11ea-8424-c34380c45fe7.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/88477625-fc3e8100-cf41-11ea-9242-151f5eeefbb2.png)
