### PR TITLE
NetCore: Migrate GetCurrentUserLinkedLogins api

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -416,6 +416,8 @@ namespace Umbraco.Web.BackOffice.Controllers
             return Ok();
         }
 
+
+
         /// <summary>
         /// Return the <see cref="UserDetail"/> for the given <see cref="IUser"/>
         /// </summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/CurrentUserController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/CurrentUserController.cs
@@ -235,5 +235,12 @@ namespace Umbraco.Web.BackOffice.Controllers
             throw HttpResponseException.CreateValidationErrorResponse(ModelState);
         }
 
+        [UmbracoAuthorize]
+        [ValidateAngularAntiForgeryToken]
+        public async Task<Dictionary<string, string>> GetCurrentUserLinkedLogins()
+        {
+            var identityUser = await _backOfficeUserManager.FindByIdAsync(_webSecurity.GetUserId().ResultOr(0).ToString());
+            return identityUser.Logins.ToDictionary(x => x.LoginProvider, x => x.ProviderKey);
+        }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/auth.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/auth.resource.js
@@ -4,7 +4,7 @@
  * @description
  * This Resource perfomrs actions to common authentication tasks for the Umbraco backoffice user
  *
- * @requires $q 
+ * @requires $q
  * @requires $http
  * @requires umbRequestHelper
  * @requires angularHelper
@@ -62,7 +62,7 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
      *    .then(function(data) {
      *        //Do stuff for login...
      *    });
-     * </pre> 
+     * </pre>
      * @param {string} login Username of backoffice user
      * @param {string} password Password of backoffice user
      * @returns {Promise} resourcePromise object
@@ -91,9 +91,9 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
      * There are not parameters for this since when the user has clicked on their invite email they will be partially
      * logged in (but they will not be approved) so we need to use this method to verify the non approved logged in user's details.
      * Using the getCurrentUser will not work since that only works for approved users
-     * @returns {} 
+     * @returns {}
      */
-    getCurrentInvitedUser: function () {      
+    getCurrentInvitedUser: function () {
       return umbRequestHelper.resourcePromise(
         $http.get(
           umbRequestHelper.getApiUrl(
@@ -117,7 +117,7 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
      *    .then(function(data) {
      *        //Do stuff for password reset request...
      *    });
-     * </pre> 
+     * </pre>
      * @param {string} email Email address of backoffice user
      * @returns {Promise} resourcePromise object
      *
@@ -164,7 +164,7 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
      *    .then(function(data) {
      *        //Allow reset of password
      *    });
-     * </pre> 
+     * </pre>
      * @param {integer} userId User Id
      * @param {string} resetCode Password reset code
      * @returns {Promise} resourcePromise object
@@ -195,14 +195,14 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
           }),
         'Password reset code validation failed for userId ' + userId + ', code' + resetCode);
     },
-    
+
     /**
      * @ngdoc method
      * @name umbraco.resources.currentUserResource#getPasswordConfig
      * @methodOf umbraco.resources.currentUserResource
      *
      * @description
-     * Gets the configuration of the user membership provider which is used to configure the change password form         
+     * Gets the configuration of the user membership provider which is used to configure the change password form
      */
       getPasswordConfig: function (userId) {
           return umbRequestHelper.resourcePromise(
@@ -227,7 +227,7 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
      *    .then(function(data) {
      *        //Password set
      *    });
-     * </pre> 
+     * </pre>
      * @param {integer} userId User Id
      * @param {string} password New password
      * @param {string} confirmPassword Confirmation of new password
@@ -346,15 +346,6 @@ function authResource($q, $http, umbRequestHelper, angularHelper) {
         'Server call failed for getting current user');
     },
 
-    getCurrentUserLinkedLogins: function () {
-
-      return umbRequestHelper.resourcePromise(
-        $http.get(
-          umbRequestHelper.getApiUrl(
-            "authenticationApiBaseUrl",
-            "GetCurrentUserLinkedLogins")),
-        'Server call failed for getting current users linked logins');
-    },
 
     /**
      * @ngdoc method

--- a/src/Umbraco.Web.UI.Client/src/common/resources/currentuser.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/currentuser.resource.js
@@ -2,7 +2,7 @@
     * @ngdoc service
     * @name umbraco.resources.currentUserResource
     * @description Used for read/updates for the currently logged in user
-    * 
+    *
     *
     **/
 function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
@@ -35,10 +35,10 @@ function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
           *    .then(function() {
           *        alert('You are allowed to publish this item');
           *    });
-          * </pre> 
+          * </pre>
           *
           * @param {String} permission char representing the permission to check
-          * @param {Int} id id of content item to delete        
+          * @param {Int} id id of content item to delete
           * @returns {Promise} resourcePromise object.
           *
           */
@@ -50,6 +50,16 @@ function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
                         "HasPermission",
                         [{ permissionToCheck: permission }, { nodeId: id }])),
                 'Failed to check permission for item ' + id);
+        },
+
+        getCurrentUserLinkedLogins: function () {
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "currentUserApiBaseUrl",
+                        "GetCurrentUserLinkedLogins")),
+                'Server call failed for getting current users linked logins');
         },
 
         saveTourStatus: function (tourStatus) {
@@ -68,7 +78,7 @@ function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
         },
 
         getTours: function () {
-            
+
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl(
@@ -98,7 +108,7 @@ function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
          *
          * @description
          * Changes the current users password
-         * 
+         *
          * @returns {Promise} resourcePromise object containing the user array.
          *
          */
@@ -108,7 +118,7 @@ function currentUserResource($q, $http, umbRequestHelper, umbDataFormatter) {
             if (!changePasswordArgs) {
                 throw 'No password data to change';
             }
-            
+
             return umbRequestHelper.resourcePromise(
                 $http.post(
                     umbRequestHelper.getApiUrl(

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
@@ -71,7 +71,7 @@ angular.module("umbraco")
                     //set the timer
                     //updateTimeout();
 
-                    authResource.getCurrentUserLinkedLogins().then(function(logins) {
+                    currentUserResource.getCurrentUserLinkedLogins().then(function(logins) {
                         //reset all to be un-linked
                         for (var provider in $scope.externalLoginProviders) {
                             $scope.externalLoginProviders[provider].linkedProviderKey = undefined;
@@ -142,7 +142,7 @@ angular.module("umbraco")
 
                 currentUserResource.changePassword($scope.changePasswordModel.value).then(function(data) {
 
-                    //reset old data 
+                    //reset old data
                     clearPasswordFields();
 
                     formHelper.resetForm({ scope: $scope });

--- a/src/Umbraco.Web/Editors/AuthenticationController.cs
+++ b/src/Umbraco.Web/Editors/AuthenticationController.cs
@@ -107,16 +107,6 @@ namespace Umbraco.Web.Editors
             }
         }
 
-
-        // TODO: This should be on the CurrentUserController?
-        [WebApi.UmbracoAuthorize]
-        [ValidateAngularAntiForgeryToken]
-        public async Task<Dictionary<string, string>> GetCurrentUserLinkedLogins()
-        {
-            var identityUser = await UserManager.FindByIdAsync(Security.GetUserId().ResultOr(0).ToString());
-            return identityUser.Logins.ToDictionary(x => x.LoginProvider, x => x.ProviderKey);
-        }
-
         /// <summary>
         /// Used to retrieve the 2FA providers for code submission
         /// </summary>


### PR DESCRIPTION
Migrated the `Authentication/GetCurrentUserLinkedLogins`, and resolved the TODO by moving it to `CurrentUserController`

# Test:
- Go to backoffice and click to current user button.