### PR TITLE
V8.7RC Add filter css class for not allowed thumbnail extensions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -20,7 +20,7 @@
         loadElementTypes();
 
         function loadElementTypes() {
-            return elementTypeResource.getAll().then(function (elementTypes) {
+            return elementTypeResource.getAll().then(function(elementTypes) {
                 vm.elementTypes = elementTypes;
 
                 vm.contentPreview = vm.getElementTypeByKey(vm.block.contentElementTypeKey);
@@ -46,7 +46,7 @@
                 }
             };
             editorService.documentTypeEditor(editor);
-        }
+        };
 
         vm.createElementTypeAndCallback = function(callback) {
             const editor = {
@@ -62,9 +62,9 @@
                 }
             };
             editorService.documentTypeEditor(editor);
-        }
+        };
 
-        vm.addSettingsForBlock = function ($event, block) {
+        vm.addSettingsForBlock = function($event, block) {
 
             localizationService.localizeMany(["blockEditor_headlineAddSettingsElementType", "blockEditor_labelcreateNewElementType"]).then(function(localized) {
 
@@ -95,9 +95,9 @@
                 };
 
                 overlayService.open(elemTypeSelectorOverlay);
-
             });
         };
+
         vm.applySettingsToBlock = function(block, key) {
             block.settingsElementTypeKey = key;
             vm.settingsPreview = vm.getElementTypeByKey(vm.block.settingsElementTypeKey);
@@ -121,10 +121,10 @@
                 });
             });
         };
+
         vm.removeSettingsForBlock = function(block) {
             block.settingsElementTypeKey = null;
         };
-
 
         function updateUsedElementTypes(event, args) {
             var key = args.documentType.key;
@@ -141,13 +141,12 @@
                 vm.settingsPreview = args.documentType;
                 $scope.$evalAsync();
             }
-
         }
+
         unsubscribe.push(eventsService.on("editors.documentType.saved", updateUsedElementTypes));
 
-
         vm.addViewForBlock = function(block) {
-            localizationService.localize("blockEditor_headlineAddCustomView").then(function(localizedTitle) {
+            localizationService.localize("blockEditor_headlineAddCustomView").then(function (localizedTitle) {
 
                 const filePicker = {
                     title: localizedTitle,
@@ -170,7 +169,8 @@
                 editorService.treePicker(filePicker);
 
             });
-        }
+        };
+
         vm.requestRemoveViewForBlock = function(block) {
             localizationService.localizeMany(["general_remove", "defaultdialogs_confirmremoveusageof"]).then(function (data) {
                 overlayService.confirmRemove({
@@ -186,14 +186,13 @@
                 });
             });
         };
+
         vm.removeViewForBlock = function(block) {
             block.view = null;
         };
 
-
-
         vm.addStylesheetForBlock = function(block) {
-            localizationService.localize("blockEditor_headlineAddCustomStylesheet").then(function(localizedTitle) {
+            localizationService.localize("blockEditor_headlineAddCustomStylesheet").then(function (localizedTitle) {
 
                 const filePicker = {
                     title: localizedTitle,
@@ -216,7 +215,8 @@
                 editorService.treePicker(filePicker);
 
             });
-        }
+        };
+
         vm.requestRemoveStylesheetForBlock = function(block) {
             localizationService.localizeMany(["general_remove", "defaultdialogs_confirmremoveusageof"]).then(function (data) {
                 overlayService.confirmRemove({
@@ -232,15 +232,14 @@
                 });
             });
         };
+
         vm.removeStylesheetForBlock = function(block) {
             block.stylesheet = null;
         };
 
-
-
         vm.addThumbnailForBlock = function(block) {
 
-            localizationService.localize("blockEditor_headlineAddThumbnail").then(function(localizedTitle) {
+            localizationService.localize("blockEditor_headlineAddThumbnail").then(function (localizedTitle) {
 
                 const thumbnailPicker = {
                     title: localizedTitle,
@@ -263,27 +262,25 @@
                 editorService.treePicker(thumbnailPicker);
 
             });
-        }
+        };
+
         vm.removeThumbnailForBlock = function(entry) {
             entry.thumbnail = null;
         };
 
-
-
-
-        vm.submit = function () {
+        vm.submit = function() {
             if ($scope.model && $scope.model.submit) {
                 $scope.model.submit($scope.model);
             }
-        }
+        };
 
         vm.close = function() {
             if ($scope.model && $scope.model.close) {
                 $scope.model.close($scope.model);
             }
-        }
+        };
 
-        $scope.$on('$destroy', function () {
+        $scope.$on('$destroy', function() {
             unsubscribe.forEach(u => { u(); });
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -250,6 +250,7 @@
                     filter: function (i) {
                         return !(i.name.indexOf(".jpg") !== -1 || i.name.indexOf(".jpeg") !== -1 || i.name.indexOf(".png") !== -1 || i.name.indexOf(".svg") !== -1 || i.name.indexOf(".webp") !== -1 || i.name.indexOf(".gif") !== -1);
                     },
+                    filterCssClass: "not-allowed",
                     select: function (file) {
                         const id = decodeURIComponent(file.id.replace(/\+/g, " "));
                         block.thumbnail = "~/" + id;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add the `not-allowed` cursor style when however not allowed files in block thumbnail picker similar to file picker in packager: https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js#L286