### PR TITLE
Fix media picker clickhandler

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -286,7 +286,7 @@ angular.module("umbraco")
                     gotoFolder(item);
                 }
                 else {
-                    $scope.clickHandler(item, event, index);
+                    clickHandler(item, event, index);
                 }
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When open media picker and clicking media item name, I noticed a console error. This is because it call `$scope.clickHandler()` but it should just be `clickHandler()`.

![image](https://user-images.githubusercontent.com/2919859/89067896-728f1900-d370-11ea-89ba-d1d7d73cbcac.png)
