### PR TITLE
moving load to the bottom of init

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -29,7 +29,7 @@
         });
 
     function BlockListController($scope, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper) {
-        
+
         var unsubscribe = [];
         var modelObject;
 
@@ -84,7 +84,7 @@
             vm.validationLimit = vm.model.config.validationLimit;
 
             vm.listWrapperStyles = {};
-            
+
             if (vm.model.config.maxPropertyWidth) {
                 vm.listWrapperStyles['max-width'] = vm.model.config.maxPropertyWidth;
             }
@@ -100,10 +100,6 @@
             } else if(vm.umbElementEditorContent && vm.umbElementEditorContent.getScope) {
                 scopeOfExistence = vm.umbElementEditorContent.getScope();
             }
-            
-            // Create Model Object, to manage our data for this Block Editor.
-            modelObject = blockEditorService.createModelObject(vm.model.value, vm.model.editor, vm.model.config.blocks, scopeOfExistence, $scope);
-            modelObject.load().then(onLoaded);
 
             copyAllBlocksAction = {
                 labelKey: "clipboard_labelForCopyAllEntries",
@@ -124,15 +120,20 @@
                 copyAllBlocksAction,
                 deleteAllBlocksAction
             ];
-            
+
             if (vm.umbProperty) {
                 vm.umbProperty.setPropertyActions(propertyActions);
             }
+
+            // Create Model Object, to manage our data for this Block Editor.
+            modelObject = blockEditorService.createModelObject(vm.model.value, vm.model.editor, vm.model.config.blocks, scopeOfExistence, $scope);
+            modelObject.load().then(onLoaded);
+
         };
 
         // Called when we save the value, the server may return an updated data and our value is re-synced
         // we need to deal with that here so that our model values are all in sync so we basically re-initialize.
