### PR TITLE
Re-style the "more" button in editor app navigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -141,21 +141,21 @@
     // item__more, appears when there is not enough room for the visible items.
     // --------------------------------
 
-    &-more__icon {
-        margin-bottom: 10px;
+    &-more {
+        .umb-button-ellipsis {
+            opacity: 1;
 
-        i {
-            height: 5px;
-            width: 5px;
-            border-radius: 50%;
-            background: @ui-active-type; // fallback if browser doesnt support currentColor
-            background: currentColor;
-            display: inline-block;
-            margin: 0 5px 0 0;
-        }
-
-        i:last-of-type {
-            margin-right: 0;
+            .umb-button-ellipsis__icon {
+                margin-top: 4px;
+                margin-bottom: 6px;
+                flex: none;
+                display: block;
+            }
+        
+            .umb-button-ellipsis__text {
+                flex: none;
+                display: block;
+            }
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -22,6 +22,7 @@
                 color="#1b264f"
                 text="{{moreButton.name}}"
                 show-text="true"
+                css-class="umb-sub-views-nav-item__action umb-outline umb-outline--thin {{moreButton.active ? 'is-active' : ''}}"
                 >
             </umb-button-ellipsis>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is an alternate approach to fixing #8486.

As-is the "more" button in the editor app navigation looks rather off when you have content apps and not enough space for them all:

![more-button-before-1](https://user-images.githubusercontent.com/7405322/88624356-18a7fe00-d0a7-11ea-9306-d9b78275c1e5.gif)

![more-button-before-2](https://user-images.githubusercontent.com/7405322/88624357-19409480-d0a7-11ea-9ed6-b1ec228b4312.gif)

This PR re-applies the styles for the "more" button that were lost in #8132. Once applied the "more" button looks like it used to:

![more-button-after-1](https://user-images.githubusercontent.com/7405322/88624404-32e1dc00-d0a7-11ea-8a54-0cd1a191c0d0.gif)

![more-button-after-2](https://user-images.githubusercontent.com/7405322/88624405-337a7280-d0a7-11ea-8333-8cc274555144.gif)