### PR TITLE
Add missing shortcut to close overlay via esc key

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
@@ -36,6 +36,7 @@
 
                     <umb-button
                         action="vm.close()"
+                        shortcut="esc"
                         button-style="link"
                         label="{{vm.closeLabel}}"
                         type="button">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -69,6 +69,7 @@
 
                 <umb-button
                     action="vm.close()"
+                    shortcut="esc"
                     button-style="link"
                     label-key="general_cancel"
                     type="button">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Noticed a few missing `shortcut` attributes, so it is possible to close overlays via `esc` key.