### PR TITLE
Show only settings and styles boxes when each of them has configuration

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
@@ -13,6 +13,10 @@
         <umb-editor-container>
             <ng-form name="gridItemConfigEditor" val-form-manager>
 
+                <umb-empty-state position="center" ng-if="model.config.length === 0 && model.styles.length === 0">
+                    <localize key="grid_noConfiguration">No further configuration available</localize>
+                </umb-empty-state>
+
                 <umb-box ng-if="model.config && model.config.length > 0">
                     <umb-box-header title-key="grid_settings"></umb-box-header>
                     <umb-box-content>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
@@ -13,7 +13,7 @@
         <umb-editor-container>
             <ng-form name="gridItemConfigEditor" val-form-manager>
 
-                <umb-box ng-if="model.config">
+                <umb-box ng-if="model.config && model.config.length > 0">
                     <umb-box-header title-key="grid_settings"></umb-box-header>
                     <umb-box-content>
                         <div>
@@ -25,7 +25,7 @@
                     </umb-box-content>
                 </umb-box>
 
-                <umb-box ng-if="model.styles">
+                <umb-box ng-if="model.styles && model.styles.length > 0">
                     <umb-box-header title-key="grid_styles"></umb-box-header>
                     <umb-box-content>
                         <div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/config.html
@@ -52,7 +52,8 @@
                             shortcut="esc"
                             action="vm.close()">
                 </umb-button>
-                <umb-button type="button"
+                <umb-button ng-if="(model.config && model.config.length > 0) || (model.styles && model.styles.length > 0)"
+                            type="button"
                             button-style="success"
                             label-key="general_submit"
                             action="vm.submit()">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1356,6 +1356,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="rowConfigurationsDetail">Rækker er foruddefinerede celler, der arrangeres vandret</key>
     <key alias="addRowConfiguration">Tilføj rækkekonfiguration</key>
     <key alias="addRowConfigurationDetail">Juster rækken ved at indstille cellebredder og tilføje yderligere celler</key>
+    <key alias="noConfiguration">Ingen yderligere konfiguration tilgængelig</key>
     <key alias="columns">Kolonner</key>
     <key alias="columnsDetails">Det totale antal kolonner i dit grid</key>
     <key alias="settings">Indstillinger</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1610,6 +1610,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="addRowConfiguration">Add row configuration</key>
     <key alias="editRowConfiguration">Edit row configuration</key>
     <key alias="addRowConfigurationDetail">Adjust the row by setting cell widths and adding additional cells</key>
+    <key alias="noConfiguration">No further configuration available</key>
     <key alias="columns">Columns</key>
     <key alias="columnsDetails">Total combined number of columns in the grid layout</key>
     <key alias="settings">Settings</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1628,6 +1628,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="addRowConfiguration">Add row configuration</key>
     <key alias="editRowConfiguration">Edit row configuration</key>
     <key alias="addRowConfigurationDetail">Adjust the row by setting cell widths and adding additional cells</key>
+    <key alias="noConfiguration">No further configuration available</key>
     <key alias="columns">Columns</key>
     <key alias="columnsDetails">Total combined number of columns in the grid layout</key>
     <key alias="settings">Settings</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When there is no grid configuration for settings and styles two empty boxes are shown for these. It would be nicer to show an empty message here.
Furtheremore if you only use e.g. styles there is no need to use valuable space to show an empty settings box. So instead we can just show each box it any items are available. I have also changes, so the submit button only is visible when any configuration is available.

![chrome_2020-09-04_14-28-16](https://user-images.githubusercontent.com/2919859/92239326-12cde580-eebb-11ea-808c-fc3432c434a7.png)

![image](https://user-images.githubusercontent.com/2919859/92238806-40fef580-eeba-11ea-8c4d-27501e5dc398.png)


