### PR TITLE
Added missing escape character on installer's DB config page

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
@@ -40,7 +40,7 @@
                         <label class="control-label" for="server">Server</label>
                         <div class="controls">
                             <input type="text" id="server" name="server"
-                                   placeholder="{{ installer.current.model.dbType == 3 ? 'umbraco-database.database.windows.net' : '127.0.0.1\SQLEXPRESS'}}"
+                                   placeholder="{{ installer.current.model.dbType == 3 ? 'umbraco-database.database.windows.net' : '127.0.0.1\\SQLEXPRESS'}}"
                                    required ng-model="installer.current.model.server" />
                             <small class="inline-help">Enter server domain or IP</small>
                         </div>


### PR DESCRIPTION
On the installer's SQL Server configuration textbox, the placeholder value is missing an escape character. Due to this, the placeholder value looks like this "127.0.0.1SQLEXPRESS".

After this fix, the placeholder value should look like "127.0.0.1\SQLEXPRESS"

**Before the fix:**
![before-back-slash-fix](https://user-images.githubusercontent.com/3383922/92045157-c75eee80-ed77-11ea-87ef-993e66424f6e.PNG)

**After the fix:**
![after-back-slash-fix](https://user-images.githubusercontent.com/3383922/92045173-d04fc000-ed77-11ea-91ce-a9a14d63903c.PNG)

