### PR TITLE
Users - fix semantics + fix focus on umb-checkmark directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-checkmark.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-checkmark.less
@@ -17,14 +17,36 @@
     }
 }
 
+.umb-checkmark__action {
+    &:hover,
+    &:focus {
+        .umb-checkmark {
+            border-color:@ui-action-discreet-border-hover;
+            color: @ui-selected-type-hover;
+        }
+    }
+}
+
 .umb-checkmark--checked {
     background: @ui-selected-border;
     border-color: @ui-selected-border;
     color: @white;
+
     &:hover {
         background: @ui-selected-border-hover;
         border-color: @ui-selected-border-hover;
         color: @white;
+    }
+}
+
+.umb-checkmark__action {
+    &:hover,
+    &:focus {
+        .umb-checkmark--checked {
+            background: @ui-selected-border-hover;
+            border-color: @ui-selected-border-hover;
+            color: @white;
+        }
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -211,9 +211,9 @@
                 <div class="umb-table-head">
                     <div class="umb-table-row">
                         <div class="umb-table-cell umb-user-table-col-avatar not-fixed" style="width: 70px; padding:10px 15px;">
-                            <a href="" style="text-decoration: none;" ng-click="vm.selectAll()">
+                            <button type="button" class="btn-reset umb-checkmark__action" style="outline: none;" ng-click="vm.selectAll()">
                                 <umb-checkmark checked="vm.areAllSelected()" size="xs"></umb-checkmark>
-                            </a>
+                            </button>
                         </div>
                         <div class="umb-table-cell umb-table__name"><localize key="general_name">Name</localize></div>
                         <div class="umb-table-cell"><localize key="user_usergroup">User group</localize></div>
@@ -347,9 +347,9 @@
                                 on-remove="vm.removeSelectedUserGroup($index, vm.newUser.userGroups)">
                             </umb-user-group-preview>
 
-                            <a href="" style="max-width: 100%;" class="umb-node-preview-add" ng-click="vm.openUserGroupPicker($event)" prevent-default>
+                            <button type="button" style="max-width: 100%;" class="btn-reset umb-node-preview-add" ng-click="vm.openUserGroupPicker($event)">
                                 <localize key="general_add">Add</localize>
-                            </a>
+                            </button>
 
                             <input type="hidden" ng-model="vm.newUser.userGroupsValidation" ng-required="!vm.newUser.userGroups.length" />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I converted 2 `<a>` elements with empty `href` attributes to be `<button>` instead. I also added som styling in order to ensure that the "checkbox" in the "list layout" of the users would receive focus styles when tabbing. Currently the `<umb-checkmark>` directive only consists of a single icon - I will soon address this specifically in another PR unless someone beats me to it wrapping the icon in the directive inside a button by default and adjust the styling accordingly.

Attached are some screendumps of the areas that have been changed and need to be tested 😄 

**Create user add button**
![create-user-add-button](https://user-images.githubusercontent.com/1932158/91796576-d54e2b80-ec20-11ea-8080-27258ef612f9.png)

**View users in list layout**
![users-view-list-layout](https://user-images.githubusercontent.com/1932158/91796591-dbdca300-ec20-11ea-8d5a-068f4ab49be3.png)
