### PR TITLE
Optimize internal examine queries to only fetch the fields required for the results.

### DIFF
--- a/src/Umbraco.Examine/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine/UmbracoContentIndex.cs
@@ -110,6 +110,8 @@ namespace Umbraco.Examine
             }
         }
 
+        private readonly ISet<string> _idOnlyFieldSet = new HashSet<string> { "id" };
+
         /// <inheritdoc />
         /// <summary>
         /// Deletes a node from the index.
@@ -130,7 +132,7 @@ namespace Umbraco.Examine
                 var rawQuery = $"{IndexPathFieldName}:{descendantPath}";
                 var searcher = GetSearcher();
                 var c = searcher.CreateQuery();
-                var filtered = c.NativeQuery(rawQuery);
+                var filtered = c.NativeQuery(rawQuery, _idOnlyFieldSet);
                 var results = filtered.Execute();
 
                 ProfilingLogger.Debug(GetType(), "DeleteFromIndex with query: {Query} (found {TotalItems} results)", rawQuery, results.TotalItemCount);

--- a/src/Umbraco.Web/IPublishedContentQuery.cs
+++ b/src/Umbraco.Web/IPublishedContentQuery.cs
@@ -60,6 +60,7 @@ namespace Umbraco.Web
         /// <param name="totalRecords">The total amount of records.</param>
         /// <param name="culture">The culture (defaults to a culture insensitive search).</param>
         /// <param name="indexName">The name of the index to search (defaults to <see cref="Constants.UmbracoIndexes.ExternalIndexName" />).</param>
+        /// <param name="loadedFields">The fields to load in the results of the search (defaults to all fields loaded).</param>
         /// <returns>
         /// The search results.
         /// </returns>
@@ -71,7 +72,7 @@ namespace Umbraco.Web
         /// </para>
         /// <para>While enumerating results, the ambient culture is changed to be the searched culture.</para>
         /// </remarks>
-        IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName);
+        IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName, ISet<string> loadedFields = null);
 
         /// <summary>
         /// Executes the query and converts the results to <see cref="PublishedSearchResult" />.

--- a/src/Umbraco.Web/PublishedContentQuery.cs
+++ b/src/Umbraco.Web/PublishedContentQuery.cs
@@ -189,7 +189,7 @@ namespace Umbraco.Web
         }
 
         /// <inheritdoc />
-        public IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName)
+        public IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName,ISet<string> loadedFields = null)
         {
             if (skip < 0)
             {
@@ -212,6 +212,10 @@ namespace Umbraco.Web
             }
 
             var query = umbIndex.GetSearcher().CreateQuery(IndexTypes.Content);
+            if(loadedFields != null)
+            {
+                query.SelectFields(loadedFields);
+            }
 
             IQueryExecutor queryExecutor;
             if (culture == "*")

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Web.Search
         private readonly IMainDom _mainDom;
         private readonly IProfilingLogger _logger;
         private readonly IUmbracoIndexesCreator _indexCreator;
-        
+        private readonly ISet<string> _idOnlyFieldSet = new HashSet<string> { "id" };
 
         // the default enlist priority is 100
         // enlist with a lower priority to ensure that anything "default" runs after us
@@ -405,7 +405,8 @@ namespace Umbraco.Web.Search
                         while (page * pageSize < total)
                         {
                             //paging with examine, see https://shazwazza.com/post/paging-with-examine/
-                            var results = searcher.CreateQuery().Field("nodeType", id.ToInvariantString()).Execute(maxResults: pageSize * (page + 1));
+                            var query = searcher.CreateQuery().Field("nodeType", id.ToInvariantString()).And().SelectFields(_idOnlyFieldSet);
+                            var results = query.Execute(maxResults: pageSize * (page + 1));
                             total = results.TotalItemCount;
                             var paged = results.Skip(page * pageSize);
 

--- a/src/Umbraco.Web/Search/IUmbracoTreeSearcherFields.cs
+++ b/src/Umbraco.Web/Search/IUmbracoTreeSearcherFields.cs
@@ -23,5 +23,23 @@ namespace Umbraco.Web.Search
         /// Propagate list of searchable fields for Documents
         /// </summary>
         IEnumerable<string> GetBackOfficeDocumentFields();
+
+        /// <summary>
+        /// Set of fields for all node types to be loaded
+        /// </summary>
+        ISet<string> GetBackOfficeFieldsToLoad();
+        /// <summary>
+        /// Set list of fields for Members to be loaded
+        /// </summary>
+        ISet<string> GetBackOfficeMembersFieldsToLoad();
+        /// <summary>
+        /// Set of fields for Media to be loaded
+        /// </summary>
+        ISet<string> GetBackOfficeMediaFieldsToLoad();
+
+        /// <summary>
+        /// Set of fields for Documents to be loaded
+        /// </summary>
+        ISet<string> GetBackOfficeDocumentFieldsToLoad();
     }
 }

