### PR TITLE
Update umb-property-actions toggle button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
@@ -70,8 +70,6 @@
             localizationService.localizeMany(labelKeys).then(values => {
                 vm.labels.openText = values[0];
                 vm.labels.closeText = values[1];
-
-                console.log("vm.labels", vm.labels);
             });
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
@@ -5,14 +5,22 @@
      * A component to render the property action toggle
      */
     
-    function umbPropertyActionsController(keyboardService) {
+    function umbPropertyActionsController(keyboardService, localizationService) {
 
         var vm = this;
 
-        vm.labels = {};
         vm.isOpen = false;
+        vm.labels = {
+            openText: "Open Property Actions",
+            closeText: "Close Property Actions"
+        };
 
+        vm.open = open;
+        vm.close = close;
+        vm.executeAction = executeAction;
 
+        vm.$onDestroy = onDestroy;
+        vm.$onInit = onInit;
 
         function initDropDown() {
             keyboardService.bind("esc", vm.close);
@@ -30,25 +38,41 @@
             }
         };
 
-        vm.open = function() {
+        function open() {
             vm.isOpen = true;
             initDropDown();
         }
-        vm.close = function () {
+
+        function close() {
             vm.isOpen = false;
             destroyDropDown();
         };
 
-        vm.executeAction = function (action) {
+        function executeAction(action) {
             action.method();
             vm.close();
-        };
+        }
 
-        vm.$onDestroy = function () {
+        function onDestroy() {
             if (vm.isOpen === true) {
                 destroyDropDown();
             }
-        };
+        }
+
+        function onInit() {
+            
+            var labelKeys = [
+                "propertyActions_tooltipForPropertyActionsMenu",
+                "propertyActions_tooltipForPropertyActionsMenuClose"
+            ]
+
+            localizationService.localizeMany(labelKeys).then(values => {
+                vm.labels.openText = values[0];
+                vm.labels.closeText = values[1];
+
+                console.log("vm.labels", vm.labels);
+            });
+        }
     }
 
     var umbPropertyActionsComponent = {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
@@ -9,46 +9,50 @@
 
         var vm = this;
 
+        vm.labels = {};
         vm.isOpen = false;
+
+
 
         function initDropDown() {
             keyboardService.bind("esc", vm.close);
         }
+
         function destroyDropDown() {
             keyboardService.unbind("esc");
         }
 
-        vm.toggle = function() {
+        vm.toggle = function () {
             if (vm.isOpen === true) {
                 vm.close();
             } else {
                 vm.open();
             }
-        }
+        };
+
         vm.open = function() {
             vm.isOpen = true;
             initDropDown();
         }
-        vm.close = function() {
+        vm.close = function () {
             vm.isOpen = false;
             destroyDropDown();
-        }
+        };
 
-        vm.executeAction = function(action) {
+        vm.executeAction = function (action) {
             action.method();
             vm.close();
-        }
+        };
 
         vm.$onDestroy = function () {
             if (vm.isOpen === true) {
                 destroyDropDown();
             }
-        }
-        
+        };
     }
 
     var umbPropertyActionsComponent = {
-        templateUrl: 'views/components/property/property-actions/umb-property-actions.html',
+        templateUrl: 'views/components/property/umb-property-actions.html',
         bindings: {
             actions: "<"
         },

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyactions.component.js
@@ -17,6 +17,7 @@
 
         vm.open = open;
         vm.close = close;
+        vm.toggle = toggle;
         vm.executeAction = executeAction;
 
         vm.$onDestroy = onDestroy;
@@ -30,13 +31,13 @@
             keyboardService.unbind("esc");
         }
 
-        vm.toggle = function () {
+        function toggle() {
             if (vm.isOpen === true) {
                 vm.close();
             } else {
                 vm.open();
             }
-        };
+        }
 
         function open() {
             vm.isOpen = true;
@@ -46,7 +47,7 @@
         function close() {
             vm.isOpen = false;
             destroyDropDown();
-        };
+        }
 
         function executeAction(action) {
             action.method();

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-actions.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-actions.less
@@ -1,9 +1,4 @@
-.umb-property-actions {
-    display: inline;
-}
-
-.umb-property-actions__toggle,
-.umb-property-actions__menu-open-toggle {
+.umb-property-actions__toggle {
     position: relative;
     display: flex;
     flex: 0 0 auto;
@@ -11,7 +6,6 @@
     text-align: center;
     cursor: pointer;
     border-radius: 3px;
-
     background-color: @ui-action-hover;
 
     i {
@@ -32,27 +26,20 @@
         }
     }
 }
-.umb-property-actions__menu-open-toggle {
-    position: absolute;
-    z-index:1;
-    outline: none;// this is not acceccible by keyboard, since we use the .umb-property-actions__toggle for that.
 
-    top: -15px;
-    border-radius: 3px 3px 0 0;
+.umb-property-actions {
+    display: inline;
 
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-
-    border: 1px solid @dropdownBorder;
-
-    border-bottom: 1px solid @gray-9;
-
-    .box-shadow(0 5px 20px rgba(0,0,0,.3));
-
-    background-color: @white;
-
+    &.-open {
+        .umb-property-actions__toggle {
+            background-color: @white;
+            border-radius: 3px 3px 0 0;
+            border: 1px solid @dropdownBorder;
+            border-bottom: 1px solid @gray-9;
+            .box-shadow(0 5px 20px rgba(0,0,0,.3));
+        }
+    }
 }
-
 .umb-property .umb-property-actions {
     float: left;
 }
@@ -66,32 +53,22 @@
 .umb-property .umb-property-actions__toggle:focus {
     opacity: 1;
 }
+
 // Revert-style-hack that ensures that we only show property-actions on properties that are directly begin hovered.
 .umb-property:hover .umb-property:not(:hover) .umb-property-actions__toggle {
     opacity: 0;
 }
 
 .umb-property-actions__menu {
-
     position: absolute;
     z-index: 1000;
-
     display: block;
-
     float: left;
     min-width: 160px;
     list-style: none;
 
     .umb-contextmenu {
-
         border-top-left-radius: 0;
-        margin-top:-2px;
-
-    }
-
-    .umb-contextmenu-item > button {
-
-        z-index:2;// need to stay on top of menu-toggle-open shadow.
-
+        margin-top: 0;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
@@ -1,4 +1,4 @@
-<div class="umb-property-actions" ng-if="vm.actions.length > 0">
+<div class="umb-property-actions" ng-class="{ '-open': vm.isOpen }" ng-if="vm.actions.length > 0">
 
     <umb-button-ellipsis
         css-class="umb-outline umb-property-actions__toggle"

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
@@ -4,20 +4,10 @@
         css-class="umb-outline umb-property-actions__toggle"
         action="vm.toggle()"
         mode="small"
-        text="Open Property Actions"
-        label-key="propertyActions_tooltipForPropertyActionsMenu">
+        text="{{vm.isOpen ? vm.labels.openText ? vm.labels.closeText}}">
     </umb-button-ellipsis>
 
     <div class="umb-property-actions__menu" role="menu" ng-if="vm.isOpen" on-outside-click="vm.close()" on-close="vm.close()" deep-blur="vm.close()">
-
-        <umb-button-ellipsis
-            css-class="umb-button-ellipsis--absolute umb-property-actions__menu-open-toggle"
-            action="vm.close()"
-            mode="small"
-            text="Close Property Actions"
-            label-key="propertyActions_tooltipForPropertyActionsMenuClose">
-        </umb-button-ellipsis>
-
         <ul class="umb-contextmenu">
             <li ng-repeat="action in vm.actions" role="menuitem" class="umb-contextmenu-item" ng-class="{'-opens-dialog': action.opensDialog}">
                 <button type="button" class="btn-reset umb-outline" ng-click="vm.executeAction(action)" ng-disabled="action.isDisabled === true">

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
@@ -4,7 +4,7 @@
         css-class="umb-outline umb-property-actions__toggle"
         action="vm.toggle()"
         mode="small"
-        text="{{vm.isOpen ? vm.labels.openText ? vm.labels.closeText}}">
+        text="{{vm.isOpen ? vm.labels.closeText : vm.labels.openText}}">
     </umb-button-ellipsis>
 
     <div class="umb-property-actions__menu" role="menu" ng-if="vm.isOpen" on-outside-click="vm.close()" on-close="vm.close()" deep-blur="vm.close()">

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property-actions.html
@@ -1,11 +1,11 @@
 <div class="umb-property-actions" ng-if="vm.actions.length > 0">
+
     <umb-button-ellipsis
         css-class="umb-outline umb-property-actions__toggle"
         action="vm.toggle()"
         mode="small"
         text="Open Property Actions"
-        label-key="propertyActions_tooltipForPropertyActionsMenu"
-        >
+        label-key="propertyActions_tooltipForPropertyActionsMenu">
     </umb-button-ellipsis>
 
     <div class="umb-property-actions__menu" role="menu" ng-if="vm.isOpen" on-outside-click="vm.close()" on-close="vm.close()" deep-blur="vm.close()">
@@ -15,8 +15,7 @@
             action="vm.close()"
             mode="small"
             text="Close Property Actions"
-            label-key="propertyActions_tooltipForPropertyActionsMenuClose"
-            >
+            label-key="propertyActions_tooltipForPropertyActionsMenuClose">
         </umb-button-ellipsis>
 
         <ul class="umb-contextmenu">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8537

### Description
This PR removes the additional close button and use the toggle button, which change the text when dropdown is open/closed.
For some reason this component was located in [src/views/components/property/property-actions](https://github.com/umbraco/Umbraco-CMS/tree/v8/contrib/src/Umbraco.Web.UI.Client/src/views/components/property/property-actions) folder and not consistent with all other components/directives which are located in [/src/common/directives/components/](https://github.com/umbraco/Umbraco-CMS/tree/v8/contrib/src/Umbraco.Web.UI.Client/src/common/directives/components)

For the view it was located in a subfolder, but I don't think we need an additional folder for just this single file, so I have moved it to this folder instead: [src/views/components/property](https://github.com/umbraco/Umbraco-CMS/tree/v8/contrib/src/Umbraco.Web.UI.Client/src/views/components/property)

![2020-08-03_15-01-00](https://user-images.githubusercontent.com/2919859/89185335-5bcc0a80-d59a-11ea-8f8e-17aeefd5db6f.gif)
