### PR TITLE
Fixes #8720 DocType Tour selector fix for 8.7

### DIFF
--- a/src/Umbraco.Web.UI/config/BackOfficeTours/getting-started.json
+++ b/src/Umbraco.Web.UI/config/BackOfficeTours/getting-started.json
@@ -200,7 +200,7 @@
                 "event": "click"
             },
             {
-                "element": "[data-element='editor-data-type-picker'] [data-element='datatypeconfig-Textarea'] > a",
+                "element": "[data-element='editor-data-type-picker'] [data-element='datatypeconfig-Textarea']",
                 "title": "Editor settings",
                 "content": "Each property editor can have individual settings. For the textarea editor you can set a character limit but in this case it is not needed.",
                 "event": "click"


### PR DESCRIPTION
Fixes #8720 

## Test Notes
* Install Umbraco CMS without Starter Kit (As this ships with its own tours)
* Verify all tours work