### PR TITLE
V8: stabilize cypress tests and add content with contentpicker test 

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -331,8 +331,8 @@ context('Content', () => {
         cy.reload();
 
         // Assert
-        cy.get('.history').find('.umb-badge').eq(0).should('contain.text', "Save");
-        cy.get('.history').find('.umb-badge').eq(1).should('contain.text', "Rollback");
+        cy.get('.history').find('.umb-badge').contains('Save').should('be.visible');
+        cy.get('.history').find('.umb-badge').contains('Rollback').should('be.visible');
         cy.get('#headerName').should('have.value', initialNodeName);
 
         // Clean up (content is automatically deleted when document types are gone)

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -48,8 +48,8 @@ context('Content', () => {
                     .withContentTypeAlias(rootDocTypeAlias)
                     .withAction("saveNew")
                     .addVariant()
-                    .withName(nodeName)
-                    .withSave(true)
+                        .withName(nodeName)
+                        .withSave(true)
                     .done()
                     .build();
 
@@ -60,8 +60,8 @@ context('Content', () => {
                         .withAction("saveNew")
                         .withParent(contentNode["id"])
                         .addVariant()
-                        .withName(childNodeName)
-                        .withSave(true)
+                            .withName(childNodeName)
+                            .withSave(true)
                         .done()
                         .build();
 
@@ -72,8 +72,8 @@ context('Content', () => {
                     .withContentTypeAlias(rootDocTypeAlias)
                     .withAction("saveNew")
                     .addVariant()
-                    .withName(anotherNodeName)
-                    .withSave(true)
+                        .withName(anotherNodeName)
+                        .withSave(true)
                     .done()
                     .build();
 
@@ -132,8 +132,8 @@ context('Content', () => {
                     .withContentTypeAlias(rootDocTypeAlias)
                     .withAction("saveNew")
                     .addVariant()
-                    .withName(nodeName)
-                    .withSave(true)
+                        .withName(nodeName)
+                        .withSave(true)
                     .done()
                     .build();
 
@@ -144,8 +144,8 @@ context('Content', () => {
                         .withAction("saveNew")
                         .withParent(contentNode["id"])
                         .addVariant()
-                        .withName(childNodeName)
-                        .withSave(true)
+                            .withName(childNodeName)
+                            .withSave(true)
                         .done()
                         .build();
 
@@ -156,8 +156,8 @@ context('Content', () => {
                     .withContentTypeAlias(rootDocTypeAlias)
                     .withAction("saveNew")
                     .addVariant()
-                    .withName(anotherNodeName)
-                    .withSave(true)
+                        .withName(anotherNodeName)
+                        .withSave(true)
                     .done()
                     .build();
 
@@ -215,8 +215,8 @@ context('Content', () => {
                     .withContentTypeAlias(generatedRootDocType["alias"])
                     .withAction("saveNew")
                     .addVariant()
-                    .withName(nodeName)
-                    .withSave(true)
+                        .withName(nodeName)
+                        .withSave(true)
                     .done()
                     .build();
 
@@ -229,8 +229,8 @@ context('Content', () => {
                         .withAction("saveNew")
                         .withParent(parentId)
                         .addVariant()
-                        .withName(firstChildNodeName)
-                        .withSave(true)
+                            .withName(firstChildNodeName)
+                            .withSave(true)
                         .done()
                         .build();
 
@@ -242,8 +242,8 @@ context('Content', () => {
                         .withAction("saveNew")
                         .withParent(parentId)
                         .addVariant()
-                        .withName(secondChildNodeName)
-                        .withSave(true)
+                            .withName(secondChildNodeName)
+                            .withSave(true)
                         .done()
                         .build();
 
@@ -293,8 +293,8 @@ context('Content', () => {
             const rootContentNode = new ContentBuilder()
                 .withContentTypeAlias(generatedRootDocType["alias"])
                 .addVariant()
-                .withName(initialNodeName)
-                .withSave(true)
+                    .withName(initialNodeName)
+                    .withSave(true)
                 .done()
                 .build();
 
@@ -348,9 +348,9 @@ context('Content', () => {
             .withName(rootDocTypeName)
             .withAllowAsRoot(true)
             .addGroup()
-            .addTextBoxProperty()
-            .withLabel(labelName)
-            .done()
+                .addTextBoxProperty()
+                    .withLabel(labelName)
+                .done()
             .done()
             .build();
 
@@ -361,8 +361,8 @@ context('Content', () => {
             const rootContentNode = new ContentBuilder()
                 .withContentTypeAlias(generatedRootDocType["alias"])
                 .addVariant()
-                .withName(nodeName)
-                .withSave(true)
+                    .withName(nodeName)
+                    .withSave(true)
                 .done()
                 .build();
 
@@ -402,8 +402,8 @@ context('Content', () => {
                 .withContentTypeAlias(generatedRootDocType["alias"])
                 .withAction("saveNew")
                 .addVariant()
-                .withName(nodeName)
-                .withSave(true)
+                    .withName(nodeName)
+                    .withSave(true)
                 .done()
                 .build();
 
@@ -440,8 +440,8 @@ context('Content', () => {
                 .withContentTypeAlias(generatedRootDocType["alias"])
                 .withAction("saveNew")
                 .addVariant()
-                .withName(nodeName)
-                .withSave(true)
+                    .withName(nodeName)
+                    .withSave(true)
                 .done()
                 .build();
 
@@ -480,8 +480,8 @@ context('Content', () => {
             const rootContentNode = new ContentBuilder()
                 .withContentTypeAlias(generatedRootDocType["alias"])
                 .addVariant()
-                .withName(nodeName)
-                .withSave(true)
+                    .withName(nodeName)
+                    .withSave(true)
                 .done()
                 .build();
 
@@ -502,10 +502,10 @@ context('Content', () => {
     });
 
     it('Content with contentpicker', () => {
-        const pickerDocTypeName = 'Content Picker Type';
+        const pickerDocTypeName = 'Content picker doc type';
         const groupName = 'ContentPickerGroup';
         const alias = AliasHelper.toAlias(pickerDocTypeName);
-        const pickedDocTypeName = 'Picked Content Type';
+        const pickedDocTypeName = 'Picked content document type';
         const pickedNodeName = 'Content to pick';
 
         cy.deleteAllContent();
@@ -518,8 +518,8 @@ context('Content', () => {
             .withName(pickedDocTypeName)
             .withAllowAsRoot(true)
             .addGroup()
-            .addTextBoxProperty()
-            .withAlias('text')
+                .addTextBoxProperty()
+                .withAlias('text')
             .done()
             .done()
             .build();
@@ -533,8 +533,8 @@ context('Content', () => {
                 .withSave(true)
                 .withPublish(true)
                 .addProperty()
-                .withAlias('text')
-                .withValue('Acceptance test')
+                    .withAlias('text')
+                    .withValue('Acceptance test')
                 .done()
                 .withSave(true)
                 .withPublish(true)
@@ -550,10 +550,10 @@ context('Content', () => {
             .withAllowAsRoot(true)
             .withDefaultTemplate(alias)
             .addGroup()
-            .withName(groupName)
-            .addContentPickerProperty()
-            .withAlias('picker')
-            .done()
+                .withName(groupName)
+                .addContentPickerProperty()
+                    .withAlias('picker')
+                .done()
             .done()
             .build();
 

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -503,10 +503,8 @@ context('Content', () => {
 
     it('Content with contentpicker', () => {
         const pickerDocTypeName = 'Content picker doc type';
-        const groupName = 'ContentPickerGroup';
-        const alias = AliasHelper.toAlias(pickerDocTypeName);
+        const pickerDocTypeAlias = AliasHelper.toAlias(pickerDocTypeName);
         const pickedDocTypeName = 'Picked content document type';
-        const pickedNodeName = 'Content to pick';
 
         cy.deleteAllContent();
         cy.umbracoEnsureDocumentTypeNameNotExists(pickerDocTypeName);
@@ -529,7 +527,7 @@ context('Content', () => {
                 .withContentTypeAlias(generatedType["alias"])
                 .withAction("publishNew")
                 .addVariant()
-                .withName(pickedNodeName)
+                .withName('Content to pick')
                 .withSave(true)
                 .withPublish(true)
                 .addProperty()
@@ -546,11 +544,11 @@ context('Content', () => {
         // Create the doctype with a the picker
         const pickerDocType = new DocumentTypeBuilder()
             .withName(pickerDocTypeName)
-            .withAlias(alias)
+            .withAlias(pickerDocTypeAlias)
             .withAllowAsRoot(true)
-            .withDefaultTemplate(alias)
+            .withDefaultTemplate(pickerDocTypeAlias)
             .addGroup()
-                .withName(groupName)
+                .withName('ContentPickerGroup')
                 .addContentPickerProperty()
                     .withAlias('picker')
                 .done()
@@ -560,7 +558,7 @@ context('Content', () => {
         cy.saveDocumentType(pickerDocType);
 
         // Edit it the template to allow us to verify the rendered view.
-        cy.editTemplate(pickerDocTypeName, `@inherits Umbraco.Web.Mvc.UmbracoViewPage<ContentModels.ContentPickerType>
+        cy.editTemplate(pickerDocTypeName, `@inherits Umbraco.Web.Mvc.UmbracoViewPage<ContentModels.ContentPickerDocType>
         @using ContentModels = Umbraco.Web.PublishedModels;
         @{
             Layout = null;
@@ -577,7 +575,7 @@ context('Content', () => {
         // Create content with content picker
         cy.get('.umb-tree-root-link').rightclick();
         cy.get('.-opens-dialog > .umb-action-link').click();
-        cy.get('[data-element="action-create-contentPickerType"] > .umb-action-link').click();
+        cy.get('[data-element="action-create-' + pickerDocTypeAlias + '"] > .umb-action-link').click();
         // Fill out content
         cy.umbracoEditorHeaderName('ContentPickerContent');
         cy.get('.umb-node-preview-add').click();
@@ -590,6 +588,7 @@ context('Content', () => {
         cy.umbracoSuccessNotification().should('be.visible');
 
         // Assert
+        cy.log('Checking that content is rendered correctly.')
         const expectedContent = '<p>Acceptance test</p>'
         cy.umbracoVerifyRenderedViewContent('contentpickercontent', expectedContent, true).should('be.true');
         // clean

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -317,11 +317,11 @@ context('Content', () => {
         // Rollback
         cy.get('.umb-box-header :button').click();
 
-        cy.get('.umb-box-content > .ng-scope > .input-block-level')
+        cy.get('.umb-box-content > div > .input-block-level')
             .find('option[label*=' + new Date().getDate() + ']')
             .then(elements => {
                 const option = elements[[elements.length - 1]].getAttribute('value');
-                cy.get('.umb-box-content > .ng-scope > .input-block-level')
+                cy.get('.umb-box-content > div > .input-block-level')
                     .select(option);
             });
 
@@ -330,8 +330,8 @@ context('Content', () => {
         cy.reload();
 
         // Assert
-        cy.get('.history').find('.umb-badge').eq(0).should('contain.text', "Rollback");
-        cy.get('.history').find('.umb-badge').eq(1).should('contain.text', "Save");
+        cy.get('.history').find('.umb-badge').eq(0).should('contain.text', "Save");
+        cy.get('.history').find('.umb-badge').eq(1).should('contain.text', "Rollback");
         cy.get('#headerName').should('have.value', initialNodeName);
 
         // Clean up (content is automatically deleted when document types are gone)

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -313,6 +313,7 @@ context('Content', () => {
 
         // Save and publish
         cy.get('.btn-success').first().click();
+        cy.umbracoSuccessNotification().should('be.visible');
 
         // Rollback
         cy.get('.umb-box-header :button').click();

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -517,8 +517,8 @@ context('Content', () => {
             .withAllowAsRoot(true)
             .addGroup()
                 .addTextBoxProperty()
-                .withAlias('text')
-            .done()
+                    .withAlias('text')
+                .done()
             .done()
             .build();
             

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -1,5 +1,5 @@
 /// <reference types="Cypress" />
-import { DocumentTypeBuilder, ContentBuilder } from 'umbraco-cypress-testhelpers';
+import { DocumentTypeBuilder, ContentBuilder, AliasHelper } from 'umbraco-cypress-testhelpers';
 context('Content', () => {
 
     beforeEach(() => {
@@ -498,5 +498,102 @@ context('Content', () => {
 
         // Clean up (content is automatically deleted when document types are gone)
         cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+    });
+
+    it('Content with contentpicker', () => {
+        const pickerDocTypeName = 'Content Picker Type';
+        const groupName = 'ContentPickerGroup';
+        const alias = AliasHelper.toAlias(pickerDocTypeName);
+        const pickedDocTypeName = 'Picked Content Type';
+        const pickedNodeName = 'Content to pick';
+
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(pickerDocTypeName);
+        cy.umbracoEnsureTemplateNameNotExists(pickerDocTypeName);
+        cy.umbracoEnsureDocumentTypeNameNotExists(pickedDocTypeName);
+
+        // Create the content type and content we'll be picking from.
+        const pickedDocType = new DocumentTypeBuilder()
+            .withName(pickedDocTypeName)
+            .withAllowAsRoot(true)
+            .addGroup()
+            .addTextBoxProperty()
+            .withAlias('text')
+            .done()
+            .done()
+            .build();
+            
+        cy.saveDocumentType(pickedDocType).then((generatedType) => {
+            const pickedContentNode = new ContentBuilder()
+                .withContentTypeAlias(generatedType["alias"])
+                .withAction("publishNew")
+                .addVariant()
+                .withName(pickedNodeName)
+                .withSave(true)
+                .withPublish(true)
+                .addProperty()
+                .withAlias('text')
+                .withValue('Acceptance test')
+                .done()
+                .withSave(true)
+                .withPublish(true)
+                .done()
+                .build();
+            cy.saveContent(pickedContentNode);
+        });
+
+        // Create the doctype with a the picker
+        const pickerDocType = new DocumentTypeBuilder()
+            .withName(pickerDocTypeName)
+            .withAlias(alias)
+            .withAllowAsRoot(true)
+            .withDefaultTemplate(alias)
+            .addGroup()
+            .withName(groupName)
+            .addContentPickerProperty()
+            .withAlias('picker')
+            .done()
+            .done()
+            .build();
+
+        cy.saveDocumentType(pickerDocType);
+
+        // Edit it the template to allow us to verify the rendered view.
+        cy.editTemplate(pickerDocTypeName, `@inherits Umbraco.Web.Mvc.UmbracoViewPage<ContentModels.ContentPickerType>
+        @using ContentModels = Umbraco.Web.PublishedModels;
+        @{
+            Layout = null;
+        }
+        
+        @{
+            IPublishedContent typedContentPicker = Model.Value<IPublishedContent>("picker");
+            if (typedContentPicker != null)
+            {
+                <p>@typedContentPicker.Value("text")</p>
+            }
+        }`);
+
+        // Create content with content picker
+        cy.get('.umb-tree-root-link').rightclick();
+        cy.get('.-opens-dialog > .umb-action-link').click();
+        cy.get('[data-element="action-create-contentPickerType"] > .umb-action-link').click();
+        // Fill out content
+        cy.umbracoEditorHeaderName('ContentPickerContent');
+        cy.get('.umb-node-preview-add').click();
+        // Should really try and find a better way to do this, but umbracoTreeItem tries to click the content pane in the background
+        cy.get('[ng-if="vm.treeReady"] > .umb-tree > [ng-if="!tree.root.containsGroups"] > .umb-animated > .umb-tree-item__inner').click();
+        // We have to wait for the picked content to show up or it wont be added.
+        cy.get('.umb-node-preview__description').should('be.visible');
+        //save and publish
+        cy.umbracoButtonByLabelKey('buttons_saveAndPublish').click();
+        cy.umbracoSuccessNotification().should('be.visible');
+
+        // Assert
+        const expectedContent = '<p>Acceptance test</p>'
+        cy.umbracoVerifyRenderedViewContent('contentpickercontent', expectedContent, true).should('be.true');
+        // clean
+        cy.umbracoEnsureDocumentTypeNameNotExists(pickerDocTypeName);
+        cy.umbracoEnsureTemplateNameNotExists(pickerDocTypeName);
+        cy.umbracoEnsureDocumentTypeNameNotExists(pickedDocTypeName);
     });
 });

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Content/content.ts
@@ -6,6 +6,14 @@ context('Content', () => {
         cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'));
     });
 
+    function refreshContentTree(){
+        // Refresh to update the tree
+        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
+        cy.umbracoContextMenuAction("action-refreshNode").click();
+        // We have to wait in case the execution is slow, otherwise we'll try and click the item before it appears in the UI
+        cy.get('.umb-tree-item__inner').should('exist', {timeout: 10000});
+    }
+
     it('Copy content', () => {
         const rootDocTypeName = "Test document type";
         const childDocTypeName = "Child test document type";
@@ -74,8 +82,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Copy node
         cy.umbracoTreeItem("content", [nodeName, childNodeName]).rightclick({ force: true });
@@ -159,8 +166,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Move node
         cy.umbracoTreeItem("content", [nodeName, childNodeName]).rightclick({ force: true });
@@ -247,8 +253,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Sort nodes
         cy.umbracoTreeItem("content", [nodeName]).rightclick({ force: true });
@@ -297,8 +302,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Access node
         cy.umbracoTreeItem("content", [initialNodeName]).click();
@@ -326,8 +330,8 @@ context('Content', () => {
         cy.reload();
 
         // Assert
-        cy.get('.history').find('.umb-badge').eq(0).should('contain.text', "Save");
-        cy.get('.history').find('.umb-badge').eq(1).should('contain.text', "Rollback");
+        cy.get('.history').find('.umb-badge').eq(0).should('contain.text', "Rollback");
+        cy.get('.history').find('.umb-badge').eq(1).should('contain.text', "Save");
         cy.get('#headerName').should('have.value', initialNodeName);
 
         // Clean up (content is automatically deleted when document types are gone)
@@ -365,8 +369,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Access node
         cy.umbracoTreeItem("content", [nodeName]).click();
@@ -407,8 +410,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Access node
         cy.umbracoTreeItem("content", [nodeName]).click();
@@ -446,8 +448,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Access node
         cy.umbracoTreeItem("content", [nodeName]).click();
@@ -487,8 +488,7 @@ context('Content', () => {
         });
 
         // Refresh to update the tree
-        cy.get('li .umb-tree-root:contains("Content")').should("be.visible").rightclick();
-        cy.umbracoContextMenuAction("action-refreshNode").click();
+        refreshContentTree();
 
         // Access node
         cy.umbracoTreeItem("content", [nodeName]).click();

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Members/members.js
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Members/members.js
@@ -8,7 +8,7 @@ context('Members', () => {
     it('Create member', () => {
         const name = "Alice Bobson";
         const email = "alice-bobson@acceptancetest.umbraco";
-        const password = "$AUlkoF*St0kgPiyyVEk5iU5JWdN*F7&@OSl5Y4pOofnidfifkBj5Ns2ONv%FzsTl36V1E924Gw97zcuSeT7UwK&qb5l&O9h!d!w";
+        const password = "$AUlkoF*St0kgPiyyVEk5iU5JWdN*F7&";
         const passwordTimeout = 20000
 
         cy.umbracoEnsureMemberEmailNotExists(email);

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Members/members.js
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Members/members.js
@@ -9,6 +9,7 @@ context('Members', () => {
         const name = "Alice Bobson";
         const email = "alice-bobson@acceptancetest.umbraco";
         const password = "$AUlkoF*St0kgPiyyVEk5iU5JWdN*F7&@OSl5Y4pOofnidfifkBj5Ns2ONv%FzsTl36V1E924Gw97zcuSeT7UwK&qb5l&O9h!d!w";
+        const passwordTimeout = 20000
 
         cy.umbracoEnsureMemberEmailNotExists(email);
         cy.umbracoSection('member');
@@ -24,8 +25,8 @@ context('Members', () => {
 
         cy.get('input#_umb_login').clear().type(email);
         cy.get('input#_umb_email').clear().type(email);
-        cy.get('input#password').clear().type(password);
-        cy.get('input#confirmPassword').clear().type(password);
+        cy.get('input#password').clear().type(password, { timeout: passwordTimeout });
+        cy.get('input#confirmPassword').clear().type(password, { timeout: passwordTimeout });
 
         // Save
         cy.get('.btn-success').click();

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -27,12 +27,14 @@ context('Templates', () => {
         createTemplate();
         //Type name
         cy.umbracoEditorHeaderName(name);
-        /* Make an edit, if you don't the file will be create twice,
-        only happens in testing though, probably because the test is too fast
-        Certifiably mega wonk regardless */
-        cy.get('.ace_text-input').type("var num = 5;", {force:true} );
-
-        //Save
+        /*
+        Click the content area, if we don't do this we wont get redirected
+        to the new edit url, this will cause the test to save two copies at best
+        worst case, we'll get an error "The process cannot access the file" on the
+        template.
+         */
+        cy.get('.ace_content').click();
+        // Save
         cy.get('.btn-success').click();
 
         //Assert

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -21,20 +21,21 @@ context('Templates', () => {
 
 
     it('Create template', () => {
-        const name = "Test template test";
+        const name = "Create Template test";
         cy.umbracoEnsureTemplateNameNotExists(name);
 
         createTemplate();
         //Type name
         cy.umbracoEditorHeaderName(name);
-        /*
-        Click the content area, if we don't do this we wont get redirected
-        to the new edit url, this will cause the test to save two copies at best
-        worst case, we'll get an error "The process cannot access the file" on the
-        template.
-         */
-        cy.get('.ace_content').click();
         // Save
+        // We must drop focus for the auto save event to occur.
+        cy.get('.btn-success').focus();
+        // And then wait for the auto save event to finish but finding the page in the tree view
+        // This is a bit of a roundabout way to find items in a treev view since we dont use umbracoTreeItem
+        // But we must be able to wait for the save evnent to finish, and we can't do that with umbracoTreeItem
+        cy.get('[data-element="tree-item-templates"] > :nth-child(2) > .umb-animated > .umb-tree-item__inner > .umb-tree-item__label').contains(name).should('be.visible', {timeout:10000});
+        // Now that the auto save event has finished we can save
+        // And there wont be any duplicates or file in use errors.
         cy.get('.btn-success').click();
 
         //Assert

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -19,7 +19,7 @@ context('Templates', () => {
     }
 
     it('Create template', () => {
-        const name = "Create Template test";
+        const name = "Create template test";
         cy.umbracoEnsureTemplateNameNotExists(name);
 
         createTemplate();

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -18,8 +18,6 @@ context('Templates', () => {
         cy.umbracoContextMenuAction("action-create").click();
     }
 
-
-
     it('Create template', () => {
         const name = "Create Template test";
         cy.umbracoEnsureTemplateNameNotExists(name);
@@ -40,6 +38,9 @@ context('Templates', () => {
 
         //Assert
         cy.umbracoSuccessNotification().should('be.visible');
+        // For some reason cy.umbracoErrorNotification tries to click the element which is not possible
+        // if it doesn't actually exist, making should('not.be.visible') impossible.
+        cy.get('.umb-notifications__notifications > .alert-error', {timeout: 5000}).should('not.be.visible');
 
         //Clean up
         cy.umbracoEnsureTemplateNameNotExists(name);

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -28,19 +28,20 @@ context('Templates', () => {
         // Save
         // We must drop focus for the auto save event to occur.
         cy.get('.btn-success').focus();
-        // And then wait for the auto save event to finish but finding the page in the tree view
+        // And then wait for the auto save event to finish by finding the page in the tree view.
         // This is a bit of a roundabout way to find items in a treev view since we dont use umbracoTreeItem
-        // But we must be able to wait for the save evnent to finish, and we can't do that with umbracoTreeItem
-        cy.get('[data-element="tree-item-templates"] > :nth-child(2) > .umb-animated > .umb-tree-item__inner > .umb-tree-item__label').contains(name).should('be.visible', {timeout:10000});
+        // but we must be able to wait for the save evnent to finish, and we can't do that with umbracoTreeItem
+        cy.get('[data-element="tree-item-templates"] > :nth-child(2) > .umb-animated > .umb-tree-item__inner > .umb-tree-item__label')
+            .contains(name).should('be.visible', { timeout: 10000 });
         // Now that the auto save event has finished we can save
-        // And there wont be any duplicates or file in use errors.
+        // and there wont be any duplicates or file in use errors.
         cy.get('.btn-success').click();
 
         //Assert
         cy.umbracoSuccessNotification().should('be.visible');
         // For some reason cy.umbracoErrorNotification tries to click the element which is not possible
         // if it doesn't actually exist, making should('not.be.visible') impossible.
-        cy.get('.umb-notifications__notifications > .alert-error', {timeout: 5000}).should('not.be.visible');
+        cy.get('.umb-notifications__notifications > .alert-error').should('not.be.visible');
 
         //Clean up
         cy.umbracoEnsureTemplateNameNotExists(name);

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
@@ -71,7 +71,7 @@ function resetTourData() {
 function runBackOfficeIntroTour(percentageComplete, buttonText, timeout) {
     cy.get('[data-element="help-tours"]').should("be.visible");
     cy.get('[data-element="help-tours"]').click();
-    cy.get('[data-element="help-tours"] .umb-progress-circle', { timeout: timeout }).get('[percentage]').contains(percentageComplete + '%');
+    cy.get('[data-element="help-tours"] .umb-progress-circle', { timeout: timeout }).get('[percentage]').contains(percentageComplete + '%', {timeout: timeout});
     cy.get('[data-element="help-tours"]').click();
     cy.get('[data-element="tour-umbIntroIntroduction"] .umb-button').should("be.visible");
     cy.get('[data-element="tour-umbIntroIntroduction"] .umb-button').contains(buttonText);

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
@@ -71,7 +71,7 @@ function resetTourData() {
 function runBackOfficeIntroTour(percentageComplete, buttonText, timeout) {
     cy.get('[data-element="help-tours"]').should("be.visible");
     cy.get('[data-element="help-tours"]').click();
-    cy.get('[data-element="help-tours"] .umb-progress-circle', { timeout: timeout }).get('[percentage]').contains(percentageComplete + '%', {timeout: timeout});
+    cy.get('[data-element="help-tours"] .umb-progress-circle', { timeout: timeout }).get('[percentage]').contains(percentageComplete + '%', { timeout: timeout });
     cy.get('[data-element="help-tours"]').click();
     cy.get('[data-element="tour-umbIntroIntroduction"] .umb-button').should("be.visible");
     cy.get('[data-element="tour-umbIntroIntroduction"] .umb-button').contains(buttonText);

--- a/src/Umbraco.Tests.AcceptanceTest/package.json
+++ b/src/Umbraco.Tests.AcceptanceTest/package.json
@@ -7,7 +7,7 @@
     "cross-env": "^7.0.2",
     "cypress": "^5.1.0",
     "ncp": "^2.0.0",
-    "umbraco-cypress-testhelpers": "^1.0.0-beta-50"
+    "umbraco-cypress-testhelpers": "^1.0.0-beta-51"
   },
   "dependencies": {
     "typescript": "^3.9.2"


### PR DESCRIPTION
I added the content with contentpicker test. 

I also did some tweaks to the existing tests, to make them more stable. 

### Content tests
I fetch the content node tree after refreshing content, this is just to wait for the content to appear after refreshing if we don't do this the tests will fail because it tries to click an item that does not exist yet, while doing so I also put in in a function since it's used in almost all test.

A very minor thing but I indented function calls to child builders, making it easier to see what belongs where

### Content rollback test
I also changed the content rollback test, we no longer expect the badges to be in a certain order since it's not deterministic in this version of the UI, I managed to get this result when doing rollback manually 
![non determenistic badges](https://user-images.githubusercontent.com/16456704/95435091-6ddb7800-0952-11eb-9276-a1527bf12966.png)
The first time it's Rollback -> Save
The other time it's Save -> Rollback.
Since the order is not deterministic we cannot assume that one badge appears before the other, the test does, however, assert that the title is actually being rolled back, so it's still a valid test. 

I also changed the selector when selecting the rollback version since this has been changed in the UI.


### Create template test
I did some tweaks to the create template test as well, instead of trying to write something in the editor to force the autosave, we just remove focus from it by focusing on something else, this triggers the autosave, after that, we wait for the autosave to complete by waiting for the template to appear in the tree view. If we don't do all this there will at best be saved a duplicate of the template, and at worst, it will error out because of the template file being in use. 
At one point I thought this was an actual bug, but I cannot reproduce it manually anymore.

### Tours tests
I added a timeout to the ```contains``` call when getting the percentages before running a test, once in a while, it took a little too long before the value got loaded into the progress tracker causing the test to fail 

### Members tests
I add an increased timeout when typing in the password. The password is very long and may exceed the default 4-second timeout for typing causing the last portion of the password to be cut off on slower systems.

### Needs to be fixed in testhelpers package
Having run the tests a multitude of times one of the tests failed once due to umbracoEditorHeaderName, this issue is related to the one in member tests, the issue occurs because the type command in
```cy.get('#headerName', { log: false }).type(typedText).should('have.value', typedText);``` 
times out before the whole name has been typed, meaning that the should assert failes, because it does not match the expected.

This is easily fixed by adding a longer timeout on the type command, but can't be done in this PR 