### PR TITLE
"Selected"-checkbox in mini listview is always visible

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-table.less
@@ -164,7 +164,7 @@ input.umb-table__input {
     }
 }
 
-.umb-table-body__icon {
+.umb-table-body .umb-table-body__icon {
     margin: 0 auto;
     font-size: 20px;
     line-height: 20px;
@@ -173,7 +173,7 @@ input.umb-table__input {
     text-decoration: none;
 }
 
-.umb-table-body__checkicon {
+.umb-table-body .umb-table-body__icon.umb-table-body__checkicon {
     display: none;
     font-size: 18px;
     line-height: 20px;
@@ -218,15 +218,15 @@ input.umb-table__input {
 }
 
 // Show checkmark when checked, hide file icon
-.umb-table-row.-selected {
-    
-    .umb-table-body__fileicon {
-        display: none;
-    }
-    .umb-table-body__checkicon {
-        display: inline-block;
-    }
-    
+.umb-table-body .umb-table-row.-selected {
+    .umb-table-body__icon {
+        &.umb-table-body__fileicon {
+            display: none;
+        }
+        &.umb-table-body__checkicon {
+            display: inline-block;
+        }
+    }    
 }
 
 // Table Row Styles


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It seems #5606 made the "Selected"-checkbox visible at all times for all items in mini list views, despite these items not being selected:

![image](https://user-images.githubusercontent.com/7405322/88897436-8b51de80-d24b-11ea-9c58-fb0215cb5658.png)


This PR fixes it:

![image](https://user-images.githubusercontent.com/7405322/88897341-652c3e80-d24b-11ea-8734-2a9c1b218df6.png)
