### PR TITLE
Add more tags on document types to show whether the property has custom mandatory message and validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -198,6 +198,16 @@
                                         <localize key="general_mandatory"></localize>
                                     </div>
 
+                                    <div class="umb-group-builder__property-tag -white" ng-if="property.validation.mandatoryMessage">
+                                        <i class="umb-group-builder__property-tag-icon">*</i>
+                                        <localize key="general_mandatoryMessage">Custom Mandatory Message</localize>
+                                    </div>
+
+                                    <div class="umb-group-builder__property-tag -white" ng-if="property.validation.pattern">
+                                        <i class="umb-group-builder__property-tag-icon">*</i>
+                                        <localize key="general_customValidation">Custom Validation</localize>
+                                    </div>
+
                                     <div class="umb-group-builder__property-tag -white" ng-if="property.showOnMemberProfile">
                                         <i class="icon-eye umb-group-builder__property-tag-icon"></i>
                                         <localize key="contentTypeEditor_showOnMemberProfile"></localize>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -794,6 +794,8 @@
     <key alias="videos">Videos</key>
     <key alias="clear">Clear</key>
     <key alias="installing">Installing</key>
+    <key alias="customValidation">Custom Validation Pattern</key>
+    <key alias="mandatoryMessage">Custom Mandatory Message</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blue</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -801,6 +801,8 @@
     <key alias="videos">Videos</key>
     <key alias="clear">Clear</key>
     <key alias="installing">Installing</key>
+    <key alias="customValidation">Custom Validation Pattern</key>
+    <key alias="mandatoryMessage">Custom Mandatory Message</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blue</key>


### PR DESCRIPTION
Hi,

With this PR I have tried to add more tags to the property view when there is a custom validation message or pattern on the field. I think it will be good if we can get an overview of fields with custom mandatory messages and custom validation pattern.

![tags](https://user-images.githubusercontent.com/3941753/90753705-d69e6080-e2d0-11ea-9ac2-c735712c84a9.gif)

Poornima