### PR TITLE
Fix styling of buttons in grid cells

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -751,9 +751,19 @@
     margin-right: 5px;
     position: relative;
     cursor: pointer;
-    display:inline-block;
+    display: inline-block;
 }
 
+.umb-grid .cell-tools {
+.umb-grid .umb-control-tool {
+    .btn-icon {
+        padding: 0;
+    }
+}
+
+.umb-grid .umb-control-tool .btn-icon {
+    color: @white;
+}
 
 
 // Template
@@ -1006,8 +1016,6 @@
     color: @gray-6;
     display: block;
 }
-
-
 
 // Configuration specific styles
 // -------------------------

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-action.html
@@ -1,8 +1,10 @@
 <div class="umb_confirm-action">
     <button ng-if="onDelete" type="button" class="btn-icon" ng-click="clickButton($event)" localize="title" title="@general_delete">
         <umb-icon icon="icon-trash" class="icon-trash"></umb-icon>
-        <span class="sr-only">Delete</span>
-     </button>
+        <span class="sr-only">
+            <localize key="general_delete">Delete</localize>
+        </span>
+    </button>
 
      <div class="umb_confirm-action__overlay"
         ng-class="{

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -155,8 +155,8 @@
                                                       </div>
 
                                                       <div class="cell-tools" ng-if="(area === active || area === currentCellWithActiveChild) && !sortMode">
-                                                         <button type="button" aria-haspopup="true" class="btn-reset cell-tool" ng-click="editGridItemSettings(area, 'cell')">
-                                                            <i class="icon-settings" aria-hidden></i>
+                                                         <button type="button" aria-haspopup="true" class="btn-icon cell-tool" ng-click="editGridItemSettings(area, 'cell')">
+                                                            <i class="icon-settings" aria-hidden="true"></i>
                                                             <span class="sr-only">Open column settings</span>
                                                          </button>
                                                       </div>
@@ -201,7 +201,7 @@
                                                                       <div class="umb-tools" ng-if="control === active">
 
                                                                           <div class="umb-control-tool" ng-if="control.editor.config.settings">
-                                                                              <button type="button" class="umb-control-tool-icon icon-settings btn-reset" ng-click="editGridItemSettings(control, 'control')">
+                                                                              <button type="button" class="umb-control-tool-icon icon-settings btn-icon" ng-click="editGridItemSettings(control, 'control')">
                                                                                   <span class="sr-only">
                                                                                       <localize key="general_edit">Edit</localize>
                                                                                   </span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -201,7 +201,11 @@
                                                                       <div class="umb-tools" ng-if="control === active">
 
                                                                           <div class="umb-control-tool" ng-if="control.editor.config.settings">
-                                                                              <button class="umb-control-tool-icon icon-settings btn-reset" ng-click="editGridItemSettings(control, 'control')" type="button"></button>
+                                                                              <button type="button" class="umb-control-tool-icon icon-settings btn-reset" ng-click="editGridItemSettings(control, 'control')">
+                                                                                  <span class="sr-only">
+                                                                                      <localize key="general_edit">Edit</localize>
+                                                                                  </span>
+                                                                              </button>
                                                                           </div>
 
                                                                           <div class="umb-control-tool">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adjust styling of buttons in grid cells and optimize the buttons for accessibility.

**Before**

![2020-07-31_15-38-02](https://user-images.githubusercontent.com/2919859/89051416-80cf3c00-d354-11ea-91aa-3432db5ccedd.gif)


**After**

![2020-07-31_15-34-46](https://user-images.githubusercontent.com/2919859/89040349-ef57ce00-d343-11ea-9c98-8819da2b457f.gif)