### PR TITLE
Fix server validation issue with block editor due to cultures not being carried over correctly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -168,6 +168,7 @@
                         vm.inviteStep = 2;
 
                     }, function (err) {
+                        formHelper.resetForm({ scope: $scope, hasErrors: true });
                         formHelper.handleError(err);
                         vm.invitedUserPasswordModel.buttonState = "error";
                     });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -581,6 +581,7 @@
                                 eventsService.emit("content.unpublished", { content: $scope.content });
                                 overlayService.close();
                             }, function (err) {
+                                formHelper.resetForm({ scope: $scope, hasErrors: true });
                                 $scope.page.buttonGroupState = 'error';
                                 handleHttpException(err);
                             });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -159,9 +159,6 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
                 element.removeClass(SHOW_VALIDATION_CLASS_NAME);
                 scope.showValidation = false;
                 notifySubView();
-                //clear form state as at this point we retrieve new data from the server
-                //and all validation will have cleared at this point
-                formCtrl.$setPristine();
             }));
 
             var confirmed = false;
@@ -238,6 +235,8 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
                 }
             });
 
+            // TODO: I'm unsure why this exists, i believe this may be a hack for something like tinymce which might automatically
+            // change a form value on load but we need it to be $pristine?
             $timeout(function () {
                 formCtrl.$setPristine();
             }, 1000);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valpropertymsg.directive.js
