### PR TITLE
Fix the Nested Content "add content" dialog handling of the clipboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -265,6 +265,7 @@
             });
 
             dialog.title = dialog.pasteItems.length > 0 ? labels.grid_addElement : labels.content_createEmpty;
+            dialog.hideHeader = dialog.pasteItems.length > 0;
 
             dialog.clickClearPaste = function ($event) {
                 $event.stopPropagation();
@@ -272,7 +273,7 @@
                 clipboardService.clearEntriesOfType("elementType", contentTypeAliases);
                 clipboardService.clearEntriesOfType("elementTypeArray", contentTypeAliases);
                 dialog.pasteItems = [];// This dialog is not connected via the clipboardService events, so we need to update manually.
-                dialog.overlayMenu.hideHeader = false;
+                dialog.hideHeader = false;
             };
 
             if (dialog.availableItems.length === 1 && dialog.pasteItems.length === 0) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The refactoring of the Nested Content "add content" dialog in #8044 has left the handling of the clipboard somewhat broken.

First of all the header ("Add content") should be hidden if the clipboard contains any applicable items, as the other dialog headers ("Paste from clipboard" and "Create new") take its place:

![nc-clipboard-01](https://user-images.githubusercontent.com/7405322/92223681-19e7fa00-eea1-11ea-8da0-1db80090f67f.png)

Second when you attempt to clear the clipboard you'll see an error in the JS console (even if the clipboard is actually cleared):

![nc-clipboard-02](https://user-images.githubusercontent.com/7405322/92223812-47cd3e80-eea1-11ea-845b-075a26cc52a0.png)

This PR fixes the clipboard handling - the JS error is removed and the header is hidden when the clipboard contains items:

![image](https://user-images.githubusercontent.com/7405322/92223895-67646700-eea1-11ea-8cfd-3a40e3f78cbf.png)
