### PR TITLE
(Rework) Block editor - Fix for when you have no access to settings

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/CommonMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/CommonMapper.cs
@@ -49,18 +49,9 @@ namespace Umbraco.Web.Models.Mapping
 
         public ContentTypeBasic GetContentType(IContentBase source, MapperContext context)
         {
-            // TODO: We can resolve the UmbracoContext from the IValueResolver options!
-            // OMG
-            if (HttpContext.Current != null && Composing.Current.UmbracoContext != null && Composing.Current.UmbracoContext.Security.CurrentUser != null
-                && Composing.Current.UmbracoContext.Security.CurrentUser.AllowedSections.Any(x => x.Equals(Constants.Applications.Settings)))
-            {
-                var contentType = _contentTypeBaseServiceProvider.GetContentTypeOf(source);
-                var contentTypeBasic = context.Map<IContentTypeComposition, ContentTypeBasic>(contentType);
-
-                return contentTypeBasic;
-            }
-            //no access
-            return null;
+            var contentType = _contentTypeBaseServiceProvider.GetContentTypeOf(source);
+            var contentTypeBasic = context.Map<IContentTypeComposition, ContentTypeBasic>(contentType);
+            return contentTypeBasic;
         }
 
         public string GetTreeNodeUrl<TController>(IContentBase source)


### PR DESCRIPTION
## Test Notes
* Create a block list editor datatype on a content node
* Create a new user with NO access to the Settings section
* Add a block to the block list editor in a content node
* Verify you have a list of empty block cards with no names, description or icons
* Apply PR & retest to ensure name, icon & description is visible