### PR TITLE
Support include in sql server indexes

### DIFF
--- a/src/Umbraco.Core/Persistence/DatabaseAnnotations/IndexAttribute.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseAnnotations/IndexAttribute.cs
@@ -31,5 +31,10 @@ namespace Umbraco.Core.Persistence.DatabaseAnnotations
         /// Gets or sets the column name(s) for the current index
         /// </summary>
         public string ForColumns { get; set; }
+
+        /// <summary>
+        /// Gets or sets the column name(s) for the columns to include in the index
+        /// </summary>
+        public string IncludeColumns { get; set; }
     }
 }

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DefinitionFactory.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/DefinitionFactory.cs
@@ -166,6 +166,14 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
                     definition.Columns.Add(new IndexColumnDefinition {Name = column, Direction = Direction.Ascending});
                 }
             }
+            if (string.IsNullOrEmpty(attribute.IncludeColumns) == false)
+            {
+                var columns = attribute.IncludeColumns.Split(',').Select(p => p.Trim());
+                foreach (var column in columns)
+                {
+                    definition.IncludeColumns.Add(new IndexColumnDefinition { Name = column, Direction = Direction.Ascending });
+                }
+            }
             return definition;
         }
     }

--- a/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
+++ b/src/Umbraco.Core/Persistence/DatabaseModelDefinitions/IndexDefinition.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Core.Persistence.DatabaseModelDefinitions
         public virtual string ColumnName { get; set; }
 
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
+        public virtual ICollection<IndexColumnDefinition> IncludeColumns { get; set; }
         public IndexTypes IndexType { get; set; }
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -236,6 +236,20 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
         }
 
         public override string DropIndex { get { return "DROP INDEX {1}.{0}"; } }
+        public override string CreateIndex => "CREATE {0}{1}INDEX {2} ON {3} ({4})";
+        public override string Format(IndexDefinition index)
+        {
+            var name = string.IsNullOrEmpty(index.Name)
+                ? $"IX_{index.TableName}_{index.ColumnName}"
+                : index.Name;
 
+            var columns = index.Columns.Any()
+                ? string.Join(",", index.Columns.Select(x => GetQuotedColumnName(x.Name)))
+                : GetQuotedColumnName(index.ColumnName);
+
+
+            return string.Format(CreateIndex, GetIndexType(index.IndexType), " ", GetQuotedName(name),
+                                 GetQuotedTableName(index.TableName), columns);
+        }
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -348,7 +348,7 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
                 ? string.Join(",", index.Columns.Select(x => GetQuotedColumnName(x.Name)))
                 : GetQuotedColumnName(index.ColumnName);
 
-            var includeColumns = index.IncludeColumns.Any()
+            var includeColumns = index.IncludeColumns?.Any() ?? false
                ? $" INCLUDE ({string.Join(",", index.IncludeColumns.Select(x => GetQuotedColumnName(x.Name)))})"
                : string.Empty;
 

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -336,5 +336,24 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
         public override string DropIndex => "DROP INDEX {0} ON {1}";
 
         public override string RenameColumn => "sp_rename '{0}.{1}', '{2}', 'COLUMN'";
+
+        public override string CreateIndex => "CREATE {0}{1}INDEX {2} ON {3} ({4}){5}";
+        public override string Format(IndexDefinition index)
+        {
+            var name = string.IsNullOrEmpty(index.Name)
+                ? $"IX_{index.TableName}_{index.ColumnName}"
+                : index.Name;
+
+            var columns = index.Columns.Any()
+                ? string.Join(",", index.Columns.Select(x => GetQuotedColumnName(x.Name)))
+                : GetQuotedColumnName(index.ColumnName);
+
+            var includeColumns = index.IncludeColumns.Any()
+               ? " INCLUDE " + string.Join(",", index.IncludeColumns.Select(x => GetQuotedColumnName(x.Name)))
+               : GetQuotedColumnName(index.ColumnName);
+
+            return string.Format(CreateIndex, GetIndexType(index.IndexType), " ", GetQuotedName(name),
+                                 GetQuotedTableName(index.TableName), columns, includeColumns);
+        }
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -349,8 +349,8 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
                 : GetQuotedColumnName(index.ColumnName);
 
             var includeColumns = index.IncludeColumns.Any()
-               ? " INCLUDE " + string.Join(",", index.IncludeColumns.Select(x => GetQuotedColumnName(x.Name)))
-               : GetQuotedColumnName(index.ColumnName);
+               ? $" INCLUDE ({string.Join(",", index.IncludeColumns.Select(x => GetQuotedColumnName(x.Name)))})"
+               : string.Empty;
 
             return string.Format(CreateIndex, GetIndexType(index.IndexType), " ", GetQuotedName(name),
                                  GetQuotedTableName(index.TableName), columns, includeColumns);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

RE https://github.com/umbraco/Umbraco-CMS/pull/8365

### Description
Use the new IncludeColumns property in the same way as ForColumns property for the Index attribute during a db migration. This will allow for inclusion of columns that don't make up the key of an index
