### PR TITLE
Support SQL Server 2012 syntax on SQL Server 2019

### DIFF
--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -30,6 +30,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
             V2014 = 6,
             V2016 = 7,
             V2017 = 8,
+            V2019 = 9,
             Other = 99
         }
 
@@ -38,7 +39,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
             Unknown = 0,
             Desktop = 1,
             Standard = 2,
-            Enterprise = 3,
+            Enterprise = 3,// Also developer edition
             Express = 4,
             Azure = 5
         }
@@ -79,6 +80,8 @@ namespace Umbraco.Core.Persistence.SqlSyntax
             {
                 case "??":
                     return VersionName.Invalid;
+                case "15":
+                    return VersionName.V2019;
                 case "14":
                     return VersionName.V2017;
                 case "13":

--- a/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
@@ -156,6 +156,7 @@ namespace Umbraco.Core.Persistence
                 case SqlServerSyntaxProvider.VersionName.V2014:
                 case SqlServerSyntaxProvider.VersionName.V2016:
                 case SqlServerSyntaxProvider.VersionName.V2017:
+                case SqlServerSyntaxProvider.VersionName.V2019:
                     _databaseType = DatabaseType.SqlServer2012;
                     break;
                 // else leave unchanged


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Add support for SQL server 2019 to use SQL Server 2012 syntax.
Use SQL Server 2019, check that queries use OFFSET and FETCH.
