### PR TITLE
Remove usages of angular.forEach in users and groups editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -185,7 +185,7 @@
          * however the list to display the permissions isn't via the dictionary way so we need to format it
          */
         function formatGranularPermissionSelection() {
-            angular.forEach(vm.userGroup.assignedPermissions, function (node) {
+            vm.userGroup.assignedPermissions.forEach(function (node) {
                 formatGranularPermissionSelectionForNode(node);
             });
         }
@@ -193,8 +193,8 @@
         function formatGranularPermissionSelectionForNode(node) {
             //the dictionary is assigned via node.permissions we will reformat to node.allowedPermissions
             node.allowedPermissions = [];
-            angular.forEach(node.permissions, function (permissions, key) {
-                angular.forEach(permissions, function (p) {
+            Object.values(node.permissions).forEach(function (permissions) {
+                permissions.forEach(function (p) {
                     if (p.checked) {
                         node.allowedPermissions.push(p);
                     }
@@ -299,7 +299,7 @@
         }
 
         function setSectionIcon(sections) {
-            angular.forEach(sections, function (section) {
+            sections.forEach(function (section) {
                 section.icon = "icon-section";
             });
         }

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -281,7 +281,7 @@
                 submit: function (model) {
                     // select items
                     if (model.selection) {
-                        angular.forEach(model.selection, function (item) {
+                        model.selection.forEach(function (item) {
                             if (item.id === "-1") {
                                 item.name = vm.labels.contentRoot;
                                 item.icon = "icon-folder";
@@ -310,7 +310,7 @@
                 submit: function (model) {
                     // select items
                     if (model.selection) {
-                        angular.forEach(model.selection, function (item) {
+                        model.selection.forEach(function (item) {
                             if (item.id === "-1") {
                                 item.name = vm.labels.mediaRoot;
                                 item.icon = "icon-folder";
@@ -333,7 +333,7 @@
             var found = false;
             // check if item is already in the selected list
             if (selection.length > 0) {
-                angular.forEach(selection, function (selectedItem) {
+                selection.forEach(function (selectedItem) {
                     if (selectedItem.udi === item.udi) {
                         found = true;
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
@@ -123,7 +123,7 @@
         }
 
         function clearSelection() {
-            angular.forEach(vm.userGroups, function (userGroup) {
+            vm.userGroups.forEach(function (userGroup) {
                 userGroup.selected = false;
             });
             vm.selection = [];

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -274,7 +274,7 @@
         }
 
         function clearSelection() {
-            angular.forEach(vm.users, function (user) {
+            vm.users.forEach(function (user) {
                 user.selected = false;
             });
             vm.selection = [];
@@ -305,7 +305,7 @@
             vm.disableUserButtonState = "busy";
             usersResource.disableUsers(vm.selection).then(function (data) {
                 // update userState
-                angular.forEach(vm.selection, function (userId) {
+                vm.selection.forEach(function (userId) {
                     var user = getUserFromArrayById(userId, vm.users);
                     if (user) {
                         user.userState = 1;
@@ -326,7 +326,7 @@
             vm.enableUserButtonState = "busy";
             usersResource.enableUsers(vm.selection).then(function (data) {
                 // update userState
-                angular.forEach(vm.selection, function (userId) {
+                vm.selection.forEach(function (userId) {
                     var user = getUserFromArrayById(userId, vm.users);
                     if (user) {
                         user.userState = 0;
@@ -345,7 +345,7 @@
             vm.unlockUserButtonState = "busy";
             usersResource.unlockUsers(vm.selection).then(function (data) {
                 // update userState
-                angular.forEach(vm.selection, function (userId) {
+                vm.selection.forEach(function (userId) {
                     var user = getUserFromArrayById(userId, vm.users);
                     if (user) {
                         user.userState = 0;
@@ -423,14 +423,14 @@
         function selectAll() {
             if (areAllSelected()) {
                 vm.selection = [];
-                angular.forEach(vm.users, function (user) {
+                vm.users.forEach(function (user) {
                     user.selected = false;
                 });
             } else {
                 // clear selection so we don't add the same user twice
                 vm.selection = [];
                 // select all users
-                angular.forEach(vm.users, function (user) {
+                vm.users.forEach(function (user) {
                     // prevent the current user to be selected
                     if (!user.isCurrentUser) {
                         user.selected = true;
@@ -470,7 +470,7 @@
         function getFilterName(array) {
             var name = vm.labels.all;
             var found = false;
-            angular.forEach(array, function (item) {
+            array.forEach(function (item) {
                 if (item.selected) {
                     if (!found) {
                         name = item.name
@@ -491,7 +491,7 @@
 
             //If the selection is "ALL" then we need to unselect everything else since this is an 'odd' filter
             if (userState.key === "All") {
-                angular.forEach(vm.userStatesFilter, function (i) {
+                vm.userStatesFilter.forEach(function (i) {
                     i.selected = false;
                 });
                 //we can't unselect All
@@ -500,7 +500,7 @@
                 vm.usersOptions.userStates = [];
             }
             else {
-                angular.forEach(vm.userStatesFilter, function (i) {
+                vm.userStatesFilter.forEach(function (i) {
                     if (i.key === "All") {
                         i.selected = false;
                     }
@@ -715,13 +715,13 @@
         }
 
         function setUserDisplayState(users) {
-            angular.forEach(users, function (user) {
+            users.forEach(function (user) {
                 user.userDisplayState = usersHelper.getUserStateFromValue(user.userState);
             });
         }
 
         function formatDates(users) {
-            angular.forEach(users, function (user) {
+            users.forEach(function (user) {
                 if (user.lastLoginDate) {
                     var dateVal;
                     var serverOffset = Umbraco.Sys.ServerVariables.application.serverTimeOffset;
@@ -752,7 +752,7 @@
 
             var firstSelectedUserGroups;
 
-            angular.forEach(users, function (user) {
+            users.forEach(function (user) {
 
                 if (!user.selected) {
                     return;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7718 (in part)

### Description

Continuing the effort to minimize the angular dependency, I have rewritten all usages of angular.forEach with the native equivalent in the users and groups section.

## Testing this PR

Basically there should be no noticeable difference when applying this PR; users and groups editing and management should "just work". Here are a few things to test and try out:

### Groups

![image](https://user-images.githubusercontent.com/7405322/88671563-bb33a180-d0e6-11ea-9c18-08b6760f8f97.png)

![image](https://user-images.githubusercontent.com/7405322/88671862-15ccfd80-d0e7-11ea-9f02-b8d019dcaed6.png)

![image](https://user-images.githubusercontent.com/7405322/88671589-c555a000-d0e6-11ea-8e38-222b24e7b3b8.png)

### Users

![image](https://user-images.githubusercontent.com/7405322/88671908-22e9ec80-d0e7-11ea-8037-52f72f1a9782.png)

![image](https://user-images.githubusercontent.com/7405322/88671920-28473700-d0e7-11ea-89c6-734a468a9a96.png)

![image](https://user-images.githubusercontent.com/7405322/88671942-2e3d1800-d0e7-11ea-9876-f072f449cdb3.png)

![image](https://user-images.githubusercontent.com/7405322/88671962-3301cc00-d0e7-11ea-998a-eb96fe9d3fb2.png)

![image](https://user-images.githubusercontent.com/7405322/88671979-385f1680-d0e7-11ea-84ae-0d8bfc15dd5a.png)

![image](https://user-images.githubusercontent.com/7405322/88671998-3dbc6100-d0e7-11ea-8e4f-270509f4fcd6.png)

![image](https://user-images.githubusercontent.com/7405322/88672033-44e36f00-d0e7-11ea-9150-022536fafed9.png)
