### PR TITLE
Fix: v7 BeginTransaction null reference after custom migrations

### DIFF
--- a/src/Umbraco.Core/Persistence/PetaPoco.cs
+++ b/src/Umbraco.Core/Persistence/PetaPoco.cs
@@ -344,7 +344,7 @@ namespace Umbraco.Core.Persistence
                 _transactionCancelled = false;
 				OnBeginTransaction();
 			}
-            else if (isolationLevel > _transaction.IsolationLevel)
+            else if (isolationLevel > CurrentTransactionIsolationLevel)
                 throw new Exception("Already in a transaction with a lower isolation level.");
         }
 

--- a/src/Umbraco.Core/Scoping/Scope.cs
+++ b/src/Umbraco.Core/Scoping/Scope.cs
@@ -400,10 +400,14 @@ namespace Umbraco.Core.Scoping
             {
                 try
                 {
-                    if (completed)
-                        _database.CompleteTransaction();
-                    else
-                        _database.AbortTransaction();
+                    // Only call a close on transaction when db is in transaction
+                    if (_database.InTransaction)
+                    {
+                        if (completed)
+                            _database.CompleteTransaction();
+                        else
+                            _database.AbortTransaction();
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
### Problem
After executing custom migrations, the following null reference exceptions was often encountered.
![image](https://user-images.githubusercontent.com/16972182/91564047-469b8f00-e940-11ea-82ef-b92055c4904c.png)

This caused the migration version to not be updated and all custom migrations to run again on start-up. The null reference could be easily fixed by using an existing property that has a built in null check. However, this was not the underlying issue since another exception would take its place:
![image](https://user-images.githubusercontent.com/16972182/91564408-e0633c00-e940-11ea-9153-1af9192b0d5c.png)

### Cause
The underlying issue is that PetaPoco's _transactionDepth could be a negative number. This was caused by an IDisposable implementation on the database to always close the transaction and reducing the _transactionDepth, even if no transaction was active/present.

### Changes
- Replace direct object reference with property that has built in null check
![image](https://user-images.githubusercontent.com/16972182/91564685-451e9680-e941-11ea-953f-46c49e01d82a.png)

- Add a check to close transaction only if db is in transaction
![image](https://user-images.githubusercontent.com/16972182/91564797-74350800-e941-11ea-952a-c955432a379c.png)

### Test
Unfortunately, this is not an easy one to test. We could reproduce this issue by running our custom migrations and there would be a big chance (almost always) this issue would occur. After this change this issue never occurred again.

The general steps would be:
1. Test with latest v7: run custom migrations and encounter the error (might require multiple tests before occurrence)
2. Test with branch: run the same custom migrations and never encounter the error (test multiple times)