### PR TITLE
Ensure event handlers are unsubscribed  in Core Components

### DIFF
--- a/src/Umbraco.Core/Compose/AuditEventsComponent.cs
+++ b/src/Umbraco.Core/Compose/AuditEventsComponent.cs
@@ -42,7 +42,19 @@ namespace Umbraco.Core.Compose
         }
 
         public void Terminate()
-        { }
+        {
+            UserService.SavedUserGroup -= OnSavedUserGroupWithUsers;
+
+            UserService.SavedUser -= OnSavedUser;
+            UserService.DeletedUser -= OnDeletedUser;
+            UserService.UserGroupPermissionsAssigned -= UserGroupPermissionAssigned;
+
+            MemberService.Saved -= OnSavedMember;
+            MemberService.Deleted -= OnDeletedMember;
+            MemberService.AssignedRoles -= OnAssignedRoles;
+            MemberService.RemovedRoles -= OnRemovedRoles;
+            MemberService.Exported -= OnMemberExported;
+        }
 
         internal static IUser UnknownUser => new User { Id = Constants.Security.UnknownUserId, Name = Constants.Security.UnknownUserName, Email = "" };
 

--- a/src/Umbraco.Core/Compose/RelateOnCopyComponent.cs
+++ b/src/Umbraco.Core/Compose/RelateOnCopyComponent.cs
@@ -14,7 +14,9 @@ namespace Umbraco.Core.Compose
         }
 
         public void Terminate()
-        { }
+        {
+            ContentService.Copied -= ContentServiceCopied;
+        }
 
         private static void ContentServiceCopied(IContentService sender, Events.CopyEventArgs<IContent> e)
         {

--- a/src/Umbraco.Core/Compose/RelateOnTrashComponent.cs
+++ b/src/Umbraco.Core/Compose/RelateOnTrashComponent.cs
@@ -18,7 +18,12 @@ namespace Umbraco.Core.Compose
         }
 
         public void Terminate()
-        { }
+        {
+            ContentService.Moved -= ContentService_Moved;
+            ContentService.Trashed -= ContentService_Trashed;
+            MediaService.Moved -= MediaService_Moved;
+            MediaService.Trashed -= MediaService_Trashed;
+        }
 
         private static void ContentService_Moved(IContentService sender, MoveEventArgs<IContent> e)
         {

--- a/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComponent.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComponent.cs
@@ -50,32 +50,38 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
         }
 
         public void Terminate()
