### PR TITLE
Sort dictionary translations by display name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/edit.html
@@ -22,7 +22,7 @@
                 <umb-box>
                     <umb-box-content>
                         <p ng-bind-html="vm.description"></p>
-                        <umb-property ng-repeat="translation in vm.content.translations" property="translation.property">
+                        <umb-property ng-repeat="translation in vm.content.translations | orderBy:'displayName'" property="translation.property">
                             <textarea rows="2" class="autogrow" style="width: 100%;" ng-model="translation.translation" maxlength="1000"></textarea>
                         </umb-property>
                     </umb-box-content>

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
@@ -28,11 +28,11 @@
                 <thead>
                     <tr>
                         <th><localize key="general_name">Name</localize></th>
-                        <th ng-repeat="column in vm.items[0].translations">{{column.displayName}}</th>
+                        <th ng-repeat="column in vm.items[0].translations | orderBy:'displayName'">{{column.displayName}}</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="item in vm.items track by item.id" style="cursor: pointer;">
+                    <tr ng-repeat="item in vm.items | orderBy:'displayName' track by item.id" style="cursor: pointer;">
                         <th>
                             <span class="bold" ng-style="item.style"><a href="" ng-click="vm.clickItem(item.id)">{{item.name}}</a></span>
                         </th>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It's been bugging me for a bit now... when you have more than a few languages, the dictionary translations become annoying to manage, because they're not sorted by language display name but rather by the order of which the languages were created (apparently):

![image](https://user-images.githubusercontent.com/7405322/91708867-383cb580-eb82-11ea-95f5-b2deee735175.png)

![image](https://user-images.githubusercontent.com/7405322/91708897-44c10e00-eb82-11ea-946d-5ffbb376808e.png)

This PR ensures that both the dictionary overview and the dictionary item editing sorts the translations by language display name:

![image](https://user-images.githubusercontent.com/7405322/91708794-1ba07d80-eb82-11ea-8666-e4f888281675.png)

![image](https://user-images.githubusercontent.com/7405322/91708758-10e5e880-eb82-11ea-8283-a085b0f78d7b.png)
