### PR TITLE
Add color picker component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -83,7 +83,7 @@
 
         ctrl.$onInit = function() {
             
-            //load the separate css for the editor to avoid it blocking our js loading
+            // load the separate css for the editor to avoid it blocking our js loading
             assetsService.loadCss("lib/spectrum/spectrum.css", $scope);
 
             // load the js file for the color picker

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -29,6 +29,15 @@
         function Controller() {
     
             var vm = this;
+
+            vm.options = {
+                type: "color",
+                color: defaultColor,
+                showAlpha: false,
+                showPalette: true,
+                showPaletteOnly: false,
+                preferredFormat: "hex",
+            };
             
             vm.show = show;
             vm.hide = hide;
@@ -111,6 +120,8 @@
         }
 
         function setColorPicker(element, labels) {
+
+            // Spectrum options: https://seballot.github.io/spectrum/#options
 
             const defaultOptions = {
                 type: "color",

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -12,9 +12,8 @@
     <div ng-controller="My.ColorController as vm">
         
         <umb-color-picker
-            on-select="vm.selectItem"
-            on-cancel="vm.cancel">
-        </umb-table>
+            on-change="vm.selectItem">
+        </umb-color-picker>
     
     </div>
 </pre>
@@ -30,11 +29,9 @@
     
             vm.change = change;
 
-            function change(item, $index, $event) {
+            function change(color) {
                 
             }
-            
-    
         }
     
         angular.module("umbraco").controller("My.ColorController", Controller);
@@ -42,6 +39,8 @@
     })();
 </pre>
 
+@param {object} ngModel (<code>binding</code>): Value for the color picker.
+@param {object} options (<code>binding</code>): Config object for the color picker.
 @param {function} onBeforeShow (<code>expression</code>): Callback function before color picker is shown.
 @param {function} onChange (<code>expression</code>): Callback function when the color is changed.
 @param {function} onShow (<code>expression</code>): Callback function when color picker is shown.

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -150,7 +150,6 @@
             $scope.$applyAsync();
         }
 
