### PR TITLE
Allow for changing the weight of built-in and 3rd party dashboards

### DIFF
--- a/src/Umbraco.Web/Dashboards/DashboardCollectionBuilder.cs
+++ b/src/Umbraco.Web/Dashboards/DashboardCollectionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
@@ -9,7 +10,21 @@ namespace Umbraco.Web.Dashboards
 {
     public class DashboardCollectionBuilder : WeightedCollectionBuilderBase<DashboardCollectionBuilder, DashboardCollection, IDashboard>
     {
+        private Dictionary<Type, int> _customWeights = new Dictionary<Type, int>();
+
         protected override DashboardCollectionBuilder This => this;
+
+        /// <summary>
+        /// Changes the default weight of a dashboard
+        /// </summary>
+        /// <typeparam name="T">The type of dashboard</typeparam>
+        /// <param name="weight">The new dashboard weight</param>
+        /// <returns></returns>
+        public DashboardCollectionBuilder SetWeight<T>(int weight) where T : IDashboard
+        {
+            _customWeights[typeof(T)] = weight;
+            return this;
+        }
 
         protected override IEnumerable<IDashboard> CreateItems(IFactory factory)
         {
@@ -32,6 +47,12 @@ namespace Umbraco.Web.Dashboards
 
         private int GetWeight(IDashboard dashboard)
         {
+            var typeOfDashboard = dashboard.GetType();
+            if(_customWeights.ContainsKey(typeOfDashboard))
+            {
+                return _customWeights[typeOfDashboard];
+            }
+
             switch (dashboard)
             {
                 case ManifestDashboard manifestDashboardDefinition:


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As you start piling 3rd party dashboards onto a solution, sometimes you find yourself wanting to move them around in an order that makes more sense to the editors. As of right now, the only way to do so is pretty cumbersome:

1. Create your own implementation (specialization) of the dashboards in question. 
2. Set the applicable `[Weight]` attribute on your own dashboard classes (it denotes the dashboard sort order).
3. Replace the dashboards in your composer.

[Check the docs](https://our.umbraco.com/documentation/extending/dashboards/#remove-an-umbraco-dashboard) for guidance on how to pull off something along those lines.

This PR allows you to change the weight of dashboards in code, so you don't have to go through the hassle of creating your own implementations. It allows you to do this: `composition.Dashboards().SetWeight<type-of-dashboard>(new-weight-of-dashboard)`.

#### Testing this PR

To test this, add this composer to a site (you can dump it in the `App_Code` folder for easier testing):

```cs
using Umbraco.Core.Composing;
using Umbraco.Web;
using Umbraco.Web.Dashboards;

namespace Test
{
    public class TestDashboardComposer : IUserComposer
    {
        public void Compose(Composition composition)
        {
            // place the "Redirect URL Management" dashboard before the "Getting Started" dashboard
            composition.Dashboards().SetWeight<Umbraco.Web.Dashboards.RedirectUrlDashboard>(5);
        }
    }
}
```

When you reboot the site, the "Getting Started" and "Redirect URL Management" dashboards will have changed places, the latter becoming the first one (since "Getting Started" has the built-in weight of 10).

![image](https://user-images.githubusercontent.com/7405322/90053137-5bd6b380-dcda-11ea-8794-66bba0f5e43a.png)