-        { }
+        {
+            ServerVariablesParser.Parsing -= ServerVariablesParser_Parsing;
+            ContentModelBinder.ModelBindingException -= ContentModelBinder_ModelBindingException;
+            FileService.SavingTemplate -= FileService_SavingTemplate;
+        }
 
         private void InstallServerVars()
         {
             // register our url - for the backoffice api
-            ServerVariablesParser.Parsing += (sender, serverVars) =>
-            {
-                if (!serverVars.ContainsKey("umbracoUrls"))
-                    throw new ArgumentException("Missing umbracoUrls.");
-                var umbracoUrlsObject = serverVars["umbracoUrls"];
-                if (umbracoUrlsObject == null)
-                    throw new ArgumentException("Null umbracoUrls");
-                if (!(umbracoUrlsObject is Dictionary<string, object> umbracoUrls))
-                    throw new ArgumentException("Invalid umbracoUrls");
+            ServerVariablesParser.Parsing += ServerVariablesParser_Parsing;
+        }
 
-                if (!serverVars.ContainsKey("umbracoPlugins"))
-                    throw new ArgumentException("Missing umbracoPlugins.");
-                if (!(serverVars["umbracoPlugins"] is Dictionary<string, object> umbracoPlugins))
-                    throw new ArgumentException("Invalid umbracoPlugins");
+        private void ServerVariablesParser_Parsing(object sender, Dictionary<string, object> serverVars)
+        {
+            if (!serverVars.ContainsKey("umbracoUrls"))
+                throw new ArgumentException("Missing umbracoUrls.");
+            var umbracoUrlsObject = serverVars["umbracoUrls"];
+            if (umbracoUrlsObject == null)
+                throw new ArgumentException("Null umbracoUrls");
+            if (!(umbracoUrlsObject is Dictionary<string, object> umbracoUrls))
+                throw new ArgumentException("Invalid umbracoUrls");
 
-                if (HttpContext.Current == null) throw new InvalidOperationException("HttpContext is null");
-                var urlHelper = new UrlHelper(new RequestContext(new HttpContextWrapper(HttpContext.Current), new RouteData()));
+            if (!serverVars.ContainsKey("umbracoPlugins"))
+                throw new ArgumentException("Missing umbracoPlugins.");
+            if (!(serverVars["umbracoPlugins"] is Dictionary<string, object> umbracoPlugins))
+                throw new ArgumentException("Invalid umbracoPlugins");
 
-                umbracoUrls["modelsBuilderBaseUrl"] = urlHelper.GetUmbracoApiServiceBaseUrl<ModelsBuilderDashboardController>(controller => controller.BuildModels());
-                umbracoPlugins["modelsBuilder"] = GetModelsBuilderSettings();
-            };
+            if (HttpContext.Current == null) throw new InvalidOperationException("HttpContext is null");
+            var urlHelper = new UrlHelper(new RequestContext(new HttpContextWrapper(HttpContext.Current), new RouteData()));
+
+            umbracoUrls["modelsBuilderBaseUrl"] = urlHelper.GetUmbracoApiServiceBaseUrl<ModelsBuilderDashboardController>(controller => controller.BuildModels());
+            umbracoPlugins["modelsBuilder"] = GetModelsBuilderSettings();
         }
 
         private Dictionary<string, object> GetModelsBuilderSettings()

--- a/src/Umbraco.Web/Compose/BackOfficeUserAuditEventsComponent.cs
+++ b/src/Umbraco.Web/Compose/BackOfficeUserAuditEventsComponent.cs
@@ -35,7 +35,19 @@ namespace Umbraco.Web.Compose
         }
 
         public void Terminate()
