### PR TITLE
Fix broken Nested Content "add content" dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -260,7 +260,7 @@
                 });
             });
 
-            vm.overlayMenu.pasteItems.sort( (a, b) => {
+            dialog.pasteItems.sort( (a, b) => {
                 return b.date - a.date
             });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As a slight regression (possibly a merge conflict), we're no longer able to add items to Nested Content; the editor simply throws a JS error:

![image](https://user-images.githubusercontent.com/7405322/92222835-e48edc80-ee9f-11ea-970e-5e893bb2ff17.png)

This PR fixes it:

![nested-content-add-broken](https://user-images.githubusercontent.com/7405322/92222806-d640c080-ee9f-11ea-963e-f161044643f1.gif)
