### PR TITLE
V8.7RC: Removing extensions for GetBlockListHtml on IPublishedContent

### DIFF
--- a/src/Umbraco.Web/BlockListTemplateExtensions.cs
+++ b/src/Umbraco.Web/BlockListTemplateExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Web.Mvc;
 using System.Web.Mvc.Html;
 using Umbraco.Core.Models.Blocks;
@@ -35,11 +34,5 @@ namespace Umbraco.Web
 
             return GetBlockListHtml(html, prop?.GetValue() as BlockListModel, template);
         }
-
-        public static IHtmlString GetBlockListHtml(this IPublishedProperty property, HtmlHelper html, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
-
-        public static IHtmlString GetBlockListHtml(this IPublishedContent contentItem, HtmlHelper html, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
-
-        public static IHtmlString GetBlockListHtml(this IPublishedContent contentItem, HtmlHelper html, string propertyAlias, string template) => GetBlockListHtml(html, contentItem, propertyAlias, template);
     }
 }


### PR DESCRIPTION
These are "duplicates" of the extension method on HtmlHelper (just with the input switched around) and should not be needed.
It can actually encourage people to do bad things, when they think they need to instantiate the HtmlHelper dependency by newing it up, so we've decided to simply just remove this to avoid having that happen.

This is part of the changes proposed by @ronaldbarendse in his latest PRs (see: https://github.com/umbraco/Umbraco-CMS/issues/8727) but as we will not be pulling all of it in currently, we decided to break this one out from the rest and include it in 8.7.

@ronaldbarendse we'll be following up on the rest of the proposed additions (esp. the Partials stuff which looks really good) we're just not ready to include it in the 8.7 release.