### PR TITLE
Allow to pass in boolean to umbAutoFocus directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
@@ -1,18 +1,28 @@
 angular.module("umbraco.directives")
     .directive('umbAutoFocus', function($timeout) {
 
-        return function(scope, element, attr){
+        return function (scope, element, attrs) {
+            
             var update = function() {
                 //if it uses its default naming
-                if(element.val() === "" || attr.focusOnFilled){
+                if (element.val() === "" || attrs.focusOnFilled) {
                     element.trigger("focus");
                 }
             };
 
-            if (attr.umbAutoFocus !== "false") {
+            var enabled = true;
+            //check if there's a value for the attribute, if there is and it's false then we conditionally don't
+            //use auto focus.
+            if (attrs.umbAutoFocus) {
+                attrs.$observe("umbAutoFocus", function (newVal) {
+                    enabled = (newVal === "false" || newVal === 0 || newVal === false) ? false : true;
+                });
+            }
+
+            if (enabled) {
                 $timeout(function() {
                     update();
                 });
             }
-    };
+        };
 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR allow to pass in truthy values (0/1, 'true'/'false', true/false) to `umbAutoFocus` similar to `preventEnterSubmit ` and `preventDefault` directives.

Originally added to this PR https://github.com/umbraco/Umbraco-CMS/pull/8639 but moved to a separate PR instead.