### PR TITLE
Make sure the RTE always loads minified resources

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -1,5 +1,5 @@
 angular.module("umbraco.directives")
-    .directive('gridRte', function (tinyMceService, angularHelper, assetsService, $q, $timeout, eventsService) {
+    .directive('gridRte', function (tinyMceService, angularHelper, assetsService, $q, $timeout, eventsService, tinyMceAssets) {
         return {
             scope: {
                 uniqueId: '=',
@@ -22,11 +22,6 @@ angular.module("umbraco.directives")
                 // because now we have to support having 2x (maybe more at some stage) content editors being displayed at once. This is because
                 // we have this mini content editor panel that can be launched with MNTP.
                 scope.textAreaHtmlId = scope.uniqueId + "_" + String.CreateGuid();
-                
-                //queue file loading
-                if (typeof (tinymce) === "undefined") {
-                    promises.push(assetsService.loadJs("lib/tinymce/tinymce.min.js", scope));
-                }
 
                 var editorConfig = scope.configuration ? scope.configuration : null;
                 if (!editorConfig || Utilities.isString(editorConfig)) {
@@ -50,6 +45,10 @@ angular.module("umbraco.directives")
                 //stores a reference to the editor
                 var tinyMceEditor = null;
 
+                //queue file loading
+                tinyMceAssets.forEach(function (tinyJsAsset) {
+                    promises.push(assetsService.loadJs(tinyJsAsset, scope));
+                });
                 promises.push(tinyMceService.getTinyMceEditorConfig({
                     htmlId: scope.textAreaHtmlId,
                     stylesheets: editorConfig.stylesheets,

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1367,6 +1367,9 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             //    throw "args.model.value is required";
             //}
 
+            // force TinyMCE to load plugins/themes from minified files (see http://archive.tinymce.com/wiki.php/api4:property.tinymce.suffix.static)
+            args.editor.suffix = ".min";
+
             var unwatch = null;
 
             //Starts a watch on the model value so that we can update TinyMCE if the model changes behind the scenes or from the server


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8328 

### Description

As described in #8328 the RTE loads un-minified resources in release mode. As it turns out it's not only plugins but also themes that are loaded un-minified:

![image](https://user-images.githubusercontent.com/7405322/88829454-e7295280-d1cc-11ea-900a-88e94341c9e7.png)

This issue _does_ indeed affect both normal and grid RTEs.

This PR forces TinyMCE to always load minified resources, no matter if Umbraco runs in debug or release mode. When applied the loaded resources are significantly smaller:

![image](https://user-images.githubusercontent.com/7405322/88829919-8cdcc180-d1cd-11ea-9cec-d25b998df5af.png)

While I was at it I also redid the way the grid RTE loads TinyMCE resources to match that of the normal RTE (as implemented in #6147).

#### Testing this PR

After building the frontend (`gulp dev`), be sure to set `debug="false"` in web.config:

![image](https://user-images.githubusercontent.com/7405322/88830122-cad9e580-d1cd-11ea-853b-34af3e0d8f3e.png)

Then increment `version` in ClientDependency.config:

![image](https://user-images.githubusercontent.com/7405322/88830198-e6dd8700-d1cd-11ea-9a93-4576e5cbd629.png)

Now reload any content item with an RTE with the Network tab open in Chrome (or whatever browser), and verify that only minified TinyMCE resources are loaded.