### PR TITLE
rename contentTypeKey for consistency.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -363,12 +363,12 @@
              * @ngdoc method
              * @name getBlockConfiguration
              * @methodOf umbraco.services.blockEditorModelObject
-             * @description Get block configuration object for a given contentTypeKey.
-             * @param {string} key contentTypeKey to recive the configuration model for.
-             * @returns {Object | null} Configuration model for the that specific block. Or ´null´ if the contentTypeKey isnt available in the current block configurations.
+             * @description Get block configuration object for a given contentElementTypeKey.
+             * @param {string} key contentElementTypeKey to recive the configuration model for.
+             * @returns {Object | null} Configuration model for the that specific block. Or ´null´ if the contentElementTypeKey isnt available in the current block configurations.
              */
             getBlockConfiguration: function (key) {
-                return this.blockConfigurations.find(bc => bc.contentTypeKey === key) || null;
+                return this.blockConfigurations.find(bc => bc.contentElementTypeKey === key) || null;
             },
 
             /**
@@ -397,7 +397,8 @@
                 var scaffoldKeys = [];
 
                 this.blockConfigurations.forEach(blockConfiguration => {
-                    scaffoldKeys.push(blockConfiguration.contentTypeKey);
+                    console.log(blockConfiguration)
+                    scaffoldKeys.push(blockConfiguration.contentElementTypeKey);
                     if (blockConfiguration.settingsElementTypeKey != null) {
                         scaffoldKeys.push(blockConfiguration.settingsElementTypeKey);
                     }
@@ -426,7 +427,7 @@
              * @return {Array} array of strings representing alias.
              */
             getAvailableAliasesForBlockContent: function () {
-                return this.blockConfigurations.map(blockConfiguration => this.getScaffoldFromKey(blockConfiguration.contentTypeKey).contentTypeAlias);
+                return this.blockConfigurations.map(blockConfiguration => this.getScaffoldFromKey(blockConfiguration.contentElementTypeKey).contentTypeAlias);
             },
 
             /**
@@ -442,7 +443,7 @@
                 var blocks = [];
 
                 this.blockConfigurations.forEach(blockConfiguration => {
-                    var scaffold = this.getScaffoldFromKey(blockConfiguration.contentTypeKey);
+                    var scaffold = this.getScaffoldFromKey(blockConfiguration.contentElementTypeKey);
                     if (scaffold) {
                         blocks.push({
                             blockConfigModel: blockConfiguration,
@@ -514,12 +515,12 @@
                 var contentScaffold;
 
                 if (blockConfiguration === null) {
-                    console.error("The block entry of " + contentUdi + " is not being initialized because its contentTypeKey is not allowed for this PropertyEditor");
+                    console.error("The block of " + contentUdi + " is not being initialized because its contentTypeKey('" + dataModel.contentTypeKey + "') is not allowed for this PropertyEditor");
                 }
                 else {
-                    contentScaffold = this.getScaffoldFromKey(blockConfiguration.contentTypeKey);
+                    contentScaffold = this.getScaffoldFromKey(blockConfiguration.contentElementTypeKey);
                     if (contentScaffold === null) {
-                        console.error("The block entry of " + contentUdi + " is not begin initialized cause its Element Type was not loaded.");
+                        console.error("The block of " + contentUdi + " is not begin initialized cause its Element Type was not loaded.");
                     }
                 }
 
@@ -705,18 +706,18 @@
              * @name create
              * @methodOf umbraco.services.blockEditorModelObject
              * @description Create a empty layout entry, notice the layout entry is not added to the property editors model layout object, since the layout sturcture depends on the property editor.
-             * @param {string} contentTypeKey the contentTypeKey of the block you wish to create, if contentTypeKey is not avaiable in the block configuration then ´null´ will be returned.
-             * @return {Object | null} Layout entry object, to be inserted at a decired location in the layout object. Or null if contentTypeKey is unavaiaible.
+             * @param {string} contentElementTypeKey the contentElementTypeKey of the block you wish to create, if contentElementTypeKey is not avaiable in the block configuration then ´null´ will be returned.
+             * @return {Object | null} Layout entry object, to be inserted at a decired location in the layout object. Or null if contentElementTypeKey is unavaiaible.
              */
