### PR TITLE
Use umb-icon in listview layout selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -18,7 +18,6 @@
 
    <button data-element="button-group-toggle"
       type="button"
-      prevent-default
       class="btn btn-{{buttonStyle}} dropdown-toggle umb-button-group__toggle umb-button--{{size}}"
       ng-if="subButtons.length > 0"
       ng-click="toggleDropdown()"
@@ -42,8 +41,7 @@
             data-element="{{subButton.alias ? 'button-' + subButton.alias : 'button-group-secondary-' + $index }}"
             type="button" ng-click="executeMenuItem(subButton)"
             hotkey="{{subButton.hotKey}}"
-            hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}"
-            prevent-default>
+            hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}">
                <localize key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>
                <span ng-if="subButton.addEllipsis === 'true'">...</span>
          </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -1,9 +1,9 @@
 <div class="btn-group umb-button-group" ng-class="{ 'dropup': direction === 'up', '-with-button-group-toggle': subButtons.length > 0 }">
 
    <umb-button
+      type="button"
       ng-if="defaultButton"
       alias="{{defaultButton.alias ? defaultButton.alias : 'groupPrimary' }}"
-      type="button"
       action="defaultButton.handler()"
       button-style="{{buttonStyle}}"
       state="state"
@@ -16,8 +16,9 @@
       add-ellipsis={{defaultButton.addEllipsis}}>
    </umb-button>
 
-   <button data-element="button-group-toggle"
+   <button
       type="button"
+      data-element="button-group-toggle"
       class="btn btn-{{buttonStyle}} dropdown-toggle umb-button-group__toggle umb-button--{{size}}"
       ng-if="subButtons.length > 0"
       ng-click="toggleDropdown()"
@@ -38,8 +39,9 @@
          ng-class="{'-align-right': float === 'right'}">
       <umb-dropdown-item ng-repeat="subButton in subButtons">
          <button
+            type="button"
             data-element="{{subButton.alias ? 'button-' + subButton.alias : 'button-group-secondary-' + $index }}"
-            type="button" ng-click="executeMenuItem(subButton)"
+            ng-click="executeMenuItem(subButton)"
             hotkey="{{subButton.hotKey}}"
             hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}">
                <localize key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
@@ -1,5 +1,5 @@
 <div class="umb_confirm-action">
-    <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)">
+    <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)" localize="title" title="@general_delete">
         <umb-icon icon="icon-trash" class="icon-trash"></umb-icon>
         <span class="sr-only">Delete</span>
      </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
@@ -1,6 +1,6 @@
 <div class="umb_confirm-action">
     <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)">
-        <i class="icon-trash" aria-hidden="true"></i>
+        <umb-icon icon="icon-trash" class="icon-trash"></umb-icon>
         <span class="sr-only">Delete</span>
      </button>
 
@@ -12,15 +12,15 @@
         '-left': direction === 'left'}"
         on-outside-click="clickCancel()" ng-if="show">
 
-        <button type="button" class="umb_confirm-action__overlay-action -confirm btn-reset" ng-click="clickConfirm()" localize="title" title="@buttons_confirmActionConfirm">
-            <i class="icon-check" aria-hidden="true"></i>
+        <button type="button" class="btn-reset umb_confirm-action__overlay-action -confirm" ng-click="clickConfirm()" localize="title" title="@buttons_confirmActionConfirm">
+            <umb-icon icon="icon-check" class="icon-check"></umb-icon>
             <span class="sr-only">
                 <localize key="buttons_confirmActionConfirm">Confirm</localize>
             </span>
         </button>
 
-        <button type="button" class="umb_confirm-action__overlay-action -cancel btn-reset" ng-click="clickCancel()" localize="title" title="@buttons_confirmActionCancel">
-            <i class="icon-delete" aria-hidden="true"></i>
+        <button type="button" class="btn-reset umb_confirm-action__overlay-action -cancel" ng-click="clickCancel()" localize="title" title="@buttons_confirmActionCancel">
+            <umb-icon icon="icon-delete" class="icon-delete"></umb-icon>
             <span class="sr-only">
                 <localize key="buttons_confirmActionCancel">Cancel</localize>
             </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
@@ -1,5 +1,5 @@
 <div class="umb_confirm-action">
-    <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)" localize="title" title="@general_delete">
+    <button ng-if="onDelete" type="button" class="btn-icon" ng-click="clickButton($event)" localize="title" title="@general_delete">
         <umb-icon icon="icon-trash" class="icon-trash"></umb-icon>
         <span class="sr-only">Delete</span>
      </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -259,7 +259,7 @@
 
                                     <!-- settings for property -->
                                     <div class="umb-group-builder__property-action">
-                                        <button aria-label="Open settings" class="btn-reset" ng-click="editPropertyTypeSettings(property, tab)">
+                                        <button aria-label="Open settings" class="btn-reset" ng-click="editPropertyTypeSettings(property, tab)" localize="title" title="@general_edit">
                                             <umb-icon icon="icon-settings" class="icon-settings"></umb-icon>
                                         </button>
                                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -228,13 +228,13 @@
                                 <div class="umb-group-builder__property-tags -right">
 
                                     <div class="umb-group-builder__property-tag" ng-if="property.inherited">
