### PR TITLE
Languages names do not show in publish/unpublish dialogs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-list.less
@@ -40,7 +40,7 @@ a.umb-list-item:focus {
 }
 
 .umb-list-item__description--checkbox{
-    margin: 0 0 0 26px;
+    margin: 0 0 0 30px;
 }
 
 .umb-list-checkbox {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewpublish.html
@@ -29,8 +29,8 @@
                             <umb-checkbox name="publishLanguageSelector"
                                           model="language.publish"
                                           on-change="vm.changeSelection(language)"
-                                          text="{{language.name}}"
-                                           />
+                                          text="{{language.name}}">
+                            </umb-checkbox>
 
                             <div>
                                 <span class="db umb-list-item__description umb-list-item__description--checkbox">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.controller.js
@@ -18,7 +18,7 @@
             $scope.model.disableSubmitButton = !firstSelected;
 
             if (language.isMandatory) {
-                angular.forEach($scope.model.languages, function (lang) {
+                $scope.model.languages.forEach(function (lang) {
                     if (lang !== language) {
                         lang.unpublish = true;
                         lang.disabled = language.unpublish;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.html
@@ -30,8 +30,8 @@
                                           model="language.unpublish"
                                           on-change="vm.changeSelection(language)"
                                           text="{{language.name}}"
-                                          disabled="language.disabled"
-                                          />
+                                          disabled="language.disabled">
+                            </umb-checkbox>
 
                             <div>
                                 <span class="db umb-list-item__description umb-list-item__description--checkbox">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The listview publish/unpublish dialogs are Completely Broken™ (the language names are missing):

![listview-publish-unpublish-languages-before](https://user-images.githubusercontent.com/7405322/89034571-88351c00-d339-11ea-971a-2bc2a045c02e.gif)

I'm not entirely sure why 🤷 but it seems related to the frontend changes that were (accidentally?) included in #7700 (possibly the addition of `transclude` in the checkbox directive) ... or maybe it's something entirely different. Whatever the case is, it's fixable by _not_ auto-closing the `<umb-checkbox/>` element, so that's exactly what this PR does to fix it:

![listview-publish-unpublish-languages](https://user-images.githubusercontent.com/7405322/89034407-2aa0cf80-d339-11ea-916e-6de0220d172d.gif)

Also the "mandatory language" label was a bit off, so I fixed that - and I removed the usage of `angular.forEach` just because.