### PR TITLE
Update to nouislider v14.6.1

### DIFF
--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -38,7 +38,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.22.2",
     "ng-file-upload": "12.2.13",
-    "nouislider": "14.6.0",
+    "nouislider": "14.6.1",
     "npm": "^6.14.7",
     "signalr": "2.4.0",
     "spectrum-colorpicker": "1.8.0",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Updating noUiSlider to v14.6.1 to fix a minor issue with pips not being rendered.
https://github.com/leongersen/noUiSlider/issues/1088

Can be cherry picked to v8.7 branch as well.