### PR TITLE
Align icons on document type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -398,14 +398,15 @@ input.umb-group-builder__group-title-input:disabled:hover {
     padding: 0 4px;
     display: flex;
     border-radius: 3px;
-}
+    align-items: center;
 
-.umb-group-builder__property-tag:first-child {
-    margin-left: 0;
-}
+    &:first-child {
+        margin-left: 0;
+    }
 
-.umb-group-builder__property-tag.-white {
-    background-color: @white;
+    &.-white {
+        background-color: @white;
+    }
 }
 
 .umb-group-builder__property-tag-icon {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -410,6 +410,8 @@ input.umb-group-builder__group-title-input:disabled:hover {
 
 .umb-group-builder__property-tag-icon {
     margin-right: 3px;
+    display: flex;
+    align-items: center;
 }
 
 /* ---------- SORTABLE ---------- */

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -514,13 +514,10 @@ input.umb-group-builder__group-sort-value {
         display: flex;
         align-items: center;
         align-content: stretch;
-
         min-height: 80px;
-
         border: 1px solid @gray-9;
         color: @ui-action-discreet-type;
         border-radius: @baseBorderRadius;
-
     }
 
     .editor-info {
@@ -538,6 +535,9 @@ input.umb-group-builder__group-sort-value {
     }
 
     .editor-icon-wrapper {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         width: 60px;
         height: 60px;
         text-align: center;
@@ -549,12 +549,12 @@ input.umb-group-builder__group-sort-value {
             font-size: 32px;
         }
     }
-    
+
     .editor-details {
         flex: 1 1 auto;
         margin-top: 10px;
         margin-bottom: 10px;
-        
+
         .editor-name {
             display: block;
             font-weight: bold;
@@ -571,9 +571,9 @@ input.umb-group-builder__group-sort-value {
         width: 48px;
         height: 48px;
         font-size: 18px;
-        
         min-height: 80px;
         color: @ui-action-discreet-type;
+
         &:hover {
             color: @ui-action-discreet-type-hover;
             background-color: @ui-action-discreet-hover;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR align a few icons on the document type page after merging PR https://github.com/umbraco/Umbraco-CMS/pull/5293

- Vary by culture tag icon
- Datatype editor icon
- Inherit tag icon

![image](https://user-images.githubusercontent.com/2919859/88971267-fe8f3b00-d2b3-11ea-99e9-8d5df7bddced.png)

![image](https://user-images.githubusercontent.com/2919859/88971236-f0d9b580-d2b3-11ea-8949-bc61b68328d2.png)

![image](https://user-images.githubusercontent.com/2919859/88971206-e4555d00-d2b3-11ea-973e-5efeb1af0838.png)
