### PR TITLE
Use button elements in schedule overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/properties.less
+++ b/src/Umbraco.Web.UI.Client/src/less/properties.less
@@ -16,8 +16,8 @@
     border-left: 1px solid @gray-10;
 }
 
-.date-wrapper__date .flatpickr-input > a {
-    
+.date-wrapper__date .flatpickr-input > a,
+.date-wrapper__date .flatpickr-input > button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -25,16 +25,15 @@
     padding: 4px 15px;
     box-sizing: border-box;
     min-width: 200px;
-    
     color: @ui-action-discreet-type;
     border: 1px dashed @ui-action-discreet-border;
     border-radius: 3px;
-    
+
     &:hover, &:focus {
         text-decoration: none;
         color: @ui-action-discreet-type-hover;
         border-color: @ui-action-discreet-border-hover;
-        
+
         localize {
             text-decoration: none;
         }

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-date-time-picker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-date-time-picker.html
@@ -1,7 +1,7 @@
 <div class="datepicker" style="position: relative;">
 
     <div ng-hide="hasTranscludedContent" class="input-append date">
-        <input data-format="{{ options.format }}" type="text" class="datepickerinput" />
+        <input type="text" data-format="{{ options.format }}" class="datepickerinput" />
         <span class="add-on" aria-hidden="true">
             <i class="icon-calendar"></i>
         </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-date-time-picker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-date-time-picker.html
@@ -2,7 +2,7 @@
 
     <div ng-hide="hasTranscludedContent" class="input-append date">
         <input data-format="{{ options.format }}" type="text" class="datepickerinput" />
-        <span class="add-on">
+        <span class="add-on" aria-hidden="true">
             <i class="icon-calendar"></i>
         </span>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
@@ -56,7 +56,7 @@
                                    on-close="vm.datePickerClose(vm.variants[0], 'unpublish')">
 
                         <div>
-                            <button ng-show="vm.variants[0].expireDate" class="btn btn-reset umb-button--xs" style="outline: none;">
+                            <button type="button" ng-show="vm.variants[0].expireDate" class="btn btn-reset umb-button--xs" style="outline: none;">
                                 {{vm.variants[0].expireDateFormatted}}
                             </button>
 
@@ -126,7 +126,7 @@
                                                        on-open="vm.datePickerShow(variant, 'publish')"
                                                        on-close="vm.datePickerClose(variant, 'publish')">
                                             <div>
-                                                <button ng-show="variant.releaseDate" class="btn btn-reset umb-button--xxs btn-outline umb-outline">
+                                                <button type="button" ng-show="variant.releaseDate" class="btn btn-reset umb-button--xxs btn-outline umb-outline">
                                                     {{variant.releaseDateFormatted}}
                                                 </button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
@@ -23,18 +23,18 @@
                                    on-close="vm.datePickerClose(vm.variants[0], 'publish')">
 
                         <div>
-                            <button type="button" ng-show="vm.variants[0].releaseDate" class="btn umb-button--xs" style="outline: none;">
+                            <button type="button" ng-show="vm.variants[0].releaseDate" class="btn btn-reset umb-button--xs" style="outline: none;">
                                 {{vm.variants[0].releaseDateFormatted}}
                             </button>
 
-                            <button type="button" ng-hide="vm.variants[0].releaseDate">
+                            <button type="button" class="btn-reset" ng-hide="vm.variants[0].releaseDate">
                                 <localize key="content_setDate">Set date</localize>
                             </button>
                         </div>
 
                     </umb-date-time-picker>
 
-                    <button type="button" ng-show="vm.variants[0].releaseDate" ng-click="vm.clearPublishDate(vm.variants[0])" class="btn umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
+                    <button type="button" ng-show="vm.variants[0].releaseDate" ng-click="vm.clearPublishDate(vm.variants[0])" class="btn btn-reset umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
                         <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
                     </button>
 
@@ -56,18 +56,18 @@
                                    on-close="vm.datePickerClose(vm.variants[0], 'unpublish')">
 
                         <div>
-                            <button ng-show="vm.variants[0].expireDate" class="btn umb-button--xs" style="outline: none;">
+                            <button ng-show="vm.variants[0].expireDate" class="btn btn-reset umb-button--xs" style="outline: none;">
                                 {{vm.variants[0].expireDateFormatted}}
                             </button>
 
-                            <button type="button" ng-hide="vm.variants[0].expireDate">
+                            <button type="button" class="btn-reset" ng-hide="vm.variants[0].expireDate">
                                 <localize key="content_setDate">Set date</localize>
                             </button>
                         </div>
 
                     </umb-date-time-picker>
 
-                    <button type="button" ng-show="vm.variants[0].expireDate" ng-click="vm.clearUnpublishDate(vm.variants[0])" class="btn umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
+                    <button type="button" ng-show="vm.variants[0].expireDate" ng-click="vm.clearUnpublishDate(vm.variants[0])" class="btn btn-reset umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
                         <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
                     </button>
 
@@ -126,11 +126,11 @@
                                                        on-open="vm.datePickerShow(variant, 'publish')"
                                                        on-close="vm.datePickerClose(variant, 'publish')">
                                             <div>
-                                                <button ng-show="variant.releaseDate" class="btn umb-button--xxs btn-outline umb-outline">
+                                                <button ng-show="variant.releaseDate" class="btn btn-reset umb-button--xxs btn-outline umb-outline">
                                                     {{variant.releaseDateFormatted}}
                                                 </button>
 
-                                                <button type="button" ng-hide="variant.releaseDate">
+                                                <button type="button" class="btn-reset" ng-hide="variant.releaseDate">
                                                     <localize key="content_setDate">Set date</localize>
                                                 </button>
                                             </div>
@@ -152,16 +152,16 @@
                                                        on-open="vm.datePickerShow(variant, 'unpublish')"
                                                        on-close="vm.datePickerClose(variant, 'unpublish')">
                                             <div>
-                                                <button type="button" ng-show="variant.expireDate" class="btn umb-button--xxs btn-outline umb-outline">
+                                                <button type="button" ng-show="variant.expireDate" class="btn btm-reset umb-button--xxs btn-outline umb-outline">
                                                     {{variant.expireDateFormatted}}
                                                 </button>
 
-                                                <button type="button" ng-hide="variant.expireDate">
+                                                <button type="button" class="btn-reset" ng-hide="variant.expireDate">
                                                     <localize key="content_setDate">Set date</localize>
                                                 </button>
                                             </div>
                                         </umb-date-time-picker>
-                                        <button type="button" ng-show="variant.expireDate" ng-click="vm.clearUnpublishDate(variant)" class="btn umb-button--xxs dropdown-toggle umb-button-group__toggle btn-outline umb-outline" style="margin-left: -2px;">
+                                        <button type="button" ng-show="variant.expireDate" ng-click="vm.clearUnpublishDate(variant)" class="btn btn-reset umb-button--xxs dropdown-toggle umb-button-group__toggle btn-outline umb-outline" style="margin-left: -2px;">
                                             <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
                                         </button>
                                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.html
@@ -23,25 +23,26 @@
                                    on-close="vm.datePickerClose(vm.variants[0], 'publish')">
 
                         <div>
-                            <button ng-show="vm.variants[0].releaseDate" class="btn umb-button--xs" style="outline: none;">
+                            <button type="button" ng-show="vm.variants[0].releaseDate" class="btn umb-button--xs" style="outline: none;">
                                 {{vm.variants[0].releaseDateFormatted}}
                             </button>
 
-                            <a ng-hide="vm.variants[0].releaseDate" href="">
+                            <button type="button" ng-hide="vm.variants[0].releaseDate">
                                 <localize key="content_setDate">Set date</localize>
-                            </a>
+                            </button>
                         </div>
 
                     </umb-date-time-picker>
 
-                    <a ng-show="vm.variants[0].releaseDate" ng-click="vm.clearPublishDate(vm.variants[0])" class="btn umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
+                    <button type="button" ng-show="vm.variants[0].releaseDate" ng-click="vm.clearPublishDate(vm.variants[0])" class="btn umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
                         <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
-                    </a>
+                    </button>
 
                 </div>
             </div>
 
             <div class="date-wrapper__date">
+
                 <label class="bold">
                     <localize key="content_unpublishDate"></localize>
                 </label>
@@ -59,16 +60,16 @@
                                 {{vm.variants[0].expireDateFormatted}}
                             </button>
 
-                            <a ng-hide="vm.variants[0].expireDate" href="">
+                            <button type="button" ng-hide="vm.variants[0].expireDate">
                                 <localize key="content_setDate">Set date</localize>
-                            </a>
+                            </button>
                         </div>
 
                     </umb-date-time-picker>
 
-                    <a ng-show="vm.variants[0].expireDate" ng-click="vm.clearUnpublishDate(vm.variants[0])" class="btn umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
+                    <button type="button" ng-show="vm.variants[0].expireDate" ng-click="vm.clearUnpublishDate(vm.variants[0])" class="btn umb-button--xs dropdown-toggle umb-button-group__toggle" style="margin-left: -2px;">
                         <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
-                    </a>
+                    </button>
 
                 </div>
             </div>
@@ -129,12 +130,12 @@
                                                     {{variant.releaseDateFormatted}}
                                                 </button>
 
-                                                <a ng-hide="variant.releaseDate" href="">
+                                                <button type="button" ng-hide="variant.releaseDate">
                                                     <localize key="content_setDate">Set date</localize>
-                                                </a>
+                                                </button>
                                             </div>
                                         </umb-date-time-picker>
-                                        <button ng-show="variant.releaseDate" ng-click="vm.clearPublishDate(variant)" class="btn umb-button--xxs dropdown-toggle umb-button-group__toggle btn-outline umb-outline" style="margin-left: -2px;">
+                                        <button type="button" ng-show="variant.releaseDate" ng-click="vm.clearPublishDate(variant)" class="btn umb-button--xxs dropdown-toggle umb-button-group__toggle btn-outline umb-outline" style="margin-left: -2px;">
                                             <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
                                         </button>
                                     </div>
@@ -151,18 +152,18 @@
                                                        on-open="vm.datePickerShow(variant, 'unpublish')"
                                                        on-close="vm.datePickerClose(variant, 'unpublish')">
                                             <div>
-                                                <button ng-show="variant.expireDate" class="btn umb-button--xxs btn-outline umb-outline">
+                                                <button type="button" ng-show="variant.expireDate" class="btn umb-button--xxs btn-outline umb-outline">
                                                     {{variant.expireDateFormatted}}
                                                 </button>
 
-                                                <a ng-hide="variant.expireDate" href="">
+                                                <button type="button" ng-hide="variant.expireDate">
                                                     <localize key="content_setDate">Set date</localize>
-                                                </a>
+                                                </button>
                                             </div>
                                         </umb-date-time-picker>
-                                        <a ng-show="variant.expireDate" ng-click="vm.clearUnpublishDate(variant)" class="btn umb-button--xxs dropdown-toggle umb-button-group__toggle btn-outline umb-outline" style="margin-left: -2px;">
+                                        <button type="button" ng-show="variant.expireDate" ng-click="vm.clearUnpublishDate(variant)" class="btn umb-button--xxs dropdown-toggle umb-button-group__toggle btn-outline umb-outline" style="margin-left: -2px;">
                                             <umb-icon icon="icon-wrong" class="icon icon-wrong"></umb-icon>
-                                        </a>
+                                        </button>
                                     </div>
                                 </div>
                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
@@ -11,15 +11,14 @@
                 on-change="datePickerChange(dateStr)">
 
                 <div class="input-append">
-                    <input
-                        name="datepicker"
-                        id="{{model.alias}}"
-                        type="text"
-                        ng-model="model.datetimePickerValue"
-                        ng-blur="inputChanged()"
-                        ng-required="model.validation.mandatory"
-                        val-server="value"
-                        class="datepickerinput">
+                    <input type="text"
+                           name="datepicker"
+                           id="{{model.alias}}"
+                           ng-model="model.datetimePickerValue"
+                           ng-blur="inputChanged()"
+                           ng-required="model.validation.mandatory"
+                           val-server="value"
+                           class="datepickerinput" />
                     <button type="button" class="on-top" ng-click="clearDate()" ng-show="hasDatetimePickerValue === true || datePickerForm.datepicker.$error.pickerError === true">
                         <i class="icon-delete" aria-hidden="true"></i>
                         <span class="sr-only"><localize key="content_removeDate">Clear date</localize></span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replaces a few `<a>` (anchor) elements in schedule overlay with `<button>` elements for accessibility.

At the moment it seems the datepicker doesn't open when focusing the button and hitting enter, which might because of the transcluded content, but we can look at this in another PR.

![image](https://user-images.githubusercontent.com/2919859/90442632-3e8b5600-e0db-11ea-9e28-fc70578e0462.png)
