### PR TITLE
Remove usages of angular.forEach in help drawer, content and infinite editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.controller.js
@@ -157,8 +157,8 @@
         }
 
         function openTourGroup(tourAlias) {
-            angular.forEach(vm.tours, function (group) {
-                angular.forEach(group, function (tour) {
+            vm.tours.forEach(function (group) {
+                group.tours.forEach(function (tour) {
                     if (tour.alias === tourAlias) {
                         group.open = true;
                     }
@@ -168,9 +168,9 @@
 
         function getTourGroupCompletedPercentage() {
             // Finding out, how many tours are completed for the progress circle
-            angular.forEach(vm.tours, function(group){
+            vm.tours.forEach(function(group){
                 var completedTours = 0;
-                angular.forEach(group.tours, function(tour){
+                group.tours.forEach(function(tour){
                     if(tour.completed) {
                         completedTours++;
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.controller.js
@@ -202,7 +202,7 @@
                 var match = false;
 
                 // find and show if a match from the list has been chosen
-                angular.forEach(vm.validationTypes, function (validationType, index) {
+                vm.validationTypes.forEach(function (validationType, index) {
                     if ($scope.model.property.validation.pattern === validationType.pattern) {
                         vm.selectedValidationType = vm.validationTypes[index];
                         vm.showValidationPattern = true;
@@ -212,7 +212,7 @@
 
                 // if there is no match - choose the custom validation option.
                 if (!match) {
-                    angular.forEach(vm.validationTypes, function (validationType) {
+                    vm.validationTypes.forEach(function (validationType) {
                         if (validationType.key === "custom") {
                             vm.selectedValidationType = validationType;
                             vm.showValidationPattern = true;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.controller.js
@@ -47,8 +47,8 @@
         }
 
         function preSelect(selection) {
-            angular.forEach(selection, function(selected){
-                angular.forEach(vm.sections, function(section){
+            selection.forEach(function(selected){
+                vm.sections.forEach(function(section){
                     if(selected.alias === section.alias) {
                         section.selected = true;
                     }
@@ -65,7 +65,7 @@
 
             } else {
 
-                angular.forEach($scope.model.selection, function(selectedSection, index){
+                $scope.model.selection.forEach(function(selectedSection, index){
                     if(selectedSection.alias === section.alias) {
                         section.selected = false;
                         $scope.model.selection.splice(index, 1);
@@ -77,7 +77,7 @@
         }
 
         function setSectionIcon(sections) {
-            angular.forEach(sections, function(section) {
+            sections.forEach(function(section) {
                 section.icon = "icon-section";
             });
         }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -460,8 +460,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                     ? _.filter(nodes, $scope.model.filter)
                     : _.where(nodes, $scope.model.filter);
 
-                angular.forEach(filtered,
-                    function (value, key) {
+                filtered.forEach(function (value) {
                         value.filtered = true;
                         if ($scope.model.filterCssClass) {
                             if (!value.cssClasses) {
@@ -474,8 +473,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             }
             else {
                 var a = $scope.model.filter.toLowerCase().replace(/\s/g, '').split(',');
-                angular.forEach(nodes,
-                    function (value, key) {
+                nodes.forEach(function (value) {
 
                         var found = a.indexOf(value.metaData.contentType.toLowerCase()) >= 0;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.controller.js
@@ -46,9 +46,9 @@
 
         function preSelect(selection) {
 
-            angular.forEach(selection, function(selected){
-                
-                angular.forEach(vm.userGroups, function(userGroup){
+            selection.forEach(function (selected) {
+
+                vm.userGroups.forEach(function(userGroup){
                     if(selected.id === userGroup.id) {
                         userGroup.selected = true;
                     }
@@ -66,7 +66,7 @@
 
             } else {
 
-                angular.forEach($scope.model.selection, function(selectedUserGroup, index){
+                $scope.model.selection.forEach(function(selectedUserGroup, index){
                     if(selectedUserGroup.id === userGroup.id) {
                         userGroup.selected = false;
                         $scope.model.selection.splice(index, 1);

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.notify.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.notify.controller.js
@@ -31,7 +31,7 @@
             vm.saveError = false;
             vm.saveSuccces = false;
             var selectedString = [];
-            angular.forEach(notifyOptions, function (option) {
+            notifyOptions.forEach(function (option) {
                     if (option.checked === true && option.notifyCode) {
                         selectedString.push(option.notifyCode);
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.rights.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.rights.controller.js
@@ -39,7 +39,7 @@
           //reset this
           vm.selectedUserGroups = [];
           vm.availableUserGroups = userGroups;
-          angular.forEach(vm.availableUserGroups, function (group) {
+          vm.availableUserGroups.forEach(function (group) {
             if (group.permissions) {
               //if there's explicit permissions assigned than it's selected
               assignGroupPermissions(group);
@@ -70,8 +70,8 @@
           group.allowedPermissions = [];
 
           // get list of checked permissions
-          angular.forEach(group.permissions, function (permissionGroup) {
-            angular.forEach(permissionGroup, function (permission) {
+          Object.values(group.permissions).forEach(function (permissionGroup) {
+            permissionGroup.forEach(function (permission) {
               if (permission.checked) {
                 //the `allowedPermissions` is what will get sent up to the server for saving
                 group.allowedPermissions.push(permission);
@@ -117,9 +117,9 @@
         }
 
         function formatSaveModel(permissionsSave, groupCollection) {
-          angular.forEach(groupCollection, function (g) {
+          groupCollection.forEach(function (g) {
             permissionsSave[g.id] = [];
-            angular.forEach(g.allowedPermissions, function (p) {
+            g.allowedPermissions.forEach(function (p) {
               permissionsSave[g.id].push(p.permissionCode);
             });
           });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7718 (in part)

### Description

Continuing the effort to minimize the angular dependency, I have rewritten the remaining usages of angular.forEach with the native equivalent in the help drawer, the remaining content editing and infinite editors.

### Testing this PR

Basically there should be no noticeable difference when applying this PR; the UI should "just work" as it does now. Validate the following:

#### Help drawer - tours

![image](https://user-images.githubusercontent.com/7405322/89042782-c2a5b580-d347-11ea-8e68-a5f2918e6c5d.png)

#### Content permission assignments

![image](https://user-images.githubusercontent.com/7405322/89042805-cf2a0e00-d347-11ea-9088-585a2d50cb7e.png)

#### Section selector

_Easiest to test by editing a group._

![image](https://user-images.githubusercontent.com/7405322/89042848-e49f3800-d347-11ea-8b28-941b7bbd1c34.png)

#### Group selector

_Easiest to test by editing a user._

![image](https://user-images.githubusercontent.com/7405322/89042938-0dbfc880-d348-11ea-9198-b55a6117e5b1.png)

#### Content type - property validation

![image](https://user-images.githubusercontent.com/7405322/89042893-f84a9e80-d347-11ea-8065-313704e1bf1a.png)

#### Tree picker - item filtering (simple)

_Can be tested with a MNTP configured to allow only certain content types._

![image](https://user-images.githubusercontent.com/7405322/89043144-5aa39f00-d348-11ea-95a9-3344c6a49f58.png)

#### Tree picker - item filtering (advanced)

_Can be tested setting up member based public access for content._

![image](https://user-images.githubusercontent.com/7405322/89043031-2d56f100-d348-11ea-982a-6988e3f451fd.png)