-        { }
+        {
+            //BackOfficeUserManager.AccountLocked -= ;
+            //BackOfficeUserManager.AccountUnlocked -= ;
+            BackOfficeUserManager.ForgotPasswordRequested -= OnForgotPasswordRequest;
+            BackOfficeUserManager.ForgotPasswordChangedSuccess -= OnForgotPasswordChange;
+            BackOfficeUserManager.LoginFailed -= OnLoginFailed;
+            //BackOfficeUserManager.LoginRequiresVerification -= ;
+            BackOfficeUserManager.LoginSuccess -= OnLoginSuccess;
+            BackOfficeUserManager.LogoutSuccess -= OnLogoutSuccess;
+            BackOfficeUserManager.PasswordChanged -= OnPasswordChanged;
+            BackOfficeUserManager.PasswordReset -= OnPasswordReset;
+            //BackOfficeUserManager.ResetAccessFailedCount -= ;
+        }
 
         private IUser GetPerformingUser(int userId)
         {

--- a/src/Umbraco.Web/Compose/NotificationsComponent.cs
+++ b/src/Umbraco.Web/Compose/NotificationsComponent.cs
@@ -32,42 +32,78 @@ namespace Umbraco.Web.Compose
         public void Initialize()
         {
             //Send notifications for the send to publish action
-            ContentService.SentToPublish += (sender, args) => _notifier.Notify(_actions.GetAction<ActionToPublish>(), args.Entity);
-
+            ContentService.SentToPublish += ContentService_SentToPublish;
             //Send notifications for the published action
-            ContentService.Published += (sender, args) => _notifier.Notify(_actions.GetAction<ActionPublish>(), args.PublishedEntities.ToArray());
-
+            ContentService.Published += ContentService_Published;
             //Send notifications for the saved action
-            ContentService.Sorted += (sender, args) => ContentServiceSorted(_notifier, sender, args, _actions);
-
+            ContentService.Sorted += ContentService_Sorted;
             //Send notifications for the update and created actions
-            ContentService.Saved += (sender, args) => ContentServiceSaved(_notifier, sender, args, _actions);
-
+            ContentService.Saved += ContentService_Saved;
             //Send notifications for the unpublish action
-            ContentService.Unpublished += (sender, args) => _notifier.Notify(_actions.GetAction<ActionUnpublish>(), args.PublishedEntities.ToArray());
-
+            ContentService.Unpublished += ContentService_Unpublished;
             //Send notifications for the move/move to recycle bin and restore actions
-            ContentService.Moved += (sender, args) => ContentServiceMoved(_notifier, sender, args, _actions);
-
+            ContentService.Moved += ContentService_Moved;
             //Send notifications for the delete action when content is moved to the recycle bin
-            ContentService.Trashed += (sender, args) => _notifier.Notify(_actions.GetAction<ActionDelete>(), args.MoveInfoCollection.Select(m => m.Entity).ToArray());
-            
+            ContentService.Trashed += ContentService_Trashed;
             //Send notifications for the copy action
-            ContentService.Copied += (sender, args) => _notifier.Notify(_actions.GetAction<ActionCopy>(), args.Original);
-			
+            ContentService.Copied += ContentService_Copied;
             //Send notifications for the rollback action
-            ContentService.RolledBack += (sender, args) => _notifier.Notify(_actions.GetAction<ActionRollback>(), args.Entity);	
-			
+            ContentService.RolledBack += ContentService_RolledBack;
             //Send notifications for the public access changed action
-            PublicAccessService.Saved += (sender, args) => PublicAccessServiceSaved(_notifier, sender, args, _contentService, _actions);
-			
-            UserService.UserGroupPermissionsAssigned += (sender, args) => UserServiceUserGroupPermissionsAssigned(_notifier, sender, args, _contentService, _actions);
+            PublicAccessService.Saved += PublicAccessService_Saved;
+
+            UserService.UserGroupPermissionsAssigned += UserService_UserGroupPermissionsAssigned;
         }
 
         public void Terminate()
-        { }
+        {
+            ContentService.SentToPublish -= ContentService_SentToPublish;
+            ContentService.Published -= ContentService_Published;
+            ContentService.Sorted -= ContentService_Sorted;
+            ContentService.Saved -= ContentService_Saved;
+            ContentService.Unpublished -= ContentService_Unpublished;
+            ContentService.Moved -= ContentService_Moved;
+            ContentService.Trashed -= ContentService_Trashed;
+            ContentService.Copied -= ContentService_Copied;
+            ContentService.RolledBack -= ContentService_RolledBack;
+            PublicAccessService.Saved -= PublicAccessService_Saved;
+            UserService.UserGroupPermissionsAssigned -= UserService_UserGroupPermissionsAssigned;
+        }
 
-        private void ContentServiceSorted(Notifier notifier, IContentService sender, Core.Events.SaveEventArgs<IContent> args, ActionCollection actions)
+        private void UserService_UserGroupPermissionsAssigned(IUserService sender, Core.Events.SaveEventArgs<EntityPermission> args)
+            => UserServiceUserGroupPermissionsAssigned(args, _contentService);
+
+        private void PublicAccessService_Saved(IPublicAccessService sender, Core.Events.SaveEventArgs<PublicAccessEntry> args)
+            => PublicAccessServiceSaved(args, _contentService);
+
+        private void ContentService_RolledBack(IContentService sender, Core.Events.RollbackEventArgs<IContent> args)
+            => _notifier.Notify(_actions.GetAction<ActionRollback>(), args.Entity);
+
+        private void ContentService_Copied(IContentService sender, Core.Events.CopyEventArgs<IContent> args)
+            => _notifier.Notify(_actions.GetAction<ActionCopy>(), args.Original);
+
+        private void ContentService_Trashed(IContentService sender, Core.Events.MoveEventArgs<IContent> args)
+            => _notifier.Notify(_actions.GetAction<ActionDelete>(), args.MoveInfoCollection.Select(m => m.Entity).ToArray());
+
+        private void ContentService_Moved(IContentService sender, Core.Events.MoveEventArgs<IContent> args)
+            => ContentServiceMoved(args);
+
+        private void ContentService_Unpublished(IContentService sender, Core.Events.PublishEventArgs<IContent> args)
+            => _notifier.Notify(_actions.GetAction<ActionUnpublish>(), args.PublishedEntities.ToArray());
+
+        private void ContentService_Saved(IContentService sender, Core.Events.ContentSavedEventArgs args)
+            => ContentServiceSaved(args);
+
+        private void ContentService_Sorted(IContentService sender, Core.Events.SaveEventArgs<IContent> args)
+            => ContentServiceSorted(sender, args);
+
+        private void ContentService_Published(IContentService sender, Core.Events.ContentPublishedEventArgs args)
+            => _notifier.Notify(_actions.GetAction<ActionPublish>(), args.PublishedEntities.ToArray());
+
+        private void ContentService_SentToPublish(IContentService sender, Core.Events.SendToPublishEventArgs<IContent> args)
+            => _notifier.Notify(_actions.GetAction<ActionToPublish>(), args.Entity);
+
+        private void ContentServiceSorted(IContentService sender, Core.Events.SaveEventArgs<IContent> args)
         {
             var parentId = args.SavedEntities.Select(x => x.ParentId).Distinct().ToList();
             if (parentId.Count != 1) return; // this shouldn't happen, for sorting all entities will have the same parent id
@@ -79,10 +115,10 @@ namespace Umbraco.Web.Compose
             var parent = sender.GetById(parentId[0]);
             if (parent == null) return; // this shouldn't happen
 
-            notifier.Notify(actions.GetAction<ActionSort>(), new[] { parent });
+            _notifier.Notify(_actions.GetAction<ActionSort>(), new[] { parent });
         }
 
-        private void ContentServiceSaved(Notifier notifier, IContentService sender, Core.Events.SaveEventArgs<IContent> args, ActionCollection actions)
+        private void ContentServiceSaved(Core.Events.SaveEventArgs<IContent> args)
         {
             var newEntities = new List<IContent>();
             var updatedEntities = new List<IContent>();
@@ -102,21 +138,21 @@ namespace Umbraco.Web.Compose
                     updatedEntities.Add(entity);
                 }
             }
