### PR TITLE
Adjust image cropper crops

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.controller.js
@@ -38,7 +38,6 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiValuesControl
         $scope.add = function (evt) {
             evt.preventDefault();
             
-            
             if ($scope.newItem) {
                 if (!_.contains($scope.model.value, $scope.newItem)) {                
                     $scope.model.value.push({ value: $scope.newItem });
@@ -79,7 +78,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiValuesControl
             if (event.keyCode == 13) {
                 $scope.add(event);
             }
-        }
+        };
 
         function getElementIndexByPrevalueText(value) {
             for (var i = 0; i < $scope.model.value.length; i++) {

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/multivalues.html
@@ -1,7 +1,7 @@
 <div class="umb-property-editor umb-prevalues-multivalues" ng-controller="Umbraco.PrevalueEditors.MultiValuesController">
     <div class="control-group umb-prevalues-multivalues__add">
         <div class="umb-prevalues-multivalues__left">
-            <input overlay-submit-on-enter="false" name="newItem" focus-when="{{focusOnNew}}" ng-keydown="createNew($event)" type="text" ng-model="newItem" val-highlight="{{hasError}}" />
+            <input type="text" name="newItem" focus-when="{{focusOnNew}}" ng-keydown="createNew($event)" ng-model="newItem" val-highlight="{{hasError}}" overlay-submit-on-enter="false" />
         </div>
         <div class="umb-prevalues-multivalues__right">
             <button type="button" class="btn btn-info" ng-click="add($event)"><localize key="general_add">Add</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -69,6 +69,12 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	        $scope.hasError = true;
         };
 
+        $scope.createNew = function (event) {
+            if (event.keyCode == 13) {
+                $scope.add(event);
+            }
+        };
+
         $scope.sortableOptions = {
             axis: 'y',
             containment: 'parent',

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -69,12 +69,6 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	        $scope.hasError = true;
         };
 
-        $scope.createNew = function (event) {
-            if (event.keyCode == 13) {
-                $scope.add(event);
-            }
-        };
-
 	    $scope.sortableOptions = {
             axis: 'y',
             containment: 'parent',

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -69,10 +69,11 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	        $scope.hasError = true;
         };
 
-	    $scope.sortableOptions = {
+        $scope.sortableOptions = {
             axis: 'y',
             containment: 'parent',
             cursor: 'move',
             tolerance: 'pointer'
-	    }
+        };
+
 	});

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -71,6 +71,9 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
         };
 
 	    $scope.sortableOptions = {
-	        axis: 'y'
+            axis: 'y',
+            containment: 'parent',
+            cursor: 'move',
+            tolerance: 'pointer'
 	    }
 	});

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -69,6 +69,12 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 	        $scope.hasError = true;
         };
 
