### PR TITLE
Netcore/fix install api url

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Extensions
         /// <returns></returns>
         public static string GetInstallerApiUrl(this LinkGenerator linkGenerator)
         {
-            return linkGenerator.GetPathByAction(nameof(InstallController.Index), ControllerExtensions.GetControllerName<InstallApiController>(), new { area = Constants.Web.Mvc.InstallArea });
+            return linkGenerator.GetPathByAction(nameof(InstallController.Index), ControllerExtensions.GetControllerName<InstallApiController>(), new { area = Constants.Web.Mvc.InstallArea }).EnsureEndsWith('/');
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

The install routing is broken

### Description
The current extension method GetInstallerApiUrl returns a url without / at its end. As umbraco.install.js combines "GetSetup" with this url, the route is broken.

@bergmania I hope this helps you to fix the issue;-)  
