### PR TITLE
V8.7RC Block Editor: Cannot reuse existing element types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
@@ -98,7 +98,8 @@
         vm.openAddDialog = function ($event, entry) {
 
             //we have to add the 'alias' property to the objects, to meet the data requirements of itempicker.
-            var selectedItems = Utilities.copy($scope.model.value).forEach((obj) => {
+            var selectedItems = Utilities.copy($scope.model.value);
+            selectedItems.forEach((obj) => {
                 obj.alias = vm.getElementTypeByKey(obj.contentTypeKey).alias;
                 return obj;
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It seems we're quite unable to use existing element types in block editor:

![image](https://user-images.githubusercontent.com/7405322/91940151-4c55f380-ecf7-11ea-80fb-38f4e114d6e6.png)

Turns out a JS error is making a mess of things:

![image](https://user-images.githubusercontent.com/7405322/91940214-64c60e00-ecf7-11ea-9c1e-1e9e483f5a2e.png)

This PR fixes the JS error, thus bringing back selection of existing element types:

![be-reuse-element](https://user-images.githubusercontent.com/7405322/91940252-760f1a80-ecf7-11ea-9850-5d665c4f3c05.gif)
