### PR TITLE
Button doesn't show success or error icon after save

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -14,7 +14,7 @@
         hotkey="{{vm.shortcut}}"
         hotkey-when-hidden="{{vm.shortcutWhenHidden}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
-            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon" aria-hidden="true"></i>
+            <umb-icon icon="{{vm.icon}}" class="{{vm.icon}} umb-button__icon" ng-if="vm.icon"></umb-icon>
             {{vm.buttonLabel}}
             <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
@@ -30,10 +30,9 @@
         ng-disabled="vm.disabled"
         umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}"
         aria-haspopup="{{vm.hasPopup}}"
-        aria-expanded="{{vm.isExpanded}}"
-        >
+        aria-expanded="{{vm.isExpanded}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
-            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon" aria-hidden="true"></i>
+            <umb-icon icon="{{vm.icon}}" class="{{vm.icon}} umb-button__icon" ng-if="vm.icon"></umb-icon>
             {{vm.buttonLabel}}
             <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
@@ -48,11 +47,10 @@
         ng-disabled="vm.disabled"
         umb-auto-focus="{{vm.autoFocus && !vm.disabled ? 'true' : 'false'}}">
         <span class="umb-button__content" ng-class="{'-hidden': vm.innerState !== 'init'}">
-            <i ng-if="vm.icon" class="{{vm.icon}} umb-button__icon" aria-hidden="true"></i>
+            <umb-icon icon="{{vm.icon}}" class="{{vm.icon}} umb-button__icon" ng-if="vm.icon"></umb-icon>
             {{vm.buttonLabel}}
             <span ng-if="vm.showCaret" class="umb-button__caret caret" aria-hidden="true"></span>
         </span>
     </button>
-
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -1,8 +1,8 @@
 <div class="umb-button" ng-class="{'ml0': vm.generalActions, 'umb-button--block': vm.blockElement}" data-element="{{ vm.alias ? 'button-' + vm.alias : '' }}">
 
     <div ng-if="vm.innerState">
-        <div class="icon-check umb-button__success" ng-class="{'-hidden': vm.innerState !== 'success', '-white': vm.isPrimaryButtonStyle}"></div>
-        <div class="icon-delete umb-button__error" ng-class="{'-hidden': vm.innerState !== 'error', '-white': vm.isPrimaryButtonStyle}"></div>
+        <umb-icon icon="icon-check" class="icon-check umb-button__success" ng-class="{'-hidden': vm.innerState !== 'success', '-white': vm.isPrimaryButtonStyle}"></umb-icon>
+        <umb-icon icon="icon-delete" class="icon-check umb-button__error" ng-class="{'-hidden': vm.innerState !== 'error', '-white': vm.isPrimaryButtonStyle}"></umb-icon>
         <div class="umb-button__progress" ng-class="{'-hidden': vm.innerState !== 'busy', '-white': vm.isPrimaryButtonStyle}"></div>
         <div ng-if="vm.innerState !== 'init'" class="umb-button__overlay"></div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button.html
@@ -2,7 +2,7 @@
 
     <div ng-if="vm.innerState">
         <umb-icon icon="icon-check" class="icon-check umb-button__success" ng-class="{'-hidden': vm.innerState !== 'success', '-white': vm.isPrimaryButtonStyle}"></umb-icon>
-        <umb-icon icon="icon-delete" class="icon-check umb-button__error" ng-class="{'-hidden': vm.innerState !== 'error', '-white': vm.isPrimaryButtonStyle}"></umb-icon>
+        <umb-icon icon="icon-delete" class="icon-delete umb-button__error" ng-class="{'-hidden': vm.innerState !== 'error', '-white': vm.isPrimaryButtonStyle}"></umb-icon>
         <div class="umb-button__progress" ng-class="{'-hidden': vm.innerState !== 'busy', '-white': vm.isPrimaryButtonStyle}"></div>
         <div ng-if="vm.innerState !== 'init'" class="umb-button__overlay"></div>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After merging https://github.com/umbraco/Umbraco-CMS/pull/5606 it seems the success or error icon after save isn't shown.

I have fixed this and also replaced the additional icons with `<umb-icon>` components. These are used in e.g. bulk actions in listviews.

![image](https://user-images.githubusercontent.com/2919859/88846631-2d3ee000-d1e6-11ea-98af-8166417c27f3.png)

Demo of saving a user.

**Before**

![2020-07-29_21-57-23](https://user-images.githubusercontent.com/2919859/88846926-9b83a280-d1e6-11ea-981c-47b688bd66d5.gif)


**After**

![2020-07-29_21-55-19](https://user-images.githubusercontent.com/2919859/88846984-ae967280-d1e6-11ea-9a07-8fcc71a2d240.gif)
