### PR TITLE
Make the entire tree menu ellipsis button clickable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -96,7 +96,6 @@ body.touch .umb-tree {
             width: auto;
             height: auto;
             margin: 0 5px 0 auto;
-            padding: 7px 5px;
             overflow: visible;
             clip: auto;
         }
@@ -185,11 +184,14 @@ body.touch .umb-tree {
     display: flex;
     flex: 0 0 auto;
     justify-content: flex-end;
-    padding: 7px 5px;
     text-align: center;
     margin: 0 5px 0 auto;
     cursor: pointer;
     border-radius: @baseBorderRadius;
+
+    .umb-button-ellipsis {
+        padding: 3px 5px;
+    }
 
     i {
         height: 5px !important;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It's a tad annoying how the tree menu ellipsis button is only clickable at the very center, despite the hover effect and mouse cursor indicating that the entire button should be clickable:

![tree-menu-clickable-before](https://user-images.githubusercontent.com/7405322/89182524-28877c80-d596-11ea-8058-f18a274e9035.gif)

Kinda get the feeling that there are no menu items available when the menu doesn't appear 🤔 

This PR makes the entire button clickable:

![tree-menu-clickable-after](https://user-images.githubusercontent.com/7405322/89182577-448b1e00-d596-11ea-96b9-dfb56c486967.gif)
