### PR TITLE
correct for the new spelling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -730,7 +730,7 @@
                     return null;
                 }
 
-                var dataModel = getDataByUdi(layoutEntry.udi, this.value.contentData);
+                var dataModel = getDataByUdi(layoutEntry.contentUdi, this.value.contentData);
                 if (dataModel === null) {
                     return null;
                 }


### PR DESCRIPTION
correcting udi to contentUdi for createFromElementType to work again.. used for clipboard features.