### PR TITLE
Migrates remaining non-oauth AuthenticationController actions to netcore

### DIFF
--- a/src/Umbraco.Core/IEmailSender.cs
+++ b/src/Umbraco.Core/IEmailSender.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Core
     /// </summary>
     public interface IEmailSender
     {
+        // TODO: This would be better if MailMessage was our own abstraction!
         Task SendAsync(MailMessage message);
     }
 }

--- a/src/Umbraco.Web.Common/ActionsResults/ValidationErrorResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/ValidationErrorResult.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Umbraco.Web.Common.ActionsResults
+{
+    /// <summary>
+    /// Custom result to return a validation error message with a 400 http response and required headers
+    /// </summary>
+    public class ValidationErrorResult : ObjectResult
+    {
+        public ValidationErrorResult(string errorMessage) : base(new { Message = errorMessage })
+        {
+            StatusCode = (int)HttpStatusCode.BadRequest;           
+        }
+
+        public override void OnFormatting(ActionContext context)
+        {
+            base.OnFormatting(context);
+            context.HttpContext.Response.Headers["X-Status-Reason"] = "Validation failed";
+        }
+    }
+}


### PR DESCRIPTION
for [AB#6972](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/6972)

migrates remaining non-oauth AuthenticationController actions to netcore. This migration is nearly 1:1. There's barely any code changes between the two and we can't really test right now without email functionality which i don't think we've ever tried yet. 