### PR TITLE
Query builder buttons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -71,7 +71,7 @@
 
                                     <umb-dropdown ng-if="vm.propertyFilterOpen[$index]" on-close="console.log(1);vm.propertyFilterOpen[$index] = false">
                                         <umb-dropdown-item ng-repeat="property in vm.properties">
-                                            <a href ng-click="vm.setFilterProperty(filter, property); vm.propertyFilterOpen[$parent.$parent.$index] = false;">
+                                            <a href="" ng-click="vm.setFilterProperty(filter, property); vm.propertyFilterOpen[$parent.$parent.$index] = false;">
                                                 {{property.name}}
                                             </a>
                                         </umb-dropdown-item>
@@ -90,7 +90,7 @@
 
                                     <umb-dropdown ng-if="vm.termFilterOpen[$index]" on-close="vm.termFilterOpen[$index] = false">
                                         <umb-dropdown-item ng-repeat="term in vm.getPropertyOperators(filter.property)">
-                                            <a href ng-click="vm.setFilterTerm(filter, term); vm.termFilterOpen[$parent.$parent.$index] = false;">
+                                            <a href="" ng-click="vm.setFilterTerm(filter, term); vm.termFilterOpen[$parent.$parent.$index] = false;">
                                                 {{term.name}}
                                             </a>
                                         </umb-dropdown-item>
@@ -137,7 +137,7 @@
 
                                     <umb-dropdown ng-if="vm.sortPropertyOpen" on-close="vm.sortPropertyOpen = false">
                                         <umb-dropdown-item ng-repeat="property in vm.properties">
-                                            <a href ng-click="vm.setSortProperty(vm.query, property); vm.sortPropertyOpen = false;">
+                                            <a href="" ng-click="vm.setSortProperty(vm.query, property); vm.sortPropertyOpen = false;">
                                                 {{property.name}}
                                             </a>
                                         </umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -112,13 +112,13 @@
 
                                 </span>
 
-                                <a href ng-click="vm.addFilter(vm.query)">
+                                <button type="button" class="btn-reset" ng-click="vm.addFilter(vm.query)">
                                     <i class="icon-add" aria-hidden="true"></i>
-                                </a>
+                                </button>
 
-                                <a href ng-click="vm.trashFilter(vm.query, filter)">
+                                <button type="button" class="btn-reset" ng-click="vm.trashFilter(vm.query, filter)">
                                     <i class="icon-trash" aria-hidden="true"></i>
-                                </a>
+                                </button>
 
                             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -159,7 +159,7 @@
 
                         <ul class="nav unstyled">
                             <li ng-repeat="item in model.result.sampleResults">
-                                <i class="icon icon-document turquoise-d1" aria-hidden="true"></i> {{item.name}}
+                                <i class="icon {{item.icon}} turquoise-d1" aria-hidden="true"></i> {{item.name}}
                             </li>
                         </ul>
 

--- a/src/Umbraco.Web/Editors/TemplateQueryController.cs
+++ b/src/Umbraco.Web/Editors/TemplateQueryController.cs
@@ -71,7 +71,11 @@ namespace Umbraco.Web.Editors
                 QueryExpression = queryExpression.ToString(),
                 ResultCount = results.Count,
                 ExecutionTime = timer.ElapsedMilliseconds,
-                SampleResults = results.Take(20).Select(x => new TemplateQueryResult { Icon = "icon-file", Name = x.Name })
+                SampleResults = results.Take(20).Select(x => new TemplateQueryResult
+                {
+                    Icon = "icon-document",
+                    Name = x.Name
+                })
             };
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have replaced a few anchor elements with `<button>` elements in template query builder.
Furthermore the samle result didn't use the icon from the json, so I changed that and use `icon-document` since `icon-file` doesn't exist.

It would be nice if it could use the respective icons for the nodes, but `IPublishedContentType` doesn't have a `Icon` property like `IContentType`. So I guess that would require looking up the specific content types from the results.