@@ -306,7 +306,15 @@ function valPropertyMsg(serverValidationManager, localizationService, angularHel
                                 formCtrl.$setValidity('valPropertyMsg', false);
                                 startWatch();
 
-                                
+                                // This check is required in order to be able to reset ourselves and is typically for complex editor
+                                // scenarios where the umb-property itself doesn't contain any ng-model controls which means that the
+                                // above serverValidityResetter technique will not work to clear valPropertyMsg errors.
+                                // In order for this to work we rely on the current form controller's $pristine state. This means that anytime
+                                // the form is submitted whether there are validation errors or not the state must be reset... this is automatically
+                                // taken care of with the formHelper.resetForm method that should be used in all cases. $pristine is required because it's
+                                // a value that is cascaded to all form controls based on the hierarchy of child ng-model controls. This allows us to easily
+                                // know if a value has changed. The alternative is what we used to do which was to put a deep $watch on the entire complex value
+                                // which is hugely inefficient. 
                                 if (propertyErrors.length === 1 && hadError && !formCtrl.$pristine) {
                                     var propertyValidationPath = umbPropCtrl.getValidationPath();
                                     serverValidationManager.removePropertyError(propertyValidationPath, currentCulture, "", currentSegment);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valservermatch.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valservermatch.directive.js
@@ -54,6 +54,8 @@ function valServerMatch(serverValidationManager) {
 
             function bindCallback(validationKey, matchVal, matchType) {
 
+                if (!matchVal) return;
+
                 if (Utilities.isString(matchVal)) {
                     matchVal = [matchVal]; // normalize to an array since the value can also natively be an array
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -351,7 +351,8 @@
                 // update our values
                 this.value = propertyModelValue;
                 this.value.layout = this.value.layout || {};
-                this.value.data = this.value.data || [];
+                this.value.contentData = this.value.contentData || [];
+                this.value.settingsData = this.value.settingsData || [];
 
                 // re-create the watchers
                 this.__watchers = [];

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -117,6 +117,9 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                         return $q.resolve(data);
 
                     }, function (err) {
+
+                        formHelper.resetForm({ scope: args.scope, hasErrors: true });
+
                         self.handleSaveError({
                             showNotifications: args.showNotifications,
                             softRedirect: args.softRedirect,

--- a/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
@@ -47,6 +47,9 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
             // Some property editors need to perform an action after all property editors have reacted to the formSubmitting.
             args.scope.$broadcast("postFormSubmitting", { scope: args.scope, action: args.action });
 
+            // Set the form state to submitted
+            currentForm.$setSubmitted();
+
             //then check if the form is valid
             if (!args.skipValidation) {
                 if (currentForm.$invalid) {
@@ -77,14 +80,28 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
          * @param {object} args An object containing arguments for form submission
          */
         resetForm: function (args) {
+
+            var currentForm;
+
             if (!args) {
                 throw "args cannot be null";
             }
             if (!args.scope) {
                 throw "args.scope cannot be null";
             }
+            if (!args.formCtrl) {
+                //try to get the closest form controller
+                currentForm = angularHelper.getRequiredCurrentForm(args.scope);
+            }
+            else {
+                currentForm = args.formCtrl;
+            }
 
-            args.scope.$broadcast("formSubmitted", { scope: args.scope });
+            // Set the form state to pristine
+            currentForm.$setPristine();
+            currentForm.$setUntouched();
+
+            args.scope.$broadcast(args.hasErrors ? "formSubmittedValidationFailed" : "formSubmitted", { scope: args.scope });
         },
 
         showNotifications: function (args) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
@@ -160,7 +160,7 @@ angular.module("umbraco")
                     }, 2000);
 
                 }, function (err) {
-
+                    formHelper.resetForm({ scope: $scope, hasErrors: true });
                     formHelper.handleError(err);
 
                     $scope.changePasswordButtonState = "error";

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.createblueprint.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.createblueprint.controller.js
@@ -1,50 +1,50 @@
 ﻿(function () {
 
-  function CreateBlueprintController(
-    $scope,
-    contentResource,
-    navigationService,
-    localizationService,
-    formHelper,
-    contentEditingHelper) {
+    function CreateBlueprintController(
+        $scope,
+        contentResource,
+        navigationService,
+        localizationService,
+        formHelper,
+        contentEditingHelper) {
 
-    $scope.message = {
-      name: $scope.currentNode.name
-    };
+        $scope.message = {
+            name: $scope.currentNode.name
+        };
 
-    localizationService.localize("blueprints_createBlueprintFrom", ["<em>" + $scope.message.name + "</em>"]).then(function (localizedVal) {
-      $scope.title = localizedVal;
-    });
+        localizationService.localize("blueprints_createBlueprintFrom", ["<em>" + $scope.message.name + "</em>"]).then(function (localizedVal) {
+            $scope.title = localizedVal;
+        });
 
-    $scope.cancel = function () {
-      navigationService.hideMenu();
-    };
+        $scope.cancel = function () {
+            navigationService.hideMenu();
+        };
 
-    $scope.create = function () {
-      if (formHelper.submitForm({
-        scope: $scope,
-        formCtrl: this.blueprintForm
-      })) {
+        $scope.create = function () {
+            if (formHelper.submitForm({
+                scope: $scope,
+                formCtrl: this.blueprintForm
+            })) {
 
-        contentResource.createBlueprintFromContent($scope.currentNode.id, $scope.message.name)
-          .then(function(data) {
+                contentResource.createBlueprintFromContent($scope.currentNode.id, $scope.message.name)
+                    .then(function (data) {
 
-              formHelper.resetForm({ scope: $scope });
+                        formHelper.resetForm({ scope: $scope });
 
-              navigationService.hideMenu();
-            },
-            function(err) {
+                        navigationService.hideMenu();
+                    },
+                        function (err) {
+                            formHelper.resetForm({ scope: $scope, hasErrors: true });
+                            contentEditingHelper.handleSaveError({
+                                err: err
+                            });
 
-              contentEditingHelper.handleSaveError({
-                err: err
-              });
-
+                        }
+                    );
             }
-          );
-      }
-    };
-  }
+        };
+    }
 
-  angular.module("umbraco").controller("Umbraco.Editors.Content.CreateBlueprintController", CreateBlueprintController);
+    angular.module("umbraco").controller("Umbraco.Editors.Content.CreateBlueprintController", CreateBlueprintController);
 
 }());

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.controller.js
@@ -28,10 +28,11 @@ function DataTypeCreateController($scope, $location, navigationService, dataType
                 var currPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "datatypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderFor });
 
             }, function(err) {
 
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderFor, hasErrors: true });
                // TODO: Handle errors
             });
         };

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/datatype.edit.controller.js
@@ -128,6 +128,7 @@ function DataTypeEditController($scope, $routeParams, appState, navigationServic
 
                 }, function(err) {
 
+                    formHelper.resetForm({ scope: $scope, hasErrors: true });
                     //NOTE: in the case of data type values we are setting the orig/new props
                     // to be the same thing since that only really matters for content/media.
                     contentEditingHelper.handleSaveError({

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.create.controller.js
@@ -28,13 +28,14 @@ function DictionaryCreateController($scope, $location, dictionaryResource, navig
                 navigationService.syncTree({ tree: "dictionary", path: currPath + "," + data, forceReload: true, activate: true });
 
                 // reset form state
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createDictionaryForm });
 
                 // navigate to edit view
                 var currentSection = appState.getSectionState("currentSection");
                 $location.path("/" + currentSection + "/dictionary/edit/" + data);
 
             }, function (err) {
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createDictionaryForm, hasErrors: true });
                 if (err.data && err.data.message) {
                     notificationsService.error(err.data.message);
                     navigationService.hideMenu();

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.edit.controller.js
@@ -86,13 +86,15 @@ function DictionaryEditController($scope, $routeParams, $location, dictionaryRes
             dictionaryResource.save(vm.content, vm.nameDirty)
                 .then(function (data) {
 
-                    formHelper.resetForm({ scope: $scope, notifications: data.notifications });
+                        formHelper.resetForm({ scope: $scope });
 
                         bindDictionary(data);
 
                         vm.page.saveButtonState = "success";
                     },
                     function (err) {
+
+                        formHelper.resetForm({ scope: $scope, hasErrors: true });
 
                         contentEditingHelper.handleSaveError({
                             err: err

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -47,12 +47,13 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
                     activate: true
                 });
 
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm });
 
                 var section = appState.getSectionState("currentSection");
 
             }, function (err) {
 
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm, hasErrors: true });
                 $scope.error = err;
 
             });
@@ -83,9 +84,7 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
                         $location.search('create', null);
                         $location.search('notemplate', null);
 
-                        formHelper.resetForm({
-                            scope: $scope
-                        });
+                        formHelper.resetForm({ scope: $scope, formCtrl: this.createDoctypeCollectionForm });
 
                         var section = appState.getSectionState("currentSection");
 
@@ -94,6 +93,7 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
 
                     }, function (err) {
 
+                        formHelper.resetForm({ scope: $scope, formCtrl: this.createDoctypeCollectionForm, hasErrors: true });
                         $scope.error = err;
 
                         //show any notifications

--- a/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js
@@ -161,7 +161,7 @@
 
             }, function (err) {
                 vm.page.saveButtonState = "error";
-
+                formHelper.resetForm({ scope: $scope, hasErrors: true });
                 formHelper.handleError(err);
 
             });

