### PR TITLE
Adjustments of colorpicker prevalue and property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/colorpicker.html
@@ -4,10 +4,11 @@
         <localize key="colorpicker_noColors">You haven't defined any colors</localize>
     </div>
 
-    <umb-color-swatches colors="model.items"
-                        selected-color="model.value"
-                        size="s"
-                        use-label="model.config.useLabel">
+    <umb-color-swatches
+        colors="model.items"
+        selected-color="model.value"
+        size="s"
+        use-label="model.config.useLabel">
     </umb-color-swatches>
 
     <input type="hidden" name="modelValue" ng-model="model.value" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -60,7 +60,7 @@ function ColorPickerController($scope, $timeout) {
             var newColor = color ? color.value : null;
             $scope.propertyForm.selectedColor.$setViewValue(newColor);
         });
-    }
+    };
 
     // Method required by the valPropertyValidator directive (returns true if the property editor has at least one color selected)
     $scope.validateMandatory = function () {
@@ -74,8 +74,7 @@ function ColorPickerController($scope, $timeout) {
             errorMsg: $scope.model.validation.mandatoryMessage || "Value cannot be empty",
             errorKey: "required"
         };
-    }
-    $scope.isConfigured = $scope.model.config && $scope.model.config.items && _.keys($scope.model.config.items).length > 0;
+    };
 
     // Finds the color best matching the model's color,
     // and sets the model color to that one. This is useful when

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -18,10 +18,13 @@ function ColorPickerController($scope, $timeout) {
 
         for (var key in $scope.model.config.items) {
             if (!$scope.model.config.items[key].hasOwnProperty("value"))
-                $scope.model.config.items[key] = { value: $scope.model.config.items[key], label: $scope.model.config.items[key] };
+                $scope.model.config.items[key] = {
+                    value: $scope.model.config.items[key],
+                    label: $scope.model.config.items[key]
+                };
         }
 
-        $scope.model.useLabel = isTrue($scope.model.config.useLabel);
+        $scope.model.useLabel = Object.toBoolean($scope.model.config.useLabel);
         initActiveColor();
     }
 
@@ -136,11 +139,6 @@ function ColorPickerController($scope, $timeout) {
             $scope.model.value.value = foundItem.value;
             $scope.model.value.label = foundItem.label;
         }
-    }
-
-    // figures out if a value is trueish enough
-    function isTrue(bool) {
-        return !!bool && bool !== "0" && bool.toString().toLowerCase() !== "false";
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.controller.js
@@ -1,5 +1,7 @@
 function ColorPickerController($scope, $timeout) {
 
+    var vm = this;
+
     //setup the default config
     var config = {
         items: [],
@@ -57,7 +59,7 @@ function ColorPickerController($scope, $timeout) {
         $scope.model.config.items = items;
     }
 
-    $scope.selectColor = function (color) {
+    vm.selectColor = function (color) {
         // this is required to re-validate
         $timeout(function () {
             var newColor = color ? color.value : null;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController">
+﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController as vm">
 
     <div ng-if="!isConfigured">
         <localize key="colorpicker_noColors">You haven't defined any colors</localize>
@@ -9,7 +9,7 @@
         selected-color="model.value"
         size="m"
         use-label="model.useLabel"
-        on-select="selectColor(color)">
+        on-select="vm.selectColor(color)">
     </umb-color-swatches>
 
     <input type="hidden" name="selectedColor" ng-model="model.selectedColor" val-property-validator="validateMandatory" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.html
@@ -1,6 +1,5 @@
 ﻿<div ng-controller="Umbraco.PropertyEditors.ColorPickerController">
 
-
     <div ng-if="!isConfigured">
         <localize key="colorpicker_noColors">You haven't defined any colors</localize>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR has a few adjustments to colorpicker prevalue and property editors.
While looking at this issue https://github.com/umbraco/Umbraco-CMS/issues/8825 (although I didn't find a solution for now) I noticed a few other things to update.

- `$scope.isConfigured` was defined twice in colorpicker property editor (exact same line)
- Update to use `vm` in colorpicker property editor
- In colorpicker property editor we have an `isTrue()` function - however we have a `Object.toBoolean()` extension method, so we can use this instead.