### PR TITLE
Checkboxlist prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
@@ -11,12 +11,9 @@
 
             var prevalues = ($scope.model.config ? $scope.model.config.prevalues : $scope.model.prevalues) || [];
 
-            console.log("prevalues", prevalues);
-
             var items = [];
 
             for (var i = 0; i < prevalues.length; i++) {
-                console.log("item", prevalues[i]);
                 var item = {};
 
                 if (Utilities.isObject(prevalues[i])) {
@@ -30,8 +27,6 @@
 
                 items.push({ value: item.value, label: item.label });
             }
-
-            console.log("items", items);
 
             vm.configItems = items;
 
@@ -61,8 +56,6 @@
         }
 
         function change(model, value) {
-
-            console.log("checkboxlist prevalues", model, value);
 
             var index = $scope.model.value.indexOf(value);
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
@@ -3,9 +3,59 @@
         
         var vm = this;
 
+        vm.configItems = [];
+        vm.viewItems = [];
         vm.change = change;
 
         function init() {
+
+            var prevalues = [];
+            if ($scope.model.config) {
+                prevalues = $scope.model.config.prevalues || [];
+            }
+            else {
+                prevalues = $scope.model.prevalues || [];
+            }
+
+            console.log("prevalues", prevalues);
+
+            var items = [];
+            var vals = _.values(prevalues);
+            var keys = _.keys(prevalues);
+            console.log("vals", vals);
+            console.log("keys", keys);
+
+            for (var i = 0; i < vals.length; i++) {
+                items.push({ key: keys[i], value: vals[i].value });
+            }
+
+            console.log("items", items);
+
+            vm.configItems = items;
+
+            if ($scope.model.value === null || $scope.model.value === undefined) {
+                $scope.model.value = [];
+            }
+
+            // update view model.
+            generateViewModel($scope.model.value);
+
+        }
+
+        function generateViewModel(newVal) {
+
+            vm.viewItems = [];
+
+            var iConfigItem;
+            for (var i = 0; i < vm.configItems.length; i++) {
+                iConfigItem = vm.configItems[i];
+                var isChecked = _.contains(newVal, iConfigItem.value);
+                vm.viewItems.push({
+                    checked: isChecked,
+                    key: iConfigItem.key,
+                    value: iConfigItem.value
+                });
+            }
 
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
@@ -9,24 +9,26 @@
 
         function init() {
 
-            var prevalues = [];
-            if ($scope.model.config) {
-                prevalues = $scope.model.config.prevalues || [];
-            }
-            else {
-                prevalues = $scope.model.prevalues || [];
-            }
+            var prevalues = ($scope.model.config ? $scope.model.config.prevalues : $scope.model.prevalues) || [];
 
             console.log("prevalues", prevalues);
 
             var items = [];
-            var vals = _.values(prevalues);
-            var keys = _.keys(prevalues);
-            console.log("vals", vals);
-            console.log("keys", keys);
 
-            for (var i = 0; i < vals.length; i++) {
-                items.push({ key: keys[i], value: vals[i].value });
+            for (var i = 0; i < prevalues.length; i++) {
+                console.log("item", prevalues[i]);
+                var item = {};
+
+                if (Utilities.isObject(prevalues[i])) {
+                    item.value = prevalues[i].value;
+                    item.label = prevalues[i].label;
+                }
+                else {
+                    item.value = prevalues[i];
+                    item.label = prevalues[i];
+                }
+
+                items.push({ value: item.value, label: item.label });
             }
 
             console.log("items", items);
@@ -39,7 +41,6 @@
 
             // update view model.
             generateViewModel($scope.model.value);
-
         }
 
         function generateViewModel(newVal) {
@@ -52,8 +53,8 @@
                 var isChecked = _.contains(newVal, iConfigItem.value);
                 vm.viewItems.push({
                     checked: isChecked,
-                    key: iConfigItem.key,
-                    value: iConfigItem.value
+                    value: iConfigItem.value,
+                    label: iConfigItem.label
                 });
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.controller.js
@@ -1,0 +1,34 @@
+﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.CheckboxListController",
+    function ($scope) {
+        
+        var vm = this;
+
+        vm.change = change;
+
+        function init() {
+
+        }
+
+        function change(model, value) {
+
+            console.log("checkboxlist prevalues", model, value);
+
+            var index = $scope.model.value.indexOf(value);
+
+            if (model === true) {
+                //if it doesn't exist in the model, then add it
+                if (index < 0) {
+                    $scope.model.value.push(value);
+                }
+            } else {
+                //if it exists in the model, then remove it
+                if (index >= 0) {
+                    $scope.model.value.splice(index, 1);
+                }
+            }
+
+        }
+
+        init();
+
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -1,27 +1,23 @@
 ﻿<div ng-controller="Umbraco.PrevalueEditors.CheckboxListController as vm">
 
     <ul class="unstyled">
+
         <li ng-repeat="item in vm.viewItems track by item.key">
             <umb-checkbox value="{{item.value}}" model="item.checked" text="{{item.value}}" on-change="vm.change(model, value)"></umb-checkbox>
         </li>
 
+        {{model.value}}
 
-        <li ng-repeat="preval in model.prevalues">
+        <!--<li ng-repeat="preval in model.prevalues">
 
             <umb-checkbox model="preval.value" value="{{preval.value || preval}}" on-change="vm.change(model, value)">
                 {{preval.label || preval.value || preval}}
             </umb-checkbox>
 
-            {{model.value}}
-
-            <!--<label class="checkbox">
-            <input type="checkbox" ng-hide="preval.icon" checklist-model="model.value" checklist-value="preval" value="{{preval.value || preval}}" />
-            <i ng-if="preval.icon" class="icon {{preval.icon}}"></i> <span>{{preval.label || preval.value || preval}}</span>
-        </label>-->
-        </li>
+        </li>-->
     </ul>
 
-    <ul class="unstyled" ng-if="model.config.prevalues">
+    <!--<ul class="unstyled" ng-if="model.config.prevalues">
         <li ng-repeat="(key, value) in model.config.prevalues">
 
             <umb-checkbox model="value.checked" value="{{value.value}}" on-change="vm.change(model, value)">
@@ -29,6 +25,6 @@
             </umb-checkbox>
 
         </li>
-    </ul>
+    </ul>-->
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -8,13 +8,6 @@
 
         {{model.value}}
 
-        <!--<li ng-repeat="preval in model.prevalues">
-
-            <umb-checkbox model="preval.value" value="{{preval.value || preval}}" on-change="vm.change(model, value)">
-                {{preval.label || preval.value || preval}}
-            </umb-checkbox>
-
-        </li>-->
     </ul>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.PrevalueEditors.CheckboxListController as vm">
+﻿<div class="umb-checkboxlist-preval" ng-controller="Umbraco.PrevalueEditors.CheckboxListController as vm">
 
     <ul class="unstyled">
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -2,8 +2,8 @@
 
     <ul class="unstyled">
 
-        <li ng-repeat="item in vm.viewItems track by item.key">
-            <umb-checkbox value="{{item.value}}" model="item.checked" text="{{item.value}}" on-change="vm.change(model, value)"></umb-checkbox>
+        <li ng-repeat="item in vm.viewItems track by $id(item)">
+            <umb-checkbox value="{{item.value}}" model="item.checked" text="{{item.label}}" on-change="vm.change(model, value)"></umb-checkbox>
         </li>
 
         {{model.value}}
@@ -16,15 +16,5 @@
 
         </li>-->
     </ul>
-
-    <!--<ul class="unstyled" ng-if="model.config.prevalues">
-        <li ng-repeat="(key, value) in model.config.prevalues">
-
-            <umb-checkbox model="value.checked" value="{{value.value}}" on-change="vm.change(model, value)">
-                {{value.label}}
-            </umb-checkbox>
-
-        </li>
-    </ul>-->
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -1,13 +1,9 @@
 ﻿<div class="umb-checkboxlist-preval" ng-controller="Umbraco.PrevalueEditors.CheckboxListController as vm">
 
     <ul class="unstyled">
-
         <li ng-repeat="item in vm.viewItems track by $id(item)">
             <umb-checkbox value="{{item.value}}" model="item.checked" text="{{item.label}}" on-change="vm.change(model, value)"></umb-checkbox>
         </li>
-
-        {{model.value}}
-
     </ul>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/checkboxlist.html
@@ -1,0 +1,34 @@
+﻿<div ng-controller="Umbraco.PrevalueEditors.CheckboxListController as vm">
+
+    <ul class="unstyled">
+        <li ng-repeat="item in vm.viewItems track by item.key">
+            <umb-checkbox value="{{item.value}}" model="item.checked" text="{{item.value}}" on-change="vm.change(model, value)"></umb-checkbox>
+        </li>
+
+
+        <li ng-repeat="preval in model.prevalues">
+
+            <umb-checkbox model="preval.value" value="{{preval.value || preval}}" on-change="vm.change(model, value)">
+                {{preval.label || preval.value || preval}}
+            </umb-checkbox>
+
+            {{model.value}}
+
+            <!--<label class="checkbox">
+            <input type="checkbox" ng-hide="preval.icon" checklist-model="model.value" checklist-value="preval" value="{{preval.value || preval}}" />
+            <i ng-if="preval.icon" class="icon {{preval.icon}}"></i> <span>{{preval.label || preval.value || preval}}</span>
+        </label>-->
+        </li>
+    </ul>
+
+    <ul class="unstyled" ng-if="model.config.prevalues">
+        <li ng-repeat="(key, value) in model.config.prevalues">
+
+            <umb-checkbox model="value.checked" value="{{value.value}}" on-change="vm.change(model, value)">
+                {{value.label}}
+            </umb-checkbox>
+
+        </li>
+    </ul>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/radiobuttonlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/radiobuttonlist.html
@@ -1,19 +1,23 @@
-<ul class="unstyled" ng-if="model.prevalues">
-    <li ng-repeat="preval in model.prevalues">
+<div>
 
-        <umb-radiobutton model="model.value" value="{{preval.value || preval}}">
-            {{preval.label || preval.value || preval}}
-        </umb-radiobutton>
+    <ul class="unstyled" ng-if="model.prevalues">
+        <li ng-repeat="preval in model.prevalues">
 
-    </li>
-</ul>
+            <umb-radiobutton model="model.value" value="{{preval.value || preval}}">
+                {{preval.label || preval.value || preval}}
+            </umb-radiobutton>
 
-<ul class="unstyled" ng-if="model.config.prevalues">
-    <li ng-repeat="(key, value) in model.config.prevalues">
+        </li>
+    </ul>
 
-        <umb-radiobutton model="model.value" value="{{value.value}}">
-            {{value.label}}
-        </umb-radiobutton>
+    <ul class="unstyled" ng-if="model.config.prevalues">
+        <li ng-repeat="(key, value) in model.config.prevalues">
 
-    </li>
-</ul>
+            <umb-radiobutton model="model.value" value="{{value.value}}">
+                {{value.label}}
+            </umb-radiobutton>
+
+        </li>
+    </ul>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/radiobuttonlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/radiobuttonlist.html
@@ -1,4 +1,4 @@
-<div>
+<div class="umb-radiobuttons-preval">
 
     <ul class="unstyled" ng-if="model.prevalues">
         <li ng-repeat="preval in model.prevalues">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
@@ -9,7 +9,7 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
         
         function init() {
             
-            // currently the property editor will onyl work if our input is an object.
+            // currently the property editor will only work if our input is an object.
             if (Utilities.isObject($scope.model.config.items)) {
 
                 // formatting the items in the dictionary into an array


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add a checkboxlist prevalue editor similar to that we have radiobuttonlist prevalue editor.
Previous this PR https://github.com/umbraco/Umbraco-CMS/pull/1496 was rejected but I have now submitted this one a made it a bit simpler as a start.

This can be useful in both grid configuration, but also as prevalue editor in a property editor without the need to add your own in most cases.

Much of the logic it similar to the checkboxlist property editor. Radiobuttonlist prevalue editor both support `model.config.prevalues` and `model.prevalues` (I guess one of them is legacy format) so I think it makes sense to make checkboxlist prevalue editor support similar format.

An example JSON for grid configuration using a string array and object array of prevalues.

```
[
  {
    "label": "Weekdays",
    "description": "Select weekdays",
    "key": "weekdays",
    "view": "checkboxlist",
    "applyTo": "row",
    "prevalues": [
      {
        "label": "Monday",
        "value": "mon"
      },
      {
        "label": "Tuesday",
        "value": "tue"
      },
      {
        "label": "Wednesday",
        "value": "wed"
      },
      {
        "label": "Thursday",
        "value": "thu"
      },
      {
        "label": "Friday",
        "value": "fri"
      },
      {
        "label": "Saturday",
        "value": "sat"
      },
      {
        "label": "Sunday",
        "value": "sun"
      }
    ]
  },
  {
    "label": "Fruits",
    "description": "Select fruits",
    "key": "fruits",
    "view": "checkboxlist",
    "applyTo": "row",
    "prevalues": [
      "apple",
      "banana",
      "cherries",
      "dates",
      "elderberry"
    ]
  }
]
```

![2020-09-05_10-36-00](https://user-images.githubusercontent.com/2919859/92301382-b70b6700-ef63-11ea-9c49-fd00f5afd61e.gif)