### PR TITLE
7731 bye bye underscore => _.each pt2 => content overlays

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function PublishController($scope, localizationService, contentEditingHelper) {
+    function PublishController($scope, localizationService) {
 
         var vm = this;
         vm.loading = true;
@@ -9,23 +9,23 @@
 
         vm.changeSelection = changeSelection;
 
-        /** Returns true if publish meets the requirements of mandatory languages */
+        /** 
+         * Returns true if publish meets the requirements of mandatory languages 
+         * */
         function canPublish() {
             
             var hasSomethingToPublish = false;
 
-            for (var i = 0; i < vm.variants.length; i++) {
-                var variant = vm.variants[i];
-
-                // if varaint is mandatory and not already published:
+            vm.variants.forEach(variant => {
+                // if variant is mandatory and not already published:
                 if (variant.publish === false && notPublishedMandatoryFilter(variant)) {
                     return false;
                 }
                 if (variant.publish === true) {
                     hasSomethingToPublish = true;
                 }
+            });
 
-            }
             return hasSomethingToPublish;
         }
 
@@ -35,7 +35,6 @@
             //need to set the Save state to same as publish.
             variant.save = variant.publish;
         }
-
 
         function hasAnyDataFilter(variant) {
 
@@ -47,49 +46,64 @@
                 return true;
             }
 
-            for (var t=0; t < variant.tabs.length; t++){
-                for (var p=0; p < variant.tabs[t].properties.length; p++){
-                    var property = variant.tabs[t].properties[p];
+            variant.tabs.forEach(tab => {
+                tab.properties.forEach(property => {
                     if (property.value != null && property.value.length > 0) {
                         return true;
                     }
-                }
-            }
+                });
+            });
 
             return false;
         }
 
+        /**
+         * determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
+         *  * it's editor is in a $dirty state
+         *  * it has pending saves
+         *  * it is unpublished
+         * @param {*} variant 
+         */
         function dirtyVariantFilter(variant) {
-            //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
-            // * it's editor is in a $dirty state
-            // * it has pending saves
-            // * it is unpublished
             return (variant.isDirty || variant.state === "Draft" || variant.state === "PublishedPendingChanges");
         }
 
+        /**
+         * determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
+         *  * variant is active
+         *  * it's editor is in a $dirty state
+         *  * it has pending saves
+         *  * it is unpublished
+         * @param {*} variant 
+         */
         function publishableVariantFilter(variant) {
-            //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
-            // * variant is active
-            // * it's editor is in a $dirty state
-            // * it has pending saves
-            // * it is unpublished
+
             return (variant.active || variant.isDirty || variant.state === "Draft" || variant.state === "PublishedPendingChanges");
         }
 
         function notPublishedMandatoryFilter(variant) {
             return variant.state !== "Published" && isMandatoryFilter(variant);
         }
