### PR TITLE
Add `!important' to the color in the style attribute

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,6 +1,6 @@
 
     <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.blockConfigModel.thumbnail ? 'url('+vm.blockConfigModel.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
-        <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{ vm.elementTypeModel.icon }}" ng-style="{'color':vm.blockConfigModel.iconColor}" aria-hidden="true"></i>
+        <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{ vm.elementTypeModel.icon }}" ng-attr-style="{{'color:'+vm.blockConfigModel.iconColor+' !important'}}" aria-hidden="true"></i>
     </div>
     <div class="__info">
         <div class="__name" ng-bind="vm.elementTypeModel.name"></div>


### PR DESCRIPTION
### Why have I changed from `ng-style` attribute to `ng-attr-style` ?

It turns out that `!important` doesn't work with the `ng-style` attribute, so I have switched to use `ng-attr-style` instead, which works by setting the exact string, instead of using an object.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #8688 

### Description

* Create a new property on a document type and use the BlockList property editor for it
* In the Editor settings, create a new block and assign it an icon using the red color
* In the Configuration for the block, in its "Catalogue appearance" section, set its **Background color** to `#ff8000` and the **Icon color** to `#000000`
* When using the block editor in the Content section, observe that the block's icon color will be the black color, thus correctly overriding the red color initially chosen for the document type's icon.

