### PR TITLE
Section picker: Fix accessibility and semantic issues

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -169,7 +169,9 @@ body.touch .umb-tree {
 .umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class^="icon-"],
 .umb-tree .umb-tree-node-checked > .umb-tree-item__inner > i[class*=" icon-"],
 .umb-tree .umb-tree-node-checked .umb-search-group-item-name > i[class^="icon-"],
-.umb-tree .umb-tree-node-checked .umb-search-group-item-name > i[class*=" icon-"] {
+.umb-tree .umb-tree-node-checked .umb-search-group-item-name > i[class*=" icon-"], 
+.umb-tree .umb-tree-node-checked > i[class^="icon-"],
+.umb-tree .umb-tree-node-checked > i[class*="icon-"] {
     font-family: 'icomoon' !important;
     color: @green !important;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.html
@@ -19,12 +19,12 @@
             <umb-box ng-if="!vm.loading">
                 <umb-box-content>
                     <ul class="umb-tree">
-                        <li ng-repeat="section in vm.sections" class="umb-tree-item" ng-class="{'umb-tree-node-checked': section.selected }">
-                            <div class="umb-tree-item__inner cursor-pointer" ng-click="vm.selectSection(section)" style="padding: 5px 10px;">
-                                <i class="icon umb-tree-icon {{section.icon}}"></i>
-                                <a class="flex-auto" href="" prevent-default>
+                        <li ng-repeat="section in vm.sections" class="umb-tree-item">
+                            <div class="umb-tree-item__inner" style="padding: 5px 10px;">
+                                <button type="button" class="btn-reset text-left flex-auto" ng-click="vm.selectSection(section)" ng-class="{'umb-tree-node-checked': section.selected }">
+                                    <i class="icon umb-tree-icon {{section.icon}}" aria-hidden="true"></i>
                                     <span>{{ section.name }}</span>
-                                </a>
+                                </button>
                             </div>
                         </li>
                     </ul>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Depending on whether or not the "mediatypepicker.html" and controller is actively being used or not this PR is probably the final of it's kind turning `<a>` containing and empty `href` into a proper `<button>` and adding `aria-hidden="true"` on the icon 😃 

I've fixed some styling as well.

This is the view in question and the screendump is taken after the changes were made 👍 

![section-picker](https://user-images.githubusercontent.com/1932158/92971192-43e08400-f480-11ea-9ad7-5e27848d2ca8.png)