--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.create.controller.js
@@ -25,7 +25,7 @@ function MacrosCreateController($scope, $location, macroResource, navigationServ
                 navigationService.syncTree({ tree: "macros", path: currPath + "," + data, forceReload: true, activate: true });
 
                 // reset form state
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createMacroForm });
 
                 // navigate to edit view
                 var currentSection = appState.getSectionState("currentSection");
@@ -33,6 +33,7 @@ function MacrosCreateController($scope, $location, macroResource, navigationServ
 
 
             }, function (err) {
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createMacroForm, hasErrors: true });
                 if (err.data && err.data.message) {
                     notificationsService.error(err.data.message);
                     navigationService.hideMenu();

--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.edit.controller.js
@@ -33,10 +33,11 @@ function MacrosEditController($scope, $q, $routeParams, macroResource, editorSta
             vm.page.saveButtonState = "busy";
             
             macroResource.saveMacro(vm.macro).then(function (data) {
-                formHelper.resetForm({ scope: $scope, notifications: data.notifications });
+                formHelper.resetForm({ scope: $scope });
                 bindMacro(data);
                 vm.page.saveButtonState = "success";
             }, function (error) {
+                formHelper.resetForm({ scope: $scope, hasErrors: true });
                 contentEditingHelper.handleSaveError({
                     err: error
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -206,6 +206,7 @@ function mediaEditController($scope, $routeParams, $q, appState, mediaResource,
 
                 }, function(err) {
 
+                    formHelper.resetForm({ scope: $scope, hasErrors: true });
                     contentEditingHelper.handleSaveError({
                         err: err,
                         rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, err.data)

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.controller.js
@@ -30,11 +30,12 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
                 var currPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "mediatypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm });
 
                 var section = appState.getSectionState("currentSection");
 
-            }, function(err) {
+            }, function (err) {
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm, hasErrors: true });
                 $scope.error = err;
             });
         };

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -208,7 +208,7 @@ function MemberEditController($scope, $routeParams, $location, appState, memberR
                     navigationService.syncTree({ tree: "member", path: path.split(","), forceReload: true });
 
             }, function (err) {
-
+                    formHelper.resetForm({ scope: $scope, hasErrors: true });
                     contentEditingHelper.handleSaveError({
                         err: err,
                         rebindCallback: contentEditingHelper.reBindChangedProperties($scope.content, err.data)

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
@@ -88,6 +88,7 @@ function MemberGroupsEditController($scope, $routeParams, appState, navigationSe
 
                 }, function (err) {
 
+                    formHelper.resetForm({ scope: $scope, hasErrors: true });
                     contentEditingHelper.handleSaveError({
                         err: err
                     });

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/create.controller.js
@@ -31,10 +31,10 @@ function MemberTypesCreateController($scope, $location, navigationService, membe
                 var currPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "membertypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm });
 
             }, function(err) {
-
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm, hasErrors: true });
                // TODO: Handle errors
             });
         };

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -194,7 +194,7 @@
                     vm.package = updatedPackage;
                     vm.buttonState = "success";
 
-                    formHelper.resetForm({ scope: $scope });
+                    formHelper.resetForm({ scope: $scope, formCtrl: editPackageForm });
 
                     if (create) {
                         //if we are creating, then redirect to the correct url and reload
@@ -204,6 +204,7 @@
                     }
 
                 }, function (err) {
+                    formHelper.resetForm({ scope: $scope, formCtrl: editPackageForm, hasErrors: true });
                     formHelper.handleError(err);
                     vm.buttonState = "error";
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.controller.js
@@ -46,12 +46,13 @@
                         activate: true
                     });
 
-                    formHelper.resetForm({ scope: $scope });
+                    formHelper.resetForm({ scope: $scope, formCtrl: form });
 
                     var section = appState.getSectionState("currentSection");
 
                 }, function (err) {
 
+                    formHelper.resetForm({ scope: $scope, formCtrl: form, hasErrors: true });
                     vm.createFolderError = err;
 
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/create.controller.js
@@ -56,12 +56,13 @@
                         activate: true
                     });
 
