### PR TITLE
V8/fix tracked references query

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IRelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRelationRepository.cs
@@ -28,6 +28,10 @@ namespace Umbraco.Core.Persistence.Repositories
 
         IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int childId, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes);
 
+        IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int childId, long pageIndex, int pageSize, out long totalRecords, int[] relationTypes, params Guid[] entityTypes);
+
         IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes);
+
+        IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords, int[] relationTypes, params Guid[] entityTypes);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -192,6 +192,11 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
                 sql.Where<RelationDto>(rel => rel.ChildId == childId);
                 sql.Where<RelationDto, NodeDto>((rel, node) => rel.ParentId == childId || node.NodeId != childId);
+
+                if (relationTypes != null && relationTypes.Any())
+                {
+                    sql.WhereIn<RelationDto>(rel => rel.RelationType, relationTypes);
+                }
             });
         }
 
@@ -215,6 +220,12 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
                 sql.Where<RelationDto>(rel => rel.ParentId == parentId);
                 sql.Where<RelationDto, NodeDto>((rel, node) => rel.ChildId == parentId || node.NodeId != parentId);
+
+
+                if (relationTypes != null && relationTypes.Any())
+                {
+                    sql.WhereIn<RelationDto>(rel => rel.RelationType, relationTypes);
+                }
             });
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -174,6 +174,12 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int childId, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes)
         {
+            return GetPagedParentEntitiesByChildId(childId, pageIndex, pageSize, out totalRecords, new int[0], entityTypes);
+        }
+
+        public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int childId, long pageIndex, int pageSize, out long totalRecords,
+            int[] relationTypes, params Guid[] entityTypes)
+        {
             // var contentObjectTypes = new[] { Constants.ObjectTypes.Document, Constants.ObjectTypes.Media, Constants.ObjectTypes.Member }
             // we could pass in the contentObjectTypes so that the entity repository sql is configured to do full entity lookups so that we get the full data
             // required to populate content, media or members, else we get the bare minimum data needed to populate an entity. BUT if we do this it
@@ -190,6 +196,12 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         }
 
         public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes)
+        {
+            return GetPagedChildEntitiesByParentId(parentId, pageIndex, pageSize, out totalRecords, new int[0], entityTypes);
+        }
+
+        public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords,
+            int[] relationTypes, params Guid[] entityTypes)
         {
             // var contentObjectTypes = new[] { Constants.ObjectTypes.Document, Constants.ObjectTypes.Media, Constants.ObjectTypes.Member }
             // we could pass in the contentObjectTypes so that the entity repository sql is configured to do full entity lookups so that we get the full data

--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -210,6 +210,17 @@ namespace Umbraco.Core.Services
         IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int id, long pageIndex, int pageSize, out long totalChildren, params UmbracoObjectTypes[] entityTypes);
 
         /// <summary>
+        /// Returns paged parent entities for a related child id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="pageSize"></param>
+        /// <param name="totalChildren"></param>
+        /// <param name="relationTypes">A list of relation types to filter</param>
+        /// <returns></returns>
+        IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int id, long pageIndex, int pageSize, out long totalChildren, string[] relationTypes, params UmbracoObjectTypes[] entityTypes);
+
+        /// <summary>
         /// Returns paged child entities for a related parent id
         /// </summary>
         /// <param name="id"></param>
@@ -218,6 +229,17 @@ namespace Umbraco.Core.Services
         /// <param name="totalChildren"></param>
         /// <returns></returns>
         IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int id, long pageIndex, int pageSize, out long totalChildren, params UmbracoObjectTypes[] entityTypes);
+
+        /// <summary>
+        /// Returns paged child entities for a related parent id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="pageSize"></param>
+        /// <param name="totalChildren"></param>
+        /// <param name="relationTypes">A list of relation types to filter</param>
+        /// <returns></returns>
+        IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int id, long pageIndex, int pageSize, out long totalChildren, string[] relationTypes, params UmbracoObjectTypes[] entityTypes);
 
         /// <summary>
         /// Gets the Parent and Child objects from a list of Relations as a list of <see cref="IUmbracoEntity"/> objects.

