### PR TITLE
Fix panel header spacing when a description is present

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -428,7 +428,7 @@ input.umb-panel-header-description {
 
 .umb-panel-header-locked-description {
     font-size: 12px;
-    margin-top: 2px;
+    margin: 2px 0 0 0;
     height: 22px;
     line-height: 22px;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The editor panel header has lost its (top) spacing when a description is present underneath the name input field:

![image](https://user-images.githubusercontent.com/7405322/88769521-cdf8b580-d17c-11ea-9a01-7a953a1d8a7b.png)

This applies to every editor under Templating in the Settings section (Templates, Partial Views, Partial View Macro Files, Stylesheets and Scripts).

This PR brings back the spacing:

![image](https://user-images.githubusercontent.com/7405322/88769441-b0c3e700-d17c-11ea-980f-57827a104b3b.png)