-                    formHelper.resetForm({ scope: $scope });
+                    formHelper.resetForm({ scope: $scope, formCtrl: form });
 
                     var section = appState.getSectionState("currentSection");
 
                 }, function(err) {
 
+                    formHelper.resetForm({ scope: $scope, formCtrl: form, hasErrors: true });
                     vm.createFolderError = err;
                 });
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -285,8 +285,12 @@
             var removed = vm.layout.splice(layoutIndex, 1);
             removed.forEach(x => {
                 // remove any server validation errors associated
-                var guid = udiService.getKey(x.contentUdi);
-                serverValidationManager.removePropertyError(guid, vm.umbProperty.property.culture, vm.umbProperty.property.segment, "", { matchType: "contains" });
+                var guids = [udiService.getKey(x.contentUdi), (x.settingsUdi ? udiService.getKey(x.settingsUdi) : null)];
+                guids.forEach(guid => {
+                    if (guid) {
+                        serverValidationManager.removePropertyError(guid, vm.umbProperty.property.culture, vm.umbProperty.property.segment, "", { matchType: "contains" });
+                    }
+                })
             });
 
             modelObject.removeDataAndDestroyModel(block);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -202,25 +202,36 @@
             return "views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html";
         }
 
+        /**
+         * Ensure that the containing content variant languag and current property culture is transfered along
+         * to the scaffolded content object representing this block.
+         * This is required for validation along with ensuring that the umb-property inheritance is constently maintained.
+         * @param {any} content
+         */
+        function ensureCultureData(content) {
+
+            if (!content) return;
+
+            if (vm.umbVariantContent.editor.content.language) {
+                // set the scaffolded content's language to the language of the current editor
+                content.language = vm.umbVariantContent.editor.content.language;
+            }
+            // currently we only ever deal with invariant content for blocks so there's only one
+            content.variants[0].tabs.forEach(tab => {
+                tab.properties.forEach(prop => {
+                    // set the scaffolded property to the culture of the containing property
+                    prop.culture = vm.umbProperty.property.culture;
+                });
+            });
+        }
+
         function getBlockObject(entry) {
             var block = modelObject.getBlockObject(entry);
 
             if (block === null) return null;
 
-            // ensure that the containing content variant language/culture is transfered along
-            // to the scaffolded content object representing this block. This is required for validation
-            // along with ensuring that the umb-property inheritance is constently maintained.
-            if (vm.umbVariantContent.editor.content.language) {
-                // set the scaffolded content's language to the language of the current editor
-                block.content.language = vm.umbVariantContent.editor.content.language;                
-            }
-            // currently we only ever deal with invariant content for blocks so there's only one
-            block.content.variants[0].tabs.forEach(tab => {
-                tab.properties.forEach(prop => {
-                    // set the scaffolded property to the culture of the containing property
-                    prop.culture = vm.umbProperty.property.culture ;
-                });
-            });
+            ensureCultureData(block.content);
+            ensureCultureData(block.settings);
 
             // TODO: Why is there a '/' prefixed? that means this will never work with virtual directories
             block.view = (block.config.view ? "/" + block.config.view : getDefaultViewForBlock(block));

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -211,14 +211,16 @@
             // to the scaffolded content object representing this block. This is required for validation
             // along with ensuring that the umb-property inheritance is constently maintained.
             if (vm.umbVariantContent.editor.content.language) {
-                block.content.language = vm.umbVariantContent.editor.content.language;
-                // currently we only ever deal with invariant content for blocks so there's only one
-                block.content.variants[0].tabs.forEach(tab => {
-                    tab.properties.forEach(prop => {
-                        prop.culture = vm.umbVariantContent.editor.content.language.culture;
-                    });
-                });
+                // set the scaffolded content's language to the language of the current editor
+                block.content.language = vm.umbVariantContent.editor.content.language;                
             }
+            // currently we only ever deal with invariant content for blocks so there's only one
+            block.content.variants[0].tabs.forEach(tab => {
+                tab.properties.forEach(prop => {
+                    // set the scaffolded property to the culture of the containing property
+                    prop.culture = vm.umbProperty.property.culture ;
+                });
+            });
 
             // TODO: Why is there a '/' prefixed? that means this will never work with virtual directories
             block.view = (block.config.view ? "/" + block.config.view : getDefaultViewForBlock(block));

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.controller.js
@@ -36,11 +36,12 @@ function RelationTypeCreateController($scope, $location, relationTypeResource, n
                 var currentPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "relationTypes", path: currentPath + "," + data, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope });
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createRelationTypeForm });
 
                 var currentSection = appState.getSectionState("currentSection");
                 $location.path("/" + currentSection + "/relationTypes/edit/" + data);
             }, function (err) {
+                formHelper.resetForm({ scope: $scope, formCtrl: this.createRelationTypeForm, hasErrors: true });
                 if (err.data && err.data.message) {
                     notificationsService.error(err.data.message);
                     navigationService.hideMenu();

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/edit.controller.js
@@ -116,12 +116,13 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
             vm.page.saveButtonState = "busy";
 
             relationTypeResource.save(vm.relationType).then(function (data) {
-                formHelper.resetForm({ scope: $scope, notifications: data.notifications });
+                formHelper.resetForm({ scope: $scope });
                 bindRelationType(data);
 
                 vm.page.saveButtonState = "success";
 
             }, function (error) {
+                formHelper.resetForm({ scope: $scope, hasErrors: true });
                 contentEditingHelper.handleSaveError({
                     err: error
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/scripts/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/scripts/create.controller.js
@@ -27,7 +27,7 @@
 
         function createFolder(form) {
 
-            if (formHelper.submitForm({scope: $scope, formCtrl: form })) {
+            if (formHelper.submitForm({ scope: $scope, formCtrl: form })) {
 
                 codefileResource.createContainer("scripts", node.id, vm.folderName).then(function (saved) {
 
@@ -40,14 +40,15 @@
                         activate: true
                     });
 
-                    formHelper.resetForm({ scope: $scope });
+                    formHelper.resetForm({ scope: $scope, formCtrl: form });
 
                     var section = appState.getSectionState("currentSection");
 
-                }, function(err) {
+                }, function (err) {
 
-                  vm.createFolderError = err;
-                    
+                    formHelper.resetForm({ scope: $scope, formCtrl: form, hasErrors: true });
+                    vm.createFolderError = err;
+
                 });
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.controller.js
@@ -22,14 +22,14 @@
             $location.path("/settings/stylesheets/edit/" + node.id).search("create", "true").search("rtestyle", "true");
             navigationService.hideMenu();
         }
-        
+
         function showCreateFolder() {
             vm.creatingFolder = true;
         }
 
         function createFolder(form) {
 
-            if (formHelper.submitForm({scope: $scope, formCtrl: form })) {
+            if (formHelper.submitForm({ scope: $scope, formCtrl: form })) {
 
                 codefileResource.createContainer("stylesheets", node.id, vm.folderName).then(function (saved) {
 
@@ -42,12 +42,13 @@
                         activate: true
                     });
 
-                    formHelper.resetForm({ scope: $scope });
+                    formHelper.resetForm({ scope: $scope, formCtrl: form });
 
-                }, function(err) {
+                }, function (err) {
 
-                  vm.createFolderError = err;
-                    
+                    formHelper.resetForm({ scope: $scope, formCtrl: form, hasErrors: true });
+                    vm.createFolderError = err;
+
                 });
             }
 
@@ -57,7 +58,7 @@
             const showMenu = true;
             navigationService.hideDialog(showMenu);
         }
-        
+
     }
 
     angular.module("umbraco").controller("Umbraco.Editors.StyleSheets.CreateController", StyleSheetsCreateController);

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -168,7 +168,9 @@
                         extendedSave(saved).then(function (result) {
                             //if all is good, then reset the form
                             formHelper.resetForm({ scope: $scope });
-                        }, Utilities.noop);
+                        }, function () {
+                            formHelper.resetForm({ scope: $scope, hasErrors: true });
+                        });
 
                         vm.user = _.omit(saved, "navigation");
                         //restore
@@ -179,7 +181,7 @@
                         vm.page.saveButtonState = "success";
 
                     }, function (err) {
-
+                        formHelper.resetForm({ scope: $scope, hasErrors: true });
                         contentEditingHelper.handleSaveError({
                             err: err,
                             showNotifications: true


### PR DESCRIPTION
This fixes an issue where property validators were not being cleared for server errors. The problem was because we were not transferring the correct culture values to the sub-block properties.

## Testing

* Make sure server validation works for invariant content for both content/settings and that validation errors clear when you change data
* Make sure server validation works for variant content but for an invariant block editor property for both content/settings and that validation errors clear when you change data. Test without split view open and with split view open.
* Make sure server validation works for variant content for an variant block editor property for both content/settings and that validation errors clear when you change data. Test without split view open and with split view open.

