### PR TITLE
Fix self closing umb-toggle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -8,10 +8,13 @@
         <div class="flex mb3">
             <umb-toggle
                 checked="vm.includeUnpublished"
+                input-id="includeUnpublished"
                 on-click="vm.toggleIncludeUnpublished()"
                 class="mr2">
             </umb-toggle>
-            <localize key="content_includeUnpublished"></localize>
+            <label for="includeUnpublished">
+                <localize key="content_includeUnpublished">Include drafts and unpublished content items.</localize>
+            </label>
         </div>
 
     </div>
@@ -25,10 +28,13 @@
         <div class="flex mb3">
             <umb-toggle
                 checked="vm.includeUnpublished"
+                input-id="includeUnpublished"
                 on-click="vm.toggleIncludeUnpublished()"
                 class="mr2">
             </umb-toggle>
-            <localize key="content_includeUnpublished"></localize>
+            <label for="includeUnpublished">
+                <localize key="content_includeUnpublished">Include drafts and unpublished content items.</localize>
+            </label>
         </div>
 
         <div class="umb-list umb-list--condensed">

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -9,8 +9,8 @@
             <umb-toggle
                 checked="vm.includeUnpublished"
                 on-click="vm.toggleIncludeUnpublished()"
-                class="mr2"
-            />
+                class="mr2">
+            </umb-toggle>
             <localize key="content_includeUnpublished"></localize>
         </div>
 
@@ -26,8 +26,8 @@
             <umb-toggle
                 checked="vm.includeUnpublished"
                 on-click="vm.toggleIncludeUnpublished()"
-                class="mr2"
-            />
+                class="mr2">
+            </umb-toggle>
             <localize key="content_includeUnpublished"></localize>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
@@ -38,10 +38,10 @@
         <umb-box-header title="Editor settings"></umb-box-header>
         <umb-box-content>
             <umb-control-group label="Use in rich text editor and the grid">
-                <umb-toggle checked="model.macro.useInEditor" on-click="model.toggle('useInEditor')" ></umb-toggle>
+                <umb-toggle checked="model.macro.useInEditor" on-click="model.toggle('useInEditor')"></umb-toggle>
             </umb-control-group>
             <umb-control-group label="Render in rich text editor and the grid" ng-if="model.macro.useInEditor">
-                <umb-toggle checked="model.macro.renderInEditor && model.macro.useInEditor"  on-click="model.toggle('renderInEditor')" ></umb-toggle>
+                <umb-toggle checked="model.macro.renderInEditor && model.macro.useInEditor" on-click="model.toggle('renderInEditor')"></umb-toggle>
             </umb-control-group>
         </umb-box-content>
     </umb-box>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8602

### Description
The `umb-toggle` is a custom angular directive, where custom angular directives/components can't be void elements (self-closing), so it needs to be non-void element - in this case has a end-closing `</umb-toggle>`.

There is a great explanation of it here: https://stackoverflow.com/a/25012451/1693918

**Before**

![chrome_2020-08-06_19-50-02](https://user-images.githubusercontent.com/2919859/89566183-fb4dff00-d81f-11ea-8ae6-b1ed03b3ae8f.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/89566194-00ab4980-d820-11ea-8620-844bab9d1f23.png)
