### PR TITLE
Align icon in media grid item overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -138,6 +138,7 @@
 
 .umb-media-grid__item-overlay {
    display: flex;
+   align-items: center;
    width: 100%;
    opacity: 0;
    position: absolute;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Just a minor change, so info icon is aligned in media grid item name.

**Before**

![image](https://user-images.githubusercontent.com/2919859/89120830-8e520680-d4b9-11ea-8e85-ac7cf87d3c9c.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/89120816-682c6680-d4b9-11ea-9859-55b1a6f927d8.png)
