### PR TITLE
Check for null before checking the length or value of first entry.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -15,14 +15,14 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
 
         //ensure this is a bool, old data could store zeros/ones or string versions
         $scope.model.config.multiple = Object.toBoolean($scope.model.config.multiple);
-        
+
         //ensure when form is saved that we don't store [] or [null] as string values in the database when no items are selected
         $scope.$on("formSubmitting", function () {
-            if ($scope.model.value.length === 0 || $scope.model.value[0] === null) {
+            if ($scope.model.value && ($scope.model.value.length === 0 || $scope.model.value[0] === null)) {
                 $scope.model.value = null;
             }
         });
-        
+
         function convertArrayToDictionaryArray(model){
             //now we need to format the items in the dictionary because we always want to have an array
             var newItems = [];
@@ -41,7 +41,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
             var keys = _.keys($scope.model.config.items);
 
             for (var i = 0; i < vals.length; i++) {
-                var label = vals[i].value ? vals[i].value : vals[i]; 
+                var label = vals[i].value ? vals[i].value : vals[i];
                 newItems.push({ id: keys[i], sortOrder: vals[i].sortOrder, value: label });
             }
 
@@ -65,7 +65,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
         else {
             throw "The items property must be either an array or a dictionary";
         }
-        
+
 
         //sort the values
         $scope.model.config.items.sort(function (a, b) { return (a.sortOrder > b.sortOrder) ? 1 : ((b.sortOrder > a.sortOrder) ? -1 : 0); });
@@ -80,7 +80,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.DropdownFlexibleCo
                 $scope.model.value = "";
             }
         }
-        
+
         // if we run in single mode we'll store the value in a local variable
         // so we can pass an array as the model as our PropertyValueEditor expects that
         $scope.model.singleDropdownValue = "";


### PR DESCRIPTION
I experience this issue when a dropdown is used in a content-app that is not active on submit in the block list editor.

![image](https://user-images.githubusercontent.com/6791648/89278543-8a072400-d646-11ea-9363-2961206543e7.png)

This is because the value gets set to null, and if the control isn't initialized, aka. not shown. Then this value never gets reset to anything and therefor this event handler fails cause it cant check the length of null. So there I added this check.