### PR TITLE
umb-editor-header view: Fix h1 styling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -413,6 +413,8 @@ input.umb-panel-header-name-input.name-is-empty {
 .umb-panel-header-name {
    font-size: 16px;
    font-weight: bold;
+   margin: 0;
+   line-height: 1.2;
 }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
@KevinJump Discovered that the styling was a bit off after the merge of #8160 /cc @nul800sebastiaan 

I did not notice intially since the margin and line-height issues did not appear in the scenarios I tested. Now I realise that the reason why is becuase flexbox is used to center the headline vertically in a box with a height that means one won't notice the neither the margin nor the line-height default styling on h1 elements.

This is addressed and fixed with this PR setting the margin to 0 and the line-height to 1.2 (For the h1 in the umb-editor-header view).

@KevinJump Can you give this one a spin and ensure that this fix don't have any unexpected side effects please? 😃 