### PR TITLE
Fixes issue with scopes being disposed or referenced incorrectly

### DIFF
--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Examine
                         || !validator.ValidateProtectedContent(path, v.Category))
                     ? 0
                     : 1;
-            });
+            }).ToList();
 
             var hasDeletes = false;
             var hasUpdates = false;
@@ -105,7 +105,7 @@ namespace Umbraco.Examine
                 {
                     hasUpdates = true;
                     //these are the valid ones, so just index them all at once
-                    base.PerformIndexItems(group, onComplete);
+                    base.PerformIndexItems(group.ToList(), onComplete);
                 }
             }
 

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -63,6 +63,13 @@ namespace Umbraco.Core.Sync
             _lastPruned = _lastSync = DateTime.UtcNow;
             _syncIdle = new ManualResetEvent(true);
             _distCacheFilePath = new Lazy<string>(() => GetDistCacheFilePath(hostingEnvironment));
+
+            // See notes on LocalIdentity
+            LocalIdentity = NetworkHelper.MachineName // eg DOMAIN\SERVER
+                + "/" + _hostingEnvironment.ApplicationId // eg /LM/S3SVC/11/ROOT
+                + " [P" + Process.GetCurrentProcess().Id // eg 1234
+                + "/D" + AppDomain.CurrentDomain.Id // eg 22
+                + "] " + Guid.NewGuid().ToString("N").ToUpper(); // make it truly unique
         }
 
         protected ILogger Logger { get; }
@@ -526,11 +533,7 @@ namespace Umbraco.Core.Sync
         /// <para>Practically, all we really need is the guid, the other infos are here for information
         /// and debugging purposes.</para>
         /// </remarks>
-        protected string LocalIdentity => NetworkHelper.MachineName // eg DOMAIN\SERVER
-            + "/" + _hostingEnvironment.ApplicationId // eg /LM/S3SVC/11/ROOT
-            + " [P" + Process.GetCurrentProcess().Id // eg 1234
-            + "/D" + AppDomain.CurrentDomain.Id // eg 22
-            + "] " + Guid.NewGuid().ToString("N").ToUpper(); // make it truly unique
+        protected string LocalIdentity { get; }
 
         private string GetDistCacheFilePath(IHostingEnvironment hostingEnvironment)
         {


### PR DESCRIPTION
See TODO notes in code for some explanation. I will need to fix this up and have a look at v8 next week.

Also fixed a critical issue with DatabaseServerMessenger.LocalIdentity being set incorrectly and not as a property. This means it was recalculated every time with a new GUID so it was changing every time. This meant that this local identity was processing it's own DB instructions which meant that it was processing it's own events twice - essentially double publishing, double indexing, etc... every time. (careful using => assignments! ;)