### PR TITLE
Block editor - Fix for when you have no access to settings

### DIFF
--- a/src/Umbraco.Core/Models/ISimpleContentType.cs
+++ b/src/Umbraco.Core/Models/ISimpleContentType.cs
@@ -15,6 +15,8 @@ namespace Umbraco.Core.Models
         /// </summary>
         string Alias { get; }
 
+        string Description { get; }
+
         /// <summary>
         /// Gets the default template of the content type.
         /// </summary>

--- a/src/Umbraco.Core/Models/SimpleContentType.cs
+++ b/src/Umbraco.Core/Models/SimpleContentType.cs
@@ -45,6 +45,7 @@ namespace Umbraco.Core.Models
             Name = contentType.Name;
             AllowedAsRoot = contentType.AllowedAsRoot;
             IsElement = contentType.IsElement;
+            Description = contentType.Description;
         }
 
         /// <inheritdoc />
@@ -73,6 +74,9 @@ namespace Umbraco.Core.Models
 
         /// <inheritdoc />
         public bool IsElement { get; }
+
+        /// <inheritdoc />
+        public string Description { get; }
 
         /// <inheritdoc />
         public bool SupportsPropertyVariation(string culture, string segment, bool wildcards = false)

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -447,7 +447,7 @@
                     if (scaffold) {
                         blocks.push({
                             blockConfigModel: blockConfiguration,
-                            elementTypeModel: scaffold.documentType
+                            elementTypeModel: {icon: scaffold.icon, name: scaffold.contentTypeName, description: scaffold.contentTypeDescription}
                         });
                     }
                 });

--- a/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
@@ -118,6 +118,9 @@ namespace Umbraco.Web.Models.ContentEditing
         [Required(AllowEmptyStrings = false)]
         public string ContentTypeAlias { get; set; }
 
+        [DataMember(Name = "contentTypeDescription")]
+        public string ContentTypeDescription { get; set; }
+
         [DataMember(Name = "sortOrder")]
         public int SortOrder { get; set; }
 

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -79,6 +79,7 @@ namespace Umbraco.Web.Models.Mapping
             target.ContentTypeKey = source.ContentType.Key;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = _localizedTextService.UmbracoDictionaryTranslate(source.ContentType.Name);
+            target.ContentTypeDescription = source.ContentType.Description;
             target.DocumentType = _commonMapper.GetContentType(source, context);
             target.Icon = source.ContentType.Icon;
             target.Id = source.Id;


### PR DESCRIPTION
### Test Notes
* Create a block list editor datatype on a content node
* Create a new user with NO access to the Settings section
* Add a block to the block list editor in a content node
* Verify you have a list of empty block cards with no names, description or icons
* Apply PR & retest to ensure name, icon & description is visible

### Problem
The problem was that we were trying to access JSON properties in DataType that would return null

### Fix
* Adds a new property `ContentTypeDescription` to SimpleContentType
* Updates JS to select the properties needed fro the Block Card component (Icon, Name & Description) which are available as root properties on the request made to `/umbraco/backoffice/UmbracoApi/Content/GetEmptyByKey?contentTypeKey=`