### PR TITLE
Fix the alignment of the "delete property" button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -355,7 +355,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
     position: relative;
     margin: 5px 0;
     
-    > button {
+    button {
         border: none;
         
         font-size: 18px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Somewhere along the lines, the "delete property" button on the content type builder has gone and got itself a bit crooked:

![image](https://user-images.githubusercontent.com/7405322/88760841-2e342b00-d16e-11ea-810b-6f18ab34d792.png)

This PR fixes the button so it goes back to being centered under the "property settings" button:

![image](https://user-images.githubusercontent.com/7405322/88760897-51f77100-d16e-11ea-8a5c-ea07248d2ae1.png)

