### PR TITLE
Associate existing label to the button for a umb-toggle-group item (#8716)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtogglegroup.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtogglegroup.directive.js
@@ -71,7 +71,9 @@ Use this directive to render a group of toggle buttons.
     function ToggleGroupDirective() {
 
         function link(scope, el, attr, ctrl) {
-
+            for(let i = 0; i < scope.items.length; i++) {
+                scope.items[i].inputId = "umb-toggle-group-item_" + String.CreateGuid();
+            }
             scope.change = function(item) {
                 if (item.disabled) {
                     return;

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle-group.html
@@ -3,11 +3,11 @@
         <umb-toggle class="umb-toggle-group-item__toggle"
                     checked="item.checked"
                     disabled="item.disabled"
-                    input-id="{{$id}}-{{$index}}"
+                    input-id="{{item.inputId}}"
                     on-click="change(item)">
         </umb-toggle>
         <div class="umb-toggle-group-item__content" ng-click="change(item)">
-            <div><label for="{{$id}}-{{$index}}">{{ item.name }}</label> </div>
+            <div><label for="{{item.inputId}}">{{ item.name }}</label> </div>
             <div class="umb-toggle-group-item__description">{{ item.description }}</div>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-toggle-group.html
@@ -3,10 +3,11 @@
         <umb-toggle class="umb-toggle-group-item__toggle"
                     checked="item.checked"
                     disabled="item.disabled"
+                    input-id="{{$id}}-{{$index}}"
                     on-click="change(item)">
         </umb-toggle>
         <div class="umb-toggle-group-item__content" ng-click="change(item)">
-            <div>{{ item.name }} </div>
+            <div><label for="{{$id}}-{{$index}}">{{ item.name }}</label> </div>
             <div class="umb-toggle-group-item__description">{{ item.description }}</div>
         </div>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8716 

### Description

Specify `input-id` for `umb-toggle` and add a label to refer to that id.

Before:

![image](https://user-images.githubusercontent.com/17951/92238319-f9ab4180-ee86-11ea-9974-e1e4d9b67ac6.png)

After:

![image](https://user-images.githubusercontent.com/17951/92238330-0039b900-ee87-11ea-80d4-1ba145aa4cb9.png)
