### PR TITLE
Show keyboard input focus on file property editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-file-upload.less
@@ -14,6 +14,12 @@
             color: @gray-8;
         }
 
+        &:focus-within {
+            .tabbing-active & {
+                box-shadow: 0 0 2px @ui-outline, inset 0 0 2px 1px @ui-outline;
+            }
+        }
+
         i.icon {
             font-size: 55px;
             line-height: 70px


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The property editors for file upload and image cropper do not show the keyboard input focus when you're tabbing through the editor interface:

![file-upload-keyboard-focus-before](https://user-images.githubusercontent.com/7405322/88905657-cb6a8e80-d256-11ea-9939-b1f39fab9e54.gif)

...but with this PR - they do 😄 

![file-upload-keyboard-focus-after](https://user-images.githubusercontent.com/7405322/88905490-a4ac5800-d256-11ea-9abc-f32fa9c5fd38.gif)
