### PR TITLE
Make it possible to use existing base tests from the unit test project in the BenchmarkTests project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cypress.env.json
 /src/Umbraco.Tests.AcceptanceTest/package-lock.json
 /src/Umbraco.Tests.AcceptanceTest/cypress/videos/
 /src/Umbraco.Tests.AcceptanceTest/cypress/screenshots/
+/src/Umbraco.Tests.Benchmarks/App_Data/TEMP/TypesCache

--- a/src/Umbraco.Tests.Benchmarks/IndexBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/IndexBenchmarks.cs
@@ -1,0 +1,61 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Examine;
+using Umbraco.Tests.Testing;
+using Umbraco.Tests.UmbracoExamine;
+using Umbraco.Core;
+using Moq;
+
+namespace Umbraco.Tests.Benchmarks
+{
+
+    [MemoryDiagnoser]
+    [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+    public class IndexBenchmarks : ExamineBaseTest
+    {
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            this._profilingLogger = new Mock<IProfilingLogger>().Object;
+            TestOptionAttributeBase.ScanAssemblies.Add(typeof(IndexBenchmarks).Assembly);
+            this.SetUp();
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            this.Reset();
+        }
+
+        [Benchmark]
+        public void Rebuild_Index()
+        {
+            Console.WriteLine("Rebuilding Index");
+            var contentRebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider, false);
+            var mediaRebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+
+            using (var luceneDir = new RandomIdRamDirectory())
+            using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
+                validator: new ContentValueSetValidator(false)))
+            using (indexer.ProcessNonAsync())
+            {
+
+                var searcher = indexer.GetSearcher();
+
+                //create the whole thing
+                contentRebuilder.Populate(indexer);
+                mediaRebuilder.Populate(indexer);
+
+                var result = searcher.CreateQuery().All().Execute();
+
+                //Assert.AreEqual(29, result.TotalItemCount);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
+++ b/src/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
@@ -53,6 +53,7 @@
     <Compile Include="CtorInvokeBenchmarks.cs" />
     <Compile Include="HexStringBenchmarks.cs" />
     <Compile Include="EnumeratorBenchmarks.cs" />
+    <Compile Include="IndexBenchmarks.cs" />
     <Compile Include="LinqCastBenchmarks.cs" />
     <Compile Include="ModelToSqlExpressionHelperBenchmarks.cs" />
     <Compile Include="Program.cs" />
@@ -90,6 +91,9 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet">
       <Version>0.11.3</Version>
+    </PackageReference>
+    <PackageReference Include="Umbraco.SqlServerCE">
+      <Version>4.0.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Umbraco.Tests.Benchmarks/app.config
+++ b/src/Umbraco.Tests.Benchmarks/app.config
@@ -3,4 +3,13 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+    <connectionStrings>
+        <add name="umbracoDbDSN" connectionString="Datasource=|DataDirectory|UmbracoNPocoTests.sdf;Flush Interval=1;" providerName="System.Data.SqlServerCe.4.0"/>
+    </connectionStrings>
+    <system.data>
+        <DbProviderFactories>
+            <remove invariant="System.Data.SqlServerCe.4.0"/>
+            <add name="Microsoft SQL Server Compact Data Provider 4.0" invariant="System.Data.SqlServerCe.4.0" description=".NET Framework Data Provider for Microsoft SQL Server Compact" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91"/>
+        </DbProviderFactories>
+    </system.data>
 </configuration>

--- a/src/Umbraco.Tests/Properties/AssemblyInfo.cs
+++ b/src/Umbraco.Tests/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("Umbraco.Tests.Benchmarks")]

--- a/src/Umbraco.Tests/UmbracoExamine/ExamineBaseTest.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/ExamineBaseTest.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Tests.UmbracoExamine
             _profilingLogger = new ProfilingLogger(logger, new LogProfiler(logger));
         }
 
-        private IProfilingLogger _profilingLogger;
+        protected IProfilingLogger _profilingLogger;
         protected override IProfilingLogger ProfilingLogger => _profilingLogger;
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A

### Description
Adds a benchmark test for examine index population. Makes it possible to reuse the existing test classes in the benchmark project.
