### PR TITLE
Update styling of grid editor add button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -596,9 +596,10 @@
 }
 
 .umb-grid .iconBox i {
-    font-size: 16px !important;
-    color: @gray-3 ;
+    color: @gray-3;
     display: block;
+    font-size: 16px;
+    line-height: inherit;
 }
 
 .umb-grid .help-text {
@@ -608,8 +609,6 @@
     display: inline-block;
     clear: both;
 }
-
-
 
 // TINYMCE EDITOR
 // -------------------------

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -265,7 +265,7 @@
                                ng-if="!showRowConfigurations">
                             <i class="icon icon-add" aria-hidden="true"></i>
                             <span class="sr-only">
-                            <localize key="visuallyHiddenTexts_addNewRow">Add new row</localize>
+                                <localize key="visuallyHiddenTexts_addNewRow">Add new row</localize>
                             </span>
                         </button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -260,7 +260,7 @@
 
                        <button type="button"
                                class="iconBox btn-reset"
-                               title="{{ section.$allowedLayouts.length == 1 ? section.$allowedLayouts[0].label || section.$allowedLayouts[0].name : '' }}"
+                               title="{{section.$allowedLayouts.length == 1 ? section.$allowedLayouts[0].label || section.$allowedLayouts[0].name : ''}}"
                                ng-click="section.$allowedLayouts.length == 1 ? addRow(section, section.$allowedLayouts[0]) : toggleAddRow()"
                                ng-if="!showRowConfigurations">
                             <i class="icon icon-add" aria-hidden="true"></i>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -258,17 +258,15 @@
 
                     <div class="umb-add-row" ng-if="!sortMode">
 
-                       <button
-                          class="iconBox btn-reset"
-                          type="button"
-                          title="{{ section.$allowedLayouts.length == 1 ? section.$allowedLayouts[0].label || section.$allowedLayouts[0].name : '' }}"
-                          ng-click="section.$allowedLayouts.length == 1 ? addRow(section, section.$allowedLayouts[0]) : toggleAddRow()"
-                          ng-if="!showRowConfigurations">
-
-                          <i class="icon icon-add" ></i>
-                          <span class="sr-only">
+                       <button type="button"
+                               class="iconBox btn-reset"
+                               title="{{ section.$allowedLayouts.length == 1 ? section.$allowedLayouts[0].label || section.$allowedLayouts[0].name : '' }}"
+                               ng-click="section.$allowedLayouts.length == 1 ? addRow(section, section.$allowedLayouts[0]) : toggleAddRow()"
+                               ng-if="!showRowConfigurations">
+                            <i class="icon icon-add" aria-hidden="true"></i>
+                            <span class="sr-only">
                             <localize key="visuallyHiddenTexts_addNewRow">Add new row</localize>
-                          </span>
+                            </span>
                         </button>
 
                     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add some minor updates to the styling of grid editor add button, so the icon is aligned in the button and the button itself is more round.

**Before**

![image](https://user-images.githubusercontent.com/2919859/89214899-f2fb8700-d5c7-11ea-8a0b-6553e521830a.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/89214805-c47dac00-d5c7-11ea-81b8-3d1b72cbf8ea.png)