-            notifier.Notify(actions.GetAction<ActionNew>(), newEntities.ToArray());
-            notifier.Notify(actions.GetAction<ActionUpdate>(), updatedEntities.ToArray());
+            _notifier.Notify(_actions.GetAction<ActionNew>(), newEntities.ToArray());
+            _notifier.Notify(_actions.GetAction<ActionUpdate>(), updatedEntities.ToArray());
         }
 
-        private void UserServiceUserGroupPermissionsAssigned(Notifier notifier, IUserService sender, Core.Events.SaveEventArgs<EntityPermission> args, IContentService contentService, ActionCollection actions)
+        private void UserServiceUserGroupPermissionsAssigned(Core.Events.SaveEventArgs<EntityPermission> args, IContentService contentService)
         {
             var entities = contentService.GetByIds(args.SavedEntities.Select(e => e.EntityId)).ToArray();
-            if(entities.Any() == false)
+            if (entities.Any() == false)
             {
                 return;
             }
-            notifier.Notify(actions.GetAction<ActionRights>(), entities);
+            _notifier.Notify(_actions.GetAction<ActionRights>(), entities);
         }
-                
-        private void ContentServiceMoved(Notifier notifier, IContentService sender, Core.Events.MoveEventArgs<IContent> args, ActionCollection actions)
+
+        private void ContentServiceMoved(Core.Events.MoveEventArgs<IContent> args)
         {
             // notify about the move for all moved items
             _notifier.Notify(_actions.GetAction<ActionMove>(), args.MoveInfoCollection.Select(m => m.Entity).ToArray());
@@ -126,22 +162,22 @@ namespace Umbraco.Web.Compose
                 .Where(m => m.OriginalPath.Contains(Constants.System.RecycleBinContentString))
                 .Select(m => m.Entity)
                 .ToArray();
-            if(restoredEntities.Any())
+            if (restoredEntities.Any())
             {
                 _notifier.Notify(_actions.GetAction<ActionRestore>(), restoredEntities);
             }
         }
 
