### PR TITLE
Don't log message if svg icon isn't found

### DIFF
--- a/src/Umbraco.Web/Editors/IconController.cs
+++ b/src/Umbraco.Web/Editors/IconController.cs
@@ -90,9 +90,8 @@ namespace Umbraco.Web.Editors
 
                 return svg;
             }
-            catch (Exception ex)
+            catch
             {
-                Logger.Error<IconController>(ex, $"Could not load {iconName}.svg");
                 return null;
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment the changes regarding `umb-icon` directive extended IconController to look for svg icons and log an error if it isn't found.
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Editors/IconController.cs#L95

However this will fill log with errors, when using custom font icons where svg icons are not available, e.g. when Umbraco Forms is installed.

![chrome_2020-07-30_13-30-20](https://user-images.githubusercontent.com/2919859/88919111-dc24ff80-d26a-11ea-87ae-cb7b686c923d.png)