--- a/src/Umbraco.Core/Services/Implement/RelationService.cs
+++ b/src/Umbraco.Core/Services/Implement/RelationService.cs
@@ -286,9 +286,11 @@ namespace Umbraco.Core.Services.Implement
         public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int id, long pageIndex, int pageSize, out long totalChildren,
             string[] relationTypes, params UmbracoObjectTypes[] entityTypes)
         {
+            var relationTypeIds = this.GetRelationTypeIdsFromAliases(relationTypes);
+
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                return _relationRepository.GetPagedParentEntitiesByChildId(id, pageIndex, pageSize, out totalChildren, entityTypes.Select(x => x.GetGuid()).ToArray());
+                return _relationRepository.GetPagedParentEntitiesByChildId(id, pageIndex, pageSize, out totalChildren, relationTypeIds, entityTypes.Select(x => x.GetGuid()).ToArray());
             }
         }
 
@@ -303,9 +305,11 @@ namespace Umbraco.Core.Services.Implement
         public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int id, long pageIndex, int pageSize, out long totalChildren,
             string[] relationTypes, params UmbracoObjectTypes[] entityTypes)
         {
+            var relationTypeIds = this.GetRelationTypeIdsFromAliases(relationTypes);
+
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                return _relationRepository.GetPagedChildEntitiesByParentId(id, pageIndex, pageSize, out totalChildren, entityTypes.Select(x => x.GetGuid()).ToArray());
+                return _relationRepository.GetPagedChildEntitiesByParentId(id, pageIndex, pageSize, out totalChildren, relationTypeIds, entityTypes.Select(x => x.GetGuid()).ToArray());
             }
         }
 
@@ -589,6 +593,27 @@ namespace Umbraco.Core.Services.Implement
         {
             _auditRepository.Save(new AuditItem(objectId, type, userId, ObjectTypes.GetName(UmbracoObjectTypes.RelationType), message));
         }
+
+        private int[] GetRelationTypeIdsFromAliases(string[] aliases)
+        {
+            var relationTypeIds = new List<int>();
+
+            if (aliases != null && aliases.Any())
+            {
+                foreach (var relType in aliases)
+                {
+                    var relationType = this.GetRelationTypeByAlias(relType);
+
+                    if (relationType != null)
+                    {
+                        relationTypeIds.Add(relationType.Id);
+                    }
+                }
+            }
+
+            return relationTypeIds.ToArray();
+        }
+
         #endregion
 
         #region Events Handlers

--- a/src/Umbraco.Core/Services/Implement/RelationService.cs
+++ b/src/Umbraco.Core/Services/Implement/RelationService.cs
@@ -278,6 +278,14 @@ namespace Umbraco.Core.Services.Implement
         /// <inheritdoc />
         public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int id, long pageIndex, int pageSize, out long totalChildren, params UmbracoObjectTypes[] entityTypes)
         {
+            return this.GetPagedParentEntitiesByChildId(id, pageIndex, pageSize, out totalChildren, new string[0],
+                entityTypes);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int id, long pageIndex, int pageSize, out long totalChildren,
+            string[] relationTypes, params UmbracoObjectTypes[] entityTypes)
+        {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _relationRepository.GetPagedParentEntitiesByChildId(id, pageIndex, pageSize, out totalChildren, entityTypes.Select(x => x.GetGuid()).ToArray());
@@ -286,6 +294,14 @@ namespace Umbraco.Core.Services.Implement
 
         /// <inheritdoc />
         public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int id, long pageIndex, int pageSize, out long totalChildren, params UmbracoObjectTypes[] entityTypes)
