### PR TITLE
umb-ellispsis-component: Fix visuals when used in the content app section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbuttonellipsis.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbuttonellipsis.directive.js
@@ -29,6 +29,7 @@
 @param {boolean} showText Set to <code>true</code> to show the text. <code>false</code> by default
 @param {domElement} element Highlights a DOM-element (HTML-selector)
 @param {string} state Set the initial state of the component. To have it hidden use <code>hidden</code>
+@param {string} mode Set the mode, which decides how to style the component. Currently only "default" and "tab" are supported
 **/
 
 (function () {
@@ -82,7 +83,8 @@
             color: "@?",
             showText: "<?",
             element: "@?",
-            state: "@?"
+            state: "@?",
+            mode: "@?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
@@ -15,7 +15,7 @@
         justify-content: center;
     }
 
-    .umb-button-ellipsis__content-app,
+    .umb-button-ellipsis--tab,
     .umb-tour-is-visible .umb-tree &,
     &:hover,
     &:focus{
@@ -40,7 +40,7 @@
         color: inherit;
         flex-basis: 100%;
 
-        .umb-button-ellipsis__content-app & {
+        .umb-button-ellipsis--tab & {
             margin: 0 0 7px
         }
     }
@@ -51,7 +51,7 @@
         line-height: 1em;
         flex-basis: 100%;
 
-        .umb-button-ellipsis__content-app & {
+        .umb-button-ellipsis--tab & {
             position: absolute;
             right: 0;
             left: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
@@ -15,6 +15,7 @@
         justify-content: center;
     }
 
+    .umb-button-ellipsis__content-app,
     .umb-tour-is-visible .umb-tree &,
     &:hover,
     &:focus{
@@ -30,7 +31,7 @@
         }
     }
 
-    &__umb-button-ellipsis__content {
+    &__content {
         display: flex;
         flex-wrap: wrap;
     }
@@ -38,6 +39,10 @@
     &__icon {
         color: inherit;
         flex-basis: 100%;
+
+        .umb-button-ellipsis__content-app & {
+            margin: 0 0 7px
+        }
     }
 
     &__text {
@@ -45,5 +50,13 @@
         font-size: 12px;
         line-height: 1em;
         flex-basis: 100%;
+
+        .umb-button-ellipsis__content-app & {
+            position: absolute;
+            right: 0;
+            left: 0;
+            bottom: 13px;
+            margin: 0 auto;
+        }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
@@ -30,6 +30,11 @@
         }
     }
 
+    &__umb-button-ellipsis__content {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
     &__icon {
         color: inherit;
         flex-basis: 100%;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -40,7 +40,7 @@
         }
 
         &.is-active {
-            color: @ui-light-active-type;
+            color: @ui-light-active-type !important;
 
             &::before {
                 opacity: 1;

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-ellipsis.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-ellipsis.html
@@ -3,7 +3,7 @@
     data-element="{{vm.element}}"
     class="btn-reset umb-button-ellipsis {{vm.cssClass}}"
     style="color:{{vm.color}};"
-    ng-class="{'umb-button-ellipsis--hidden': vm.state === 'hidden', 'show-text': vm.showText}"
+    ng-class="{'umb-button-ellipsis--hidden': vm.state === 'hidden', 'show-text': vm.showText, 'umb-button-ellipsis--tab' : vm.mode === 'tab'}"
     ng-click="vm.clickButton($event)">
     <span class="umb-button-ellipsis__content">
         <span class="umb-button-ellipsis__icon" aria-hidden="true">&bull;&bull;&bull;</span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-ellipsis.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-ellipsis.html
@@ -5,6 +5,8 @@
     style="color:{{vm.color}};"
     ng-class="{'umb-button-ellipsis--hidden': vm.state === 'hidden', 'show-text': vm.showText}"
     ng-click="vm.clickButton($event)">
-    <span class="umb-button-ellipsis__icon" aria-hidden="true">&bull;&bull;&bull;</span>
-    <span class="umb-button-ellipsis__text" ng-class="{'sr-only': vm.showText !== true}">{{vm.text}}</span>
+    <span class="umb-button-ellipsis__content">
+        <span class="umb-button-ellipsis__icon" aria-hidden="true">&bull;&bull;&bull;</span>
+        <span class="umb-button-ellipsis__text" ng-class="{'sr-only': vm.showText !== true}">{{vm.text}}</span>
+    </span>
 </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -22,7 +22,8 @@
                 color="#1b264f"
                 text="{{moreButton.name}}"
                 show-text="true"
-                css-class="umb-button-ellipsis__content-app umb-sub-views-nav-item__action umb-outline umb-outline--thin {{moreButton.active ? 'is-active' : ''}}"
+                mode="tab"
+                css-class="umb-sub-views-nav-item__action umb-outline umb-outline--thin {{moreButton.active ? 'is-active' : ''}}"
                 >
             </umb-button-ellipsis>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -22,6 +22,7 @@
                 color="#1b264f"
                 text="{{moreButton.name}}"
                 show-text="true"
+                css-class="umb-sub-views-nav-item__action umb-outline umb-outline--thin"
                 >
             </umb-button-ellipsis>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -22,7 +22,7 @@
                 color="#1b264f"
                 text="{{moreButton.name}}"
                 show-text="true"
-                css-class="umb-sub-views-nav-item__action umb-outline umb-outline--thin"
+                css-class="umb-button-ellipsis__content-app umb-sub-views-nav-item__action umb-outline umb-outline--thin {{moreButton.active ? 'is-active' : ''}}"
                 >
             </umb-button-ellipsis>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
@nul800sebastiaan This is my approach to fix the issue filed by @kjac in #8486 and the alternate approach in #8492 

I have passed the css classes used on the "Content app" buttons, which fixes the height issue and also fixed the general styling of the "more" button actually using the "css-class" attribute provided by the directive.

Furthermore in order to vertically align the ellispsis and the text I've added a "content" wrapper around the 2 existing spans in order to be able to do this in the directive itself. This does not affect the usage where there is no text to display.

I can't see any downsides to this approach since the only change added to the component is a span that wraps the icon and text and otherwise it's just accepting the passed css class, which was the intention from the very beginning. Please let me know if you think I'm missing something 😃

This is what it looks like when these changes are applied

![directive-fix](https://user-images.githubusercontent.com/1932158/88672351-a3a8e880-d0e7-11ea-9579-befd4f788f5e.png)

**UPDATE** - Fixed the issues with this PR that @kjac pointed out in his comment below 👍 

![ellipsis-component-content-app-after](https://user-images.githubusercontent.com/1932158/88719125-14212b00-d123-11ea-87de-f688fa5ccc3f.gif)
