### PR TITLE
Custom components need to be non-void elements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklist.html
@@ -1,1 +1,1 @@
-<umb-block-list-property-editor model="model"/>
+<umb-block-list-property-editor model="model"></umb-block-list-property-editor>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Angular element directives/components and custom HTML elements, so the need to be non-void elements (not self-closing elements), e.g here:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklist.html

Void elements can of course still be used for native elements according to the HTML specification: https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements

So the following:

```
<umb-block-list-property-editor model="model"/>
```

need to be this:

```
<umb-block-list-property-editor model="model"></umb-block-list-property-editor>
```

Here is a great explanation of why it can't be self-closing: https://stackoverflow.com/a/25012451/1693918

We have seens some issues recently, where this is causing issues when having following sibling elements
Some examples:
https://github.com/umbraco/Umbraco-CMS/pull/8605
https://github.com/umbraco/Umbraco-CMS/pull/8478