### PR TITLE
Preserve superuser access

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -19,6 +19,7 @@
         vm.openUserPicker = openUserPicker;
         vm.removeSelectedItem = removeSelectedItem;
         vm.clearStartNode = clearStartNode;
+        vm.allowRemoveUserFromGroup = allowRemoveUserFromGroup;
         vm.save = save;
         vm.openGranularPermissionsPicker = openGranularPermissionsPicker;
         vm.setPermissionsForNode = setPermissionsForNode;
@@ -270,6 +271,16 @@
 
             editorService.nodePermissions(vm.nodePermissions);
 
+        }
+
+        function allowRemoveUserFromGroup(user, userGroup) {
+
+            // Don't allow to remove super user (id = -1) from admin group
+            if (user.id === -1 && userGroup.alias === "admin") {
+                return false;
+            }
+
+            return true;
         }
 
         function removeSelectedItem(index, selection) {

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -19,6 +19,7 @@
         vm.openUserPicker = openUserPicker;
         vm.removeSelectedItem = removeSelectedItem;
         vm.clearStartNode = clearStartNode;
+        vm.allowRemoveSection = allowRemoveSection;
         vm.allowRemoveUserFromGroup = allowRemoveUserFromGroup;
         vm.save = save;
         vm.openGranularPermissionsPicker = openGranularPermissionsPicker;
@@ -271,6 +272,17 @@
 
             editorService.nodePermissions(vm.nodePermissions);
 
+        }
+
+        function allowRemoveSection(section, user) {
+            
+            // Don't allow to remove super user (id = -1) from sections
+            var sections = ["content", "media", "settings", "users", "members"];
+            if (sections.includes(section.alias) && user.id === -1) {
+                return false;
+            }
+
+            return true;
         }
 
         function allowRemoveUserFromGroup(user, userGroup) {

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -31,12 +31,13 @@
                                 <umb-box-content class="block-form">
 
                                     <umb-control-group style="margin-bottom: 20px;" label="@main_sections" description="@user_sectionsHelp">
+
                                         <umb-node-preview
                                             style="max-width: 100%;"
                                             ng-repeat="section in vm.userGroup.sections"
                                             icon="section.icon"
                                             name="section.name"
-                                            allow-remove="true"
+                                            allow-remove="vm.allowRemoveSection(section, user)"
                                             on-remove="vm.removeSelectedItem($index, vm.userGroup.sections)">
                                         </umb-node-preview>
 
@@ -49,6 +50,7 @@
                                     </umb-control-group>
 
                                     <umb-control-group style="margin-bottom: 20px;" label="@user_startnode" description="@user_startnodehelp">
+
                                         <umb-node-preview
                                             ng-if="vm.userGroup.contentStartNode.id"
                                             style="max-width: 100%;"
@@ -59,7 +61,6 @@
                                             on-edit="vm.openContentPicker()"
                                             on-remove="vm.clearStartNode('content')">
                                         </umb-node-preview>
-
 
                                         <button type="button"
                                                 ng-if="!vm.userGroup.contentStartNode"
@@ -120,10 +121,10 @@
                                             icon="node.icon"
                                             name="node.name"
                                             permissions="node.allowedPermissions"
-                                            allow-remove="true"
-                                            on-remove="vm.removeSelectedItem($index, vm.userGroup.assignedPermissions)"
                                             allow-edit="true"
-                                            on-edit="vm.setPermissionsForNode(node)">
+                                            allow-remove="true"
+                                            on-edit="vm.setPermissionsForNode(node)"
+                                            on-remove="vm.removeSelectedItem($index, vm.userGroup.assignedPermissions)">
                                         </umb-node-preview>
 
                                         <button type="button"
@@ -149,7 +150,7 @@
                                         ng-repeat="user in vm.userGroup.users"
                                         name="user.name"
                                         avatars="user.avatars"
-                                        allow-remove="true"
+                                        allow-remove="vm.allowRemoveUserFromGroup(user, vm.userGroup)"
                                         on-remove="vm.removeSelectedItem($index, vm.userGroup.users)">
                                     </umb-user-preview>
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -37,8 +37,8 @@
         vm.deleteNonLoggedInUser = deleteNonLoggedInUser;
         vm.changeAvatar = changeAvatar;
         vm.clearAvatar = clearAvatar;
+        vm.allowRemoveUserFromGroup = allowRemoveUserFromGroup;
         vm.save = save;
-
         vm.changePassword = changePassword;
         vm.toggleChangePassword = toggleChangePassword;
 
@@ -343,6 +343,16 @@
             if (!found) {
                 selection.push(item);
             }
+        }
+
+        function allowRemoveUserFromGroup(user, userGroup) {
+
+            // Don't allow to remove super user (id = -1) from admin group
+            if (user.id === -1 && userGroup.alias === "admin") {
+                return false;
+            }
+
+            return true;
         }
 
         function removeSelectedItem(index, selection) {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -71,7 +71,7 @@
                                             sections="userGroup.sections"
                                             content-start-node="userGroup.contentStartNode"
                                             media-start-node="userGroup.mediaStartNode"
-                                            allow-remove="true"
+                                            allow-remove="model.allowRemoveUserFromGroup(model.user, userGroup)"
                                             on-remove="model.removeSelectedItem($index, model.user.userGroups)">
                     </umb-user-group-preview>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment the user sections have some issues regarding administrator access as mentioned in 
https://github.com/umbraco/Umbraco-CMS/issues/8487

Highlight of the current issues

- It is possible to remove users section from Administrators ("admin") group which mean if logged in as super admin (user id -1), the user is logged out and when logging back in the user has no longer access to users section and there is no way to grant access to users section again (at least not if no other users has access to users section) or without modifying data in database.

- It is possible to remove (super) user from Administrators group under Users -> Groups

- The (super) user can remove Administrators group under user details page

This PR adjust this so the remove button isn't shown these places for super user and furthermore for Administrators group doesn't allow to remove the following sections: Content, Media, Settings, Users, Members.

The prevent removing these by mistake and saving the user/group. However it is still possible via userpicker and sectionpicker to remove these existing sections/users. It would be great if sectionpicker and userpicker supported `filter` and maybe `filterCssClass` similar to treepicker, so it can disable selection/deselection of the items in the overlays.

https://github.com/umbraco/Umbraco-CMS/blob/0bd9e3ca9955844389556ce512fa0aab181703fb/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js#L448-L500

But it think this is a bit better than the current behavior and prevents that you by mistake remove access to mainly users section.