-                                        <i class="icon icon-merge"></i>
+                                        <umb-icon icon="icon-merge" class="icon-merge"></umb-icon>
                                         <span style="margin-right: 3px"><localize key="contentTypeEditor_inheritedFrom"></localize></span>
                                         {{property.contentTypeName}}
                                     </div>
 
                                     <div class="umb-group-builder__property-tag" ng-if="property.locked">
-                                        <i class="icon icon-lock"></i>
+                                        <umb-icon icon="icon-lock" class="icon-lock"></umb-icon>
                                         <localize key="general_locked"></localize>
                                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -259,7 +259,9 @@
 
                                     <!-- settings for property -->
                                     <div class="umb-group-builder__property-action">
-                                        <button aria-label="Open settings"  class="icon icon-settings" ng-click="editPropertyTypeSettings(property, tab)"></button>
+                                        <button aria-label="Open settings" class="btn-reset" ng-click="editPropertyTypeSettings(property, tab)">
+                                            <umb-icon icon="icon-settings" class="icon-settings"></umb-icon>
+                                        </button>
                                     </div>
 
                                     <!-- delete property -->

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -259,7 +259,7 @@
 
                                     <!-- settings for property -->
                                     <div class="umb-group-builder__property-action">
-                                        <button aria-label="Open settings" class="btn-reset" ng-click="editPropertyTypeSettings(property, tab)" localize="title" title="@general_edit">
+                                        <button aria-label="Open settings" class="btn-icon" ng-click="editPropertyTypeSettings(property, tab)" localize="title" title="@general_edit">
                                             <umb-icon icon="icon-settings" class="icon-settings"></umb-icon>
                                         </button>
                                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-layout-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-layout-selector.html
@@ -1,7 +1,7 @@
 <div class="umb-layout-selector" ng-show="vm.showLayoutSelector">
 
-   <button type="button" aria-expanded="{{vm.layoutDropDownIsOpen}}" class="umb-layout-selector__active-layout umb-outline" ng-click="vm.toggleLayoutDropdown()" prevent-default>
-      <i class="{{ vm.activeLayout.icon }}" aria-hidden="true"></i>
+   <button type="button" aria-expanded="{{vm.layoutDropDownIsOpen}}" class="umb-layout-selector__active-layout umb-outline" ng-click="vm.toggleLayoutDropdown()">
+      <umb-icon icon="{{vm.activeLayout.icon}}" class="{{vm.activeLayout.icon}}"></umb-icon>
       <span class="sr-only">
           <localize key="visuallyHiddenTexts_activeListLayout">Active layout:</localize>&nbsp;
           {{vm.activeLayout.name}}
@@ -13,13 +13,14 @@
         on-outside-click="vm.closeLayoutDropdown()"
         deep-blur="vm.leaveLayoutDropdown()">
 
-       <button type="button" prevent-default ng-repeat="layout in vm.layouts | filter:{selected:true} track by $id(layout)"
-            class="umb-layout-selector__dropdown-item"
-            ng-click="vm.pickLayout(layout)"
-            ng-class="{'-active': layout.active }"
-            ng-attr-title="{{layout.name}}">
+       <button type="button"
+               ng-repeat="layout in vm.layouts | filter: { selected: true } track by $id(layout)"
+               class="umb-layout-selector__dropdown-item"
+               ng-click="vm.pickLayout(layout)"
+               ng-class="{'-active': layout.active }"
+               ng-attr-title="{{layout.name}}">
 
-           <i class="{{ layout.icon }} umb-layout-selector__dropdown-item-icon" aria-hidden="true"></i>
+           <umb-icon icon="{{layout.icon}}" class="{{layout.icon}} umb-layout-selector__dropdown-item-icon"></umb-icon>
            <span class="sr-only">{{layout.name}}</span>
        </button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -41,7 +41,9 @@
             <button type="button"
                     class="btn-reset"
                     ng-click="showSettingsOverlay()"
-                    aria-label="Edit">
+                    aria-label="Edit"
+                    localize="title"
+                    title="@general_edit">
                 <umb-icon icon="icon-settings" class="icon-settings"></umb-icon>
             </button>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings.html
@@ -38,10 +38,12 @@
     </div>    
     <div class="umb-group-builder__property-actions">
         <div class="umb-group-builder__property-action">
-            <button                 
-                class="btn-icon icon-settings"                 
-                ng-click="showSettingsOverlay()"                     
-                aria-label="Edit"></button>
+            <button type="button"
+                    class="btn-reset"
+                    ng-click="showSettingsOverlay()"
+                    aria-label="Edit">
+                <umb-icon icon="icon-settings" class="icon-settings"></umb-icon>
+            </button>
         </div>
     </div>
   </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR use `<umb-icon>` in the listview layout selector and removes a few unnecessary `prevent-default` on the button elements.

I also noticed a few missing icons, while looking at the listview.

### Document type properties

**Before**

![chrome_2020-07-29_22-43-52](https://user-images.githubusercontent.com/2919859/88853202-a55dd380-d1ef-11ea-82fd-70b581508d07.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/88855226-d2f84c00-d1f2-11ea-812a-093c160737e9.png)


### Listview configuration

**Before**

![chrome_2020-07-29_23-00-32](https://user-images.githubusercontent.com/2919859/88853189-a0991f80-d1ef-11ea-89d4-585a11c34b35.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/88853340-db9b5300-d1ef-11ea-88e8-c0209b62b1c6.png)