-        private void PublicAccessServiceSaved(Notifier notifier, IPublicAccessService sender, Core.Events.SaveEventArgs<PublicAccessEntry> args, IContentService contentService, ActionCollection actions)
+        private void PublicAccessServiceSaved(Core.Events.SaveEventArgs<PublicAccessEntry> args, IContentService contentService)
         {
             var entities = contentService.GetByIds(args.SavedEntities.Select(e => e.ProtectedNodeId)).ToArray();
-            if(entities.Any() == false)
+            if (entities.Any() == false)
             {
                 return;
             }
-            notifier.Notify(actions.GetAction<ActionProtect>(), entities);
+            _notifier.Notify(_actions.GetAction<ActionProtect>(), entities);
         }
-		
+
         /// <summary>
         /// This class is used to send the notifications
         /// </summary>

--- a/src/Umbraco.Web/Compose/PublicAccessComponent.cs
+++ b/src/Umbraco.Web/Compose/PublicAccessComponent.cs
@@ -14,7 +14,9 @@ namespace Umbraco.Web.Compose
         }
 
         public void Terminate()
-        { }
+        {
+            MemberGroupService.Saved -= MemberGroupService_Saved;
+        }
 
         static void MemberGroupService_Saved(IMemberGroupService sender, Core.Events.SaveEventArgs<Core.Models.IMemberGroup> e)
         {

--- a/src/Umbraco.Web/PropertyEditors/PropertyEditorsComponent.cs
+++ b/src/Umbraco.Web/PropertyEditors/PropertyEditorsComponent.cs
@@ -1,7 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Events;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
 
 namespace Umbraco.Web.PropertyEditors
@@ -9,6 +13,7 @@ namespace Umbraco.Web.PropertyEditors
     internal sealed class PropertyEditorsComponent : IComponent
     {
         private readonly PropertyEditorCollection _propertyEditors;
+        private readonly List<Action> _terminate = new List<Action>();
 
         public PropertyEditorsComponent(PropertyEditorCollection propertyEditors)
         {
@@ -27,32 +32,48 @@ namespace Umbraco.Web.PropertyEditors
         }
 
         public void Terminate()
-        { }
-
-        private static void Initialize(FileUploadPropertyEditor fileUpload)
         {
-            MediaService.Saving += fileUpload.MediaServiceSaving;
-            ContentService.Copied += fileUpload.ContentServiceCopied;
-
-            MediaService.Deleted += (sender, args)
-                => args.MediaFilesToDelete.AddRange(fileUpload.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
-            ContentService.Deleted += (sender, args)
-                => args.MediaFilesToDelete.AddRange(fileUpload.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
-            MemberService.Deleted += (sender, args)
-                => args.MediaFilesToDelete.AddRange(fileUpload.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            foreach (var t in _terminate) t();
         }
 
-        private static void Initialize(ImageCropperPropertyEditor imageCropper)
+        private void Initialize(FileUploadPropertyEditor fileUpload)
+        {
+            MediaService.Saving += fileUpload.MediaServiceSaving;
+            _terminate.Add(() => MediaService.Saving -= fileUpload.MediaServiceSaving);
+            ContentService.Copied += fileUpload.ContentServiceCopied;
+            _terminate.Add(() => ContentService.Copied -= fileUpload.ContentServiceCopied);
+
+            void mediaServiceDeleted(IMediaService sender, DeleteEventArgs<IMedia> args) => args.MediaFilesToDelete.AddRange(fileUpload.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            MediaService.Deleted += mediaServiceDeleted;
+            _terminate.Add(() => MediaService.Deleted -= mediaServiceDeleted);
+
+            void contentServiceDeleted(IContentService sender, DeleteEventArgs<IContent> args) => args.MediaFilesToDelete.AddRange(fileUpload.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            ContentService.Deleted += contentServiceDeleted;
+            _terminate.Add(() => ContentService.Deleted -= contentServiceDeleted);
+
+            void memberServiceDeleted(IMemberService sender, DeleteEventArgs<IMember> args) => args.MediaFilesToDelete.AddRange(fileUpload.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            MemberService.Deleted += memberServiceDeleted;
+            _terminate.Add(() => MemberService.Deleted -= memberServiceDeleted);
+        }
+
+        private void Initialize(ImageCropperPropertyEditor imageCropper)
         {
             MediaService.Saving += imageCropper.MediaServiceSaving;
+            _terminate.Add(() => MediaService.Saving -= imageCropper.MediaServiceSaving);
             ContentService.Copied += imageCropper.ContentServiceCopied;
+            _terminate.Add(() => ContentService.Copied -= imageCropper.ContentServiceCopied);
 
-            MediaService.Deleted += (sender, args)
-                => args.MediaFilesToDelete.AddRange(imageCropper.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
-            ContentService.Deleted += (sender, args)
-                => args.MediaFilesToDelete.AddRange(imageCropper.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
-            MemberService.Deleted += (sender, args)
-                => args.MediaFilesToDelete.AddRange(imageCropper.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            void mediaServiceDeleted(IMediaService sender, DeleteEventArgs<IMedia> args) => args.MediaFilesToDelete.AddRange(imageCropper.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            MediaService.Deleted += mediaServiceDeleted;
+            _terminate.Add(() => MediaService.Deleted -= mediaServiceDeleted);
+
+            void contentServiceDeleted(IContentService sender, DeleteEventArgs<IContent> args) => args.MediaFilesToDelete.AddRange(imageCropper.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            ContentService.Deleted += contentServiceDeleted;
+            _terminate.Add(() => ContentService.Deleted -= contentServiceDeleted);
+
+            void memberServiceDeleted(IMemberService sender, DeleteEventArgs<IMember> args) => args.MediaFilesToDelete.AddRange(imageCropper.ServiceDeleted(args.DeletedEntities.Cast<ContentBase>()));
+            MemberService.Deleted += memberServiceDeleted;
+            _terminate.Add(() => MemberService.Deleted -= memberServiceDeleted);
         }
     }
 }

--- a/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
@@ -52,7 +52,12 @@ namespace Umbraco.Web.Routing
         }
 
         public void Terminate()
-        { }
+        {
+            ContentService.Publishing -= ContentService_Publishing;
+            ContentService.Published -= ContentService_Published;
+            ContentService.Moving -= ContentService_Moving;
+            ContentService.Moved -= ContentService_Moved;
+        }
 
         private void ContentService_Publishing(IContentService sender, PublishEventArgs<IContent> args)
         {

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -117,7 +117,13 @@ namespace Umbraco.Web.Search
         }
 
         public void Terminate()
-        { }
+        {
+            ContentCacheRefresher.CacheUpdated -= ContentCacheRefresherUpdated;
+            ContentTypeCacheRefresher.CacheUpdated -= ContentTypeCacheRefresherUpdated;
+            MediaCacheRefresher.CacheUpdated -= MediaCacheRefresherUpdated;
+            MemberCacheRefresher.CacheUpdated -= MemberCacheRefresherUpdated;
+            LanguageCacheRefresher.CacheUpdated -= LanguageCacheRefresherUpdated;
+        }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method should not be used and will be removed in future versions, rebuilding indexes can be done with the IndexRebuilder or the BackgroundIndexRebuilder")]


### PR DESCRIPTION
Static events are pretty evil because if you don't unsubscribe from them the event handler will pin an object that should be GC'd to the root of the app. This can cause memory leaks but worse can cause really odd things to happen. I'm surprised this hasn't been an issue in our integration tests. There's a chance it is causing problems but we don't visibly see it happening. There's also a chance this is causing problems in websites in rare circumstances like overlapping appdomains but I can't be sure. What is clear is that we absolutely must unsubscribe from these events so this fixes that to ensure there isn't weird problems occuring. 

This is a backport from the netcore project because this was absolutely causing problems with integration tests so it's strange we don't see these in the netframework projects.

---
_This item has been added to our backlog [AB#8094](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8094)_