### PR TITLE
Userpicker: Add warning overlay when the "Remove" button is hit

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -288,7 +288,7 @@
                     view: "views/users/views/overlays/remove.html",
                     username: selection[index].username,
                     userGroupName: vm.userGroup.name.toLowerCase(),
-                    submitButtonLabelKey: "contentTypeEditor_yesDelete",
+                    submitButtonLabelKey: "defaultdialogs_yesRemove",
                     submitButtonStyle: "danger",
 
                     submit: function () {

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function UserGroupEditController($scope, $location, $routeParams, userGroupsResource, localizationService, contentEditingHelper, editorService) {
+    function UserGroupEditController($scope, $location, $routeParams, userGroupsResource, localizationService, contentEditingHelper, editorService, overlayService) {
 
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
         var id = infiniteMode ? $scope.model.id : $routeParams.id;
@@ -283,7 +283,25 @@
 
         function removeSelectedItem(index, selection) {
             if (selection && selection.length > 0) {
-                selection.splice(index, 1);
+
+                const dialog = {
+                    view: "views/users/views/overlays/remove.html",
+                    username: selection[index].username,
+                    userGroupName: vm.userGroup.name.toLowerCase(),
+                    submitButtonLabelKey: "contentTypeEditor_yesDelete",
+                    submitButtonStyle: "danger",
+
+                    submit: function () {
+                        selection.splice(index, 1);
+
+                        overlayService.close();
+                    },
+                    close: function () {
+                        overlayService.close();
+                    }
+                };
+
+                overlayService.open(dialog);
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/overlays/remove.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/overlays/remove.html
@@ -1,0 +1,9 @@
+<div>
+
+    <div class="umb-alert umb-alert--warning mb2">
+        <localize key="defaultdialogs_userremovewarning" tokens="[model.username, model.userGroupName]">This will remove the user <strong>{{ model.username }} from the {{ model.userGropName }} group</strong>.</localize>
+    </div>
+
+    <localize key="defaultdialogs_confirmremove"></localize>?
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/overlays/remove.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/overlays/remove.html
@@ -4,6 +4,6 @@
         <localize key="defaultdialogs_userremovewarning" tokens="[model.username, model.userGroupName]">This will remove the user <strong>{{ model.username }} from the {{ model.userGropName }} group</strong>.</localize>
     </div>
 
-    <localize key="defaultdialogs_confirmremove"></localize>?
+    <localize key="defaultdialogs_confirmremove">Yes, remove</localize>?
 
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -514,6 +514,7 @@
     <key alias="selectEditor">Select editor</key>
     <key alias="selectSnippet">Select snippet</key>
     <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language, you should unpublish the node in that language instead.</key>
+    <key alias="userremovewarning"><![CDATA[This will remove the user <b>%0%</b> from the <b>%1%</b> group]]></key>
   </area>
   <area alias="dictionary">
     <key alias="noItems">There are no dictionary items.</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -515,6 +515,7 @@
     <key alias="selectSnippet">Select snippet</key>
     <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language, you should unpublish the node in that language instead.</key>
     <key alias="userremovewarning"><![CDATA[This will remove the user <b>%0%</b> from the <b>%1%</b> group]]></key>
+    <key alias="yesRemove">Yes, remove</key>
   </area>
   <area alias="dictionary">
     <key alias="noItems">There are no dictionary items.</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -520,6 +520,7 @@
     <key alias="selectSnippet">Select snippet</key>
     <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language, you should unpublish the node in that language instead.</key>
     <key alias="userremovewarning"><![CDATA[This will remove the user <b>%0%</b> from the <b>%1%</b> group]]></key>
+    <key alias="yesRemove">Yes, remove</key>
   </area>
   <area alias="dictionary">
     <key alias="noItems">There are no dictionary items.</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -519,6 +519,7 @@
     <key alias="selectEditorConfiguration">Select configuration</key>
     <key alias="selectSnippet">Select snippet</key>
     <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one language, you should unpublish the node in that language instead.</key>
+    <key alias="userremovewarning"><![CDATA[This will remove the user <b>%0%</b> from the <b>%1%</b> group]]></key>
   </area>
   <area alias="dictionary">
     <key alias="noItems">There are no dictionary items.</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have added a warning dialog when one hits the "Remove" button next to a user listed in the user picker so that the user is not removed immediately but you have to confirm your action - This is aligning the UI with what happens in other places in the backoffice as well.

**Before**
![userpicker-before](https://user-images.githubusercontent.com/1932158/91387073-b1f83a80-e834-11ea-8b10-b7cce8b5bb3e.gif)

**After**
![userpicker-after](https://user-images.githubusercontent.com/1932158/91387081-b6245800-e834-11ea-99ac-6da65891f4fa.gif)
