### PR TITLE
Only show mediapicker edit button if media is found

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -51,22 +51,25 @@ function mediaEditController($scope, $routeParams, $location, $http, $q, appStat
 
         $scope.page.loading = true;
 
-        mediaResource.getScaffold(nodeId, $routeParams.doctype)
-            .then(function (data) {
-                $scope.content = data;
+        mediaResource.getScaffold(nodeId, $routeParams.doctype).then(function (data) {
+            $scope.content = data;
 
-                init();
+            init();
 
-                $scope.page.loading = false;
-
-            });
+            $scope.page.loading = false;
+        }, function () {
+            $scope.page.loading = false;
+        });
     }
     else {
         $scope.page.loading = true;
-        loadMedia()
-            .then(function(){
-                $scope.page.loading = false;
-            });
+
+        loadMedia().then(function(){
+            $scope.page.loading = false;
+        }, function (error) {
+            console.log("loadMedia error", error);
+            $scope.page.loading = false;
+        });
     }
 
     function init() {
@@ -121,6 +124,8 @@ function mediaEditController($scope, $routeParams, $location, $http, $q, appStat
             if(args && args.mediaType && args.mediaType.key === $scope.content.contentType.key) {
                 $scope.page.loading = true;
                 loadMedia().then(function() {
+                    $scope.page.loading = false;
+                }, function () {
                     $scope.page.loading = false;
                 });
             }
@@ -258,8 +263,12 @@ function mediaEditController($scope, $routeParams, $location, $http, $q, appStat
                 $scope.page.loading = false;
 
                 $q.resolve($scope.content);
-            });
 
+            }, function (error) {
+                $scope.page.loading = false;
+
+                $q.reject(error);
+            });
     }
 
     $scope.close = function() {

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -66,8 +66,7 @@ function mediaEditController($scope, $routeParams, $location, $http, $q, appStat
 
         loadMedia().then(function(){
             $scope.page.loading = false;
-        }, function (error) {
-            console.log("loadMedia error", error);
+        }, function () {
             $scope.page.loading = false;
         });
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -65,7 +65,6 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                         };
 
                         mediaItem.found = found ? true : false;
-                        console.log("mediaItem 1", mediaItem);
 
                         return mediaItem;
                     });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -53,18 +53,21 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                         // it's prone to someone "fixing" it at some point without knowing the effects. Rather use toString()
                         // compares and be completely sure it works.
                         var found = medias.find(m => m.udi.toString() === id.toString() || m.id.toString() === id.toString());
-                        if (found) {
-                            return found;
-                        } else {
-                            return {
-                                name: vm.labels.deletedItem,
-                                id: $scope.model.config.idType !== "udi" ? id : null,
-                                udi: $scope.model.config.idType === "udi" ? id : null,
-                                icon: "icon-picture",
-                                thumbnail: null,
-                                trashed: true
-                            };
-                        }
+                        
+                        var mediaItem = found ||
+                        {
+                            name: vm.labels.deletedItem,
+                            id: $scope.model.config.idType !== "udi" ? id : null,
+                            udi: $scope.model.config.idType === "udi" ? id : null,
+                            icon: "icon-picture",
+                            thumbnail: null,
+                            trashed: true
+                        };
+
+                        mediaItem.found = found ? true : false;
+                        console.log("mediaItem 1", mediaItem);
+
+                        return mediaItem;
                     });
 
                     medias.forEach(media => {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -37,7 +37,7 @@
                 </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <button type="button" aria-label="Edit media" ng-if="allowEditMedia" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
+                    <button type="button" aria-label="Edit media" ng-if="allowEditMedia && media.found" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
                         <i class="icon icon-edit" aria-hidden="true"></i>
                     </button>
                     <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="vm.remove($index)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment when a media is deleted, but the media picker still has the stored reference, the edit button is shown and when clicking this button the infinite mode of media is opened. However because the media isn't available `$scope.page.loading` is never set to false and `$scope.content` is not set.

So basically it keeps showing the loading indicator
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/media/edit.html#L3

and because content isn't shown while loading, content editors doesn't have the option to click close or using `esc` shortcut.
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/media/edit.html#L9

the only option is to refresh page.

![2020-08-03_18-57-38](https://user-images.githubusercontent.com/2919859/89207764-8e3a2f80-d5bb-11ea-8bc0-7552fa1e3295.gif)



I have improved the error handling and only show the edit button in media picker, when the media is actually found (also true if in media recycle bin).


![2020-08-03_18-43-22](https://user-images.githubusercontent.com/2919859/89206348-7bbef680-d5b9-11ea-90ec-0f3bdaadc309.gif)

I tried a different approach to keep showing edit button for not found media items and showing an empty state message, but it would require hide e.g. header, main content and submit button.

https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/media/edit.html#L9

```
<div data-element="editor-media" ng-controller="Umbraco.Editors.Media.EditController">

    <umb-load-indicator ng-if="page.loading"></umb-load-indicator>

    <form novalidate name="contentForm"
          ng-submit="save()"
          val-form-manager>

        <umb-editor-view ng-if="!page.loading">

            <umb-editor-header ng-if="content"
                               name="content.name"
                               menu="page.menu"
                               hide-icon="true"
                               hide-description="true"
                               hide-alias="true"
                               navigation="content.apps"
                               on-select-navigation-item="appChanged(item)"
                               show-back-button="showBack()"
                               on-back="onBack()"
                               setpagetitle="header.setPageTitle">
            </umb-editor-header>

            <umb-editor-container>

                <div class="umb-editor-sub-views" ng-if="!page.loading && content">
                    <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
                        <umb-editor-sub-view model="app" content="content" />
                    </div>
                </div>

                <umb-empty-state ng-if="!page.loading && !content"
                                 position="center">
                    <localize key="media_itemNotFound">The media item was not found</localize>
                </umb-empty-state>

            </umb-editor-container>

            <umb-editor-footer>

                <umb-editor-footer-content-left>

                    <umb-breadcrumbs ng-if="ancestors && ancestors.length > 0"
                                     ancestors="ancestors"
                                     entity-type="media">
                    </umb-breadcrumbs>

                </umb-editor-footer-content-left>

                <umb-editor-footer-content-right>

                    <umb-button ng-if="model.infiniteMode"
                                type="button"
                                button-style="link"
                                label-key="general_close"
                                shortcut="esc"
                                action="close()">
                    </umb-button>

                    <umb-button alias="returnToList"
                                ng-if="page.listViewPath && !model.infiniteMode"
                                type="link"
                                href="#{{page.listViewPath}}"
                                label-key="buttons_returnToList">
                    </umb-button>

                    <!-- label-key="buttons_save" -->
                    <umb-button alias="save"
                                type="submit"
                                button-style="success"
                                ng-if="content"
                                state="page.saveButtonState"
                                label-key="{{page.submitButtonLabelKey}}"
                                shortcut="ctrl+s">
                    </umb-button>

                </umb-editor-footer-content-right>


            </umb-editor-footer>

        </umb-editor-view>

    </form>
</div>

```

![2020-08-03_18-46-17](https://user-images.githubusercontent.com/2919859/89207199-ac536000-d5ba-11ea-8827-3d7bf251419e.gif)


In the end I don't think it add any value to the content editor, so I felt it was a better option to hide to edit button.

I have however improved the error handing in media.edit.controller.js in case we want to make improvements on this later.