### PR TITLE
Update UmbracoAuthorizeFilter.cs

### DIFF
--- a/src/Umbraco.Web.BackOffice/Filters/UmbracoAuthorizeFilter.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/UmbracoAuthorizeFilter.cs
@@ -6,6 +6,7 @@ using Umbraco.Core;
 using Umbraco.Extensions;
 using Umbraco.Web.Security;
 using IHostingEnvironment = Umbraco.Core.Hosting.IHostingEnvironment;
+using Umbraco.Core.Security;
 
 namespace Umbraco.Web.BackOffice.Filters
 {
@@ -84,6 +85,10 @@ namespace Umbraco.Web.BackOffice.Filters
                 {
                     context.Result = new ForbidResult();
                 }
+            }
+            else
+            {
+                context.HttpContext.User.Identity.EnsureCulture();
             }
         }
 


### PR DESCRIPTION
### Issue
The users culture is not set in back office controllers like Umbraco.Web.Editors.SectionController. 

### Fix?
Maybe UmbracoAuthorizeFilter is the right place to add context.HttpContext.User.Identity.EnsureCulture() - what do you think?


