### PR TITLE
Do not require the umbVariantContent in the context of the DocumentTypeEditor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -64,7 +64,7 @@
         });
 
         vm.$onInit = function() {
-            if (!vm.umbVariantContent) {
+            if (vm.umbProperty && !vm.umbVariantContent) {// if we dont have vm.umbProperty, it means we are in the DocumentTypeEditor.
                 // not found, then fallback to searching the scope chain, this may be needed when DOM inheritance isn't maintained but scope
                 // inheritance is (i.e.infinite editing)
                 var found = angularHelper.traverseScopeChain($scope, s => s && s.vm && s.vm.constructor.name === "umbVariantContentController");


### PR DESCRIPTION
When preview the Block List editor in the DocumentTypeEditor we do not have umbVariantContent available which resulted in this error: "Could not find umbVariantContent in the $scope chain".
But we can use "vm.umbProperty" to check whether we are in this weird context of the DocumentTypeEditor, and then not start the scope searching.