### PR TITLE
Bugfix: Tour's next button not clickable when infinite editing bar is open

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -72,16 +72,16 @@
                 </section>
 
             </div>
-
-            <umb-tour
-                ng-if="tour.show"
-                model="tour">
-            </umb-tour>
-
+            
             <umb-notifications></umb-notifications>
 
         </div>
-
+        
+        <umb-tour
+            ng-if="tour.show"
+            model="tour">
+        </umb-tour>
+        
         <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
         <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
 


### PR DESCRIPTION
### Details
- When the Get started tour is executed, the tour is locked at step 8 of 12 because the next button is not clickable

### Changes
- Moved the `<umb-tour>` tag out of the current scope. 

### Test
- Run the get started tour. Before the next butten of step `8/12` was not clickable.
- Now
![tour](https://user-images.githubusercontent.com/1561480/89174865-da1eb180-d586-11ea-9aa9-845d67ff1c15.gif)
