### PR TITLE
Grid cell error could use "umb-code-snippet" directive?

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/error.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/error.html
@@ -1,2 +1,2 @@
 <p class="red">Something went wrong with this editor, below is the data stored:</p>
-<pre>{{control | json}}</pre>
+<umb-code-snippet language="'JSON'">{{control | json}}</umb-code-snippet>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Thanks to @bjarnef's excellent `umb-code-snippet` component #7294, it could be used when displaying errors with Grid editors cells?

Currently the [error.html#L2](https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.4/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/error.html#L2) is using a `<pre>`, where as with `<umb-code-snippet>` it would also offer the *Copy* button - useful for sharing/debugging purposes.

**with `<pre>`**
![1](https://user-images.githubusercontent.com/209066/89055647-ab1ffa00-d352-11ea-984b-fc5a7a808c30.png)

**with `<umb-code-snippet>`**
![2](https://user-images.githubusercontent.com/209066/89055646-aa876380-d352-11ea-87d0-6f37b0ef573d.png)

_A small incremental improvement._