### PR TITLE
Fixing publish descendants dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -562,6 +562,7 @@
                     view: "views/content/overlays/unpublish.html",
                     variants: $scope.content.variants, //set a model property for the dialog
                     skipFormValidation: true, //when submitting the overlay form, skip any client side validation
+                    includeUnpublished: false,
                     submitButtonLabelKey: "content_unpublish",
                     submitButtonStyle: "warning",
                     submit: function (model) {

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
@@ -5,21 +5,26 @@
 
         var vm = this;
 
-        vm.includeUnpublished = false;
+        vm.includeUnpublished = $scope.model.includeUnpublished || false;
 
         vm.changeSelection = changeSelection;
         vm.toggleIncludeUnpublished = toggleIncludeUnpublished;
 
-
         function onInit() {
 
             vm.variants = $scope.model.variants;
-            vm.displayVariants = vm.variants.slice(0);// shallow copy, we dont want to share the array-object(because we will be performing a sort method) but each entry should be shared (because we need validation and notifications).
+            vm.displayVariants = vm.variants.slice(0); // shallow copy, we don't want to share the array-object (because we will be performing a sort method) but each entry should be shared (because we need validation and notifications).
             vm.labels = {};
 
+            // get localized texts for use in directives
             if (!$scope.model.title) {
                 localizationService.localize("buttons_publishDescendants").then(function (value) {
                     $scope.model.title = value;
+                });
+            }
+            if (!vm.labels.includeUnpublished) {
+                localizationService.localize("content_includeUnpublished").then(function (value) {
+                    vm.labels.includeUnpublished = value;
                 });
             }
 
@@ -72,8 +77,9 @@
         }
 
         function toggleIncludeUnpublished() {
-            console.log("toggleIncludeUnpublished")
             vm.includeUnpublished = !vm.includeUnpublished;
+            // make sure this value is pushed back to the scope
+            $scope.model.includeUnpublished = vm.includeUnpublished;
         }
 
         /** Returns true if publishing is possible based on if there are un-published mandatory languages */

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -6,15 +6,13 @@
         </div>
 
         <div class="flex mb3">
-
             <umb-toggle checked="vm.includeUnpublished"
                         on-click="vm.toggleIncludeUnpublished()"
                         class="mr2"
                         label-on="{{vm.labels.includeUnpublished}}"
                         label-off="{{vm.labels.includeUnpublished}}"
                         label-position="right"
-                        show-labels="true"/>
-
+                        show-labels="true"></umb-toggle>
         </div>
 
     </div>
@@ -26,12 +24,13 @@
         </div>
 
         <div class="flex mb3">
-            <umb-toggle
-                checked="vm.includeUnpublished"
-                on-click="vm.toggleIncludeUnpublished()"
-                class="mr2"
-            />
-            <localize key="content_includeUnpublished"></localize>
+            <umb-toggle checked="vm.includeUnpublished"
+                        on-click="vm.toggleIncludeUnpublished()"
+                        class="mr2"
+                        label-on="{{vm.labels.includeUnpublished}}"
+                        label-off="{{vm.labels.includeUnpublished}}"
+                        label-position="right"
+                        show-labels="true"></umb-toggle>
         </div>
 
         <div class="umb-list umb-list--condensed">

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -6,12 +6,15 @@
         </div>
 
         <div class="flex mb3">
-            <umb-toggle
-                checked="vm.includeUnpublished"
-                on-click="vm.toggleIncludeUnpublished()"
-                class="mr2"
-            />
-            <localize key="content_includeUnpublished"></localize>
+
+            <umb-toggle checked="vm.includeUnpublished"
+                        on-click="vm.toggleIncludeUnpublished()"
+                        class="mr2"
+                        label-on="{{vm.labels.includeUnpublished}}"
+                        label-off="{{vm.labels.includeUnpublished}}"
+                        label-position="right"
+                        show-labels="true"/>
+
         </div>
 
     </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -285,7 +285,7 @@
     <key alias="addTextBox">Tilføj en ny tekstboks</key>
     <key alias="removeTextBox">Fjern denne tekstboks</key>
     <key alias="contentRoot">Indholdsrod</key>
-    <key alias="includeUnpublished">Medtag udkast: udgiv også ikke-publicerede sider.</key>
+    <key alias="includeUnpublished">Inkluder ikke-udgivet indhold.</key>
     <key alias="isSensitiveValue">Denne værdi er skjult.Hvis du har brug for adgang til at se denne værdi, bedes du kontakte din web-administrator.</key>
     <key alias="isSensitiveValue_short">Denne værdi er skjult.</key>
     <key alias="languagesToPublishForFirstTime">Hvilke sprog vil du gerne udgive? Alle sprog med indhold gemmes!</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -295,7 +295,7 @@
     <key alias="addTextBox">Add another text box</key>
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>
-    <key alias="includeUnpublished">Include drafts and unpublished content items.</key>
+    <key alias="includeUnpublished">Include unpublished content items.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your website administrator.</key>
     <key alias="isSensitiveValue_short">This value is hidden.</key>
     <key alias="languagesToPublishForFirstTime">What languages would you like to publish? All languages with content are saved!</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -300,7 +300,7 @@
     <key alias="addTextBox">Add another text box</key>
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>
-    <key alias="includeUnpublished">Include drafts and unpublished content items.</key>
+    <key alias="includeUnpublished">Include unpublished content items.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your website administrator.</key>
     <key alias="isSensitiveValue_short">This value is hidden.</key>
     <key alias="languagesToPublishForFirstTime">What languages would you like to publish? All languages with content are saved!</key>


### PR DESCRIPTION
### Description
The publish descendants dialog was broken at some point going from 8.6->8.7.

I've fixed it up, using the label on the toggle directive instead of using a separate label.

Also updated the localized texts to better reflect what is happening here:
- The toggle allows you to include or exclude publishing of items that have a published state.
- The old help text could indicate that items in a published state but with a "draft" on top would not be published if deselected ... they would be - so this is now more clear.

The last fix done here is that the selected value would not be pushed back to the scope which means your selection would never make it back.

---
_This item has been added to our backlog [AB#7682](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7682)_