### PR TITLE
V8.7RC Block Editor: Use correct label for custom view headline

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -146,7 +146,7 @@
 
 
         vm.addViewForBlock = function(block) {
-            localizationService.localize("blockEditor_headlineSelectView").then(function(localizedTitle) {
+            localizationService.localize("blockEditor_headlineAddCustomView").then(function(localizedTitle) {
 
                 const filePicker = {
                     title: localizedTitle,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It looks like the wrong label is being used in the "Select view" dialog when selecting custom block editor views:

![image](https://user-images.githubusercontent.com/7405322/91936243-c5514d00-ecef-11ea-9cf3-5b512cb7a4a0.png)

Perhaps `headlineSelectView` was renamed to `headlineAddCustomView` along the way to ensure consistency... at least that makes sense in my head 😆 `headlineAddCustomView` seems to be a better fit for the dialog title:

![image](https://user-images.githubusercontent.com/7405322/91936263-d0a47880-ecef-11ea-9b90-13fd86d39fb8.png)
