### PR TITLE
Removing "Shift-Tab" focus trap in Rich Text Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
@@ -2,7 +2,7 @@
     <umb-load-indicator ng-if="isLoading"></umb-load-indicator>
 
     <div class="umb-rte-editor-con">
-        <input type="text" id="{{model.alias}}" ng-focus="focus()" style="position:absolute;top:0;width:0;height:0;" />
+        <input type="text" id="{{model.alias}}" ng-focus="focus()" style="position:absolute;top:0;width:0;height:0;display:none;" />
         <div disable-hotkeys id="{{textAreaHtmlId}}" class="umb-rte-editor" ng-style="{ width: containerWidth, height: containerHeight, overflow: containerOverflow}"></div>
     </div>
 </div>


### PR DESCRIPTION
Prevents focus trap on "shift tab" in RTE

### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
Tab navigating through the properties when creating a new node does not allow Shift-Tab to navigate back to the previous property on a Rich Text Editor field.

![rte-focus-trap](https://user-images.githubusercontent.com/17262858/91609882-126aa300-e92d-11ea-8fe7-1a66873b4586.gif)

Changes sets display:none on the already non-visible input element that RTE is invoked using.  This removes it from the tab navigation that was trapping the focus.