### PR TITLE
Use an equality comparer in the union for PropertyEditorCollection (Fixes 8681)

### DIFF
--- a/src/Umbraco.Core/PropertyComparer.cs
+++ b/src/Umbraco.Core/PropertyComparer.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core
+{
+    //https://gist.github.com/DForshner/5688879
+    public class PropertyComparer<T> : IEqualityComparer<T>
+    {
+        private Expression<Func<T, object>>[] properties;
+
+        /// <summary>
+        /// Creates an instance of PropertyComparer with a single property to compare.
+        /// </summary>
+        /// <param name="propertyName">Property to perform the comparison on.</param>
+        public PropertyComparer(Expression<Func<T, object>> property)
+        {
+            ThrowExceptionIfPropertyIsNull(property);
+
+            this.properties = new Expression<Func<T, object>>[] { property };
+        }
+
+        private static void ThrowExceptionIfPropertyIsNull(Expression<Func<T, object>> property)
+        {
+            if (property == null)
+                throw new NullReferenceException("Property expression cannot be null.");
+        }
+
+        /// <summary>
+        /// Creates an instance of PropertyComparer using an array of properties to compare.
+        /// </summary>
+        /// <param name="propertyName">Array of properties to perform comparisons on.</param>
+        public PropertyComparer(Expression<Func<T, object>>[] properties)
+        {
+            if (properties.Length == 0)
+                throw new ArgumentException("Array must contain at least on property to compare");
+
+            foreach (var property in properties)
+                ThrowExceptionIfPropertyIsNull(property);
+
+            this.properties = properties;
+        }
+
+        public bool Equals(T x, T y)
+        {
+            // Check each property and return false if any fail to match.
+            foreach (Expression<Func<T, object>> property in properties)
+            {
+                if (!PropertyEquals(x, y, property))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool PropertyEquals(T x, T y, Expression<Func<T, object>> property)
+        {
+            object xValue = property.Compile()(x);
+            object yValue = property.Compile()(y);
+
+            // If the xValue is null then it is equal only if yValue is also Null;
+            if (xValue == null)
+                return yValue == null;
+
+            // Use the default type Equals comparer.
+            return xValue.Equals(yValue);
+        }
+
+        /// <summary>
+        /// Returns the hash code of the object using the configured properties.
+        /// </summary>
+        /// <param name="obj">Object to get hash code for</param>
+        /// <returns></returns>
+        public int GetHashCode(T obj)
+        {
+            if (properties.Length == 1)
+                return GetHashCodeForSingleProperty(obj);
+
+            return GetHashCodeForMultipleProperties(obj);
+        }
+
+        /// <summary>
+        /// In case where there is only a single property just return the properties default GetHashCode method.
+        /// </summary>
+        private int GetHashCodeForSingleProperty(T obj)
+        {
+            object objValue = this.properties[0].Compile()(obj);
+
+            if (objValue == null)
+                return 0;
+            else
+                return objValue.GetHashCode();
+        }
+
+        /// <summary>
+        /// Hashing strategy is based on http://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+        /// </summary>
+        private int GetHashCodeForMultipleProperties(T obj)
+        {
+            int hash = 17;
+
+            // Check each property and return false if any fail to match.
+            foreach (Expression<Func<T, object>> property in properties)
+            {
+                object objValue = property.Compile()(obj);
+
+                if (objValue == null)
+                    hash = hash * 31;
+                else
+                    hash = hash * 31 + objValue.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+}

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorCollection.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.PropertyEditors
         public PropertyEditorCollection(DataEditorCollection dataEditors, ManifestParser manifestParser)
             : base(dataEditors
                 .Where(x => (x.Type & EditorType.PropertyValue) > 0)
-                .Union(manifestParser.Manifest.PropertyEditors))
+                .Union(manifestParser.Manifest.PropertyEditors, new PropertyComparer<IDataEditor>(pe => pe.Alias)))
         { }
 
         public PropertyEditorCollection(DataEditorCollection dataEditors)

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -322,6 +322,7 @@
     <Compile Include="Models\PublishedContent\ILivePublishedModelFactory.cs" />
     <Compile Include="Models\PublishedContent\IPublishedContentType.cs" />
     <Compile Include="Models\PublishedContent\IPublishedPropertyType.cs" />
+    <Compile Include="PropertyComparer.cs" />
     <Compile Include="PropertyEditors\ConfigurationFieldsExtensions.cs" />
     <Compile Include="PropertyEditors\DataValueReferenceFactoryCollection.cs" />
     <Compile Include="PropertyEditors\DataValueReferenceFactoryCollectionBuilder.cs" />

--- a/src/Umbraco.Tests/Misc/PropertyComparerTests.cs
+++ b/src/Umbraco.Tests/Misc/PropertyComparerTests.cs
@@ -1,0 +1,182 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core;
+
+namespace Umbraco.Tests.Misc
+{
+    [TestFixture]
+    public class PropertyComparerTests
+    {
+        #region SETUP
+
+        private class TestObject
+        {
+            public string Name { get; set; }
+
+            public decimal Rating { get; set; }
+        }
+
+        private PropertyComparer<TestObject> nameComparer = new PropertyComparer<TestObject>(x => x.Name);
+        private PropertyComparer<TestObject> ratingComparer = new PropertyComparer<TestObject>(x => x.Rating);
+
+        private PropertyComparer<TestObject> nameAndRatingComparer =
+            new PropertyComparer<TestObject>(
+                new Expression<Func<TestObject, object>>[] { x => x.Name, x => x.Rating }
+            );
+
+        #endregion SETUP
+
+        [Test]
+        public void Equals_WhenSameString_ExpectTrue()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1M };
+            var t2 = new TestObject() { Name = "A", Rating = 1M };
+            // Act
+            var result = nameComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Equals_WhenDifferentString_ExpectFalse()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1M };
+            var t2 = new TestObject() { Name = "B", Rating = 1M };
+            // Act
+            var result = nameComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_WhenSameDecimal_ExpectTrue()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 1.0M };
+            // Act
+            var result = ratingComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Equals_WhenDifferentDecimal_ExpectFalse()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 1.1M };
+            // Act
+            var result = ratingComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void GetHashCode_WhenSameDecimal_ExpectSameHashCode()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 5.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 5.0M };
+            // Act
+            var result = ratingComparer.GetHashCode(t1);
+            var result2 = ratingComparer.GetHashCode(t2);
+            // Assert
+            Assert.AreEqual(result, result2);
+        }
+
+        [Test]
+        public void GetHashCode_WhenDifferentDecimal_ExpectDiffertHashCode()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 5.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 5.1M };
+            // Act
+            var result = ratingComparer.GetHashCode(t1);
+            var result2 = ratingComparer.GetHashCode(t2);
+            // Assert
+            Assert.AreNotEqual(result, result2);
+        }
+
+        [Test]
+        public void Equals_WhenSameStringAndDecimal_ExpectTrue()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 1.0M };
+            // Act
+            var result = nameAndRatingComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Equals_WhenSameStringAndDifferentDecimal_ExpectFalse()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 1.1M };
+            // Act
+            var result = nameAndRatingComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_WhenDifferentStringAndSameDecimal_ExpectFalse()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1.0M };
+            var t2 = new TestObject() { Name = "B", Rating = 1.0M };
+            // Act
+            var result = nameAndRatingComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_WhenDifferentStringAndDecimal_ExpectFalse()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 1.0M };
+            var t2 = new TestObject() { Name = "B", Rating = 1.1M };
+            // Act
+            var result = nameAndRatingComparer.Equals(t1, t2);
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void GetHashCode_WhenSameStringAndDecimal_ExpectSameHashCode()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 5.0M };
+            var t2 = new TestObject() { Name = "A", Rating = 5.0M };
+            // Act
+            var result = nameAndRatingComparer.GetHashCode(t1);
+            var result2 = nameAndRatingComparer.GetHashCode(t2);
+            // Assert
+            Assert.AreEqual(result, result2);
+        }
+
+        [Test]
+        public void GetHashCode_WhenDifferentStringAndDecimal_ExpectDiffertHashCode()
+        {
+            // Arrange
+            var t1 = new TestObject() { Name = "A", Rating = 5.0M };
+            var t2 = new TestObject() { Name = "B", Rating = 5.1M };
+            // Act
+            var result = nameAndRatingComparer.GetHashCode(t1);
+            var result2 = nameAndRatingComparer.GetHashCode(t2);
+            // Assert
+            Assert.AreNotEqual(result, result2);
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Mapping\MappingTests.cs" />
     <Compile Include="Migrations\MigrationPlanTests.cs" />
     <Compile Include="Migrations\MigrationTests.cs" />
+    <Compile Include="Misc\PropertyComparerTests.cs" />
     <Compile Include="ModelsBuilder\BuilderTests.cs" />
     <Compile Include="ModelsBuilder\ConfigTests.cs" />
     <Compile Include="ModelsBuilder\StringExtensions.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8681

### Description

Adds a IEqualityComparer that takes an expression to select (one or more) properties which should be used in an implementaton of GetHashCode and Equals. 
Adds tests for this
Adds the usage of this in PropertyEditorCollection to fix the Union between attribute defined PropertyEditors and Manifest defined

See linked issue for more detail