### PR TITLE
Adjust tags editor typeahead to fit within container in splitview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-tags-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-tags-editor.less
@@ -36,18 +36,17 @@
         }
     }
 
-    input {
-        border: none;
-        background: @white;
-    }
-
     .twitter-typeahead {
         margin: 10px;
         margin-top: 16px;
         vertical-align: top;
+        max-width: calc(100% - 20px);
 
         input {
+            border: none;
+            background: @white;
             padding-left: 0;
+            max-width: 100%;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When opening splitview the tags editor overflow its container a bit which in causing horizontal scroll.

I have adjusted the styling, so the input fit within its container.

**Before**

![2020-09-04_12-04-38](https://user-images.githubusercontent.com/2919859/92227728-fb84fd00-eea6-11ea-8530-0fdbaed50cbd.gif)


**After**

![2020-09-04_12-01-14](https://user-images.githubusercontent.com/2919859/92227439-9204ee80-eea6-11ea-903b-0df175219695.gif)
