### PR TITLE
Use convertVirtualToAbsolutePath for all file URLs of a block config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -14,7 +14,7 @@
     'use strict';
 
 
-    function blockEditorModelObjectFactory($interpolate, $q, udiService, contentResource, localizationService) {
+    function blockEditorModelObjectFactory($interpolate, $q, udiService, contentResource, localizationService, umbRequestHelper) {
 
         /**
          * Simple mapping from property model content entry to editing model,

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -325,6 +325,18 @@
             this.propertyEditorAlias = propertyEditorAlias;
             this.blockConfigurations = blockConfigurations;
 
+            this.blockConfigurations.forEach(blockConfiguration => {
+                if (blockConfiguration.view != null && blockConfiguration.view !== "") {
+                    blockConfiguration.view = umbRequestHelper.convertVirtualToAbsolutePath(blockConfiguration.view);
+                }
+                if (blockConfiguration.stylesheet != null && blockConfiguration.stylesheet !== "") {
+                    blockConfiguration.stylesheet = umbRequestHelper.convertVirtualToAbsolutePath(blockConfiguration.stylesheet);
+                }
+                if (blockConfiguration.thumbnail != null && blockConfiguration.thumbnail !== "") {
+                    blockConfiguration.thumbnail = umbRequestHelper.convertVirtualToAbsolutePath(blockConfiguration.thumbnail);
+                }
+            });
+
             this.scaffolds = [];
 
             this.isolatedScope = scopeOfExistance.$new(true);
@@ -541,15 +553,6 @@
                 }
                 blockObject.key = String.CreateGuid().replace(/-/g, "");
                 blockObject.config = Utilities.copy(blockConfiguration);
-                if (blockObject.config.view != null && blockObject.config.view !== "") {
-                    blockObject.config.view = umbRequestHelper.convertVirtualToAbsolutePath(blockObject.config.view);
-                }
-                if (blockObject.config.stylesheet != null && blockObject.config.stylesheet !== "") {
-                    blockObject.config.stylesheet = umbRequestHelper.convertVirtualToAbsolutePath(blockObject.config.stylesheet);
-                }
-                if (blockObject.config.thumbnail != null && blockObject.config.thumbnail !== "") {
-                    blockObject.config.thumbnail = umbRequestHelper.convertVirtualToAbsolutePath(blockObject.config.thumbnail);
-                }
                 if (blockObject.config.label && blockObject.config.label !== "") {
                     blockObject.labelInterpolator = $interpolate(blockObject.config.label);
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -541,6 +541,15 @@
                 }
                 blockObject.key = String.CreateGuid().replace(/-/g, "");
                 blockObject.config = Utilities.copy(blockConfiguration);
+                if (blockObject.config.view != null && blockObject.config.view !== "") {
+                    blockObject.config.view = umbRequestHelper.convertVirtualToAbsolutePath(blockObject.config.view);
+                }
+                if (blockObject.config.stylesheet != null && blockObject.config.stylesheet !== "") {
+                    blockObject.config.stylesheet = umbRequestHelper.convertVirtualToAbsolutePath(blockObject.config.stylesheet);
+                }
+                if (blockObject.config.thumbnail != null && blockObject.config.thumbnail !== "") {
+                    blockObject.config.thumbnail = umbRequestHelper.convertVirtualToAbsolutePath(blockObject.config.thumbnail);
+                }
                 if (blockObject.config.label && blockObject.config.label !== "") {
                     blockObject.labelInterpolator = $interpolate(blockObject.config.label);
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,5 +1,5 @@
 
-    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.thumbnail ? 'url('+vm.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
+    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.blockConfigModel.thumbnail ? 'url('+vm.blockConfigModel.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
         <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{ vm.elementTypeModel.icon }}" ng-style="{'color':vm.blockConfigModel.iconColor}" aria-hidden="true"></i>
     </div>
     <div class="__info">

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,5 +1,5 @@
 
-    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.blockConfigModel.thumbnail ? 'url('+vm.blockConfigModel.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
+    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.thumbnail ? 'url('+vm.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
         <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{ vm.elementTypeModel.icon }}" ng-style="{'color':vm.blockConfigModel.iconColor}" aria-hidden="true"></i>
     </div>
     <div class="__info">

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -14,9 +14,15 @@
             }
         });
 
-    function BlockCardController() {
-        
+    function BlockCardController(umbRequestHelper) {
+
         var vm = this;
+
+        vm.$onInit = function() {
+            if(vm.blockConfigModel.thumbnail != null && vm.blockConfigModel.thumbnail != "") {
+                vm.thumbnail = convertVirtualToAbsolutePath(vm.blockConfigModel.thumbnail);
+            }
+        }
 
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -14,15 +14,9 @@
             }
         });
 
-    function BlockCardController(umbRequestHelper) {
+    function BlockCardController() {
 
         var vm = this;
-
-        vm.$onInit = function() {
-            if(vm.blockConfigModel.thumbnail != null && vm.blockConfigModel.thumbnail != "") {
-                vm.thumbnail = convertVirtualToAbsolutePath(vm.blockConfigModel.thumbnail);
-            }
-        }
 
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -147,7 +147,7 @@
 
 
         vm.addViewForBlock = function(block) {
-            localizationService.localize("blockEditor_headlineSelectView").then(function(localizedTitle) {
+            localizationService.localize("blockEditor_headlineAddCustomView").then(function(localizedTitle) {
 
                 const filePicker = {
                     title: localizedTitle,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -28,7 +28,7 @@
             }
         });
 
-    function BlockListController($scope, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper, umbRequestHelper) {
+    function BlockListController($scope, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper) {
 
         var unsubscribe = [];
         var modelObject;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -233,7 +233,7 @@
             ensureCultureData(block.content);
             ensureCultureData(block.settings);
 
-            block.view = (block.config.view ? umbRequestHelper.convertVirtualToAbsolutePath(block.config.view) : getDefaultViewForBlock(block));
+            block.view = (block.config.view ? block.config.view : getDefaultViewForBlock(block));
             block.showValidation = block.config.view ? true : false;
 
             block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true || inlineEditing === true;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -28,7 +28,7 @@
             }
         });
 
-    function BlockListController($scope, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper) {
+    function BlockListController($scope, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper, umbRequestHelper) {
 
         var unsubscribe = [];
         var modelObject;
@@ -233,8 +233,7 @@
             ensureCultureData(block.content);
             ensureCultureData(block.settings);
 
-            // TODO: Why is there a '/' prefixed? that means this will never work with virtual directories
-            block.view = (block.config.view ? "/" + block.config.view : getDefaultViewForBlock(block));
+            block.view = (block.config.view ? umbRequestHelper.convertVirtualToAbsolutePath(block.config.view) : getDefaultViewForBlock(block));
             block.showValidation = block.config.view ? true : false;
 
             block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true || inlineEditing === true;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -48,7 +48,6 @@
             $scope.valFormManager = model.valFormManager;
 
             if (model.stylesheet) {
-                model.stylesheet = umbRequestHelper.convertVirtualToAbsolutePath(model.stylesheet);
                 var shadowRoot = $element[0].attachShadow({ mode: 'open' });
                 shadowRoot.innerHTML = `
                     <style>

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/block-editor-service.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/block-editor-service.spec.js
@@ -41,7 +41,7 @@
     }));
 
 
-    var blockConfigurationMock = { contentElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: null, view: "testview.html" };
+    var blockConfigurationMock = { contentElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: null, view: "/testview.html" };
 
     var propertyModelMock = {
         layout: {
@@ -60,7 +60,7 @@
         ]
     };
 
-    var blockWithSettingsConfigurationMock = { contentElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", view: "testview.html" };
+    var blockWithSettingsConfigurationMock = { contentElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", label: "Test label", settingsElementTypeKey: "7C5B74D1-E2F9-45A3-AE4B-FC7A829BF8AB", view: "/testview.html" };
     var propertyModelWithSettingsMock = {
         layout: {
             "Umbraco.TestBlockEditor": [


### PR DESCRIPTION
Fixing the issue of missing the use of ´convertVirtualToAbsolutePath´. Plus refactored to the init of a BlockObject, so Devs don't need to worry about this.