### PR TITLE
Netcore: Get rid of System.Web in netcore and netstandard projects

### DIFF
--- a/src/Umbraco.Core/IUmbracoContextFactory.cs
+++ b/src/Umbraco.Core/IUmbracoContextFactory.cs
@@ -1,5 +1,4 @@
-﻿using System.Web;
-
+﻿
 namespace Umbraco.Web
 {
     /// <summary>

--- a/src/Umbraco.Core/Install/InstallSteps/StarterKitCleanupStep.cs
+++ b/src/Umbraco.Core/Install/InstallSteps/StarterKitCleanupStep.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using Umbraco.Core.IO;
 using Umbraco.Web.Install.Models;
 
@@ -33,7 +33,7 @@ namespace Umbraco.Web.Install.InstallSteps
 
         private void CleanupInstallation(int packageId, string packageFile)
         {
-            var zipFile = new FileInfo(Path.Combine(_ioHelper.MapPath(Core.Constants.SystemDirectories.Packages), HttpUtility.UrlDecode(packageFile)));
+            var zipFile = new FileInfo(Path.Combine(_ioHelper.MapPath(Core.Constants.SystemDirectories.Packages), WebUtility.UrlDecode(packageFile)));
 
             if (zipFile.Exists)
                 zipFile.Delete();

--- a/src/Umbraco.Core/Models/PublishedContent/IndexedArrayItem.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IndexedArrayItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Web;
+﻿using System.Net;
 using Umbraco.Core.Strings;
 
 namespace Umbraco.Core.Models.PublishedContent
@@ -79,7 +79,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsFirst(string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsFirst() ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsFirst() ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsNotFirst(string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsNotFirst() ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsNotFirst() ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsIndex(int index, string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsIndex(index) ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsIndex(index) ? valueIfTrue : valueIfFalse));
          }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsModZero(int modulus, string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsModZero(modulus) ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsModZero(modulus) ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -243,7 +243,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsNotModZero(int modulus, string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsNotModZero(modulus) ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsNotModZero(modulus) ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsNotIndex(int index, string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsNotIndex(index) ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsNotIndex(index) ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsLast(string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsLast() ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsLast() ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsNotLast(string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsNotLast() ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsNotLast() ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsEven(string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsEven() ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsEven() ? valueIfTrue : valueIfFalse));
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace Umbraco.Core.Models.PublishedContent
         // TODO: This method should be removed or moved to an extension method on HtmlHelper.
         public IHtmlEncodedString IsOdd(string valueIfTrue, string valueIfFalse)
         {
-            return new HtmlEncodedString(HttpUtility.HtmlEncode(IsOdd() ? valueIfTrue : valueIfFalse));
+            return new HtmlEncodedString(WebUtility.HtmlEncode(IsOdd() ? valueIfTrue : valueIfFalse));
         }
     }
 }

--- a/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Web;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;

--- a/src/Umbraco.Core/Routing/RoutableAttemptEventArgs.cs
+++ b/src/Umbraco.Core/Routing/RoutableAttemptEventArgs.cs
@@ -1,6 +1,4 @@
-﻿using System.Web;
-
-namespace Umbraco.Web.Routing
+﻿namespace Umbraco.Web.Routing
 {
     /// <summary>
     /// Event args containing information about why the request was not routable, or if it is routable

--- a/src/Umbraco.Core/Routing/UmbracoRequestEventArgs.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestEventArgs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Web;
 
 namespace Umbraco.Web.Routing
 {

--- a/src/Umbraco.Core/Routing/UriUtility.cs
+++ b/src/Umbraco.Core/Routing/UriUtility.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using System.Web;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Configuration.UmbracoSettings;

--- a/src/Umbraco.Core/Templates/UmbracoComponentRenderer.cs
+++ b/src/Umbraco.Core/Templates/UmbracoComponentRenderer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.IO;
-using System.Web;
 using Umbraco.Web.Templates;
 using System.Collections.Generic;
+using System.Net;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Strings;
 using Umbraco.Web;
@@ -120,7 +120,7 @@ namespace Umbraco.Core.Templates
             //NOTE: the value could have HTML encoded values, so we need to deal with that
             var macroProps = parameters?.ToDictionary(
                 x => x.Key.ToLowerInvariant(),
-                i => (i.Value is string) ? HttpUtility.HtmlDecode(i.Value.ToString()) : i.Value);
+                i => (i.Value is string) ? WebUtility.HtmlDecode(i.Value.ToString()) : i.Value);
 
             var html = _macroRenderer.Render(alias, content, macroProps).Text;
 

--- a/src/Umbraco.Infrastructure/Media/EmbedProviders/Flickr.cs
+++ b/src/Umbraco.Infrastructure/Media/EmbedProviders/Flickr.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Web;
+using System.Net;
 
 namespace Umbraco.Web.Media.EmbedProviders
 {
@@ -14,7 +14,7 @@ namespace Umbraco.Web.Media.EmbedProviders
         };
 
         public override Dictionary<string, string> RequestParams => new Dictionary<string, string>();
-                
+
         public override string GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
         {
             var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
@@ -25,7 +25,7 @@ namespace Umbraco.Web.Media.EmbedProviders
             var imageHeight = GetXmlProperty(xmlDocument, "/oembed/height");
             var imageTitle = GetXmlProperty(xmlDocument, "/oembed/title");
 
-            return string.Format("<img src=\"{0}\" width=\"{1}\" height=\"{2}\" alt=\"{3}\" />", imageUrl, imageWidth, imageHeight, HttpUtility.HtmlEncode(imageTitle));
-        }        
+            return string.Format("<img src=\"{0}\" width=\"{1}\" height=\"{2}\" alt=\"{3}\" />", imageUrl, imageWidth, imageHeight, WebUtility.HtmlEncode(imageTitle));
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Media/EmbedProviders/OEmbedResponse.cs
+++ b/src/Umbraco.Infrastructure/Media/EmbedProviders/OEmbedResponse.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using System.Web;
+﻿using System.Net;
 using Newtonsoft.Json;
 
 namespace Umbraco.Web.Media.EmbedProviders
@@ -52,7 +51,7 @@ namespace Umbraco.Web.Media.EmbedProviders
         {
             if (Type == "photo")
             {
-                return "<img src=\"" + Url + "\" width=\"" + Width + "\" height=\"" + Height + "\" alt=\"" + HttpUtility.HtmlEncode(Title) + "\" />";
+                return "<img src=\"" + Url + "\" width=\"" + Width + "\" height=\"" + Height + "\" alt=\"" + WebUtility.HtmlEncode(Title) + "\" />";
             }
 
             return string.IsNullOrEmpty(Html) == false ? Html : string.Empty;

--- a/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
@@ -7,7 +7,6 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Umbraco.Core.Configuration;
-using System.Web;
 using Umbraco.Core.Hosting;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;

--- a/src/Umbraco.Web.BackOffice/Controllers/PackageController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PackageController.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Web;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
 using Semver;
@@ -113,16 +112,15 @@ namespace Umbraco.Web.BackOffice.Controllers
 
             var cd = new System.Net.Mime.ContentDisposition
             {
-                FileName =  HttpUtility.UrlEncode(fileName, encoding),
+                FileName =  WebUtility.UrlEncode(fileName),
                 Inline = false  // false = prompt the user for downloading;  true = browser to try to show the file inline
             };
             Response.Headers.Add("Content-Disposition", cd.ToString());
             // Set custom header so umbRequestHelper.downloadFile can save the correct filename
-            Response.Headers.Add("x-filename", HttpUtility.UrlEncode(fileName, encoding));
+            Response.Headers.Add("x-filename", WebUtility.UrlEncode(fileName));
             return new FileStreamResult(System.IO.File.OpenRead(fullPath), new MediaTypeHeaderValue("application/octet-stream")
             {
                 Charset = encoding.WebName,
-
             });
 
         }

--- a/src/Umbraco.Web.BackOffice/Trees/FileSystemTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/FileSystemTreeController.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Web;
+using System.Net;
 using Microsoft.AspNetCore.Http;
 using Umbraco.Core;
 using Umbraco.Core.IO;
@@ -48,7 +48,7 @@ namespace Umbraco.Web.BackOffice.Trees
         protected override TreeNodeCollection GetTreeNodes(string id, FormCollection queryStrings)
         {
             var path = string.IsNullOrEmpty(id) == false && id != Constants.System.RootString
-                ? HttpUtility.UrlDecode(id).TrimStart("/")
+                ? WebUtility.UrlDecode(id).TrimStart("/")
                 : "";
 
             var directories = FileSystem.GetDirectories(path);
@@ -59,7 +59,7 @@ namespace Umbraco.Web.BackOffice.Trees
                 var hasChildren = FileSystem.GetFiles(directory).Any() || FileSystem.GetDirectories(directory).Any();
 
                 var name = Path.GetFileName(directory);
-                var node = CreateTreeNode(HttpUtility.UrlEncode(directory), path, queryStrings, name, "icon-folder", hasChildren);
+                var node = CreateTreeNode(WebUtility.UrlEncode(directory), path, queryStrings, name, "icon-folder", hasChildren);
                 OnRenderFolderNode(ref node);
                 if (node != null)
                     nodes.Add(node);
@@ -83,7 +83,7 @@ namespace Umbraco.Web.BackOffice.Trees
                 if (withoutExt.IsNullOrWhiteSpace()) continue;
 
                 var name = Path.GetFileName(file);
-                var node = CreateTreeNode(HttpUtility.UrlEncode(file), path, queryStrings, name, FileIcon, false);
+                var node = CreateTreeNode(WebUtility.UrlEncode(file), path, queryStrings, name, FileIcon, false);
                 OnRenderFileNode(ref node);
                 if (node != null)
                     nodes.Add(node);
@@ -159,7 +159,7 @@ namespace Umbraco.Web.BackOffice.Trees
             var menu = MenuItemCollectionFactory.Create();
 
             var path = string.IsNullOrEmpty(id) == false && id != Constants.System.RootString
-                ? HttpUtility.UrlDecode(id).TrimStart("/")
+                ? WebUtility.UrlDecode(id).TrimStart("/")
                 : "";
 
             var isFile = FileSystem.FileExists(path);

--- a/src/Umbraco.Web.BackOffice/Trees/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/UrlHelperExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Text;
-using System.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Core;
@@ -32,7 +32,7 @@ namespace Umbraco.Extensions
 
             for (var p = 0; p < pathPaths.Length; p++)
             {
-                var path = HttpUtility.UrlEncode(string.Join("/", pathPaths.Take(p + 1)));
+                var path = WebUtility.UrlEncode(string.Join("/", pathPaths.Take(p + 1)));
                 if (string.IsNullOrEmpty(path) == false)
                 {
                     sb.Append(",");

--- a/src/Umbraco.Web.Website/Controllers/SurfaceController.cs
+++ b/src/Umbraco.Web.Website/Controllers/SurfaceController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using Microsoft.AspNetCore.Http;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
@@ -58,20 +59,9 @@ namespace Umbraco.Web.Website.Controllers
         /// Redirects to the Umbraco page with the given id and passes provided querystring
         /// </summary>
         /// <param name="pageId"></param>
-        /// <param name="queryStringValues"></param>
-        /// <returns></returns>
-        protected RedirectToUmbracoPageResult RedirectToUmbracoPage(int pageId, NameValueCollection queryStringValues)
-        {
-            return new RedirectToUmbracoPageResult(pageId, queryStringValues, _publishedUrlProvider, UmbracoContextAccessor);
-        }
-
-        /// <summary>
-        /// Redirects to the Umbraco page with the given id and passes provided querystring
-        /// </summary>
-        /// <param name="pageId"></param>
         /// <param name="queryString"></param>
         /// <returns></returns>
-        protected RedirectToUmbracoPageResult RedirectToUmbracoPage(int pageId, string queryString)
+        protected RedirectToUmbracoPageResult RedirectToUmbracoPage(int pageId, QueryString queryString)
         {
             return new RedirectToUmbracoPageResult(pageId, queryString, _publishedUrlProvider, UmbracoContextAccessor);
         }
@@ -90,20 +80,9 @@ namespace Umbraco.Web.Website.Controllers
         /// Redirects to the Umbraco page with the given published content and passes provided querystring
         /// </summary>
         /// <param name="publishedContent"></param>
-        /// <param name="queryStringValues"></param>
-        /// <returns></returns>
-        protected RedirectToUmbracoPageResult RedirectToUmbracoPage(IPublishedContent publishedContent, NameValueCollection queryStringValues)
-        {
-            return new RedirectToUmbracoPageResult(publishedContent, queryStringValues, _publishedUrlProvider, UmbracoContextAccessor);
-        }
-
-        /// <summary>
-        /// Redirects to the Umbraco page with the given published content and passes provided querystring
-        /// </summary>
-        /// <param name="publishedContent"></param>
         /// <param name="queryString"></param>
         /// <returns></returns>
-        protected RedirectToUmbracoPageResult RedirectToUmbracoPage(IPublishedContent publishedContent, string queryString)
+        protected RedirectToUmbracoPageResult RedirectToUmbracoPage(IPublishedContent publishedContent, QueryString queryString)
         {
             return new RedirectToUmbracoPageResult(publishedContent, queryString, _publishedUrlProvider, UmbracoContextAccessor);
         }
@@ -120,19 +99,9 @@ namespace Umbraco.Web.Website.Controllers
         /// <summary>
         /// Redirects to the currently rendered Umbraco page and passes provided querystring
         /// </summary>
-        /// <param name="queryStringValues"></param>
-        /// <returns></returns>
-        protected RedirectToUmbracoPageResult RedirectToCurrentUmbracoPage(NameValueCollection queryStringValues)
-        {
-            return new RedirectToUmbracoPageResult(CurrentPage, queryStringValues, _publishedUrlProvider, UmbracoContextAccessor);
-        }
-
-        /// <summary>
-        /// Redirects to the currently rendered Umbraco page and passes provided querystring
-        /// </summary>
         /// <param name="queryString"></param>
         /// <returns></returns>
-        protected RedirectToUmbracoPageResult RedirectToCurrentUmbracoPage(string queryString)
+        protected RedirectToUmbracoPageResult RedirectToCurrentUmbracoPage(QueryString queryString)
         {
             return new RedirectToUmbracoPageResult(CurrentPage, queryString, _publishedUrlProvider, UmbracoContextAccessor);
         }


### PR DESCRIPTION
- Replaced `System.Web.HttpUtility` with `System.Net.WebUtility`
- Replaced querystrings as `String`s and `NameValueCollection`s with the `QueryString` type