### PR TITLE
Make the page name label visible at all times

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -17,7 +17,7 @@
                         {{a11yMessage}}
                     </p>
                 </div>
-                <label for="headerName" class="control-label">{{a11yName}}</label>
+                <label for="headerName" class="control-label">{{a11yName}} <span><strong class="umb-control-required">*</strong></span></label>
                 <div class="umb-editor-header__name-wrapper">
                     <ng-form name="headerNameForm">
                         <input data-element="editor-name-field"

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -17,8 +17,8 @@
                         {{a11yMessage}}
                     </p>
                 </div>
+                <label for="headerName" class="control-label">{{a11yName}}</label>
                 <div class="umb-editor-header__name-wrapper">
-                    <label for="headerName" class="sr-only">{{a11yName}}</label>
                     <ng-form name="headerNameForm">
                         <input data-element="editor-name-field"
                                type="text"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description

I have no idea if this is controversial. This was clearly deliberately made not visible to users not using a screen reader (see: `sr-only` class). However, for 508 Compliance in the United States, the guidelines specifically state "The label or instruction must be visible when the form field has focus". https://www.dhs.gov/sites/default/files/publications/trusted_tester_test_process_v5_0_aug_16_2019.pdf#page=29

![image](https://user-images.githubusercontent.com/17951/91901979-fdfd1200-ec6e-11ea-82a8-b707ee803059.png)

Before:

![image](https://user-images.githubusercontent.com/17951/91902008-09503d80-ec6f-11ea-892b-5f6f56ffc496.png)

After: 

![image](https://user-images.githubusercontent.com/17951/91902025-0fdeb500-ec6f-11ea-9836-0ce98d7502b9.png)
