### PR TITLE
Block List - hide add-content button when maximum items is reached

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/showvalidationonsubmit.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/showvalidationonsubmit.directive.js
@@ -11,6 +11,7 @@
             link: function (scope, element, attr, ctrl) {
 
                 var formMgr = ctrl.length > 1 ? ctrl[1] : null;
+                const cssHide = 'ng-hide';
 
                 //We can either get the form submitted status by the parent directive valFormManager
                 //or we can check upwards in the DOM for the css class... lets try both :)
@@ -18,17 +19,17 @@
                 //reset the status.
                 var submitted = element.closest(".show-validation").length > 0 || (formMgr && formMgr.showValidation);
                 if (!submitted) {
-                    element.hide();
+                    element[0].classList.add(cssHide);
                 }
 
                 var unsubscribe = [];
 
                 unsubscribe.push(scope.$on("formSubmitting", function (ev, args) {
-                    element.show();
+                    element[0].classList.remove(cssHide);
                 }));
 
                 unsubscribe.push(scope.$on("formSubmitted", function (ev, args) {
-                    element.hide();
+                    element[0].classList.add(cssHide);
                 }));
 
                 //no isolate scope to listen to element destroy

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -10,6 +10,7 @@
 
                 <button type="button"
                         class="btn-reset umb-block-list__block--create-button"
+                        ng-hide="vm.validationLimit.max && vm.layout.length >= vm.validationLimit.max"
                         ng-click="vm.showCreateDialog($index, $event)"
                         ng-controller="Umbraco.PropertyEditors.BlockListPropertyEditor.CreateButtonController as inlineCreateButtonCtrl"
                         ng-mousemove="inlineCreateButtonCtrl.onMouseMove($event)">
@@ -25,7 +26,7 @@
         </div>
 
         <button ng-if="vm.loading !== true"
-                ng-hide="vm.validationLimit.max && vm.layout.length === vm.validationLimit.max"
+                ng-hide="vm.validationLimit.max && vm.layout.length >= vm.validationLimit.max"
                 id="{{vm.model.alias}}"
                 type="button"
                 class="btn-reset umb-block-list__create-button umb-outline"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -10,7 +10,6 @@
 
                 <button type="button"
                         class="btn-reset umb-block-list__block--create-button"
-                        ng-hide="vm.validationLimit.max && vm.layout.length >= vm.validationLimit.max"
                         ng-click="vm.showCreateDialog($index, $event)"
                         ng-controller="Umbraco.PropertyEditors.BlockListPropertyEditor.CreateButtonController as inlineCreateButtonCtrl"
                         ng-mousemove="inlineCreateButtonCtrl.onMouseMove($event)">
@@ -26,7 +25,6 @@
         </div>
 
         <button ng-if="vm.loading !== true"
-                ng-hide="vm.validationLimit.max && vm.layout.length >= vm.validationLimit.max"
                 id="{{vm.model.alias}}"
                 type="button"
                 class="btn-reset umb-block-list__create-button umb-outline"
@@ -38,13 +36,18 @@
         <input type="hidden" name="minCount" ng-model="vm.layout" val-server="minCount" />
         <input type="hidden" name="maxCount" ng-model="vm.layout" val-server="maxCount" />
 
-        <div ng-messages="vm.propertyForm.minCount.$error" show-validation-on-submit>
+        <div ng-messages="vm.propertyForm.minCount.$error" 
+             ng-show="vm.propertyForm.minCount.$error.minCount"
+             show-validation-on-submit>
             <div class="help text-error" ng-message="minCount">
                 <localize key="validation_entriesShort" tokens="[vm.validationLimit.min, vm.validationLimit.min - vm.layout.length]" watch-tokens="true">Minimum %0% entries, needs <strong>%1%</strong> more.</localize>
             </div>
             <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.minCount.errorMsg">></span>
         </div>
-        <div ng-messages="vm.propertyForm.maxCount.$error" show-validation-on-submit>
+        
+        <div ng-messages="vm.propertyForm.maxCount.$error" 
+             ng-show="vm.propertyForm.maxCount.$error.maxCount"
+             show-validation-on-submit>
             <div class="help text-error" ng-message="maxCount">
                 <localize key="validation_entriesExceed" tokens="[vm.validationLimit.max, vm.layout.length - vm.validationLimit.max]" watch-tokens="true">Maximum %0% entries, <strong>%1%</strong> too many.</localize>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -25,6 +25,7 @@
         </div>
 
         <button ng-if="vm.loading !== true"
+                ng-hide="vm.validationLimit.max && vm.layout.length === vm.validationLimit.max"
                 id="{{vm.model.alias}}"
                 type="button"
                 class="btn-reset umb-block-list__create-button umb-outline"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8894 

### Description
When the block list has maximum items, the add content button should not be shown when the number of blocks is equal to the maximum permitted - this PR makes that happen. Means that editors won't be able to add 10 blocks then get a nasty surprise on saving, when the validation says no, too many.

Test by setting max amount to 1, block list will hide add-content button when one block exists.

If the maximum amount is reduced (say from 5 to 2), the UI will display only the valid number of blocks (ie 3, 4 and 5 will be discarded, 1 and 2 will be displayed). Given that, the validation messages for exceeding the maximum number of blocks will never be shown (but have not been changed as part of this PR). 

I still think it would be useful to show a count on the block list component so editors are aware of how many blocks are permitted, but this is a one-line PR that's taken long to write about than to make the change so I'm stopping now.
