### PR TITLE
Ensure directives use end-closing tag

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -43,8 +43,7 @@
 
         <umb-box data-element="node-info-history">
 
-            <umb-box-header title="{{historyLabel}}"> 
-                
+            <umb-box-header title="{{historyLabel}}">
                 <umb-button
                     ng-hide="node.trashed"
                     type="button"

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/overview.html
@@ -19,7 +19,7 @@
                 <div class="umb-logviewer__main-content">
                     <div ng-show="!vm.canLoadLogs">
                         <umb-box>
-                            <umb-box-header title="Unable to view logs"/>
+                            <umb-box-header title="Unable to view logs"></umb-box-header>
                             <umb-box-content>
                                 <p>Today's log file is too large to be viewed and would cause performance problems.</p>
                                 <p>If you need to view the log files, try opening them manually</p>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
@@ -14,7 +14,7 @@
             <ng-form name="gridItemConfigEditor" val-form-manager>
 
                 <umb-box ng-if="model.config">
-                    <umb-box-header title-key="grid_settings" />
+                    <umb-box-header title-key="grid_settings"></umb-box-header>
                     <umb-box-content>
                         <div>
                             <umb-property property="configValue"
@@ -26,7 +26,7 @@
                 </umb-box>
 
                 <umb-box ng-if="model.styles">
-                    <umb-box-header title-key="grid_styles" />
+                    <umb-box-header title-key="grid_styles"></umb-box-header>
                     <umb-box-content>
                         <div>
                             <umb-property property="styleValue"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I just noticed a few other issues with void elements (self-closing) with directives, which are custom HTML elements.

In this case is was causing layout issues in grid configuration settings/styles.

**Before**

![chrome_2020-08-31_18-27-48](https://user-images.githubusercontent.com/2919859/91746801-799e8680-ebbd-11ea-93de-3fa39f5ed679.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/91746832-858a4880-ebbd-11ea-920d-700f19fc8a91.png)

I have the following json configuration in grid settings:

```
[
  {
    "label": "Background color of row",
    "description": "Choose background color",
    "key": "background-color",
    "view": "colorpicker",
    "applyTo": "row",
    "prevalues": [
      "#D30535",
      {
        "value": "#32CD32"
      },
      "#81E6E0",
      "#109D95",
      "red",
      {
        "label": "White",
        "value": "#fff"
      },
      "#53B3AE",
      {
        "value": "#f00",
        "label": "Red"
      }
    ]
  },
  {
    "label": "Position",
    "description": "Set position",
    "key": "position",
    "view": "radiobuttonlist",
    "applyTo": "row",
    "prevalues": [
      "left",
      {
        "value": "center"
      },
      {
        "label": "Right",
        "value": "right"
      }
    ]
  }
] 
```