### PR TITLE
Adjust styling of variant switcher for not created variant

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -174,17 +174,6 @@ a.umb-editor-header__close-split-view:hover {
 	cursor: default;
 }
 
-.umb-variant-switcher__name-wrapper {
-	font-size: 14px;
-	flex: 1;
-	cursor: pointer;
-	padding-top: 6px !important;
-    padding-bottom: 6px !important;
-    background-color: transparent;
-    border: none;
-    border-left: 2px solid transparent;
-}
-
 // container
 
 .umb-editor-container {

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -140,25 +140,20 @@ input.umb-editor-header__name-input:disabled {
 	margin-left: auto;
 }
 
-// TODO: Remove this to umb-variant-switcher.less
-a.umb-editor-header__close-split-view {
-    
+.umb-editor-header__close-split-view {
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
     height: 69px;
     width: 69px;
-    
-	font-size: 20px;
-	color: @gray-6;
-	text-decoration: none !important;
-}
+    font-size: 20px;
+    color: @gray-6;
 
-a.umb-editor-header__close-split-view:hover {
-	color: @black;
+    &:hover {
+        color: @black;
+    }
 }
-/* ---------------------------*/
 
 .umb-editor-header {
 	.btn-white {

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -140,6 +140,7 @@ input.umb-editor-header__name-input:disabled {
 	margin-left: auto;
 }
 
+// TODO: Remove this to umb-variant-switcher.less
 a.umb-editor-header__close-split-view {
     
     display: flex;
@@ -157,6 +158,7 @@ a.umb-editor-header__close-split-view {
 a.umb-editor-header__close-split-view:hover {
 	color: @black;
 }
+/* ---------------------------*/
 
 .umb-editor-header {
 	.btn-white {

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -167,69 +167,8 @@ a.umb-editor-header__close-split-view:hover {
     }
 }
 
+// TODO: variant switcher styling should be in umb-variant-switcher.less
 /* variant switcher */
-.umb-variant-switcher__toggle {
-    position: relative;
-	display: flex;
-	align-items: center;
-	padding: 0 10px; 
-    margin: 1px 1px;
-    right: 0;
-    height: 30px;
-	text-decoration: none !important;
-	font-size: 13px;
-    color: @ui-action-discreet-type;
-    background: transparent;
-    border: none;
-    
-    max-width: 50%;
-    white-space: nowrap;
-    
-    user-select: none;
-    
-    span {
-        text-overflow: ellipsis;
-        overflow: hidden;
-    }
-}
-
-button.umb-variant-switcher__toggle {
-	transition: color 0.2s ease-in-out;
-	&:hover {
-		//background-color: @gray-10;
-        color: @ui-action-discreet-type-hover;
-        .umb-variant-switcher__expand {
-            color: @ui-action-discreet-type-hover;
-        }
-	}
-    
-    &.--error {
-        &::before {
-            content: '!';
-            position: absolute;
-            top: -8px;
-            right: -10px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            width: 20px;
-            height: 20px;
-            border-radius: 10px;
-            text-align: center;
-            font-weight: bold;
-            background-color: @errorBackground;
-            color: @errorText;
-        }
-    }
-}
-
-.umb-variant-switcher__expand {
-    color: @ui-action-discreet-type;
-	margin-left: 5px;
-	margin-right: -5px;
-    transition: color 0.2s ease-in-out;
-}
-
 .umb-variant-switcher__item {
 	display: flex;
     justify-content: space-between;
@@ -238,19 +177,11 @@ button.umb-variant-switcher__toggle {
     position: relative;
 }
 
-.umb-variant-switcher__item:last-child {
-	border-bottom: none;
-}
-
 .umb-variant-switcher__item.--current {
     color: @ui-light-active-type;
 }
 .umb-variant-switcher__item.--current .umb-variant-switcher__name-wrapper {
 	border-left: 4px solid @ui-active;
-}
-
-.umb-variant-switcher__item:hover {
-	outline: none;
 }
 
 .umb-variant-switcher__item.--not-allowed:not(.--current) .umb-variant-switcher__name-wrapper:hover {
@@ -263,29 +194,6 @@ button.umb-variant-switcher__toggle {
 	cursor: pointer;
 }
 
-.umb-variant-switcher__item.--error {
-    .umb-variant-switcher__name {
-        color: @red;
-        &::after {
-            content: '!';
-            position: relative;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            margin-left: 5px;
-            top: -3px;
-            width: 14px;
-            height: 14px;
-            border-radius: 7px;
-            font-size: 8px;
-            text-align: center;
-            font-weight: bold;
-            background-color: @errorBackground;
-            color: @errorText;
-        }
-    }
-}
-
 .umb-variant-switcher__name-wrapper {
 	font-size: 14px;
 	flex: 1;
@@ -295,31 +203,6 @@ button.umb-variant-switcher__toggle {
     background-color: transparent;
     border: none;
     border-left: 2px solid transparent;
-}
-
-.umb-variant-switcher__name {
-	display: block;
-}
-
-.umb-variant-switcher__state {
-	font-size: 13px;
-	color: @gray-4;
-}
-
-.umb-variant-switcher__split-view {
-    font-size: 13px;
-    display: none;
-    padding: 16px 20px;
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    background-color: @white;
-
-    &:hover {
-        background-color: @ui-option-hover;
-        color: @ui-option-type-hover;
-    }
 }
 
 // container

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -169,17 +169,7 @@ a.umb-editor-header__close-split-view:hover {
 
 // TODO: variant switcher styling should be in umb-variant-switcher.less
 /* variant switcher */
-.umb-variant-switcher__item {
-	display: flex;
-    justify-content: space-between;
-	align-items: center;
-	border-bottom: 1px solid @gray-9;
-    position: relative;
-}
 
-.umb-variant-switcher__item.--current {
-    color: @ui-light-active-type;
-}
 .umb-variant-switcher__item.--current .umb-variant-switcher__name-wrapper {
 	border-left: 4px solid @ui-active;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -167,15 +167,7 @@ a.umb-editor-header__close-split-view:hover {
     }
 }
 
-// TODO: variant switcher styling should be in umb-variant-switcher.less
-/* variant switcher */
-.umb-variant-switcher__item.--not-allowed:not(.--current) .umb-variant-switcher__name-wrapper:hover {
-	//background-color: @white !important;
-	cursor: default;
-}
-
 // container
-
 .umb-editor-container {
 	position: absolute;
 	top: @editorHeaderHeight;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -179,11 +179,6 @@ a.umb-editor-header__close-split-view:hover {
 	cursor: default;
 }
 
-.umb-variant-switcher__item:hover .umb-variant-switcher__split-view {
-	display: block;
-	cursor: pointer;
-}
-
 .umb-variant-switcher__name-wrapper {
 	font-size: 14px;
 	flex: 1;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -169,11 +169,6 @@ a.umb-editor-header__close-split-view:hover {
 
 // TODO: variant switcher styling should be in umb-variant-switcher.less
 /* variant switcher */
-
-.umb-variant-switcher__item.--current .umb-variant-switcher__name-wrapper {
-	border-left: 4px solid @ui-active;
-}
-
 .umb-variant-switcher__item.--not-allowed:not(.--current) .umb-variant-switcher__name-wrapper:hover {
 	//background-color: @white !important;
 	cursor: default;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -179,6 +179,9 @@ button.umb-variant-switcher__toggle {
 .umb-variant-switcher__item.--current {
     color: @ui-light-active-type;
     //background-color: @pinkExtraLight;
+    .umb-variant-switcher__name-wrapper {
+        border-left: 4px solid @ui-active;
+    }
     .umb-variant-switcher__name {
         //color: @ui-light-active-type;
         font-weight: 700;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -87,6 +87,11 @@ button.umb-variant-switcher__toggle {
         }
     }
 }
+
+.umb-variant-switcher__item.--not-allowed:not(.--current) .umb-variant-switcher__name-wrapper:hover {
+    cursor: default;
+}
+
 .umb-variant-switcher__item.--state-notCreated:not(.--active) {
     .umb-variant-switcher__name-wrapper::before {
         content: "+";
@@ -247,6 +252,8 @@ button.umb-variant-switcher__toggle {
 	cursor: pointer;
     background-color: transparent;
     border: none;
+	padding-top: 6px !important;
+    padding-bottom: 6px !important;
 }
 
 .dropdown-menu>li {

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -248,6 +248,7 @@ button.umb-variant-switcher__toggle {
     background-color: transparent;
     border: none;
 }
+
 .dropdown-menu>li {
     > .umb-variant-switcher__name-wrapper {
         padding-top: 10px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -77,6 +77,7 @@ button.umb-variant-switcher__toggle {
 	align-items: center;
 	border-bottom: 1px solid @gray-9;
     position: relative;
+
     .umb-variant-switcher__name-wrapper:hover {
         .umb-variant-switcher__name {
             color: @blueMid;
@@ -176,7 +177,7 @@ button.umb-variant-switcher__toggle {
 }
 
 .umb-variant-switcher__item.--current {
-    //color: @ui-light-active-type;
+    color: @ui-light-active-type;
     //background-color: @pinkExtraLight;
     .umb-variant-switcher__name {
         //color: @ui-light-active-type;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -93,38 +93,44 @@ button.umb-variant-switcher__toggle {
         float: left;
         font-size: 15px;
         font-weight: 900;
-        padding: 8px 16px 8px 6px;
+        padding: 8px 12px 8px 0;
         color: @gray-5;
     }
+
     .umb-variant-switcher__item-expand-button + .umb-variant-switcher__name-wrapper::before {
         padding: 8px 16px 8px 20px;
     }
+
     .umb-variant-switcher__name {
         color: @gray-5;
     }
+
     .umb-variant-switcher__state {
         color: @gray-6;
     }
+
     .umb-variant-switcher__name-wrapper::after {
         content: "";
         position: absolute;
         z-index: 1;
-        border: 1px dashed @gray-9;
-        top: 7px;
-        bottom: 7px;
-        left: 7px;
-        right: 7px;
-        border-radius: 3px;
+        border: 2px dashed @gray-9;
+        margin: 2px;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
         pointer-events: none;
     }
-    
+
     .umb-variant-switcher__name-wrapper:hover {
         &::before {
             color: @blueMid;
         }
+
         .umb-variant-switcher__name {
             color: @blueMid;
         }
+
         .umb-variant-switcher__state {
             color: @blueMid;
         }
@@ -203,7 +209,7 @@ button.umb-variant-switcher__toggle {
 .umb-variant-switcher__item:focus-within .umb-variant-switcher__split-view,
 .umb-variant-switcher__item:hover .umb-variant-switcher__split-view,
 .umb-variant-switcher__split-view:focus {
-	display: block;
+	display: flex;
 	cursor: pointer;
 }
 
@@ -264,7 +270,6 @@ button.umb-variant-switcher__toggle {
 .umb-variant-switcher__split-view {
     font-size: 12px;
     display: none;
-    padding: 20px 20px;
     position: absolute;
     right: 0;
     top: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -282,6 +282,7 @@ button.umb-variant-switcher__toggle {
 .umb-variant-switcher__split-view {
     font-size: 12px;
     display: none;
+    padding: 16px 20px;
     position: absolute;
     right: 0;
     top: 0;
@@ -293,7 +294,6 @@ button.umb-variant-switcher__toggle {
         color: @ui-option-type-hover;
     }
 }
-
 
 .umb-variant-switcher__sub-variants {
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -59,7 +59,7 @@
                                 <i class="icon icon-navigation-down" ng-if="entry.open"></i>
                                 <i class="icon icon-navigation-right" ng-if="!entry.open"></i>
                             </button>
-                            <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, entry.variant)" prevent-default>
+                            <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, entry.variant)">
                                 <span class="umb-variant-switcher__name" ng-bind="entry.variant.displayName"></span>
                                 <umb-variant-state variant="entry.variant" class="umb-variant-switcher__state"></umb-variant-state>
                             </button>
@@ -75,7 +75,7 @@
                                 class="umb-variant-switcher__item"
                                 ng-class="{'--current': subVariant === editor.content, '--active': subVariant.active && vm.dropdownOpen, '--error': subVariant.active !== true && subVariant.hasError, '--state-notCreated':subVariant.state==='NotCreated', '--state-draft':subVariant.state==='Draft'}"
                             >
-                                <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, subVariant)" prevent-default>
+                                <button type="button" class="umb-variant-switcher__name-wrapper umb-outline" ng-click="selectVariant($event, subVariant)">
                                     <span class="umb-variant-switcher__name" ng-bind="subVariant.segment"></span>
                                     <umb-variant-state variant="subVariant" class="umb-variant-switcher__state"></umb-variant-state>
                                 </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I think the variant switcher looked a bit off and the "Open in split view" button wasn't center aligned vertically.

**Before**

![chrome_2020-07-29_13-48-07](https://user-images.githubusercontent.com/2919859/88798235-e1b81200-d1a4-11ea-895b-5705ee4e3f26.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/88798308-fd231d00-d1a4-11ea-863c-5b58e01e3e4d.png)


Not sure about the "+" icon in front since it doesn't align the languages, but we can look at that in another PR.
When the language (not created) is selected I am not sure if this styling should also be applied. Otherwise it seems to be a few pixels off to align with other languages.

![image](https://user-images.githubusercontent.com/2919859/88799058-30b27700-d1a6-11ea-95ea-beabecbcec33.png)
