### PR TITLE
Change wrong URL in KeepAlive XML Comments

### DIFF
--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -259,7 +259,7 @@
       Defaults to "false".
     @keepAlivePingUrl
       The url of the KeepAlivePing action. By default, the url will use the umbracoApplicationUrl setting as the basis.
-      Change this setting to specify an alternative url to reach the KeepAlivePing action. eg http://localhost/api/keepalive/ping
+      Change this setting to specify an alternative url to reach the KeepAlivePing action. eg http://localhost/umbraco/api/keepalive/ping
       Defaults to "{umbracoApplicationUrl}/api/keepalive/ping".
   -->
   <keepAlive disableKeepAliveTask="false" keepAlivePingUrl="{umbracoApplicationUrl}/api/keepalive/ping" />


### PR DESCRIPTION
The XML comments for KeepAlive mention the URL for the KeepAlive.Ping action but incorrectly omit 'umbraco' from the path.
The change adds the 'umbraco' section to the path.