### PR TITLE
Ensure replacement of angular.copy still works with second parameter…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -18,7 +18,7 @@
     /**
      * Facade to angular.copy
      */
-    const copy = val => angular.copy(val);
+    const copy = (src, dst) => angular.copy(src, dst);
 
     /**
      * Equivalent to angular.isArray


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8487

### Description
At the moment when opening section picker from user group, none of the current sections where preselected. This happens because `currentSelection` here always is empty.

https://github.com/umbraco/Umbraco-CMS/blob/bd26cb36ecce2bbe86f11b61dd1a01c314378c89/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js#L104

The `Utilities.copy` works as `angular.copy` but unlike `angular.copy` it doesn't accept a second optional paramter to copy to a destination object/array.

This was cause by the changes in https://github.com/umbraco/Umbraco-CMS/pull/7950 where it a few places use the second optional parameter.

![2020-07-27_21-17-17](https://user-images.githubusercontent.com/2919859/88582253-af949c00-d04e-11ea-9644-4b1c2d114172.gif)

Note the issue also affected user picker in a user group, so when picking new users in a group (and you forget to select the existing users) they are cleared from the list, which could be problematic since these users no longer has access to what they used to have access to.