### PR TITLE
Block Editor: Automatically add item if there is only one item type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -420,23 +420,7 @@
                         blockPickerModel.close();
                     }
                 },
-                submit: function(blockPickerModel, mouseEvent) {
-                    var added = false;
-                    if (blockPickerModel && blockPickerModel.selectedItem) {
-                        added = addNewBlock(createIndex, blockPickerModel.selectedItem.blockConfigModel.contentElementTypeKey);
-                    }
-
-                    if(!(mouseEvent.ctrlKey || mouseEvent.metaKey)) {
-                        editorService.close();
-                        if (added && vm.layout.length > createIndex) {
-                            if (inlineEditing === true) {
-                                activateBlock(vm.layout[createIndex].$block);
-                            } else if (inlineEditing === false && vm.layout[createIndex].$block.hideContentInOverlay !== true) {
-                                editBlock(vm.layout[createIndex].$block, false, createIndex, blockPickerModel.$parentForm);
-                            }
-                        }
-                    }
-                },
+                submit: handleAddNewBlock,
                 close: function() {
                     // if opned by a inline creator button(index less than length), we want to move the focus away, to hide line-creator.
                     if (createIndex < vm.layout.length) {
@@ -444,6 +428,24 @@
                     }
 
                     editorService.close();
+                }
+            };
+
+            function handleAddNewBlock(blockPickerModel, mouseEvent) {
+                var added = false;
+                if (blockPickerModel && blockPickerModel.selectedItem) {
+                    added = addNewBlock(createIndex, blockPickerModel.selectedItem.blockConfigModel.contentElementTypeKey);
+                }
+
+                if (!(mouseEvent.ctrlKey || mouseEvent.metaKey)) {
+                    editorService.close();
+                    if (added && vm.layout.length > createIndex) {
+                        if (inlineEditing === true) {
+                            activateBlock(vm.layout[createIndex].$block);
+                        } else if (inlineEditing === false && vm.layout[createIndex].$block.hideContentInOverlay !== true) {
+                            editBlock(vm.layout[createIndex].$block, false, createIndex, blockPickerModel.$parentForm);
+                        }
+                    }
                 }
             };
 
@@ -490,7 +492,13 @@
                 return b.date - a.date
             });
 
-            // open block picker overlay
+            // if there is only one item type available and nothing in the clipboard, simply add that one item type
+            if (blockPickerModel.availableItems.length === 1 && blockPickerModel.clipboardItems.length === 0) {
+                blockPickerModel.selectedItem = blockPickerModel.availableItems[0];
+                handleAddNewBlock(blockPickerModel, {});
+                return;
+            }
+            // ...otherwise open block picker overlay
             editorService.open(blockPickerModel);
 
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #8760

### Description

If you have a Block Editor with only one item type, you're still prompted to pick that item type when adding new items, despite that item type being the only choice (i.e. even when there is nothing in the clipboard).

I reckon the block editor should automatically add a new item to the item list if there is only one available item type (and nothing in the clipboard):

![be-auto-add-item](https://user-images.githubusercontent.com/7405322/92247316-5a5a6e80-eec7-11ea-86cd-7fae3350d6d0.gif)