--- a/src/Umbraco.Web/Search/UmbracoTreeSearcherFields.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcherFields.cs
@@ -6,26 +6,51 @@ namespace Umbraco.Web.Search
 {
     public class UmbracoTreeSearcherFields : IUmbracoTreeSearcherFields
     {
-        private IReadOnlyList<string> _backOfficeFields = new List<string> {"id", "__NodeId", "__Key"};
+        private readonly IReadOnlyList<string> _backOfficeFields = new List<string> { "id", "__NodeId", "__Key" };
         public IEnumerable<string> GetBackOfficeFields()
         {
             return _backOfficeFields;
         }
-
-
-        private IReadOnlyList<string> _backOfficeMembersFields = new List<string> {"email", "loginName"};
+       
+        private readonly IReadOnlyList<string> _backOfficeMembersFields = new List<string> { "email", "loginName" };
         public IEnumerable<string> GetBackOfficeMembersFields()
         {
             return _backOfficeMembersFields;
         }
-        private IReadOnlyList<string> _backOfficeMediaFields = new List<string> {UmbracoExamineIndex.UmbracoFileFieldName };
+
+        private readonly IReadOnlyList<string> _backOfficeMediaFields = new List<string> { UmbracoExamineIndex.UmbracoFileFieldName };
         public IEnumerable<string> GetBackOfficeMediaFields()
         {
             return _backOfficeMediaFields;
         }
+        
         public IEnumerable<string> GetBackOfficeDocumentFields()
         {
             return Enumerable.Empty<string>();
+        }
+
+        private readonly ISet<string> _backOfficeFieldsToLoad = new HashSet<string> { "id", "__NodeId", "__Key" };
+        public ISet<string> GetBackOfficeFieldsToLoad()
+        {
+            return _backOfficeFieldsToLoad;
+        }
+
+        private readonly ISet<string> _backOfficeMembersFieldsToLoad = new HashSet<string> { "id", "__NodeId", "__Key" , "email", "loginName" };
+        public ISet<string> GetBackOfficeMembersFieldsToLoad()
+        {
+            return _backOfficeMembersFieldsToLoad;
+        }
+
+        private readonly ISet<string> _backOfficeMediaFieldsToLoad = new HashSet<string> { "id", "__NodeId", "__Key", UmbracoExamineIndex.UmbracoFileFieldName };
+        public ISet<string> GetBackOfficeMediaFieldsToLoad()
+        {
+            return _backOfficeMediaFieldsToLoad;
+        }
+        private readonly ISet<string> _backOfficeDocumentFieldsToLoad = new HashSet<string> { "id", "__NodeId", "__Key" };
+
+        public ISet<string> GetBackOfficeDocumentFieldsToLoad()
+        {
+            return _backOfficeDocumentFieldsToLoad;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
What?
Optimize examine queries used in Umbraco to only retrieve the field values required in the result set.

Why?
Reduce memory / speed up query execution as only the fields being used are loaded. Saves on loading large rte/grid/json fields into memory when they are unused in the result set.

How to test?
Run a PublishedContentQuery.Search passing in a HashSet of fields to load and check only those fields loaded.

Requires this PR in examine to be merged and umbraco to be updated to use a new examine package including this pr:
https://github.com/Shazwazza/Examine/pull/178

<!-- Thanks for contributing to Umbraco CMS! -->
