### PR TITLE
Fixed log viewer level filter by correcting binding for provided array of selected values to filter by.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -2441,7 +2441,7 @@ namespace Umbraco.Web.Editors
         // set up public access using role based access
         [EnsureUserPermissionForContent("contentId", ActionProtect.ActionLetter)]
         [HttpPost]
-        public IActionResult PostPublicAccess(int contentId, [FromQuery]string[] groups, [FromQuery]string[] usernames, int loginPageId, int errorPageId)
+        public IActionResult PostPublicAccess(int contentId, [FromQuery(Name = "groups[]")]string[] groups, [FromQuery(Name = "usernames[]")]string[] usernames, int loginPageId, int errorPageId)
         {
             if ((groups == null || groups.Any() == false) && (usernames == null || usernames.Any() == false))
             {

--- a/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
@@ -80,7 +80,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         }
 
         [HttpGet]
-        public PagedResult<LogMessage> GetLogs(string orderDirection = "Descending", int pageNumber = 1, string filterExpression = null, [FromQuery]string[] logLevels = null, [FromQuery] DateTime? startDate = null,[FromQuery] DateTime? endDate = null)
+        public PagedResult<LogMessage> GetLogs(string orderDirection = "Descending", int pageNumber = 1, string filterExpression = null, [FromQuery(Name = "logLevels[]")]string[] logLevels = null, [FromQuery]DateTime? startDate = null, [FromQuery]DateTime? endDate = null)
         {
             var logTimePeriod = GetTimePeriod(startDate, endDate);
 


### PR DESCRIPTION
Resolves an issue caused by the `[FromQuery]` parameter binding for arrays, which [needs the parameter name explicitly provided](https://stackoverflow.com/a/55516012/489433).

Without this the array comes through as empty so no level filter is applied.