### PR TITLE
Fix JS error preventing newly created dictionary items from opening automatically

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/dictionary.create.controller.js
@@ -15,7 +15,7 @@ function DictionaryCreateController($scope, $location, dictionaryResource, navig
 
     function createItem() {
 
-        if (formHelper.submitForm({ scope: $scope, formCtrl: this.createDictionaryForm })) {
+        if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createDictionaryForm })) {
 
             var node = $scope.currentNode;
 
@@ -27,14 +27,14 @@ function DictionaryCreateController($scope, $location, dictionaryResource, navig
                 navigationService.syncTree({ tree: "dictionary", path: currPath + "," + data, forceReload: true, activate: true });
 
                 // reset form state
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createDictionaryForm });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createDictionaryForm });
 
                 // navigate to edit view
                 var currentSection = appState.getSectionState("currentSection");
                 $location.path("/" + currentSection + "/dictionary/edit/" + data);
 
             }, function (err) {
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createDictionaryForm, hasErrors: true });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createDictionaryForm, hasErrors: true });
                 if (err.data && err.data.message) {
                     notificationsService.error(err.data.message);
                     navigationService.hideMenu();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I spotted another bug along the lines of what is described in #8805 - same problem, only related to creating new dictionary items:

![image](https://user-images.githubusercontent.com/7405322/92216627-d5576100-ee96-11ea-8c59-6c2ae2c0e73f.png)

With this PR the JS error is removed, and newly created dictionary items are opened automatically for editing:

![create-dictionary](https://user-images.githubusercontent.com/7405322/92216578-c7a1db80-ee96-11ea-8452-3ace947ec369.gif)
