### PR TITLE
Show mediapicker edit button after adding media items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -64,8 +64,6 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                             trashed: true
                         };
 
-                        mediaItem.found = found ? true : false;
-
                         return mediaItem;
                     });
 
@@ -200,7 +198,6 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                 multiPicker: multiPicker,
                 onlyImages: onlyImages,
                 disableFolderSelect: disableFolderSelect,
-
                 submit: function (model) {
 
                     editorService.close();
@@ -221,6 +218,7 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
                         }
 
                     });
+
                     sync();
                     reloadUpdatedMediaItems(model.updatedMediaNodes);
                     setDirty();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.html
@@ -37,7 +37,7 @@
                 </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <button type="button" aria-label="Edit media" ng-if="allowEditMedia && media.found" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
+                    <button type="button" aria-label="Edit media" ng-if="allowEditMedia && !media.trashed" class="umb-sortable-thumbnails__action btn-reset" data-element="action-edit" ng-click="vm.editItem(media)">
                         <i class="icon icon-edit" aria-hidden="true"></i>
                     </button>
                     <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="vm.remove($index)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8920

### Description
Previous in https://github.com/umbraco/Umbraco-CMS/pull/8569 the edit button was only shown if the media item was found. However right after a media item has been picked, this property was not set and therefore the condition evaluated as false.

@kjac submitted an alternative fix for this in https://github.com/umbraco/Umbraco-CMS/pull/7406
I have used part of the changes he requested to fix this issue 🎉 🥳 

![2020-09-17_18-01-07](https://user-images.githubusercontent.com/2919859/93496811-f9438980-f90f-11ea-9287-6eb1e6886ae2.gif)