### PR TITLE
Move scope management outside of iterator method

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
@@ -53,6 +53,11 @@ namespace Umbraco.Examine
                 scope.Complete();
             }
 
+            return GetValueSetsEnumerable(content, creatorIds, writerIds);
+        }
+
+        private IEnumerable<ValueSet> GetValueSetsEnumerable(IContent[] content, Dictionary<int, IProfile> creatorIds, Dictionary<int, IProfile> writerIds)
+        {
             // TODO: There is a lot of boxing going on here and ultimately all values will be boxed by Lucene anyways
             // but I wonder if there's a way to reduce the boxing that we have to do or if it will matter in the end since
             // Lucene will do it no matter what? One idea was to create a `FieldValue` struct which would contain `object`, `object[]`, `ValueType` and `ValueType[]`


### PR DESCRIPTION
@Shazwazza this is an alternative way to fix the issue you were fixing in PR #8678 .  By moving the scope management piece outside the method with the yield statement in it, the scope management will be executed and completed at the time the method is called, instead of happening later when iterating over the enumerable.