### PR TITLE
Replace underscore _.throttle function with utility function

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
@@ -292,7 +292,7 @@ angular.module("umbraco.directives")
                         }
                     });
 
-                    var throttledResizing = _.throttle(function () {
+                    var throttledResizing = Utilities.throttle(() => {
                         resizeImageToScale(scope.dimensions.scale.current);
                         calculateCropBox();
                     }, 15);

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -82,7 +82,8 @@
           val = '$SCOPE';
         }      
         return val;
-      }
+    }
+
     /**
      * Equivalent to angular.toJson
      */
@@ -114,6 +115,17 @@
         return obj;
     }
 
+    const throttle = (func, timeFrame) => {
+        var lastTime = 0;
+        return function () {
+            var now = new Date();
+            if (now - lastTime >= timeFrame) {
+                func();
+                lastTime = now;
+            }
+        };
+    }
+
     let _utilities = {
         noop: noop,
         copy: copy,
@@ -128,7 +140,8 @@
         isObject: isObject,
         fromJson: fromJson,
         toJson: toJson,
-        forEach: forEach
+        forEach: forEach,
+        throttle: throttle
     };
 
     if (typeof (window.Utilities) === 'undefined') {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.controller.js
@@ -198,15 +198,12 @@
             }
         }
 
-        var throttledFunc = _.throttle(function() {
-
-                templateQueryResource.postTemplateQuery(vm.query)
-                    .then(function(response) {
-                        $scope.model.result = response;
-                    });
-
-            },
-            200);
+        var throttledFunc = Utilities.throttle(() => {
+            templateQueryResource.postTemplateQuery(vm.query)
+                .then(function (response) {
+                    $scope.model.result = response;
+                });
+        }, 200);
 
         localizationService.localizeMany([
                 "template_allContent", "template_websiteRoot", "template_ascending", "template_descending"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the underscore `_.throttle` function is used a few places.
This PR replaces this with an utility function using vanilla javascript.

To test this it is easiest to increase timeout to e.g. 2000 milliseconds (2 seconds) and in query builder check in the browser network panel that `PostTemplateQuery` isn't requested each time when you click ascending/descending button fast.