### PR TITLE
Replace underscore _.debounce function with utility function

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
@@ -195,7 +195,7 @@
             //vm.center.top = (offsetY + 10) / scope.dimensions.height;
         };
 
-        var lazyEndEvent = _.debounce(function () {
+        var lazyEndEvent = Utilities.debounce(() => {
             $scope.$apply(function () {
                 $scope.$emit("imageFocalPointStop");
             });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreesearchbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreesearchbox.directive.js
@@ -79,7 +79,7 @@ function treeSearchBox(localizationService, searchService, $q) {
                 }
             }
 
-            scope.$watch("term", _.debounce(function(newVal, oldVal) {
+            scope.$watch("term", Utilities.debounce((newVal, oldVal) => {
                 scope.$apply(function() {
                     if (newVal !== null && newVal !== undefined && newVal !== oldVal) {
                         performSearch();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
@@ -190,7 +190,7 @@
                 searchMiniListView(miniListView);
             };
 
-            var searchMiniListView = _.debounce(function (miniListView) {
+            var searchMiniListView = Utilities.debounce((miniListView) => {
                 scope.$apply(function () {
                     getChildrenForMiniListView(miniListView);
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/services/windowresizelistener.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/windowresizelistener.service.js
@@ -14,7 +14,7 @@ function windowResizeListener($rootScope) {
     var WinReszier = (function () {
         var registered = [];
         var inited = false;        
-        var resize = _.debounce(function(ev) {
+        var resize = Utilities.debounce(() => {
             notify();
         }, 100);
         var notify = function () {

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -114,6 +114,19 @@
         return obj;
     }
 
+    const debounce = (func, wait, immediate) => {
+        var timeout;
+        return function () {
+            var context = this, args = arguments;
+            clearTimeout(timeout);
+            timeout = setTimeout(function () {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            }, wait);
+            if (immediate && !timeout) func.apply(context, args);
+        };
+    }
+
     let _utilities = {
         noop: noop,
         copy: copy,
@@ -128,7 +141,8 @@
         isObject: isObject,
         fromJson: fromJson,
         toJson: toJson,
-        forEach: forEach
+        forEach: forEach,
+        debounce: debounce
     };
 
     if (typeof (window.Utilities) === 'undefined') {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -398,7 +398,7 @@ angular.module("umbraco")
                 });
             };
 
-            var debounceSearchMedia = _.debounce(function () {
+            var debounceSearchMedia = Utilities.debounce(() => {
                 $scope.$apply(function () {
                     if (vm.searchOptions.filter) {
                         searchMedia();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js
@@ -87,7 +87,7 @@
             users.length = 0;
         }
 
-        var search = _.debounce(function () {
+        var search = Utilities.debounce(() => {
             $scope.$apply(function () {
                 getUsers();
             });

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-search/umbminisearch.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-search/umbminisearch.component.js
@@ -19,7 +19,7 @@
         
         var vm = this;
         
-        var searchDelay = _.debounce(function () {
+        var searchDelay = Utilities.debounce(() => {
             $scope.$apply(function () {
                 if (vm.onSearch) {
                     vm.onSearch();

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js
@@ -190,7 +190,7 @@
             });
         }
 
-        var filterDebounced = _.debounce(function(e) {
+        var filterDebounced = Utilities.debounce(() => {
 
             $scope.$apply(function() {
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
@@ -288,7 +288,7 @@
         }
 
 
-        var searchDebounced = _.debounce(function (e) {
+        var searchDebounced = Utilities.debounce(() => {
 
             $scope.$apply(function () {
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -452,7 +452,7 @@
             }
         }
 
-        var search = _.debounce(function () {
+        var search = Utilities.debounce(() => {
             $scope.$apply(function () {
                 vm.usersOptions.pageNumber = 1;
                 getUsers();

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -58,8 +58,24 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web.UI.Client", "ht
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest\", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
 	ProjectSection(WebsiteProperties) = preProject
+		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
+		Debug.AspNetCompiler.VirtualPath = "/localhost_60632"
+		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
+		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_60632\"
+		Debug.AspNetCompiler.Updateable = "true"
+		Debug.AspNetCompiler.ForceOverwrite = "true"
+		Debug.AspNetCompiler.FixedNames = "false"
+		Debug.AspNetCompiler.Debug = "True"
+		Release.AspNetCompiler.VirtualPath = "/localhost_60632"
+		Release.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
+		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_60632\"
+		Release.AspNetCompiler.Updateable = "true"
+		Release.AspNetCompiler.ForceOverwrite = "true"
+		Release.AspNetCompiler.FixedNames = "false"
+		Release.AspNetCompiler.Debug = "False"
+		VWDPort = "60632"
 		SlnRelativePath = "Umbraco.Tests.AcceptanceTest\"
 	EndProjectSection
 EndProject
@@ -123,6 +139,10 @@ Global
 		{4C4C194C-B5E4-4991-8F87-4373E24CC19F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -157,6 +177,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{227C3B55-80E5-4E7E-A802-BE16C5128B9D} = {2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{5D3B8245-ADA6-453F-A008-50ED04BFE770} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{E3F9F378-AFE1-40A5-90BD-82833375DBFE} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
 		{5B03EF4E-E0AC-4905-861B-8C3EC1A0D458} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
@@ -164,7 +185,6 @@ Global
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}

--- a/src/umbraco.sln
+++ b/src/umbraco.sln
@@ -58,24 +58,8 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Web.UI.Client", "ht
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTest\", "Umbraco.Tests.AcceptanceTest\", "{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}"
 	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_60632"
-		Debug.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_60632\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_60632"
-		Release.AspNetCompiler.PhysicalPath = "Umbraco.Tests.AcceptanceTest\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_60632\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "60632"
 		SlnRelativePath = "Umbraco.Tests.AcceptanceTest\"
 	EndProjectSection
 EndProject
@@ -139,10 +123,6 @@ Global
 		{4C4C194C-B5E4-4991-8F87-4373E24CC19F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3819A550-DCEC-4153-91B4-8BA9F7F0B9B4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{651E1350-91B6-44B7-BD60-7207006D7003}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -177,7 +157,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{227C3B55-80E5-4E7E-A802-BE16C5128B9D} = {2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}
-		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{5D3B8245-ADA6-453F-A008-50ED04BFE770} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{E3F9F378-AFE1-40A5-90BD-82833375DBFE} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
 		{5B03EF4E-E0AC-4905-861B-8C3EC1A0D458} = {227C3B55-80E5-4E7E-A802-BE16C5128B9D}
@@ -185,6 +164,7 @@ Global
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
+		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the underscore `_.debounce` function is used a few places.
This PR replaces this with an utility function using vanilla javascript.

To test this check mainly search, e.g. listview search, that search happens with a delay of few milliseconds and therefore no search on each keypress.