+        {
+            return this.GetPagedChildEntitiesByParentId(id, pageIndex, pageSize, out totalChildren, new string[0],
+                entityTypes);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int id, long pageIndex, int pageSize, out long totalChildren,
+            string[] relationTypes, params UmbracoObjectTypes[] entityTypes)
         {
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {

--- a/src/Umbraco.Tests/Persistence/Repositories/RelationRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/RelationRepositoryTest.cs
@@ -208,6 +208,10 @@ namespace Umbraco.Tests.Persistence.Repositories
 
                 parents.AddRange(repository.GetPagedParentEntitiesByChildId(createdMedia[0].Id, 0, 100, out totalRecords, UmbracoObjectTypes.Media.GetGuid()));
                 Assert.AreEqual(0, totalRecords);
+
+                var contentParents = repository.GetPagedParentEntitiesByChildId(createdContent[0].Id, 0, 11, out  totalRecords).ToList();
+                Assert.AreEqual(20, totalRecords);
+                Assert.AreEqual(11, contentParents.Count);
             }
         }
 
@@ -251,19 +255,19 @@ namespace Umbraco.Tests.Persistence.Repositories
 
                 // Get parent entities for child id
                 var parents = repository.GetPagedChildEntitiesByParentId(createdContent[0].Id, 0, 6, out var totalRecords).ToList();
-                Assert.AreEqual(10, totalRecords);
+                Assert.AreEqual(20, totalRecords);
                 Assert.AreEqual(6, parents.Count);
 
                 //add the next page
                 parents.AddRange(repository.GetPagedChildEntitiesByParentId(createdContent[0].Id, 1, 6, out totalRecords));
-                Assert.AreEqual(10, totalRecords);
-                Assert.AreEqual(10, parents.Count);
+                Assert.AreEqual(20, totalRecords);
+                Assert.AreEqual(12, parents.Count);
 
                 var contentEntities = parents.OfType<IDocumentEntitySlim>().ToList();
                 var mediaEntities = parents.OfType<IMediaEntitySlim>().ToList();
                 var memberEntities = parents.OfType<IMemberEntitySlim>().ToList();
 
-                Assert.AreEqual(0, contentEntities.Count);
+                Assert.AreEqual(2, contentEntities.Count);
                 Assert.AreEqual(10, mediaEntities.Count);
                 Assert.AreEqual(0, memberEntities.Count);
 
@@ -292,6 +296,16 @@ namespace Umbraco.Tests.Persistence.Repositories
                 createdContent.Add(c1);
             }
 
+            //Related content
+            var relatedContents = new List<IContent>();
+            
+            for (int i = 0; i < 10; i++)
+            {
+                var c1 = MockedContent.CreateBasicContent(contentType);
+                ServiceContext.ContentService.Save(c1);
+                relatedContents.Add(c1);
+            }
+
             //Create media
             createdMedia = new List<IMedia>();
             var imageType = MockedContentTypes.CreateImageMediaType("myImage");
@@ -309,16 +323,71 @@ namespace Umbraco.Tests.Persistence.Repositories
             createdMembers = MockedMember.CreateSimpleMember(memberType, 10).ToList();
             ServiceContext.MemberService.Save(createdMembers);
 
-            var relType = ServiceContext.RelationService.GetRelationTypeByAlias(Constants.Conventions.RelationTypes.RelatedMediaAlias);
+            var relatedMediaRelType = ServiceContext.RelationService.GetRelationTypeByAlias(Constants.Conventions.RelationTypes.RelatedMediaAlias);
+            var relatedContentRelType = ServiceContext.RelationService.GetRelationTypeByAlias(Constants.Conventions.RelationTypes.RelatedDocumentAlias);
 
             // Relate content to media
             foreach (var content in createdContent)
                 foreach (var media in createdMedia)
