### PR TITLE
Replace splitview close button with button element

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
@@ -32,7 +32,7 @@ This format is only used in the iconpicker.html
 (function () {
     "use strict";
 
-    function UmbIconDirective($http, $sce, iconHelper) {
+    function UmbIconDirective(iconHelper) {
 
         var directive = {
             replace: true,

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
@@ -44,7 +44,8 @@ This format is only used in the iconpicker.html
             },
 
             link: function (scope) {
-                if (scope.svgString === undefined) {
+                
+                if (scope.svgString === undefined && scope.icon !== undefined) {
                     var icon = scope.icon.split(" ")[0]; // Ensure that only the first part of the icon is used as sometimes the color is added too, e.g. see umbeditorheader.directive scope.openIconPicker
 
                     _requestIcon(icon);

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -140,22 +140,19 @@ input.umb-editor-header__name-input:disabled {
 	margin-left: auto;
 }
 
-a.umb-editor-header__close-split-view {
-    
+.umb-editor-header__close-split-view {
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
     height: 69px;
     width: 69px;
-    
-	font-size: 20px;
-	color: @gray-6;
-	text-decoration: none !important;
-}
+    font-size: 20px;
+    color: @gray-6;
 
-a.umb-editor-header__close-split-view:hover {
-	color: @black;
+    &:hover {
+        color: @black;
+    }
 }
 
 .umb-editor-header {

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -91,9 +91,9 @@
         </div>
 
         <div ng-if="splitViewOpen">
-            <a class="umb-editor-header__close-split-view" href="" ng-click="closeSplitView()">
-                <i class="icon-delete"></i>
-            </a>
+            <button type="button" class="btn-reset umb-editor-header__close-split-view" ng-click="closeSplitView()">
+                <umb-icon icon="icon-delete" class="icon-delete"></umb-icon>
+            </button>
         </div>
 
         <div ng-if="editor.variantApps && splitViewOpen !== true">

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -56,8 +56,7 @@
                             ng-class="{'--current': entry.variant === editor.content, '--active': entry.variant.active && vm.dropdownOpen, '--error': entry.variant.active !== true && entry.variant.hasError, '--state-notCreated':entry.variant.state==='NotCreated' && entry.variant.name == null, '--state-draft':entry.variant.state==='Draft' || (entry.variant.state==='NotCreated' && entry.variant.name != null)}"
                         >
                             <button type="button" ng-if="entry.subVariants && entry.subVariants.length > 0" class="umb-variant-switcher__item-expand-button umb-outline" ng-click="entry.open = !entry.open">
-                                <i class="icon icon-navigation-down" ng-if="entry.open"></i>
-                                <i class="icon icon-navigation-right" ng-if="!entry.open"></i>
+                                <i class="icon {{entry.open ? 'icon-navigation-down' : 'icon-navigation-right'}}"></i>
                             </button>
                             <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, entry.variant)" prevent-default>
                                 <span class="umb-variant-switcher__name" ng-bind="entry.variant.displayName"></span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html
@@ -1,5 +1,4 @@
-
-<span aria-hidden="true">
+<span aria-hidden="true" class="umb-icon">
     <span ng-if="svgString" ng-bind-html="svgString"></span>
     <i ng-if="!svgString && iconName" class="{{iconName}}"></i>
 </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html
@@ -1,4 +1,4 @@
 <span aria-hidden="true" class="umb-icon">
     <span ng-if="svgString" ng-bind-html="svgString"></span>
-    <i ng-if="!svgString && iconName" class="{{iconName}}"></i>
+    <i ng-if="!svgString && icon" class="{{icon}}"></i>
 </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replace the close button when splitview is opened with `<button>` element and futhermore use `umb-icon`.

It also removes a unnecessary use of `ng-if`.

![image](https://user-images.githubusercontent.com/2919859/88792619-cb598880-d19b-11ea-9c56-8000b0bb339b.png)

It does however seems to be a bit strange I need to set `icon-delete` twice. Maybe when setting `icon` attribute it should set this as class in the `umb-icon` component.

```
<umb-icon icon="icon-delete" class="icon-delete"></umb-icon>
```