### PR TITLE
Use String.CreateGuid in grid editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -627,21 +627,8 @@ angular.module("umbraco")
 
             }
 
-
-            var guid = (function () {
-                function s4() {
-                    return Math.floor((1 + Math.random()) * 0x10000)
-                        .toString(16)
-                        .substring(1);
-                }
-                return function () {
-                    return s4() + s4() + "-" + s4() + "-" + s4() + "-" +
-                        s4() + "-" + s4() + s4() + s4();
-                };
-            })();
-
-            $scope.setUniqueId = function (cell, index) {
-                return guid();
+            $scope.setUniqueId = function () {
+                return String.CreateGuid();
             };
 
             $scope.addControl = function (editor, cell, index, initialize) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment grid editor is using its own local function to create a guid for an unique id of e.g. controls.
However most places in backoffice we already use `String.CreateGuid()` extension method: https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/lib/umbraco/Extensions.js#L49-L59

So I think we should remove this function and use the extension method instead to create an unique id. No need to reinvent the wheel 😄🎡

Here is an example with the current function vs `String.CreateGuid()`:

```
$scope.setUniqueId = function () {
    var guid1 = guid();
    var guid2 = String.CreateGuid();

    console.log("guid1", guid1);
    console.log("guid2", guid2);

    return guid1;
};
```

![chrome_2020-09-12_17-14-59](https://user-images.githubusercontent.com/2919859/92998870-d8002900-f51c-11ea-9594-d4b301417353.png)


Furthermore I couldn't find any references where the parameters in `setUniqueId()` function was used, so I have removed these.