### PR TITLE
V8.7RC Block Editor: Fix JS validation error for missing settings block

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
@@ -1,4 +1,4 @@
-<ng-form name="vm.blockRowForm" val-server-match="{ 'contains' : { 'valServerMatchContent': vm.layout.$block.content.key, 'valServerMatchSettings': vm.layout.$block.settings.key } }">
+<ng-form name="vm.blockRowForm" val-server-match="vm.valServerMatch">
     <div class="umb-block-list__block" ng-class="{'--active':vm.layout.$block.active}">
 
         <umb-block-list-block stylesheet="{{::vm.layout.$block.config.stylesheet}}"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistrow.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistrow.component.js
@@ -30,7 +30,14 @@
         var vm = this;
 
         vm.$onInit = function () {
-          
+            vm.valServerMatch = {
+                contains: {
+                    valServerMatchContent: vm.layout.$block.content.key
+                }
+            };
+            if (vm.layout.$block.settings) {
+                vm.valServerMatch.contains.valServerMatchSettings = vm.layout.$block.settings.key;
+            }
         };
     }   
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you configure a block in Block Editor without a settings model, the editor throws a nasty JS error:

![image](https://user-images.githubusercontent.com/7405322/91938730-cc2e8e80-ecf4-11ea-8be1-7d5752330f89.png)

It happens when the editor displays server side validation errors. Obviously there can be no server side validation of the settings model if there is none, but Block Editor assumes there is one - and then things fail.

This PR ensures that we only show server side validation errors for the settings model if there indeed is one configured for the block.