### PR TITLE
Netcore: Optimizations for non-windows development

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/NoopBackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Infrastructure/Examine/NoopBackOfficeExamineSearcher.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Examine;
+using Umbraco.Examine;
+using Umbraco.Web.Models.ContentEditing;
+
+namespace Umbraco.Infrastructure.Examine
+{
+    public class NoopBackOfficeExamineSearcher : IBackOfficeExamineSearcher
+    {
+        public IEnumerable<ISearchResult> Search(string query, UmbracoEntityTypes entityType, int pageSize, long pageIndex, out long totalFound,
+            string searchFrom = null, bool ignoreUserStartNodes = false)
+        {
+            totalFound = 0;
+            return new ISearchResult[0];
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Examine/NoopBackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Infrastructure/Examine/NoopBackOfficeExamineSearcher.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Examine;
 using Umbraco.Examine;
 using Umbraco.Web.Models.ContentEditing;
@@ -11,7 +12,7 @@ namespace Umbraco.Infrastructure.Examine
             string searchFrom = null, bool ignoreUserStartNodes = false)
         {
             totalFound = 0;
-            return new ISearchResult[0];
+            return Enumerable.Empty<ISearchResult>();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Examine/NoopUmbracoIndexesCreator.cs
+++ b/src/Umbraco.Infrastructure/Examine/NoopUmbracoIndexesCreator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Examine;
 using Umbraco.Examine;
 
@@ -8,7 +9,7 @@ namespace Umbraco.Infrastructure.Examine
     {
         public IEnumerable<IIndex> Create()
         {
-            return new IIndex[0];
+            return Enumerable.Empty<IIndex>();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Examine/NoopUmbracoIndexesCreator.cs
+++ b/src/Umbraco.Infrastructure/Examine/NoopUmbracoIndexesCreator.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Examine;
+using Umbraco.Examine;
+
+namespace Umbraco.Infrastructure.Examine
+{
+    public class NoopUmbracoIndexesCreator : IUmbracoIndexesCreator
+    {
+        public IEnumerable<IIndex> Create()
+        {
+            return new IIndex[0];
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Runtime/CoreInitialComposer.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreInitialComposer.cs
@@ -30,6 +30,7 @@ using Umbraco.Core.Services.Implement;
 using Umbraco.Core.Strings;
 using Umbraco.Core.Sync;
 using Umbraco.Examine;
+using Umbraco.Infrastructure.Examine;
 using Umbraco.Infrastructure.Media;
 using Umbraco.Web;
 using Umbraco.Web.Actions;
@@ -365,7 +366,9 @@ namespace Umbraco.Core.Runtime
 
             composition.RegisterUnique<IUmbracoComponentRenderer, UmbracoComponentRenderer>();
 
-
+            // Register noop versions for examine to be overridden by examine
+            composition.RegisterUnique<IUmbracoIndexesCreator, NoopUmbracoIndexesCreator>();
+            composition.RegisterUnique<IBackOfficeExamineSearcher, NoopBackOfficeExamineSearcher>();
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Umbraco.Web.BackOffice.csproj
+++ b/src/Umbraco.Web.BackOffice/Umbraco.Web.BackOffice.csproj
@@ -32,7 +32,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Umbraco.Configuration\Umbraco.Configuration.csproj" />
         <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />
-        <ProjectReference Include="..\Umbraco.Examine.Lucene\Umbraco.Examine.Lucene.csproj" />
+        <ProjectReference Include="..\Umbraco.Examine.Lucene\Umbraco.Examine.Lucene.csproj" Condition="'$(OS)' == 'Windows_NT'" />
         <ProjectReference Include="..\Umbraco.Infrastructure\Umbraco.Infrastructure.csproj" />
         <ProjectReference Include="..\Umbraco.Web.Common\Umbraco.Web.Common.csproj" />
     </ItemGroup>

--- a/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
+++ b/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
@@ -17,6 +17,7 @@
       <ProjectReference Include="..\Umbraco.Web.BackOffice\Umbraco.Web.BackOffice.csproj" />
       <ProjectReference Include="..\Umbraco.Web.Common\Umbraco.Web.Common.csproj" />
       <ProjectReference Include="..\Umbraco.Web.Website\Umbraco.Web.Website.csproj" />
+      <ProjectReference Include="..\Umbraco.Persistance.SqlCe\Umbraco.Persistance.SqlCe.csproj" Condition="'$(OS)' == 'Windows_NT'"  />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Notes
- Registers noop implementations of required Examine interfaces in core. These are replaced by the `ExamineLuceneComposer`.
- Add conditions on project references of .net framework assemblies to only be used on windows