### PR TITLE
V8.7RC Update block list live editing description

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockListConfiguration.cs
@@ -4,14 +4,11 @@ using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
-
     /// <summary>
     /// The configuration object for the Block List editor
     /// </summary>
     public class BlockListConfiguration
     {
-
-
         [ConfigurationField("blocks", "Available Blocks", "views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html", Description = "Define the available blocks.")]
         public BlockConfiguration[] Blocks { get; set; }
 
@@ -61,7 +58,7 @@ namespace Umbraco.Web.PropertyEditors
             public int? Max { get; set; }
         }
 
-        [ConfigurationField("useLiveEditing", "Live editing mode", "boolean", Description = "Live editing in editor overlays for live updated custom views.")]
+        [ConfigurationField("useLiveEditing", "Live editing mode", "boolean", Description = "Live editing in editor overlays for live updated custom views or labels using custom expression.")]
         public bool UseLiveEditing { get; set; }
 
         [ConfigurationField("useInlineEditingAsDefault", "Inline editing mode", "boolean", Description = "Use the inline editor as the default block view.")]
@@ -69,7 +66,5 @@ namespace Umbraco.Web.PropertyEditors
 
         [ConfigurationField("maxPropertyWidth", "Property editor width", "textstring", Description = "optional css overwrite, example: 800px or 100%")]
         public string MaxPropertyWidth { get; set; }
-
-
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/BlockListConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockListConfigurationEditor.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text.RegularExpressions;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Umbraco.Core;
-using Umbraco.Core.PropertyEditors;
+﻿using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The block list live editing property in prevalues says it is for live updated custom views. However it also works without custom views, when using dynamic expression in label, e.g. `{{myPropertyAlias}}`.

When live editing is enabled the label text updates as you type. When it is disabled it only update the label text after submitting the overlay.

![chrome_2020-08-19_21-31-13](https://user-images.githubusercontent.com/2919859/90681384-9c4aaa00-e263-11ea-920d-7b68793ad3f0.png)
