### PR TITLE
Fix broken "more" button in editor app navigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -142,21 +142,7 @@
     // --------------------------------
 
     &-more__icon {
-        margin-bottom: 10px;
-
-        i {
-            height: 5px;
-            width: 5px;
-            border-radius: 50%;
-            background: @ui-active-type; // fallback if browser doesnt support currentColor
-            background: currentColor;
-            display: inline-block;
-            margin: 0 5px 0 0;
-        }
-
-        i:last-of-type {
-            margin-right: 0;
-        }
+        margin-bottom: 6px;
     }
 
     &-more__dropdown {

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -16,14 +16,14 @@
 
         <div class="umb-sub-views-nav-item umb-sub-views-nav-item-more">
 
-            <umb-button-ellipsis
-                element="sub-view-{{moreButton.alias}}"
-                action="toggleDropdown()"
-                color="#1b264f"
-                text="{{moreButton.name}}"
-                show-text="true"
-                >
-            </umb-button-ellipsis>
+            <button data-element="sub-view-{{moreButton.alias}}"
+                    type="button"
+                    ng-click="toggleDropdown()"
+                    ng-class="{'is-active': moreButton.active}"
+                    class="umb-sub-views-nav-item__action umb-outline umb-outline--thin">
+                <div class="umb-sub-views-nav-item-more__icon">&bull;&bull;&bull;</div>
+                <span class="umb-sub-views-nav-item-text">{{ moreButton.name }}</span>
+            </button>
 
             <umb-dropdown ng-show="showDropdown" on-close="hideDropdown()" class="umb-sub-views-nav-item-more__dropdown">
                 <umb-dropdown-item ng-repeat="navItem in navigation | limitTo: overflowingItems">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "more" button in the editor app navigation has gone and gotten slightly broken after merging in #8132. Actually it looks pretty good when there are no apps displayed at all, but soon as only some apps are there (i.e. when using content apps), it starts looking really weird:

![image](https://user-images.githubusercontent.com/7405322/88536755-aaaef880-d00c-11ea-8399-132c768668c5.png)

![image](https://user-images.githubusercontent.com/7405322/88537148-4ccee080-d00d-11ea-8417-c6efcfbc1a84.png)

![image](https://user-images.githubusercontent.com/7405322/88537115-3b85d400-d00d-11ea-96a9-1f8a64a1446b.png)

This PR reverts the editor app navigation part of #8132 and redoes it to be keyboard navigation friendly. Once applied, the "more" button looks like the rest of the content app buttons once again:

![image](https://user-images.githubusercontent.com/7405322/88537314-a0412e80-d00d-11ea-8fdc-9043bace3173.png)

![image](https://user-images.githubusercontent.com/7405322/88537233-7b4cbb80-d00d-11ea-9e62-f440e62263dd.png)

![image](https://user-images.githubusercontent.com/7405322/88537272-8b649b00-d00d-11ea-974a-d2bbed55c76e.png)
