### PR TITLE
Some UI update to validation messages

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/alerts.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/alerts.less
@@ -77,3 +77,20 @@
 .alert-block p + p {
   margin-top: 5px;
 }
+
+
+// Property error alerts
+// -------------------------
+.alert.property-error {
+    &::after {
+        content:'';
+        position: absolute;
+        bottom:0;
+        left: 32px;
+        width: 0;
+        height: 0;
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-top: 8px solid @warningBackground;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/alerts.less
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/alerts.less
@@ -77,20 +77,3 @@
 .alert-block p + p {
   margin-top: 5px;
 }
-
-
-// Property error alerts
-// -------------------------
-.alert.property-error {
-    &::after {
-        content:'';
-        position: absolute;
-        bottom:0;
-        left: 32px;
-        width: 0;
-        height: 0;
-        border-left: 8px solid transparent;
-        border-right: 8px solid transparent;
-        border-top: 8px solid @warningBackground;
-    }
-}

--- a/src/Umbraco.Web.UI.Client/src/less/alerts.less
+++ b/src/Umbraco.Web.UI.Client/src/less/alerts.less
@@ -7,6 +7,7 @@
 // -------------------------
 
 .alert {
+  position: relative;
   padding: 8px 35px 8px 14px;
   margin-bottom: @baseLineHeight;
   background-color: @warningBackground;
@@ -97,4 +98,30 @@
 }
 .alert-block p + p {
   margin-top: 5px;
+}
+
+
+// Property error alerts
+// -------------------------
+.alert.property-error {
+
+    display: inline-block;
+    font-size: 14px;
+    padding: 6px 16px 6px 12px;
+    margin-bottom: 6px;
+
+    &::after {
+        content:'';
+        position: absolute;
+        bottom:-6px;
+        left: 6px;
+        width: 0;
+        height: 0;
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        border-top: 6px solid;
+    }
+    &.alert-error::after {
+        border-top-color: @errorBackground;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-variant-switcher.less
@@ -50,6 +50,19 @@ button.umb-variant-switcher__toggle {
             font-weight: bold;
             background-color: @errorBackground;
             color: @errorText;
+
+            animation-duration: 1.4s;
+            animation-iteration-count: infinite;
+            animation-name: umb-variant-switcher__toggle--badge-bounce;
+            animation-timing-function: ease;
+            @keyframes umb-variant-switcher__toggle--badge-bounce {
+                0%   { transform: translateY(0); }
+                20%  { transform: translateY(-6px); }
+                40%  { transform: translateY(0); }
+                55%  { transform: translateY(-3px); }
+                70%  { transform: translateY(0); }
+                100% { transform: translateY(0); }
+            }
         }
     }
 }
@@ -226,6 +239,19 @@ button.umb-variant-switcher__toggle {
             font-weight: bold;
             background-color: @errorBackground;
             color: @errorText;
+            
+            animation-duration: 1.4s;
+            animation-iteration-count: infinite;
+            animation-name: umb-variant-switcher__name--badge-bounce;
+            animation-timing-function: ease;
+            @keyframes umb-variant-switcher__name--badge-bounce {
+                0%   { transform: translateY(0); }
+                20%  { transform: translateY(-6px); }
+                40%  { transform: translateY(0); }
+                55%  { transform: translateY(-3px); }
+                70%  { transform: translateY(0); }
+                100% { transform: translateY(0); }
+            }
         }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -65,8 +65,25 @@
             &::before {
                 background-color: @red;
             }
-            .badge.--error-badge {
-                display: block;
+
+            &:not(.is-active) {
+                .badge {
+                    animation-duration: 1.4s;
+                    animation-iteration-count: infinite;
+                    animation-name: umb-sub-views-nav-item--badge-bounce;
+                    animation-timing-function: ease;
+                    @keyframes umb-sub-views-nav-item--badge-bounce {
+                        0%   { transform: translateY(0); }
+                        20%  { transform: translateY(-6px); }
+                        40%  { transform: translateY(0); }
+                        55%  { transform: translateY(-3px); }
+                        70%  { transform: translateY(0); }
+                        100% { transform: translateY(0); }
+                    }
+                }
+                .badge.--error-badge {
+                    display: block;
+                }
             }
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -53,6 +53,22 @@
                 height: 4px;
             }
         }
+
+        // Validation
+        .show-validation &.-has-error {
+            color: @red;
+
+            &:hover {
+                color: @red !important;
+            }
+
+            &::before {
+                background-color: @red;
+            }
+            .badge.--error-badge {
+                display: block;
+            }
+        }
     }
 
     &__action:active,
