### PR TITLE
Fix styling of confirm actions in tags editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -175,6 +175,7 @@
 @import "components/umb-dropdown.less";
 @import "components/umb-range-slider.less";
 @import "components/umb-number.less";
+@import "components/umb-tags-editor.less";
 
 @import "components/buttons/umb-button.less";
 @import "components/buttons/umb-button-group.less";

--- a/src/Umbraco.Web.UI.Client/src/less/buttons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/buttons.less
@@ -336,20 +336,17 @@ input[type="submit"].btn {
 // This is lifted from umb-group-builder.less
 
 .btn-icon {
-    border: none;
-        
+    border: none;      
     font-size: 18px;
     position: relative;
     cursor: pointer;
     color: @ui-icon;
-
     margin: 0;
     padding: 5px 10px;
     width: auto;
     overflow: visible;
     background: transparent;
     line-height: normal;
-    outline: 0;
     -webkit-appearance: none;
 
     &:hover {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-action.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-action.less
@@ -21,16 +21,15 @@
 
     .umb_confirm-action__overlay-action {
         margin-bottom: 5px;
-    }
 
-    .umb_confirm-action__overlay-action.-confirm {
-        order: 1;
-    }
+        &.-confirm {
+            order: 2;
+        }
 
-    .umb_confirm-action__overlay-action.-cancel {
-        order: 2;
+        &.-cancel {
+            order: 1;
+        }
     }
-
 }
 
 .umb_confirm-action__overlay.-right {
@@ -43,14 +42,14 @@
 
     .umb_confirm-action__overlay-action {
         margin-left: 5px;
-    }
 
-    .umb_confirm-action__overlay-action.-confirm {
-        order: 2;
-    }
+        &.-confirm {
+            order: 2;
+        }
 
-    .umb_confirm-action__overlay-action.-cancel {
-        order: 1;
+        &.-cancel {
+            order: 1;
+        }
     }
 }
 
@@ -64,14 +63,13 @@
 
     .umb_confirm-action__overlay-action {
         margin-top: 5px;
-    }
 
-    .umb_confirm-action__overlay-action.-confirm {
-        order: 2;
-    }
-
-    .umb_confirm-action__overlay-action.-cancel {
-        order: 1;
+        &.-confirm {
+            order: 2;
+        }
+        &.-cancel {
+            order: 1;
+        }
     }
 }
 
@@ -98,39 +96,39 @@
 
 // BUTTONS
 .umb_confirm-action__overlay-action {
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: @white;
-  border-radius: 40px;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
-  font-size: 18px;
-  cursor: pointer;
-}
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: @white;
+    border-radius: 40px;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+    font-size: 18px;
+    cursor: pointer;
+    user-select: none;
 
-.umb_confirm-action__overlay-action:hover {
-  text-decoration: none;
-  color: @white;
-}
+    &:hover {
+        text-decoration: none;
+        color: @white;
+    }
 
-// confirm button
-.umb_confirm-action__overlay-action.-confirm {
-  background: @white;
-  color: @green !important;
-}
+    // confirm button
+    &.-confirm {
+        background: @white;
+        color: @green !important;
 
-.umb_confirm-action__overlay-action.-confirm:hover {
-    color: @green !important;
-}
+        &:hover {
+            color: @green !important;
+        }
+    }
+    // cancel button
+    &.-cancel {
+        background: @white;
+        color: @red !important;
 
-// cancel button
-.umb_confirm-action__overlay-action.-cancel {
-  background: @white;
-  color: @red !important;
-}
-
-.umb_confirm-action__overlay-action.-cancel:hover {
-    color: @red !important;
+        &:hover {
+            color: @red !important;
+        }
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-action.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-action.less
@@ -18,18 +18,6 @@
     left: 0;
     animation: fadeInUp 0.2s;
     flex-direction: column;
-
-    .umb_confirm-action__overlay-action {
-        margin-bottom: 5px;
-
-        &.-confirm {
-            order: 2;
-        }
-
-        &.-cancel {
-            order: 1;
-        }
-    }
 }
 
 .umb_confirm-action__overlay.-right {
@@ -39,18 +27,6 @@
     left: auto;
     animation: fadeInLeft 0.2s;
     flex-direction: row;
-
-    .umb_confirm-action__overlay-action {
-        margin-left: 5px;
-
-        &.-confirm {
-            order: 2;
-        }
-
-        &.-cancel {
-            order: 1;
-        }
-    }
 }
 
 .umb_confirm-action__overlay.-bottom {
@@ -60,17 +36,6 @@
     left: 0;
     animation: fadeInDown 0.2s;
     flex-direction: column;
-
-    .umb_confirm-action__overlay-action {
-        margin-top: 5px;
-
-        &.-confirm {
-            order: 2;
-        }
-        &.-cancel {
-            order: 1;
-        }
-    }
 }
 
 .umb_confirm-action__overlay.-left {
@@ -80,55 +45,59 @@
     left: -50px;
     animation: fadeInRight 0.2s;
     flex-direction: row;
+}
+
+.umb_confirm-action__overlay {
 
     .umb_confirm-action__overlay-action {
         margin-right: 5px;
-    }
 
-    .umb_confirm-action__overlay-action.-confirm {
-        order: 1;
-    }
+        &.-confirm {
+            order: 1;
+        }
 
-    .umb_confirm-action__overlay-action.-cancel {
-        order: 2;
-    }
-}
-
-// BUTTONS
-.umb_confirm-action__overlay-action {
-    width: 20px;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: @white;
-    border-radius: 40px;
-    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
-    font-size: 18px;
-    cursor: pointer;
-    user-select: none;
-
-    &:hover {
-        text-decoration: none;
-        color: @white;
-    }
-
-    // confirm button
-    &.-confirm {
-        background: @white;
-        color: @green !important;
-
-        &:hover {
-            color: @green !important;
+        &.-cancel {
+            order: 2;
         }
     }
-    // cancel button
-    &.-cancel {
-        background: @white;
-        color: @red !important;
+
+    // BUTTONS
+    .umb_confirm-action__overlay-action {
+        width: 20px;
+        height: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: @white;
+        border-radius: 40px;
+        box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+        font-size: 18px;
+        cursor: pointer;
+        user-select: none;
 
         &:hover {
+            text-decoration: none;
+            color: @white;
+        }
+
+        // confirm button
+        &.-confirm {
+            background: @white;
+            color: @green !important;
+
+            &:hover {
+                color: @green !important;
+            }
+        }
+
+        // cancel button
+        &.-cancel {
+            background: @white;
             color: @red !important;
+
+            &:hover {
+                color: @red !important;
+            }
         }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -355,14 +355,12 @@ input.umb-group-builder__group-title-input:disabled:hover {
     position: relative;
     margin: 5px 0;
     
-    button {
+    > button {
         border: none;
-        
         font-size: 18px;
         position: relative;
         cursor: pointer;
         color: @ui-icon;
-        
         margin: 0;
         padding: 5px 10px;
         width: auto;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-tags-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-tags-editor.less
@@ -1,0 +1,53 @@
+﻿.umb-tags-editor {
+    border: @inputBorder solid 1px;
+    padding: 5px;
+    min-height: 54px;
+    font-size: 13px;
+    text-shadow: none;
+    box-sizing: border-box;
+
+    .tag {
+        cursor: default;
+        margin: 10px;
+        padding: 10px 15px;
+        background: @blueExtraDark;
+        position: relative;
+        user-select: all;
+
+        .umb_confirm-action {
+
+            > .btn-icon {
+                color: @white;
+                padding: 0;
+                position: relative;
+                cursor: pointer;
+                padding-left: 2px;
+                font-size: 15px;
+                right: -5px;
+                bottom: -1px;
+                user-select: none;
+            }
+
+            .umb_confirm-action__overlay.-left {
+                top: 8px;
+                left: auto;
+                right: 15px;
+            }
+        }
+    }
+
+    input {
+        border: none;
+        background: @white;
+    }
+
+    .twitter-typeahead {
+        margin: 10px;
+        margin-top: 16px;
+        vertical-align: top;
+
+        input {
+            padding-left: 0;
+        }
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -818,58 +818,7 @@
 // Tags
 // --------------------------------------------------
 .umb-tags {
-    border: @inputBorder solid 1px;
-    padding: 5px;
-    min-height: 54px;
-    font-size: 13px;
-    text-shadow: none;
-    box-sizing: border-box;
     .umb-property-editor--limit-width();
-
-    .tag {
-        cursor: default;
-        margin: 10px;
-        padding: 10px 15px;
-        background: @blueExtraDark;
-        position: relative;
-        user-select: all;
-
-        .umb_confirm-action {
-
-            > .btn-icon {
-                color: @white;
-                padding: 0;
-                position: relative;
-                cursor: pointer;
-                padding-left: 2px;
-                font-size: 15px;
-                right: -5px;
-                bottom: -1px;
-                user-select: none;
-            }
-
-            .umb_confirm-action__overlay.-left {
-                top: 8px;
-                left: auto;
-                right: 15px;
-            }
-        }
-    }
-
-    input {
-        border: none;
-        background: @white;
-    }
-
-    .twitter-typeahead {
-        margin: 10px;
-        margin-top: 16px;
-        vertical-align: top;
-
-        input {
-            padding-left: 0;
-        }
-    }
 }
 
 //

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -834,22 +834,25 @@
         position: relative;
         user-select: all;
 
-        > .btn-icon {
-            color: @white;
-            padding: 0;
-            position: relative;
-            cursor: pointer;
-            padding-left: 2px;
-            font-size: 15px;
-            right: -5px;
-            bottom: -1px;
-            user-select: none;
-        }
+        .umb_confirm-action {
 
-        .umb_confirm-action__overlay.-left {
-            top: 8px;
-            left: auto;
-            right: 15px;
+            > .btn-icon {
+                color: @white;
+                padding: 0;
+                position: relative;
+                cursor: pointer;
+                padding-left: 2px;
+                font-size: 15px;
+                right: -5px;
+                bottom: -1px;
+                user-select: none;
+            }
+
+            .umb_confirm-action__overlay.-left {
+                top: 8px;
+                left: auto;
+                right: 15px;
+            }
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -834,10 +834,7 @@
         position: relative;
         user-select: all;
 
-        .icon-trash {
-        }
-
-        .btn-icon {
+        > .btn-icon {
             color: @white;
             padding: 0;
             position: relative;
@@ -850,7 +847,7 @@
         }
 
         .umb_confirm-action__overlay.-left {
-            top: 6px;
+            top: 8px;
             left: auto;
             right: 15px;
         }

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -835,15 +835,21 @@
         user-select: all;
 
         .icon-trash {
+        }
+
+        .btn-icon {
+            color: @white;
+            padding: 0;
             position: relative;
             cursor: pointer;
             padding-left: 2px;
             font-size: 15px;
             right: -5px;
             bottom: -1px;
+            user-select: none;
         }
 
-        .umb_confirm-action__overlay.-left{
+        .umb_confirm-action__overlay.-left {
             top: 6px;
             left: auto;
             right: 15px;
@@ -859,6 +865,7 @@
         margin: 10px;
         margin-top: 16px;
         vertical-align: top;
+
         input {
             padding-left: 0;
         }

--- a/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
@@ -1,5 +1,6 @@
-<div>
+<div class="umb-tags-editor">
     <ng-form name="vm.tagEditorForm">
+
         <div ng-if="vm.isLoading">
             <localize key="loading">Loading</localize>...
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8526

### Description
This PR fixes some styling issues after merging https://github.com/umbraco/Umbraco-CMS/pull/5293 and moved trash icon inside `umb-confirm-action` in https://github.com/umbraco/Umbraco-CMS/pull/8198

It also fixes issues where no outline was shown on focus.
Since `umb-tags-editor` is a separate component I have moved the styling to `umb-tags-editor.less`, so it re-used developers will get the same styling. The property editor still has the `umb-tags` class which has styling with the limited width.

![2020-07-30_20-27-37](https://user-images.githubusercontent.com/2919859/88960076-43f73c80-d2a3-11ea-9f7e-aaf0ddc50abe.gif)
