### PR TITLE
Add missing backdrop when using the "Actions" button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -127,6 +127,13 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
         }
     }
 
+    function showBackdrop() {
+        var backDropOptions = {
+            'element': $('#leftcolumn')[0]
+        };
+        backdropService.open(backDropOptions);
+    }
+
     var service = {
 
         /**
@@ -427,13 +434,9 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
         showMenu: function (args) {
             var self = this;
 
-            var backDropOptions = {
-                'element': $('#leftcolumn')[0]
-            };
-
             return treeService.getMenu({ treeNode: args.node })
                 .then(function (data) {
-                    backdropService.open(backDropOptions);
+                    showBackdrop();
                     //check for a default
                     //NOTE: event will be undefined when a call to hideDialog is made so it won't re-load the default again.
                     // but perhaps there's a better way to deal with with an additional parameter in the args ? it works though.
@@ -544,6 +547,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 }
             }
             else {
+                showBackdrop();
                 service.showDialog({
                     node: node,
                     action: action,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When invoking a menu item from the tree, a nice backdrop is added behind the resulting dialog. The same backdrop does not appear if you invoke the same menu item from the "Actions" button:

![actions-menu-backdrop-before](https://user-images.githubusercontent.com/7405322/89181076-41daf980-d593-11ea-9959-7efeb28da8bf.gif)

...but this PR takes care of it:

![actions-menu-backdrop-after](https://user-images.githubusercontent.com/7405322/89181088-47384400-d593-11ea-9ecd-57798a11507e.gif)
