### PR TITLE
append lost drag class

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
@@ -3,6 +3,7 @@
 
         <umb-block-list-block stylesheet="{{::vm.layout.$block.config.stylesheet}}"
                               class="umb-block-list__block--content"
+                              ng-class="{'blockelement__draggable-element': vm.layout.$block.config.stylesheet}"
                               view="{{vm.layout.$block.view}}"
                               api="vm.blockEditorApi"
                               block="vm.layout.$block"


### PR DESCRIPTION
The "blockelement__draggable-element" class was present on the scoped block list block components before validation was merged in, but it somehow got lost. Its appended cause the scoping makes it unable to search and find it inside the scoped component, therefore we need to make the full entry draggable.