### PR TITLE
Various fixes for macroparameterpicker view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
@@ -74,7 +74,7 @@
                         </div>
 
                         <umb-empty-state position="center" ng-if="vm.filterResult.totalResults === 0">
-                            <localize key="general_searchNoResult"></localize>
+                            <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
                         </umb-empty-state>
                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
@@ -34,15 +34,18 @@
                             <h5>{{key}}</h5>
                             <ul class="umb-card-grid -four-in-row" ng-mouseleave="vm.hideDetailsOverlay()">
                                 <li ng-repeat="parameterEditor in value | orderBy:'name'"
-                                    data-element="editor-{{parameterEditor.name}}"
-                                    ng-mouseover="vm.showDetailsOverlay(parameterEditor)"
-                                    ng-click="vm.pickParameterEditor(parameterEditor)">
-                                    <a class="umb-card-grid-item" href="" title="{{parameterEditor.name}}">
+                                    data-element="editor-{{parameterEditor.name}}">
+                                    <button
+                                        type="button"
+                                        ng-mouseover="vm.showDetailsOverlay(parameterEditor)"
+                                        ng-click="vm.pickParameterEditor(parameterEditor)"
+                                        class="btn-reset umb-card-grid-item"
+                                        title="{{parameterEditor.name}}">
                                         <span>
-                                            <i class="{{parameterEditor.icon}}" ng-class="{'icon-autofill': parameterEditor.icon == null}"></i>
+                                            <i class="{{parameterEditor.icon}}" ng-class="{'icon-autofill': parameterEditor.icon == null}" aria-hidden="true"></i>
                                             {{parameterEditor.name}}
                                         </span>
-                                    </a>
+                                    </button>
                                 </li>
                             </ul>
                         </div>
@@ -55,15 +58,18 @@
                                 <div ng-if="result.parameterEditors.length > 0">
                                     <h5>{{result.group}}</h5>
                                     <ul class="umb-card-grid -four-in-row" ng-mouseleave="vm.hideDetailsOverlay()">
-                                        <li ng-repeat="parameterEditor in result.parameterEditors | orderBy:'name'"
-                                            ng-mouseover="vm.showDetailsOverlay(parameterEditor)"
-                                            ng-click="vm.pickParameterEditor(parameterEditor)">
+                                        <li ng-repeat="parameterEditor in result.parameterEditors | orderBy:'name'">
                                             <div ng-if="parameterEditor.loading" class="umb-card-grid-item__loading">
                                                 <div class="umb-button__progress"></div>
                                             </div>
-                                            <a class="umb-card-grid-item" href="" title="{{parameterEditor.name}}">
+                                            <button
+                                                type="button"
+                                                ng-mouseover="vm.showDetailsOverlay(parameterEditor)"
+                                                ng-click="vm.pickParameterEditor(parameterEditor)"
+                                                class="btn-reset umb-card-grid-item"
+                                                title="{{parameterEditor.name}}">
                                                 <span>
-                                                    <i class="{{parameterEditor.icon}}" ng-class="{'icon-autofill': parameterEditor.icon == null}"></i>
+                                                    <i class="{{parameterEditor.icon}}" ng-class="{'icon-autofill': parameterEditor.icon == null}" aria-hidden="true"></i>
                                                     {{parameterEditor.name}}
                                                 </span>
                                             </a>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
During the work I'm currently doing on #8522 I noticed that there were some issues in this view where tabbing between the items would have a weird double effect. This PR addresses those issues + hides the `<i>` element from screen readers and provides an English fallback text in case the dictionary key does not exist for a certain language.

In the gif's below I display what the filter acts like as well since it's 2 different parts of the code.

**Before**
![macropickerview-before](https://user-images.githubusercontent.com/1932158/89573333-be3b3a00-d82a-11ea-9332-e83982021f6f.gif)

**After**
![macropickerview-after](https://user-images.githubusercontent.com/1932158/89573386-d448fa80-d82a-11ea-9686-650e1f42d0ed.gif)

