### PR TITLE
Update styling of listview layouts add button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/listview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/listview.less
@@ -281,20 +281,9 @@
 }
 
 .list-view-add-layout {
-   width:100%; 
-   background:0 0;
-   margin-top: 10px;
-   color: @ui-action-discreet-type;
-   border: 1px dashed @ui-action-discreet-border;
-   display: flex;
-   align-items: center;
-   justify-content: center;
-   padding: 5px 0;
-   box-sizing: border-box;
+    &:extend(.umb-node-preview-add);
 }
 
 .list-view-add-layout:hover {
-   text-decoration: none;
-   color: @ui-action-discreet-type-hover;
-   border-color: @ui-action-discreet-border-hover;
+    &:extend(.umb-node-preview-add:hover);
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -47,7 +47,7 @@
 
        </div>
 
-      <button type="button" class="list-view-add-layout" ng-click="vm.addLayout()">Add layout</button>
+      <button type="button" class="list-view-add-layout mt2" ng-click="vm.addLayout()">Add layout</button>
 
    </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adjust the styling of listview layouts add button, where it extend styling from `umb-node-preview-add` class instead, so the styling is consistent, e.g. note the bold text of the button label.

**Before**

![image](https://user-images.githubusercontent.com/2919859/89124843-4a232e00-d4da-11ea-9653-ec90bb4c0cdd.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/89124803-0d573700-d4da-11ea-9961-43ab62fbfdc7.png)
