### PR TITLE
Deprecate IsRequired on Email datatype

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/EmailAddressConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/EmailAddressConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using System;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -8,6 +9,7 @@ namespace Umbraco.Web.PropertyEditors
     public class EmailAddressConfiguration
     {
         [ConfigurationField("IsRequired", "Required?", "hidden", Description = "Deprecated; Make this required by selecting mandatory when adding to the document type")]
+        [Obsolete("No longer used, use `Mandatory` for the property instead. Will be removed in the next major version")]
         public bool IsRequired { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/EmailAddressConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/EmailAddressConfiguration.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class EmailAddressConfiguration
     {
-        [ConfigurationField("IsRequired", "Required?", "boolean")]
+        [ConfigurationField("IsRequired", "Required?", "hidden", Description = "Deprecated; Make this required by selecting mandatory when adding to the document type")]
         public bool IsRequired { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

For issue https://github.com/umbraco/Umbraco-CMS/issues/3013

### Description

On the email datatype there is a field IsRequired, which when true makes the field mandatory overriding the mandatory selection when the datatype is added to a doctype making it mandatory without showing the * etc for a mandatory field. 

This then has confusing and unexpected validation. In discussion with @nul800sebastiaan we thought it would be best to hide the IsRequired field for now. The best I could do was make it hidden and including a deprecated message.

To reproduce the issue, add an email datatype with Is Required set to true to a doctype with mandatory set to false. You'll see it doesn't have the UI of a mandatory field but does have validation for a mandatory field.

<!-- Thanks for contributing to Umbraco CMS! -->
