### PR TITLE
Adding `display: none;` prevents `ng-show` from working

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -22,7 +22,7 @@
                 </ul>
             </umb-box-content>
         </umb-box>
-        <umb-box data-element="node-info-redirects" style="display:none;" ng-cloak ng-show="!urlTrackerDisabled && hasRedirects">
+        <umb-box data-element="node-info-redirects" ng-cloak ng-show="!urlTrackerDisabled && hasRedirects">
             <umb-box-header title-key="redirectUrls_redirectUrlManagement"></umb-box-header>
             <umb-box-content class="block-form">
                 <div style="position: relative;">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8705

### Description
As described in #8705: 

- Rename a node while the built-in URL tracker is enabled
- Go to the info panel and see if the redirect panel (see below) shows up
- Before applying this change it won't show up, after applying this it will show up
- Also test that the redirect panel is still hidden on items that have no redirects.
