### PR TITLE
Ensure that we validate all properties for a block based on it's element type properties, not just the property values that are POSTed

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockItemData.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockItemData.cs
@@ -49,8 +49,14 @@ namespace Umbraco.Core.Models.Blocks
         /// </summary>
         public class BlockPropertyValue
         {
-            public object Value { get; set; }
-            public PropertyType PropertyType { get; set; }
+            public BlockPropertyValue(object value, PropertyType propertyType)
+            {
+                Value = value;
+                PropertyType = propertyType ?? throw new ArgumentNullException(nameof(propertyType));
+            }
+
+            public object Value { get; }
+            public PropertyType PropertyType { get; }
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Web.PropertyEditors
                 _dataTypeService = dataTypeService;
                 _logger = logger;
                 _nestedContentValues = new NestedContentValues(contentTypeService);
-                Validators.Add(new NestedContentValidator(_nestedContentValues, propertyEditors, dataTypeService, textService));
+                Validators.Add(new NestedContentValidator(_nestedContentValues, propertyEditors, dataTypeService, textService, contentTypeService));
             }
 
             /// <inheritdoc />
@@ -283,17 +283,48 @@ namespace Umbraco.Web.PropertyEditors
         internal class NestedContentValidator : ComplexEditorValidator
         {
             private readonly NestedContentValues _nestedContentValues;
+            private readonly IContentTypeService _contentTypeService;
 
-            public NestedContentValidator(NestedContentValues nestedContentValues, PropertyEditorCollection propertyEditors, IDataTypeService dataTypeService, ILocalizedTextService textService)
+            public NestedContentValidator(NestedContentValues nestedContentValues, PropertyEditorCollection propertyEditors, IDataTypeService dataTypeService, ILocalizedTextService textService, IContentTypeService contentTypeService)
                 : base(propertyEditors, dataTypeService, textService)
             {
                 _nestedContentValues = nestedContentValues;
+                _contentTypeService = contentTypeService;
             }
 
             protected override IEnumerable<ElementTypeValidationModel> GetElementTypeValidation(object value)
             {
-                foreach (var row in _nestedContentValues.GetPropertyValues(value))
+                var rows = _nestedContentValues.GetPropertyValues(value);
+                if (rows.Count == 0) yield break;
+
+                // There is no guarantee that the client will post data for every property defined in the Element Type but we still
+                // need to validate that data for each property especially for things like 'required' data to work.
+                // Lookup all element types for all content/settings and then we can populate any empty properties.
+                var allElementAliases = rows.Select(x => x.ContentTypeAlias).ToList();
+                // unfortunately we need to get all content types and post filter - but they are cached so its ok, there's
+                // no overload to lookup by many aliases.
+                var allElementTypes = _contentTypeService.GetAll().Where(x => allElementAliases.Contains(x.Alias)).ToDictionary(x => x.Alias);
+
+                foreach (var row in rows)
                 {
+                    if (!allElementTypes.TryGetValue(row.ContentTypeAlias, out var elementType))
+                        throw new InvalidOperationException($"No element type found with alias {row.ContentTypeAlias}");
+
+                    // now ensure missing properties
+                    foreach (var elementTypeProp in elementType.CompositionPropertyTypes)
+                    {
+                        if (!row.PropertyValues.ContainsKey(elementTypeProp.Alias))
+                        {
+                            // set values to null
+                            row.PropertyValues[elementTypeProp.Alias] = new NestedContentValues.NestedContentPropertyValue
+                            {
+                                PropertyType = elementTypeProp,
+                                Value = null
+                            };
+                            row.RawPropertyValues[elementTypeProp.Alias] = null;
+                        }
+                    }
+
                     var elementValidation = new ElementTypeValidationModel(row.ContentTypeAlias, row.Id);
                     foreach (var prop in row.PropertyValues)
                     {


### PR DESCRIPTION
Fixes [AB#7590](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7590)

The problem is that the block editor or any other complex editor might not post a key/value for a given property if that property is empty. Before this PR it meant that this property was not actually validated. I think this solves the issue that might have been seen in [AB#7599](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7599). This fix also covers Nested Content server side validation for the same issue.

## Testing

Previous to this PR if you setup a block editor that has a property of type textfield that is 'required'. Create a content item and create a single row with this value filled in and save it which should be successful. Now if you refresh that page/editor and then open that single block row, remove that value and minimize that block row, then press save and publish, you may or may not get a server validation error. If you don't ... that is the bug. If you do get a validation error for that required field, then expand the row, remove the value and collapse the row which will clear validation errors. Then save and publish and you will not get a validation error ... that is the bug.

Try this PR and all should be fixed.