### PR TITLE
Do not rebind content types on save errors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -100,10 +100,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                         self.handleSaveError({
                             showNotifications: args.showNotifications,
                             softRedirect: args.softRedirect,
-                            err: err,
-                            rebindCallback: function () {
-                                rebindCallback.apply(self, [args.content, err.data]);
-                            }
+                            err: err
                         });
 
                         //update editor state to what is current


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8465

### Description

See #8465 for an issue description and a screencast of the issue as it plays out.

The issue happens because the content type editor is rebound with data from the server after an unsuccessful save event. The way the rebind callback is implemented, it accidentally assigns duplicate IDs to the groups with matching names, and thus one of them ends up overwritten on the next successful save.

I don't believe it makes sense to rebind the content type editor if the save fails. Nothing has been persisted on the server anyway. So this PR simply removes the rebinding upon failed saves.

With this PR applied, the editor behaves like you'd expect - preserving the previously duplicated groups after renaming them appropriately:

![do-not-rebind-on-save-error](https://user-images.githubusercontent.com/7405322/88528985-a7614000-cfff-11ea-8f7f-cd4ff8771b49.gif)
