### PR TITLE
8.7RC Add generic BlockListItem classes

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
@@ -25,8 +25,8 @@ namespace Umbraco.Core.Models.Blocks
         {
             ContentUdi = contentUdi ?? throw new ArgumentNullException(nameof(contentUdi));
             Content = content ?? throw new ArgumentNullException(nameof(content));
-            Settings = settings; // can be null
-            SettingsUdi = settingsUdi; // can be null
+            SettingsUdi = settingsUdi;
+            Settings = settings;
         }
 
         /// <summary>
@@ -87,6 +87,12 @@ namespace Umbraco.Core.Models.Blocks
             Content = content;
         }
 
+        /// <summary>
+        /// Gets the content.
+        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
         public new T Content { get; }
     }
 
@@ -100,12 +106,25 @@ namespace Umbraco.Core.Models.Blocks
         where TContent : IPublishedElement
         where TSettings : IPublishedElement
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlockListItem{TContent, TSettings}" /> class.
+        /// </summary>
+        /// <param name="contentUdi">The content udi.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="settingsUdi">The settings udi.</param>
+        /// <param name="settings">The settings.</param>
         public BlockListItem(Udi contentUdi, TContent content, Udi settingsUdi, TSettings settings)
             : base(contentUdi, content, settingsUdi, settings)
         {
             Settings = settings;
         }
 