-
         // Spectrum events: https://seballot.github.io/spectrum/#events
 
         function setUpCallbacks() {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -92,16 +92,13 @@
             });
 
             $timeout(function () {
-                const element = $element.find('.umb-color-picker')[0];
+                const element = $element.find('.umb-color-picker input')[0];
                 setColorPicker(element, labels);
             }, 0, true);
 
         }
 
         function setColorPicker(element, labels) {
-
-            //colorPickerInstance = element;
-            //console.log("colorPickerInstance", colorPickerInstance);
 
             const defaultOptions = {
                 type: "color",
@@ -126,11 +123,12 @@
 
             var elem = angular.element(element);
 
-            // Create new color pickr
+            // Create new color pickr instance
             const colorPicker = elem.spectrum(options);
-            console.log("colorPicker", colorPicker);
 
             colorPickerInstance = colorPicker;
+
+            console.log("colorPickerInstance", colorPickerInstance);
 
             // destroy the color picker instance when the dom element is removed
             elem.on('$destroy', function () {
@@ -147,19 +145,23 @@
             
             if (colorPickerInstance) {
 
+                console.log("setUpCallbacks", colorPickerInstance);
+
                 // bind hook for beforeShow
-                if (ctrl.beforeShow) {
-                    colorPickerInstance.on('beforeShow', (color) => {
+                if (ctrl.onBeforeShow) {
+                    colorPickerInstance.on('beforeShow.spectrum', (e, color) => {
                         $timeout(function () {
-                            ctrl.beforeShow({ color: color });
+                            console.log("beforeShow", color);
+                            ctrl.onBeforeShow({ color: color });
                         });
                     });
                 }
 
                 // bind hook for show
                 if (ctrl.onShow) {
-                    colorPickerInstance.on('show', (color) => {
+                    colorPickerInstance.on('show.spectrum', (e, color) => {
                         $timeout(function () {
+                            console.log("onShow", color);
                             ctrl.onShow({ color: color });
                         });
                     });
@@ -167,8 +169,9 @@
 
                 // bind hook for hide
                 if (ctrl.onHide) {
-                    colorPickerInstance.on('hide', (color) => {
+                    colorPickerInstance.on('hide.spectrum', (e, color) => {
                         $timeout(function () {
+                            console.log("onHide", color);
                             ctrl.onHide({ color: color });
                         });
                     });
@@ -176,8 +179,9 @@
 
                 // bind hook for change
                 if (ctrl.onChange) {
-                    colorPickerInstance.on('change', (color) => {
+                    colorPickerInstance.on('change.spectrum', (e, color) => {
                         $timeout(function () {
+                            console.log("onChange", color);
                             ctrl.onChange({ color: color });
                         });
                     });
@@ -185,8 +189,9 @@
 
                 // bind hook for move
                 if (ctrl.onMove) {
-                    colorPickerInstance.on('move', (color) => {
+                    colorPickerInstance.on('move.spectrum', (e, color) => {
                         $timeout(function () {
+                            console.log("onMove", color);
                             ctrl.onMove({ color: color });
                         });
                     });
@@ -199,13 +204,12 @@
     angular
         .module('umbraco.directives')
         .component('umbColorPicker', {
-            template: '<div class="umb-color-picker"></div>',
+            template: '<div class="umb-color-picker"><input type="hidden" /></div>',
             controller: ColorPickerController,
-            controllerAs: 'vm',
             bindings: {
                 ngModel: '<',
                 options: '<',
-                beforeShow: '&',
+                onBeforeShow: '&',
                 onShow: '&',
                 onHide: '&',
                 onChange: '&',

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -30,7 +30,7 @@
             vm.change = change;
 
             function change(color) {
-                
+                color.toHexString().trimStart("#");
             }
         }
     
@@ -39,7 +39,7 @@
     })();
 </pre>
 
-@param {object} ngModel (<code>binding</code>): Value for the color picker.
+@param {string} ngModel (<code>binding</code>): Value for the color picker.
 @param {object} options (<code>binding</code>): Config object for the color picker.
 @param {function} onBeforeShow (<code>expression</code>): Callback function before color picker is shown.
 @param {function} onChange (<code>expression</code>): Callback function when the color is changed.
@@ -138,51 +138,54 @@
             $scope.$applyAsync();
         }
 
+
+        // Spectrum events: https://seballot.github.io/spectrum/#events
+
         function setUpCallbacks() {
             
             if (colorPickerInstance) {
 
                 // bind hook for beforeShow
                 if (ctrl.onBeforeShow) {
-                    colorPickerInstance.on('beforeShow.spectrum', (e, color) => {
+                    colorPickerInstance.on('beforeShow.spectrum', (e, tinycolor) => {
                         $timeout(function () {
-                            ctrl.onBeforeShow({ color: color });
+                            ctrl.onBeforeShow({ color: tinycolor });
                         });
                     });
                 }
 
                 // bind hook for show
                 if (ctrl.onShow) {
-                    colorPickerInstance.on('show.spectrum', (e, color) => {
+                    colorPickerInstance.on('show.spectrum', (e, tinycolor) => {
                         $timeout(function () {
-                            ctrl.onShow({ color: color });
+                            ctrl.onShow({ color: tinycolor });
                         });
                     });
                 }
 
                 // bind hook for hide
                 if (ctrl.onHide) {
-                    colorPickerInstance.on('hide.spectrum', (e, color) => {
+                    colorPickerInstance.on('hide.spectrum', (e, tinycolor) => {
                         $timeout(function () {
-                            ctrl.onHide({ color: color });
+                            ctrl.onHide({ color: tinycolor });
                         });
                     });
                 }
 
                 // bind hook for change
                 if (ctrl.onChange) {
-                    colorPickerInstance.on('change.spectrum', (e, color) => {
+                    colorPickerInstance.on('change.spectrum', (e, tinycolor) => {
                         $timeout(function () {
-                            ctrl.onChange({ color: color });
+                            ctrl.onChange({ color: tinycolor });
                         });
                     });
                 }
 
                 // bind hook for move
                 if (ctrl.onMove) {
-                    colorPickerInstance.on('move.spectrum', (e, color) => {
+                    colorPickerInstance.on('move.spectrum', (e, tinycolor) => {
                         $timeout(function () {
-                            ctrl.onMove({ color: color });
+                            ctrl.onMove({ color: tinycolor });
                         });
                     });
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -1,0 +1,216 @@
+﻿/**
+@ngdoc directive
+@name umbraco.directives.directive:umbColorPicker
+@restrict E
+@scope
+
+@description
+<strong>Added in Umbraco v. 8.8:</strong> Use this directive to render a color picker.
+
+<h3>Markup example</h3>
+<pre>
+    <div ng-controller="My.ColorController as vm">
+        
+        <umb-color-picker
+            on-select="vm.selectItem"
+            on-cancel="vm.cancel">
+        </umb-table>
+    
+    </div>
+</pre>
+
+<h3>Controller example</h3>
+<pre>
+    (function () {
+        "use strict";
+    
+        function Controller() {
+    
+            var vm = this;
+    
+            vm.change = change;
+
+            function change(item, $index, $event) {
+                
+            }
+            
+    
+        }
+    
+        angular.module("umbraco").controller("My.ColorController", Controller);
+    
+    })();
+</pre>
+
+@param {function} beforeShow (<code>expression</code>): Callback function before color picker is shown.
+@param {function} onChange (<code>expression</code>): Callback function when the color is changed.
+@param {function} onShow (<code>expression</code>): Callback function when color picker is shown.
+@param {function} onHide (<code>expression</code>): Callback function when color picker is hidden.
+@param {function} onMove (<code>expression</code>): Callback function when the color is moved in color picker.
+
+**/
+
+(function () {
+    'use strict';
+
+    function ColorPickerController($scope, $element, $timeout, assetsService, localizationService) {
+
+        const ctrl = this;
+
+        let colorPickerInstance = null;
+        let labels = {};
+
+        ctrl.$onInit = function() {
+            
+            //load the separate css for the editor to avoid it blocking our js loading
+            assetsService.loadCss("lib/spectrum/spectrum.css", $scope);
+
+            // load the js file for the color picker
+            assetsService.load([
+                //"lib/spectrum/tinycolor.js",
+                "lib/spectrum/spectrum.js"
+            ], $scope).then(function () {
+
+                // init color picker
+                grabElementAndRun();
+            });
+
+        }
+
+        function grabElementAndRun() {
+
+            var labelKeys = [
+                "general_cancel",
+                "general_choose",
+                "general_clear"
+            ];
+
+            localizationService.localizeMany(labelKeys).then(values => {
+                labels.cancel = values[0];
+                labels.choose = values[1];
+                labels.clear = values[2];
+            });
+
+            $timeout(function () {
+                const element = $element.find('.umb-color-picker')[0];
+                setColorPicker(element, labels);
+            }, 0, true);
+
+        }
+
+        function setColorPicker(element, labels) {
+
+            //colorPickerInstance = element;
+            //console.log("colorPickerInstance", colorPickerInstance);
+
+            const defaultOptions = {
+                type: "color",
+                color: null,
+                showAlpha: false,
+                showInitial: false,
+                showInput: true,
+                cancelText: labels.cancel,
+                clearText: labels.clear,
+                chooseText: labels.choose,
+                preferredFormat: "hex",
+                clickoutFiresChange: true
+            };
+
+            // If has ngModel set the color
+            if (ctrl.ngModel) {
+                defaultOptions.color = ctrl.ngModel;
+            }
+
+            //const options = ctrl.options ? ctrl.options : defaultOptions;
+            const options = angular.extend({}, defaultOptions, ctrl.options);
+
+            var elem = angular.element(element);
+
+            // Create new color pickr
+            const colorPicker = elem.spectrum(options);
+            console.log("colorPicker", colorPicker);
+
+            colorPickerInstance = colorPicker;
+
+            // destroy the color picker instance when the dom element is removed
+            elem.on('$destroy', function () {
+                colorPickerInstance.destroy();
+            });
+
+            setUpCallbacks();
+
+            // Refresh the scope
+            $scope.$applyAsync();
+        }
+
+        function setUpCallbacks() {
+            
+            if (colorPickerInstance) {
+
+                // bind hook for beforeShow
+                if (ctrl.beforeShow) {
+                    colorPickerInstance.on('beforeShow', (color) => {
+                        $timeout(function () {
+                            ctrl.beforeShow({ color: color });
+                        });
+                    });
+                }
+
+                // bind hook for show
+                if (ctrl.onShow) {
+                    colorPickerInstance.on('show', (color) => {
+                        $timeout(function () {
+                            ctrl.onShow({ color: color });
+                        });
+                    });
+                }
+
+                // bind hook for hide
+                if (ctrl.onHide) {
+                    pickrInstance.on('hide', (color) => {
+                        $timeout(function () {
+                            ctrl.onHide({ color: color });
+                        });
+                    });
+                }
+
+                // bind hook for change
+                if (ctrl.onChange) {
+                    colorPickerInstance.on('change', (color) => {
+                        $timeout(function () {
+                            ctrl.onChange({ color: color });
+                        });
+                    });
+                }
+
+                // bind hook for move
+                if (ctrl.onMove) {
+                    colorPickerInstance.on('move', (color) => {
+                        $timeout(function () {
+                            ctrl.onMove({ color: color });
+                        });
+                    });
+                }
+
+            }
+        }
+    }
+
+    angular
+        .module('umbraco.directives')
+        .component('umbColorPicker', {
+            template: '<div class="umb-color-picker"></div>',
+            controller: ColorPickerController,
+            controllerAs: 'vm',
+            bindings: {
+                ngModel: '<',
+                options: '<',
+                beforeShow: '&',
+                onShow: '&',
+                onHide: '&',
+                onChange: '&',
+                onMove: '&'
+            }
+        });
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -26,8 +26,18 @@
         function Controller() {
     
             var vm = this;
-    
+            
+            vm.show = show;
+            vm.hide = hide;
             vm.change = change;
+
+            function show(color) {
+                color.toHexString().trimStart("#");
+            }
+
+            function hide(color) {
+                color.toHexString().trimStart("#");
+            }
 
             function change(color) {
                 color.toHexString().trimStart("#");

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -118,7 +118,7 @@
             }
 
             //const options = ctrl.options ? ctrl.options : defaultOptions;
-            const options = angular.extend({}, defaultOptions, ctrl.options);
+            const options = Utilities.extend(defaultOptions, ctrl.options);
 
             var elem = angular.element(element);
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -92,7 +92,7 @@
             });
 
             $timeout(function () {
-                const element = $element.find('.umb-color-picker input')[0];
+                const element = $element.find('.umb-color-picker > input')[0];
                 setColorPicker(element, labels);
             }, 0, true);
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -167,7 +167,7 @@
 
                 // bind hook for hide
                 if (ctrl.onHide) {
-                    pickrInstance.on('hide', (color) => {
+                    colorPickerInstance.on('hide', (color) => {
                         $timeout(function () {
                             ctrl.onHide({ color: color });
                         });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -12,7 +12,10 @@
     <div ng-controller="My.ColorController as vm">
         
         <umb-color-picker
-            on-change="vm.selectItem">
+            options="vm.options"
+            on-show="vm.show(color)"
+            on-hide="vm.hide(color)"
+            on-change="vm.change(color)">
         </umb-color-picker>
     
     </div>

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -42,7 +42,7 @@
     })();
 </pre>
 
-@param {function} beforeShow (<code>expression</code>): Callback function before color picker is shown.
+@param {function} onBeforeShow (<code>expression</code>): Callback function before color picker is shown.
 @param {function} onChange (<code>expression</code>): Callback function when the color is changed.
 @param {function} onShow (<code>expression</code>): Callback function when color picker is shown.
 @param {function} onHide (<code>expression</code>): Callback function when color picker is hidden.
@@ -128,8 +128,6 @@
 
             colorPickerInstance = colorPicker;
 
-            console.log("colorPickerInstance", colorPickerInstance);
-
             // destroy the color picker instance when the dom element is removed
             elem.on('$destroy', function () {
                 colorPickerInstance.destroy();
@@ -145,13 +143,10 @@
             
             if (colorPickerInstance) {
 
-                console.log("setUpCallbacks", colorPickerInstance);
-
                 // bind hook for beforeShow
                 if (ctrl.onBeforeShow) {
                     colorPickerInstance.on('beforeShow.spectrum', (e, color) => {
                         $timeout(function () {
-                            console.log("beforeShow", color);
                             ctrl.onBeforeShow({ color: color });
                         });
                     });
@@ -161,7 +156,6 @@
                 if (ctrl.onShow) {
                     colorPickerInstance.on('show.spectrum', (e, color) => {
                         $timeout(function () {
-                            console.log("onShow", color);
                             ctrl.onShow({ color: color });
                         });
                     });
@@ -171,7 +165,6 @@
                 if (ctrl.onHide) {
                     colorPickerInstance.on('hide.spectrum', (e, color) => {
                         $timeout(function () {
-                            console.log("onHide", color);
                             ctrl.onHide({ color: color });
                         });
                     });
@@ -181,7 +174,6 @@
                 if (ctrl.onChange) {
                     colorPickerInstance.on('change.spectrum', (e, color) => {
                         $timeout(function () {
-                            console.log("onChange", color);
                             ctrl.onChange({ color: color });
                         });
                     });
@@ -191,7 +183,6 @@
                 if (ctrl.onMove) {
                     colorPickerInstance.on('move.spectrum', (e, color) => {
                         $timeout(function () {
-                            console.log("onMove", color);
                             ctrl.onMove({ color: color });
                         });
                     });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -154,7 +154,7 @@
             if (colorPickerInstance) {
                 // destroy the color picker instance when the dom element is removed
                 elem.on('$destroy', function () {
-                    colorPickerInstance.destroy();
+                    colorPickerInstance.spectrum('destroy');
                 });
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -127,10 +127,12 @@
 
             colorPickerInstance = colorPicker;
 
-            // destroy the color picker instance when the dom element is removed
-            elem.on('$destroy', function () {
-                colorPickerInstance.destroy();
-            });
+            if (colorPickerInstance) {
+                // destroy the color picker instance when the dom element is removed
+                elem.on('$destroy', function () {
+                    colorPickerInstance.destroy();
+                });
+            }
 
             setUpCallbacks();
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -46,7 +46,7 @@ For extra details about options and events take a look here: https://refreshless
 </pre>
 
 @param {object} ngModel (<code>binding</code>): Value for the slider.
-@param {object} options (<code>binding</code>): Config object for the date picker.
+@param {object} options (<code>binding</code>): Config object for the slider.
 @param {callback} onSetup (<code>callback</code>): onSetup gets triggered when the slider is initialized
 @param {callback} onUpdate (<code>callback</code>): onUpdate fires every time the slider values are changed.
 @param {callback} onSlide (<code>callback</code>): onSlide gets triggered when the handle is being dragged.

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtable.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtable.directive.js
@@ -98,9 +98,9 @@
     })();
 </pre>
 
-@param {string} icon (<code>binding</code>): The node icon.
-@param {string} name (<code>binding</code>): The node name.
-@param {string} published (<code>binding</code>): The node published state.
+@param {array} items (<code>binding</code>): The items for the table.
+@param {array} itemProperties (<code>binding</code>): The properties for the items to use in table.
+@param {boolean} allowSelectAll (<code>binding</code>): Specify whether to allow select all.
 @param {function} onSelect (<code>expression</code>): Callback function when the row is selected.
 @param {function} onClick (<code>expression</code>): Callback function when the "Name" column link is clicked.
 @param {function} onSelectAll (<code>expression</code>): Callback function when selecting all items.

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -143,6 +143,7 @@
 @import "components/umb-property-editor.less";
 @import "components/umb-property-actions.less";
 @import "components/umb-code-snippet.less";
+@import "components/umb-color-picker.less";
 @import "components/umb-color-swatches.less";
 @import "components/check-circle.less";
 @import "components/umb-file-icon.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-picker.less
@@ -1,0 +1,17 @@
+﻿.umb-color-picker {
+
+    .sp-replacer {
+        display: inline-flex;
+        margin-right: 18px;
+        height: 32px;
+
+        .sp-preview {
+            margin: 5px;
+            height: auto;
+        }
+
+        .sp-dd {
+            line-height: 2rem;
+        }
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-picker.less
@@ -5,6 +5,10 @@
         margin-right: 18px;
         height: 32px;
 
+        &.sp-light {
+            background-color: @white; 
+        }
+
         .sp-preview {
             margin: 5px;
             height: auto;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -163,7 +163,6 @@
     .sp-replacer {
         display: inline-flex;
         margin-right: 18px;
-        height: auto;
 
         .sp-preview {
             margin: 5px;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -160,20 +160,6 @@
         width: auto;
     }
 
-    .sp-replacer {
-        display: inline-flex;
-        margin-right: 18px;
-
-        .sp-preview {
-            margin: 5px;
-            height: auto;
-        }
-
-        .sp-dd {
-            line-height: 2rem;
-        }
-    }
-
     label {
         border: 1px solid @white;
         padding: 6px 10px;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -14,7 +14,7 @@
             <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">
-            <button type="button" class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button type="button" class="btn btn-info add" ng-click="vm.add($event)"><localize key="general_add">Add</localize></button>
         </div>
     </div>
     <div ui-sortable="sortableOptions" ng-model="model.value">
@@ -29,7 +29,7 @@
                 </div>
             </div>
             <div class="umb-prevalues-multivalues__right">
-                <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)"><localize key="general_remove">Remove</localize></button>
+                <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove(item, $event)"><localize key="general_remove">Remove</localize></button>
             </div>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -10,7 +10,7 @@
                 on-change="vm.change(color)">
             </umb-color-picker>
 
-            <label for="newColor" val-highlight="{{hasError}}">#{{newColor}}</label>
+            <label val-highlight="{{hasError}}">#{{newColor}}</label>
             <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -11,7 +11,7 @@
             </umb-color-picker>
 
             <label for="newColor" val-highlight="{{hasError}}">#{{newColor}}</label>
-            <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" placeholder="Label" ng-show="labelEnabled" />
+            <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">
             <button class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -11,7 +11,7 @@
             </umb-color-picker>
 
             <label val-highlight="{{hasError}}">#{{newColor}}</label>
-            <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
+            <input type="text" name="newLabel" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">
             <button type="button" class="btn btn-info add" ng-click="vm.add($event)"><localize key="general_add">Add</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -1,7 +1,17 @@
-<div class="umb-property-editor umb-prevalues-multivalues" ng-controller="Umbraco.PrevalueEditors.MultiColorPickerController">
+<div class="umb-property-editor umb-prevalues-multivalues" ng-controller="Umbraco.PrevalueEditors.MultiColorPickerController as vm">
     <div class="control-group  umb-prevalues-multivalues__add color-picker-preval">
         <div class="umb-prevalues-multivalues__left">
-            <input name="newColor" type="hidden" />
+
+            <umb-color-picker
+                ng-model="newColor"
+                options="options"
+                on-hide="vm.hide(color)"
+                on-show="vm.show(color)"
+                on-change="vm.change(color)">
+            </umb-color-picker>
+
+            <input name="newColor" id="newColor" type="hidden" />
+
             <label for="newColor" val-highlight="{{hasError}}">#{{newColor}}</label>
             <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" placeholder="Label" ng-show="labelEnabled" />
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -14,7 +14,7 @@
             <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">
-            <button class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>
+            <button type="button" class="btn btn-info add" ng-click="add($event)"><localize key="general_add">Add</localize></button>
         </div>
     </div>
     <div ui-sortable="sortableOptions" ng-model="model.value">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -10,8 +10,6 @@
                 on-change="vm.change(color)">
             </umb-color-picker>
 
-            <input name="newColor" id="newColor" type="hidden" />
-
             <label for="newColor" val-highlight="{{hasError}}">#{{newColor}}</label>
             <input name="newLabel" type="text" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" placeholder="Label" ng-show="labelEnabled" />
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -1,5 +1,5 @@
 ﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiColorPickerController",
-    function ($scope, assetsService, angularHelper, $element, eventsService) {
+    function ($scope, angularHelper, $element, eventsService) {
 
         var vm = this;
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -1,5 +1,12 @@
 ﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiColorPickerController",
     function ($scope, $timeout, assetsService, angularHelper, $element, localizationService, eventsService) {
+
+        var vm = this;
+
+        vm.show = show;
+        vm.hide = hide;
+        vm.change = change;
+
         //NOTE: We need to make each color an object, not just a string because you cannot 2-way bind to a primitive.
         var defaultColor = "000000";
         var defaultLabel = null;
@@ -8,6 +15,38 @@
         $scope.newLabel = defaultLabel;
         $scope.hasError = false;
         $scope.focusOnNew = false;
+
+        //$scope.options = {
+        //    type: "color",
+        //    color: defaultColor,
+        //    showAlpha: false,
+        //    showInitial: false,
+        //    showInput: true,
+        //    chooseText: $scope.labels.choose,
+        //    cancelText: $scope.labels.cancel,
+        //    preferredFormat: "hex",
+        //    clickoutFiresChange: true
+        //};
+
+        function hide(color) {
+            // show the add button
+            $element.find(".btn.add").show();
+        }
+
+        function show(color) {
+            // hide the add button
+            $element.find(".btn.add").hide();
+        }
+
+        function change(color) {
+            console.log("color", color);
+
+            console.log("hex color", color.toHexString());
+
+            angularHelper.safeApply($scope, function () {
+                $scope.newColor = color.toHexString().trimStart("#"); // #ff0000
+            });
+        }
 
         $scope.labels = {};
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -1,5 +1,5 @@
 ﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiColorPickerController",
-    function ($scope, $timeout, assetsService, angularHelper, $element, localizationService, eventsService) {
+    function ($scope, assetsService, angularHelper, $element, eventsService) {
 
         var vm = this;
 
@@ -39,61 +39,14 @@
         }
 
         function change(color) {
-            console.log("color", color);
-
-            console.log("hex color", color.toHexString());
-
             angularHelper.safeApply($scope, function () {
                 $scope.newColor = color.toHexString().trimStart("#"); // #ff0000
             });
         }
 
-        $scope.labels = {};
-
-        var labelKeys = [
-            "general_cancel",
-            "general_choose"
-        ];
-
         $scope.labelEnabled = false;
         eventsService.on("toggleValue", function (e, args) {
             $scope.labelEnabled = args.value;
-        });
-        
-        localizationService.localizeMany(labelKeys).then(function (values) {
-            $scope.labels.cancel = values[0];
-            $scope.labels.choose = values[1];
-        });
-
-        assetsService.load([
-            //"lib/spectrum/tinycolor.js",
-            "lib/spectrum/spectrum.js"
-        ], $scope).then(function () {
-            var elem = $element.find("input[name='newColor']");
-            elem.spectrum({
-                type: "color",
-                color: defaultColor,
-                showAlpha: false,
-                showInitial: false,
-                showInput: true,
-                chooseText: $scope.labels.choose,
-                cancelText: $scope.labels.cancel,
-                preferredFormat: "hex",
-                clickoutFiresChange: true,
-                hide: function (color) {
-                    //show the add butotn
-                    $element.find(".btn.add").show();
-                },
-                change: function (color) {
-                    angularHelper.safeApply($scope, function () {
-                        $scope.newColor = color.toHexString().trimStart("#"); // #ff0000
-                    });
-                },
-                show: function() {
-                    //hide the add butotn
-                    $element.find(".btn.add").hide();
-                }
-            });
         });
 
         if (!Utilities.isArray($scope.model.value)) {
@@ -184,6 +137,4 @@
             }
         };
 
-        //load the separate css for the editor to avoid it blocking our js loading
-        assetsService.loadCss("lib/spectrum/spectrum.css", $scope);
     });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -39,7 +39,9 @@
 
         function change(color) {
             angularHelper.safeApply($scope, function () {
-                $scope.newColor = color.toHexString().trimStart("#"); // #ff0000
+                if (color) {
+                    $scope.newColor = color.toHexString().trimStart("#");
+                }
             });
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -24,6 +24,7 @@
         $scope.options = {
             type: "color",
             color: defaultColor,
+            allowEmpty: false,
             showAlpha: false
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -7,6 +7,8 @@
         vm.hide = hide;
         vm.change = change;
 
+        vm.labelEnabled = false;
+
         //NOTE: We need to make each color an object, not just a string because you cannot 2-way bind to a primitive.
         var defaultColor = "000000";
         var defaultLabel = null;
@@ -44,9 +46,8 @@
             });
         }
 
-        $scope.labelEnabled = false;
         eventsService.on("toggleValue", function (e, args) {
-            $scope.labelEnabled = args.value;
+            vm.labelEnabled = args.value;
         });
 
         if (!Utilities.isArray($scope.model.value)) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -18,17 +18,11 @@
         $scope.hasError = false;
         $scope.focusOnNew = false;
 
-        //$scope.options = {
-        //    type: "color",
-        //    color: defaultColor,
-        //    showAlpha: false,
-        //    showInitial: false,
-        //    showInput: true,
-        //    chooseText: $scope.labels.choose,
-        //    cancelText: $scope.labels.cancel,
-        //    preferredFormat: "hex",
-        //    clickoutFiresChange: true
-        //};
+        $scope.options = {
+            type: "color",
+            color: defaultColor,
+            showAlpha: false
+        };
 
         function hide(color) {
             // show the add button

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -3,6 +3,9 @@
 
         var vm = this;
 
+        vm.add = add;
+        vm.remove = remove;
+
         vm.show = show;
         vm.hide = hide;
         vm.change = change;
@@ -83,7 +86,7 @@
             return label !== null && typeof label !== "undefined" && label !== "" && label.length && label.length > 0;
         }
 
-        $scope.remove = function (item, evt) {
+        function remove(item, evt) {
 
             evt.preventDefault();
 
@@ -92,9 +95,9 @@
             });
 
             angularHelper.getCurrentForm($scope).$setDirty();
-        };
+        }
 
-        $scope.add = function (evt) {
+        function add(evt) {
             evt.preventDefault();
 
             if ($scope.newColor) {
@@ -114,11 +117,10 @@
                     return;
                 }
 
-                //there was an error, do the highlight (will be set back by the directive)
+                // there was an error, do the highlight (will be set back by the directive)
                 $scope.hasError = true;
             }
-
-        };
+        }
 
         $scope.sortableOptions = {
             axis: 'y',


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently we have color picker using spectrum plugin and used in prevalues of Color Picker property editor. It would howeever be great to re-use this various places in backoffice. E.g. in a custom dashboard, a custom property editor or as prevalue editor in grid configuration. We have a `colorpicker` prevalue editor, but with this it would make it easier to add a new prevalue editor (or your own prevalue editor) allowing to re-use this.

So this it adding a new component `<umb-color-picker>`.

I have recently released a new property editor `Color Pickr` https://our.umbraco.com/packages/backoffice-extensions/color-pickr/ inspired from this vanilla JS plugin called Pickr: https://simonwep.github.io/pickr/ 🥳🎉🚀

I could use much of the same approach to create this component wrapping spectrum color picker and then use this instead in the prevalue editor for color picker property editor.


![2020-09-03_17-24-46](https://user-images.githubusercontent.com/2919859/92135099-a3002200-ee0a-11ea-83db-672549f228d2.gif)
