### PR TITLE
Don't retain "move media" in busy state on error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.move.controller.js
@@ -105,6 +105,7 @@ angular.module("umbraco").controller("Umbraco.Editors.Media.MoveController",
                     });
 
                 }, function (err) {
+                    $scope.busy = false;
                     $scope.success = false;
                     $scope.error = err;
                 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you attempt to move a media item to its parent folder, the operation will fail with a big ol' red error message. But the cancel/move buttons are never re-enabled, thus leaving the editor with no visible ways out (you can still click outside the dialog to close it, but still... not nice):

![image](https://user-images.githubusercontent.com/7405322/89276010-5d9dd880-d643-11ea-8a4d-74acbcd31547.png)

This PR ensures that the "busy" state (which removes the cancel button and disables the move button) is not retained when an error occurs during the move operation:

![media-move-to-same-parent-after](https://user-images.githubusercontent.com/7405322/89276102-83c37880-d643-11ea-8696-a90f36d7a965.gif)
