### PR TITLE
Use umb-code-snippet in unsupported block

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.html
@@ -8,6 +8,6 @@
         You might want to remove this block, or contact your developer to take actions for making this block available again.<br/><br/>
         <a href="http://our.umbraco.com" target="_blank" rel="noreferrer">Learn about this circumstance</a>
         <h5>Block data:</h5>
-        <pre ng-bind="block.data | json : 4"></pre>
+        <umb-code-snippet language="'JSON'">{{block.data | json : 4 }}</umb-code-snippet>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.less
@@ -1,5 +1,4 @@
 .blockelement-unsupportedblock-editor {
-
     position: relative;
     display: block;
     box-sizing: border-box;
@@ -10,15 +9,12 @@
     border-radius: @baseBorderRadius;
 
     > .__header {
-
         display: flex;
         align-items: center;
-        
         padding-left: 20px;
         padding-bottom: 2px;
         min-height: 48px;
-        border-bottom: 1px solid @gray-9;
-        
+        border-bottom: 1px solid @gray-9;    
         background-color: @gray-11;
         color: @gray-6;
         
@@ -35,24 +31,16 @@
     }
 
     > .__body {
-
         padding: 20px;
-
         background-color: @gray-11;
 
         a {
             text-decoration: underline;
             color: @ui-action-type;
+
             &:hover {
-                color:@ui-action-type-hover;
+                color: @ui-action-type-hover;
             }
         }
-
-        pre {
-            border: none;
-            padding: 0;
-            background-color: transparent;
-        }
-
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When a block is unsupported in block list editor, we can use `<umb-code-snippet>` to show the json, which also makes it easy to copy the snippet.
It is also a bit more consistent with grid error https://github.com/umbraco/Umbraco-CMS/pull/8548 and query builder https://github.com/umbraco/Umbraco-CMS/pull/7294

For testing I has just comment out this line locally https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js#L200

**Before**

![chrome_2020-09-04_14-57-02](https://user-images.githubusercontent.com/2919859/92243225-6d6a4000-eec1-11ea-8c97-0e2df5826b8d.png)

**After**

![2020-09-04_15-15-59](https://user-images.githubusercontent.com/2919859/92243348-a73b4680-eec1-11ea-8db1-31de1edf1e89.gif)