-        function onServerValueChanged(newVal, oldVal) {   
+        function onServerValueChanged(newVal, oldVal) {
 
             // We need to ensure that the property model value is an object, this is needed for modelObject to recive a reference and keep that updated.
             if (typeof newVal !== 'object' || newVal === null) {// testing if we have null or undefined value or if the value is set to another type than Object.
@@ -142,13 +143,13 @@
             modelObject.update(newVal, $scope);
             onLoaded();
         }
-        
+
         function setDirty() {
             if (vm.propertyForm) {
                 vm.propertyForm.$setDirty();
             }
         }
-        
+
         function onLoaded() {
 
             // Store a reference to the layout model, because we need to maintain this model.
@@ -161,7 +162,7 @@
                 // $block must have the data property to be a valid BlockObject, if not its considered as a destroyed blockObject.
                 if (entry.$block === undefined || entry.$block === null || entry.$block.data === undefined) {
                     var block = getBlockObject(entry);
-    
+
                     // If this entry was not supported by our property-editor it would return 'null'.
                     if (block !== null) {
                         entry.$block = block;
@@ -192,7 +193,7 @@
         }
 
         function getDefaultViewForBlock(block) {
-            
+
             if (block.config.unsupported === true)
                 return "views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.html";
 
@@ -207,8 +208,8 @@
             if (block === null) return null;
 
             // ensure that the containing content variant language/culture is transfered along
-            // to the scaffolded content object representing this block. This is required for validation 
-            // along with ensuring that the umb-property inheritance is constently maintained.            
+            // to the scaffolded content object representing this block. This is required for validation
+            // along with ensuring that the umb-property inheritance is constently maintained.
             if (vm.umbVariantContent.editor.content.language) {
                 block.content.language = vm.umbVariantContent.editor.content.language;
                 // currently we only ever deal with invariant content for blocks so there's only one
@@ -243,7 +244,7 @@
             if (blockObject === null) {
                 return false;
             }
-            
+
             // If we reach this line, we are good to add the layoutEntry and blockObject to our models.
 
             // Add the Block Object to our layout entry.
@@ -251,7 +252,7 @@
 
             // add layout entry at the decired location in layout.
             vm.layout.splice(index, 0, layoutEntry);
-            
+
             // lets move focus to this new block.
             vm.setBlockFocus(blockObject);
 
@@ -271,7 +272,7 @@
             var removed = vm.layout.splice(layoutIndex, 1);
             removed.forEach(x => {
                 // remove any server validation errors associated
-                var guid = udiService.getKey(x.contentUdi);                
+                var guid = udiService.getKey(x.contentUdi);
                 serverValidationManager.removePropertyError(guid, vm.umbProperty.property.culture, vm.umbProperty.property.segment, "", { matchType: "contains" });
             });
 
@@ -284,7 +285,7 @@
                 deleteBlock(entry.$block);
             });
         }
-        
+
         function activateBlock(blockObject) {
             blockObject.active = true;
         }
@@ -317,7 +318,7 @@
             if (blockObject.config.settingsElementTypeKey) {
                 blockSettingsClone = Utilities.copy(blockObject.settings);
             }
-            
+
             var blockEditorModel = {
                 $parentScope: $scope, // pass in a $parentScope, this maintains the scope inheritance in infinite editing
                 $parentForm: parentForm || vm.propertyForm, // pass in a $parentForm, this maintains the FormController hierarchy with the infinite editing view (if it contains a form)
@@ -366,11 +367,11 @@
 
         vm.showCreateDialog = showCreateDialog;
         function showCreateDialog(createIndex, $event) {
-            
+
             if (vm.blockTypePicker) {
                 return;
             }
-            
+
             if (vm.availableBlockTypes.length === 0) {
                 return;
             }
@@ -405,7 +406,7 @@
                     if (blockPickerModel && blockPickerModel.selectedItem) {
                         added = addNewBlock(createIndex, blockPickerModel.selectedItem.blockConfigModel.contentTypeKey);
                     }
-                    
+
                     if(!(mouseEvent.ctrlKey || mouseEvent.metaKey)) {
                         editorService.close();
                         if (added && vm.layout.length > createIndex) {
@@ -448,7 +449,7 @@
                     }
                 );
             });
-            
+
             var arrayEntriesForPaste = clipboardService.retriveEntriesOfType("elementTypeArray", vm.availableContentTypesAliases);
             arrayEntriesForPaste.forEach(function (entry) {
                 blockPickerModel.clipboardItems.push(
@@ -472,13 +473,13 @@
         var requestCopyAllBlocks = function() {
 
             var elementTypesToCopy = vm.layout.filter(entry => entry.$block.config.unsupported !== true).map(entry => entry.$block.content);
-            
+
             // list aliases
             var aliases = elementTypesToCopy.map(content => content.contentTypeAlias);
 
             // remove dublicates
             aliases = aliases.filter((item, index) => aliases.indexOf(item) === index);
-            
+
             var contentNodeName = "";
             if(vm.umbVariantContent) {
                 contentNodeName = vm.umbVariantContent.editor.content.name;
@@ -494,7 +495,7 @@
             clipboardService.copy("elementType", block.content.contentTypeAlias, block.content, block.label);
         }
         function requestPasteFromClipboard(index, pasteEntry) {
-            
+
             if (pasteEntry === undefined) {
                 return false;
             }
@@ -512,7 +513,7 @@
 
             // set the BlockObject on our layout entry.
             layoutEntry.$block = blockObject;
-            
+
             // insert layout entry at the decired location in layout.
             vm.layout.splice(index, 0, layoutEntry);
 
@@ -565,7 +566,7 @@
             copyBlock: copyBlock,
             requestDeleteBlock: requestDeleteBlock,
             deleteBlock: deleteBlock,
-            openSettingsForBlock: openSettingsForBlock 
+            openSettingsForBlock: openSettingsForBlock
         }
 
         vm.sortableOptions = {
@@ -594,15 +595,15 @@
 
                 var isMinRequirementGood = vm.validationLimit.min === null || vm.layout.length >= vm.validationLimit.min;
                 vm.propertyForm.minCount.$setValidity("minCount", isMinRequirementGood);
-                
+
                 var isMaxRequirementGood = vm.validationLimit.max === null || vm.layout.length <= vm.validationLimit.max;
                 vm.propertyForm.maxCount.$setValidity("maxCount", isMaxRequirementGood);
-                
+
             }
         }
         unsubscribe.push($scope.$watch(() => vm.layout.length, onAmountOfBlocksChanged));
 
-        
+
         $scope.$on("$destroy", function () {
             for (const subscription of unsubscribe) {
                 subscription();


### PR DESCRIPTION
Sometimes load happens instant, so to avoid runtime issues this needs to be placed in the bottom of init.