### PR TITLE
Use correct woff and woff2 MIME types

### DIFF
--- a/build/NuSpecs/tools/Web.config.install.xdt
+++ b/build/NuSpecs/tools/Web.config.install.xdt
@@ -84,9 +84,9 @@
       <remove fileExtension=".svg" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
       <mimeMap fileExtension=".svg" mimeType="image/svg+xml" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
       <remove fileExtension=".woff" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
-      <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
+      <mimeMap fileExtension=".woff" mimeType="font/woff" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
       <remove fileExtension=".woff2" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
-      <mimeMap fileExtension=".woff2" mimeType="application/x-font-woff2" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
+      <mimeMap fileExtension=".woff2" mimeType="font/woff2" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
       <remove fileExtension=".less" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
       <mimeMap fileExtension=".less" mimeType="text/css" xdt:Locator="Match(fileExtension)" xdt:Transform="InsertIfMissing" />
     </staticContent>

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -175,9 +175,9 @@
             <remove fileExtension=".svg" />
             <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
             <remove fileExtension=".woff" />
-            <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
+            <mimeMap fileExtension=".woff" mimeType="font/woff" />
             <remove fileExtension=".woff2" />
-            <mimeMap fileExtension=".woff2" mimeType="application/x-font-woff2" />
+            <mimeMap fileExtension=".woff2" mimeType="font/woff2" />
             <remove fileExtension=".less" />
             <mimeMap fileExtension=".less" mimeType="text/css" />
             <remove fileExtension=".mp4" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The MIME types for `.woff` and `.woff2` file extensions are updated by Umbraco and set to outdated/incorrect values:

https://github.com/umbraco/Umbraco-CMS/blob/44fbc29541604973df5311af9898fc4ceaad583d/src/Umbraco.Web.UI/web.Template.config#L196-L197

https://github.com/umbraco/Umbraco-CMS/blob/3f5729767d362c86011865845cebea28f1ea5c92/src/Umbraco.Web.UI/web.Template.config#L320-L321

The correct MIME types are `font/woff` and `font/woff2` (see [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) and the [official IANA list](http://www.iana.org/assignments/media-types/media-types.xhtml#font)). This PR makes sure these are set in the default `web.Template.config` (new installs) and updated in `Web.config.install.xdt` (when upgrading via NuGet).

To test this PR, make sure that on new installs and after upgrading using NuGet, the `Content-Type` response header (visible in Developers Tools\Network) of requests like `/umbraco/assets/fonts/lato/LatoLatin-Regular.woff` and `/umbraco/assets/fonts/lato/LatoLatin-Regular.woff2` return the correct MIME types.