### PR TITLE
Enable MultiNodeTreePicker to allow editing Editing for picked media …

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -15,7 +15,7 @@
                               allow-remove="allowRemoveButton"
                               allow-open="model.config.showOpenButton && allowOpenButton && !dialogEditor"
                               on-remove="remove($index)"
-                              on-open="openContentEditor(node)">
+                              on-open="openItemEditor(node)">
             </umb-node-preview>
         </div>
 


### PR DESCRIPTION
…items

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8896

### Description
This PR enables editing Media items from the MultiNodeTreePicker.  To test:

1. Add a new MultiNodeTreePicker with the Media type and make sure editing is allowed
2. Pick a Media Item
3. Click the Edit Button
4. Win 💯 
