### PR TITLE
Spectrum colorpicker v2

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -217,10 +217,10 @@ function dependencies() {
         {
             "name": "spectrum",
             "src":  [
-                "./node_modules/spectrum-colorpicker/spectrum.js",
-                "./node_modules/spectrum-colorpicker/spectrum.css"
+                "./node_modules/spectrum-colorpicker2/dist/spectrum.js",
+                "./node_modules/spectrum-colorpicker2/dist/spectrum.css"
             ],
-            "base": "./node_modules/spectrum-colorpicker"
+            "base": "./node_modules/spectrum-colorpicker2/dist"
         },
         {
             "name": "tinymce",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -41,7 +41,7 @@
     "nouislider": "14.6.0",
     "npm": "^6.14.7",
     "signalr": "2.4.0",
-    "spectrum-colorpicker": "1.8.0",
+    "spectrum-colorpicker2": "2.0.3",
     "tinymce": "4.9.11",
     "typeahead.js": "0.11.1",
     "underscore": "1.9.1",

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -163,6 +163,16 @@
     .sp-replacer {
         display: inline-flex;
         margin-right: 18px;
+        height: auto;
+
+        .sp-preview {
+            margin: 5px;
+            height: auto;
+        }
+
+        .sp-dd {
+            line-height: 2rem;
+        }
     }
 
     label {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -33,11 +33,12 @@
             var elem = $element.find("input[name='newColor']");
             elem.spectrum({
                 color: null,
+                showAlpha: false,
                 showInitial: false,
+                showInput: true,
                 chooseText: $scope.labels.choose,
                 cancelText: $scope.labels.cancel,
                 preferredFormat: "hex",
-                showInput: true,
                 clickoutFiresChange: true,
                 hide: function (color) {
                     //show the add butotn

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -32,8 +32,8 @@
         ], $scope).then(function () {
             var elem = $element.find("input[name='newColor']");
             elem.spectrum({
-                color: null,
                 type: "color",
+                color: defaultColor,
                 showAlpha: false,
                 showInitial: false,
                 showInput: true,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -33,6 +33,7 @@
             var elem = $element.find("input[name='newColor']");
             elem.spectrum({
                 color: null,
+                type: "color",
                 showAlpha: false,
                 showInitial: false,
                 showInput: true,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that we at the moment are using the spectrum color picker here:
https://bgrins.github.io/spectrum/

However it seems this is unmaintained and another developer has taken over the project and continued the work:
https://seballot.github.io/spectrum/

With some minor adjustments this PR replaces spectrum-colorpicker with spectrum-colorpicker2. The configuration is pretty much the same as this existing one, but with some enhancements.

**Before**

![chrome_2020-09-01_10-12-38](https://user-images.githubusercontent.com/2919859/91834529-78666b80-ec48-11ea-837d-980b37f4c817.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/91834801-cc715000-ec48-11ea-9335-15b760001505.png)
