### PR TITLE
Add filter css class for not allowed thumbnail extensions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,11 +1,9 @@
+<div class="__showcase" ng-style="{'background-color': vm.blockConfigModel.backgroundColor, 'background-image': vm.blockConfigModel.thumbnail ? 'url('+ vm.blockConfigModel.thumbnail + '?upscale=false&width=400)' : 'none'}">
+    <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{vm.elementTypeModel.icon}}" ng-style="{'color': vm.blockConfigModel.iconColor}" aria-hidden="true"></i>
+</div>
+<div class="__info">
+    <div class="__name" ng-bind="vm.elementTypeModel.name"></div>
+    <div class="__subname" ng-if="vm.elementTypeModel.description" ng-bind="vm.elementTypeModel.description"></div>
+</div>
 
-    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.blockConfigModel.thumbnail ? 'url('+vm.blockConfigModel.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
-        <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{ vm.elementTypeModel.icon }}" ng-style="{'color':vm.blockConfigModel.iconColor}" aria-hidden="true"></i>
-    </div>
-    <div class="__info">
-        <div class="__name" ng-bind="vm.elementTypeModel.name"></div>
-        <div class="__subname" ng-if="vm.elementTypeModel.description" ng-bind="vm.elementTypeModel.description"></div>
-    </div>
-
-    <ng-transclude></ng-transclude>
-
+<ng-transclude></ng-transclude>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -235,11 +235,9 @@
             block.stylesheet = null;
         };
 
+        vm.addThumbnailForBlock = function (block) {
 
-
-        vm.addThumbnailForBlock = function(block) {
-
-            localizationService.localize("blockEditor_headlineAddThumbnail").then(function(localizedTitle) {
+            localizationService.localize("blockEditor_headlineAddThumbnail").then(function (localizedTitle) {
 
                 const thumbnailPicker = {
                     title: localizedTitle,
@@ -250,6 +248,7 @@
                     filter: function (i) {
                         return !(i.name.indexOf(".jpg") !== -1 || i.name.indexOf(".jpeg") !== -1 || i.name.indexOf(".png") !== -1 || i.name.indexOf(".svg") !== -1 || i.name.indexOf(".webp") !== -1 || i.name.indexOf(".gif") !== -1);
                     },
+                    filterCssClass: "not-allowed",
                     select: function (file) {
                         block.thumbnail = file.name;
                         editorService.close();
@@ -259,27 +258,24 @@
                     }
                 };
                 editorService.treePicker(thumbnailPicker);
-
             });
-        }
+        };
+
         vm.removeThumbnailForBlock = function(entry) {
             entry.thumbnail = null;
         };
-
-
-
 
         vm.submit = function () {
             if ($scope.model && $scope.model.submit) {
                 $scope.model.submit($scope.model);
             }
-        }
+        };
 
-        vm.close = function() {
+        vm.close = function () {
             if ($scope.model && $scope.model.close) {
                 $scope.model.close($scope.model);
             }
-        }
+        };
 
         $scope.$on('$destroy', function () {
             unsubscribe.forEach(u => { u(); });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add the `not-allowed` cursor style when however not allowed files in block thumbnail picker similar to file picker in packager: https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js#L286


