### PR TITLE
Fix parametrized query for specific content types

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -134,7 +134,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             if (objectTypes.Any())
             {
-                sql = sql.Where("umbracoNode.nodeObjectType IN (@objectTypes)", objectTypes);
+                sql = sql.Where("umbracoNode.nodeObjectType IN (@objectTypes)", new { objectTypes = objectTypes });
             }
 
             return Database.Fetch<string>(sql);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8599

### Description

As @stefankip describes in #8599, `ContentTypeService.GetAllContentTypeAliases` has a bug when called with parameters (it works fine when there are no parameters).

To verify the problem (and that this PR fixes it), create a template with the contents below and render some content with the template. It will YSOD in the current codebase, and work as expected with this PR applied.

```cshtml
@using Umbraco.Web.Composing
@using Umbraco.Core
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
  Layout = null;
  var contentTypeAliases = Current.Services.ContentTypeService.GetAllContentTypeAliases(Constants.ObjectTypes.MediaType, Constants.ObjectTypes.MemberType);
}

<html>
  <body>
    <ul>
    @foreach(var contentTypeAlias in contentTypeAliases) {
      <li>@contentTypeAlias</li>
    }
    </ul>
  </body>
</html>
```