### PR TITLE
Fix NullReferenceException while deserializing empty value in TagsValueConverter

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/TagsValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/TagsValueConverter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
@@ -12,69 +10,42 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
     [DefaultPropertyValueConverter]
     public class TagsValueConverter : PropertyValueConverterBase
     {
-        private readonly IDataTypeService _dataTypeService;
+        public TagsValueConverter()
+        { }
 
+        [Obsolete("This constructor isn't required anymore, because we don't need services to lookup the data type configuration.")]
         public TagsValueConverter(IDataTypeService dataTypeService)
-        {
-            _dataTypeService = dataTypeService ?? throw new ArgumentNullException(nameof(dataTypeService));
-        }
+        { }
 
         public override bool IsConverter(IPublishedPropertyType propertyType)
             => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.Tags);
 
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-            => typeof (IEnumerable<string>);
+            => typeof(IEnumerable<string>);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
             => PropertyCacheLevel.Element;
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
         {
-            if (source == null) return Array.Empty<string>();
-
-            // if Json storage type deserialize and return as string array
-            if (JsonStorageType(propertyType.DataType.Id))
+            var sourceString = source?.ToString();
+            if (string.IsNullOrEmpty(sourceString))
             {
-                var jArray = JsonConvert.DeserializeObject<JArray>(source.ToString());
-                return jArray.ToObject<string[]>() ?? Array.Empty<string>();
+                return Array.Empty<string>();
             }
 
-            // Otherwise assume CSV storage type and return as string array
-            return source.ToString().Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            switch (propertyType.DataType.ConfigurationAs<TagConfiguration>().StorageType)
+            {
+                case TagsStorageType.Csv:
+                    return sourceString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                case TagsStorageType.Json:
+                    return JsonConvert.DeserializeObject<string[]>(sourceString);
+                default:
+                    throw new InvalidOperationException("Invalid storage type.");
+            }
         }
 
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object source, bool preview)
-        {
-            return (string[]) source;
-        }
-
-        /// <summary>
-        /// Discovers if the tags data type is storing its data in a Json format
-        /// </summary>
-        /// <param name="dataTypeId">
-        /// The data type id.
-        /// </param>
-        /// <returns>
-        /// The <see cref="bool"/>.
-        /// </returns>
-        private bool JsonStorageType(int dataTypeId)
-        {
-            // GetDataType(id) is cached at repository level; still, there is some
-            // deep-cloning involved (expensive) - better cache here + trigger
-            // refresh in DataTypeCacheRefresher
-
-            return Storages.GetOrAdd(dataTypeId, id =>
-            {
-                var configuration = _dataTypeService.GetDataType(id).ConfigurationAs<TagConfiguration>();
-                return configuration.StorageType == TagsStorageType.Json;
-            });
-        }
-
-        private static readonly ConcurrentDictionary<int, bool> Storages = new ConcurrentDictionary<int, bool>();
-
-        internal static void ClearCaches()
-        {
-            Storages.Clear();
-        }
+            => (string[])source;
     }
 }

--- a/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
@@ -59,7 +59,6 @@ namespace Umbraco.Web.Cache
             }
 
             // TODO: not sure I like these?
-            TagsValueConverter.ClearCaches();
             SliderValueConverter.ClearCaches();
 
             // refresh the models and cache

--- a/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
@@ -58,7 +58,6 @@ namespace Umbraco.Web.Cache
                 _idkMap.ClearCache(payload.Id);
             }
 
-            // TODO: not sure I like these?
             SliderValueConverter.ClearCaches();
 
             // refresh the models and cache


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7622.

### Description
This change ensures that stored values (especially empty strings) for the `Umbraco.Tags` editor do not result in a `NullReferenceException`, as mentioned in the linked issue.

I've also removed the dependency on the `IDataTypeService`, as getting the data type configuration can be done without services/database lookups in Umbraco 8.