-        function isMandatoryFilter(variant) {
-            //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
-            // * has a mandatory language
-            // * without having a segment, segments cant be mandatory at current state of code.
+
+        /**
+         * determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
+         *  * has a mandatory language
+         *  * without having a segment, segments cant be mandatory at current state of code.
+         * @param {*} variant 
+         */
+        function isMandatoryFilter(variant) {            
             return (variant.language && variant.language.isMandatory === true && variant.segment == null);
         }
+
+        /**
+         * determine a variant is needed, but not already a choice.
+         *  * publishable — aka. displayed as a publish option.
+         *  * published — its already published and everything is then fine.
+         *  * mandatory — this is needed, and thats why we highlight it.
+         * @param {*} variant 
+         */
         function notPublishableButMandatoryFilter(variant) {
-            //determine a variant is needed, but not already a choice.
-            // * publishable — aka. displayed as a publish option.
-            // * published — its already published and everything is then fine.
-            // * mandatory — this is needed, and thats why we highlight it.
+
             return !publishableVariantFilter(variant) && variant.state !== "Published" && variant.isMandatory === true;
         }
 
@@ -97,54 +111,48 @@
 
             vm.variants = $scope.model.variants;
 
-            _.each(vm.variants, (variant) => {
+            // If we have a variant that's not in the state of NotCreated, 
+            // then we know we have data and it's not a new content node.
+            vm.isNew = vm.variants.some(variant => variant.state === 'NotCreated');
+
+            vm.variants.forEach(variant => {
                 
                 // reset to not be published
-                variant.publish = false;
-                variant.save = false;
-                
+                variant.publish = variant.save = false;
+
                 variant.isMandatory = isMandatoryFilter(variant);
 
-                // If we have a variant thats not in the state of NotCreated, then we know we have adata and its not a new content node.
-                if(variant.state !== "NotCreated") {
-                    vm.isNew = false;
-                }
-            });
-
-            _.each(vm.variants, (variant) => {
-                
                 // if this is a new node and we have data on this variant.
-                if(vm.isNew === true && hasAnyDataFilter(variant)) {
+                if (vm.isNew === true && hasAnyDataFilter(variant)) {
                     variant.save = true;
                 }
-                
             });
 
             vm.availableVariants = vm.variants.filter(publishableVariantFilter);
             vm.missingMandatoryVariants = vm.variants.filter(notPublishableButMandatoryFilter);
 
             // if any active varaiant that is available for publish, we set it to be published:
-            _.each(vm.availableVariants, (v) => {
+            vm.availableVariants.forEach(v => {
                 if(v.active) {
                     v.save = v.publish = true;
                 }
             });
 
             if (vm.availableVariants.length !== 0) {
-                vm.availableVariants.sort(function (a, b) {
+                vm.availableVariants.sort((a, b) => {
                     if (a.language && b.language) {
-                        if (a.language.name > b.language.name) {
+                        if (a.language.name < b.language.name) {
                             return -1;
                         }
-                        if (a.language.name < b.language.name) {
+                        if (a.language.name > b.language.name) {
                             return 1;
                         }
                     } 
                     if (a.segment && b.segment) {
-                        if (a.segment > b.segment) {
+                        if (a.segment < b.segment) {
                             return -1;
                         }
-                        if (a.segment < b.segment) {
+                        if (a.segment > b.segment) {
                             return 1;
                         }
                     }
@@ -152,35 +160,28 @@
                 });
             }
 
-
             $scope.model.disableSubmitButton = !canPublish();
 
-            if (vm.missingMandatoryVariants.length > 0) {
-                localizationService.localize("content_notReadyToPublish").then(function (value) {
+            const localizeKey = vm.missingMandatoryVariants.length > 0 ? 'content_notReadyToPublish' : 
+                !$scope.model.title ? 'content_readyToPublish' : '';
+
+            if (localizeKey) {
+                localizationService.localize(localizeKey).then(value => {
                     $scope.model.title = value;
                     vm.loading = false;
                 });
             } else {
-                if (!$scope.model.title) {
-                    localizationService.localize("content_readyToPublish").then(function (value) {
-                        $scope.model.title = value;
-                        vm.loading = false;
-                    });
-                } else {
-                    vm.loading = false;
-                }
+                vm.loading = false;
             }
-
         }
 
         onInit();
 
         //when this dialog is closed, reset all 'publish' flags
-        $scope.$on('$destroy', function () {
-            for (var i = 0; i < vm.variants.length; i++) {
-                vm.variants[i].publish = false;
-                vm.variants[i].save = false;
-            }
+        $scope.$on('$destroy', () => {
+            vm.variants.forEach(variant => {
+                variant.publish = variant.save = false;
+            });
         });
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
@@ -4,12 +4,10 @@
     function PublishDescendantsController($scope, localizationService) {
 
         var vm = this;
-
         vm.includeUnpublished = false;
 
         vm.changeSelection = changeSelection;
         vm.toggleIncludeUnpublished = toggleIncludeUnpublished;
-
 
         function onInit() {
 
@@ -18,45 +16,42 @@
             vm.labels = {};
 
             if (!$scope.model.title) {
-                localizationService.localize("buttons_publishDescendants").then(function (value) {
+                localizationService.localize("buttons_publishDescendants").then(value => {
                     $scope.model.title = value;
                 });
             }
 
-            _.each(vm.variants, function (variant) {
+            vm.variants.forEach(variant => {
                 variant.isMandatory = isMandatoryFilter(variant);
             });
 
             if (vm.variants.length > 1) {
 
-                vm.displayVariants.sort(function (a, b) {
+                vm.displayVariants.sort((a, b) => {
                     if (a.language && b.language) {
-                        if (a.language.name > b.language.name) {
+                        if (a.language.name < b.language.name) {
                             return -1;
                         }
-                        if (a.language.name < b.language.name) {
+                        if (a.language.name > b.language.name) {
                             return 1;
                         }
                     }
                     if (a.segment && b.segment) {
-                        if (a.segment > b.segment) {
+                        if (a.segment < b.segment) {
                             return -1;
                         }
-                        if (a.segment < b.segment) {
+                        if (a.segment > b.segment) {
                             return 1;
                         }
                     }
                     return 0;
                 });
 
-                var active = _.find(vm.variants, function (v) {
-                    return v.active;
-                });
+                var active = vm.variants.find(v => v.active);
 
                 if (active) {
                     //ensure that the current one is selected
-                    active.publish = true;
-                    active.save = true;
+                    active.publish = active.save = true;
                 }
 
                 $scope.model.disableSubmitButton = !canPublish();
@@ -67,24 +62,21 @@
                     "key": "content_publishDescendantsHelp",
                     "tokens": [vm.variants[0].name]
                 };
-            }
-            
+            }            
         }
 
         function toggleIncludeUnpublished() {
-            console.log("toggleIncludeUnpublished")
             vm.includeUnpublished = !vm.includeUnpublished;
         }
 
         /** Returns true if publishing is possible based on if there are un-published mandatory languages */
         function canPublish() {
             var selected = [];
-            for (var i = 0; i < vm.variants.length; i++) {
-                var variant = vm.variants[i];
+            vm.variants.forEach(variant => {
 
                 var published = !(variant.state === "NotCreated" || variant.state === "Draft");
 
-                if (variant.segment == null &&  variant.language && variant.language.isMandatory && !published && !variant.publish) {
+                if (variant.segment == null && variant.language && variant.language.isMandatory && !published && !variant.publish) {
                     //if a mandatory variant isn't published 
                     //and not flagged for saving
                     //then we cannot continue
@@ -96,7 +88,8 @@
                 if (variant.publish) {
                     selected.push(variant.publish);
                 }
-            }
+            });
+
             return selected.length > 0;
         }
 
@@ -115,11 +108,10 @@
         }
 
         //when this dialog is closed, reset all 'publish' flags
-        $scope.$on('$destroy', function () {
-            for (var i = 0; i < vm.variants.length; i++) {
-                vm.variants[i].publish = false;
-                vm.variants[i].save = false;
-            }
+        $scope.$on('$destroy', () => {
+            vm.variants.forEach(variant => {
+                variant.publish = variant.save = false;
+            });
         });
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
@@ -58,57 +58,47 @@
         function onInit() {
             vm.variants = $scope.model.variants;
             vm.availableVariants = vm.variants.filter(saveableVariantFilter);
+            vm.isNew = vm.variants.some(variant => variant.state === 'NotCreated');
 
-            if(!$scope.model.title) {
-                localizationService.localize("content_readyToSave").then(function(value){
+            if (!$scope.model.title) {
+                localizationService.localize("content_readyToSave").then(value => {
                     $scope.model.title = value;
                 });
             }
 
-            _.each(vm.variants,
-                function (variant) {
+            vm.variants.forEach(variant => {
 
-                    //reset state:
-                    variant.save = false;
-                    variant.publish = false;
+                //reset state:
+                variant.save = variant.publish = false;
+                variant.isMandatory = isMandatoryFilter(variant);
 
-                    variant.isMandatory = isMandatoryFilter(variant);
-
-                    if(variant.state !== "NotCreated"){
-                        vm.isNew = false;
-                    }
-                });
-
-            _.each(vm.variants,
-                function (variant) {
-                    if(vm.isNew && hasAnyData(variant)){
-                        variant.save = true;
-                    }
-                });
+                if(vm.isNew && hasAnyData(variant)){
+                    variant.save = true;
+                }
+            });
 
             if (vm.variants.length !== 0) {
+                        
+                //ensure that the current one is selected
+                var active = vm.variants.find(v => v.active);
+                if (active) {
+                    active.save = true;
+                }
 
-                _.find(vm.variants, function (v) {
-                    if(v.active) {
-                        //ensure that the current one is selected
-                        v.save = true;
-                    }
-                });
-
-                vm.availableVariants.sort(function (a, b) {
+                vm.availableVariants.sort((a, b) => {
                     if (a.language && b.language) {
-                        if (a.language.name > b.language.name) {
+                        if (a.language.name < b.language.name) {
                             return -1;
                         }
-                        if (a.language.name < b.language.name) {
+                        if (a.language.name > b.language.name) {
                             return 1;
                         }
                     }
                     if (a.segment && b.segment) {
-                        if (a.segment > b.segment) {
+                        if (a.segment < b.segment) {
                             return -1;
                         }
-                        if (a.segment < b.segment) {
+                        if (a.segment > b.segment) {
                             return 1;
                         }
                     }
@@ -126,10 +116,10 @@
         onInit();
 
         //when this dialog is closed, reset all 'save' flags
-        $scope.$on('$destroy', function () {
-            for (var i = 0; i < vm.variants.length; i++) {
-                vm.variants[i].save = false;
-            }
+        $scope.$on('$destroy', () => {
+            vm.variants.forEach(variant => {
+                variant.save = false;
+            });
         });
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
     
-    function ScheduleContentController($scope, $timeout, localizationService, dateHelper, userService, contentEditingHelper) {
+    function ScheduleContentController($scope, $timeout, localizationService, dateHelper, userService) {
 
         var vm = this;
 
@@ -25,64 +25,60 @@
             vm.variants = $scope.model.variants;
             vm.displayVariants = vm.variants.slice(0);// shallow copy, we dont want to share the array-object(because we will be performing a sort method) but each entry should be shared (because we need validation and notifications).
 
-            for (let i = 0; i < vm.variants.length; i++) {
-                origDates.push({
-                    releaseDate: vm.variants[i].releaseDate,
-                    expireDate: vm.variants[i].expireDate
-                });
-            }
-
             if(!$scope.model.title) {
-                localizationService.localize("general_scheduledPublishing").then(function(value){
+                localizationService.localize("general_scheduledPublishing").then(value => {
                     $scope.model.title = value;
                 });
             }
-           
-            _.each(vm.variants, function (variant) {
-                variant.isMandatory = isMandatoryFilter(variant);
 
+            vm.variants.forEach(variant => {
+                origDates.push({
+                    releaseDate: variant.releaseDate,
+                    expireDate: variant.expireDate
+                });
+
+                variant.isMandatory = isMandatoryFilter(variant);
             });
 
             // Check for variants: if a node is invariant it will still have the default language in variants
             // so we have to check for length > 1
             if (vm.variants.length > 1) {
 
-                vm.displayVariants.sort(function (a, b) {
+                vm.displayVariants.sort((a, b) => {
                     if (a.language && b.language) {
-                        if (a.language.name > b.language.name) {
+                        if (a.language.name < b.language.name) {
                             return -1;
                         }
-                        if (a.language.name < b.language.name) {
+                        if (a.language.name > b.language.name) {
                             return 1;
                         }
                     }
                     if (a.segment && b.segment) {
-                        if (a.segment > b.segment) {
+                        if (a.segment < b.segment) {
                             return -1;
                         }
-                        if (a.segment < b.segment) {
+                        if (a.segment > b.segment) {
                             return 1;
                         }
                     }
                     return 0;
                 });
 
-                _.each(vm.variants, function (v) {
+                vm.variants.forEach(v => {
                     if (v.active) {
                         v.save = true;
                     }
                 });
                 
-                $scope.model.disableSubmitButton = !canSchedule();
-            
+                $scope.model.disableSubmitButton = !canSchedule();            
             }
 
             // get current backoffice user and format dates
-            userService.getCurrentUser().then(function (currentUser) {
+            userService.getCurrentUser().then(currentUser => {
 
                 vm.currentUser = currentUser;
 
-                angular.forEach(vm.variants, function(variant) {
+                vm.variants.forEach(variant => {
 
                     // prevent selecting publish/unpublish date before today
                     var now = new Date();
@@ -103,9 +99,7 @@
                         formatDatesToLocal(variant);
                     }
                 });
-
             });
-
         }
 
         /**
@@ -132,7 +126,6 @@
          * @param {any} type publish or unpublish
          */
         function datePickerChange(variant, dateStr, type) {
-            console.log("datePickerChange", variant, dateStr, type)
             if (type === 'publish') {
                 setPublishDate(variant, dateStr);
             } else if (type === 'unpublish') {
@@ -179,9 +172,7 @@
          */
         function checkForBackdropClick() {
 
-            var open = _.find(vm.variants, function (variant) {
-                return variant.releaseDatePickerOpen || variant.expireDatePickerOpen;
-            });
+            var open = vm.variants.find(variant => variant.releaseDatePickerOpen || variant.expireDatePickerOpen);
 
             if(open) {
                 $scope.model.disableBackdropClick = true;
@@ -247,7 +238,6 @@
          * @param {any} variant 
          */
         function clearPublishDate(variant) {
-            console.log("clearPublishDate", variant, variant.releaseDate)
             if(variant && variant.releaseDate) {
                 variant.releaseDate = null;
                 // we don't have a publish date anymore so we can clear the min date for unpublish
@@ -263,7 +253,6 @@
          * @param {any} variant 
          */
         function clearUnpublishDate(variant) {
-            console.log("clearUnpublishDate", variant)
             if(variant && variant.expireDate) {
                 variant.expireDate = null;
                 // we don't have a unpublish date anymore so we can clear the max date for publish
@@ -358,20 +347,19 @@
         onInit();
 
         //when this dialog is closed, clean up
-        $scope.$on('$destroy', function () {
-            for (var i = 0; i < vm.variants.length; i++) {
-                vm.variants[i].save = false;
+        $scope.$on('$destroy', () => {
+            vm.variants.forEach(variant => {
+                variant.save = false;
                 // remove properties only needed for this dialog
-                delete vm.variants[i].releaseDateFormatted;
-                delete vm.variants[i].expireDateFormatted;
-                delete vm.variants[i].datePickerConfig;
-                delete vm.variants[i].releaseDatePickerInstance;
-                delete vm.variants[i].expireDatePickerInstance;
-                delete vm.variants[i].releaseDatePickerOpen;
-                delete vm.variants[i].expireDatePickerOpen;
-            } 
+                delete variant.releaseDateFormatted;
+                delete variant.expireDateFormatted;
+                delete variant.datePickerConfig;
+                delete variant.releaseDatePickerInstance;
+                delete variant.expireDatePickerInstance;
+                delete variant.releaseDatePickerOpen;
+                delete variant.expireDatePickerOpen;
+            }); 
         });
-
     }
 
     angular.module("umbraco").controller("Umbraco.Overlays.ScheduleContentController", ScheduleContentController);

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function SendToPublishController($scope, localizationService, contentEditingHelper) {
+    function SendToPublishController($scope, localizationService) {
 
         var vm = this;
         vm.loading = true;
@@ -19,7 +19,7 @@
                 });
             }
 
-            _.each(vm.variants, function (variant) {
+            vm.variants.forEach(variant => {
                 variant.isMandatory = isMandatoryFilter(variant);
             });
             
@@ -27,27 +27,27 @@
             
             if (vm.availableVariants.length !== 0) {
 
-                vm.availableVariants = vm.availableVariants.sort(function (a, b) {
+                vm.availableVariants.sort((a, b) => {
                     if (a.language && b.language) {
-                        if (a.language.name > b.language.name) {
+                        if (a.language.name < b.language.name) {
                             return -1;
                         }
-                        if (a.language.name < b.language.name) {
+                        if (a.language.name > b.language.name) {
                             return 1;
                         }
                     }
                     if (a.segment && b.segment) {
-                        if (a.segment > b.segment) {
+                        if (a.segment < b.segment) {
                             return -1;
                         }
-                        if (a.segment < b.segment) {
+                        if (a.segment > b.segment) {
                             return 1;
                         }
                     }
                     return 0;
                 });
 
-                _.each(vm.availableVariants, function (v) {
+                vm.availableVariants.forEach(v => {
                     if(v.active) {
                         v.save = true;
                     }
@@ -63,9 +63,7 @@
         }
 
         function changeSelection() {
-            var firstSelected = _.find(vm.variants, function (v) {
-                return v.save;
-            });
+            var firstSelected = vm.variants.find(v => v.save);
             $scope.model.disableSubmitButton = !firstSelected; //disable submit button if there is none selected
         }
 
@@ -87,9 +85,9 @@
 
         //when this dialog is closed, reset all 'save' flags
         $scope.$on('$destroy', function () {
-            for (var i = 0; i < vm.variants.length; i++) {
-                vm.variants[i].save = false;
-            }
+            vm.variants.forEach(variant => {
+                variant.save = false;
+            });
         });
 
         onInit();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is an addition to #8475, splitting into multiple PRs to avoid giant merges. These changes remove underscore from the content overlay controllers (the ones used for the publish/save/unpublish overlays). Also fixes the sort order of variants displayed in the overlays (were previously in reverse alphabetical order, now in alpha order).

Change replace all underscore methods with native JS, and makes some general improvements (avoids iterating collections multiple times where possible, syntax fixes etc). Functionally, nothing has changed.

Testing requirement is to verify everything still works. Can save, publish, save+publish, unpublish, schedule with variant and invariant content. Changes are pretty safe and predictable as most relate to iterating the variants collection, which is always an array even if content is invariant.

There's a lot of duplication across these controllers, as there's a lot of common functionality (sorting, filtering) which would be really good to refactor. Hypothetically (😃) Typescript would make this more manageable as a variant object could become a variant class with its own methods, so duplicated controller functions would no longer be required to check properties as the variant would provide those values...

````javascript
export class Variant {
  // lots of variant properties
  language: VariantLanguage;
  segment: VariantSegment;
  state: string;

  get isMandatory(): boolean {
    return this.language && this.language.isMandatory && this.segment;
  }
}

// elsewhere
const mandatoryVariants = vm.variants.filter(v => v.isMandatory());
````

Oh so lovely!
