### PR TITLE
NetCore: Fix for disabling/enabling url tracking

### DIFF
--- a/src/Umbraco.Core/Configuration/IConfigManipulator.cs
+++ b/src/Umbraco.Core/Configuration/IConfigManipulator.cs
@@ -7,5 +7,6 @@ namespace Umbraco.Core.Configuration
         void RemoveConnectionString();
         void SaveConnectionString(string connectionString, string providerName);
         void SaveConfigValue(string itemPath, object value);
+        void SaveDisableRedirectUrlTracking(bool disable);
     }
 }

--- a/src/Umbraco.Core/Configuration/XmlConfigManipulator.cs
+++ b/src/Umbraco.Core/Configuration/XmlConfigManipulator.cs
@@ -2,8 +2,8 @@
 using System.Configuration;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
-using Umbraco.Composing;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 
@@ -109,6 +109,26 @@ namespace Umbraco.Core.Configuration
         public void SaveConfigValue(string itemPath, object value)
         {
             throw new NotImplementedException();
+        }
+
+        public void SaveDisableRedirectUrlTracking(bool disable)
+        {
+            var fileName = _ioHelper.MapPath("~/config/umbracoSettings.config");
+
+            var umbracoConfig = new XmlDocument { PreserveWhitespace = true };
+            umbracoConfig.Load(fileName);
+
+            var action = disable ? "disable" : "enable";
+
+            if (File.Exists(fileName) == false)
+                throw new Exception($"Couldn't {action} URL Tracker, the umbracoSettings.config file does not exist.");
+
+            if (!(umbracoConfig.SelectSingleNode("//web.routing") is XmlElement webRoutingElement))
+                throw new Exception($"Couldn't {action} URL Tracker, the web.routing element was not found in umbracoSettings.config.");
+
+            // note: this adds the attribute if it does not exist
+            webRoutingElement.SetAttribute("disableRedirectUrlTracking", disable.ToString().ToLowerInvariant());
+            umbracoConfig.Save(fileName);
         }
 
         private static void AddOrUpdateAttribute(XElement element, string name, string value)

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -65,6 +65,40 @@ namespace Umbraco.Core.Configuration
 
         }
 
+        public void SaveDisableRedirectUrlTracking(bool disable)
+        {
+            var provider = GetJsonConfigurationProvider();
+
+            var json = GetJson(provider);
+
+            var item = GetDisableRedirectUrlItem(disable.ToString().ToLowerInvariant());
+
+            json.Merge(item, new JsonMergeSettings());
+
+            SaveJson(provider, json);
+        }
+
+        private JToken GetDisableRedirectUrlItem(string value)
+        {
+            JTokenWriter writer = new JTokenWriter();
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("Umbraco");
+            writer.WriteStartObject();
+            writer.WritePropertyName("CMS");
+            writer.WriteStartObject();
+            writer.WritePropertyName("WebRouting");
+            writer.WriteStartObject();
+            writer.WritePropertyName("DisableRedirectUrlTracking");
+            writer.WriteValue(value);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+
+            return writer.Token;
+        }
+
         private JToken GetConnectionItem(string connectionString, string providerName)
         {
             JTokenWriter writer = new JTokenWriter();
@@ -135,7 +169,7 @@ namespace Umbraco.Core.Configuration
             {
                 foreach (var provider in configurationRoot.Providers)
                 {
-                    if(provider is JsonConfigurationProvider jsonConfigurationProvider)
+                    if (provider is JsonConfigurationProvider jsonConfigurationProvider)
                     {
                         if (requiredKey is null || provider.TryGet(requiredKey, out _))
                         {

--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingComponent.cs
@@ -40,9 +40,6 @@ namespace Umbraco.Web.Routing
 
         public void Initialize()
         {
-            // don't let the event handlers kick in if Redirect Tracking is turned off in the config
-            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
-
             ContentService.Publishing += ContentService_Publishing;
             ContentService.Published += ContentService_Published;
             ContentService.Moving += ContentService_Moving;
@@ -66,6 +63,9 @@ namespace Umbraco.Web.Routing
 
         private void ContentService_Publishing(IContentService sender, PublishEventArgs<IContent> args)
         {
+            // don't let the event handlers kick in if Redirect Tracking is turned off in the config
+            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+
             var oldRoutes = GetOldRoutes(args.EventState);
             foreach (var entity in args.PublishedEntities)
             {
@@ -75,12 +75,18 @@ namespace Umbraco.Web.Routing
 
         private void ContentService_Published(IContentService sender, ContentPublishedEventArgs args)
         {
+            // don't let the event handlers kick in if Redirect Tracking is turned off in the config
+            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+
             var oldRoutes = GetOldRoutes(args.EventState);
             CreateRedirects(oldRoutes);
         }
 
         private void ContentService_Moving(IContentService sender, MoveEventArgs<IContent> args)
         {
+            // don't let the event handlers kick in if Redirect Tracking is turned off in the config
+            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+
             var oldRoutes = GetOldRoutes(args.EventState);
             foreach (var info in args.MoveInfoCollection)
             {
@@ -90,6 +96,9 @@ namespace Umbraco.Web.Routing
 
         private void ContentService_Moved(IContentService sender, MoveEventArgs<IContent> args)
         {
+            // don't let the event handlers kick in if Redirect Tracking is turned off in the config
+            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+
             var oldRoutes = GetOldRoutes(args.EventState);
             CreateRedirects(oldRoutes);
         }


### PR DESCRIPTION
Issue: https://github.com/umbraco/Umbraco-CMS/issues/8835 reported on alpha001.

Testing notes:
- Navigate to the _Redirect Url Management_ dashboard in the **Content** section;
- Clicking "Disable URL tracker" and confirming will present you with a success notification stating _"**URL tracker has now been disabled.**"_ 
  - check appsettings.json ➡️ there needs to be a new property object like:
```
"Umbraco": {
    "CMS": {
      . . .
      "WebRouting": {
        "DisableRedirectUrlTracking": "true"
      }
   }
}
```
- Clicking then "Enable URL tracker" will present you once more with a success notification this time saying _"**URL tracker has now been enabled.**"_ 
  - check appsettings.json ➡️ the value of `DisableRedirectUrlTracking` should be set to `"false"`