### PR TITLE
Don't allow the grid to steal focus on init

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -405,14 +405,16 @@ angular.module("umbraco")
 
                 eventsService.emit("grid.rowAdded", { scope: $scope, element: $element, row: row });
 
-                // TODO: find a nicer way to do this without relying on setTimeout
-                setTimeout(function () {
-                    var newRowEl = $element.find("[data-rowid='" + row.$uniqueId + "']");
+                if (!isInit) {
+                    // TODO: find a nicer way to do this without relying on setTimeout
+                    setTimeout(function () {
+                        var newRowEl = $element.find("[data-rowid='" + row.$uniqueId + "']");
 
-                    if (newRowEl !== null) {
-                        newRowEl.focus();
-                    }
-                }, 0);
+                        if (newRowEl !== null) {
+                            newRowEl.focus();
+                        }
+                    }, 0);
+                }
 
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8324

### Description

_See also #8324 for a brilliant issue description_

If a Grid configuration has only one layout and one row configuration, the property editor will automatically initialize itself with one layout + row. This makes sense. However, in combination with the excellent accessibility effort in #6804, this causes the grid to steal focus on init - most noticeably when creating new content:

![grid-init-focus-before](https://user-images.githubusercontent.com/7405322/88640996-e86c5980-d0be-11ea-8313-bd675fb2a1a2.gif)

This PR ensures that the auto-focus is not performed on init, but is retained on subsequent row additions to preserve the accessibility:

![grid-init-focus-after](https://user-images.githubusercontent.com/7405322/88641085-020da100-d0bf-11ea-99e9-14fdc864b455.gif)

