### PR TITLE
Macropicker: Fix semantics

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -118,6 +118,10 @@ label.control-label, .control-label {
     width: 100%;
 }
 
+.macro-select .form-search {
+    margin: 0 0 10px;
+}
+
 // GENERAL STYLES
 // --------------
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.html
@@ -15,7 +15,7 @@
                 <umb-box-content class="block-form">
                     <div ng-switch="wizardStep">
 
-                        <div ng-switch-when="macroSelect">
+                        <div ng-switch-when="macroSelect" class="macro-select">
 
                             <div class="form-search">
                                 <i class="icon-search"></i>
@@ -32,12 +32,12 @@
                             <ul class="umb-card-grid -three-in-row">
                                 <li ng-repeat="availableItem in macros | orderBy:'name' | filter:searchTerm"
                                     ng-click="selectMacro(availableItem)">
-                                    <a class="umb-card-grid-item" href="" title="{{availableItem.name}}">
+                                    <button class="btn-reset umb-card-grid-item" title="{{availableItem.name}}">
                                         <span>
-                                            <i class="icon-settings-alt"></i>
+                                            <i class="icon-settings-alt" aria-hidden="true"></i>
                                             {{availableItem.name}}
                                         </span>
-                                    </a>
+                                    </button>
                                 </li>
                             </ul>
 


### PR DESCRIPTION
…ckable items

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With this PR I have changed the `<a>` element containing an empty `href` attribute to be `<button>`. I have also made a little styling adjustment so that there is 10px button margin from the search form and down to the card items so when one hovers the items there is a little space between the search box and the items.