### PR TITLE
Adjustments to umb-icon with custom font icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
@@ -32,7 +32,7 @@ This format is only used in the iconpicker.html
 (function () {
     "use strict";
 
-    function UmbIconDirective($http, $sce, iconHelper) {
+    function UmbIconDirective(iconHelper) {
 
         var directive = {
             replace: true,
@@ -44,7 +44,7 @@ This format is only used in the iconpicker.html
             },
 
             link: function (scope) {
-                if (scope.svgString === undefined) {
+                if (scope.svgString === undefined && scope.svgString !== null && scope.icon !== undefined && scope.icon !== null) {
                     var icon = scope.icon.split(" ")[0]; // Ensure that only the first part of the icon is used as sometimes the color is added too, e.g. see umbeditorheader.directive scope.openIconPicker
 
                     _requestIcon(icon);
@@ -64,6 +64,8 @@ This format is only used in the iconpicker.html
                     iconHelper.getIcon(icon)
                         .then(icon => {
                             if (icon !== null && icon.svgString !== undefined) {
+                                // Watch source SVG string
+                                //icon.svgString.$$unwrapTrustedValue();
                                 scope.svgString = icon.svgString;
                             }
                         });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbicon.directive.js
@@ -61,12 +61,15 @@ This format is only used in the iconpicker.html
                 });
 
                 function _requestIcon(icon) {
+                    // Reset svg string before requesting new icon.
+                    scope.svgString = null;
+
                     iconHelper.getIcon(icon)
-                        .then(icon => {
-                            if (icon !== null && icon.svgString !== undefined) {
+                        .then(data => {
+                            if (data !== null && data.svgString !== undefined) {
                                 // Watch source SVG string
                                 //icon.svgString.$$unwrapTrustedValue();
-                                scope.svgString = icon.svgString;
+                                scope.svgString = data.svgString;
                             }
                         });
                 }

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -147,6 +147,7 @@
 @import "components/umb-color-swatches.less";
 @import "components/check-circle.less";
 @import "components/umb-file-icon.less";
+@import "components/umb-icon.less";
 @import "components/umb-iconpicker.less";
 @import "components/umb-insert-code-box.less";
 @import "components/umb-packages.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
@@ -3,7 +3,7 @@
         content: none !important;
     }
 
-    i {
+    > i {
         font-family: inherit;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
@@ -1,0 +1,9 @@
+﻿.umb-icon {
+    &:before, &:after {
+        content: none !important;
+    }
+
+    i {
+        font-family: inherit;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -58,28 +58,29 @@
 }
 
 .umb-iconpicker-item i {
+    font-family: inherit;
     font-size: 30px;
 }
 
 // Color swatch
  .button {
-        border: none;
-        color: @white;
-        padding: 5px;
-        text-align: center;
-        text-decoration: none;
-        display: inline-block;
-        margin: 5px;
-        border-radius: 3px;
-    }
+    border: none;
+    color: @white;
+    padding: 5px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    margin: 5px;
+    border-radius: 3px;
+}
 
-    // Circle behind the checkmark
-    i.small.active{
-        font-size: 14px;
-        display: inline-block;
-        width: 20px;
-        height: 20px;
-        border-radius: 50%;
-        background-color: rgba(0,0,0,.15);
-        float: right;
-    }
+// Circle behind the checkmark
+i.small.active{
+    font-size: 14px;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: rgba(0,0,0,.15);
+    float: right;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/helveticons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/helveticons.less
@@ -35,18 +35,24 @@ span[class*=" icon-"] {
     }
 }
 
-i[class^="icon-"],
-i[class*=" icon-"],
+[class^="icon-"],
+[class*=" icon-"],
 button.icon-trash {
-  font-family: icomoon;
-  font-weight: normal;
-  font-style: normal;
-  text-decoration: inherit;
-  -webkit-font-smoothing: antialiased;
+    font-family: 'icomoon';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+
+    /* Better Font Rendering =========== */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
-i[class^="icon-"]:before,
-i[class*=" icon-"]:before,
+[class^="icon-"]:before,
+[class*=" icon-"]:before,
 button.icon-trash {
     text-decoration: inherit;
     display: inline-block;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -46,7 +46,7 @@
                 <div class="umb-control-group" ng-show="!vm.loading && filtered.length > 0 ">
                     <ul class="umb-iconpicker" ng-class="vm.color.value" ng-show="vm.icons">
                         <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: searchTerm | orderBy:'name') track by $id(icon)">
-                            <button type="button" title="{{icon.name}}" ng-click="vm.selectIcon(icon.name, vm.color.value)" prevent-default>
+                            <button type="button" title="{{icon.name}}" ng-click="vm.selectIcon(icon.name, vm.color.value)">
                                 <umb-icon class="umb-iconpicker-svg {{icon.name}} large" icon="{{icon.name}}" svg-string="icon.svgString"></umb-icon>
                                 <span class="sr-only"><localize key="buttons_select">Select</localize> {{icon.name}}</span>
                             </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -18,7 +18,7 @@
                     ng-click="openIconPicker()"
                     ng-class="{'-placeholder': $parent.icon==='' || $parent.icon===null}"
                     title="{{$parent.icon}}">
-                        <umb-icon class="icon {{$parent.icon}}" icon="{{$parent.icon}}" ng-if="$parent.icon!=='' && $parent.icon!==null" aria-hidden="true"></umb-icon>
+                        <umb-icon class="icon {{$parent.icon}}" icon="{{$parent.icon}}" ng-if="$parent.icon!=='' && $parent.icon!==null"></umb-icon>
                         <span class="umb-panel-header-icon-text" ng-if="$parent.icon==='' || $parent.icon===null">
                             <localize key="settings_addIcon">Add icon</localize>
                         </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html
@@ -1,5 +1,4 @@
-
-<span aria-hidden="true">
+<span aria-hidden="true" class="umb-icon">
     <span ng-if="svgString" ng-bind-html="svgString"></span>
-    <i ng-if="!svgString && iconName" class="{{iconName}}"></i>
+    <i ng-if="!svgString && icon" class="{{icon}}"></i>
 </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After merging PR https://github.com/umbraco/Umbraco-CMS/pull/5606 I have noticed some issues with custom font icons. At the moment it expect the font-family is `icomoon`, but it could be something else like `icomoonforms` shipped with Umbraco Forms.

Furthermore these fonts didn't look nice in the iconpicker.

**Before**

![2020-07-30_12-33-58](https://user-images.githubusercontent.com/2919859/88913413-21443400-d261-11ea-8c88-fdeb82bd5db5.gif)


**After**

![2020-07-30_12-30-38](https://user-images.githubusercontent.com/2919859/88913131-a8dd7300-d260-11ea-8daf-1ba72b1cd987.gif)
