### PR TITLE
Grid Textstring editor - Bug with unique ID.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/textstring.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/textstring.html
@@ -3,7 +3,7 @@
 		rows="1"
 		umb-auto-resize
 		umb-auto-focus
-		class="textstring input-block-level" id="{{control.uniqueId}}_text"
+		class="textstring input-block-level" id="{{control.$uniqueId}}_text"
 		ng-model="control.value"
 		ng-attr-style="{{control.editor.config.style}}" localize="placeholder" placeholder="@grid_placeholderWriteHere"></textarea>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Whilst using the textstring grid editor (aka. Headline), I'd noticed in Chrome Dev Tools there was a warning of multiple/duplicated ID attributes of `id="_text"`.

Digging deeper, turns out to be a small bug when setting the ID in [views/propertyeditors/grid/editors/textstring.html#L6](https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.4/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/textstring.html#L6), the `uniqueId` property is missing the leading `$` symbol, (a-la `$uniqueId`, [as it's set in the Grid controller](https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.4/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js#L917).)

Steps for reproduction, add multiple Headline editors to a Grid, view Chrome Dev Tools _(other web browsers are available 🤑)_ see the multiple same IDs warning.

Once patched, the ID is generated as `id="{GUID}_text"`, making the ID unique on the page.
