### PR TITLE
Logviewer adjustments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-badge.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-badge.less
@@ -29,6 +29,11 @@
     color: @white;
 }
 
+.umb-badge--info {
+    background-color: @blue;
+    color: @white;
+}
+
 .umb-badge--warning {
     background-color: @orange;
     color: @white;
@@ -36,6 +41,11 @@
 
 .umb-badge--success {
     background-color: @green;
+    color: @white;
+}
+
+.umb-badge--dark {
+    background-color: @grayDark;
     color: @white;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.controller.js
@@ -25,7 +25,7 @@
         // ChartJS Options - for count/overview of log distribution
         vm.logTypeLabels = ["Debug", "Info", "Warning", "Error", "Fatal"];
         vm.logTypeData = [0, 0, 0, 0, 0];
-        vm.logTypeColors = ['#eaddd5', '#2bc37c', '#3544b1', '#ff9412', '#d42054'];
+        vm.logTypeColors = ['#2e8aea', '#2bc37c', '#ff9412', '#d42054', '#343434'];
         vm.chartOptions = {
             legend: {
                 display: true,

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -11,6 +11,7 @@
         </umb-editor-header>
 
         <umb-editor-container>
+
             <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
             <!-- Warning message (if unable to view log files) -->

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.controller.js
@@ -16,11 +16,11 @@
         vm.logLevels = [
             {
                 name: 'Verbose',
-                logTypeColor: ''
+                logTypeColor: 'gray'
             },
             {
                 name: 'Debug',
-                logTypeColor: 'gray'
+                logTypeColor: 'info'
             },
             {
                 name: 'Information',
@@ -28,15 +28,15 @@
             },
             {
                 name: 'Warning',
-                logTypeColor: 'primary'
-            },
-            {
-                name: 'Error',
                 logTypeColor: 'warning'
             },
             {
-                name: 'Fatal',
+                name: 'Error',
                 logTypeColor: 'danger'
+            },
+            {
+                name: 'Fatal',
+                logTypeColor: 'dark'
             }
         ];
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -196,7 +196,7 @@
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.google.co.uk/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" href="" target="_blank" localize="title" title="@logViewer_searchOurUmbracoForumsUsingGoogle">
+                                                        <a ng-href="https://www.google.com/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" href="" target="_blank" localize="title" title="@logViewer_searchOurUmbracoForumsUsingGoogle">
                                                             <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchOurUmbracoWithGoogle">Search Our Umbraco with Google</localize>
                                                         </a>
                                                     </umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -64,12 +64,10 @@
                                 </button>
 
                                 <!-- Saved Searches -->
-                                <a class="umb-variant-switcher__toggle ng-scope" href="" ng-click="vm.dropdownOpen = !vm.dropdownOpen">
-                                    <span class="ng-binding">
-                                        <localize key="logViewer_savedSearches">Saved Searches</localize>
-                                    </span>
-                                    <umb-icon icon="icon-navigation-down" class="umb-variant-switcher__expand icon-navigation-down" ng-class="{'icon-navigation-down': !vm.dropdownOpen, 'icon-navigation-up': vm.dropdownOpen}">&nbsp;</umb-icon>
-                                </a>
+                                <button type="button" class="umb-variant-switcher__toggle" ng-click="vm.dropdownOpen = !vm.dropdownOpen">
+                                    <localize key="logViewer_savedSearches">Saved Searches</localize>
+                                    <umb-icon icon="{{vm.dropdownOpen ? 'icon-navigation-up' : 'icon-navigation-down'}}" class="umb-variant-switcher__expand {{vm.dropdownOpen ? 'icon-navigation-up' : 'icon-navigation-down'}}"></umb-icon>
+                                </button>
 
                                 <!-- Saved Searches Dropdown -->
                                 <umb-dropdown ng-if="vm.dropdownOpen" class="saved-searches" on-close="vm.dropdownOpen = false" umb-keyboard-list>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -39,7 +39,7 @@
                             <umb-dropdown class="pull-left" ng-if="vm.page.showLevelFilter" on-close="vm.page.showLevelFilter = false;">
                                 <umb-dropdown-item ng-repeat="level in vm.logLevels" class="dropdown-item">
                                     <div class="flex items-center">
-                                        <umb-checkbox input-id="loglevel-{{$index}}" name="loglevel" model="level.selected" on-change="vm.setLogLevelFilter(level)" />
+                                        <umb-checkbox input-id="loglevel-{{$index}}" name="loglevel" model="level.selected" on-change="vm.setLogLevelFilter(level)"></umb-checkbox>
                                         <label for="loglevel-{{$index}}">
                                             <umb-badge size="s" color="{{level.logTypeColor}}">{{level.name}}</umb-badge>
                                         </label>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -54,11 +54,11 @@
                                 <input class="form-control search-input" type="text" ng-model="vm.logOptions.filterExpression" placeholder="Search logs..." />
 
                                 <!-- Save Search & Clear Search icon buttons -->
-                                <button class="save-search btn-reset" type="button" ng-show="vm.checkForSavedSearch()" ng-click="vm.addToSavedSearches()">
+                                <button type="button" class="save-search btn-reset" ng-show="vm.checkForSavedSearch()" ng-click="vm.addToSavedSearches()">
                                     <umb-icon icon="icon-rate" class="icon-rate" aria-hidden="true"></umb-icon>
                                     <localize class="sr-only" key="logViewer_saveSearch">Save Search</localize>
                                 </button>
-                                <button class="filter-search btn-reset" ng-show="vm.logOptions.filterExpression" ng-click="vm.resetSearch()">
+                                <button type="button" class="filter-search btn-reset" ng-show="vm.logOptions.filterExpression" ng-click="vm.resetSearch()">
                                     <umb-icon icon="icon-wrong" class="icon-wrong" aria-hidden="true"></umb-icon>
                                     <localize class="sr-only" key="logViewer_filterSearch">Filter Search</localize>
                                 </button>
@@ -76,15 +76,14 @@
                                     <umb-dropdown-item class="umb-variant-switcher__item" ng-class="{'umb-variant-switcher_item--current': variant.active}" ng-repeat="search in vm.searches">
                                         <button type="button" class="umb-variant-switcher__name-wrapper" ng-click="vm.selectSearch(search)">
                                             <span class="umb-variant-switcher__name">{{search.name}}</span>
-                                            <span>{{ search.query }}</span>
+                                            <span>{{search.query}}</span>
                                         </button>
-                                        <button type="button" ng-click="vm.deleteSavedSearch(search)" localize="title" title="@logViewer_deleteThisSearch">
-                                            <span>
-                                                <i class="icon icon-trash text-error"></i>
-                                            </span>
+                                        <button type="button" class="btn-reset" style="width: auto;" ng-click="vm.deleteSavedSearch(search)" localize="title" title="@logViewer_deleteThisSearch">
+                                            <umb-icon icon="icon-trash" class="icon-trash text-error"></umb-icon>
                                         </button>
                                     </umb-dropdown-item>
                                 </umb-dropdown>
+
                             </div>
 
                             <!-- Search Button -->

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -208,7 +208,7 @@
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/issues?q={{ log.Properties['SourceContext'].Value }}" target="_blank" localize="title" title="@logViewer_searchUmbracoIssuesOnGithub">
+                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/issues?q={{ log.Properties['SourceContext'].Value }}" href="" target="_blank" localize="title" title="@logViewer_searchUmbracoIssuesOnGithub">
                                                             <img src="https://www.github.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchUmbracoIssues">Search Umbraco Issues</localize>
                                                         </a>
                                                     </umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -178,31 +178,31 @@
 
                                                 <umb-dropdown ng-if="log.searchDropdownOpen" on-close="log.searchDropdownOpen = false">
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.google.com/search?q={{ log.RenderedMessage }}" target="_blank" localize="title" title="@logViewer_searchThisMessageWithGoogle">
+                                                        <a ng-href="https://www.google.com/search?q={{ log.RenderedMessage }}" href="" target="_blank" localize="title" title="@logViewer_searchThisMessageWithGoogle">
                                                             <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchWithGoogle">Search With Google</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.bing.com/search?q={{ log.RenderedMessage }}" target="_blank" localize="title" title="@logViewer_searchThisMessageWithBing">
+                                                        <a ng-href="https://www.bing.com/search?q={{ log.RenderedMessage }}" href="" target="_blank" localize="title" title="@logViewer_searchThisMessageWithBing">
                                                             <img src="https://www.bing.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchWithBing">Search With Bing</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://our.umbraco.com/search?q={{ log.RenderedMessage }}&content=wiki,forum,documentation" target="_blank" localize="title" title="@logViewer_searchThisMessageOnOurUmbracoForumsAndDocs">
+                                                        <a ng-href="https://our.umbraco.com/search?q={{ log.RenderedMessage }}&content=wiki,forum,documentation" href="" target="_blank" localize="title" title="@logViewer_searchThisMessageOnOurUmbracoForumsAndDocs">
                                                             <img src="https://our.umbraco.com/assets/images/app-icons/favicon.png" width="16" height="16" alt="" /> <localize key="logViewer_searchOurUmbraco">Search Our Umbraco</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.google.co.uk/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" target="_blank" localize="title" title="@logViewer_searchOurUmbracoForumsUsingGoogle">
+                                                        <a ng-href="https://www.google.co.uk/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" href="" target="_blank" localize="title" title="@logViewer_searchOurUmbracoForumsUsingGoogle">
                                                             <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchOurUmbracoWithGoogle">Search Our Umbraco with Google</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/search?q={{ log.Properties['SourceContext'].Value }}" target="_blank" localize="title" title="@logViewer_searchWithinUmbracoSourceCodeOnGithub">
+                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/search?q={{ log.Properties['SourceContext'].Value }}" href="" target="_blank" localize="title" title="@logViewer_searchWithinUmbracoSourceCodeOnGithub">
                                                             <img src="https://www.github.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchUmbracoSource">Search Umbraco Source</localize>
                                                         </a>
                                                     </umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -23,13 +23,11 @@
 
                         <!-- Log Level filter -->
                         <div class="flex log-viewer-filter" style="position: relative;">
-                            <button
-                                type="button"
-                                class="btn-link dropdown-toggle flex mb2 filter-toggle"
-                                ng-click="vm.page.showLevelFilter = !vm.page.showLevelFilter"
-                                aria-haspopup="true"
-                                aria-expanded="{{vm.page.showLevelFilter === undefined ? false : vm.page.showLevelFilter}}"
-                                >
+                            <button type="button"
+                                    class="btn-link dropdown-toggle flex mb2 filter-toggle"
+                                    ng-click="vm.page.showLevelFilter = !vm.page.showLevelFilter"
+                                    aria-haspopup="true"
+                                    aria-expanded="{{vm.page.showLevelFilter === undefined ? false : vm.page.showLevelFilter}}">
                                 <span>
                                     <localize key="logViewer_logLevels">Log Levels</localize>:
                                 </span>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -157,7 +157,7 @@
                                                             <a ng-switch-when="HttpRequestNumber" ng-click="vm.findItem(key, val.Value)" localize="title" title="@logViewer_findLogsWithRequestId">{{val.Value}} <i class="icon-search"></i></a>
                                                             <a ng-switch-when="SourceContext" ng-click="vm.findItem(key, val.Value)" localize="title" title="@logViewer_findLogsWithNamespace">{{val.Value}} <i class="icon-search"></i></a>
                                                             <a ng-switch-when="MachineName" ng-click="vm.findItem(key, val.Value)" localize="title" title="@logViewer_findLogsWithMachineName">{{val.Value}} <i class="icon-search"></i></a>
-                                                            <a ng-switch-when="RequestUrl" href="{{val.Value}}" target="_blank" rel="noopener" localize="title" title="@logViewer_Open">{{val.Value}} <i class="icon-link"></i></a>
+                                                            <a ng-switch-when="RequestUrl" href="{{val.Value}}" target="_blank" rel="noreferrer" localize="title" title="@logViewer_Open">{{val.Value}} <i class="icon-link"></i></a>
                                                             <span ng-switch-default>{{val.Value}}</span>
                                                         </td>
                                                     </tr>
@@ -178,37 +178,37 @@
 
                                                 <umb-dropdown ng-if="log.searchDropdownOpen" on-close="log.searchDropdownOpen = false">
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.google.com/search?q={{ log.RenderedMessage }}" href="" target="_blank" localize="title" title="@logViewer_searchThisMessageWithGoogle">
+                                                        <a ng-href="https://www.google.com/search?q={{ log.RenderedMessage }}" href="" target="_blank" rel="noreferrer" localize="title" title="@logViewer_searchThisMessageWithGoogle">
                                                             <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchWithGoogle">Search With Google</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.bing.com/search?q={{ log.RenderedMessage }}" href="" target="_blank" localize="title" title="@logViewer_searchThisMessageWithBing">
+                                                        <a ng-href="https://www.bing.com/search?q={{ log.RenderedMessage }}" href="" target="_blank" rel="noreferrer" localize="title" title="@logViewer_searchThisMessageWithBing">
                                                             <img src="https://www.bing.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchWithBing">Search With Bing</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://our.umbraco.com/search?q={{ log.RenderedMessage }}&content=wiki,forum,documentation" href="" target="_blank" localize="title" title="@logViewer_searchThisMessageOnOurUmbracoForumsAndDocs">
+                                                        <a ng-href="https://our.umbraco.com/search?q={{ log.RenderedMessage }}&content=wiki,forum,documentation" href="" target="_blank" rel="noreferrer" localize="title" title="@logViewer_searchThisMessageOnOurUmbracoForumsAndDocs">
                                                             <img src="https://our.umbraco.com/assets/images/app-icons/favicon.png" width="16" height="16" alt="" /> <localize key="logViewer_searchOurUmbraco">Search Our Umbraco</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://www.google.com/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" href="" target="_blank" localize="title" title="@logViewer_searchOurUmbracoForumsUsingGoogle">
+                                                        <a ng-href="https://www.google.com/?q=site:our.umbraco.com {{ log.RenderedMessage }}&safe=off#q=site:our.umbraco.com {{ log.RenderedMessage }} {{ log.Properties['SourceContext'].Value }}&safe=off" href="" target="_blank" rel="noreferrer" localize="title" title="@logViewer_searchOurUmbracoForumsUsingGoogle">
                                                             <img src="https://www.google.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchOurUmbracoWithGoogle">Search Our Umbraco with Google</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/search?q={{ log.Properties['SourceContext'].Value }}" href="" target="_blank" localize="title" title="@logViewer_searchWithinUmbracoSourceCodeOnGithub">
+                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/search?q={{ log.Properties['SourceContext'].Value }}" href="" target="_blank" rel="noreferrer" localize="title" title="@logViewer_searchWithinUmbracoSourceCodeOnGithub">
                                                             <img src="https://www.github.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchUmbracoSource">Search Umbraco Source</localize>
                                                         </a>
                                                     </umb-dropdown-item>
 
                                                     <umb-dropdown-item>
-                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/issues?q={{ log.Properties['SourceContext'].Value }}" href="" target="_blank" localize="title" title="@logViewer_searchUmbracoIssuesOnGithub">
+                                                        <a ng-href="https://github.com/umbraco/Umbraco-CMS/issues?q={{ log.Properties['SourceContext'].Value }}" href="" target="_blank" rel="noreferrer" localize="title" title="@logViewer_searchUmbracoIssuesOnGithub">
                                                             <img src="https://www.github.com/favicon.ico" width="16" height="16" alt="" /> <localize key="logViewer_searchUmbracoIssues">Search Umbraco Issues</localize>
                                                         </a>
                                                     </umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -74,11 +74,15 @@
                                 <!-- Saved Searches Dropdown -->
                                 <umb-dropdown ng-if="vm.dropdownOpen" class="saved-searches" on-close="vm.dropdownOpen = false" umb-keyboard-list>
                                     <umb-dropdown-item class="umb-variant-switcher__item" ng-class="{'umb-variant-switcher_item--current': variant.active}" ng-repeat="search in vm.searches">
-                                        <a href="" class="umb-variant-switcher__name-wrapper" ng-click="vm.selectSearch(search)" prevent-default>
+                                        <button type="button" class="umb-variant-switcher__name-wrapper" ng-click="vm.selectSearch(search)">
                                             <span class="umb-variant-switcher__name">{{search.name}}</span>
                                             <span>{{ search.query }}</span>
-                                        </a>
-                                        <a href=""><span><i class="icon icon-trash text-error" localize="title" title="@logViewer_deleteThisSearch" ng-click="vm.deleteSavedSearch(search)"></i></span></a>
+                                        </button>
+                                        <button type="button" ng-click="vm.deleteSavedSearch(search)" localize="title" title="@logViewer_deleteThisSearch">
+                                            <span>
+                                                <i class="icon icon-trash text-error"></i>
+                                            </span>
+                                        </button>
                                     </umb-dropdown-item>
                                 </umb-dropdown>
                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -100,7 +100,7 @@
                     <umb-load-indicator ng-if="vm.logsLoading"></umb-load-indicator>
 
                     <!-- Empty states -->
-                    <umb-empty-state ng-if="vm.logItems.totalItems === 0" position="center">
+                    <umb-empty-state ng-if="vm.logItems.totalItems === 0 && !vm.logsLoading" position="center">
                         <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
                     </umb-empty-state>
 

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -54,12 +54,12 @@
                                 <input class="form-control search-input" type="text" ng-model="vm.logOptions.filterExpression" placeholder="Search logs..." />
 
                                 <!-- Save Search & Clear Search icon buttons -->
-                                <button type="button" class="save-search btn-reset" ng-show="vm.checkForSavedSearch()" ng-click="vm.addToSavedSearches()">
-                                    <umb-icon icon="icon-rate" class="icon-rate" aria-hidden="true"></umb-icon>
+                                <button type="button" class="btn-reset save-search" ng-show="vm.checkForSavedSearch()" ng-click="vm.addToSavedSearches()">
+                                    <umb-icon icon="icon-rate" class="icon-rate"></umb-icon>
                                     <localize class="sr-only" key="logViewer_saveSearch">Save Search</localize>
                                 </button>
-                                <button type="button" class="filter-search btn-reset" ng-show="vm.logOptions.filterExpression" ng-click="vm.resetSearch()">
-                                    <umb-icon icon="icon-wrong" class="icon-wrong" aria-hidden="true"></umb-icon>
+                                <button type="button" class="btn-reset filter-search" ng-show="vm.logOptions.filterExpression" ng-click="vm.resetSearch()">
+                                    <umb-icon icon="icon-wrong" class="icon-wrong"></umb-icon>
                                     <localize class="sr-only" key="logViewer_filterSearch">Filter Search</localize>
                                 </button>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR updates a few things in log viewer:

- Replace anchors with `<button>` elements
- Use `<umb-icon>` and fixes issue with toggle arrow up/down icon when open/close "saved searches"
- Fixes issue with self-closing angular `<umb-checkbox>` component in log levels dropdown (in this case the self-closing custom angular element didn't cause issues except additional whitespace)
- Updates log levels colors to better match the log level type
- Empty state message isn't showm while loading (e.g. when selecting the different log levels from the dropdown)

I think the colors of the log levels was a bit off. Often "orange" is associated with "warning" and "red" is associated with "error".
I have then chosen a dark gray (close to black for "Fatal" log level). Furthermore I have updated "Debug" to use a blue "info" color, since "Debug" and "Verbose" colors is a bit too close to each other.

I searched a bit for "log level colors" and something like these examples seemed to be familiar:

![image](https://user-images.githubusercontent.com/2919859/88841279-02e92480-d1de-11ea-8fe9-a3408fcdbebf.png)

![image](https://user-images.githubusercontent.com/2919859/88841373-2b711e80-d1de-11ea-8903-6da2ac4ac390.png)
