### PR TITLE
Update WebSecurity.cs to fix back office culture

### DIFF
--- a/src/Umbraco.Web.Common/Security/WebSecurity.cs
+++ b/src/Umbraco.Web.Common/Security/WebSecurity.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.Hosting;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Services;
+using Umbraco.Core.Security;
 using Umbraco.Extensions;
 using Umbraco.Web.Security;
 using Umbraco.Core.Models;
@@ -110,6 +111,10 @@ namespace Umbraco.Web.Common.Security
                 if (throwExceptions) throw new ArgumentException("You have no privileges to the umbraco console. Please contact your administrator");
                 return ValidateRequestAttempt.FailedNoPrivileges;
             }
+
+            var identity = _httpContextAccessor.GetRequiredHttpContext().GetCurrentIdentity();
+            identity.EnsureCulture();
+
             return ValidateRequestAttempt.Success;
         }
 


### PR DESCRIPTION
### Issue
Back office culture is currently not set. 
### Fix
ValidateCurrentUser gets called from Umbraco.Web.BackOffice.Filters.UmbracoAuthorizeFilter and maybe this could be the right place to ensure culture as set by user's property - right?

_One problem remains: The user needs to logout and login again to see the changes._ 