@@ -185,18 +201,4 @@
             border-left: none;
         }
     }
-}
-
-// Validation
-.show-validation .umb-sub-views-nav-item__action.-has-error,
-.show-validation .umb-sub-views-nav-item > a.-has-error {
-    color: @red;
-
-    &::before {
-        background-color: @red;
-    }
-    .badge.--error-badge {
-        display: block;
-    }
-
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -101,6 +101,10 @@
             height: 12px;
             min-width: 12px;
         }
+        &.--error-badge {
+            display: none;
+            font-weight: 900;
+        }
     }
 
     &-text {
@@ -191,4 +195,8 @@
     &::before {
         background-color: @red;
     }
+    .badge.--error-badge {
+        display: block;
+    }
+
 }

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -272,6 +272,7 @@ label:not([for]) {
 /* CONTROL VALIDATION */
 .umb-control-required {
     color: @controlRequiredColor;
+    font-weight: 900;
 }
 
 .controls-row {

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -138,7 +138,9 @@
 // additional targetting of the ng-invalid class.
 .formFieldState(@textColor: @gray-4, @borderColor: @gray-7, @backgroundColor: @gray-10) {
   // Set the text color
-  .control-label,
+  > .control-label,
+  > .umb-el-wrap > .control-label,
+  > .umb-el-wrap > .control-header > .control-label,
   .help-block,
   .help-inline {
     color: @textColor;

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -481,7 +481,7 @@
 
 @formErrorText:               @errorBackground;
 @formErrorBackground:         lighten(@errorBackground, 55%);
-@formErrorBorder:             darken(spin(@errorBackground, -10), 3%);
+@formErrorBorder:             @red;
 
 @formSuccessText:             @successBackground;
 @formSuccessBackground:       lighten(@successBackground, 48%);

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -9,6 +9,7 @@
     <i class="icon {{ vm.item.icon }}" aria-hidden="true"></i>
     <span class="umb-sub-views-nav-item-text">{{ vm.item.name }}</span>
     <div ng-show="vm.item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>
+    <div ng-show="!vm.item.badge" class="badge -type-alert --error-badge">!</div>
 </button>
 
 <ul class="dropdown-menu umb-sub-views-nav-item__anchor_dropdown" ng-if="vm.item.anchors && vm.item.anchors.length > 1">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
@@ -39,6 +39,9 @@
         }
     }
 }
+ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-block-list__block--actions {
+    opacity: 1;
+}
 .umb-block-list__block--actions {
     position: absolute;
     z-index:999999999;// We always want to be on top of custom view, but we need to make sure we still are behind relevant Umbraco CMS UI. ToDo: Needs further testing.
@@ -57,6 +60,40 @@
         padding: 5px;
         &:hover {
             color: @ui-action-discreet-type-hover;
+        }
+        > .__error-badge {
+            position: absolute;
+            top: -2px;
+            right: -2px;
+            min-width: 8px;
+            color: @white;
+            background-color: @ui-active-type;
+            border: 2px solid @white;
+            border-radius: 50%;
+            font-size: 8px;
+            font-weight: bold;
+            padding: 2px;
+            line-height: 8px;
+            background-color: @red;
+            display: none;
+            font-weight: 900;
+        }
+        &.--error > .__error-badge {
+            display: block;
+
+            animation-duration: 1.4s;
+            animation-iteration-count: infinite;
+            animation-name: umb-block-list__action--badge-bounce;
+            animation-timing-function: ease;
+            @keyframes umb-block-list__action--badge-bounce {
+                0%   { transform: translateY(0); }
+                20%  { transform: translateY(-4px); }
+                40%  { transform: translateY(0); }
+                55%  { transform: translateY(-2px); }
+                70%  { transform: translateY(0); }
+                100% { transform: translateY(0); }
+            }
+
         }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
@@ -19,6 +19,7 @@
                 <span class="sr-only">
                     <localize key="general_settings">Settings</localize>
                 </span>
+                <div class="__error-badge">!</div>
             </button>
             <button type="button" class="btn-reset umb-outline action --copy" localize="title" title="actions_copy"
                     ng-click="vm.blockEditorApi.copyBlock(vm.layout.$block);"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6791648/89019166-367e9880-d31d-11ea-921f-e26d7a80a552.png)
Making the property-error message into a speech bubble style, so it yells less in your face.


Shows a error-badge on content-apps if no badge already is present, and colors the badge in red to make it even more visible that there is issues.
![image](https://user-images.githubusercontent.com/6791648/89019287-5e6dfc00-d31d-11ea-8a2a-86694caf6f73.png)
