### PR TITLE
Update prevalues multivalues sortable styling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -43,7 +43,10 @@
     margin: 10px 0px !important;
     background: @gray-10;
 
-    .handle {
+    &.ui-sortable-handle,
+    .ui-sortable-handle,
+    .handle
+    {
         cursor: move;
     }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -28,11 +28,8 @@
 }
 
 .umb-prevalues-multivalues__add input {
-    width: 320px;
-}
-
-.umb-prevalues-multivalues__add input {
     display: flex;
+    width: 320px;
 }
 
 .umb-prevalues-multivalues__add button {

--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -23,18 +23,18 @@
     align-items: center;
 }
 
-.umb-prevalues-multivalues__add  {
+.umb-prevalues-multivalues__add {
     display: flex;
-}
 
-.umb-prevalues-multivalues__add input {
-    display: flex;
-    width: 320px;
-}
+    input {
+        display: flex;
+        width: 320px;
+    }
 
-.umb-prevalues-multivalues__add button {
-    margin: 0 6px 0 0;
-    margin-left: auto;
+    button {
+        margin: 0 6px 0 0;
+        margin-left: auto;
+    }
 }
 
 .umb-prevalues-multivalues__listitem {
@@ -46,19 +46,19 @@
     .handle {
         cursor: move;
     }
-}
 
-.umb-prevalues-multivalues__listitem i {
-    display: flex;
-    align-items: center;
-    margin-right: 5px
-}
+    i {
+        display: flex;
+        align-items: center;
+        margin-right: 5px
+    }
 
-.umb-prevalues-multivalues__listitem a {
-    cursor: pointer;
-    margin-left: auto;
-}
+    a {
+        cursor: pointer;
+        margin-left: auto;
+    }
 
-.umb-prevalues-multivalues__listitem input {
-    width: 295px;
+    input {
+        width: 295px;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -6,7 +6,7 @@
         width: 500px;
     }
 
-    p{
+    p {
         margin: 7px 0;
     }
 }
@@ -45,7 +45,10 @@
     padding: 6px;
     margin: 10px 0px !important;
     background: @gray-10;
-    cursor: move;
+
+    .handle {
+        cursor: move;
+    }
 }
 
 .umb-prevalues-multivalues__listitem i {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -11,7 +11,7 @@
     </div>
     <div ui-sortable="sortableOptions" ng-model="model.value">
         <div class="control-group umb-prevalues-multivalues__listitem color-picker-preval" ng-repeat="item in model.value track by $id(item)">
-            <i class="icon icon-navigation handle"></i>
+            <i class="icon icon-navigation handle" aria-hidden="true"></i>
             <div class="umb-prevalues-multivalues__left">
                 <div class="thumbnail span1" hex-bg-color="{{item.value}}" hex-bg-orig="transparent"></div>
                 <div class="color-picker-prediv">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment is was assumed that left column in multivalues prevalue editor is always sortable and therefore added `cursor:move`.
However that is not always the case e.g. in macro parameter editors, where only the icon was acting as sortable handle.

I have updated this to be move specific on `handle` class which is often used or `ui-sortable-handle` which is added on sortable items.

![image](https://user-images.githubusercontent.com/2919859/89122054-8b104800-d4c4-11ea-966f-e095d0a28b4f.png)

Also note the move cursor is still shown in colorpicker prevalue editor, when hover the color preview and hex code.

![image](https://user-images.githubusercontent.com/2919859/89122174-80a27e00-d4c5-11ea-86b4-b54602f2627f.png)

