### PR TITLE
Prevent InvalidCastException being thrown when ContentPicker has picked a Udi

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
@@ -36,9 +36,14 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         {
             if (source == null) return null;
 
-            var attemptConvertInt = source.TryConvertTo<int>();
-            if (attemptConvertInt.Success)
-                return attemptConvertInt.Result;
+            //Don't attempt to convert to int for UDI
+            if(!(source is string) || source is string strSource && !string.IsNullOrWhiteSpace(strSource) && !strSource.StartsWith("umb"))
+            {
+                 var attemptConvertInt = source.TryConvertTo<int>();
+                    if (attemptConvertInt.Success)
+                        return attemptConvertInt.Result;
+            }
+
             var attemptConvertUdi = source.TryConvertTo<Udi>();
             if (attemptConvertUdi.Success)
                 return attemptConvertUdi.Result;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
Prevent InvalidCastException being thrown when ContentPicker has picked a Udi. Trying to convert to an int will fail for Udis with an InvalidCastException.

Checks if the value starts with umb to determine if it is a udi, if Udi, don't try cast to int.

How to test?

Use a content picker on a document, pick a udi. InvalidCastException should not be thrown when the property converter runs