### PR TITLE
Fix JS error when creating macros and relation types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/macros.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/macros.create.controller.js
@@ -13,7 +13,7 @@ function MacrosCreateController($scope, $location, macroResource, navigationServ
 
     function createItem() {
 
-        if (formHelper.submitForm({ scope: $scope, formCtrl: this.createMacroForm })) {
+        if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createMacroForm })) {
 
             var node = $scope.currentNode;
 
@@ -25,7 +25,7 @@ function MacrosCreateController($scope, $location, macroResource, navigationServ
                 navigationService.syncTree({ tree: "macros", path: currPath + "," + data, forceReload: true, activate: true });
 
                 // reset form state
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createMacroForm });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createMacroForm });
 
                 // navigate to edit view
                 var currentSection = appState.getSectionState("currentSection");
@@ -33,7 +33,7 @@ function MacrosCreateController($scope, $location, macroResource, navigationServ
 
 
             }, function (err) {
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createMacroForm, hasErrors: true });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createMacroForm, hasErrors: true });
                 if (err.data && err.data.message) {
                     notificationsService.error(err.data.message);
                     navigationService.hideMenu();

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.controller.js
@@ -26,7 +26,7 @@ function RelationTypeCreateController($scope, $location, relationTypeResource, n
     }
 
     function createRelationType() {
-        if (formHelper.submitForm({ scope: $scope, formCtrl: this.createRelationTypeForm, statusMessage: "Creating relation type..." })) {
+        if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createRelationTypeForm, statusMessage: "Creating relation type..." })) {
             var node = $scope.currentNode;
 
             relationTypeResource.create(vm.relationType).then(function (data) {
@@ -36,12 +36,12 @@ function RelationTypeCreateController($scope, $location, relationTypeResource, n
                 var currentPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "relationTypes", path: currentPath + "," + data, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createRelationTypeForm });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createRelationTypeForm });
 
                 var currentSection = appState.getSectionState("currentSection");
                 $location.path("/" + currentSection + "/relationTypes/edit/" + data);
             }, function (err) {
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createRelationTypeForm, hasErrors: true });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createRelationTypeForm, hasErrors: true });
                 if (err.data && err.data.message) {
                     notificationsService.error(err.data.message);
                     navigationService.hideMenu();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8805

### Description

This PR fixes the JS errors that occur in V8.7RC when creating macros and relation types (see #8805).

When applied, macro and relation type creation work once more:

![create-macro-relation-type](https://user-images.githubusercontent.com/7405322/92212888-eef6a980-ee92-11ea-9871-18bb541c2017.gif)


