### PR TITLE
Don't auto-expand all content anchors on small screens

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -54,8 +54,8 @@
         .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
     }
 
-    &:focus-within &__anchor_dropdown,
-    &:hover &__anchor_dropdown {
+    &:focus-within > &__anchor_dropdown,
+    &:hover > &__anchor_dropdown {
         visibility: visible;
         opacity: 1;
         transition: opacity 20ms 0;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

While fixing the "more" button styling in the content app navigation, I noticed how the content anchor list kept expanding on small screens, making the content apps behind it unreachable:

![app-navigation-anchor-toggle-before](https://user-images.githubusercontent.com/7405322/88627905-5e67c500-d0ad-11ea-8364-80fb09580a28.gif)

Turns out the CSS selector that expands the anchor list is a tad too greedy. This PR narrows it down a tad, and once applied the content app navigation works somewhat nicer on small screens:

![app-navigation-anchor-toggle-after-1](https://user-images.githubusercontent.com/7405322/88627992-822b0b00-d0ad-11ea-8aae-a86a062f91f1.gif)

...and of course it still works on larger screens:

![app-navigation-anchor-toggle-after-2](https://user-images.githubusercontent.com/7405322/88628020-8ce5a000-d0ad-11ea-85a0-fcdee167c0bc.gif)