+        $scope.createNew = function (event) {
+            if (event.keyCode == 13) {
+                $scope.add(event);
+            }
+        };
+
 	    $scope.sortableOptions = {
             axis: 'y',
             containment: 'parent',

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.controller.js
@@ -33,17 +33,16 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.CropSizesControlle
 
         $scope.change = function () {
             // Listen to the change event and set focus 2 false
-            if($scope.setFocus){
+            if ($scope.setFocus) {
                 $scope.setFocus = false;
                 return;
             }
-        }
+        };
 
 	    $scope.add = function (evt) {
             evt.preventDefault();
 
             $scope.editMode = false;
-
             $scope.setFocus = true;
 
 	        if ($scope.newItem && $scope.newItem.alias &&

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -46,8 +46,8 @@
         </div>
 
         <div class="umb-cropsizes__controls">
-            <button class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
-            <button class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
+            <button type="button" class="btn btn-info add" ng-hide="editMode" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button type="button" class="btn btn-info add" ng-show="editMode" ng-click="add($event)"><localize key="general_update">Update</localize></button>
             <button type="button" class="btn btn-link" ng-show="editMode" ng-click="cancel($event)"><localize key="general_cancel">Cancel</localize></button>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -32,8 +32,7 @@
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
             <label for="addcropheight"><localize key="general_height">Height</localize></label>
-            <input
-                   type="number"
+            <input type="number"
                    name="newItem.height"
                    localize="placeholder"
                    placeholder="@general_height"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -13,7 +13,9 @@
                    localize="placeholder"
                    placeholder="@general_alias"
                    focus-when="{{setFocus}}"
-                   ng-change="change()" />
+                   ng-change="change()"
+                   ng-keydown="createNew($event)"
+                   overlay-submit-on-enter="false" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
@@ -27,13 +29,14 @@
                    val-highlight="{{hasError}}"
                    id="addcropwidth"
                    min="0"
-                   pattern="[0-9]*" />
+                   pattern="[0-9]*"
+                   ng-keydown="createNew($event)"
+                   overlay-submit-on-enter="false" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
             <label for="addcropheight"><localize key="general_height">Height</localize></label>
-            <input
-                   type="number"
+            <input type="number"
                    name="newItem.height"
                    localize="placeholder"
                    placeholder="@general_height"
@@ -42,7 +45,9 @@
                    val-highlight="{{hasError}}"
                    id="addcropheight"
                    min="0"
-                   pattern="[0-9]*" />
+                   pattern="[0-9]*"
+                   ng-keydown="createNew($event)"
+                   overlay-submit-on-enter="false" />
         </div>
 
         <div class="umb-cropsizes__controls">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -13,9 +13,7 @@
                    localize="placeholder"
                    placeholder="@general_alias"
                    focus-when="{{setFocus}}"
-                   ng-change="change()"
-                   ng-keydown="createNew($event)"
-                   overlay-submit-on-enter="false" />
+                   ng-change="change()" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
@@ -29,14 +27,13 @@
                    val-highlight="{{hasError}}"
                    id="addcropwidth"
                    min="0"
-                   pattern="[0-9]*"
-                   ng-keydown="createNew($event)"
-                   overlay-submit-on-enter="false" />
+                   pattern="[0-9]*" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
             <label for="addcropheight"><localize key="general_height">Height</localize></label>
-            <input type="number"
+            <input
+                   type="number"
                    name="newItem.height"
                    localize="placeholder"
                    placeholder="@general_height"
@@ -45,9 +42,7 @@
                    val-highlight="{{hasError}}"
                    id="addcropheight"
                    min="0"
-                   pattern="[0-9]*"
-                   ng-keydown="createNew($event)"
-                   overlay-submit-on-enter="false" />
+                   pattern="[0-9]*" />
         </div>
 
         <div class="umb-cropsizes__controls">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -4,50 +4,45 @@
 
         <div class="umb-cropsizes__input-wrap">
             <label for="addcropalias"><localize key="general_alias">Alias</localize></label>
-            <input
-                id="addcropalias"
-                name="newItem.alias"
-                type="text"
-                ng-model="newItem.alias"
-                class="umb-cropsizes__input"
-                val-highlight="{{hasError}}"
-                localize="placeholder"
-                placeholder="@general_alias"
-                focus-when="{{setFocus}}"
-                ng-change="change()"
-            />
+            <input type="text"
+                   id="addcropalias"
+                   name="newItem.alias"
+                   ng-model="newItem.alias"
+                   class="umb-cropsizes__input"
+                   val-highlight="{{hasError}}"
+                   localize="placeholder"
+                   placeholder="@general_alias"
+                   focus-when="{{setFocus}}"
+                   ng-change="change()" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
             <label for="addcropwidth"><localize key="general_width">Width</localize></label>
-            <input
-                name="newItem.width"
-                type="number"
-                localize="placeholder"
-                placeholder="@general_width"
-                ng-model="newItem.width"
-                class="umb-cropsizes__input"
-                val-highlight="{{hasError}}"
-                id="addcropwidth"
-                min="0"
-                pattern="[0-9]*"
-            />
+            <input type="number"
+                   name="newItem.width"
+                   localize="placeholder"
+                   placeholder="@general_width"
+                   ng-model="newItem.width"
+                   class="umb-cropsizes__input"
+                   val-highlight="{{hasError}}"
+                   id="addcropwidth"
+                   min="0"
+                   pattern="[0-9]*" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
             <label for="addcropheight"><localize key="general_height">Height</localize></label>
             <input
-                name="newItem.height"
-                type="number"
-                localize="placeholder"
-                placeholder="@general_height"
-                ng-model="newItem.height"
-                class="umb-cropsizes__input"
-                val-highlight="{{hasError}}"
-                id="addcropheight"
-                min="0"
-                pattern="[0-9]*"
-            />
+                   type="number"
+                   name="newItem.height"
+                   localize="placeholder"
+                   placeholder="@general_height"
+                   ng-model="newItem.height"
+                   class="umb-cropsizes__input"
+                   val-highlight="{{hasError}}"
+                   id="addcropheight"
+                   min="0"
+                   pattern="[0-9]*" />
         </div>
 
         <div class="umb-cropsizes__controls">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -13,7 +13,9 @@
                    localize="placeholder"
                    placeholder="@general_alias"
                    focus-when="{{setFocus}}"
-                   ng-change="change()" />
+                   ng-change="change()"
+                   ng-keydown="createNew($event)"
+                   overlay-submit-on-enter="false" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
@@ -27,7 +29,9 @@
                    val-highlight="{{hasError}}"
                    id="addcropwidth"
                    min="0"
-                   pattern="[0-9]*" />
+                   pattern="[0-9]*"
+                   ng-keydown="createNew($event)"
+                   overlay-submit-on-enter="false" />
         </div>
 
         <div class="umb-cropsizes__input-wrap umb-cropsizes__input-wrap--narrow">
@@ -41,7 +45,9 @@
                    val-highlight="{{hasError}}"
                    id="addcropheight"
                    min="0"
-                   pattern="[0-9]*" />
+                   pattern="[0-9]*"
+                   ng-keydown="createNew($event)"
+                   overlay-submit-on-enter="false" />
         </div>
 
         <div class="umb-cropsizes__controls">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -55,7 +55,7 @@
 
     <div ui-sortable="sortableOptions" class="umb-cropsizes__sortable" ng-model="model.value">
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
-            <i class="icon icon-navigation handle"></i>
+            <i class="icon icon-navigation handle" aria-hidden="true"></i>
             <div class="umb-prevalues-multivalues__left">
                 <p><span>{{item.alias}}</span> <small>({{item.width}}px &times; {{item.height}}px)</small></p>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adjust of few things in image cropper prevalues.

- Restrict sortable within parent container
- Add new item on enter instead of submitting form and therefore saving datatype


![2020-08-02_20-13-06](https://user-images.githubusercontent.com/2919859/89129334-ec540d80-d4fc-11ea-942b-ef509e49b737.gif)
