### PR TITLE
Fix IndexOutOfRangeException when converting single value to range in SliderValueConverter

### DIFF
--- a/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
@@ -60,7 +60,6 @@ namespace Umbraco.Web.Cache
 
             // TODO: not sure I like these?
             TagsValueConverter.ClearCaches();
-            SliderValueConverter.ClearCaches();
 
             // refresh the models and cache
 

--- a/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/DataTypeCacheRefresher.cs
@@ -58,7 +58,6 @@ namespace Umbraco.Web.Cache
                 _idkMap.ClearCache(payload.Id);
             }
 
-            // TODO: not sure I like these?
             TagsValueConverter.ClearCaches();
 
             // refresh the models and cache


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While doing PR https://github.com/umbraco/Umbraco-CMS/pull/8906, I noticed `SliderValueConverter` could also throw an `IndexOutOfRangeException` if the saved value was still a single value, but the configuration changed to return a range. It will now return a `Range<decimal>` with both minimum and maximum set to the same value.

I've also removed the dependency on the `IDataTypeService`, as getting the data type configuration can be done without services/database lookups in Umbraco 8.