### PR TITLE
[DRAFT] Started moving to JSON instead of config for Healthchecks

### DIFF
--- a/src/Umbraco.Core/Configuration/HealthChecks/CompilationDebugCheck.cs
+++ b/src/Umbraco.Core/Configuration/HealthChecks/CompilationDebugCheck.cs
@@ -1,23 +1,22 @@
 ﻿using System.Collections.Generic;
-using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
-namespace Umbraco.Web.HealthCheck.Checks.Config
+namespace Umbraco.Core.Configuration.HealthChecks
 {
     [HealthCheck("61214FF3-FC57-4B31-B5CF-1D095C977D6D", "Debug Compilation Mode",
         Description = "Leaving debug compilation mode enabled can severely slow down a website and take up more memory on the server.",
         Group = "Live Environment")]
     public class CompilationDebugCheck : AbstractConfigCheck
     {
-        public CompilationDebugCheck(ILocalizedTextService textService, IHostingEnvironment hostingEnvironment, ILogger logger)
-            : base(textService, hostingEnvironment, logger)
+        public CompilationDebugCheck(IConfiguration configuration, ILocalizedTextService textService, ILogger logger)
+            : base(configuration, textService, logger)
         { }
 
-        public override string FilePath => "~/Web.config";
-
-        public override string XPath => "/configuration/system.web/compilation/@debug";
+        public override string Key => "/configuration/system.web/compilation/@debug";
 
         public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldEqual;
 

--- a/src/Umbraco.Core/Configuration/HealthChecks/CustomErrorsCheck.cs
+++ b/src/Umbraco.Core/Configuration/HealthChecks/CustomErrorsCheck.cs
@@ -1,24 +1,23 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
-namespace Umbraco.Web.HealthCheck.Checks.Config
+namespace Umbraco.Core.Configuration.HealthChecks
 {
     [HealthCheck("4090C0A1-2C52-4124-92DD-F028FD066A64", "Custom Errors",
         Description = "Leaving custom errors off will display a complete stack trace to your visitors if an exception occurs.",
         Group = "Live Environment")]
     public class CustomErrorsCheck : AbstractConfigCheck
     {
-        public CustomErrorsCheck(ILocalizedTextService textService, IHostingEnvironment hostingEnvironment, ILogger logger)
-            : base(textService, hostingEnvironment, logger)
+        public CustomErrorsCheck(IConfiguration configuration, ILocalizedTextService textService, ILogger logger)
+            : base(configuration, textService, logger)
         { }
 
-        public override string FilePath => "~/Web.config";
-
-        public override string XPath => "/configuration/system.web/customErrors/@mode";
+        public override string Key => "/configuration/system.web/customErrors/@mode";
 
         public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldEqual;
 

--- a/src/Umbraco.Core/Configuration/HealthChecks/MacroErrorsCheck.cs
+++ b/src/Umbraco.Core/Configuration/HealthChecks/MacroErrorsCheck.cs
@@ -1,24 +1,24 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
-namespace Umbraco.Web.HealthCheck.Checks.Config
+namespace Umbraco.Core.Configuration.HealthChecks
 {
     [HealthCheck("D0F7599E-9B2A-4D9E-9883-81C7EDC5616F", "Macro errors",
         Description = "Checks to make sure macro errors are not set to throw a YSOD (yellow screen of death), which would prevent certain or all pages from loading completely.",
         Group = "Configuration")]
     public class MacroErrorsCheck : AbstractConfigCheck
     {
-        public MacroErrorsCheck(ILocalizedTextService textService, IHostingEnvironment hostingEnvironment, ILogger logger)
-            : base(textService, hostingEnvironment, logger)
+        public MacroErrorsCheck(IConfiguration configuration, ILocalizedTextService textService, ILogger logger)
+        : base(configuration, textService, logger)
         { }
 
-        public override string FilePath => "~/Config/umbracoSettings.config";
-
-        public override string XPath => "/settings/content/MacroErrors";
+        public override string Key => "Umbraco:CMS:Content:MacroErrors";
 
         public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldEqual;
 

--- a/src/Umbraco.Core/Configuration/HealthChecks/NotificationEmailCheck.cs
+++ b/src/Umbraco.Core/Configuration/HealthChecks/NotificationEmailCheck.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
-namespace Umbraco.Web.HealthCheck.Checks.Config
+namespace Umbraco.Core.Configuration.HealthChecks
 {
     [HealthCheck("3E2F7B14-4B41-452B-9A30-E67FBC8E1206", "Notification Email Settings",
         Description = "If notifications are used, the 'from' email address should be specified and changed from the default value.",
@@ -13,13 +15,12 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
     {
         private const string DefaultFromEmail = "your@email.here";
 
-        public NotificationEmailCheck(ILocalizedTextService textService, IHostingEnvironment hostingEnvironment, ILogger logger)
-            : base(textService, hostingEnvironment, logger)
-        { }
+        public NotificationEmailCheck(IConfiguration configuration, ILocalizedTextService textService, ILogger logger)
+            : base(configuration, textService, logger)
+        {
+        }
 
-        public override string FilePath => "~/Config/umbracoSettings.config";
-
-        public override string XPath => "/settings/content/notifications/email";
+        public override string Key => "Umbraco:CMS:Content:Notifications:Email";
 
         public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldNotEqual;
 
@@ -28,7 +29,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
             new AcceptableConfiguration { IsRecommended = false, Value = DefaultFromEmail }
         };
 
-        public override string CheckSuccessMessage => TextService.Localize("healthcheck/notificationEmailsCheckSuccessMessage", new [] { CurrentValue } );
+        public override string CheckSuccessMessage => TextService.Localize("healthcheck/notificationEmailsCheckSuccessMessage", new[] { CurrentValue });
 
         public override string CheckErrorMessage => TextService.Localize("healthcheck/notificationEmailsCheckErrorMessage", new[] { DefaultFromEmail });
     }

--- a/src/Umbraco.Core/Configuration/HealthChecks/TraceCheck.cs
+++ b/src/Umbraco.Core/Configuration/HealthChecks/TraceCheck.cs
@@ -1,24 +1,22 @@
 ﻿using System.Collections.Generic;
-using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
-namespace Umbraco.Web.HealthCheck.Checks.Config
+namespace Umbraco.Core.Configuration.HealthChecks
 {
     [HealthCheck("9BED6EF4-A7F3-457A-8935-B64E9AA8BAB3", "Trace Mode",
         Description = "Leaving trace mode enabled can make valuable information about your system available to hackers.",
         Group = "Live Environment")]
     public class TraceCheck : AbstractConfigCheck
     {
-
-        public TraceCheck(ILocalizedTextService textService, IHostingEnvironment hostingEnvironment, ILogger logger)
-            : base(textService, hostingEnvironment, logger)
+        public TraceCheck(IConfiguration configuration, ILocalizedTextService textService, ILogger logger)
+        : base(configuration, textService, logger)
         { }
 
-        public override string FilePath => "~/Web.config";
-
-        public override string XPath => "/configuration/system.web/trace/@enabled";
+        public override string Key => "/configuration/system.web/trace/@enabled";
 
         public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldEqual;
 

--- a/src/Umbraco.Core/Configuration/HealthChecks/TrySkipIisCustomErrorsCheck.cs
+++ b/src/Umbraco.Core/Configuration/HealthChecks/TrySkipIisCustomErrorsCheck.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Hosting;
-using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.Checks.Config;
 
-namespace Umbraco.Web.HealthCheck.Checks.Config
+namespace Umbraco.Core.Configuration.HealthChecks
 {
+    //TODO: this is not currently in the appsettings.JSON
     [HealthCheck("046A066C-4FB2-4937-B931-069964E16C66", "Try Skip IIS Custom Errors",
         Description = "Starting with IIS 7.5, this must be set to true for Umbraco 404 pages to show. Otherwise, IIS will takeover and render its built-in error page.",
         Group = "Configuration")]
@@ -15,16 +18,14 @@ namespace Umbraco.Web.HealthCheck.Checks.Config
     {
         private readonly Version _iisVersion;
 
-        public TrySkipIisCustomErrorsCheck(ILocalizedTextService textService, ILogger logger,
-            IHostingEnvironment hostingEnvironment)
-            : base(textService, hostingEnvironment, logger)
+        public TrySkipIisCustomErrorsCheck
+            (IConfiguration configuration, ILocalizedTextService textService, IHostingEnvironment hostingEnvironment, ILogger logger)
+            : base(configuration, textService, logger)
         {
             _iisVersion = hostingEnvironment.IISVersion;
         }
 
-        public override string FilePath => "~/Config/umbracoSettings.config";
-
-        public override string XPath => "/settings/web.routing/@trySkipIisCustomErrors";
+        public override string Key => "/settings/web.routing/@trySkipIisCustomErrors";
 
         public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldEqual;
 

--- a/src/Umbraco.Core/HealthCheck/Checks/Data/DatabaseIntegrityCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Data/DatabaseIntegrityCheck.cs
@@ -4,8 +4,9 @@ using System.Linq;
 using System.Text;
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck.Checks.Data
+namespace Umbraco.Core.HealthCheck.Checks.Data
 {
     [HealthCheck(
         "73DD0C1C-E0CA-4C31-9564-1DCA509788AF",

--- a/src/Umbraco.Core/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Permissions/FolderAndFilePermissionsCheck.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Umbraco.Core;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Install;
 using Umbraco.Core.IO;
 using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck.Checks.Permissions
+namespace Umbraco.Core.HealthCheck.Checks.Permissions
 {
     internal enum PermissionCheckRequirement
     {
@@ -26,7 +26,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Permissions
         "Folder & File Permissions",
         Description = "Checks that the web server folder and file permissions are set correctly for Umbraco to run.",
         Group = "Permissions")]
-    public class FolderAndFilePermissionsCheck : HealthCheck
+    public class FolderAndFilePermissionsCheck : Core.HealthCheck.HealthCheck
     {
         private readonly ILocalizedTextService _textService;
         private readonly IGlobalSettings _globalSettings;

--- a/src/Umbraco.Core/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Security/BaseHttpHeaderCheck.cs
@@ -4,13 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
-using System.Xml.XPath;
-using Umbraco.Core;
-using Umbraco.Core.IO;
+using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Services;
+using Umbraco.Web;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck.Checks.Security
+namespace Umbraco.Core.HealthCheck.Checks.Security
 {
     public abstract class BaseHttpHeaderCheck : HealthCheck
     {
@@ -23,16 +22,17 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         private readonly string _localizedTextPrefix;
         private readonly bool _metaTagOptionAvailable;
         private readonly IRequestAccessor _requestAccessor;
-        private readonly IIOHelper _ioHelper;
+        private readonly IConfiguration _configuration;
 
         protected BaseHttpHeaderCheck(
+            IConfiguration configuration,
             IRequestAccessor requestAccessor,
             ILocalizedTextService textService,
-            string header, string value, string localizedTextPrefix, bool metaTagOptionAvailable, IIOHelper ioHelper)
+            string header, string value, string localizedTextPrefix, bool metaTagOptionAvailable)
         {
             TextService = textService ?? throw new ArgumentNullException(nameof(textService));
+            _configuration = configuration;
             _requestAccessor = requestAccessor;
-            _ioHelper = ioHelper;
             _header = header;
             _value = value;
             _localizedTextPrefix = localizedTextPrefix;
@@ -72,7 +72,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             var success = false;
 
             // Access the site home page and check for the click-jack protection header or meta tag
-            var url =  _requestAccessor.GetApplicationUrl();
+            var url = _requestAccessor.GetApplicationUrl();
             var request = WebRequest.Create(url);
             request.Method = "GET";
             try
@@ -158,7 +158,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             }
 
             return
-                new HealthCheckStatus(TextService.Localize("healthcheck/setHeaderInConfigError", new [] { errorMessage }))
+                new HealthCheckStatus(TextService.Localize("healthcheck/setHeaderInConfigError", new[] { errorMessage }))
                 {
                     ResultType = StatusResultType.Error
                 };
@@ -170,43 +170,42 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             {
                 // There don't look to be any useful classes defined in https://msdn.microsoft.com/en-us/library/system.web.configuration(v=vs.110).aspx
                 // for working with the customHeaders section, so working with the XML directly.
-                var configFile = _ioHelper.MapPath("~/Web.config");
-                var doc = XDocument.Load(configFile);
-                var systemWebServerElement = doc.XPathSelectElement("/configuration/system.webServer");
-                var httpProtocolElement = systemWebServerElement.Element("httpProtocol");
+                //TODO: Custom headers for appsettings
+                //TODO: pass section in instead
+                //TODO: correct logic according to JSON structure
+                IConfigurationSection systemWebServerElement = _configuration.GetSection("system.webServer");
+                string httpProtocolElement = systemWebServerElement["httpProtocol"];
                 if (httpProtocolElement == null)
                 {
-                    httpProtocolElement = new XElement("httpProtocol");
-                    systemWebServerElement.Add(httpProtocolElement);
+                    //TODO: add httpProtocol to JSON
                 }
 
-                var customHeadersElement = httpProtocolElement.Element("customHeaders");
+                var customHeadersElement = systemWebServerElement["customHeaders"];
                 if (customHeadersElement == null)
                 {
-                    customHeadersElement = new XElement("customHeaders");
-                    httpProtocolElement.Add(customHeadersElement);
+                    //TODO: customHeaders to JSON
                 }
 
-                var removeHeaderElement = customHeadersElement.Elements("remove")
-                    .SingleOrDefault(x => x.Attribute("name")?.Value.Equals(_value, StringComparison.InvariantCultureIgnoreCase) == true);
-                if (removeHeaderElement == null)
-                {
-                    customHeadersElement.Add(
-                        new XElement("remove",
-                            new XAttribute("name", _header)));
-                }
+                //var removeHeaderElement = customHeadersElement.Elements("remove")
+                //    .SingleOrDefault(x => x.Attribute("name")?.Value.Equals(_value, StringComparison.InvariantCultureIgnoreCase) == true);
+                //if (removeHeaderElement == null)
+                //{
+                //    customHeadersElement.Add(
+                //        new XElement("remove",
+                //            new XAttribute("name", _header)));
+                //}
 
-                var addHeaderElement = customHeadersElement.Elements("add")
-                    .SingleOrDefault(x => x.Attribute("name")?.Value.Equals(_header, StringComparison.InvariantCultureIgnoreCase) == true);
-                if (addHeaderElement == null)
-                {
-                    customHeadersElement.Add(
-                        new XElement("add",
-                            new XAttribute("name", _header),
-                            new XAttribute("value", _value)));
-                }
+                //var addHeaderElement = customHeadersElement.Elements("add")
+                //    .SingleOrDefault(x => x.Attribute("name")?.Value.Equals(_header, StringComparison.InvariantCultureIgnoreCase) == true);
+                //if (addHeaderElement == null)
+                //{
+                //    customHeadersElement.Add(
+                //        new XElement("add",
+                //            new XAttribute("name", _header),
+                //            new XAttribute("value", _value)));
+                //}
 
-                doc.Save(configFile);
+                //TODO: save config
 
                 errorMessage = string.Empty;
                 return true;

--- a/src/Umbraco.Core/HealthCheck/Checks/Security/ClickJackingCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Security/ClickJackingCheck.cs
@@ -1,8 +1,9 @@
-﻿using Umbraco.Core;
-using Umbraco.Core.IO;
+﻿using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Services;
+using Umbraco.Web;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck.Checks.Security
+namespace Umbraco.Core.HealthCheck.Checks.Security
 {
     [HealthCheck(
         "ED0D7E40-971E-4BE8-AB6D-8CC5D0A6A5B0",
@@ -11,8 +12,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         Group = "Security")]
     public class ClickJackingCheck : BaseHttpHeaderCheck
     {
-        public ClickJackingCheck(IRequestAccessor requestAccessor, ILocalizedTextService textService, IIOHelper ioHelper)
-            : base(requestAccessor, textService, "X-Frame-Options", "sameorigin", "clickJacking", true, ioHelper)
+        public ClickJackingCheck(IConfiguration configuration, IRequestAccessor requestAccessor, ILocalizedTextService textService)
+            : base(configuration, requestAccessor, textService, "X-Frame-Options", "sameorigin", "clickJacking", true)
         {
         }
     }

--- a/src/Umbraco.Core/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         "Excessive Headers",
         Description = "Checks to see if your site is revealing information in its headers that gives away unnecessary details about the technology used to build and host it.",
         Group = "Security")]
-    public class ExcessiveHeadersCheck : HealthCheck
+    public class ExcessiveHeadersCheck : Core.HealthCheck.HealthCheck
     {
         private readonly ILocalizedTextService _textService;
         private readonly IRequestAccessor _requestAccessor;

--- a/src/Umbraco.Core/HealthCheck/Checks/Security/HstsCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Security/HstsCheck.cs
@@ -1,8 +1,9 @@
-﻿using Umbraco.Core;
-using Umbraco.Core.IO;
+﻿using Microsoft.Extensions.Configuration;
 using Umbraco.Core.Services;
+using Umbraco.Web;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck.Checks.Security
+namespace Umbraco.Core.HealthCheck.Checks.Security
 {
     [HealthCheck(
         "E2048C48-21C5-4BE1-A80B-8062162DF124",
@@ -16,8 +17,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         // and the blog post of Troy Hunt (https://www.troyhunt.com/understanding-http-strict-transport/)
         // If you want do to it perfectly, you have to submit it https://hstspreload.org/,
         // but then you should include subdomains and I wouldn't suggest to do that for Umbraco-sites.
-        public HstsCheck(IRequestAccessor requestAccessor, ILocalizedTextService textService, IIOHelper ioHelper)
-            : base(requestAccessor, textService, "Strict-Transport-Security", "max-age=10886400", "hSTS", true, ioHelper)
+        public HstsCheck(IConfiguration configuration, IRequestAccessor requestAccessor, ILocalizedTextService textService)
+            : base(configuration, requestAccessor, textService, "Strict-Transport-Security", "max-age=10886400", "hSTS", true)
         {
         }
     }

--- a/src/Umbraco.Core/HealthCheck/Checks/Security/NoSniffCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Security/NoSniffCheck.cs
@@ -1,8 +1,10 @@
-﻿using Umbraco.Core;
+﻿using Microsoft.Extensions.Configuration;
 using Umbraco.Core.IO;
 using Umbraco.Core.Services;
+using Umbraco.Web;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck.Checks.Security
+namespace Umbraco.Core.HealthCheck.Checks.Security
 {
     [HealthCheck(
         "1CF27DB3-EFC0-41D7-A1BB-EA912064E071",
@@ -11,8 +13,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         Group = "Security")]
     public class NoSniffCheck : BaseHttpHeaderCheck
     {
-        public NoSniffCheck(IRequestAccessor requestAccessor, ILocalizedTextService textService, IIOHelper ioHelper)
-            : base(requestAccessor, textService, "X-Content-Type-Options", "nosniff", "noSniff", false, ioHelper)
+        public NoSniffCheck(IConfiguration configuration, IRequestAccessor requestAccessor, ILocalizedTextService textService)
+            : base(configuration, requestAccessor, textService, "X-Content-Type-Options", "nosniff", "noSniff", false)
         {
         }
     }

--- a/src/Umbraco.Core/HealthCheck/Checks/Security/XssProtectionCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Security/XssProtectionCheck.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Core;
+﻿using Microsoft.Extensions.Configuration;
+using Umbraco.Core;
+using Umbraco.Core.HealthCheck.Checks.Security;
 using Umbraco.Core.IO;
 using Umbraco.Core.Services;
 
@@ -16,8 +18,8 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         // and the blog post of Troy Hunt (https://www.troyhunt.com/understanding-http-strict-transport/)
         // If you want do to it perfectly, you have to submit it https://hstspreload.appspot.com/,
         // but then you should include subdomains and I wouldn't suggest to do that for Umbraco-sites.
-        public XssProtectionCheck(IRequestAccessor requestAccessor,ILocalizedTextService textService, IIOHelper ioHelper)
-            : base(requestAccessor, textService, "X-XSS-Protection", "1; mode=block", "xssProtection", true, ioHelper)
+        public XssProtectionCheck(IConfiguration configuration, IRequestAccessor requestAccessor,ILocalizedTextService textService)
+            : base(configuration, requestAccessor, textService, "X-XSS-Protection", "1; mode=block", "xssProtection", true)
         {
         }
     }

--- a/src/Umbraco.Core/HealthCheck/Checks/Services/SmtpCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/Checks/Services/SmtpCheck.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Services
         "SMTP Settings",
         Description = "Checks that valid settings for sending emails are in place.",
         Group = "Services")]
-    public class SmtpCheck : HealthCheck
+    public class SmtpCheck : Core.HealthCheck.HealthCheck
     {
         private readonly ILocalizedTextService _textService;
         private readonly IRuntimeState _runtime;

--- a/src/Umbraco.Core/HealthCheck/HealthCheck.cs
+++ b/src/Umbraco.Core/HealthCheck/HealthCheck.cs
@@ -1,24 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Umbraco.Core;
 using Umbraco.Core.Composing;
+using Umbraco.Web.HealthCheck;
 
-namespace Umbraco.Web.HealthCheck
+namespace Umbraco.Core.HealthCheck
 {
     /// <summary>
-    /// Provides a base class for health checks.
+    /// Provides a base class for health checks, filling in the healthcheck metadata on construction
     /// </summary>
     [DataContract(Name = "healthCheck", Namespace = "")]
     public abstract class HealthCheck : IDiscoverable
     {
         protected HealthCheck()
         {
-            //Fill in the metadata
-            var thisType = GetType();
-            var meta = thisType.GetCustomAttribute<HealthCheckAttribute>(false);
+            Type thisType = GetType();
+            HealthCheckAttribute meta = thisType.GetCustomAttribute<HealthCheckAttribute>(false);
             if (meta == null)
-                throw new InvalidOperationException($"The health check {thisType} requires a {typeof (HealthCheckAttribute)}");
+            {
+                throw new InvalidOperationException(
+                    $"The health check {thisType} requires a {typeof(HealthCheckAttribute)}");
+            }
+
             Name = meta.Name;
             Description = meta.Description;
             Group = meta.Group;
@@ -49,7 +52,5 @@ namespace Umbraco.Web.HealthCheck
         /// <param name="action"></param>
         /// <returns></returns>
         public abstract HealthCheckStatus ExecuteAction(HealthCheckAction action);
-
-        // TODO: What else?
     }
 }

--- a/src/Umbraco.Core/HealthCheck/HealthCheckCollection.cs
+++ b/src/Umbraco.Core/HealthCheck/HealthCheckCollection.cs
@@ -3,9 +3,9 @@ using Umbraco.Core.Composing;
 
 namespace Umbraco.Web.HealthCheck
 {
-    public class HealthCheckCollection : BuilderCollectionBase<HealthCheck>
+    public class HealthCheckCollection : BuilderCollectionBase<Core.HealthCheck.HealthCheck>
     {
-        public HealthCheckCollection(IEnumerable<HealthCheck> items)
+        public HealthCheckCollection(IEnumerable<Core.HealthCheck.HealthCheck> items)
             : base(items)
         { }
     }

--- a/src/Umbraco.Core/HealthCheck/HealthCheckGroup.cs
+++ b/src/Umbraco.Core/HealthCheck/HealthCheckGroup.cs
@@ -10,6 +10,6 @@ namespace Umbraco.Web.HealthCheck
         public string Name { get; set; }
 
         [DataMember(Name = "checks")]
-        public List<HealthCheck> Checks { get; set; }
+        public List<Core.HealthCheck.HealthCheck> Checks { get; set; }
     }
 }

--- a/src/Umbraco.Core/HealthCheck/HeathCheckCollectionBuilder.cs
+++ b/src/Umbraco.Core/HealthCheck/HeathCheckCollectionBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Web.HealthCheck
 {
-    public class HealthCheckCollectionBuilder : LazyCollectionBuilderBase<HealthCheckCollectionBuilder, HealthCheckCollection, HealthCheck>
+    public class HealthCheckCollectionBuilder : LazyCollectionBuilderBase<HealthCheckCollectionBuilder, HealthCheckCollection, Core.HealthCheck.HealthCheck>
     {
         protected override HealthCheckCollectionBuilder This => this;
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -15,6 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.2" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
       <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />

--- a/src/Umbraco.Infrastructure/HealthCheck/HealthCheckResults.cs
+++ b/src/Umbraco.Infrastructure/HealthCheck/HealthCheckResults.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web.HealthCheck
 
         private ILogger Logger => Current.Logger; // TODO: inject
 
-        public HealthCheckResults(IEnumerable<HealthCheck> checks)
+        public HealthCheckResults(IEnumerable<Core.HealthCheck.HealthCheck> checks)
         {
             _results = checks.ToDictionary(
                 t => t.Name,

--- a/src/Umbraco.Infrastructure/Runtime/CoreInitialComposer.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreInitialComposer.cs
@@ -300,7 +300,7 @@ namespace Umbraco.Core.Runtime
 
             // register *all* checks, except those marked [HideFromTypeFinder] of course
             composition.HealthChecks()
-                .Add(() => composition.TypeLoader.GetTypes<HealthCheck>());
+                .Add(() => composition.TypeLoader.GetTypes<HealthCheck.HealthCheck>());
 
 
             composition.WithCollectionBuilder<HealthCheckNotificationMethodCollectionBuilder>()

--- a/src/Umbraco.Tests.Integration/Views/template1.cshtml
+++ b/src/Umbraco.Tests.Integration/Views/template1.cshtml
@@ -1,4 +1,5 @@
-﻿@inherits Umbraco.Web.Common.AspNetCore.UmbracoViewPage
+﻿@using Umbraco.Web.PublishedModels;
+@inherits Umbraco.Web.Common.AspNetCore.UmbracoViewPage
 @{
 	Layout = null;
 }

--- a/src/Umbraco.Tests.Integration/Views/template2.cshtml
+++ b/src/Umbraco.Tests.Integration/Views/template2.cshtml
@@ -1,4 +1,5 @@
-﻿@inherits Umbraco.Web.Common.AspNetCore.UmbracoViewPage
+﻿@using Umbraco.Web.PublishedModels;
+@inherits Umbraco.Web.Common.AspNetCore.UmbracoViewPage
 @{
 	Layout = null;
 }

--- a/src/Umbraco.Tests.Integration/Views/test.cshtml
+++ b/src/Umbraco.Tests.Integration/Views/test.cshtml
@@ -1,4 +1,5 @@
-﻿@inherits Umbraco.Web.Common.AspNetCore.UmbracoViewPage
+﻿@using Umbraco.Web.PublishedModels;
+@inherits Umbraco.Web.Common.AspNetCore.UmbracoViewPage
 @{
 	Layout = null;
 }

--- a/src/Umbraco.Tests/Web/HealthChecks/HealthCheckResultsTests.cs
+++ b/src/Umbraco.Tests/Web/HealthChecks/HealthCheckResultsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using Umbraco.Core.Configuration.HealthChecks;
+using Umbraco.Core.HealthCheck;
 using Umbraco.Web.HealthCheck;
 
 namespace Umbraco.Tests.Web.HealthChecks

--- a/src/Umbraco.Web.BackOffice/HealthCheck/HealthCheckController.cs
+++ b/src/Umbraco.Web.BackOffice/HealthCheck/HealthCheckController.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Web.BackOffice.Controllers
             return check.ExecuteAction(action);
         }
 
-        private HealthCheck.HealthCheck GetCheckById(Guid id)
+        private Core.HealthCheck.HealthCheck GetCheckById(Guid id)
         {
             var check = _checks
                 .Where(x => _disabledCheckIds.Contains(x.Id) == false)


### PR DESCRIPTION
### Incomplete draft

I wanted to test the health checks and decided to try amending the, to use the injected IConfiguration. This works for a few of the health checks but not all, and some will undoubtedly become invalid. There will also be new ones needed I expect

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

Will add issue if this PR covers it <!-- link to the issue here! -->

### Description

* Mild refactoring but overall keeping it the same, except for injecting IConfiguration and JSON parsing instead of XML
* Health check tests currently unaffected, but we need to increase coverage

After discussing with team, needs to be moved to IOptions<T> and use the IConfigManipulator to update settings as required

<!-- Thanks for contributing to Umbraco CMS! -->
