### PR TITLE
Remove usages of angular.forEach in settings and translation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.list.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.list.controller.js
@@ -19,7 +19,7 @@ function DictionaryListController($scope, $location, dictionaryResource, localiz
         dictionaryResource.getList()
             .then(function (data) {
                 vm.items = data;
-                angular.forEach(vm.items, function(item){
+                vm.items.forEach(function(item){
                     item.style = { "paddingLeft": item.level * 10 };
                 });
                 vm.loading = false;

--- a/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js
@@ -68,7 +68,7 @@
             //load all culture/languages
             promises.push(languageResource.getCultures().then(function (culturesDictionary) {
                 var cultures = [];
-                angular.forEach(culturesDictionary, function (value, key) {
+                Object.entries(culturesDictionary).forEach(function ([key, value]) {
                     cultures.push({
                         name: key,
                         displayName: value

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
@@ -181,7 +181,7 @@
         function getFilterName(array) {
             var name = "All";
             var found = false;
-            angular.forEach(array, function (item) {
+            array.forEach(function (item) {
                 if (item.selected) {
                     if (!found) {
                         name = item.name

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -102,7 +102,7 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
     function formatDates(relations) {
         if (relations) {
             userService.getCurrentUser().then(function (currentUser) {
-                angular.forEach(relations, function (relation) {
+                relations.forEach(function (relation) {
                     relation.timestampFormatted = dateHelper.getLocalDate(relation.createDate, currentUser.locale, 'LLL');
                 });
             });

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -549,7 +549,7 @@
             var availableMasterTemplates = [];
 
             // filter out the current template and the selected master template
-            angular.forEach(vm.templates, function (template) {
+            vm.templates.forEach(function (template) {
                 if (template.alias !== vm.template.alias && template.alias !== vm.template.masterTemplateAlias) {
                     var templatePathArray = template.path.split(',');
                     // filter descendant templates of current template
@@ -602,7 +602,7 @@
         function getMasterTemplateName(masterTemplateAlias, templates) {
             if (masterTemplateAlias) {
                 var templateName = "";
-                angular.forEach(templates, function (template) {
+                templates.forEach(function (template) {
                     if (template.alias === masterTemplateAlias) {
                         templateName = template.name;
                     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7718 (in part)

### Description

Continuing the effort to minimize the angular dependency, I have rewritten all usages of angular.forEach with the native equivalent in the settings and translation sections.

### Testing this PR

Basically there should be no noticeable difference when applying this PR; the settings and translation sections should "just work". Here are a few things to test and try out:

#### Templates

![image](https://user-images.githubusercontent.com/7405322/88766795-f1b9fc80-d178-11ea-9d86-f80031af782a.png)

#### Relation types

![image](https://user-images.githubusercontent.com/7405322/88766820-fc749180-d178-11ea-8fdd-40e9ca4460f5.png)

#### Log viewer

![image](https://user-images.githubusercontent.com/7405322/88766834-04cccc80-d179-11ea-90e8-6c85c0579d07.png)

#### Languages

![image](https://user-images.githubusercontent.com/7405322/88766882-1910c980-d179-11ea-8e60-d5bb69ae0b82.png)

#### Translations

![image](https://user-images.githubusercontent.com/7405322/88766946-32197a80-d179-11ea-8573-fac0f657c9df.png)
