### PR TITLE
Fix JS error in empty listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.listviewlayout.controller.js
@@ -89,18 +89,15 @@
             $scope.options.includeProperties.forEach(function (option) {
                 option.isSensitive = false;
 
-                $scope.items.forEach(function (item) {
-
-                    item.properties.forEach(function (property) {
-
+                if ($scope.items && $scope.items.length) {
+                    $scope.items.forEach(function (item) {
+                        item.properties.forEach(function (property) {
                             if (option.alias === property.alias) {
                                 option.isSensitive = property.isSensitive;
                             }
-
-                     });
-
-                });
-
+                         });
+                    });
+                }
             });
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Slight unintended side effect of #8538 is the JS error that occurs when a listview is empty - try searching the "all members" view for a member that does not exist and see the JS console:

![image](https://user-images.githubusercontent.com/7405322/89194878-42ca5600-d5a8-11ea-96a3-6c13a4b9f71f.png)

This PR adds some defensive coding around the failing method to remove the JS error.