### PR TITLE
Cleanup unused function shouldShowUrl

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -22,7 +22,6 @@ angular.module("umbraco")
             vm.clickHandler = clickHandler;
             vm.clickItemName = clickItemName;
             vm.gotoFolder = gotoFolder;
-            vm.shouldShowUrl = shouldShowUrl;
             vm.toggleListView = toggleListView;
             vm.selectLayout = selectLayout;
             vm.showMediaList = false;
@@ -239,19 +238,6 @@ angular.module("umbraco")
                 localStorageService.set("umbLastOpenedMediaNodeId", folder.id);
 
                 return getChildren(folder.id);
-            }
-
-            function shouldShowUrl() {
-                if (!$scope.model.target) {
-                    return false;
-                }
-                if ($scope.model.target.id) {
-                    return false;
-                }
-                if ($scope.model.target.url && $scope.model.target.url.toLower().indexOf("blob:") === 0) {
-                    return false;
-                }
-                return true;
             }
             
             function toggleListView() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The previous merged PR https://github.com/umbraco/Umbraco-CMS/pull/8023 moved the `umb-overlay` for crop details in media picker to a separate overlay, where the function `shouldShowUrl` is used.

However when merging PR https://github.com/umbraco/Umbraco-CMS/pull/7912 the function was re-added to mediapicker infinite editor. The function is only used in this overlay.

https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html#L13

