### PR TITLE
Fetch membergroup by guid

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IMemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberGroupRepository.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models;
 
 namespace Umbraco.Core.Persistence.Repositories
 {
     public interface IMemberGroupRepository : IReadWriteQueryRepository<int, IMemberGroup>
     {
+        IMemberGroup Get(Guid uniqueId);
+
         /// <summary>
         /// Gets a member group by it's name
         /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/IMemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberGroupRepository.cs
@@ -6,6 +6,11 @@ namespace Umbraco.Core.Persistence.Repositories
 {
     public interface IMemberGroupRepository : IReadWriteQueryRepository<int, IMemberGroup>
     {
+        /// <summary>
+        /// Gets a member group by it's uniqueId
+        /// </summary>
+        /// <param name="uniqueId"></param>
+        /// <returns></returns>
         IMemberGroup Get(Guid uniqueId);
 
         /// <summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -69,7 +69,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoNode.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Node}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -119,7 +119,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             var sql = GetBaseQuery(false);
             //sql.Where(GetBaseWhereClause(), new { uniqueId = uniqueId });
-            sql.Where("umbracoNode.uniqueId = @uniqueId)", new { uniqueId = uniqueId.ToString() });
+            sql.Where("umbracoNode.uniqueId = @uniqueId", new { uniqueId });
 
             var dto = Database.Fetch<NodeDto>(SqlSyntax.SelectTop(sql, 1)).FirstOrDefault();
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -118,7 +118,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         public IMemberGroup Get(Guid uniqueId)
         {
             var sql = GetBaseQuery(false);
-            //sql.Where(GetBaseWhereClause(), new { uniqueId = uniqueId });
             sql.Where("umbracoNode.uniqueId = @uniqueId", new { uniqueId });
 
             var dto = Database.Fetch<NodeDto>(SqlSyntax.SelectTop(sql, 1)).FirstOrDefault();

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -115,6 +115,17 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             entity.ResetDirtyProperties();
         }
 
+        public IMemberGroup Get(Guid uniqueId)
+        {
+            var sql = GetBaseQuery(false);
+            //sql.Where(GetBaseWhereClause(), new { uniqueId = uniqueId });
+            sql.Where("umbracoNode.uniqueId = @uniqueId)", new { uniqueId = uniqueId.ToString() });
+
+            var dto = Database.Fetch<NodeDto>(SqlSyntax.SelectTop(sql, 1)).FirstOrDefault();
+
+            return dto == null ? null : MemberGroupFactory.BuildEntity(dto);
+        }
+
         public IMemberGroup GetByName(string name)
         {
             return IsolatedCache.GetCacheItem<IMemberGroup>(

--- a/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
@@ -74,7 +74,9 @@ namespace Umbraco.Core.Services.Implement
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                return _memberGroupRepository.GetMany().FirstOrDefault(x => x.Key == id);
+                return _memberGroupRepository.Get(id);
+
+                //return _memberGroupRepository.GetMany().FirstOrDefault(x => x.Key == id);
             }
         }
 

--- a/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberGroupService.cs
@@ -75,8 +75,6 @@ namespace Umbraco.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _memberGroupRepository.Get(id);
-
-                //return _memberGroupRepository.GetMany().FirstOrDefault(x => x.Key == id);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adjust previous merged PR https://github.com/umbraco/Umbraco-CMS/pull/7528 to fetch member group by Guid (uniqueId in umbracoNode) table.

It seems many of the repository classes use a `GetBaseWhereClause()` which query by id. Some of these use the constant for table name, while others don't.
https://github.com/umbraco/Umbraco-CMS/search?p=3&q=GetBaseWhereClause&unscoped_q=GetBaseWhereClause

I have updated this in https://github.com/umbraco/Umbraco-CMS/commit/d5d5d077c5d5bfc8634fc57745429cd81300f6e1 (but we could probably do with the other repositories as well).