### PR TITLE
8.7RC umb-block-card absolute path and dont scale SVGs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,5 +1,5 @@
 
-    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.blockConfigModel.thumbnail ? 'url('+vm.blockConfigModel.thumbnail+'?upscale=false&width=400)' : 'transparent'}">
+    <div class="__showcase" ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.styleBackgroundImage}">
         <i ng-if="vm.blockConfigModel.thumbnail == null && vm.elementTypeModel.icon" class="__icon {{ vm.elementTypeModel.icon }}" ng-style="{'color':vm.blockConfigModel.iconColor}" aria-hidden="true"></i>
     </div>
     <div class="__info">

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -17,10 +17,9 @@
     function BlockCardController($scope, umbRequestHelper) {
 
         var vm = this;
-        vm.styleBackgroundImage = "transparent";
+        vm.styleBackgroundImage = "none";
 
         var unwatch = $scope.$watch("vm.blockConfigModel.thumbnail", (newValue, oldValue) => {
-            console.log("updateThumbnail")
             if(newValue !== oldValue) {
                 vm.updateThumbnail();
             }
@@ -37,7 +36,7 @@
 
         vm.updateThumbnail = function () {
             if (vm.blockConfigModel.thumbnail == null || vm.blockConfigModel.thumbnail === "") {
-                vm.styleBackgroundImage = "transparent";
+                vm.styleBackgroundImage = "none";
                 return;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -42,7 +42,7 @@
 
             var path = umbRequestHelper.convertVirtualToAbsolutePath(vm.blockConfigModel.thumbnail);
             if (path.toLowerCase().endsWith(".svg") === false) {
-                path += "?upscale=false&width=400)";
+                path += "?upscale=false&width=400";
             }
             vm.styleBackgroundImage = 'url(\''+path+'\')';
         }

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -14,9 +14,39 @@
             }
         });
 
-    function BlockCardController() {
+    function BlockCardController($scope, umbRequestHelper) {
 
         var vm = this;
+        vm.styleBackgroundImage = "transparent";
+
+        var unwatch = $scope.$watch("vm.blockConfigModel.thumbnail", (newValue, oldValue) => {
+            console.log("updateThumbnail")
+            if(newValue !== oldValue) {
+                vm.updateThumbnail();
+            }
+        });
+
+        vm.$onInit = function () {
+
+            vm.updateThumbnail();
+
+        }
+        vm.$onDestroy = function () {
+            unwatch();
+        }
+
+        vm.updateThumbnail = function () {
+            if (vm.blockConfigModel.thumbnail == null || vm.blockConfigModel.thumbnail === "") {
+                vm.styleBackgroundImage = "transparent";
+                return;
+            }
+
+            var path = umbRequestHelper.convertVirtualToAbsolutePath(vm.blockConfigModel.thumbnail);
+            if (path.toLowerCase().endsWith(".svg") === false) {
+                path += "?upscale=false&width=400)";
+            }
+            vm.styleBackgroundImage = 'url(\''+path+'\')';
+        }
 
     }
 


### PR DESCRIPTION
Make thumbnails paths work and don't scale SVGs

---
_This item has been added to our backlog [AB#7910](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7910)_