-            create: function (contentTypeKey) {
+            create: function (contentElementTypeKey) {
 
-                var blockConfiguration = this.getBlockConfiguration(contentTypeKey);
+                var blockConfiguration = this.getBlockConfiguration(contentElementTypeKey);
                 if (blockConfiguration === null) {
                     return null;
                 }
 
                 var entry = {
-                    contentUdi: createDataEntry(contentTypeKey, this.value.contentData)
+                    contentUdi: createDataEntry(contentElementTypeKey, this.value.contentData)
                 }
 
                 if (blockConfiguration.settingsElementTypeKey != null) {
@@ -737,9 +738,9 @@
 
                 elementTypeDataModel = Utilities.copy(elementTypeDataModel);
 
-                var contentTypeKey = elementTypeDataModel.contentTypeKey;
+                var contentElementTypeKey = elementTypeDataModel.contentTypeKey;
 
-                var layoutEntry = this.create(contentTypeKey);
+                var layoutEntry = this.create(contentElementTypeKey);
                 if (layoutEntry === null) {
                     return null;
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
@@ -51,7 +51,7 @@
 
         vm.requestRemoveBlockByIndex = function (index) {
             localizationService.localizeMany(["general_delete", "blockEditor_confirmDeleteBlockMessage", "blockEditor_confirmDeleteBlockNotice"]).then(function (data) {
-                var contentElementType = vm.getElementTypeByKey($scope.model.value[index].contentTypeKey);
+                var contentElementType = vm.getElementTypeByKey($scope.model.value[index].contentElementTypeKey);
                 overlayService.confirmDelete({
                     title: data[0],
                     content: localizationService.tokenReplace(data[1], [contentElementType.name]),
@@ -70,19 +70,19 @@
         vm.removeBlockByIndex = function (index) {
             $scope.model.value.splice(index, 1);
         };
-        
+
         vm.sortableOptions = {
             "ui-floating": true,
             items: "umb-block-card",
             cursor: "grabbing",
             placeholder: 'umb-block-card --sortable-placeholder'
         };
-        
+
 
         vm.getAvailableElementTypes = function () {
             return vm.elementTypes.filter(function (type) {
                 return !$scope.model.value.find(function (entry) {
-                    return type.key === entry.contentTypeKey;
+                    return type.key === entry.contentElementTypeKey;
                 });
             });
         };
@@ -99,14 +99,14 @@
 
             //we have to add the 'alias' property to the objects, to meet the data requirements of itempicker.
             var selectedItems = Utilities.copy($scope.model.value).forEach((obj) => {
-                obj.alias = vm.getElementTypeByKey(obj.contentTypeKey).alias;
+                obj.alias = vm.getElementTypeByKey(obj.contentElementTypeKey).alias;
                 return obj;
             });
 
             var availableItems = vm.getAvailableElementTypes()
 
             localizationService.localizeMany(["blockEditor_headlineCreateBlock", "blockEditor_labelcreateNewElementType"]).then(function(localized) {
-                
+
                 var elemTypeSelectorOverlay = {
                     view: "itempicker",
                     title: localized[0],
@@ -133,7 +133,7 @@
                 };
 
                 overlayService.open(elemTypeSelectorOverlay);
-                
+
             });
         };
 
@@ -158,7 +158,7 @@
         vm.addBlockFromElementTypeKey = function(key) {
 
             var entry = {
-                "contentTypeKey": key,
+                "contentElementTypeKey": key,
                 "settingsElementTypeKey": null,
                 "labelTemplate": "",
                 "view": null,
@@ -178,7 +178,7 @@
 
         vm.openBlockOverlay = function (block) {
 
-            localizationService.localize("blockEditor_blockConfigurationOverlayTitle", [vm.getElementTypeByKey(block.contentTypeKey).name]).then(function (data) {
+            localizationService.localize("blockEditor_blockConfigurationOverlayTitle", [vm.getElementTypeByKey(block.contentElementTypeKey).name]).then(function (data) {
 
                 var clonedBlockData = Utilities.copy(block);
                 vm.openBlock = block;
@@ -209,7 +209,7 @@
         $scope.$on('$destroy', function () {
             unsubscribe.forEach(u => { u(); });
         });
-        
+
         onInit();
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
@@ -11,7 +11,7 @@
 
         <umb-block-card
             block-config-model="block"
-            element-type-model="vm.getElementTypeByKey(block.contentTypeKey)"
+            element-type-model="vm.getElementTypeByKey(block.contentElementTypeKey)"
             ng-repeat="block in model.value"
             ng-class="{'--isOpen':vm.openBlock === block}"
             ng-click="vm.openBlockOverlay(block)">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -23,7 +23,7 @@
             return elementTypeResource.getAll().then(function (elementTypes) {
                 vm.elementTypes = elementTypes;
 
-                vm.contentPreview = vm.getElementTypeByKey(vm.block.contentTypeKey);
+                vm.contentPreview = vm.getElementTypeByKey(vm.block.contentElementTypeKey);
                 vm.settingsPreview = vm.getElementTypeByKey(vm.block.settingsElementTypeKey);
             });
         }
@@ -167,7 +167,7 @@
                     }
                 };
                 editorService.treePicker(filePicker);
-            
+
             });
         }
         vm.requestRemoveViewForBlock = function(block) {
@@ -190,10 +190,10 @@
         };
 
 
-        
+
         vm.addStylesheetForBlock = function(block) {
             localizationService.localize("blockEditor_headlineAddCustomStylesheet").then(function(localizedTitle) {
-                    
+
                 const filePicker = {
                     title: localizedTitle,
                     section: "settings",

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -106,10 +106,10 @@
                                 <div class="umb-el-wrap">
                                     <label class="control-label"><localize key="blockEditor_labelContentElementType">Content ElementType</localize></label>
                                     <div class="controls">
-                                        <div class="__settings-input --hasValue" ng-if="vm.block.contentTypeKey !== null" >
+                                        <div class="__settings-input --hasValue" ng-if="vm.block.contentElementTypeKey !== null" >
                                             <umb-node-preview icon="vm.contentPreview.icon" name="vm.contentPreview.name" alias="vm.contentPreview.alias"></umb-node-preview>
                                             <div class="__control-actions">
-                                                <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.contentTypeKey)">
+                                                <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.contentElementTypeKey)">
                                                     <i class="icon icon-edit"></i>
                                                 </button>
                                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -225,16 +225,16 @@
 
             block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true || inlineEditing === true;
             block.showSettings = block.config.settingsElementTypeKey != null;
-            block.showCopy = vm.supportCopy && block.config.contentTypeKey != null;// if we have content, otherwise it doesn't make sense to copy.
+            block.showCopy = vm.supportCopy && block.config.contentElementTypeKey != null;// if we have content, otherwise it doesn't make sense to copy.
 
             return block;
         }
 
 
-        function addNewBlock(index, contentTypeKey) {
+        function addNewBlock(index, contentElementTypeKey) {
 
             // Create layout entry. (not added to property model jet.)
-            var layoutEntry = modelObject.create(contentTypeKey);
+            var layoutEntry = modelObject.create(contentElementTypeKey);
             if (layoutEntry === null) {
                 return false;
             }
@@ -403,7 +403,7 @@
                 submit: function(blockPickerModel, mouseEvent) {
                     var added = false;
                     if (blockPickerModel && blockPickerModel.selectedItem) {
-                        added = addNewBlock(createIndex, blockPickerModel.selectedItem.blockConfigModel.contentTypeKey);
+                        added = addNewBlock(createIndex, blockPickerModel.selectedItem.blockConfigModel.contentElementTypeKey);
                     }
 
                     if(!(mouseEvent.ctrlKey || mouseEvent.metaKey)) {

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/block-editor-service.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/block-editor-service.spec.js
@@ -11,7 +11,7 @@
     beforeEach(module('umbraco.resources'));
     beforeEach(module('umbraco.mocks'));
     beforeEach(module('umbraco'));
-    
+
     beforeEach(inject(function ($injector, mocksUtils, _$rootScope_, _$q_, _$timeout_) {
 
         mocksUtils.disableAuth();
@@ -41,7 +41,7 @@
     }));
 
 
-    var blockConfigurationMock = { contentTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: null, view: "testview.html" };
+    var blockConfigurationMock = { contentElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: null, view: "testview.html" };
 
     var propertyModelMock = {
         layout: {
@@ -60,7 +60,7 @@
         ]
     };
 
-    var blockWithSettingsConfigurationMock = { contentTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", view: "testview.html" };
+    var blockWithSettingsConfigurationMock = { contentElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", view: "testview.html" };
     var propertyModelWithSettingsMock = {
         layout: {
             "Umbraco.TestBlockEditor": [
@@ -105,17 +105,17 @@
         it('getBlockConfiguration provide the requested block configurtion', function () {
             var modelObject = blockEditorService.createModelObject({}, "Umbraco.TestBlockEditor", [blockConfigurationMock], $scope, $scope);
 
-            expect(modelObject.getBlockConfiguration(blockConfigurationMock.contentTypeKey).label).toBe(blockConfigurationMock.label);
+            expect(modelObject.getBlockConfiguration(blockConfigurationMock.contentElementTypeKey).label).toBe(blockConfigurationMock.label);
         });
 
         it('load provides data for itemPicker', function (done) {
             var modelObject = blockEditorService.createModelObject({}, "Umbraco.TestBlockEditor", [blockConfigurationMock], $scope, $scope);
 
-            modelObject.load().then(() => {                
+            modelObject.load().then(() => {
                 try {
                     var itemPickerOptions = modelObject.getAvailableBlocksForBlockPicker();
                     expect(itemPickerOptions.length).toBe(1);
-                    expect(itemPickerOptions[0].blockConfigModel.contentTypeKey).toBe(blockConfigurationMock.contentTypeKey);
+                    expect(itemPickerOptions[0].blockConfigModel.contentElementTypeKey).toBe(blockConfigurationMock.contentElementTypeKey);
                     done();
                 } catch (e) {
                     done.fail(e);
@@ -139,7 +139,7 @@
                     expect(layout).not.toBeUndefined();
                     expect(layout.length).toBe(1);
                     expect(layout[0]).toBe(propertyModelMock.layout["Umbraco.TestBlockEditor"][0]);
-                    expect(layout[0].udi).toBe(propertyModelMock.layout["Umbraco.TestBlockEditor"][0].udi);
+                    expect(layout[0].contentUdi).toBe(propertyModelMock.layout["Umbraco.TestBlockEditor"][0].contentUdi);
 
                     done();
                 } catch (e) {
@@ -241,10 +241,10 @@
                         done();
                     });
 
-                    
+
                 } catch (e) {
                     done.fail(e);
-                }                
+                }
             });
 
             $rootScope.$digest();
@@ -362,7 +362,7 @@
 
                     done();
                 });
-                
+
             });
 
             $rootScope.$digest();
@@ -406,7 +406,7 @@
                         done();
                     });
 
-                    
+
                 } catch (e) {
                     done.fail(e);
                 }

--- a/src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs
@@ -27,8 +27,7 @@ namespace Umbraco.Web.PropertyEditors
             [JsonProperty("thumbnail")]
             public string Thumbnail { get; set; }
 
-            // TODO: This is named inconsistently in JS but renaming it needs to be done in quite a lot of places, this should be contentElementTypeKey
-            [JsonProperty("contentTypeKey")]
+            [JsonProperty("contentElementTypeKey")]
             public Guid ContentElementTypeKey { get; set; }
 
             [JsonProperty("settingsElementTypeKey")]


### PR DESCRIPTION
Rename JSON property contentTypeKey to contentElementTypeKey.

the naming of contentTypeKey is inconsistent with others in src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs this PR changes that.