### PR TITLE
Sort the languages by their display name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -36,7 +36,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="language in vm.languages track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
+                    <tr ng-repeat="language in vm.languages | orderBy:'name' track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
                         <td>
                             <i class="icon-globe" style="color: #BBBABF; margin-right: 5px;"></i>
                             <span>{{ language.name }}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Following up on #8768, the list of languages seems to be sorted by the order of which they're created. 

![image](https://user-images.githubusercontent.com/7405322/91709466-18f25800-eb83-11ea-9133-23e4df32c28a.png)

This probably doesn't make a whole lot of sense to most people, so this PR ensures that the languages are explicitly sorted by name:

![image](https://user-images.githubusercontent.com/7405322/91709234-c0bb5600-eb82-11ea-96b3-6ed6faf4462a.png)
