### PR TITLE
V8.7RC Prevent usage of NestedContent in BlockEditors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -231,7 +231,8 @@
         var notSupportedProperties = [
             "Umbraco.Tags",
             "Umbraco.UploadField",
-            "Umbraco.ImageCropper"
+            "Umbraco.ImageCropper",
+            "Umbraco.NestedContent"
         ];
 
 


### PR DESCRIPTION
We have several issues in regards to use NC in BL. But there is no reason to have NC now that BL is available. Therefore we want to nudge Devs to use Block List, and mark the usage of NestedContent as unsupported in the context of Block Editors.

---
_This item has been added to our backlog [AB#7946](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7946)_