### PR TITLE
Inject icons used in login screen to the runtime icon cache

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -209,7 +209,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                             ,'Failed to retrieve icon: ' + iconName)
                         .then(icon => {
                             if(icon) {
-                                var trustedIcon = this.defineIcon(icon.name, icon.SvgString);
+                                var trustedIcon = this.defineIcon(icon.Name, icon.SvgString);
 
                                 liveRequests = _.filter(liveRequests, iconRequestPath);
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -31,7 +31,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         { oldIcon: ".sprToPublish", newIcon: "mail-forward" },
         { oldIcon: ".sprTranslate", newIcon: "comments" },
         { oldIcon: ".sprUpdate", newIcon: "save" },
-        
+
         { oldIcon: ".sprTreeSettingDomain", newIcon: "icon-home" },
         { oldIcon: ".sprTreeDoc", newIcon: "icon-document" },
         { oldIcon: ".sprTreeDoc2", newIcon: "icon-diploma-alt" },
@@ -39,21 +39,21 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         { oldIcon: ".sprTreeDoc4", newIcon: "icon-newspaper-alt" },
         { oldIcon: ".sprTreeDoc5", newIcon: "icon-notepad-alt" },
 
-        { oldIcon: ".sprTreeDocPic", newIcon: "icon-picture" },        
+        { oldIcon: ".sprTreeDocPic", newIcon: "icon-picture" },
         { oldIcon: ".sprTreeFolder", newIcon: "icon-folder" },
         { oldIcon: ".sprTreeFolder_o", newIcon: "icon-folder" },
         { oldIcon: ".sprTreeMediaFile", newIcon: "icon-music" },
         { oldIcon: ".sprTreeMediaMovie", newIcon: "icon-movie" },
         { oldIcon: ".sprTreeMediaPhoto", newIcon: "icon-picture" },
-        
+
         { oldIcon: ".sprTreeMember", newIcon: "icon-user" },
         { oldIcon: ".sprTreeMemberGroup", newIcon: "icon-users" },
         { oldIcon: ".sprTreeMemberType", newIcon: "icon-users" },
-        
+
         { oldIcon: ".sprTreeNewsletter", newIcon: "icon-file-text-alt" },
         { oldIcon: ".sprTreePackage", newIcon: "icon-box" },
         { oldIcon: ".sprTreeRepository", newIcon: "icon-server-alt" },
-        
+
         { oldIcon: ".sprTreeSettingDataType", newIcon: "icon-autofill" },
 
         // TODO: Something needs to be done with the old tree icons that are commented out.
@@ -61,7 +61,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         { oldIcon: ".sprTreeSettingAgent", newIcon: "" },
         { oldIcon: ".sprTreeSettingCss", newIcon: "" },
         { oldIcon: ".sprTreeSettingCssItem", newIcon: "" },
-        
+
         { oldIcon: ".sprTreeSettingDataTypeChild", newIcon: "" },
         { oldIcon: ".sprTreeSettingDomain", newIcon: "" },
         { oldIcon: ".sprTreeSettingLanguage", newIcon: "" },
@@ -94,9 +94,9 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
     var iconCache = [];
     var liveRequests = [];
     var allIconsRequested = false;
-            
+
     return {
-        
+
         /** Used by the create dialogs for content/media types to format the data so that the thumbnails are styled properly */
         formatContentTypeThumbnails: function (contentTypes) {
             for (var i = 0; i < contentTypes.length; i++) {
@@ -209,15 +209,11 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                             ,'Failed to retrieve icon: ' + iconName)
                         .then(icon => {
                             if(icon) {
-                                var trustedIcon = {
-                                    name: icon.Name,
-                                    svgString: $sce.trustAsHtml(icon.SvgString)
-                                };
-                                this._cacheIcon(trustedIcon);
+                                var trustedIcon = this.defineIcon(icon.name, icon.SvgString);
 
-                                 liveRequests = _.filter(liveRequests, iconRequestPath);
+                                liveRequests = _.filter(liveRequests, iconRequestPath);
 
-                                 resolve(trustedIcon);
+                                resolve(trustedIcon);
                             }
                         })
                         .catch(err => {
@@ -240,15 +236,10 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                         ,'Failed to retrieve icons')
                     .then(icons => {
                         icons.forEach(icon => {
-                            var trustedIcon = {
-                                name: icon.Name,
-                                svgString: $sce.trustAsHtml(icon.SvgString)
-                            };
-
-                            this._cacheIcon(trustedIcon);
+                            this.defineIcon(icon.Name, icon.SvgString);
                         });
 
-                         resolve(iconCache);
+                        resolve(iconCache);
                     })
                     .catch(err => {
                         console.warn(err);
@@ -278,7 +269,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                             console.warn("Can't read the css rules of: " + document.styleSheets[i].href, e);
                             continue;
                         }
-                        
+
                         if (classes !== null) {
                             for(var x=0;x<classes.length;x++) {
                                 var cur = classes[x];
@@ -312,11 +303,17 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
             return deferred.promise;
         },
 
-        /** A simple cache to ensure that the icon is only requested from the server if is isn't already in memory */
-         _cacheIcon: function(icon) {
-            if(_.find(iconCache, {name: icon.name}) === undefined) {
-                iconCache = _.union(iconCache, [icon]);
-			}
+        /** Creates a icon object, and caches it in a runtime cache */
+        defineIcon: function(name, svg) {
+            var icon = iconCache.find(x => x.name === name);
+            if(icon === undefined) {
+                icon = {
+                    name: name,
+                    svgString: $sce.trustAsHtml(svg)
+                };
+                iconCache.push(icon);
+            }
+            return icon;
         },
 
          /** Returns the cached icon or undefined */

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -4,7 +4,6 @@
 @using Umbraco.Core.Composing
 @using Umbraco.Core.IO
 @using Umbraco.Web
-@using Umbraco.Core.Configuration
 
 @inherits WebViewPage<Umbraco.Web.Editors.BackOfficeModel>
 
@@ -122,12 +121,9 @@
             @Html.AngularValueTinyMceAssets()
 
             app.run(["iconHelper", function (iconHelper) {
-
                 @* We inject icons to the icon helper(service), since icons can only be loaded if user is authorized. By injecting these to the service they will not be requested as they will become cached. *@
-
-                iconHelper.defineIcon("icon-check", '<svg viewBox="0 0 512 512"><path d="M461.884 68.14c-132.601 81.297-228.817 183.87-272.048 235.345l-105.874-82.95-46.751 37.691 182.941 186.049c31.485-80.646 131.198-238.264 252.956-350.252L461.884 68.14z"></path></svg>');
-                iconHelper.defineIcon("icon-delete", '<svg viewBox="0 0 512 512"><path d="M401.431 167.814l-58.757-58.76-88.029 88.026-88.028-88.026-58.76 58.76 88.026 88.027-88.026 88.024 58.76 58.768 88.028-88.031 88.029 88.031 58.757-58.768-88.027-88.024z"></path></svg>');
-
+                iconHelper.defineIcon("icon-check", '@Html.Raw(Model.IconCheckData)');
+                iconHelper.defineIcon("icon-delete", '@Html.Raw(Model.IconDeleteData)');
             }]);
 
             //required for the noscript trick

--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -72,16 +72,16 @@
                 </section>
 
             </div>
-            
+
             <umb-notifications></umb-notifications>
 
         </div>
-        
+
         <umb-tour
             ng-if="tour.show"
             model="tour">
         </umb-tour>
-        
+
         <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
         <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
 
@@ -121,8 +121,18 @@
             @Html.AngularValueResetPasswordCodeInfoScript(ViewData["PasswordResetCode"])
             @Html.AngularValueTinyMceAssets()
 
+            app.run(["iconHelper", function (iconHelper) {
+
+                @* We inject icons to the icon helper(service), since icons can only be loaded if user is authorized. By injecting these to the service they will not be requested as they will become cached. *@
+
+                iconHelper.defineIcon("icon-check", '<svg viewBox="0 0 512 512"><path d="M461.884 68.14c-132.601 81.297-228.817 183.87-272.048 235.345l-105.874-82.95-46.751 37.691 182.941 186.049c31.485-80.646 131.198-238.264 252.956-350.252L461.884 68.14z"></path></svg>');
+                iconHelper.defineIcon("icon-delete", '<svg viewBox="0 0 512 512"><path d="M401.431 167.814l-58.757-58.76-88.029 88.026-88.028-88.026-58.76 58.76 88.026 88.027-88.026 88.024 58.76 58.768 88.028-88.031 88.029 88.031 58.757-58.768-88.027-88.024z"></path></svg>');
+
+            }]);
+
             //required for the noscript trick
             document.getElementById("mainwrapper").style.display = "inherit";
+
         }
     </script>
 

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -259,7 +259,7 @@
       Defaults to "false".
     @keepAlivePingUrl
       The url of the KeepAlivePing action. By default, the url will use the umbracoApplicationUrl setting as the basis.
-      Change this setting to specify an alternative url to reach the KeepAlivePing action. eg http://localhost/api/keepalive/ping
+      Change this setting to specify an alternative url to reach the KeepAlivePing action. eg http://localhost/umbraco/api/keepalive/ping
       Defaults to "{umbracoApplicationUrl}/api/keepalive/ping".
   -->
   <keepAlive disableKeepAliveTask="false" keepAlivePingUrl="{umbracoApplicationUrl}/api/keepalive/ping" />

--- a/src/Umbraco.Web/Composing/Current.cs
+++ b/src/Umbraco.Web/Composing/Current.cs
@@ -146,6 +146,9 @@ namespace Umbraco.Web.Composing
         public static ISectionService SectionService
             => Factory.GetInstance<ISectionService>();
 
+        public static IIconService IconService
+            => Factory.GetInstance<IIconService>();
+
         #endregion
 
         #region Web Constants

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -26,6 +26,7 @@ using Umbraco.Web.Composing;
 using Umbraco.Web.Features;
 using Umbraco.Web.JavaScript;
 using Umbraco.Web.Security;
+using Umbraco.Web.Services;
 using Constants = Umbraco.Core.Constants;
 using JArray = Newtonsoft.Json.Linq.JArray;
 
@@ -42,15 +43,54 @@ namespace Umbraco.Web.Editors
         private readonly ManifestParser _manifestParser;
         private readonly UmbracoFeatures _features;
         private readonly IRuntimeState _runtimeState;
+        private readonly IIconService _iconService;
         private BackOfficeUserManager<BackOfficeIdentityUser> _userManager;
         private BackOfficeSignInManager _signInManager;
 
-        public BackOfficeController(ManifestParser manifestParser, UmbracoFeatures features, IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ServiceContext services, AppCaches appCaches, IProfilingLogger profilingLogger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
+        [Obsolete("Use the constructor that injects IIconService.")]
+        public BackOfficeController(
+            ManifestParser manifestParser,
+            UmbracoFeatures features,
+            IGlobalSettings globalSettings,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ServiceContext services,
+            AppCaches appCaches,
+            IProfilingLogger profilingLogger,
+            IRuntimeState runtimeState,
+            UmbracoHelper umbracoHelper)
+            : this(manifestParser,
+                features,
+                globalSettings,
+                umbracoContextAccessor,
+                services,
+                appCaches,
+                profilingLogger,
+                runtimeState,
+                umbracoHelper,
+                Current.IconService)
+        {
+            _manifestParser = manifestParser;
+            _features = features;
+            _runtimeState = runtimeState;
+        }
+
+        public BackOfficeController(
+            ManifestParser manifestParser,
+            UmbracoFeatures features,
+            IGlobalSettings globalSettings,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ServiceContext services,
+            AppCaches appCaches,
+            IProfilingLogger profilingLogger,
+            IRuntimeState runtimeState,
+            UmbracoHelper umbracoHelper,
+            IIconService iconService)
             : base(globalSettings, umbracoContextAccessor, services, appCaches, profilingLogger, umbracoHelper)
         {
             _manifestParser = manifestParser;
             _features = features;
             _runtimeState = runtimeState;
+            _iconService = iconService;
         }
 
         protected BackOfficeSignInManager SignInManager => _signInManager ?? (_signInManager = OwinContext.GetBackOfficeSignInManager());
@@ -66,8 +106,8 @@ namespace Umbraco.Web.Editors
         public async Task<ActionResult> Default()
         {
             return await RenderDefaultOrProcessExternalLoginAsync(
-                () => View(GlobalSettings.Path.EnsureEndsWith('/') + "Views/Default.cshtml", new BackOfficeModel(_features, GlobalSettings)),
-                () => View(GlobalSettings.Path.EnsureEndsWith('/') + "Views/Default.cshtml", new BackOfficeModel(_features, GlobalSettings)));
+                () => View(GlobalSettings.Path.EnsureEndsWith('/') + "Views/Default.cshtml", new BackOfficeModel(_features, GlobalSettings, _iconService)),
+                () => View(GlobalSettings.Path.EnsureEndsWith('/') + "Views/Default.cshtml", new BackOfficeModel(_features, GlobalSettings, _iconService)));
         }
 
         [HttpGet]
@@ -150,7 +190,7 @@ namespace Umbraco.Web.Editors
         {
             return await RenderDefaultOrProcessExternalLoginAsync(
                 //The default view to render when there is no external login info or errors
-                () => View(GlobalSettings.Path.EnsureEndsWith('/') + "Views/AuthorizeUpgrade.cshtml", new BackOfficeModel(_features, GlobalSettings)),
+                () => View(GlobalSettings.Path.EnsureEndsWith('/') + "Views/AuthorizeUpgrade.cshtml", new BackOfficeModel(_features, GlobalSettings, _iconService)),
                 //The ActionResult to perform if external login is successful
                 () => Redirect("/"));
         }

--- a/src/Umbraco.Web/Editors/BackOfficeController.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeController.cs
@@ -67,9 +67,7 @@ namespace Umbraco.Web.Editors
                 umbracoHelper,
                 Current.IconService)
         {
-            _manifestParser = manifestParser;
-            _features = features;
-            _runtimeState = runtimeState;
+
         }
 
         public BackOfficeController(

--- a/src/Umbraco.Web/Editors/BackOfficeModel.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeModel.cs
@@ -1,21 +1,29 @@
-﻿using Umbraco.Core.Configuration;
+﻿using System;
+using Umbraco.Core.Configuration;
+using Umbraco.Web.Composing;
 using Umbraco.Web.Features;
+using Umbraco.Web.Services;
 
 namespace Umbraco.Web.Editors
 {
 
     public class BackOfficeModel
     {
-        private IconController IconController { get; }
-        public BackOfficeModel(UmbracoFeatures features, IGlobalSettings globalSettings)
+
+
+        [Obsolete("Use the overload that injects IIconService.")]
+        public BackOfficeModel(UmbracoFeatures features, IGlobalSettings globalSettings) : this(features, globalSettings, Current.IconService)
+        {
+
+        }
+        public BackOfficeModel(UmbracoFeatures features, IGlobalSettings globalSettings, IIconService iconService)
         {
             Features = features;
             GlobalSettings = globalSettings;
-            IconController = new IconController();
-            IconCheckData = IconController.GetIcon("icon-check")?.SvgString;
-            IconDeleteData = IconController.GetIcon("icon-delete")?.SvgString;
+            IconCheckData = iconService.GetIcon("icon-check")?.SvgString;
+            IconDeleteData = iconService.GetIcon("icon-delete")?.SvgString;
         }
-        
+
         public UmbracoFeatures Features { get; }
         public IGlobalSettings GlobalSettings { get; }
         public string IconCheckData { get; }

--- a/src/Umbraco.Web/Editors/BackOfficeModel.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeModel.cs
@@ -6,13 +6,19 @@ namespace Umbraco.Web.Editors
 
     public class BackOfficeModel
     {
+        private IconController IconController { get; }
         public BackOfficeModel(UmbracoFeatures features, IGlobalSettings globalSettings)
         {
             Features = features;
             GlobalSettings = globalSettings;
+            IconController = new IconController();
+            IconCheckData = IconController.GetIcon("icon-check")?.SvgString;
+            IconDeleteData = IconController.GetIcon("icon-delete")?.SvgString;
         }
         
         public UmbracoFeatures Features { get; }
         public IGlobalSettings GlobalSettings { get; }
+        public string IconCheckData { get; }
+        public string IconDeleteData { get; }
     }
 }

--- a/src/Umbraco.Web/Editors/BackOfficePreviewModel.cs
+++ b/src/Umbraco.Web/Editors/BackOfficePreviewModel.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
+using Umbraco.Web.Composing;
 using Umbraco.Web.Features;
+using Umbraco.Web.Services;
 
 namespace Umbraco.Web.Editors
 {
@@ -10,7 +14,21 @@ namespace Umbraco.Web.Editors
         private readonly UmbracoFeatures _features;
         public IEnumerable<ILanguage> Languages { get; }
 
-        public BackOfficePreviewModel(UmbracoFeatures features, IGlobalSettings globalSettings, IEnumerable<ILanguage> languages) : base(features, globalSettings)
+        [Obsolete("Use the overload that injects IIconService.")]
+        public BackOfficePreviewModel(
+            UmbracoFeatures features,
+            IGlobalSettings globalSettings,
+            IEnumerable<ILanguage> languages)
+            : this(features, globalSettings, languages, Current.IconService)
+        {
+        }
+
+        public BackOfficePreviewModel(
+            UmbracoFeatures features,
+            IGlobalSettings globalSettings,
+            IEnumerable<ILanguage> languages,
+            IIconService iconService)
+            : base(features, globalSettings, iconService)
         {
             _features = features;
             Languages = languages;

--- a/src/Umbraco.Web/Editors/IconController.cs
+++ b/src/Umbraco.Web/Editors/IconController.cs
@@ -1,21 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
-using Umbraco.Core.Logging;
 using Umbraco.Web.Models;
-using System.IO;
-using Umbraco.Core;
-using Umbraco.Core.IO;
-using Ganss.XSS;
-using Umbraco.Core.Cache;
+using Umbraco.Web.Services;
 
 namespace Umbraco.Web.Editors
 {
     [PluginController("UmbracoApi")]
     public class IconController : UmbracoAuthorizedApiController
     {
+        private readonly IIconService _iconService;
+
+        public IconController(IIconService iconService)
+        {
+            _iconService = iconService;
+        }
 
         /// <summary>
         /// Gets an IconModel containing the icon name and SvgString according to an icon name found at the global icons path
@@ -24,76 +23,16 @@ namespace Umbraco.Web.Editors
         /// <returns></returns>
         public IconModel GetIcon(string iconName)
         {
-            return string.IsNullOrWhiteSpace(iconName)
-                ? null
-                : CreateIconModel(iconName.StripFileExtension(), IOHelper.MapPath($"{GlobalSettings.IconsPath}/{iconName}.svg"));
-        }
-
-        /// <summary>
-        /// Gets an IconModel using values from a FileInfo model
-        /// </summary>
-        /// <param name="fileInfo"></param>
-        /// <returns></returns>
-        public IconModel GetIcon(FileInfo fileInfo)
-        {
-            return fileInfo == null || string.IsNullOrWhiteSpace(fileInfo.Name)
-                ? null
-                : CreateIconModel(fileInfo.Name.StripFileExtension(), fileInfo.FullName);
+            return _iconService.GetIcon(iconName);
         }
 
         /// <summary>
         /// Gets a list of all svg icons found at at the global icons path.
         /// </summary>
         /// <returns></returns>
-        public List<IconModel> GetAllIcons()
+        public IList<IconModel> GetAllIcons()
         {
-            var icons = new List<IconModel>();
-            var directory = new DirectoryInfo(IOHelper.MapPath($"{GlobalSettings.IconsPath}/"));
-            var iconNames = directory.GetFiles("*.svg");
-
-            iconNames.OrderBy(f => f.Name).ToList().ForEach(iconInfo =>
-            {
-                var icon = GetIcon(iconInfo);
-
-                if (icon != null)
-                {
-                    icons.Add(icon);
-                }
-            });
-
-            return icons;
-        }
-
-        /// <summary>
-        /// Gets an IconModel containing the icon name and SvgString
-        /// </summary>
-        /// <param name="iconName"></param>
-        /// <param name="iconPath"></param>
-        /// <returns></returns>
-        private IconModel CreateIconModel(string iconName, string iconPath)
-        {
-            var sanitizer = new HtmlSanitizer();
-            sanitizer.AllowedAttributes.UnionWith(Core.Constants.SvgSanitizer.Attributes);
-            sanitizer.AllowedCssProperties.UnionWith(Core.Constants.SvgSanitizer.Attributes);
-            sanitizer.AllowedTags.UnionWith(Core.Constants.SvgSanitizer.Tags);
-
-            try
-            {
-                var svgContent = File.ReadAllText(iconPath);
-                var sanitizedString = sanitizer.Sanitize(svgContent);
-
-                var svg = new IconModel
-                {
-                    Name = iconName,
-                    SvgString = sanitizedString
-                };
-
-                return svg;
-            }
-            catch
-            {
-                return null;
-            }
+            return _iconService.GetAllIcons();
         }
     }
 }

--- a/src/Umbraco.Web/Editors/PreviewController.cs
+++ b/src/Umbraco.Web/Editors/PreviewController.cs
@@ -12,6 +12,7 @@ using Umbraco.Web.JavaScript;
 using Umbraco.Web.Models.ContentEditing;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.PublishedCache;
+using Umbraco.Web.Services;
 using Constants = Umbraco.Core.Constants;
 
 namespace Umbraco.Web.Editors
@@ -24,19 +25,39 @@ namespace Umbraco.Web.Editors
         private readonly IPublishedSnapshotService _publishedSnapshotService;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly ILocalizationService _localizationService;
+        private readonly IIconService _iconService;
 
+        [Obsolete("Use the constructor that injects IIconService.")]
         public PreviewController(
             UmbracoFeatures features,
             IGlobalSettings globalSettings,
             IPublishedSnapshotService publishedSnapshotService,
             IUmbracoContextAccessor umbracoContextAccessor,
             ILocalizationService localizationService)
+            :this(features,
+                globalSettings,
+                publishedSnapshotService,
+                umbracoContextAccessor,
+                localizationService,
+                Current.IconService)
+        {
+
+        }
+
+        public PreviewController(
+            UmbracoFeatures features,
+            IGlobalSettings globalSettings,
+            IPublishedSnapshotService publishedSnapshotService,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ILocalizationService localizationService,
+            IIconService iconService)
         {
             _features = features;
             _globalSettings = globalSettings;
             _publishedSnapshotService = publishedSnapshotService;
             _umbracoContextAccessor = umbracoContextAccessor;
             _localizationService = localizationService;
+            _iconService = iconService;
         }
 
         [UmbracoAuthorize(redirectToUmbracoLogin: true)]
@@ -45,7 +66,7 @@ namespace Umbraco.Web.Editors
         {
             var availableLanguages = _localizationService.GetAllLanguages();
 
-            var model = new BackOfficePreviewModel(_features, _globalSettings, availableLanguages);
+            var model = new BackOfficePreviewModel(_features, _globalSettings, availableLanguages, _iconService);
 
             if (model.PreviewExtendedHeaderView.IsNullOrWhiteSpace() == false)
             {

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -139,6 +139,7 @@ namespace Umbraco.Web.Runtime
             composition.RegisterUnique<ISectionService, SectionService>();
 
             composition.RegisterUnique<IDashboardService, DashboardService>();
+            composition.RegisterUnique<IIconService, IconService>();
 
             composition.RegisterUnique<IExamineManager>(factory => ExamineManager.Instance);
 

--- a/src/Umbraco.Web/Services/IIconService.cs
+++ b/src/Umbraco.Web/Services/IIconService.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.Services
+{
+    public interface IIconService
+    {
+        /// <summary>
+        /// Gets an IconModel containing the icon name and SvgString according to an icon name found at the global icons path
+        /// </summary>
+        /// <param name="iconName"></param>
+        /// <returns></returns>
+        IconModel GetIcon(string iconName);
+
+        /// <summary>
+        /// Gets a list of all svg icons found at at the global icons path.
+        /// </summary>
+        /// <returns></returns>
+        IList<IconModel> GetAllIcons();
+    }
+}

--- a/src/Umbraco.Web/Services/IconService.cs
+++ b/src/Umbraco.Web/Services/IconService.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Ganss.XSS;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.IO;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.Services
+{
+    public class IconService : IIconService
+    {
+        private readonly IGlobalSettings _globalSettings;
+
+        public IconService(IGlobalSettings globalSettings)
+        {
+            _globalSettings = globalSettings;
+        }
+
+
+        /// <inheritdoc />
+        public IList<IconModel> GetAllIcons()
+        {
+            var icons = new List<IconModel>();
+            var directory = new DirectoryInfo(IOHelper.MapPath($"{_globalSettings.IconsPath}/"));
+            var iconNames = directory.GetFiles("*.svg");
+
+            iconNames.OrderBy(f => f.Name).ToList().ForEach(iconInfo =>
+            {
+                var icon = GetIcon(iconInfo);
+
+                if (icon != null)
+                {
+                    icons.Add(icon);
+                }
+            });
+
+            return icons;
+        }
+
+        /// <inheritdoc />
+        public IconModel GetIcon(string iconName)
+        {
+            return string.IsNullOrWhiteSpace(iconName)
+                ? null
+                : CreateIconModel(iconName.StripFileExtension(), IOHelper.MapPath($"{_globalSettings.IconsPath}/{iconName}.svg"));
+        }
+
+        /// <summary>
+        /// Gets an IconModel using values from a FileInfo model
+        /// </summary>
+        /// <param name="fileInfo"></param>
+        /// <returns></returns>
+        private IconModel GetIcon(FileInfo fileInfo)
+        {
+            return fileInfo == null || string.IsNullOrWhiteSpace(fileInfo.Name)
+                ? null
+                : CreateIconModel(fileInfo.Name.StripFileExtension(), fileInfo.FullName);
+        }
+
+        /// <summary>
+        /// Gets an IconModel containing the icon name and SvgString
+        /// </summary>
+        /// <param name="iconName"></param>
+        /// <param name="iconPath"></param>
+        /// <returns></returns>
+        private IconModel CreateIconModel(string iconName, string iconPath)
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.AllowedAttributes.UnionWith(Core.Constants.SvgSanitizer.Attributes);
+            sanitizer.AllowedCssProperties.UnionWith(Core.Constants.SvgSanitizer.Attributes);
+            sanitizer.AllowedTags.UnionWith(Core.Constants.SvgSanitizer.Tags);
+
+            try
+            {
+                var svgContent = File.ReadAllText(iconPath);
+                var sanitizedString = sanitizer.Sanitize(svgContent);
+
+                var svg = new IconModel
+                {
+                    Name = iconName,
+                    SvgString = sanitizedString
+                };
+
+                return svg;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -238,8 +238,8 @@
     <Compile Include="Models\ContentEditing\LinkDisplay.cs" />
     <Compile Include="Models\ContentEditing\MacroDisplay.cs" />
     <Compile Include="Models\ContentEditing\MacroParameterDisplay.cs" />
-    <Compile Include="Models\IconModel.cs" />
     <Compile Include="Models\ContentEditing\UrlAndAnchors.cs" />
+    <Compile Include="Models\IconModel.cs" />
     <Compile Include="Models\ImageProcessorImageUrlGenerator.cs" />
     <Compile Include="Models\Mapping\CommonMapper.cs" />
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />
@@ -284,10 +284,12 @@
     <Compile Include="Search\IUmbracoTreeSearcherFields.cs" />
     <Compile Include="Search\UmbracoTreeSearcherFields.cs" />
     <Compile Include="Services\DashboardService.cs" />
+    <Compile Include="Services\IconService.cs" />
     <Compile Include="Services\IDashboardService.cs" />
     <Compile Include="Models\Link.cs" />
     <Compile Include="Models\LinkType.cs" />
     <Compile Include="Models\TemplateQuery\OperatorFactory.cs" />
+    <Compile Include="Services\IIconService.cs" />
     <Compile Include="Templates\HtmlLocalLinkParser.cs" />
     <Compile Include="Templates\HtmlImageSourceParser.cs" />
     <Compile Include="Templates\HtmlUrlParser.cs" />


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/8919

As you are required to be authorized to retrieve icons through the getIcon end-point, we cannot retrieve icons on the client-side when the user is not authorized. Meaning that the icons used in the login view cannot be loaded in the same manner.
To fix this we will inject the two known icons into the runtime cache through the razor document, which is allowed to retrieve the icons no matter authorization.

This Draft PR does not retrieve the icons from disc, meaning that we have to replace line 128 and 129 in Default.cshtml with razor code that gets the correct SVG.

This draft PR solve the client-side part and needs some Razor work to be done.