-                    ServiceContext.RelationService.Relate(content.Id, media.Id, relType);
+                    ServiceContext.RelationService.Relate(content.Id, media.Id, relatedMediaRelType);
+
+            // Relate content to content
+            foreach (var relContent in relatedContents)
+                foreach (var content in createdContent)
+                    ServiceContext.RelationService.Relate(relContent.Id, content.Id, relatedContentRelType);
+
             // Relate members to media
             foreach (var member in createdMembers)
                 foreach (var media in createdMedia)
-                    ServiceContext.RelationService.Relate(member.Id, media.Id, relType);
+                    ServiceContext.RelationService.Relate(member.Id, media.Id, relatedMediaRelType);
+
+
+            //Create "copied" content
+            var copiedContents = new List<IContent>();
+            for (int i = 0; i < 10; i++)
+            {
+                var c1 = MockedContent.CreateBasicContent(contentType);
+                ServiceContext.ContentService.Save(c1);
+                copiedContents.Add(c1);
+            }
+
+            var copiedContentRelType =
+                ServiceContext.RelationService.GetRelationTypeByAlias(Constants.Conventions.RelationTypes
+                    .RelateDocumentOnCopyAlias);
+
+            // Relate content to content (mimics copy)
+            foreach (var content in createdContent)
+            {
+                foreach (var copiedContent in copiedContents)
+                {
+                    ServiceContext.RelationService.Relate(content.Id, copiedContent.Id, copiedContentRelType);
+                }
+                   
+            }
+
+            // create trashed content
+            var trashedContents = new List<IContent>();
+            for (int i = 0; i < 10; i++)
+            {
+                var c1 = MockedContent.CreateBasicContent(contentType);
+                ServiceContext.ContentService.Save(c1);
+                trashedContents.Add(c1);
+            }
+
+            var trashedRelType =
+                ServiceContext.RelationService.GetRelationTypeByAlias(Constants.Conventions.RelationTypes
+                    .RelateParentDocumentOnDeleteAlias);
+
+            // Relate to trashed content
+            foreach (var trashedContent in trashedContents)
+            {
+                foreach (var content in createdContent)
+                {
+                    ServiceContext.RelationService.Relate(trashedContent.Id, content.Id, trashedRelType);
+                }
+
+            }
+
         }
 
         [Test]

--- a/src/Umbraco.Web/Editors/TrackedReferencesController.cs
+++ b/src/Umbraco.Web/Editors/TrackedReferencesController.cs
@@ -36,8 +36,13 @@ namespace Umbraco.Web.Editors
 
             var objectType = ObjectTypes.GetUmbracoObjectType(entityType);
             var udiType = ObjectTypes.GetUdiType(objectType);
+            var relationTypes = new string[]
+            {
+                Constants.Conventions.RelationTypes.RelatedDocumentAlias,
+                Constants.Conventions.RelationTypes.RelatedMediaAlias
+            };
 
-            var relations = Services.RelationService.GetPagedParentEntitiesByChildId(id, pageNumber - 1, pageSize, out var totalRecords, objectType);
+            var relations = Services.RelationService.GetPagedParentEntitiesByChildId(id, pageNumber - 1, pageSize, out var totalRecords, relationTypes, objectType);
 
             return new PagedResult<EntityBasic>(totalRecords, pageNumber, pageSize)
             {


### PR DESCRIPTION
While working on the UI improvements for the item tracking feature (#8679) I noticed that all relations types are shown on the info tab.

To reproduce you can take the following scenario's (based on the v8/item-tracking branch) using the default starter kit.

**Scenario 1**
1. Copy a existing page and check relate to original.
2. On the new page you will see the original page in the list of Used in documents

**Scenario 2**
1. Delete a existing page that is under a other page.
2. Locate the deleted page in the recycle bin and check the info tab. You will see the parent of the deleted page under used in documents.

This one is also happening with media

This PR applies filtering on the relation types that are used for filtering. Everything is backwards compatible and covered with unit tests. I discussed this with @Shazwazza 