+        /// <summary>
+        /// Gets the settings.
+        /// </summary>
+        /// <value>
+        /// The settings.
+        /// </value>
         public new TSettings Settings { get; }
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
@@ -5,41 +5,107 @@ using Umbraco.Core.Models.PublishedContent;
 namespace Umbraco.Core.Models.Blocks
 {
     /// <summary>
-    /// Represents a layout item for the Block List editor
+    /// Represents a layout item for the Block List editor.
     /// </summary>
+    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
     [DataContract(Name = "block", Namespace = "")]
     public class BlockListItem : IBlockReference<IPublishedElement>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlockListItem" /> class.
+        /// </summary>
+        /// <param name="contentUdi">The content UDI.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="settingsUdi">The settings UDI.</param>
+        /// <param name="settings">The settings.</param>
+        /// <exception cref="System.ArgumentNullException">contentUdi
+        /// or
+        /// content</exception>
         public BlockListItem(Udi contentUdi, IPublishedElement content, Udi settingsUdi, IPublishedElement settings)
         {
-            ContentUdi = contentUdi ?? throw new ArgumentNullException(nameof(contentUdi));            
+            ContentUdi = contentUdi ?? throw new ArgumentNullException(nameof(contentUdi));
             Content = content ?? throw new ArgumentNullException(nameof(content));
             Settings = settings; // can be null
             SettingsUdi = settingsUdi; // can be null
         }
 
         /// <summary>
-        /// The Id of the content data item
+        /// Gets the content UDI.
         /// </summary>
+        /// <value>
+        /// The content UDI.
+        /// </value>
         [DataMember(Name = "contentUdi")]
         public Udi ContentUdi { get; }
 
         /// <summary>
-        /// The Id of the settings data item
+        /// Gets the content.
         /// </summary>
-        [DataMember(Name = "settingsUdi")]
-        public Udi SettingsUdi { get; }
-
-        /// <summary>
-        /// The content data item referenced
-        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
         [DataMember(Name = "content")]
         public IPublishedElement Content { get; }
 
         /// <summary>
-        /// The settings data item referenced
+        /// Gets the settings UDI.
         /// </summary>
+        /// <value>
+        /// The settings UDI.
+        /// </value>
+        [DataMember(Name = "settingsUdi")]
+        public Udi SettingsUdi { get; }
+
+        /// <summary>
+        /// Gets the settings.
+        /// </summary>
+        /// <value>
+        /// The settings.
+        /// </value>
         [DataMember(Name = "settings")]
         public IPublishedElement Settings { get; }
+    }
+
+    /// <summary>
+    /// Represents a layout item with a generic content type for the Block List editor.
+    /// </summary>
+    /// <typeparam name="T">The type of the content.</typeparam>
+    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+    public class BlockListItem<T> : BlockListItem
+        where T : IPublishedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlockListItem{T}" /> class.
+        /// </summary>
+        /// <param name="contentUdi">The content UDI.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="settingsUdi">The settings UDI.</param>
+        /// <param name="settings">The settings.</param>
+        public BlockListItem(Udi contentUdi, T content, Udi settingsUdi, IPublishedElement settings)
+            : base(contentUdi, content, settingsUdi, settings)
+        {
+            Content = content;
+        }
+
+        public new T Content { get; }
+    }
+
+    /// <summary>
+    /// Represents a layout item with generic content and settings types for the Block List editor.
+    /// </summary>
+    /// <typeparam name="TContent">The type of the content.</typeparam>
+    /// <typeparam name="TSettings">The type of the settings.</typeparam>
+    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+    public class BlockListItem<TContent, TSettings> : BlockListItem<TContent>
+        where TContent : IPublishedElement
+        where TSettings : IPublishedElement
+    {
+        public BlockListItem(Udi contentUdi, TContent content, Udi settingsUdi, TSettings settings)
+            : base(contentUdi, content, settingsUdi, settings)
+        {
+            Settings = settings;
+        }
+
+        public new TSettings Settings { get; }
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockListModel.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -9,15 +9,10 @@ namespace Umbraco.Core.Models.Blocks
     /// <summary>
     /// The strongly typed model for the Block List editor.
     /// </summary>
-    /// <seealso cref="System.Collections.Generic.IReadOnlyList{Umbraco.Core.Models.Blocks.BlockListItem}" />
+    /// <seealso cref="System.Collections.ObjectModel.ReadOnlyCollection{Umbraco.Core.Models.Blocks.BlockListItem}" />
     [DataContract(Name = "blockList", Namespace = "")]
-    public class BlockListModel : IReadOnlyList<BlockListItem>
+    public class BlockListModel : ReadOnlyCollection<BlockListItem>
     {
-        /// <summary>
-        /// The layout.
-        /// </summary>
-        private readonly IReadOnlyList<BlockListItem> _layout;
-
         /// <summary>
         /// Gets the empty <see cref="BlockListModel" />.
         /// </summary>
@@ -36,31 +31,10 @@ namespace Umbraco.Core.Models.Blocks
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockListModel" /> class.
         /// </summary>
-        /// <param name="layout">The layout.</param>
-        /// <exception cref="System.ArgumentNullException">layout</exception>
-        public BlockListModel(IEnumerable<BlockListItem> layout)
-        {
-            if (layout == null) throw new ArgumentNullException(nameof(layout));
-
-            _layout = layout.ToList().AsReadOnly();
-        }
-
-        /// <summary>
-        /// Gets the number of elements in the collection.
-        /// </summary>
-        public int Count => _layout.Count;
-
-        /// <summary>
-        /// Gets the <see cref="BlockListItem" /> at the specified index.
-        /// </summary>
-        /// <value>
-        /// The <see cref="BlockListItem" />.
-        /// </value>
-        /// <param name="index">The index.</param>
-        /// <returns>
-        /// The <see cref="BlockListItem" /> at the specified index.
-        /// </returns>
-        public BlockListItem this[int index] => _layout[index];
+        /// <param name="list">The list to wrap.</param>
+        public BlockListModel(IList<BlockListItem> list)
+            : base(list)
+        { }
 
         /// <summary>
         /// Gets the <see cref="BlockListItem" /> with the specified content key.
@@ -72,7 +46,7 @@ namespace Umbraco.Core.Models.Blocks
         /// <returns>
         /// The <see cref="BlockListItem" /> with the specified content key.
         /// </returns>
-        public BlockListItem this[Guid contentKey] => _layout.FirstOrDefault(x => x.Content.Key == contentKey);
+        public BlockListItem this[Guid contentKey] => this.FirstOrDefault(x => x.Content.Key == contentKey);
 
         /// <summary>
         /// Gets the <see cref="BlockListItem" /> with the specified content UDI.
@@ -84,22 +58,6 @@ namespace Umbraco.Core.Models.Blocks
         /// <returns>
         /// The <see cref="BlockListItem" /> with the specified content UDI.
         /// </returns>
-        public BlockListItem this[Udi contentUdi] => contentUdi is GuidUdi guidUdi ? _layout.FirstOrDefault(x => x.Content.Key == guidUdi.Guid) : null;
-
-        /// <summary>
-        /// Returns an enumerator that iterates through the collection.
-        /// </summary>
-        /// <returns>
-        /// An enumerator that can be used to iterate through the collection.
-        /// </returns>
-        public IEnumerator<BlockListItem> GetEnumerator() => _layout.GetEnumerator();
-
-        /// <summary>
-        /// Returns an enumerator that iterates through a collection.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.
-        /// </returns>
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public BlockListItem this[Udi contentUdi] => contentUdi is GuidUdi guidUdi ? this.FirstOrDefault(x => x.Content.Key == guidUdi.Guid) : null;
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockListModel.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListModel.cs
@@ -3,62 +3,103 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
-using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Core.Models.Blocks
 {
     /// <summary>
-    /// The strongly typed model for the Block List editor
+    /// The strongly typed model for the Block List editor.
     /// </summary>
+    /// <seealso cref="System.Collections.Generic.IReadOnlyList{Umbraco.Core.Models.Blocks.BlockListItem}" />
     [DataContract(Name = "blockList", Namespace = "")]
     public class BlockListModel : IReadOnlyList<BlockListItem>
     {
-        private readonly IReadOnlyList<BlockListItem> _layout = new List<BlockListItem>();
+        /// <summary>
+        /// The layout.
+        /// </summary>
+        private readonly IReadOnlyList<BlockListItem> _layout;
 
+        /// <summary>
+        /// Gets the empty <see cref="BlockListModel" />.
+        /// </summary>
+        /// <value>
+        /// The empty <see cref="BlockListModel" />.
+        /// </value>
         public static BlockListModel Empty { get; } = new BlockListModel();
 
+        /// <summary>
+        /// Prevents a default instance of the <see cref="BlockListModel" /> class from being created.
+        /// </summary>
         private BlockListModel()
-        {
-        }
+            : this(new List<BlockListItem>())
+        { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlockListModel" /> class.
+        /// </summary>
+        /// <param name="layout">The layout.</param>
+        /// <exception cref="System.ArgumentNullException">layout</exception>
         public BlockListModel(IEnumerable<BlockListItem> layout)
         {
-            _layout = layout.ToList();
+            if (layout == null) throw new ArgumentNullException(nameof(layout));
+
+            _layout = layout.ToList().AsReadOnly();
         }
 
+        /// <summary>
+        /// Gets the number of elements in the collection.
+        /// </summary>
         public int Count => _layout.Count;
 
         /// <summary>
-        /// Get the block by index
+        /// Gets the <see cref="BlockListItem" /> at the specified index.
         /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
+        /// <value>
+        /// The <see cref="BlockListItem" />.
+        /// </value>
+        /// <param name="index">The index.</param>
+        /// <returns>
+        /// The <see cref="BlockListItem" /> at the specified index.
+        /// </returns>
         public BlockListItem this[int index] => _layout[index];
 
         /// <summary>
-        /// Get the block by content Guid
+        /// Gets the <see cref="BlockListItem" /> with the specified content key.
         /// </summary>
-        /// <param name="contentKey"></param>
-        /// <returns></returns>
+        /// <value>
+        /// The <see cref="BlockListItem" />.
+        /// </value>
+        /// <param name="contentKey">The content key.</param>
+        /// <returns>
+        /// The <see cref="BlockListItem" /> with the specified content key.
+        /// </returns>
         public BlockListItem this[Guid contentKey] => _layout.FirstOrDefault(x => x.Content.Key == contentKey);
 
         /// <summary>
-        /// Get the block by content element Udi
+        /// Gets the <see cref="BlockListItem" /> with the specified content UDI.
         /// </summary>
-        /// <param name="contentUdi"></param>
-        /// <returns></returns>
-        public BlockListItem this[Udi contentUdi]
-        {
-            get
-            {
-                if (!(contentUdi is GuidUdi guidUdi)) return null;
-                return _layout.FirstOrDefault(x => x.Content.Key == guidUdi.Guid);
-            }
-        }
+        /// <value>
+        /// The <see cref="BlockListItem" />.
+        /// </value>
+        /// <param name="contentUdi">The content UDI.</param>
+        /// <returns>
+        /// The <see cref="BlockListItem" /> with the specified content UDI.
+        /// </returns>
+        public BlockListItem this[Udi contentUdi] => contentUdi is GuidUdi guidUdi ? _layout.FirstOrDefault(x => x.Content.Key == guidUdi.Guid) : null;
 
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>
+        /// An enumerator that can be used to iterate through the collection.
+        /// </returns>
         public IEnumerator<BlockListItem> GetEnumerator() => _layout.GetEnumerator();
 
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.
+        /// </returns>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/ContentAndSettingsReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/ContentAndSettingsReference.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Umbraco.Core.Models.Blocks
 {
@@ -12,26 +12,16 @@ namespace Umbraco.Core.Models.Blocks
         }
 
         public Udi ContentUdi { get; }
+
         public Udi SettingsUdi { get; }
 
-        public override bool Equals(object obj)
-        {
-            return obj is ContentAndSettingsReference reference && Equals(reference);
-        }
+        public override bool Equals(object obj) => obj is ContentAndSettingsReference reference && Equals(reference);
 
-        public bool Equals(ContentAndSettingsReference other)
-        {
-            return EqualityComparer<Udi>.Default.Equals(ContentUdi, other.ContentUdi) &&
-                   EqualityComparer<Udi>.Default.Equals(SettingsUdi, other.SettingsUdi);
-        }
+        public bool Equals(ContentAndSettingsReference other) => other != null
+            && EqualityComparer<Udi>.Default.Equals(ContentUdi, other.ContentUdi)
+            && EqualityComparer<Udi>.Default.Equals(SettingsUdi, other.SettingsUdi);
 
-        public override int GetHashCode()
-        {
-            var hashCode = 272556606;
-            hashCode = hashCode * -1521134295 + EqualityComparer<Udi>.Default.GetHashCode(ContentUdi);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Udi>.Default.GetHashCode(SettingsUdi);
-            return hashCode;
-        }
+        public override int GetHashCode() => (ContentUdi, SettingsUdi).GetHashCode();
 
         public static bool operator ==(ContentAndSettingsReference left, ContentAndSettingsReference right)
         {

--- a/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
@@ -1,26 +1,37 @@
 ﻿namespace Umbraco.Core.Models.Blocks
 {
-    
     /// <summary>
-    /// Represents a data item reference for a Block editor implementation
-    /// </summary>
-    /// <typeparam name="TSettings"></typeparam>
-    /// <remarks>
-    /// see: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
-    /// </remarks>
-    public interface IBlockReference<TSettings> : IBlockReference
-    {
-        TSettings Settings { get; }
-    }
-
-    /// <summary>
-    /// Represents a data item reference for a Block Editor implementation
+    /// Represents a data item reference for a Block Editor implementation.
     /// </summary>
     /// <remarks>
-    /// see: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
+    /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
     /// </remarks>
     public interface IBlockReference
     {
+        /// <summary>
+        /// Gets the content UDI.
+        /// </summary>
+        /// <value>
+        /// The content UDI.
+        /// </value>
         Udi ContentUdi { get; }
+    }
+
+    /// <summary>
+    /// Represents a data item reference with settings for a Block editor implementation.
+    /// </summary>
+    /// <typeparam name="TSettings">The type of the settings.</typeparam>
+    /// <remarks>
+    /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
+    /// </remarks>
+    public interface IBlockReference<TSettings> : IBlockReference
+    {
+        /// <summary>
+        /// Gets the settings.
+        /// </summary>
+        /// <value>
+        /// The settings.
+        /// </value>
+        TSettings Settings { get; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -120,7 +120,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                             settingsData = null;
                     }
 
-                    var layoutRef = new BlockListItem(contentGuidUdi, contentData, settingGuidUdi, settingsData);
+                    var layoutType = typeof(BlockListItem<,>).MakeGenericType(contentData.GetType(), settingsData?.GetType() ?? typeof(IPublishedElement));
+                    var layoutRef = (BlockListItem)Activator.CreateInstance(layoutType, contentGuidUdi, contentData, settingGuidUdi, settingsData);
+
                     layout.Add(layoutRef);
                 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8727.

### Description
Currently, you have to cast the content and settings from the `BlockListItem` to the correct type, before you can access the strongly typed models, e.g.:

```cshtml
@model BlockListItem
@{
   var content = Model.Content as Feature;
   var settings = Model.Settings as FeatureSettings;
}
<h1 class="@settings.CssClass">@content.FeatureName</h1>
```

This PR adds the generic classes `BlockListItem<T>` and `BlockListItem<TContent, TSettings>` that both inherit from `BlockListItem`. The PVC is updated to create instances of the most explicit, matching generic type, so that can be used in the (partial) views:

```cshtml
@model BlockListItem<Feature, FeatureSettings>
<h1 class="@Model.Settings.CssClass">@Model.Content.FeatureName</h1>
```

Also, if you don't have settings configured (or you have multiple block configurations with different setting types), you can use `BlockListItem<Feature>`. The settings will be exposed as `IPublishedElement`, just like the non-generic `BlockListItem` and you have to manually null-check/cast it.

This will make working with the Block List editor a lot easier and probably also reduce bugs in the views, as you get a `ModelBindingException` with a nice message with the model/content types (instead of ` InvalidCastException` or `NullReferenceException`s).