### PR TITLE
V8.7RC: Recreate UDIs for pasted Block Editor entries

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditor.service.js
@@ -4,26 +4,106 @@
  *
  * @description
  * <b>Added in Umbraco 8.7</b>. Service for dealing with Block Editors.
- * 
+ *
  * Block Editor Service provides the basic features for a block editor.
  * The main feature is the ability to create a Model Object which takes care of your data for your Block Editor.
- * 
- * 
+ *
+ *
  * ##Samples
  *
  * ####Instantiate a Model Object for your property editor:
- * 
+ *
  * <pre>
  *     modelObject = blockEditorService.createModelObject(vm.model.value, vm.model.editor, vm.model.config.blocks, $scope);
  *     modelObject.load().then(onLoaded);
  * </pre>
  *
- * 
+ *
  * See {@link umbraco.services.blockEditorModelObject BlockEditorModelObject} for more samples.
- * 
+ *
  */
 (function () {
     'use strict';
+
+
+
+    /**
+     * When performing a runtime copy of Block Editors entries, we copy the ElementType Data Model and inner IDs are kept identical, to ensure new IDs are changed on paste we need to provide a resolver for the ClipboardService.
+     */
+    angular.module('umbraco').run(['clipboardService', 'udiService', function (clipboardService, udiService) {
+
+        function replaceUdi(obj, key, dataObject) {
+            var udi = obj[key];
+            var newUdi = udiService.create("element");
+            obj[key] = newUdi;
+            dataObject.forEach((data) => {
+                if (data.udi === udi) {
+                    data.udi = newUdi;
+                }
+            });
+        }
+        function replaceUdisOfObject(obj, propValue) {
+            for (var k in obj) {
+                if(k === "contentUdi") {
+                    replaceUdi(obj, k, propValue.contentData);
+                } else if(k === "settingsUdi") {
+                    replaceUdi(obj, k, propValue.settingsData);
+                } else {
+                    var propType = typeof obj[k];
+                    if(propType === "object" || propType === "array") {
+                        replaceUdisOfObject(obj[k], propValue)
+                    }
+                }
+            }
+        }
+
+        function replaceBlockListUDIsResolver(obj, propClearingMethod) {
+
+            if (typeof obj === "object") {
+
+                // 'obj' can both be a property object or the raw value of a inner property.
+                var value = obj;
+
+                // if we got a property object from a ContentTypeModel we need to look at the value. We check for value and editor to, sort of, ensure this is the case.
+                if(obj.value !== undefined && obj.editor !== undefined) {
+                    value = obj.value;
+                    // If value isnt a object, lets break out.
+                    if(typeof obj.value !== "object") {
+                        return;
+                    }
+                }
+
+                // we got an object, and it has these three props then we are most likely dealing with a Block Editor.
+                if ((value.layout !== undefined && value.contentData !== undefined && value.settingsData !== undefined)) {
+
+                    replaceUdisOfObject(value.layout, value);
+
+                    // replace UDIs for inner properties of this Block Editors content data.
+                    if(value.contentData.length > 0) {
+                        value.contentData.forEach((item) => {
+                            for (var k in item) {
+                                propClearingMethod(item[k]);
+                            }
+                        });
+                    }
+                    // replace UDIs for inner properties of this Block Editors settings data.
+                    if(value.settingsData.length > 0) {
+                        value.settingsData.forEach((item) => {
+                            for (var k in item) {
+                                propClearingMethod(item[k]);
+                            }
+                        });
+                    }
+
+                }
+            }
+        }
+
+        clipboardService.registerPastePropertyResolver(replaceBlockListUDIsResolver)
+
+    }]);
+
+
 
 
     function blockEditorService(blockEditorModelObject) {
@@ -32,11 +112,11 @@
          * @ngdocs function
          * @name createModelObject
          * @methodOf umbraco.services.blockEditorService
-         * 
+         *
          * @description
          * Create a new Block Editor Model Object.
          * See {@link umbraco.services.blockEditorModelObject blockEditorModelObject}
-         * 
+         *
          * @see umbraco.services.blockEditorModelObject
          * @param {object} propertyModelValue data object of the property editor, usually model.value.
          * @param {string} propertyEditorAlias alias of the property.

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -13,8 +13,7 @@
 (function () {
     'use strict';
 
-
-    function blockEditorModelObjectFactory($interpolate, $q, udiService, contentResource, localizationService, umbRequestHelper) {
+    function blockEditorModelObjectFactory($interpolate, $q, udiService, contentResource, localizationService, umbRequestHelper, clipboardService) {
 
         /**
          * Simple mapping from property model content entry to editing model,
@@ -748,7 +747,9 @@
              */
             createFromElementType: function (elementTypeDataModel) {
 
-                elementTypeDataModel = Utilities.copy(elementTypeDataModel);
+
+                elementTypeDataModel = clipboardService.parseContentForPaste(elementTypeDataModel);
+
 
                 var contentElementTypeKey = elementTypeDataModel.contentTypeKey;
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -747,9 +747,7 @@
              */
             createFromElementType: function (elementTypeDataModel) {
 
-
                 elementTypeDataModel = clipboardService.parseContentForPaste(elementTypeDataModel);
-
 
                 var contentElementTypeKey = elementTypeDataModel.contentTypeKey;
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -28,7 +28,7 @@
             }
         }
 
-        clipboardService.registrerClearPropertyResolver(clearNestedContentPropertiesForStorage)
+        clipboardService.registerClearPropertyResolver(clearNestedContentPropertiesForStorage)
 
 
         function clearInnerNestedContentPropertiesForStorage(prop, propClearingMethod) {
@@ -50,7 +50,7 @@
             }
         }
 
-        clipboardService.registrerClearPropertyResolver(clearInnerNestedContentPropertiesForStorage)
+        clipboardService.registerClearPropertyResolver(clearInnerNestedContentPropertiesForStorage)
     }]);
 
     angular
@@ -473,6 +473,8 @@
             if (newNode === undefined) {
                 return;
             }
+
+            newNode = clipboardService.parseContentForPaste(newNode);
 
             // generate a new key.
             newNode.key = String.CreateGuid();


### PR DESCRIPTION
Our front-end rendering uses the UDIs of ElementTypes for caching, meaning that we have to ensure these are unique. Before this fix, we just copied the raw data of an elementType without manipulating it. Though pasted entries are created as new, their data is parsed on, leaving the inner properties of Block Editors with the same UDIs as their source. This problem is first visible when rendering these in the front-end as the first rendered ElementType with that UDI will be cached and stay as the data shown for other Blocks/ElementTypes using the same UDI.
This PR replaces UDIs on Paste, ensuring they are unique.

To reproduce, make this scenario happen:
![image](https://user-images.githubusercontent.com/6791648/91317800-c697ec80-e7ba-11ea-8bdc-e2fd45d15fc7.png)

You need three levels of Block Editors to imitate the scenario of copying data that contains an inner property of Block List Editor. The reason for this is because when copying a Block List Entry you get the ContentTypeModel, meaning the second-level property appears as normal properties of a node {alias: .., editor: .., value: ...} The value of the Second Block Editor will be the raw value we store of a Block Editor, aka. {layout: ..., contentData:, ..., settingsData: ...} This we need to ensure we interpret and update UDIs of.

Check that the ´contentUdi´ and ´settingsUdi´ are changed when pasting this entry.

Notice this feature is solving the broad need for Block Editors in general, meaning it's not specific towards the Block List property editor.

---
_This item has been added to our backlog [AB#7967](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/7967)_