### PR TITLE
Netcore: Added request localization from the current user.

### DIFF
--- a/src/Umbraco.Core/Security/AuthenticationExtensions.cs
+++ b/src/Umbraco.Core/Security/AuthenticationExtensions.cs
@@ -17,11 +17,21 @@ namespace Umbraco.Core.Security
         /// <param name="identity"></param>
         public static void EnsureCulture(this IIdentity identity)
         {
+            var culture = GetCulture(identity);
+            if (!(culture is null))
+            {
+                Thread.CurrentThread.CurrentUICulture = Thread.CurrentThread.CurrentCulture = culture;
+            }
+        }
+
+        public static CultureInfo GetCulture(this IIdentity identity)
+        {
             if (identity is UmbracoBackOfficeIdentity umbIdentity && umbIdentity.IsAuthenticated)
             {
-                Thread.CurrentThread.CurrentUICulture =
-                    Thread.CurrentThread.CurrentCulture = UserCultures.GetOrAdd(umbIdentity.Culture, s => new CultureInfo(s));
+                return UserCultures.GetOrAdd(umbIdentity.Culture, s => new CultureInfo(s));
             }
+
+            return null;
         }
 
 

--- a/src/Umbraco.Web.Common/ApplicationModels/BackOfficeApplicationModelProvider.cs
+++ b/src/Umbraco.Web.Common/ApplicationModels/BackOfficeApplicationModelProvider.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Web.Common.Attributes;
+
+namespace Umbraco.Web.Common.ApplicationModels
+{
+    /// <summary>
+    /// An application model provider for all Umbraco Back Office controllers
+    /// </summary>
+    public class BackOfficeApplicationModelProvider : IApplicationModelProvider
+    {
+        public BackOfficeApplicationModelProvider(IModelMetadataProvider modelMetadataProvider)
+        {
+            ActionModelConventions = new List<IActionModelConvention>()
+            {         
+                new BackOfficeIdentityCultureConvention()
+            };
+        }
+
+        /// <summary>
+        /// Will execute after <see cref="DefaultApplicationModelProvider"/>
+        /// </summary>
+        public int Order => 0;
+
+        public List<IActionModelConvention> ActionModelConventions { get; }
+
+        public void OnProvidersExecuted(ApplicationModelProviderContext context)
+        {
+        }
+
+        public void OnProvidersExecuting(ApplicationModelProviderContext context)
+        {
+            foreach (var controller in context.Result.Controllers)
+            {
+                if (!IsBackOfficeController(controller))
+                    continue;
+
+                foreach (var action in controller.Actions)
+                {
+                    foreach (var convention in ActionModelConventions)
+                    {
+                        convention.Apply(action);
+                    }
+                }
+
+            }
+        }
+
+        private bool IsBackOfficeController(ControllerModel controller)
+        {
+            var pluginControllerAttribute = controller.Attributes.OfType<PluginControllerAttribute>().FirstOrDefault();
+            return pluginControllerAttribute != null
+                && pluginControllerAttribute.AreaName == Core.Constants.Web.Mvc.BackOfficeArea;
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/ApplicationModels/BackOfficeIdentityCultureConvention.cs
+++ b/src/Umbraco.Web.Common/ApplicationModels/BackOfficeIdentityCultureConvention.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Umbraco.Web.Common.Filters;
+
+namespace Umbraco.Web.Common.ApplicationModels
+{
+    public class BackOfficeIdentityCultureConvention : IActionModelConvention
+    {
+        public void Apply(ActionModel action)
+        {
+            action.Filters.Add(new BackOfficeCultureFilter());
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/ApplicationModels/UmbracoApiBehaviorApplicationModelProvider.cs
+++ b/src/Umbraco.Web.Common/ApplicationModels/UmbracoApiBehaviorApplicationModelProvider.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Web.Common.ApplicationModels
 {
 
     /// <summary>
-    /// A custom application model provider for Umbraco controllers
+    /// An application model provider for Umbraco API controllers to behave like WebApi controllers
     /// </summary>
     /// <remarks>
     /// <para>

--- a/src/Umbraco.Web.Common/Extensions/UmbracoBackOfficeIdentityCultureProvider.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoBackOfficeIdentityCultureProvider.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Umbraco.Core.Security;
+
+namespace Umbraco.Web.Common.Extensions
+{
+    public class UmbracoBackOfficeIdentityCultureProvider : RequestCultureProvider
+    {
+        public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
+        {
+            var culture = httpContext.User.Identity.GetCulture();
+
+            if (culture is null)
+            {
+                return NullProviderCultureResult;
+            }
+
+            return Task.FromResult(new ProviderCultureResult(culture.Name, culture.Name));
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
@@ -156,24 +156,7 @@ namespace Umbraco.Extensions
                 out factory);
 
             return services;
-        }
-
-        public static IServiceCollection AddUmbracoRequestLocalization(this IServiceCollection services)
-        {
-            services.Configure<RequestLocalizationOptions>(options =>
-            {
-                var supportedCultures = CultureInfo
-                    .GetCultures(CultureTypes.AllCultures & ~ CultureTypes.NeutralCultures)
-                    .Where(cul => !String.IsNullOrEmpty(cul.Name))
-                    .ToArray();
-
-                options.SupportedCultures = supportedCultures;
-                options.SupportedUICultures = supportedCultures;
-                options.AddInitialRequestCultureProvider(new UmbracoBackOfficeIdentityCultureProvider());
-            });
-
-            return services;
-        }
+        }   
 
         /// <summary>
         /// Adds the Umbraco Back Core requirements
@@ -200,9 +183,6 @@ namespace Umbraco.Extensions
             var container = umbContainer;
             if (container is null) throw new ArgumentNullException(nameof(container));
             if (entryAssembly is null) throw new ArgumentNullException(nameof(entryAssembly));
-
-            // Set culture options
-            services.AddUmbracoRequestLocalization();
 
             // Add supported databases
             services.AddUmbracoSqlCeSupport();

--- a/src/Umbraco.Web.Common/Extensions/UmbracoWebServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoWebServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ namespace Umbraco.Extensions
         {
             services.ConfigureOptions<UmbracoMvcConfigureOptions>();
             services.TryAddEnumerable(ServiceDescriptor.Transient<IApplicationModelProvider, UmbracoApiBehaviorApplicationModelProvider>());
+            services.TryAddEnumerable(ServiceDescriptor.Transient<IApplicationModelProvider, BackOfficeApplicationModelProvider>());
 
             // TODO: We need to avoid this, surely there's a way? See ContainerTests.BuildServiceProvider_Before_Host_Is_Configured
             var serviceProvider = services.BuildServiceProvider();

--- a/src/Umbraco.Web.Common/Filters/BackOfficeCultureFilter.cs
+++ b/src/Umbraco.Web.Common/Filters/BackOfficeCultureFilter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Umbraco.Core.Security;
+using System.Globalization;
+
+namespace Umbraco.Web.Common.Filters
+{
+    /// <summary>
+    /// Applied to all Umbraco controllers to ensure the thread culture is set to the culture assigned to the back office identity
+    /// </summary>
+    public class BackOfficeCultureFilter : IActionFilter
+    {
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var culture = context.HttpContext.User.Identity.GetCulture();
+            if (culture != null)
+            {
+                SetCurrentThreadCulture(culture);
+            }
+        }
+
+        private static void SetCurrentThreadCulture(CultureInfo culture)
+        {
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+    }
+
+
+}

--- a/src/Umbraco.Web.UI.NetCore/Startup.cs
+++ b/src/Umbraco.Web.UI.NetCore/Startup.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Umbraco.Extensions;
-using Umbraco.Web.Common.Middleware;
 
 namespace Umbraco.Web.UI.BackOffice
 {
@@ -80,6 +79,7 @@ namespace Umbraco.Web.UI.BackOffice
 
             app.UseUmbracoCore();
             app.UseUmbracoRouting();
+            app.UseRequestLocalization();
             app.UseUmbracoRequestLogging();
             app.UseUmbracoWebsite();
             app.UseUmbracoBackOffice();


### PR DESCRIPTION
## Details
Added a custom `RequestCultureProvider` to use the BackOffice user's language as culture.

Even that we already call `EnsureCulture` from the `OnValidatePrincipal` event. This is not enough, as the culture is reset when the thread hits the controller. 

## Test
1. Set the users language to a non-English language. E.g. danish.
1. Sign out
1. Sign in again
1. Verify the localization are updated. 

Note: I tested with multiple users with different languages.