### PR TITLE
Checkboxlist and radiobuttonlist validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListController",
-    function ($scope) {
+    function ($scope, validationMessageService) {
         
         var vm = this;
         
@@ -8,6 +8,8 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
         vm.change = change;
         
         function init() {
+
+            vm.uniqueId = String.CreateGuid();
             
             // currently the property editor will onyl work if our input is an object.
             if (Utilities.isObject($scope.model.config.items)) {
@@ -35,6 +37,12 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
                 //watch the model.value in case it changes so that we can keep our view model in sync
                 $scope.$watchCollection("model.value", updateViewModel);
             }
+
+            // Set the message to use for when a mandatory field isn't completed.
+            // Will either use the one provided on the property type or a localised default.
+            validationMessageService.getMandatoryMessage($scope.model.validation).then(function (value) {
+                $scope.mandatoryMessage = value;
+            });  
             
         }
         

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.html
@@ -1,7 +1,16 @@
 ﻿<div class="umb-property-editor umb-checkboxlist" ng-controller="Umbraco.PropertyEditors.CheckboxListController as vm">
-    <ul class="unstyled">
-        <li ng-repeat="item in vm.viewItems track by item.key">
-            <umb-checkbox name="{{::model.alias}}" value="{{::item.value}}" model="item.checked" text="{{::item.value}}" on-change="vm.change(model, value)" required="model.validation.mandatory && !model.value.length"></umb-checkbox>
-        </li>
-    </ul>
+
+    <ng-form name="checkboxListFieldForm">
+
+        <ul class="unstyled">
+            <li ng-repeat="item in vm.viewItems track by item.key">
+                <umb-checkbox name="{{::model.alias}}_{{::vm.uniqueId}}" value="{{::item.value}}" model="item.checked" text="{{::item.value}}" on-change="vm.change(model, value)" required="model.validation.mandatory && !model.value.length"></umb-checkbox>
+            </li>
+        </ul>
+
+        <div ng-messages="checkboxListFieldForm[model.alias + '_' + vm.uniqueId].$error" show-validation-on-submit>
+            <p class="help-inline" ng-message="required">{{mandatoryMessage}}</p>
+        </div>
+
+    </ng-form>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/radiobuttons/radiobuttons.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/radiobuttons/radiobuttons.html
@@ -12,7 +12,7 @@
             </li>
         </ul>
 
-        <div ng-messages="radioButtonsFieldForm[model.alias_vm.uniqueId].$error" show-validation-on-submit>
+        <div ng-messages="radioButtonsFieldForm[model.alias + '_' + vm.uniqueId].$error" show-validation-on-submit>
             <p class="help-inline" ng-message="required">{{mandatoryMessage}}</p>
         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Recently I fixed a issue with radiobuttonlist in splitview in this PR https://github.com/umbraco/Umbraco-CMS/pull/8792
But I then noticed that when the property was mandatory and using default or a custom validation message, this wasn't shown.

This has been fixed in https://github.com/umbraco/Umbraco-CMS/commit/f5aeca5f3dacae8016488139d38ca14dba39681d

Furthermore I noticed checkboxlist didn't show this message either and the value of `name` attribute was identical in splitview although this didn't cause issues as with radiobuttons as multiple options are allowed, but could cause issues with validation of the correct "group".

So I have now made this consistent with radiobuttonlist.

![image](https://user-images.githubusercontent.com/2919859/92301637-89272200-ef65-11ea-970c-919d5cff57e1.png)

![image](https://user-images.githubusercontent.com/2919859/92301661-aeb42b80-ef65-11ea-9806-6cfcdf58742f.png)
