### PR TITLE
Remove usages of angular.forEach in property editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -446,7 +446,7 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
         if (entityType !== "Member") {
             entityResource.getUrl(entity.id, entityType).then(function (data) {
                 // update url
-                angular.forEach($scope.renderModel, function (item) {
+                $scope.renderModel.forEach(function (item) {
                     if (item.id === entity.id) {
                         if (entity.trashed) {
                             item.url = vm.labels.general_recycleBin;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -955,7 +955,7 @@ angular.module("umbraco")
                 $scope.availableEditors = response.data;
 
                 //Localize the grid editor names
-                angular.forEach($scope.availableEditors, function (value, key) {
+                $scope.availableEditors.forEach(function (value) {
                     //If no translation is provided, keep using the editor name from the manifest
                     localizationService.localize("grid_" + value.alias, undefined, value.name).then(function (v) {
                         value.name = v;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -86,22 +86,20 @@
         }
 
         function markAsSensitive() {
-            angular.forEach($scope.options.includeProperties, function (option) {
+            $scope.options.includeProperties.forEach(function (option) {
                 option.isSensitive = false;
 
-                angular.forEach($scope.items,
-                    function (item) {
+                $scope.items.forEach(function (item) {
 
-                        angular.forEach(item.properties,
-                            function (property) {
+                    item.properties.forEach(function (property) {
 
-                                if (option.alias === property.alias) {
-                                    option.isSensitive = property.isSensitive;
-                                }
+                            if (option.alias === property.alias) {
+                                option.isSensitive = property.isSensitive;
+                            }
 
-                            });
+                     });
 
-                    });
+                });
 
             });
         }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -498,8 +498,7 @@
                     if (tab) {
                         scaffold.variants[0].tabs.push(tab);
 
-                        angular.forEach(tab.properties,
-                            function (property) {
+                        tab.properties.forEach(function (property) {
                                 if (_.find(notSupported, function (x) { return x === property.editor; })) {
                                     property.notSupported = true;
                                     // TODO: Not supported message to be replaced with 'content_nestedContentEditorNotSupported' dictionary key. Currently not possible due to async/timing quirk.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7718 (in part)

### Description

Continuing the effort to minimize the angular dependency, I have rewritten the remaining usages of angular.forEach with the native equivalent in all property editors.

### Testing this PR
Basically there should be no noticeable difference when applying this PR; the property editors should "just work". Validate the following property editors:

#### Content pickers 
_For example the Multinode Treepicker_

![image](https://user-images.githubusercontent.com/7405322/89033667-9bdf8300-d337-11ea-8518-ac078d631f29.png)

#### Grid

![image](https://user-images.githubusercontent.com/7405322/89033684-a69a1800-d337-11ea-8627-78fd0201aeb0.png)

#### List view

_Best to test this one in the Members section_

![image](https://user-images.githubusercontent.com/7405322/89033715-b87bbb00-d337-11ea-8a27-2ffca477754b.png)

#### Nested Content

![image](https://user-images.githubusercontent.com/7405322/89033737-c598aa00-d337-11ea-951c-c393c221bf93.png)
