### PR TITLE
V8.7RC Block Editor: Cannot select an existing element type as settings model

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/compareArrays.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/compareArrays.filter.js
@@ -2,6 +2,10 @@ angular.module("umbraco.filters")
     .filter('compareArrays', function() {
         return function inArray(array, compareArray, compareProperty) {
 
+            if (!compareArray || !compareArray.length) {
+                return [...array];
+            }
+
             var result = [];
 
             array.forEach(function(arrayItem){


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Somewhat similar to #8795 but the source of the error is different... as an unintended side effect of #8552, the `compareArrays` filter throws an error if the array being compared to is not defined. Previously this was safeguarded by AngularJS (when AngularJS was used to perform the array iteration) .

![image](https://user-images.githubusercontent.com/7405322/91944044-c2f5ef80-ecfd-11ea-974d-903209a21ebf.png)

It becomes quite evident in the Block Editor when selecting a model for block settings - you're unable to pick any existing element types for the settings model:

![be-reuse-element-settings-before](https://user-images.githubusercontent.com/7405322/91944096-d4d79280-ecfd-11ea-97d8-3d6ccbefd306.gif)


This PR amends the `compareArrays` filter, and now the element settings picker works as you'd expect:

![be-reuse-element-settings-after](https://user-images.githubusercontent.com/7405322/91944282-1cf6b500-ecfe-11ea-917b-4dfdb9f9100c.gif)


