### PR TITLE
Reduce memory footprint of database reads and writes by avoiding params[] allocations for ReadLock() and WriteLock()

### DIFF
--- a/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -130,7 +130,6 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         void ReadLock(IDatabase db, params int[] lockIds);
         void WriteLock(IDatabase db, params int[] lockIds);
-        void WriteLock(IDatabase db, int lockId0, int lockId1);
         void WriteLock(IDatabase db, int lockId);
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -130,5 +130,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         void ReadLock(IDatabase db, params int[] lockIds);
         void WriteLock(IDatabase db, params int[] lockIds);
+        void WriteLock(IDatabase db, int lockId0, int lockId1);
+        void WriteLock(IDatabase db, int lockId);
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -129,6 +129,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
         bool TryGetDefaultConstraint(IDatabase db, string tableName, string columnName, out string constraintName);
 
         void ReadLock(IDatabase db, params int[] lockIds);
+        void ReadLock(IDatabase db, int lockId);
         void WriteLock(IDatabase db, params int[] lockIds);
         void WriteLock(IDatabase db, int lockId);
     }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -167,10 +167,24 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
             foreach (var lockId in lockIds)
             {
-                var i = db.Execute(@"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id", new { id = lockId });
-                if (i == 0) // ensure we are actually locking!
-                    throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+                ObtainWriteLock(db, lockId);
             }
+        }
+        public override void WriteLock(IDatabase db, int lockId)
+        {
+            // soon as we get Database, a transaction is started
+
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
+
+            db.Execute(@"SET LOCK_TIMEOUT 1800;");
+            ObtainWriteLock(db, lockId);
+        }
+        private static void ObtainWriteLock(IDatabase db, int lockId)
+        {
+            var i = db.Execute(@"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id", new { id = lockId });
+            if (i == 0) // ensure we are actually locking!
+                throw new ArgumentException($"LockObject with id={lockId} does not exist.");
         }
 
         public override void ReadLock(IDatabase db, params int[] lockIds)

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -203,6 +203,18 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             }
         }
 
+        public override void ReadLock(IDatabase db, int lockId)
+        {
+            // soon as we get Database, a transaction is started
+
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
+
+                var i = db.ExecuteScalar<int?>("SELECT value FROM umbracoLock WHERE id=@id", new { id = lockId });
+                if (i == null) // ensure we are actually locking!
+                    throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+        }
+
         protected override string FormatIdentity(ColumnDefinition column)
         {
             return column.IsIdentity ? GetIdentityString(column) : string.Empty;

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -235,6 +235,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         public abstract void ReadLock(IDatabase db, params int[] lockIds);
         public abstract void WriteLock(IDatabase db, params int[] lockIds);
+        public abstract void WriteLock(IDatabase db, int lockId);
 
         public virtual bool DoesTableExist(IDatabase db, string tableName)
         {

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -234,6 +234,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
         public abstract bool TryGetDefaultConstraint(IDatabase db, string tableName, string columnName, out string constraintName);
 
         public abstract void ReadLock(IDatabase db, params int[] lockIds);
+        public abstract void ReadLock(IDatabase db, int lockId);
         public abstract void WriteLock(IDatabase db, params int[] lockIds);
         public abstract void WriteLock(IDatabase db, int lockId);
 

--- a/src/Umbraco.Core/Scoping/IScope.cs
+++ b/src/Umbraco.Core/Scoping/IScope.cs
@@ -54,6 +54,12 @@ namespace Umbraco.Core.Scoping
         void ReadLock(params int[] lockIds);
 
         /// <summary>
+        /// Read-locks some lock objects.
+        /// </summary>
+        /// <param name="lockId">The lock object identifier.</param>
+        void ReadLock(int lockId);
+
+        /// <summary>
         /// Write-locks some lock objects.
         /// </summary>
         /// <param name="lockIds">The lock object identifiers.</param>

--- a/src/Umbraco.Core/Scoping/IScope.cs
+++ b/src/Umbraco.Core/Scoping/IScope.cs
@@ -58,5 +58,11 @@ namespace Umbraco.Core.Scoping
         /// </summary>
         /// <param name="lockIds">The lock object identifiers.</param>
         void WriteLock(params int[] lockIds);
+
+        /// <summary>
+        /// Write-locks some lock objects.
+        /// </summary>
+        /// <param name="lockId">The lock object identifier.</param>
+        void WriteLock(int lockId);
     }
 }

--- a/src/Umbraco.Core/Scoping/Scope.cs
+++ b/src/Umbraco.Core/Scoping/Scope.cs
@@ -489,6 +489,9 @@ namespace Umbraco.Core.Scoping
         public void ReadLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.ReadLock(Database, lockIds);
 
         /// <inheritdoc />
+        public void ReadLock(int lockId) => Database.SqlContext.SqlSyntax.ReadLock(Database, lockId);
+
+        /// <inheritdoc />
         public void WriteLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.WriteLock(Database, lockIds);
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Scoping/Scope.cs
+++ b/src/Umbraco.Core/Scoping/Scope.cs
@@ -490,5 +490,9 @@ namespace Umbraco.Core.Scoping
 
         /// <inheritdoc />
         public void WriteLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.WriteLock(Database, lockIds);
+
+        /// <inheritdoc />
+        public void WriteLock(int lockId) => Database.SqlContext.SqlSyntax.WriteLock(Database, lockId);
+
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
What?
Reduce params[] allocation for WriteLock and ReadLock. Avoids allocating an array by implementing a non params overload.

Why?
Less allocations, better performance.

How to test?
Existing unit tests pass.

