### PR TITLE
Accept PublishedPendingChanges state as a published state

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
@@ -78,7 +78,7 @@
         }
 
         function notPublishedMandatoryFilter(variant) {
-            return variant.state !== "Published" && variant.state !== "PublishedPendingChanges" && isMandatoryFilter(variant);
+            return variant.state !== "Published" && variant.state !== "PublishedPendingChanges" && variant.isMandatory === true;
         }
         function isMandatoryFilter(variant) {
             //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
@@ -11,13 +11,13 @@
 
         /** Returns true if publish meets the requirements of mandatory languages */
         function canPublish() {
-            
+
             var hasSomethingToPublish = false;
 
             for (var i = 0; i < vm.variants.length; i++) {
                 var variant = vm.variants[i];
 
-                // if varaint is mandatory and not already published:
+                // if varaint is mandatory and not already published, then we require it to be set to publish:
                 if (variant.publish === false && notPublishedMandatoryFilter(variant)) {
                     return false;
                 }
@@ -39,8 +39,9 @@
 
         function hasAnyDataFilter(variant) {
 
-            if (variant.name == null || variant.name.length === 0) {
-                return false;
+            // if we have a name, then we have data.
+            if (variant.name != null && variant.name.length > 0) {
+                return true;
             }
 
             if(variant.isDirty === true) {
@@ -77,7 +78,7 @@
         }
 
         function notPublishedMandatoryFilter(variant) {
-            return variant.state !== "Published" && isMandatoryFilter(variant);
+            return variant.state !== "Published" && variant.state !== "PublishedPendingChanges" && isMandatoryFilter(variant);
         }
         function isMandatoryFilter(variant) {
             //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
@@ -98,11 +99,11 @@
             vm.variants = $scope.model.variants;
 
             _.each(vm.variants, (variant) => {
-                
+
                 // reset to not be published
                 variant.publish = false;
                 variant.save = false;
-                
+
                 variant.isMandatory = isMandatoryFilter(variant);
 
                 // If we have a variant thats not in the state of NotCreated, then we know we have adata and its not a new content node.
@@ -112,12 +113,12 @@
             });
 
             _.each(vm.variants, (variant) => {
-                
+
                 // if this is a new node and we have data on this variant.
                 if(vm.isNew === true && hasAnyDataFilter(variant)) {
                     variant.save = true;
                 }
-                
+
             });
 
             vm.availableVariants = vm.variants.filter(publishableVariantFilter);
@@ -139,7 +140,7 @@
                         if (a.language.name < b.language.name) {
                             return 1;
                         }
-                    } 
+                    }
                     if (a.segment && b.segment) {
                         if (a.segment > b.segment) {
                             return -1;

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
@@ -21,19 +21,16 @@
                                   on-change="vm.changeSelection(variant)"
                                   server-validation-field="{{variant.htmlId}}">
 
-                        <span class="umb-variant-selector-entry__title" ng-if="!(variant.segment && variant.language)">
-                            <span ng-bind="variant.displayName"></span>
-                            <strong ng-if="variant.isMandatory" class="umb-control-required">*</strong>
-                        </span>
-                        <span class="umb-variant-selector-entry__title" ng-if="variant.segment && variant.language">
-                            <span ng-bind="variant.segment"></span>
-                            <span class="__secondarytitle"> — {{variant.language.name}}</span>
-                            <strong ng-if="variant.isMandatory" class="umb-control-required">*</strong>
+                        <span class="umb-variant-selector-entry__title">
+                            <span ng-bind="variant.displayName" ng-if="!(variant.segment && variant.language)"></span>
+                            <span ng-bind="variant.segment" ng-if="variant.segment && variant.language"></span>
+                            <span class="__secondarytitle" ng-if="variant.segment && variant.language"> — {{variant.language.name}}</span>
+                            <strong ng-if="variant.isMandatory && variant.state !== 'Published' && variant.state !== 'PublishedPendingChanges'" class="umb-control-required">*</strong>
                         </span>
                         <span class="umb-variant-selector-entry__description" ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
                             <umb-variant-state variant="variant"></umb-variant-state>
                             <span ng-if="variant.isMandatory"> - </span>
-                            <span ng-if="variant.isMandatory" ng-class="{'text-error': (variant.publish === false) }"><localize key="languages_mandatoryLanguage"></localize></span>
+                            <span ng-if="variant.isMandatory" ng-class="{'text-error': (variant.state !== 'Published' && variant.state !== 'PublishedPendingChanges' && variant.publish === false) }"><localize key="languages_mandatoryLanguage"></localize></span>
                         </span>
                         <span class="umb-variant-selector-entry__description" ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
                             <span class="text-error" ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>


### PR DESCRIPTION
Ability to perform publish on a single variant when other variants is in the "PublishedPendingChanges" state.

Plus consider the name as data, if new this ensures to save that variant no matter the choice.

**Steps to reproduce UX problem:**

Have a variant document and two languages that both are mandatory.

save and publish content for the secondary language.
make new data for the secondary language and then just save it.
Refresh browser
Try to save and publish data for the primary language. (Before the secondary language would be required/mandatory, but it is already published)