### PR TITLE
Accessibility: Fixes for "insert code snippet" view in macro pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-insert-code-box.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-insert-code-box.less
@@ -21,6 +21,7 @@
     font-size: 15px;
     margin-bottom: 5px;
     font-weight: bold;
+    line-height: 1;
 }
 
 .umb-insert-code-box__description {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-insert-code-box.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-insert-code-box.less
@@ -8,14 +8,13 @@
     padding: 15px 20px;
     margin-bottom: 10px;
     border-radius: 3px;
-    cursor: pointer;
+    text-align: left;
 }
 
 .umb-insert-code-box:hover,
 .umb-insert-code-box.-selected {
     background-color: @ui-option-hover;
     color: @ui-action-type-hover;
-    //border-color: @ui-action-border-hover;
 }
 
 .umb-insert-code-box__title {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html
@@ -16,24 +16,24 @@
                 <umb-box-content>
                     <div class="umb-insert-code-boxes">
                         <button type="button" ng-if="model.allowedTypes.umbracoField" class="btn-reset umb-insert-code-box" ng-click="vm.openPageFieldOverlay()">
-                            <div class="umb-insert-code-box__title"><localize key="template_insertPageField" />...</div>
-                            <div class="umb-insert-code-box__description"><localize key="template_insertPageFieldDesc" /></div>
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertPageField" />...</h2>
+                            <p class="umb-insert-code-box__description"><localize key="template_insertPageFieldDesc" /></p>
                         </button>
                         <button type="button" ng-if="model.allowedTypes.partial" class="btn-reset umb-insert-code-box" ng-click="vm.openPartialOverlay()">
-                            <div class="umb-insert-code-box__title"><localize key="template_insertPartialView" />...</div>
-                            <div class="umb-insert-code-box__description">
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertPartialView" />...</h2>
+                            <p class="umb-insert-code-box__description">
                                 <localize key="template_insertPartialViewDesc" />
-                            </div>
+                            </p>
                         </button>
                         <button type="button" ng-if="model.allowedTypes.macro" class="btn-reset umb-insert-code-box" ng-click="vm.openMacroPicker()">
-                            <div class="umb-insert-code-box__title"><localize key="template_insertMacro" />...</div>
-                            <div class="umb-insert-code-box__description">
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertMacro" />...</h2>
+                            <p class="umb-insert-code-box__description">
                                 <localize key="template_insertMacroDesc" />
-                            </div>
+                            </p>
                         </button>
                         <button type="button" ng-if="model.allowedTypes.dictionary" class="btn-reset umb-insert-code-box" ng-click="vm.openDictionaryItemOverlay()">
-                            <div class="umb-insert-code-box__title"><localize key="template_insertDictionaryItem" />...</div>
-                            <div class="umb-insert-code-box__description"><localize key="template_insertDictionaryItemDesc" /></div>
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertDictionaryItem" />...</h2>
+                            <p class="umb-insert-code-box__description"><localize key="template_insertDictionaryItemDesc" /></p>
                         </button>
                     </div>
                 </umb-box-content>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html
@@ -16,24 +16,24 @@
                 <umb-box-content>
                     <div class="umb-insert-code-boxes">
                         <button type="button" ng-if="model.allowedTypes.umbracoField" class="btn-reset umb-insert-code-box" ng-click="vm.openPageFieldOverlay()">
-                            <h2 class="umb-insert-code-box__title"><localize key="template_insertPageField" />...</h2>
-                            <p class="umb-insert-code-box__description"><localize key="template_insertPageFieldDesc" /></p>
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertPageField">Value</localize></h2>
+                            <p class="umb-insert-code-box__description"><localize key="template_insertPageFieldDesc">Displays the value of a named field from the current page, with options to modify the value or fallback to alternative values.</localize></p>
                         </button>
                         <button type="button" ng-if="model.allowedTypes.partial" class="btn-reset umb-insert-code-box" ng-click="vm.openPartialOverlay()">
-                            <h2 class="umb-insert-code-box__title"><localize key="template_insertPartialView" />...</h2>
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertPartialView">Partial view</localize></h2>
                             <p class="umb-insert-code-box__description">
-                                <localize key="template_insertPartialViewDesc" />
+                                <localize key="template_insertPartialViewDesc">A partial view is a separate template file which can be rendered inside another template, it's great for reusing markup or for separating complex templates into separate files.</localize>
                             </p>
                         </button>
                         <button type="button" ng-if="model.allowedTypes.macro" class="btn-reset umb-insert-code-box" ng-click="vm.openMacroPicker()">
-                            <h2 class="umb-insert-code-box__title"><localize key="template_insertMacro" />...</h2>
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertMacro">Macro</localize></h2>
                             <p class="umb-insert-code-box__description">
-                                <localize key="template_insertMacroDesc" />
+                                <localize key="template_insertMacroDesc">A Macro is a configurable component which is great for reusable parts of your design, where you need the option to provide parameters, such as galleries, forms and lists.</localize>
                             </p>
                         </button>
                         <button type="button" ng-if="model.allowedTypes.dictionary" class="btn-reset umb-insert-code-box" ng-click="vm.openDictionaryItemOverlay()">
-                            <h2 class="umb-insert-code-box__title"><localize key="template_insertDictionaryItem" />...</h2>
-                            <p class="umb-insert-code-box__description"><localize key="template_insertDictionaryItemDesc" /></p>
+                            <h2 class="umb-insert-code-box__title"><localize key="template_insertDictionaryItem">Dictionary item</localize></h2>
+                            <p class="umb-insert-code-box__description"><localize key="template_insertDictionaryItemDesc">A dictionary item is a placeholder for a translatable piece of text, which makes it easy to create designs for multilingual websites.</localize></p>
                         </button>
                     </div>
                 </umb-box-content>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/insertcodesnippet/insertcodesnippet.html
@@ -9,32 +9,32 @@
             hide-icon="true"
             hide-description="true">
         </umb-editor-header>
-        
+
         <umb-editor-container>
 
             <umb-box>
                 <umb-box-content>
                     <div class="umb-insert-code-boxes">
-                        <div ng-if="model.allowedTypes.umbracoField" class="umb-insert-code-box" ng-click="vm.openPageFieldOverlay()">
+                        <button type="button" ng-if="model.allowedTypes.umbracoField" class="btn-reset umb-insert-code-box" ng-click="vm.openPageFieldOverlay()">
                             <div class="umb-insert-code-box__title"><localize key="template_insertPageField" />...</div>
                             <div class="umb-insert-code-box__description"><localize key="template_insertPageFieldDesc" /></div>
-                        </div>
-                        <div ng-if="model.allowedTypes.partial" class="umb-insert-code-box" ng-click="vm.openPartialOverlay()">
+                        </button>
+                        <button type="button" ng-if="model.allowedTypes.partial" class="btn-reset umb-insert-code-box" ng-click="vm.openPartialOverlay()">
                             <div class="umb-insert-code-box__title"><localize key="template_insertPartialView" />...</div>
                             <div class="umb-insert-code-box__description">
                                 <localize key="template_insertPartialViewDesc" />
                             </div>
-                        </div>
-                        <div ng-if="model.allowedTypes.macro" class="umb-insert-code-box" ng-click="vm.openMacroPicker()">
+                        </button>
+                        <button type="button" ng-if="model.allowedTypes.macro" class="btn-reset umb-insert-code-box" ng-click="vm.openMacroPicker()">
                             <div class="umb-insert-code-box__title"><localize key="template_insertMacro" />...</div>
                             <div class="umb-insert-code-box__description">
                                 <localize key="template_insertMacroDesc" />
                             </div>
-                        </div>
-                        <div ng-if="model.allowedTypes.dictionary" class="umb-insert-code-box" ng-click="vm.openDictionaryItemOverlay()">
+                        </button>
+                        <button type="button" ng-if="model.allowedTypes.dictionary" class="btn-reset umb-insert-code-box" ng-click="vm.openDictionaryItemOverlay()">
                             <div class="umb-insert-code-box__title"><localize key="template_insertDictionaryItem" />...</div>
                             <div class="umb-insert-code-box__description"><localize key="template_insertDictionaryItemDesc" /></div>
-                        </div>
+                        </button>
                     </div>
                 </umb-box-content>
             </umb-box>
@@ -54,5 +54,5 @@
         </umb-editor-footer>
 
     </umb-editor-view>
-    
+
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
During the work on #8522 I discovered that this view did not contain proper `<button>` elements, for the different insert options, which means the focus lock won't be able to pickup the first focusable element properly and puts the focus on the "close" button making one unable to tab to the options inside the overlay. This is fixed in this PR with the added buttons. While I had the view opened I fixed some HTML semantics as well adding `h2` for the title and wrapped the description in `<p>` - I also added proper fallback texts in case the dictionary keys have not been translated for a certain language.

The view visually appears the same as before these changes - I decided to make this an independent PR in an attempt to keep the #8522 as clean as possible 👍 