### PR TITLE
Fix block list console errors in document type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -595,25 +595,23 @@
             }
 
             // validate limits:
-            if (vm.propertyForm) {
+            if (vm.propertyForm && vm.validationLimit) {
 
                 var isMinRequirementGood = vm.validationLimit.min === null || vm.layout.length >= vm.validationLimit.min;
                 vm.propertyForm.minCount.$setValidity("minCount", isMinRequirementGood);
                 
                 var isMaxRequirementGood = vm.validationLimit.max === null || vm.layout.length <= vm.validationLimit.max;
                 vm.propertyForm.maxCount.$setValidity("maxCount", isMaxRequirementGood);
-                
             }
         }
-        unsubscribe.push($scope.$watch(() => vm.layout.length, onAmountOfBlocksChanged));
 
+        unsubscribe.push($scope.$watch(() => vm.layout.length, onAmountOfBlocksChanged));
         
         $scope.$on("$destroy", function () {
             for (const subscription of unsubscribe) {
                 subscription();
             }
         });
-
 
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -34,8 +34,8 @@
         var modelObject;
 
         // Property actions:
-        var copyAllBlocksAction;
-        var deleteAllBlocksAction;
+        var copyAllBlocksAction = null;
+        var deleteAllBlocksAction = null;
 
         var inlineEditing = false;
         var liveEditing = true;
@@ -111,14 +111,15 @@
                 icon: "documents",
                 method: requestCopyAllBlocks,
                 isDisabled: true
-            }
+            };
+
             deleteAllBlocksAction = {
                 labelKey: 'clipboard_labelForRemoveAllEntries',
                 labelTokens: [],
                 icon: 'trash',
                 method: requestDeleteAllBlocks,
                 isDisabled: true
-            }
+            };
 
             var propertyActions = [
                 copyAllBlocksAction,
@@ -586,8 +587,12 @@
         function onAmountOfBlocksChanged() {
 
             // enable/disable property actions
-            copyAllBlocksAction.isDisabled = vm.layout.length === 0;
-            deleteAllBlocksAction.isDisabled = vm.layout.length === 0;
+            if (copyAllBlocksAction) {
+                copyAllBlocksAction.isDisabled = vm.layout.length === 0;
+            }
+            if (deleteAllBlocksAction) {
+                deleteAllBlocksAction.isDisabled = vm.layout.length === 0;
+            }
 
             // validate limits:
             if (vm.propertyForm) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed various console errors in document type editor where the block list property preview is shown.
I have fixed some of these.

**Before**

![image](https://user-images.githubusercontent.com/2919859/90664784-67caf400-e24b-11ea-8d17-2dd9252f49be.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/90664643-30f4de00-e24b-11ea-9e46-7f93362c788c.png)
