### PR TITLE
V8/bugfix/return IHtmlString from GetBlockListHtml

### DIFF
--- a/src/Umbraco.Web/BlockListTemplateExtensions.cs
+++ b/src/Umbraco.Web/BlockListTemplateExtensions.cs
@@ -4,6 +4,7 @@ using System.Web.Mvc;
 using System.Web.Mvc.Html;
 using Umbraco.Core.Models.Blocks;
 using Umbraco.Core.Models.PublishedContent;
+using System.Web;
 
 namespace Umbraco.Web
 {
@@ -12,7 +13,7 @@ namespace Umbraco.Web
         public const string DefaultFolder = "BlockList/";
         public const string DefaultTemplate = "Default";
 
-        public static MvcHtmlString GetBlockListHtml(this HtmlHelper html, BlockListModel model, string template = DefaultTemplate)
+        public static IHtmlString GetBlockListHtml(this HtmlHelper html, BlockListModel model, string template = DefaultTemplate)
         {
             if (model?.Layout == null || !model.Layout.Any()) return new MvcHtmlString(string.Empty);
 
@@ -20,11 +21,11 @@ namespace Umbraco.Web
             return html.Partial(view, model);
         }
 
-        public static MvcHtmlString GetBlockListHtml(this HtmlHelper html, IPublishedProperty property, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
+        public static IHtmlString GetBlockListHtml(this HtmlHelper html, IPublishedProperty property, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
 
-        public static MvcHtmlString GetBlockListHtml(this HtmlHelper html, IPublishedContent contentItem, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
+        public static IHtmlString GetBlockListHtml(this HtmlHelper html, IPublishedContent contentItem, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
 
-        public static MvcHtmlString GetBlockListHtml(this HtmlHelper html, IPublishedContent contentItem, string propertyAlias, string template)
+        public static IHtmlString GetBlockListHtml(this HtmlHelper html, IPublishedContent contentItem, string propertyAlias, string template)
         {
             if (propertyAlias == null) throw new ArgumentNullException(nameof(propertyAlias));
             if (string.IsNullOrWhiteSpace(propertyAlias)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(propertyAlias));
@@ -35,10 +36,10 @@ namespace Umbraco.Web
             return GetBlockListHtml(html, prop?.GetValue() as BlockListModel, template);
         }
 
-        public static MvcHtmlString GetBlockListHtml(this IPublishedProperty property, HtmlHelper html, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
+        public static IHtmlString GetBlockListHtml(this IPublishedProperty property, HtmlHelper html, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
 
-        public static MvcHtmlString GetBlockListHtml(this IPublishedContent contentItem, HtmlHelper html, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
+        public static IHtmlString GetBlockListHtml(this IPublishedContent contentItem, HtmlHelper html, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
 
-        public static MvcHtmlString GetBlockListHtml(this IPublishedContent contentItem, HtmlHelper html, string propertyAlias, string template) => GetBlockListHtml(html, contentItem, propertyAlias, template);
+        public static IHtmlString GetBlockListHtml(this IPublishedContent contentItem, HtmlHelper html, string propertyAlias, string template) => GetBlockListHtml(html, contentItem, propertyAlias, template);
     }
 }


### PR DESCRIPTION
Changed the return type from MvcHtmlString to IHtmlString in the BlockListTemplateExtensions as suggested in #8727. 

I'm having a hard time testing it since I still don't really understand how to get blocklist to actually work.

---
Edit:
Managed to figure out Block List and get it tested. It works just fine apart from having to edit the /Views/Partials/BlockList/Default.cshtml  from:

```
@inherits UmbracoViewPage<BlockListModel>
@using Umbraco.Core.Models.Blocks
@{
    if (Model?.Layout == null || !Model.Layout.Any()) { return; }
}
<div class="umb-block-list">
    @foreach (var layout in Model.Layout)
    {
        if (layout?.Udi == null) { continue; }
        var data = layout.Data;
        @Html.Partial("BlockList/Components/" + data.ContentType.Alias, layout)        
    }
</div>
```

to: 
```
@inherits UmbracoViewPage<BlockListModel>
@using Umbraco.Core.Models.Blocks
@{
    if (Model?.Layout == null || !Model.Layout.Any()) { return; }
}
<div class="umb-block-list">
    @foreach (var layout in Model.Layout)
    {
        if (layout?.ContentUdi == null) { continue; }
        var data = layout.Content;
        @Html.Partial("BlockList/Components/" + data.ContentType.Alias, layout)        
    }
</div>
```

But that seems very much unrelated to this PR