### PR TITLE
V8.7RC: Block List property editor api methods available on blockObject

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -240,6 +240,22 @@
             block.showSettings = block.config.settingsElementTypeKey != null;
             block.showCopy = vm.supportCopy && block.config.contentElementTypeKey != null;// if we have content, otherwise it doesn't make sense to copy.
 
+            block.setParentForm = function (parentForm) {
+                this._parentForm = parentForm;
+            }
+            block.activate = activateBlock.bind(null, block);
+            block.edit = function () {
+                var blockIndex = vm.layout.indexOf(this.layout);
+                editBlock(this, false, blockIndex, this._parentForm);
+            }
+            block.editSettings = function () {
+                var blockIndex = vm.layout.indexOf(this.layout);
+                editBlock(this, true, blockIndex, this._parentForm);
+            }
+            block.requestDelete = requestDeleteBlock.bind(null, block);
+            block.delete = deleteBlock.bind(null, block);
+            block.copy = copyBlock.bind(null, block);
+
             return block;
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -41,6 +41,9 @@
             // Guess we'll leave it for now but means all things need to be copied to the $scope and then all
             // primitives need to be watched.
 
+            // let the Block know about its form
+            model.block.setParentForm(model.parentForm);
+
             $scope.block = model.block;
             $scope.api = model.api;
             $scope.index = model.index;


### PR DESCRIPTION
With this PR the custom views of Block List, don't need to use the API object anymore(it will still be available). As this PR appends methods to the Block Object. Making it possible to just call 'block.edit()' instead of 'api.editBlock(block, true, index, parentForm)'.

The options available are:

block.edit();
block.editSettings();
block.copy();
block.requestDelete();
block.delete();


---
_This item has been added to our backlog [AB#7968](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7968)_