### PR TITLE
Fixes #8433 ensures there are no write locks when updating members during login

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Querying;
 
@@ -35,5 +36,17 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="query"></param>
         /// <returns></returns>
         int GetCountByQuery(IQuery<IMember> query);
+
+        /// <summary>
+        /// Sets a members last login date based on their username
+        /// </summary>
+        /// <param name="username"></param>
+        /// <param name="date"></param>
+        /// <remarks>
+        /// This is a specialized method because whenever a member logs in, the membership provider requires us to set the 'online' which requires
+        /// updating their login date. This operation must be fast and cannot use database locks which is fine if we are only executing a single query
+        /// for this data since there won't be any other data contention issues.
+        /// </remarks>
+        void SetLastLogin(string username, DateTime date);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
@@ -7,6 +7,8 @@ namespace Umbraco.Core.Persistence.Repositories
 {
     public interface IMemberRepository : IContentRepository<int, IMember>
     {
+        IMember GetByUsername(string username);
+
         /// <summary>
         /// Finds members in a given role
         /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/SimpleGetRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/SimpleGetRepository.cs
@@ -11,6 +11,8 @@ using Umbraco.Core.Scoping;
 
 namespace Umbraco.Core.Persistence.Repositories.Implement
 {
+    // TODO: Obsolete this, change all implementations of this like in Dictionary to just use custom Cache policies like in the member repository.
+
     /// <summary>
     /// Simple abstract ReadOnly repository used to simply have PerformGet and PeformGetAll with an underlying cache
     /// </summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -168,10 +168,7 @@ ORDER BY colName";
         }
 
         public Guid CreateLoginSession(int userId, string requestingIpAddress, bool cleanStaleSessions = true)
-        {
-            // TODO: I know this doesn't follow the normal repository conventions which would require us to create a UserSessionRepository
-            //and also business logic models for these objects but that's just so overkill for what we are doing
-            //and now that everything is properly in a transaction (Scope) there doesn't seem to be much reason for using that anymore
+        {            
             var now = DateTime.UtcNow;
             var dto = new UserLoginDto
             {
@@ -201,13 +198,14 @@ ORDER BY colName";
             // that query is going to run a *lot*, make it a template
             var t = SqlContext.Templates.Get("Umbraco.Core.UserRepository.ValidateLoginSession", s => s
                 .Select<UserLoginDto>()
+                .SelectTop(1)
                 .From<UserLoginDto>()
                 .Where<UserLoginDto>(x => x.SessionId == SqlTemplate.Arg<Guid>("sessionId"))
                 .ForUpdate());
 
             var sql = t.Sql(sessionId);
 
-            var found = Database.Query<UserLoginDto>(sql).FirstOrDefault();
+            var found = Database.FirstOrDefault<UserLoginDto>(sql);
             if (found == null || found.UserId != userId || found.LoggedOutUtc.HasValue)
                 return false;
 

--- a/src/Umbraco.Core/Services/IMembershipMemberService.cs
+++ b/src/Umbraco.Core/Services/IMembershipMemberService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Persistence.Querying;
@@ -106,6 +107,18 @@ namespace Umbraco.Core.Services
         /// <remarks>An <see cref="IMembershipUser"/> can be of type <see cref="IMember"/> or <see cref="IUser"/></remarks>
         /// <param name="membershipUser"><see cref="IMember"/> or <see cref="IUser"/> to Delete</param>
         void Delete(T membershipUser);
+
+        /// <summary>
+        /// Sets the last login date for the member if they are found by username
+        /// </summary>
+        /// <param name="username"></param>
+        /// <param name="date"></param>
+        /// <remarks>
+        /// This is a specialized method because whenever a member logs in, the membership provider requires us to set the 'online' which requires
+        /// updating their login date. This operation must be fast and cannot use database locks which is fine if we are only executing a single query
+        /// for this data since there won't be any other data contention issues.
+        /// </remarks>
+        void SetLastLogin(string username, DateTime date);
 
         /// <summary>
         /// Saves an <see cref="IMembershipUser"/>

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -447,15 +447,10 @@ namespace Umbraco.Core.Services.Implement
         /// <returns><see cref="IMember"/></returns>
         public IMember GetByUsername(string username)
         {
-            // TODO: Somewhere in here, whether at this level or the repository level, we need to add
-            // a caching mechanism since this method is used by all the membership providers and could be
-            // called quite a bit when dealing with members.
-
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                scope.ReadLock(Constants.Locks.MemberTree);
-                var query = Query<IMember>().Where(x => x.Username.Equals(username));
-                return _memberRepository.Get(query).FirstOrDefault();
+                scope.ReadLock(Constants.Locks.MemberTree);                
+                return _memberRepository.GetByUsername(username);
             }
         }
 

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -806,12 +806,17 @@ namespace Umbraco.Core.Services.Implement
 
         #region Save
 
-        /// <summary>
-        /// Saves an <see cref="IMember"/>
-        /// </summary>
-        /// <param name="member"><see cref="IMember"/> to Save</param>
-        /// <param name="raiseEvents">Optional parameter to raise events.
-        /// Default is <c>True</c> otherwise set to <c>False</c> to not raise events</param>
+        /// <inheritdoc />
+        public void SetLastLogin(string username, DateTime date)
+        {
+            using (var scope = ScopeProvider.CreateScope())
+            {   
+                _memberRepository.SetLastLogin(username, date);
+                scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
         public void Save(IMember member, bool raiseEvents = true)
         {
             //trimming username and email to make sure we have no trailing space
@@ -847,12 +852,7 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        /// <summary>
-        /// Saves a list of <see cref="IMember"/> objects
-        /// </summary>
-        /// <param name="members"><see cref="IEnumerable{IMember}"/> to save</param>
-        /// <param name="raiseEvents">Optional parameter to raise events.
-        /// Default is <c>True</c> otherwise set to <c>False</c> to not raise events</param>
+        /// <inheritdoc />
         public void Save(IEnumerable<IMember> members, bool raiseEvents = true)
         {
             var membersA = members.ToArray();

--- a/src/Umbraco.Core/Services/Implement/UserService.cs
+++ b/src/Umbraco.Core/Services/Implement/UserService.cs
@@ -254,6 +254,13 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        // explicit implementation because we don't need it now but due to the way that the members membership provider is put together
+        // this method must exist in this service as an implementation (legacy)
+        void IMembershipMemberService<IUser>.SetLastLogin(string username, DateTime date)
+        {
+            throw new NotSupportedException("This method is not implemented or supported for users");
+        }
+
         /// <summary>
         /// Saves an <see cref="IUser"/>
         /// </summary>

--- a/src/Umbraco.Tests/Persistence/Repositories/UserRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/UserRepositoryTest.cs
@@ -16,6 +16,7 @@ using Umbraco.Tests.Testing;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.PropertyEditors;
 using System;
+using Umbraco.Core.Persistence.Dtos;
 
 namespace Umbraco.Tests.Persistence.Repositories
 {
@@ -77,11 +78,43 @@ namespace Umbraco.Tests.Persistence.Repositories
         }
 
         [Test]
+        public void Validate_Login_Session()
+        {
+            // Arrange
+            var provider = TestObjects.GetScopeProvider(Logger);
+            var user = MockedUser.CreateUser();
+            using (var scope = provider.CreateScope(autoComplete: true))
+            {
+                var repository = CreateRepository(provider);                
+                repository.Save(user);                
+            }
+
+            using (var scope = provider.CreateScope(autoComplete: true))
+            {
+                var repository = CreateRepository(provider);
+                var sessionId = repository.CreateLoginSession(user.Id, "1.2.3.4");
+
+                // manually update this record to be in the past
+                scope.Database.Execute(SqlContext.Sql()
+                    .Update<UserLoginDto>(u => u.Set(x => x.LoggedOutUtc, DateTime.UtcNow.AddDays(-100)))
+                    .Where<UserLoginDto>(x => x.SessionId == sessionId));
+
+                var isValid = repository.ValidateLoginSession(user.Id, sessionId);
+                Assert.IsFalse(isValid);
+
+                // create a new one
+                sessionId = repository.CreateLoginSession(user.Id, "1.2.3.4");
+                isValid = repository.ValidateLoginSession(user.Id, sessionId);
+                Assert.IsTrue(isValid);
+            }
+        }
+
+        [Test]
         public void Can_Perform_Add_On_UserRepository()
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -101,7 +134,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -125,7 +158,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -150,7 +183,7 @@ namespace Umbraco.Tests.Persistence.Repositories
 
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var userRepository = CreateRepository(provider);
                 var contentRepository = CreateContentRepository(provider, out var contentTypeRepo);
@@ -209,7 +242,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -237,7 +270,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
                 var userGroupRepository = CreateUserGroupRepository(provider);
@@ -260,7 +293,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -280,7 +313,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -301,7 +334,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -322,7 +355,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -341,7 +374,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -360,7 +393,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         public void Can_Get_Paged_Results_By_Query_And_Filter_And_Groups()
         {
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -393,7 +426,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         public void Can_Get_Paged_Results_With_Filter_And_Groups()
         {
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
 
@@ -426,7 +459,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         {
             // Arrange
             var provider = TestObjects.GetScopeProvider(Logger);
-            using (var scope = provider.CreateScope())
+            using (var scope = provider.CreateScope(autoComplete: true))
             {
                 var repository = CreateRepository(provider);
                 var userGroupRepository = CreateUserGroupRepository(provider);

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -49,6 +49,28 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Can_Set_Last_Login_Date()
+        {
+            var now = DateTime.Now;
+            var memberType = ServiceContext.MemberTypeService.Get("member");
+            IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true)
+            {
+                LastLoginDate = now,
+                UpdateDate = now
+            };
+            ServiceContext.MemberService.Save(member);
+
+            var newDate = now.AddDays(10);
+            ServiceContext.MemberService.SetLastLogin(member.Username, newDate);
+
+            //re-get
+            member = ServiceContext.MemberService.GetById(member.Id);
+
+            Assert.That(member.LastLoginDate, Is.EqualTo(newDate).Within(1).Seconds);
+            Assert.That(member.UpdateDate, Is.EqualTo(newDate).Within(1).Seconds);
+        }
+
+        [Test]
         public void Can_Create_Member_With_Properties()
         {
             var memberType = ServiceContext.MemberTypeService.Get("member");

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -49,9 +49,27 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Can_Update_Member_Property_Value()
+        {
+            IMemberType memberType = MockedContentTypes.CreateSimpleMemberType();
+            ServiceContext.MemberTypeService.Save(memberType);
+            IMember member = MockedMember.CreateSimpleMember(memberType, "hello", "helloworld@test123.com", "hello", "hello");
+            member.SetValue("title", "title of mine");
+            ServiceContext.MemberService.Save(member);
+
+            // re-get
+            member = ServiceContext.MemberService.GetById(member.Id);
+            member.SetValue("title", "another title of mine");
+            ServiceContext.MemberService.Save(member);
+
+            // re-get
+            member = ServiceContext.MemberService.GetById(member.Id);
+            Assert.AreEqual("another title of mine", member.GetValue("title"));
+        }
+
+        [Test]
         public void Can_Get_By_Username()
         {
-            var now = DateTime.Now;
             var memberType = ServiceContext.MemberTypeService.Get("member");
             IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true);
             ServiceContext.MemberService.Save(member);

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -49,6 +49,20 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Can_Get_By_Username()
+        {
+            var now = DateTime.Now;
+            var memberType = ServiceContext.MemberTypeService.Get("member");
+            IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true);
+            ServiceContext.MemberService.Save(member);
+
+            var member2 = ServiceContext.MemberService.GetByUsername(member.Username);
+
+            Assert.IsNotNull(member2);
+            Assert.AreEqual(member.Email, member2.Email);
+        }
+
+        [Test]
         public void Can_Set_Last_Login_Date()
         {
             var now = DateTime.Now;

--- a/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
@@ -128,14 +128,15 @@ namespace Umbraco.Web.Cache
 
         public static void RefreshMemberCache(this DistributedCache dc, params IMember[] members)
         {
-            dc.Refresh(MemberCacheRefresher.UniqueId, x => x.Id, members);
+            if (members.Length == 0) return;
+            dc.RefreshByPayload(MemberCacheRefresher.UniqueId, members.Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username)));
         }
 
         public static void RemoveMemberCache(this DistributedCache dc, params IMember[] members)
         {
-            dc.Remove(MemberCacheRefresher.UniqueId, x => x.Id, members);
+            if (members.Length == 0) return;
+            dc.RefreshByPayload(MemberCacheRefresher.UniqueId, members.Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username)));
         }
-
 
         #endregion
 

--- a/src/Umbraco.Web/Cache/MemberCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MemberCacheRefresher.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Models;
 using Umbraco.Core.Persistence.Repositories;
@@ -7,14 +9,30 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Cache
 {
-    public sealed class MemberCacheRefresher : TypedCacheRefresherBase<MemberCacheRefresher, IMember>
+    public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCacheRefresher, MemberCacheRefresher.JsonPayload>
     {
         private readonly IdkMap _idkMap;
+        private readonly LegacyMemberCacheRefresher _legacyMemberRefresher;
 
         public MemberCacheRefresher(AppCaches appCaches, IdkMap idkMap)
             : base(appCaches)
         {
             _idkMap = idkMap;
+            _legacyMemberRefresher = new LegacyMemberCacheRefresher(this, appCaches);
+        }
+
+        public class JsonPayload 
+        {
+            [JsonConstructor]
+            public JsonPayload(int id, string username)
+            {
+                Id = id;
+                Username = username;
+            }
+
+            public int Id { get; }
+            public string Username { get; }
+
         }
 
         #region Define
@@ -31,38 +49,45 @@ namespace Umbraco.Web.Cache
 
         #region Refresher
 
+        public override void Refresh(JsonPayload[] payloads)
+        {
+            ClearCache(payloads);
+            base.Refresh(payloads);
+        }
+
         public override void Refresh(int id)
         {
-            ClearCache(id);
+            ClearCache(new JsonPayload(id, null));
             base.Refresh(id);
         }
 
         public override void Remove(int id)
         {
-            ClearCache(id);
+            ClearCache(new JsonPayload(id, null));
             base.Remove(id);
         }
 
-        public override void Refresh(IMember instance)
-        {
-            ClearCache(instance.Id);
-            base.Refresh(instance);
-        }
+        [Obsolete("This is no longer used and will be removed from the codebase in the future")]
+        public void Refresh(IMember instance) => _legacyMemberRefresher.Refresh(instance);
 
-        public override void Remove(IMember instance)
-        {
-            ClearCache(instance.Id);
-            base.Remove(instance);
-        }
+        [Obsolete("This is no longer used and will be removed from the codebase in the future")]
+        public void Remove(IMember instance) => _legacyMemberRefresher.Remove(instance);
 
-        private void ClearCache(int id)
+        private void ClearCache(params JsonPayload[] payloads)
         {
-            _idkMap.ClearCache(id);
             AppCaches.ClearPartialViewCache();
-
             var memberCache = AppCaches.IsolatedCaches.Get<IMember>();
-            if (memberCache)
-                memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember>(id));
+
+            foreach (var p in payloads)
+            {
+                _idkMap.ClearCache(p.Id);
+                if (memberCache)
+                {
+                    memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember>(p.Id));
+                    memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember>(p.Username));
+                }   
+            }
+            
         }
 
         #endregion
@@ -72,6 +97,39 @@ namespace Umbraco.Web.Cache
         public static void RefreshMemberTypes(AppCaches appCaches)
         {
             appCaches.IsolatedCaches.ClearCache<IMember>();
+        }
+
+        #endregion
+
+        #region Backwards Compat
+
+        // TODO: this is here purely for backwards compat but should be removed in netcore
+        private class LegacyMemberCacheRefresher : TypedCacheRefresherBase<MemberCacheRefresher, IMember>
+        {
+            private readonly MemberCacheRefresher _parent;
+
+            public LegacyMemberCacheRefresher(MemberCacheRefresher parent, AppCaches appCaches) : base(appCaches)
+            {
+                _parent = parent;
+            }
+
+            public override Guid RefresherUniqueId => _parent.RefresherUniqueId;
+
+            public override string Name => _parent.Name;
+
+            protected override MemberCacheRefresher This => _parent;
+
+            public override void Refresh(IMember instance)
+            {
+                _parent.ClearCache(new JsonPayload(instance.Id, instance.Username));
+                base.Refresh(instance.Id);
+            }
+
+            public override void Remove(IMember instance)
+            {
+                _parent.ClearCache(new JsonPayload(instance.Id, instance.Username));
+                base.Remove(instance);
+            }
         }
 
         #endregion

--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -261,8 +261,9 @@ namespace Umbraco.Web.Security
             {
                 return false;
             }
-            //Set member online
-            var member = provider.GetUser(username, true);
+            // Get the member, do not set to online - this is done implicitly as part of ValidateUser which is consistent with
+            // how the .NET framework SqlMembershipProvider works. Passing in true will just cause more unnecessary SQL queries/locks.
+            var member = provider.GetUser(username, false);
             if (member == null)
             {
                 //this should not happen
@@ -778,33 +779,17 @@ namespace Umbraco.Web.Security
         /// <returns></returns>
         private IMember GetCurrentPersistedMember()
         {
-            return _appCaches.RequestCache.GetCacheItem<IMember>(
-                GetCacheKey("GetCurrentPersistedMember"), () =>
-                {
-                    var provider = _membershipProvider;
+            var provider = _membershipProvider;
 
-                    if (provider.IsUmbracoMembershipProvider() == false)
-                    {
-                        throw new NotSupportedException("An IMember model can only be retrieved when using the built-in Umbraco membership providers");
-                    }
-                    var username = provider.GetCurrentUserName();
-                    var member = _memberService.GetByUsername(username);
-                    return member;
-                });
-        }
-
-        private static string GetCacheKey(string key, params object[] additional)
-        {
-            var sb = new StringBuilder();
-            sb.Append(typeof (MembershipHelper).Name);
-            sb.Append("-");
-            sb.Append(key);
-            foreach (var s in additional)
+            if (provider.IsUmbracoMembershipProvider() == false)
             {
-                sb.Append("-");
-                sb.Append(s);
+                throw new NotSupportedException("An IMember model can only be retrieved when using the built-in Umbraco membership providers");
             }
-            return sb.ToString();
+            var username = provider.GetCurrentUserName();
+
+            // The result of this is cached by the MemberRepository
+            var member = _memberService.GetByUsername(username);
+            return member;
         }
 
     }

--- a/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
+++ b/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
@@ -348,15 +348,9 @@ namespace Umbraco.Web.Security.Providers
 
             if (userIsOnline)
             {
-                member.LastLoginDate = DateTime.Now;
-                member.UpdateDate = DateTime.Now;
-                //don't raise events for this! It just sets the member dates, if we do raise events this will
-                // cause all distributed cache to execute - which will clear out some caches we don't want.
-                // http://issues.umbraco.org/issue/U4-3451
-
                 // when upgrading from 7.2 to 7.3 trying to save will throw
                 if (UmbracoVersion.Current >= new Version(7, 3, 0, 0))
-                    MemberService.Save(member, false);
+                    MemberService.SetLastLogin(username, DateTime.Now);
             }
 
             return ConvertToMembershipUser(member);

--- a/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
+++ b/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
@@ -350,7 +350,14 @@ namespace Umbraco.Web.Security.Providers
             {
                 // when upgrading from 7.2 to 7.3 trying to save will throw
                 if (UmbracoVersion.Current >= new Version(7, 3, 0, 0))
-                    MemberService.SetLastLogin(username, DateTime.Now);
+                {
+                    var now = DateTime.Now;
+                    // update the database data directly instead of a full member save which requires DB locks
+                    MemberService.SetLastLogin(username, now);
+                    member.LastLoginDate = now;
+                    member.UpdateDate = now;
+                }
+                    
             }
 
             return ConvertToMembershipUser(member);


### PR DESCRIPTION
Fixes #8433 

Ensures there are no write locks when updating members during login

This also finalizes an outstanding TODO that has been there for a very very long time that will hugely boost performance for sites that are membership heavy and have a lot of active logins at once. We never cached members by username but that is how they login and how they re-authenticate each request which is a huge amount of database calls. 



---
_This item has been added to our backlog [AB#8415](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8415)_