### PR TITLE
Fix: v7 Base64 image performance in rich text editor

### DIFF
--- a/src/Umbraco.Web/Templates/TemplateUtilities.cs
+++ b/src/Umbraco.Web/Templates/TemplateUtilities.cs
@@ -102,7 +102,7 @@ namespace Umbraco.Web.Templates
         private static readonly Regex ResolveUrlPattern = new Regex("(=[\"\']?)(\\W?\\~(?:.(?![\"\']?\\s+(?:\\S+)=|[>\"\']))+.)[\"\']?",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex ResolveImgPattern = new Regex(@"(<img[^>]*src="")([^""\?]*)([^""]*""[^>]*data-udi="")([^""]*)(""[^>]*>)",
+        private static readonly Regex ResolveImgPattern = new Regex(@"(<img[^>]*src="")([^""\?]*)((?:\?[^""]*)?""[^>]*data-udi="")([^""]*)(""[^>]*>)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

Issue: https://github.com/umbraco/Umbraco-CMS/issues/7386

This is fixed in v8: https://github.com/umbraco/Umbraco-CMS/pull/7530 

I believe this should be fixed in v7 as well. This issue causes server wide CPU spikes which can negatively influence multiple environments/processes on a single server. This makes it have a higher risk than just a performance issue.

To respect the changes already in v8, this is implemented very minimal.

### Changes
- Updated the Regex to match the v8 fix

### Test:
- Test with latest v7
1. Put an `<img src="[your base64 image string]" />` in a Rich Text Editor. (https://www.base64-image.de/)
2. Save and publish -> The process takes a long time

- Test with branch
1. Put an `<img src="[your base64 image string]" />` in a Rich Text Editor. (https://www.base64-image.de/)
2. Save and publish -> The process may take up to a few seconds