### PR TITLE
Different user flow when creating a new blocks

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
@@ -7,8 +7,8 @@ angular.module("umbraco")
             vm.tabs = [];
 
             localizationService.localizeMany([
-                vm.model.liveEditing ? "prompt_discardChanges" : "general_close",
-                vm.model.liveEditing ? "buttons_confirmActionConfirm" : "buttons_submitChanges"
+                vm.model.createFlow ? "general_cancel" : (vm.model.liveEditing ? "prompt_discardChanges" : "general_close"),
+                vm.model.createFlow ? "general_create" : (vm.model.liveEditing ? "buttons_confirmActionConfirm" : "buttons_submitChanges")
             ]).then(function (data) {
                 vm.closeLabel = data[0];
                 vm.submitLabel = data[1];
@@ -68,16 +68,16 @@ angular.module("umbraco")
                     // * It would have a 'commit' method to commit the removed errors - which we would call in the formHelper.submitForm when it's successful
                     // * It would have a 'rollback' method to reset the removed errors - which we would call here
 
-
-                    if (vm.blockForm.$dirty === true) {
-                        localizationService.localizeMany(["prompt_discardChanges", "blockEditor_blockHasChanges"]).then(function (localizations) {
+                    if (vm.model.createFlow === true || vm.blockForm.$dirty === true) {
+                        var labels = vm.model.createFlow === true ? ["blockEditor_confirmCancelBlockCreationHeadline", "blockEditor_confirmCancelBlockCreationMessage"] : ["prompt_discardChanges", "blockEditor_blockHasChanges"];
+                        localizationService.localizeMany(labels).then(function (localizations) {
                             const confirm = {
                                 title: localizations[0],
                                 view: "default",
                                 content: localizations[1],
                                 submitButtonLabelKey: "general_discard",
                                 submitButtonStyle: "danger",
-                                closeButtonLabelKey: "general_cancel",
+                                closeButtonLabelKey: "prompt_stay",
                                 submit: function () {
                                     overlayService.close();
                                     vm.model.close(vm.model);
@@ -88,11 +88,10 @@ angular.module("umbraco")
                             };
                             overlayService.open(confirm);
                         });
-
-                        return;
+                    } else {
+                        vm.model.close(vm.model);
                     }
-                    // TODO: check if content/settings has changed and ask user if they are sure.
-                    vm.model.close(vm.model);
+
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -310,7 +310,9 @@
             blockObject.active = true;
         }
 
-        function editBlock(blockObject, openSettings, blockIndex, parentForm) {
+        function editBlock(blockObject, openSettings, blockIndex, parentForm, options) {
+
+            options = options || {};
 
             // this must be set
             if (blockIndex === undefined) {
@@ -344,6 +346,7 @@
                 $parentForm: parentForm || vm.propertyForm, // pass in a $parentForm, this maintains the FormController hierarchy with the infinite editing view (if it contains a form)
                 hideContent: blockObject.hideContentInOverlay,
                 openSettings: openSettings === true,
+                createFlow: options.createFlow === true,
                 liveEditing: liveEditing,
                 title: blockObject.label,
                 view: "views/common/infiniteeditors/blockeditor/blockeditor.html",
@@ -358,15 +361,17 @@
                     blockObject.active = false;
                     editorService.close();
                 },
-                close: function() {
-
-                    if (liveEditing === true) {
-                        // revert values when closing in liveediting mode.
-                        blockObject.retrieveValuesFrom(blockContentClone, blockSettingsClone);
-                    }
-
-                    if (wasNotActiveBefore === true) {
-                        blockObject.active = false;
+                close: function(blockEditorModel) {
+                    if (blockEditorModel.createFlow) {
+                        deleteBlock(blockObject);
+                    } else {
+                        if (liveEditing === true) {
+                            // revert values when closing in liveediting mode.
+                            blockObject.retrieveValuesFrom(blockContentClone, blockSettingsClone);
+                        }
+                        if (wasNotActiveBefore === true) {
+                            blockObject.active = false;
+                        }
                     }
                     editorService.close();
                 }
@@ -432,7 +437,7 @@
                             if (inlineEditing === true) {
                                 activateBlock(vm.layout[createIndex].$block);
                             } else if (inlineEditing === false && vm.layout[createIndex].$block.hideContentInOverlay !== true) {
-                                editBlock(vm.layout[createIndex].$block, false, createIndex, blockPickerModel.$parentForm);
+                                editBlock(vm.layout[createIndex].$block, false, createIndex, blockPickerModel.$parentForm, {createFlow: true});
                             }
                         }
                     }

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1853,6 +1853,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="headlineAdvanced">Avanceret</key>
     <key alias="forceHideContentEditor">Skjuld indholds editoren</key>
     <key alias="blockHasChanges">Du har lavet ændringer til dette indhold. Er du sikker på at du vil kassere dem?</key>
+    <key alias="confirmCancelBlockCreationHeadline">Annuller oprettelse?</key>
+    <key alias="confirmCancelBlockCreationMessage"><![CDATA[Er du sikker på at du vil annullere oprettelsen.]]></key>
   </area>
 
 </language>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2469,6 +2469,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="headlineAdvanced">Advanced</key>
     <key alias="forceHideContentEditor">Force hide content editor</key>
     <key alias="blockHasChanges">You have made changes to this content. Are you sure you want to discard them?</key>
+    <key alias="confirmCancelBlockCreationHeadline">Discard creation?</key>
+    <key alias="confirmCancelBlockCreationMessage"><![CDATA[Are you sure you want to cancel the creation.]]></key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2489,6 +2489,8 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="headlineAdvanced">Advanced</key>
     <key alias="forceHideContentEditor">Force hide content editor</key>
     <key alias="blockHasChanges">You have made changes to this content. Are you sure you want to discard them?</key>
+    <key alias="confirmCancelBlockCreationHeadline">Discard creation?</key>
+    <key alias="confirmCancelBlockCreationMessage"><![CDATA[Are you sure you want to cancel the creation.]]></key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>


### PR DESCRIPTION
When user creates a new block, not in inline-editing mode, the editor overlay will appear after block type selection. If user wants to cancel at this point, we want to cancel the whole creation and not just the editing of its properties.

This PR changes the buttons when in creation flow, showing "cancel" and "create". If cancel the user will be asked if they are sure about discarding this creation.

As seen in this screenshot:
![image](https://user-images.githubusercontent.com/6791648/92236589-fe3b1e80-eeb5-11ea-8572-500a3bdf0b7d.png)
