### PR TITLE
Fix JS errors when creating folders in the settings section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.controller.js
@@ -21,18 +21,18 @@ function DataTypeCreateController($scope, $location, navigationService, dataType
     }
 
     $scope.createContainer = function () {
-        if (formHelper.submitForm({ scope: $scope, formCtrl: this.createFolderForm })) {
+        if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createFolderForm })) {
             dataTypeResource.createContainer(node.id, $scope.model.folderName).then(function (folderId) {
 
                 navigationService.hideMenu();
                 var currPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "datatypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderFor });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm });
 
             }, function(err) {
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderFor, hasErrors: true });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm, hasErrors: true });
                // TODO: Handle errors
             });
         };

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.Editors.DataType.CreateController">
     <div class="umbracoDialog umb-dialog-body with-footer" ng-cloak>
 
-        <div class="umb-pane" ng-if="!model.creatingFolder">
+        <div class="umb-pane" ng-show="!model.creatingFolder">
             <h5><localize key="create_createUnder">Create an item under</localize> {{currentNode.name}}</h5>
 
             <ul class="umb-actions umb-actions-child">
@@ -24,7 +24,7 @@
             </ul>
         </div>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
+        <div class="umb-pane" ng-show="model.creatingFolder">
             <form novalidate name="createFolderForm"
                 ng-submit="createContainer()"
                 val-form-manager>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -32,7 +32,7 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
 
     $scope.createContainer = function () {
 
-        if (formHelper.submitForm({ scope: $scope, formCtrl: this.createFolderForm })) {
+        if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createFolderForm })) {
 
             contentTypeResource.createContainer(node.id, $scope.model.folderName).then(function (folderId) {
 
@@ -47,13 +47,13 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
                     activate: true
                 });
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm });
 
                 var section = appState.getSectionState("currentSection");
 
             }, function (err) {
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm, hasErrors: true });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm, hasErrors: true });
                 $scope.error = err;
 
             });

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -2,7 +2,7 @@
 
     <div class="umbracoDialog umb-dialog-body with-footer" ng-cloak>
 
-        <div class="umb-pane" ng-if="!model.creatingFolder && !model.creatingDoctypeCollection">
+        <div class="umb-pane" ng-show="!model.creatingFolder && !model.creatingDoctypeCollection">
             <h5><localize key="create_createUnder">Create an item under</localize> {{currentNode.name}}</h5>
 
             <ul class="umb-actions umb-actions-child">
@@ -41,7 +41,7 @@
             </ul>
         </div>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
+        <div class="umb-pane" ng-show="model.creatingFolder">
             <form novalidate name="createFolderForm"
                 ng-submit="createContainer()"
                 val-form-manager>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.controller.js
@@ -22,7 +22,7 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
     $scope.createContainer = function () {
         if (formHelper.submitForm({
             scope: $scope,
-            formCtrl: this.createFolderForm
+            formCtrl: $scope.createFolderForm
         })) {
             mediaTypeResource.createContainer(node.id, $scope.model.folderName).then(function (folderId) {
 
@@ -30,12 +30,12 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
                 var currPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "mediatypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm });
 
                 var section = appState.getSectionState("currentSection");
 
             }, function (err) {
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm, hasErrors: true });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm, hasErrors: true });
                 $scope.error = err;
             });
         };

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
@@ -2,7 +2,7 @@
 
     <div class="umbracoDialog umb-dialog-body with-footer" ng-cloak>
 
-        <div class="umb-pane" ng-if="!model.creatingFolder">
+        <div class="umb-pane" ng-show="!model.creatingFolder">
             <h5><localize key="create_createUnder">Create an item under</localize> {{currentNode.name}}</h5>
 
             <ul class="umb-actions umb-actions-child">
@@ -24,7 +24,7 @@
             </ul>
         </div>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
+        <div class="umb-pane" ng-show="model.creatingFolder">
             <form novalidate name="createFolderForm"
                 ng-submit="createContainer()"
                 val-form-manager>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Somewhat related to #8805... when creating folders in the Settings section (document type folders, media type folders, data type folders) a nasty JS erorr appears in the console:

![image](https://user-images.githubusercontent.com/7405322/92220669-9b895900-ee9c-11ea-8be1-35aec93475db.png)

This PR removes the JS error 😄 