### PR TITLE
Make embed grid editor editable again

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.controller.js
@@ -34,7 +34,7 @@
         vm.close = close;
 
         function onInit() {
-            if(!$scope.model.title) {
+            if (!$scope.model.title) {
                 localizationService.localize("general_embed").then(function(value){
                     $scope.model.title = value;
                 });
@@ -122,7 +122,6 @@
            if ($scope.model.embed.url !== "") {
                showPreview();
            }
-
        }
 
        function toggleConstrain() {
@@ -130,19 +129,18 @@
        }
 
        function submit() {
-            if($scope.model && $scope.model.submit) {
+            if ($scope.model && $scope.model.submit) {
                 $scope.model.submit($scope.model);
             }
         }
 
         function close() {
-            if($scope.model && $scope.model.close) {
+            if ($scope.model && $scope.model.close) {
                 $scope.model.close();
             }
         }
 
         onInit();
-
    }
 
    angular.module("umbraco").controller("Umbraco.Editors.EmbedController", EmbedController);

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.controller.js
@@ -22,7 +22,7 @@
         };
 
         if ($scope.model.modify) {
-            angular.extend($scope.model.embed, $scope.model.modify);
+            Utilities.extend($scope.model.embed, $scope.model.modify);
 
             showPreview();
         }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.html
@@ -16,7 +16,7 @@
                     <umb-box-content>
 
                         <umb-control-group label="@general_url">
-                            <input id="url" class="umb-property-editor input-block-level" type="text" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" focus-when="{{true}}" required />
+                            <input type="text" id="url" class="umb-property-editor input-block-level" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" focus-when="{{true}}" required />
                             <umb-button
                                 type="button"
                                 action="vm.showPreview()"

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/embed/embed.html
@@ -16,7 +16,7 @@
                     <umb-box-content>
 
                         <umb-control-group label="@general_url">
-                            <input type="text" id="url" class="umb-property-editor input-block-level" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" focus-when="{{true}}" required />
+                            <input type="text" id="url" class="umb-property-editor input-block-level" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" focus-when="{{true}}" required />
                             <umb-button
                                 type="button"
                                 action="vm.showPreview()"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/embed.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/embed.controller.js
@@ -19,10 +19,10 @@ angular.module("umbraco")
 
         $scope.setEmbed = function () {
 
-            var original = Utilities.isObject($scope.control.value) ? $scope.control.value : null;
+            var modify = Utilities.isObject($scope.control.value) ? $scope.control.value : null;
 
             var embed = {
-                original: original,
+                modify: modify,
                 submit: function (model) {
 
                     var embed = {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8575

### Description
This PR fixes an issue where it was no longer possible to edit existing embed in grid editor as in PR https://github.com/umbraco/Umbraco-CMS/pull/4899

After this was merged a few days later another PR https://github.com/umbraco/Umbraco-CMS/pull/6341 was made to edit embed from TinyMCE editor. However this PR also changed the scope property in the infinite embed editor from `original` to `modify` in https://github.com/umbraco/Umbraco-CMS/commit/bf9eeb4e373a6c4c44586b4cdfba7b26c7c2ad11 but wasn't aware it was passed in from embed grid editor.
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/embed.controller.js#L25

![2020-08-04_11-31-03](https://user-images.githubusercontent.com/2919859/89278399-54623b00-d646-11ea-9359-dc514e2bc71b.gif)
