### PR TITLE
Remove usages of angular.forEach in help services and filters

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/compareArrays.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/compareArrays.filter.js
@@ -4,11 +4,11 @@ angular.module("umbraco.filters")
 
             var result = [];
 
-            angular.forEach(array, function(arrayItem){
+            array.forEach(function(arrayItem){
 
                 var exists = false;
 
-                angular.forEach(compareArray, function(compareItem){
+                compareArray.forEach(function(compareItem){
                     if( arrayItem[compareProperty] === compareItem[compareProperty]) {
                         exists = true;
                     }

--- a/src/Umbraco.Web.UI.Client/src/common/services/angularhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/angularhelper.service.js
@@ -17,7 +17,7 @@ function angularHelper($q) {
          */
         revalidateNgModel: function (scope, ngModel) {
             this.safeApply(scope, function() {
-                angular.forEach(ngModel.$parsers, function (parser) {
+                ngModel.$parsers.forEach(function (parser) {
                     parser(ngModel.$viewValue);
                 });
             });

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -128,7 +128,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
             // first check if tab is already added
             var foundInfoTab = false;
 
-            angular.forEach(tabs, function (tab) {
+            tabs.forEach(function (tab) {
                 if (tab.id === infoTab.id && tab.alias === infoTab.alias) {
                     foundInfoTab = true;
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenttypehelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenttypehelper.service.js
@@ -11,7 +11,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
 
             var newArray = [];
 
-            angular.forEach(array, function (arrayItem) {
+            array.forEach(function (arrayItem) {
 
                 if (Utilities.isObject(arrayItem)) {
                     newArray.push(arrayItem.id);
@@ -116,13 +116,12 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
                 throw new Error("Cannot add this composition, these properties already exist on the content type: " + overlappingAliases.join());
             }
 
-            angular.forEach(compositeContentType.groups, function (compositionGroup) {
-
+            compositeContentType.groups.forEach(function (compositionGroup) {
                 // order composition groups based on sort order
                 compositionGroup.properties = $filter('orderBy')(compositionGroup.properties, 'sortOrder');
 
                 // get data type details
-                angular.forEach(compositionGroup.properties, function (property) {
+                compositionGroup.properties.forEach(function (property) {
                     dataTypeResource.getById(property.dataTypeId)
                         .then(function (dataType) {
                             property.dataTypeIcon = dataType.icon;
@@ -134,7 +133,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
                 compositionGroup.inherited = true;
 
                 // set inherited state on properties
-                angular.forEach(compositionGroup.properties, function (compositionProperty) {
+                compositionGroup.properties.forEach(function (compositionProperty) {
                     compositionProperty.inherited = true;
                 });
 
@@ -142,7 +141,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
                 compositionGroup.tabState = "inActive";
 
                 // if groups are named the same - merge the groups
-                angular.forEach(contentType.groups, function (contentTypeGroup) {
+                contentType.groups.forEach(function (contentTypeGroup) {
 
                     if (contentTypeGroup.name === compositionGroup.name) {
 
@@ -224,7 +223,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
 
             var groups = [];
 
-            angular.forEach(contentType.groups, function (contentTypeGroup) {
+            contentType.groups.forEach(function (contentTypeGroup) {
 
                 if (contentTypeGroup.tabState !== "init") {
 
@@ -238,7 +237,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
                         var properties = [];
 
                         // remove all properties from composite content type
-                        angular.forEach(contentTypeGroup.properties, function (property) {
+                        contentTypeGroup.properties.forEach(function (property) {
                             if (property.contentTypeId !== compositeContentType.id) {
                                 properties.push(property);
                             }
@@ -283,7 +282,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
 
             var sortOrder = 0;
 
-            angular.forEach(properties, function (property) {
+            properties.forEach(function (property) {
                 if (!property.inherited && property.propertyState !== "init") {
                     property.sortOrder = sortOrder;
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -419,7 +419,7 @@
             
             if (isSelectedAll(items, selection)) {
                 // unselect all items
-                angular.forEach(items, function (item) {
+                items.forEach(function (item) {
                     item.selected = false;
                 });
                 
@@ -432,7 +432,7 @@
                 selection.length = 0;
                 
                 // select all items
-                angular.forEach(items, function (item) {
+                items.forEach(function (item) {
                     var obj = {
                         id: item.id
                     };

--- a/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
@@ -12,7 +12,7 @@
  *
  * <pre>
  *      searchService.searchMembers({term: 'bob'}).then(function(results){
- *          angular.forEach(results, function(result){
+ *          results.forEach(function(result){
  *                  //returns:
  *                  {name: "name", id: 1234, menuUrl: "url", editorPath: "url", metaData: {}, subtitle: "/path/etc" }
  *           })

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -107,7 +107,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
         //queue rules loading
         if (configuredStylesheets) {
-            angular.forEach(configuredStylesheets, function (val, key) {
+            configuredStylesheets.forEach(function (val, key) {
 
                 if (val.indexOf(Umbraco.Sys.ServerVariables.umbracoSettings.cssPath + "/") === 0) {
                     // current format (full path to stylesheet)
@@ -119,7 +119,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 }
 
                 promises.push(stylesheetResource.getRulesByName(val).then(function (rules) {
-                    angular.forEach(rules, function (rule) {
+                    rules.forEach(function (rule) {
                         var r = {};
                         r.title = rule.name;
                         if (rule.selector[0] == ".") {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes (in part) #7718 

### Description

Continuing the effort to minimize the angular dependency, I have rewritten the remaining usages of angular.forEach with the native equivalent in services and filters.

### Testing this PR
Basically there should be no noticeable difference when applying this PR; the UI should "just work" as it does now. Validate the following:

#### Content type

![image](https://user-images.githubusercontent.com/7405322/89108787-98cdbb00-d43b-11ea-9ad8-b6b790dcfe9a.png)

![image](https://user-images.githubusercontent.com/7405322/89108788-9d926f00-d43b-11ea-927a-a8780928806d.png)

![image](https://user-images.githubusercontent.com/7405322/89108791-a8e59a80-d43b-11ea-89d2-b4fe6a4d331f.png)

#### Content list view

![image](https://user-images.githubusercontent.com/7405322/89108797-b3a02f80-d43b-11ea-824c-cffb07ae94d7.png)

### Rich text editor

![image](https://user-images.githubusercontent.com/7405322/89108799-bc910100-d43b-11ea-8513-6e02a0e2544d.png)
