### PR TITLE
Update content type icon on save

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -190,11 +190,18 @@ angular.module("umbraco.directives")
 
             var evts = [];
 
-            //listen for section changes
+            // Listen for section changes
             evts.push(eventsService.on("appState.sectionState.changed", function(e, args) {
                 if (args.key === "currentSection") {
                     //when the section changes disable all delete animations
                     scope.node.deleteAnimations = false;
+                }
+            }));
+
+            // Update tree icon is changed
+            evts.push(eventsService.on("editors.tree.icon.changed", function (e, args) {          
+                if (args.icon !== scope.node.icon && args.id === scope.node.id) {
+                    scope.node.icon = args.icon;
                 }
             }));
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtreeitem.directive.js
@@ -198,7 +198,7 @@ angular.module("umbraco.directives")
                 }
             }));
 
-            // Update tree icon is changed
+            // Update tree icon if changed
             evts.push(eventsService.on("editors.tree.icon.changed", function (e, args) {          
                 if (args.icon !== scope.node.icon && args.id === scope.node.id) {
                     scope.node.icon = args.icon;

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <i class="icon umb-tree-icon sprTree" ng-class="::node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></i>
+        <i class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></i>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <i class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></i>
+        <i class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1" aria-hidden="true"></i>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -4,7 +4,7 @@
         <div class="umb-tree-root" data-element="tree-root" ng-class="getNodeCssClass(tree.root)" ng-hide="hideheader === 'true'" on-right-click="altSelect(tree.root, $event)">
             <h5>
                 <a ng-href="#/{{section}}" ng-click="select(tree.root, $event)" class="umb-tree-root-link umb-outline" data-element="tree-root-link">
-                    <i ng-if="enablecheckboxes === 'true'" ng-class="selectEnabledNodeClass(tree.root)"></i>
+                    <i ng-if="enablecheckboxes === 'true'" ng-class="selectEnabledNodeClass(tree.root)" aria-hidden="true"></i>
                     {{tree.name}}
                 </a>
             </h5>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -21,6 +21,7 @@
         var isElement = $routeParams.iselement;
         var allowVaryByCulture = $routeParams.culturevary;
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
+        var documentTypeIcon = "";
 
         vm.save = save;
         vm.close = close;
@@ -354,6 +355,10 @@
                     // emit event
                     var args = { documentType: vm.contentType };
                     eventsService.emit("editors.documentType.saved", args);
+                    
+                    if (documentTypeIcon !== vm.contentType.icon) {
+                        eventsService.emit("editors.tree.icon.changed", args);
+                    }
 
                     vm.page.saveButtonState = "success";
 
@@ -402,10 +407,12 @@
             // convert icons for content type
             convertLegacyIcons(contentType);
 
-            vm.contentType = contentType;
-
             //set a shared state
-            editorState.set(vm.contentType);
+            editorState.set(contentType);
+
+            vm.contentType = contentType;
+            
+            documentTypeIcon = contentType.icon;
 
             loadButtons();
         }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -9,7 +9,10 @@
 (function () {
     "use strict";
 
-    function DocumentTypesEditController($scope, $routeParams, contentTypeResource, dataTypeResource, editorState, contentEditingHelper, formHelper, navigationService, iconHelper, contentTypeHelper, notificationsService, $q, localizationService, overlayHelper, eventsService, angularHelper, editorService) {
+    function DocumentTypesEditController($scope, $routeParams, $q,
+        contentTypeResource, editorState, contentEditingHelper,
+        navigationService, iconHelper, contentTypeHelper, notificationsService,
+        localizationService, overlayHelper, eventsService, angularHelper, editorService) {
 
         var vm = this;
         var evts = [];

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -10,7 +10,7 @@
     "use strict";
 
     function MediaTypesEditController($scope, $routeParams, $q,
-        mediaTypeResource, dataTypeResource, editorState, contentEditingHelper, 
+        mediaTypeResource, editorState, contentEditingHelper, 
         navigationService, iconHelper, contentTypeHelper, notificationsService,
         localizationService, overlayHelper, eventsService, angularHelper) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -19,6 +19,7 @@
         var mediaTypeId = $routeParams.id;
         var create = $routeParams.create;
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
+        var mediaTypeIcon = "";
 
         vm.save = save;
         vm.close = close;
@@ -282,7 +283,7 @@
         function save() {
 
             // only save if there is no overlays open
-            if(overlayHelper.getNumberOfOverlays() === 0) {
+            if (overlayHelper.getNumberOfOverlays() === 0) {
 
                 var deferred = $q.defer();
 
@@ -339,9 +340,13 @@
                     var args = { mediaType: vm.contentType };
                     eventsService.emit("editors.mediaType.saved", args);
 
+                    if (mediaTypeIcon !== vm.contentType.icon) {
+                        eventsService.emit("editors.tree.icon.changed", args);
+                    }
+
                     vm.page.saveButtonState = "success";
 
-                    if(infiniteMode && $scope.model.submit) {
+                    if (infiniteMode && $scope.model.submit) {
                         $scope.model.submit();
                     }
 
@@ -378,6 +383,8 @@
             editorState.set(contentType);
 
             vm.contentType = contentType;
+
+            mediaTypeIcon = contentType.icon;
         }
 
         function convertLegacyIcons(contentType) {

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -10,7 +10,7 @@
     "use strict";
 
     function MemberTypesEditController($scope, $routeParams, $q,
-        memberTypeResource, dataTypeResource, editorState, iconHelper,
+        memberTypeResource, editorState, iconHelper,
         navigationService, contentEditingHelper, notificationsService, localizationService,
         overlayHelper, contentTypeHelper, angularHelper, eventsService) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -19,6 +19,7 @@
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
         var memberTypeId = $routeParams.id;
         var create = $routeParams.create;
+        var memberTypeIcon = "";
 
         vm.save = save;
         vm.close = close;
@@ -259,6 +260,10 @@
                     var args = { memberType: vm.contentType };
                     eventsService.emit("editors.memberType.saved", args);
 
+                    if (memberTypeIcon !== vm.contentType.icon) {
+                        eventsService.emit("editors.tree.icon.changed", args);
+                    }
+
                     vm.page.saveButtonState = "success";
 
                     if(infiniteMode && $scope.model.submit) {
@@ -299,6 +304,8 @@
             editorState.set(contentType);
 
             vm.contentType = contentType;
+
+            memberTypeIcon = contentType.icon;
         }
 
         function convertLegacyIcons(contentType) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Now that content types (document, media and member types) use the specific content type icon in tree, it would be great if the node icon updated if icon is changing (icon or color).

With the PR it update the node icon in tree if the content type icon is different from the current content type icon. At the moment the event name is `editors.tree.icon.changed` - not sure if we have something better?

### Document Types

![2020-08-04_14-07-00](https://user-images.githubusercontent.com/2919859/89292118-1a9c2f00-d65c-11ea-997b-011bab91ae7e.gif)


### Media Types

![2020-08-04_14-11-12](https://user-images.githubusercontent.com/2919859/89292370-9007ff80-d65c-11ea-9756-b2ea36738bd9.gif)


### Member Types

![2020-08-04_14-14-24](https://user-images.githubusercontent.com/2919859/89292807-394ef580-d65d-11ea-9ec6-bc9cb99d273f.gif)
