### PR TITLE
Query builder: Convert `<a>` to `<button>`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/querybuilder/querybuilder.html
@@ -33,9 +33,9 @@
 
                                     <umb-dropdown ng-if="vm.contentTypeSelectOpen" on-close="vm.contentTypeSelectOpen = false">
                                         <umb-dropdown-item ng-repeat="contentType in vm.contentTypes">
-                                            <a href ng-click="vm.setContentType(contentType); vm.contentTypeSelectOpen = false;">
+                                            <button type="button" class="btn-reset" ng-click="vm.setContentType(contentType); vm.contentTypeSelectOpen = false;">
                                                 {{contentType.name}}
-                                            </a>
+                                            </button>
                                         </umb-dropdown-item>
                                     </umb-dropdown>
 
@@ -71,9 +71,9 @@
 
                                     <umb-dropdown ng-if="vm.propertyFilterOpen[$index]" on-close="console.log(1);vm.propertyFilterOpen[$index] = false">
                                         <umb-dropdown-item ng-repeat="property in vm.properties">
-                                            <a href="" ng-click="vm.setFilterProperty(filter, property); vm.propertyFilterOpen[$parent.$parent.$index] = false;">
+                                            <button type="button" class="btn-reset" ng-click="vm.setFilterProperty(filter, property); vm.propertyFilterOpen[$parent.$parent.$index] = false;">
                                                 {{property.name}}
-                                            </a>
+                                            </button>
                                         </umb-dropdown-item>
                                     </umb-dropdown>
 
@@ -90,9 +90,9 @@
 
                                     <umb-dropdown ng-if="vm.termFilterOpen[$index]" on-close="vm.termFilterOpen[$index] = false">
                                         <umb-dropdown-item ng-repeat="term in vm.getPropertyOperators(filter.property)">
-                                            <a href="" ng-click="vm.setFilterTerm(filter, term); vm.termFilterOpen[$parent.$parent.$index] = false;">
+                                            <button type="button" class="btn-reset" ng-click="vm.setFilterTerm(filter, term); vm.termFilterOpen[$parent.$parent.$index] = false;">
                                                 {{term.name}}
-                                            </a>
+                                            </button>
                                         </umb-dropdown-item>
                                     </umb-dropdown>
 
@@ -137,9 +137,9 @@
 
                                     <umb-dropdown ng-if="vm.sortPropertyOpen" on-close="vm.sortPropertyOpen = false">
                                         <umb-dropdown-item ng-repeat="property in vm.properties">
-                                            <a href="" ng-click="vm.setSortProperty(vm.query, property); vm.sortPropertyOpen = false;">
+                                            <button type="button" class="btn-reset" ng-click="vm.setSortProperty(vm.query, property); vm.sortPropertyOpen = false;">
                                                 {{property.name}}
-                                            </a>
+                                            </button>
                                         </umb-dropdown-item>
                                     </umb-dropdown>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have converted the `<a>` tags containing an empty `href` attribute to `<button>` instead improving accessibility and semantics. I have checked that the styling remains intact after the change 😉 

It's hard to show using a GIF but it's the query builder view that opens in the template editor when clicking the "Query builder" button and the changes affect the highlighted dropdowns. It also affects some of the dropdowns that appear depending on, what you select in the first dropdown.

![querybuilder](https://user-images.githubusercontent.com/1932158/91764117-06097300-ebd7-11ea-86ad-12f16ed7dfb8.png)
