### PR TITLE
Fix styling of actions in textbox multiple

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -28,7 +28,7 @@
 }
 
 .umb-multiple-textbox .textbox-wrapper i.handle {
-    margin-left: 5px;
+    margin-left: 10px;
     cursor: move;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -1,9 +1,11 @@
-﻿.umb-multiple-textbox{
-    &__confirm{
+﻿.umb-multiple-textbox {
+    .umb-property-editor--limit-width();
+
+    &__confirm {
         position: relative;
         display: inline-block;
 
-        &-action{
+        &-action {
             margin: -2px 0 0 0;
             padding: 2px;
             background: transparent;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -12,10 +12,6 @@
     }
 }
 
-.umb-multiple-textbox .icon-wrapper {
-    width: 50px;
-}
-
 .umb-multiple-textbox .textbox-wrapper {
     align-items: center;
     margin-bottom: 15px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-multiple-textbox.less
@@ -32,11 +32,6 @@
     cursor: move;
 }
 
-.umb-multiple-textbox .textbox-wrapper a.remove {
-    margin-left: 5px;
-    text-decoration: none;
-}
-
 .umb-multiple-textbox .add-link {
     &:extend(.umb-node-preview-add);
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -9,7 +9,7 @@
                  focus-when="{{item.hasFocus}}" />
 
           <div class="icon-wrapper">
-              <i class="icon icon-navigation handle" localize="title" title="@general_move"></i>
+              <i class="icon icon-navigation handle" aria-hidden="true" localize="title" title="@general_move"></i>
 
               <div class="umb-multiple-textbox__confirm" ng-show="model.value.length > model.config.min">
                   <umb-confirm-action


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The PR fixes some styling issues in textbox multiple aka repeatable textstrings, so the actions are aligned next to each other.

**Before**

![image](https://user-images.githubusercontent.com/2919859/89036924-e8c65800-d33d-11ea-9390-32165ea7dbbb.png)

![image](https://user-images.githubusercontent.com/2919859/89036973-01367280-d33e-11ea-8201-9352e929db2d.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/89036760-8b320b80-d33d-11ea-8ee7-2c2ab38e67e7.png)

![image](https://user-images.githubusercontent.com/2919859/89036828-b3ba0580-d33d-11ea-8cba-4d5a1a965dcd.png)
