### PR TITLE
Fix the arrow direction in the content language picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-language-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-language-picker.less
@@ -24,6 +24,7 @@
 
 .umb-language-picker__expand {
     font-size: 14px;
+    pointer-events: none;
 }
 
 .umb-language-picker__toggle:hover {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
@@ -21,7 +21,7 @@
                                 <div class="umb-language-picker" ng-if="vm.showLanguageSelector && vm.languages.length > 1" on-outside-click="vm.page.languageSelectorIsOpen = false" style="padding-bottom: 5px">
                                     <button class="umb-language-picker__toggle btn-reset" ng-click="vm.toggleLanguageSelector()">
                                         <span>{{vm.selectedLanguage.name}}</span>
-                                        <umb-icon icon="icon-navigation-right" class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !vm.languageSelectorIsOpen, 'icon-navigation-up': vm.languageSelectorIsOpen}" class="icon-navigation-right"></umb-icon>
+                                        <umb-icon icon="{{vm.languageSelectorIsOpen ? 'icon-navigation-up' : 'icon-navigation-down'}}" class="umb-language-picker__expand icon-navigation-down"></umb-icon>
                                     </button>
                                     <div class="umb-language-picker__dropdown" ng-if="vm.languageSelectorIsOpen">
                                         <button class="btn-reset" ng-click="vm.selectLanguage(language)" ng-repeat="language in vm.languages">{{language.name}}</button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -15,7 +15,7 @@
                         </span>
                         <span>{{selectedLanguage.name}}</span>
                     </span>
-                    <umb-icon icon="icon-navigation-right" class="umb-language-picker__expand" ng-class="{'icon-navigation-down': !page.languageSelectorIsOpen, 'icon-navigation-up': page.languageSelectorIsOpen}" class="icon-navigation-right" aria-hidden="true">&nbsp;</umb-icon>
+                    <umb-icon icon="{{page.languageSelectorIsOpen ? 'icon-navigation-up' : 'icon-navigation-down'}}" class="umb-language-picker__expand icon-navigation-down" aria-hidden="true">&nbsp;</umb-icon>
                 </button>
                 <div class="umb-language-picker__dropdown" ng-if="page.languageSelectorIsOpen">
                     <button


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The introduction of SVG icons has had a slight unintended side effect: The language selector arrow always points to the right:

![language-selector-arrow-direction-before](https://user-images.githubusercontent.com/7405322/89280813-7610f180-d649-11ea-938d-6ad41d5f3e53.gif)

This PR fixes it:

![language-selector-arrow-direction](https://user-images.githubusercontent.com/7405322/89280740-5b3e7d00-d649-11ea-8c7c-3d8658f0d7da.gif)
