### PR TITLE
Fix broken grid LESS causing the client build to fail

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -754,11 +754,10 @@
     display: inline-block;
 }
 
-.umb-grid .cell-tools {
-    .umb-grid .umb-control-tool {
-        .btn-icon {
-            padding: 0;
-        }
+.umb-grid .cell-tools,
+.umb-grid .umb-control-tool {
+    .btn-icon {
+        padding: 0;
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -755,9 +755,10 @@
 }
 
 .umb-grid .cell-tools {
-.umb-grid .umb-control-tool {
-    .btn-icon {
-        padding: 0;
+    .umb-grid .umb-control-tool {
+        .btn-icon {
+            padding: 0;
+        }
     }
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A slight error snuck into the grid LESS in #8543. Unfortunately this error causes the entire client build to fail:

![image](https://user-images.githubusercontent.com/7405322/89095733-f7aa1a80-d3d0-11ea-9f1f-cd7ceaacada5.png)

I believe this PR fixes it; the grid styling at least looks like what's shown in #8543

/cc @bjarnef  