### PR TITLE
8.8 Revert icon styling, to ensure backwards compatibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -31,7 +31,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         { oldIcon: ".sprToPublish", newIcon: "mail-forward" },
         { oldIcon: ".sprTranslate", newIcon: "comments" },
         { oldIcon: ".sprUpdate", newIcon: "save" },
-        
+
         { oldIcon: ".sprTreeSettingDomain", newIcon: "icon-home" },
         { oldIcon: ".sprTreeDoc", newIcon: "icon-document" },
         { oldIcon: ".sprTreeDoc2", newIcon: "icon-diploma-alt" },
@@ -39,21 +39,21 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         { oldIcon: ".sprTreeDoc4", newIcon: "icon-newspaper-alt" },
         { oldIcon: ".sprTreeDoc5", newIcon: "icon-notepad-alt" },
 
-        { oldIcon: ".sprTreeDocPic", newIcon: "icon-picture" },        
+        { oldIcon: ".sprTreeDocPic", newIcon: "icon-picture" },
         { oldIcon: ".sprTreeFolder", newIcon: "icon-folder" },
         { oldIcon: ".sprTreeFolder_o", newIcon: "icon-folder" },
         { oldIcon: ".sprTreeMediaFile", newIcon: "icon-music" },
         { oldIcon: ".sprTreeMediaMovie", newIcon: "icon-movie" },
         { oldIcon: ".sprTreeMediaPhoto", newIcon: "icon-picture" },
-        
+
         { oldIcon: ".sprTreeMember", newIcon: "icon-user" },
         { oldIcon: ".sprTreeMemberGroup", newIcon: "icon-users" },
         { oldIcon: ".sprTreeMemberType", newIcon: "icon-users" },
-        
+
         { oldIcon: ".sprTreeNewsletter", newIcon: "icon-file-text-alt" },
         { oldIcon: ".sprTreePackage", newIcon: "icon-box" },
         { oldIcon: ".sprTreeRepository", newIcon: "icon-server-alt" },
-        
+
         { oldIcon: ".sprTreeSettingDataType", newIcon: "icon-autofill" },
 
         // TODO: Something needs to be done with the old tree icons that are commented out.
@@ -61,7 +61,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         { oldIcon: ".sprTreeSettingAgent", newIcon: "" },
         { oldIcon: ".sprTreeSettingCss", newIcon: "" },
         { oldIcon: ".sprTreeSettingCssItem", newIcon: "" },
-        
+
         { oldIcon: ".sprTreeSettingDataTypeChild", newIcon: "" },
         { oldIcon: ".sprTreeSettingDomain", newIcon: "" },
         { oldIcon: ".sprTreeSettingLanguage", newIcon: "" },
@@ -94,9 +94,9 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
     var iconCache = [];
     var liveRequests = [];
     var allIconsRequested = false;
-            
+
     return {
-        
+
         /** Used by the create dialogs for content/media types to format the data so that the thumbnails are styled properly */
         formatContentTypeThumbnails: function (contentTypes) {
             for (var i = 0; i < contentTypes.length; i++) {
@@ -261,7 +261,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
 
         /** LEGACY - Return a list of icons from icon fonts, optionally filter them */
         /** It fetches them directly from the active stylesheets in the browser */
-        getLegacyIcons: function(){
+        getIcons: function(){
             var deferred = $q.defer();
             $timeout(function(){
                 if(collectedIcons){
@@ -278,7 +278,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                             console.warn("Can't read the css rules of: " + document.styleSheets[i].href, e);
                             continue;
                         }
-                        
+
                         if (classes !== null) {
                             for(var x=0;x<classes.length;x++) {
                                 var cur = classes[x];
@@ -293,13 +293,8 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                                         s = s.substring(0, hasPseudo);
                                     }
 
-                                    var icon = {
-                                        name: s,
-                                        svgString: undefined
-                                    };
-
-                                    if(collectedIcons.indexOf(icon) < 0 && s !== "icon-chevron-up" && s !== "icon-chevron-down"){
-                                        collectedIcons.push(icon);
+                                    if(collectedIcons.indexOf(s) < 0){
+                                        collectedIcons.push(s);
                                     }
                                 }
                             }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
@@ -1,4 +1,27 @@
 ﻿.umb-icon {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+
+    svg {
+        width: 100%;
+        height: 100%;
+        fill: currentColor;
+    }
+
+    &.large{
+        width: 32px; 
+        height: 32px;
+    }
+    &.medium{
+        width: 24px;
+        height: 24px;
+    }
+    &.small{
+        width: 14px;
+        height: 14px;
+    }
+
     &:before, &:after {
         content: none !important;
     }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -58,7 +58,6 @@
 }
 
 .umb-iconpicker-item i {
-    font-family: inherit;
     font-size: 30px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -234,3 +234,7 @@
 .umb-media-grid__list-view .umb-table-cell.umb-table__name .item-name {
     white-space:normal;
 }
+.umb-media-grid__list-view .umb-table-cell.umb-table__name ins {
+    text-decoration: none;
+    margin-top: 3px;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/helveticons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/helveticons.less
@@ -8,32 +8,6 @@
 	font-style: normal;
 }
 
-span[icon],
-span[icon] {
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-
-    svg {
-        width: 100%;
-        height: 100%;
-        fill: currentColor;
-    }
-
-    &.large{
-        width: 32px; 
-        height: 32px;
-    }
-    &.medium{
-        width: 24px;
-        height: 24px;
-    }
-    &.small{
-        width: 14px;
-        height: 14px;
-    }
-}
-
 
 [class^="icon-"],
 [class*=" icon-"]{

--- a/src/Umbraco.Web.UI.Client/src/less/helveticons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/helveticons.less
@@ -8,6 +8,33 @@
 	font-style: normal;
 }
 
+span[icon],
+span[icon] {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+
+    svg {
+        width: 100%;
+        height: 100%;
+        fill: currentColor;
+    }
+
+    &.large{
+        width: 32px; 
+        height: 32px;
+    }
+    &.medium{
+        width: 24px;
+        height: 24px;
+    }
+    &.small{
+        width: 14px;
+        height: 14px;
+    }
+}
+
+
 [class^="icon-"],
 [class*=" icon-"]{
     font-family: 'icomoon';

--- a/src/Umbraco.Web.UI.Client/src/less/helveticons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/helveticons.less
@@ -8,36 +8,8 @@
 	font-style: normal;
 }
 
-span[class^="icon-"],
-span[class*=" icon-"] {
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    *margin-right: .3em;
-
-    svg {
-        width: 100%;
-        height: 100%;
-        fill: currentColor;
-    }
-
-    &.large{
-        width: 32px; 
-        height: 32px;
-    }
-    &.medium{
-        width: 24px;
-        height: 24px;
-    }
-    &.small{
-        width: 14px;
-        height: 14px;
-    }
-}
-
 [class^="icon-"],
-[class*=" icon-"],
-button.icon-trash {
+[class*=" icon-"]{
     font-family: 'icomoon';
     speak: none;
     font-style: normal;
@@ -52,8 +24,7 @@ button.icon-trash {
 }
 
 [class^="icon-"]:before,
-[class*=" icon-"]:before,
-button.icon-trash {
+[class*=" icon-"]:before {
     text-decoration: inherit;
     display: inline-block;
     speak: none;
@@ -69,1838 +40,1834 @@ i.small{
 	font-size: 14px;
 }
 
-i.icon-zoom-out:before {
+.icon-zoom-out:before {
 	content: "\e000";
 }
-i.icon-truck:before {
+.icon-truck:before {
 	content: "\e001";
 }
-i.icon-zoom-in:before {
+.icon-zoom-in:before {
 	content: "\e002";
 }
-i.icon-zip:before {
+.icon-zip:before {
 	content: "\e003";
 }
-i.icon-axis-rotation:before {
+.icon-axis-rotation:before {
 	content: "\e004";
 }
-i.icon-yen-bag:before {
+.icon-yen-bag:before {
 	content: "\e005";
 }
-i.icon-axis-rotation-2:before {
+.icon-axis-rotation-2:before {
 	content: "\e006";
 }
-i.icon-axis-rotation-3:before {
+.icon-axis-rotation-3:before {
 	content: "\e007";
 }
-i.icon-wrench:before {
+.icon-wrench:before {
 	content: "\e008";
 }
-i.icon-wine-glass:before {
+.icon-wine-glass:before {
 	content: "\e009";
 }
-i.icon-wrong:before {
+.icon-wrong:before {
 	content: "\e00a";
 }
-i.icon-windows:before {
+.icon-windows:before {
 	content: "\e00b";
 }
-i.icon-window-sizes:before {
+.icon-window-sizes:before {
 	content: "\e00c";
 }
-i.icon-window-popin:before {
+.icon-window-popin:before {
 	content: "\e00d";
 }
-i.icon-wifi:before {
+.icon-wifi:before {
 	content: "\e00e";
 }
-i.icon-width:before {
+.icon-width:before {
 	content: "\e00f";
 }
-i.icon-weight:before {
+.icon-weight:before {
 	content: "\e010";
 }
-i.icon-war:before {
+.icon-war:before {
 	content: "\e011";
 }
-i.icon-wand:before {
+.icon-wand:before {
 	content: "\e012";
 }
-i.icon-wallet:before {
+.icon-wallet:before {
 	content: "\e013";
 }
-i.icon-wall-plug:before {
+.icon-wall-plug:before {
 	content: "\e014";
 }
-i.icon-voice:before {
+.icon-voice:before {
 	content: "\e016";
 }
-i.icon-video:before {
+.icon-video:before {
 	content: "\e017";
 }
-i.icon-vcard:before {
+.icon-vcard:before {
 	content: "\e018";
 }
-i.icon-utilities:before {
+.icon-utilities:before {
 	content: "\e019";
 }
-i.icon-users:before {
+.icon-users:before {
 	content: "\e01a";
 }
-i.icon-users-alt:before {
+.icon-users-alt:before {
 	content: "\e01b";
 }
-i.icon-user:before {
+.icon-user:before {
 	content: "\e01c";
 }
-i.icon-user-glasses:before {
+.icon-user-glasses:before {
 	content: "\e01d";
 }
-i.icon-user-females:before {
+.icon-user-females:before {
 	content: "\e01e";
 }
-i.icon-user-females-alt:before {
+.icon-user-females-alt:before {
 	content: "\e01f";
 }
-i.icon-user-female:before {
+.icon-user-female:before {
 	content: "\e020";
 }
-i.icon-usb:before {
+.icon-usb:before {
 	content: "\e021";
 }
-i.icon-usb-connector:before {
+.icon-usb-connector:before {
 	content: "\e022";
 }
-i.icon-unlocked:before {
+.icon-unlocked:before {
 	content: "\e023";
 }
-i.icon-universal:before {
+.icon-universal:before {
 	content: "\e024";
 }
-i.icon-undo:before {
+.icon-undo:before {
 	content: "\e025";
 }
-i.icon-umbrella:before {
+.icon-umbrella:before {
 	content: "\e026";
 }
-i.icon-umb-deploy:before {
+.icon-umb-deploy:before {
 	content: "\e027";
 }
-i.icon-umb-contour:before, .traycontour:before {
+.icon-umb-contour:before, .traycontour:before {
 	content: "\e028";
 }
-i.icon-umb-settings:before, .traysettings:before {
+.icon-umb-settings:before, .traysettings:before {
 	content: "\e029";
 }
-i.icon-umb-users:before, .trayuser:before, .trayusers:before{
+.icon-umb-users:before, .trayuser:before, .trayusers:before{
 	content: "\e02a";
 }
-i.icon-umb-media:before, .traymedia:before {
+.icon-umb-media:before, .traymedia:before {
 	content: "\e02b";
 }
-i.icon-umb-content:before, .traycontent:before{
+.icon-umb-content:before, .traycontent:before{
 	content: "\e02c";
 }
-i.icon-umb-developer:before, .traydeveloper:before {
+.icon-umb-developer:before, .traydeveloper:before {
 	content: "\e02d";
 }
-i.icon-umb-members:before, .traymember:before {
+.icon-umb-members:before, .traymember:before {
 	content: "\e015";
 }
-i.icon-umb-translation:before, .traytranslation:before {
+.icon-umb-translation:before, .traytranslation:before {
 	content: "\e1fd";
 }
-i.icon-tv:before {
+.icon-tv:before {
 	content: "\e02e";
 }
-i.icon-tv-old:before {
+.icon-tv-old:before {
 	content: "\e02f";
 }
-i.icon-trophy:before {
+.icon-trophy:before {
 	content: "\e030";
 }
-i.icon-tree:before {
+.icon-tree:before {
 	content: "\e031";
 }
-i.icon-trash:before,
-button.icon-trash:before {
+.icon-trash:before {
 	content: "\e032";
 }
-i.icon-trash-alt:before,
-button.icon-trash-alt:before {
+.icon-trash-alt:before {
 	content: "\e033";
 }
-i.icon-trash-alt-2:before,
-button.icon-trash-alt-2:before  {
+.icon-trash-alt-2:before {
 	content: "\e034";
 }
-i.icon-train:before {
+.icon-train:before {
 	content: "\e035";
 }
-i.icon-trafic:before,
-i.icon-traffic:before {
+.icon-trafic:before,
+.icon-traffic:before {
 	content: "\e036";
 }
-i.icon-traffic-alt:before {
+.icon-traffic-alt:before {
 	content: "\e037";
 }
-i.icon-top:before {
+.icon-top:before {
 	content: "\e038";
 }
-i.icon-tools:before {
+.icon-tools:before {
 	content: "\e039";
 }
-i.icon-timer:before {
+.icon-timer:before {
 	content: "\e03a";
 }
-i.icon-time:before {
+.icon-time:before {
 	content: "\e03b";
 }
-i.icon-t-shirt:before {
+.icon-t-shirt:before {
 	content: "\e03c";
 }
-i.icon-tab-key:before {
+.icon-tab-key:before {
 	content: "\e03d";
 }
-i.icon-tab:before {
+.icon-tab:before {
 	content: "\e03e";
 }
-i.icon-tactics:before {
+.icon-tactics:before {
 	content: "\e03f";
 }
-i.icon-tag:before {
+.icon-tag:before {
 	content: "\e040";
 }
-i.icon-tags:before {
+.icon-tags:before {
 	content: "\e041";
 }
-i.icon-takeaway-cup:before {
+.icon-takeaway-cup:before {
 	content: "\e042";
 }
-i.icon-target:before {
+.icon-target:before {
 	content: "\e043";
 }
-i.icon-temperature-alt:before,
-i.icon-temperatrure-alt:before {
+.icon-temperature-alt:before,
+.icon-temperatrure-alt:before {
 	content: "\e044";
 }
-i.icon-temperature:before {
+.icon-temperature:before {
 	content: "\e045";
 }
-i.icon-terminal:before {
+.icon-terminal:before {
 	content: "\e046";
 }
-i.icon-theater:before {
+.icon-theater:before {
 	content: "\e047";
 }
-i.icon-thief:before,
-i.icon-theif:before {
+.icon-thief:before,
+.icon-theif:before {
 	content: "\e048";
 }
-i.icon-thought-bubble:before {
+.icon-thought-bubble:before {
 	content: "\e049";
 }
-i.icon-thumb-down:before {
+.icon-thumb-down:before {
 	content: "\e04a";
 }
-i.icon-thumb-up:before {
+.icon-thumb-up:before {
 	content: "\e04b";
 }
-i.icon-thumbnail-list:before {
+.icon-thumbnail-list:before {
 	content: "\e04c";
 }
-i.icon-thumbnails-small:before {
+.icon-thumbnails-small:before {
 	content: "\e04d";
 }
-i.icon-thumbnails:before {
+.icon-thumbnails:before {
 	content: "\e04e";
 }
-i.icon-ticket:before {
+.icon-ticket:before {
 	content: "\e04f";
 }
-i.icon-sync:before {
+.icon-sync:before {
 	content: "\e050";
 }
-i.icon-sweatshirt:before {
+.icon-sweatshirt:before {
 	content: "\e051";
 }
-i.icon-sunny:before {
+.icon-sunny:before {
 	content: "\e052";
 }
-i.icon-stream:before {
+.icon-stream:before {
 	content: "\e053";
 }
-i.icon-store:before {
+.icon-store:before {
 	content: "\e054";
 }
-i.icon-stop:before {
+.icon-stop:before {
 	content: "\e055";
 }
-i.icon-stop-hand:before {
+.icon-stop-hand:before {
 	content: "\e056";
 }
-i.icon-stop-alt:before {
+.icon-stop-alt:before {
 	content: "\e057";
 }
-i.icon-stamp:before {
+.icon-stamp:before {
 	content: "\e058";
 }
-i.icon-stacked-disks:before {
+.icon-stacked-disks:before {
 	content: "\e059";
 }
-i.icon-ssd:before {
+.icon-ssd:before {
 	content: "\e05a";
 }
-i.icon-squiggly-line:before {
+.icon-squiggly-line:before {
 	content: "\e05b";
 }
-i.icon-sprout:before {
+.icon-sprout:before {
 	content: "\e05c";
 }
-i.icon-split:before {
+.icon-split:before {
 	content: "\e05d";
 }
-i.icon-split-alt:before {
+.icon-split-alt:before {
 	content: "\e05e";
 }
-i.icon-speed-gauge:before {
+.icon-speed-gauge:before {
 	content: "\e05f";
 }
-i.icon-speaker:before {
+.icon-speaker:before {
 	content: "\e060";
 }
-i.icon-sound:before {
+.icon-sound:before {
 	content: "\e061";
 }
-i.icon-spades:before {
+.icon-spades:before {
 	content: "\e062";
 }
-i.icon-sound-waves:before {
+.icon-sound-waves:before {
 	content: "\e063";
 }
-i.icon-shipping-box:before {
+.icon-shipping-box:before {
 	content: "\e064";
 }
-i.icon-shipping:before {
+.icon-shipping:before {
 	content: "\e065";
 }
-i.icon-shoe:before {
+.icon-shoe:before {
 	content: "\e066";
 }
-i.icon-shopping-basket-alt-2:before {
+.icon-shopping-basket-alt-2:before {
 	content: "\e067";
 }
-i.icon-shopping-basket:before {
+.icon-shopping-basket:before {
 	content: "\e068";
 }
-i.icon-shopping-basket-alt:before {
+.icon-shopping-basket-alt:before {
 	content: "\e069";
 }
-i.icon-shorts:before {
+.icon-shorts:before {
 	content: "\e06a";
 }
-i.icon-shuffle:before {
+.icon-shuffle:before {
 	content: "\e06b";
 }
-i.icon-science:before,
-i.icon-sience:before {
+.icon-science:before,
+.icon-sience:before {
 	content: "\e06c";
 }
-i.icon-simcard:before {
+.icon-simcard:before {
 	content: "\e06d";
 }
-i.icon-single-note:before {
+.icon-single-note:before {
 	content: "\e06e";
 }
-i.icon-sitemap:before {
+.icon-sitemap:before {
 	content: "\e06f";
 }
-i.icon-sleep:before {
+.icon-sleep:before {
 	content: "\e070";
 }
-i.icon-slideshow:before {
+.icon-slideshow:before {
 	content: "\e071";
 }
-i.icon-smiley-inverted:before {
+.icon-smiley-inverted:before {
 	content: "\e072";
 }
-i.icon-smiley:before {
+.icon-smiley:before {
 	content: "\e073";
 }
-i.icon-snow:before {
+.icon-snow:before {
 	content: "\e074";
 }
-i.icon-sound-low:before {
+.icon-sound-low:before {
 	content: "\e075";
 }
-i.icon-sound-medium:before {
+.icon-sound-medium:before {
 	content: "\e076";
 }
-i.icon-sound-off:before {
+.icon-sound-off:before {
 	content: "\e077";
 }
-i.icon-shift:before {
+.icon-shift:before {
 	content: "\e078";
 }
-i.icon-shield:before {
+.icon-shield:before {
 	content: "\e079";
 }
-i.icon-sharing-iphone:before {
+.icon-sharing-iphone:before {
 	content: "\e07a";
 }
-i.icon-share:before {
+.icon-share:before {
 	content: "\e07b";
 }
-i.icon-share-alt:before {
+.icon-share-alt:before {
 	content: "\e07c";
 }
-i.icon-share-alt-2:before {
+.icon-share-alt-2:before {
 	content: "\e07d";
 }
-i.icon-settings:before,
-button.icon-settings:before  {
+.icon-settings:before {
 	content: "\e07e";
 }
-i.icon-settings-alt:before {
+.icon-settings-alt:before {
 	content: "\e07f";
 }
-i.icon-settings-alt-2:before {
+.icon-settings-alt-2:before {
 	content: "\e080";
 }
-i.icon-server:before {
+.icon-server:before {
 	content: "\e081";
 }
-i.icon-server-alt:before {
+.icon-server-alt:before {
 	content: "\e082";
 }
-i.icon-sensor:before {
+.icon-sensor:before {
 	content: "\e083";
 }
-i.icon-security-camera:before {
+.icon-security-camera:before {
 	content: "\e084";
 }
-i.icon-search:before {
+.icon-search:before {
 	content: "\e085";
 }
-i.icon-scull:before {
+.icon-scull:before {
 	content: "\e086";
 }
-i.icon-script:before {
+.icon-script:before {
 	content: "\e087";
 }
-i.icon-script-alt:before {
+.icon-script-alt:before {
 	content: "\e088";
 }
-i.icon-screensharing:before {
+.icon-screensharing:before {
 	content: "\e089";
 }
-i.icon-school:before {
+.icon-school:before {
 	content: "\e08a";
 }
-i.icon-scan:before {
+.icon-scan:before {
 	content: "\e08b";
 }
-i.icon-refresh:before {
+.icon-refresh:before {
 	content: "\e08c";
 }
-i.icon-remote:before {
+.icon-remote:before {
 	content: "\e08d";
 }
-i.icon-remove:before {
+.icon-remove:before {
 	content: "\e08e";
 }
-i.icon-repeat-one:before {
+.icon-repeat-one:before {
 	content: "\e08f";
 }
-i.icon-repeat:before {
+.icon-repeat:before {
 	content: "\e090";
 }
-i.icon-resize:before {
+.icon-resize:before {
 	content: "\e091";
 }
-i.icon-reply-arrow:before {
+.icon-reply-arrow:before {
 	content: "\e092";
 }
-i.icon-return-to-top:before {
+.icon-return-to-top:before {
 	content: "\e093";
 }
-i.icon-right-double-arrow:before {
+.icon-right-double-arrow:before {
 	content: "\e094";
 }
-i.icon-road:before {
+.icon-road:before {
 	content: "\e095";
 }
-i.icon-roadsign:before {
+.icon-roadsign:before {
 	content: "\e096";
 }
-i.icon-rocket:before {
+.icon-rocket:before {
 	content: "\e097";
 }
-i.icon-rss:before {
+.icon-rss:before {
 	content: "\e098";
 }
-i.icon-ruler-alt:before {
+.icon-ruler-alt:before {
 	content: "\e099";
 }
-i.icon-ruler:before {
+.icon-ruler:before {
 	content: "\e09a";
 }
-i.icon-sandbox-toys:before {
+.icon-sandbox-toys:before {
 	content: "\e09b";
 }
-i.icon-satellite-dish:before {
+.icon-satellite-dish:before {
 	content: "\e09c";
 }
-i.icon-save:before {
+.icon-save:before {
 	content: "\e09d";
 }
-i.icon-safedial:before {
+.icon-safedial:before {
 	content: "\e09e";
 }
-i.icon-safe:before {
+.icon-safe:before {
 	content: "\e09f";
 }
-i.icon-redo:before {
+.icon-redo:before {
 	content: "\e0a0";
 }
-i.icon-printer-alt:before {
+.icon-printer-alt:before {
 	content: "\e0a1";
 }
-i.icon-planet:before {
+.icon-planet:before {
 	content: "\e0a2";
 }
-i.icon-paste-in:before {
+.icon-paste-in:before {
 	content: "\e0a3";
 }
-i.icon-os-x:before {
+.icon-os-x:before {
 	content: "\e0a4";
 }
-i.icon-navigation-left:before {
+.icon-navigation-left:before {
 	content: "\e0a5";
 }
-i.icon-message:before {
+.icon-message:before {
 	content: "\e0a6";
 }
-i.icon-lock:before {
+.icon-lock:before {
 	content: "\e0a7";
 }
-i.icon-layers-alt:before {
+.icon-layers-alt:before {
 	content: "\e0a8";
 }
-i.icon-record:before {
+.icon-record:before {
 	content: "\e0a9";
 }
-i.icon-print:before {
+.icon-print:before {
 	content: "\e0aa";
 }
-i.icon-plane:before {
+.icon-plane:before {
 	content: "\e0ab";
 }
-i.icon-partly-cloudy:before {
+.icon-partly-cloudy:before {
 	content: "\e0ac";
 }
-i.icon-ordered-list:before {
+.icon-ordered-list:before {
 	content: "\e0ad";
 }
-i.icon-navigation-last:before {
+.icon-navigation-last:before {
 	content: "\e0ae";
 }
-i.icon-message-unopened:before {
+.icon-message-unopened:before {
 	content: "\e0af";
 }
-i.icon-location-nearby:before {
+.icon-location-nearby:before {
 	content: "\e0b0";
 }
-i.icon-laptop:before {
+.icon-laptop:before {
 	content: "\e0b1";
 }
-i.icon-reception:before {
+.icon-reception:before {
 	content: "\e0b2";
 }
-i.icon-price-yen:before {
+.icon-price-yen:before {
 	content: "\e0b3";
 }
-i.icon-piracy:before {
+.icon-piracy:before {
 	content: "\e0b4";
 }
-i.icon-parental-control:before {
+.icon-parental-control:before {
 	content: "\e0b5";
 }
-i.icon-operator:before {
+.icon-operator:before {
 	content: "\e0b6";
 }
-i.icon-navigation-horizontal:before {
+.icon-navigation-horizontal:before {
 	content: "\e0b7";
 }
-i.icon-message-open:before {
+.icon-message-open:before {
 	content: "\e0b8";
 }
-i.icon-lab:before {
+.icon-lab:before {
 	content: "\e0b9";
 }
-i.icon-location-near-me:before {
+.icon-location-near-me:before {
 	content: "\e0ba";
 }
-i.icon-receipt-yen:before {
+.icon-receipt-yen:before {
 	content: "\e0bb";
 }
-i.icon-price-pound:before {
+.icon-price-pound:before {
 	content: "\e0bc";
 }
-i.icon-pin-location:before {
+.icon-pin-location:before {
 	content: "\e0bd";
 }
-i.icon-parachute-drop:before {
+.icon-parachute-drop:before {
 	content: "\e0be";
 }
-i.icon-old-phone:before {
+.icon-old-phone:before {
 	content: "\e0bf";
 }
-i.icon-merge:before {
+.icon-merge:before {
 	content: "\e0c0";
 }
-i.icon-navigation-first:before {
+.icon-navigation-first:before {
 	content: "\e0c1";
 }
-i.icon-locate:before {
+.icon-locate:before {
 	content: "\e0c2";
 }
-i.icon-keyhole:before {
+.icon-keyhole:before {
 	content: "\e0c3";
 }
-i.icon-receipt-pound:before {
+.icon-receipt-pound:before {
 	content: "\e0c4";
 }
-i.icon-price-euro:before {
+.icon-price-euro:before {
 	content: "\e0c5";
 }
-i.icon-piggy-bank:before {
+.icon-piggy-bank:before {
 	content: "\e0c6";
 }
-i.icon-paper-plane:before {
+.icon-paper-plane:before {
 	content: "\e0c7";
 }
-i.icon-old-key:before {
+.icon-old-key:before {
 	content: "\e0c8";
 }
-i.icon-navigation-down:before {
+.icon-navigation-down:before {
 	content: "\e0c9";
 }
-i.icon-megaphone:before {
+.icon-megaphone:before {
 	content: "\e0ca";
 }
-i.icon-loading:before {
+.icon-loading:before {
 	content: "\e0cb";
 }
-i.icon-keychain:before {
+.icon-keychain:before {
 	content: "\e0cc";
 }
-i.icon-receipt-euro:before {
+.icon-receipt-euro:before {
 	content: "\e0cd";
 }
-i.icon-price-dollar:before {
+.icon-price-dollar:before {
 	content: "\e0ce";
 }
-i.icon-pie-chart:before {
+.icon-pie-chart:before {
 	content: "\e0cf";
 }
-i.icon-paper-plane-alt:before {
+.icon-paper-plane-alt:before {
 	content: "\e0d0";
 }
-i.icon-notepad:before {
+.icon-notepad:before {
 	content: "\e0d1";
 }
-i.icon-navigation-bottom:before {
+.icon-navigation-bottom:before {
 	content: "\e0d2";
 }
-i.icon-meeting:before {
+.icon-meeting:before {
 	content: "\e0d3";
 }
-i.icon-keyboard:before {
+.icon-keyboard:before {
 	content: "\e0d4";
 }
-i.icon-load:before {
+.icon-load:before {
 	content: "\e0d5";
 }
-i.icon-receipt-dollar:before {
+.icon-receipt-dollar:before {
 	content: "\e0d6";
 }
-i.icon-previous:before {
+.icon-previous:before {
 	content: "\e0d7";
 }
-i.icon-pictures:before {
+.icon-pictures:before {
 	content: "\e0d8";
 }
-i.icon-notepad-alt:before {
+.icon-notepad-alt:before {
 	content: "\e0d9";
 }
-i.icon-paper-bag:before {
+.icon-paper-bag:before {
 	content: "\e0da";
 }
-i.icon-badge:before {
+.icon-badge:before {
 	content: "\e0db";
 }
-i.icon-medicine:before {
+.icon-medicine:before {
 	content: "\e0dc";
 }
-i.icon-list:before {
+.icon-list:before {
 	content: "\e0dd";
 }
-i.icon-key:before {
+.icon-key:before {
 	content: "\e0de";
 }
-i.icon-receipt-alt:before {
+.icon-receipt-alt:before {
 	content: "\e0df";
 }
-i.icon-previous-media:before {
+.icon-previous-media:before {
 	content: "\e0e0";
 }
-i.icon-pictures-alt:before {
+.icon-pictures-alt:before {
 	content: "\e0e1";
 }
-i.icon-pants:before {
+.icon-pants:before {
 	content: "\e0e2";
 }
-i.icon-nodes:before {
+.icon-nodes:before {
 	content: "\e0e3";
 }
-i.icon-music:before {
+.icon-music:before {
 	content: "\e0e4";
 }
-i.icon-readonly:before {
+.icon-readonly:before {
 	content: "\e0e5";
 }
-i.icon-presentation:before {
+.icon-presentation:before {
 	content: "\e0e6";
 }
-i.icon-pictures-alt-2:before {
+.icon-pictures-alt-2:before {
 	content: "\e0e7";
 }
-i.icon-panel-close:before,
-i.icon-pannel-close:before {
+.icon-panel-close:before,
+.icon-pannel-close:before {
 	content: "\e0e8";
 }
-i.icon-next:before {
+.icon-next:before {
 	content: "\e0e9";
 }
-i.icon-multiple-windows:before {
+.icon-multiple-windows:before {
 	content: "\e0ea";
 }
-i.icon-medical-emergency:before {
+.icon-medical-emergency:before {
 	content: "\e0eb";
 }
-i.icon-medal:before {
+.icon-medal:before {
 	content: "\e0ec";
 }
-i.icon-link:before {
+.icon-link:before {
 	content: "\e0ed";
 }
-i.icon-linux-tux:before {
+.icon-linux-tux:before {
 	content: "\e0ee";
 }
-i.icon-junk:before {
+.icon-junk:before {
 	content: "\e0ef";
 }
-i.icon-item-arrangement:before {
+.icon-item-arrangement:before {
 	content: "\e0f0";
 }
-i.icon-iphone:before {
+.icon-iphone:before {
 	content: "\e0f1";
 }
-i.icon-lightning:before {
+.icon-lightning:before {
 	content: "\e0f2";
 }
-i.icon-map:before {
+.icon-map:before {
 	content: "\e0f3";
 }
-i.icon-multiple-credit-cards:before {
+.icon-multiple-credit-cards:before {
 	content: "\e0f4";
 }
-i.icon-next-media:before {
+.icon-next-media:before {
 	content: "\e0f5";
 }
-i.icon-panel-show:before {
+.icon-panel-show:before {
 	content: "\e0f6";
 }
-i.icon-picture:before {
+.icon-picture:before {
 	content: "\e0f7";
 }
-i.icon-power:before {
+.icon-power:before {
 	content: "\e0f8";
 }
-i.icon-re-post:before {
+.icon-re-post:before {
 	content: "\e0f9";
 }
-i.icon-rate:before {
+.icon-rate:before {
 	content: "\e0fa";
 }
-i.icon-rain:before {
+.icon-rain:before {
 	content: "\e0fb";
 }
-i.icon-radio:before {
+.icon-radio:before {
 	content: "\e0fc";
 }
-i.icon-radio-receiver:before {
+.icon-radio-receiver:before {
 	content: "\e0fd";
 }
-i.icon-radio-alt:before {
+.icon-radio-alt:before {
 	content: "\e0fe";
 }
-i.icon-quote:before {
+.icon-quote:before {
 	content: "\e0ff";
 }
-i.icon-qr-code:before {
+.icon-qr-code:before {
 	content: "\e100";
 }
-i.icon-pushpin:before {
+.icon-pushpin:before {
 	content: "\e101";
 }
-i.icon-pulse:before {
+.icon-pulse:before {
 	content: "\e102";
 }
-i.icon-projector:before {
+.icon-projector:before {
 	content: "\e103";
 }
-i.icon-play:before {
+.icon-play:before {
 	content: "\e104";
 }
-i.icon-playing-cards:before {
+.icon-playing-cards:before {
 	content: "\e105";
 }
-i.icon-playlist:before {
+.icon-playlist:before {
 	content: "\e106";
 }
-i.icon-plugin:before {
+.icon-plugin:before {
 	content: "\e107";
 }
-i.icon-podcast:before {
+.icon-podcast:before {
 	content: "\e108";
 }
-i.icon-poker-chip:before {
+.icon-poker-chip:before {
 	content: "\e109";
 }
-i.icon-poll:before {
+.icon-poll:before {
 	content: "\e10a";
 }
-i.icon-post-it:before {
+.icon-post-it:before {
 	content: "\e10b";
 }
-i.icon-pound-bag:before {
+.icon-pound-bag:before {
 	content: "\e10c";
 }
-i.icon-power-outlet:before {
+.icon-power-outlet:before {
 	content: "\e10d";
 }
-i.icon-photo-album:before {
+.icon-photo-album:before {
 	content: "\e10e";
 }
-i.icon-phone:before {
+.icon-phone:before {
 	content: "\e10f";
 }
-i.icon-phone-ring:before {
+.icon-phone-ring:before {
 	content: "\e110";
 }
-i.icon-people:before {
+.icon-people:before {
 	content: "\e111";
 }
-i.icon-people-female:before {
+.icon-people-female:before {
 	content: "\e112";
 }
-i.icon-people-alt:before {
+.icon-people-alt:before {
 	content: "\e113";
 }
-i.icon-people-alt-2:before {
+.icon-people-alt-2:before {
 	content: "\e114";
 }
-i.icon-pc:before {
+.icon-pc:before {
 	content: "\e115";
 }
-i.icon-pause:before {
+.icon-pause:before {
 	content: "\e116";
 }
-i.icon-path:before {
+.icon-path:before {
 	content: "\e117";
 }
-i.icon-out:before {
+.icon-out:before {
 	content: "\e118";
 }
-i.icon-outbox:before {
+.icon-outbox:before {
 	content: "\e119";
 }
-i.icon-outdent:before {
+.icon-outdent:before {
 	content: "\e11a";
 }
-i.icon-page-add:before {
+.icon-page-add:before {
 	content: "\e11b";
 }
-i.icon-page-down:before {
+.icon-page-down:before {
 	content: "\e11c";
 }
-i.icon-page-remove:before {
+.icon-page-remove:before {
 	content: "\e11d";
 }
-i.icon-page-restricted:before {
+.icon-page-restricted:before {
 	content: "\e11e";
 }
-i.icon-page-up:before {
+.icon-page-up:before {
 	content: "\e11f";
 }
-i.icon-paint-roller:before {
+.icon-paint-roller:before {
 	content: "\e120";
 }
-i.icon-palette:before {
+.icon-palette:before {
 	content: "\e121";
 }
-i.icon-newspaper:before {
+.icon-newspaper:before {
 	content: "\e122";
 }
-i.icon-newspaper-alt:before {
+.icon-newspaper-alt:before {
 	content: "\e123";
 }
-i.icon-network-alt:before {
+.icon-network-alt:before {
 	content: "\e124";
 }
-i.icon-navigational-arrow:before {
+.icon-navigational-arrow:before {
 	content: "\e125";
 }
-i.icon-navigation:before {
+.icon-navigation:before {
 	content: "\e126";
 }
-i.icon-navigation-vertical:before {
+.icon-navigation-vertical:before {
 	content: "\e127";
 }
-i.icon-navigation-up:before {
+.icon-navigation-up:before {
 	content: "\e128";
 }
-i.icon-navigation-top:before {
+.icon-navigation-top:before {
 	content: "\e129";
 }
-i.icon-navigation-road:before {
+.icon-navigation-road:before {
 	content: "\e12a";
 }
-i.icon-navigation-right:before {
+.icon-navigation-right:before {
 	content: "\e12b";
 }
-i.icon-microscope:before {
+.icon-microscope:before {
 	content: "\e12c";
 }
-i.icon-mindmap:before {
+.icon-mindmap:before {
 	content: "\e12d";
 }
-i.icon-molecular-network:before {
+.icon-molecular-network:before {
 	content: "\e12e";
 }
-i.icon-molecular:before {
+.icon-molecular:before {
 	content: "\e12f";
 }
-i.icon-mountain:before {
+.icon-mountain:before {
 	content: "\e130";
 }
-i.icon-mouse-cursor:before {
+.icon-mouse-cursor:before {
 	content: "\e131";
 }
-i.icon-mouse:before {
+.icon-mouse:before {
 	content: "\e132";
 }
-i.icon-movie-alt:before {
+.icon-movie-alt:before {
 	content: "\e133";
 }
-i.icon-map-marker:before {
+.icon-map-marker:before {
 	content: "\e134";
 }
-i.icon-movie:before {
+.icon-movie:before {
 	content: "\e135";
 }
-i.icon-map-location:before {
+.icon-map-location:before {
 	content: "\e136";
 }
-i.icon-map-alt:before {
+.icon-map-alt:before {
 	content: "\e137";
 }
-i.icon-male-symbol:before {
+.icon-male-symbol:before {
 	content: "\e138";
 }
-i.icon-male-and-female:before {
+.icon-male-and-female:before {
 	content: "\e139";
 }
-i.icon-mailbox:before {
+.icon-mailbox:before {
 	content: "\e13a";
 }
-i.icon-magnet:before {
+.icon-magnet:before {
 	content: "\e13b";
 }
-i.icon-loupe:before {
+.icon-loupe:before {
 	content: "\e13c";
 }
-i.icon-mobile:before {
+.icon-mobile:before {
 	content: "\e13d";
 }
-i.icon-logout:before {
+.icon-logout:before {
 	content: "\e13e";
 }
-i.icon-log-out:before {
+.icon-log-out:before {
 	content: "\e13f";
 }
-i.icon-layers:before {
+.icon-layers:before {
 	content: "\e140";
 }
-i.icon-left-double-arrow:before {
+.icon-left-double-arrow:before {
 	content: "\e141";
 }
-i.icon-layout:before {
+.icon-layout:before {
 	content: "\e142";
 }
-i.icon-legal:before {
+.icon-legal:before {
 	content: "\e143";
 }
-i.icon-lense:before {
+.icon-lense:before {
 	content: "\e144";
 }
-i.icon-library:before {
+.icon-library:before {
 	content: "\e145";
 }
-i.icon-light-down:before {
+.icon-light-down:before {
 	content: "\e146";
 }
-i.icon-light-up:before {
+.icon-light-up:before {
 	content: "\e147";
 }
-i.icon-lightbulb-active:before {
+.icon-lightbulb-active:before {
 	content: "\e148";
 }
-i.icon-lightbulb:before {
+.icon-lightbulb:before {
 	content: "\e149";
 }
-i.icon-ipad:before {
+.icon-ipad:before {
 	content: "\e14a";
 }
-i.icon-invoice:before {
+.icon-invoice:before {
 	content: "\e14b";
 }
-i.icon-info:before {
+.icon-info:before {
 	content: "\e14c";
 }
-i.icon-infinity:before {
+.icon-infinity:before {
 	content: "\e14d";
 }
-i.icon-indent:before {
+.icon-indent:before {
 	content: "\e14e";
 }
-i.icon-inbox:before {
+.icon-inbox:before {
 	content: "\e14f";
 }
-i.icon-inbox-full:before {
+.icon-inbox-full:before {
 	content: "\e150";
 }
-i.icon-inactive-line:before {
+.icon-inactive-line:before {
 	content: "\e151";
 }
-i.icon-imac:before {
+.icon-imac:before {
 	content: "\e152";
 }
-i.icon-hourglass:before {
+.icon-hourglass:before {
 	content: "\e153";
 }
-i.icon-home:before {
+.icon-home:before {
 	content: "\e154";
 }
-i.icon-grid:before {
+.icon-grid:before {
 	content: "\e155";
 }
-i.icon-food:before {
+.icon-food:before {
 	content: "\e156";
 }
-i.icon-favorite:before {
+.icon-favorite:before {
 	content: "\e157";
 }
-i.icon-door-open-alt:before {
+.icon-door-open-alt:before {
 	content: "\e158";
 }
-i.icon-diagnostics:before {
+.icon-diagnostics:before {
 	content: "\e159";
 }
-i.icon-contrast:before {
+.icon-contrast:before {
 	content: "\e15a";
 }
-i.icon-coins-dollar-alt:before {
+.icon-coins-dollar-alt:before {
 	content: "\e15b";
 }
-i.icon-circle-dotted-active:before {
+.icon-circle-dotted-active:before {
 	content: "\e15c";
 }
-i.icon-cinema:before {
+.icon-cinema:before {
 	content: "\e15d";
 }
-i.icon-chip:before {
+.icon-chip:before {
 	content: "\e15e";
 }
-i.icon-chip-alt:before {
+.icon-chip-alt:before {
 	content: "\e15f";
 }
-i.icon-chess:before {
+.icon-chess:before {
 	content: "\e160";
 }
-i.icon-checkbox:before {
+.icon-checkbox:before {
 	content: "\e161";
 }
-i.icon-checkbox-empty:before {
+.icon-checkbox-empty:before {
 	content: "\e162";
 }
-i.icon-checkbox-dotted:before {
+.icon-checkbox-dotted:before {
 	content: "\e163";
 }
-i.icon-checkbox-dotted-active:before {
+.icon-checkbox-dotted-active:before {
 	content: "\e164";
 }
-i.icon-check:before {
+.icon-check:before {
 	content: "\e165";
 }
-i.icon-chat:before {
+.icon-chat:before {
 	content: "\e166";
 }
-i.icon-chat-active:before {
+.icon-chat-active:before {
 	content: "\e167";
 }
-i.icon-chart:before {
+.icon-chart:before {
 	content: "\e168";
 }
-i.icon-chart-curve:before {
+.icon-chart-curve:before {
 	content: "\e169";
 }
-i.icon-certificate:before {
+.icon-certificate:before {
 	content: "\e16a";
 }
-i.icon-categories:before {
+.icon-categories:before {
 	content: "\e16b";
 }
-i.icon-cash-register:before {
+.icon-cash-register:before {
 	content: "\e16c";
 }
-i.icon-car:before {
+.icon-car:before {
 	content: "\e16d";
 }
-i.icon-caps-lock:before {
+.icon-caps-lock:before {
 	content: "\e16e";
 }
-i.icon-candy:before {
+.icon-candy:before {
 	content: "\e16f";
 }
-i.icon-circle-dotted:before {
+.icon-circle-dotted:before {
 	content: "\e170";
 }
-i.icon-circuits:before {
+.icon-circuits:before {
 	content: "\e171";
 }
-i.icon-circus:before {
+.icon-circus:before {
 	content: "\e172";
 }
-i.icon-client:before {
+.icon-client:before {
 	content: "\e173";
 }
-i.icon-clothes-hanger:before {
+.icon-clothes-hanger:before {
 	content: "\e174";
 }
-i.icon-cloud-drive:before {
+.icon-cloud-drive:before {
 	content: "\e175";
 }
-i.icon-cloud-upload:before {
+.icon-cloud-upload:before {
 	content: "\e176";
 }
-i.icon-cloud:before {
+.icon-cloud:before {
 	content: "\e177";
 }
-i.icon-cloudy:before {
+.icon-cloudy:before {
 	content: "\e178";
 }
-i.icon-clubs:before {
+.icon-clubs:before {
 	content: "\e179";
 }
-i.icon-cocktail:before {
+.icon-cocktail:before {
 	content: "\e17a";
 }
-i.icon-code:before {
+.icon-code:before {
 	content: "\e17b";
 }
-i.icon-coffee:before {
+.icon-coffee:before {
 	content: "\e17c";
 }
-i.icon-coin-dollar:before {
+.icon-coin-dollar:before {
 	content: "\e17d";
 }
-i.icon-coin-pound:before {
+.icon-coin-pound:before {
 	content: "\e17e";
 }
-i.icon-coin-yen:before {
+.icon-coin-yen:before {
 	content: "\e17f";
 }
-i.icon-coin:before {
+.icon-coin:before {
 	content: "\e180";
 }
-i.icon-coins-alt:before {
+.icon-coins-alt:before {
 	content: "\e181";
 }
-i.icon-console:before {
+.icon-console:before {
 	content: "\e182";
 }
-i.icon-connection:before {
+.icon-connection:before {
 	content: "\e183";
 }
-i.icon-compress:before {
+.icon-compress:before {
 	content: "\e184";
 }
-i.icon-company:before {
+.icon-company:before {
 	content: "\e185";
 }
-i.icon-command:before {
+.icon-command:before {
 	content: "\e186";
 }
-i.icon-coin-euro:before {
+.icon-coin-euro:before {
 	content: "\e187";
 }
-i.icon-combination-lock:before {
+.icon-combination-lock:before {
 	content: "\e188";
 }
-i.icon-combination-lock-open:before {
+.icon-combination-lock-open:before {
 	content: "\e189";
 }
-i.icon-comb:before {
+.icon-comb:before {
 	content: "\e18a";
 }
-i.icon-columns:before {
+.icon-columns:before {
 	content: "\e18b";
 }
-i.icon-colorpicker:before {
+.icon-colorpicker:before {
 	content: "\e18c";
 }
-i.icon-color-bucket:before {
+.icon-color-bucket:before {
 	content: "\e18d";
 }
-i.icon-coins:before {
+.icon-coins:before {
 	content: "\e18e";
 }
-i.icon-coins-yen:before {
+.icon-coins-yen:before {
 	content: "\e18f";
 }
-i.icon-coins-yen-alt:before {
+.icon-coins-yen-alt:before {
 	content: "\e190";
 }
-i.icon-coins-pound:before {
+.icon-coins-pound:before {
 	content: "\e191";
 }
-i.icon-coins-pound-alt:before {
+.icon-coins-pound-alt:before {
 	content: "\e192";
 }
-i.icon-coins-euro:before {
+.icon-coins-euro:before {
 	content: "\e193";
 }
-i.icon-coins-euro-alt:before {
+.icon-coins-euro-alt:before {
 	content: "\e194";
 }
-i.icon-coins-dollar:before {
+.icon-coins-dollar:before {
 	content: "\e195";
 }
-i.icon-conversation-alt:before {
+.icon-conversation-alt:before {
 	content: "\e196";
 }
-i.icon-conversation:before {
+.icon-conversation:before {
 	content: "\e197";
 }
-i.icon-coverflow:before {
+.icon-coverflow:before {
 	content: "\e198";
 }
-i.icon-credit-card-alt:before {
+.icon-credit-card-alt:before {
 	content: "\e199";
 }
-i.icon-credit-card:before {
+.icon-credit-card:before {
 	content: "\e19a";
 }
-i.icon-crop:before {
+.icon-crop:before {
 	content: "\e19b";
 }
-i.icon-crosshair:before {
+.icon-crosshair:before {
 	content: "\e19c";
 }
-i.icon-crown-alt:before {
+.icon-crown-alt:before {
 	content: "\e19d";
 }
-i.icon-crown:before {
+.icon-crown:before {
 	content: "\e19e";
 }
-i.icon-cupcake:before {
+.icon-cupcake:before {
 	content: "\e19f";
 }
-i.icon-curve:before {
+.icon-curve:before {
 	content: "\e1a0";
 }
-i.icon-cut:before {
+.icon-cut:before {
 	content: "\e1a1";
 }
-i.icon-dashboard:before {
+.icon-dashboard:before {
 	content: "\e1a2";
 }
-i.icon-defrag:before {
+.icon-defrag:before {
 	content: "\e1a3";
 }
-i.icon-delete:before {
+.icon-delete:before {
 	content: "\e1a4";
 }
-i.icon-delete-key:before {
+.icon-delete-key:before {
 	content: "\e1a5";
 }
-i.icon-departure:before {
+.icon-departure:before {
 	content: "\e1a6";
 }
-i.icon-desk:before {
+.icon-desk:before {
 	content: "\e1a7";
 }
-i.icon-desktop:before {
+.icon-desktop:before {
 	content: "\e1a8";
 }
-i.icon-donate:before {
+.icon-donate:before {
 	content: "\e1a9";
 }
-i.icon-dollar-bag:before {
+.icon-dollar-bag:before {
 	content: "\e1aa";
 }
-i.icon-documents:before {
+.icon-documents:before {
 	content: "\e1ab";
 }
-i.icon-document:before {
+.icon-document:before {
 	content: "\e1ac";
 }
-i.icon-document-dashed-line:before {
+.icon-document-dashed-line:before {
 	content: "\e1ad";
 }
-i.icon-dock-connector:before {
+.icon-dock-connector:before {
 	content: "\e1ae";
 }
-i.icon-dna:before {
+.icon-dna:before {
 	content: "\e1af";
 }
-i.icon-display:before {
+.icon-display:before {
 	content: "\e1b0";
 }
-i.icon-disk-image:before {
+.icon-disk-image:before {
 	content: "\e1b1";
 }
-i.icon-disc:before {
+.icon-disc:before {
 	content: "\e1b2";
 }
-i.icon-directions:before {
+.icon-directions:before {
 	content: "\e1b3";
 }
-i.icon-directions-alt:before {
+.icon-directions-alt:before {
 	content: "\e1b4";
 }
-i.icon-diploma:before {
+.icon-diploma:before {
 	content: "\e1b5";
 }
-i.icon-diploma-alt:before {
+.icon-diploma-alt:before {
 	content: "\e1b6";
 }
-i.icon-dice:before {
+.icon-dice:before {
 	content: "\e1b7";
 }
-i.icon-diamonds:before {
+.icon-diamonds:before {
 	content: "\e1b8";
 }
-i.icon-diamond:before {
+.icon-diamond:before {
 	content: "\e1b9";
 }
-i.icon-diagonal-arrow:before {
+.icon-diagonal-arrow:before {
 	content: "\e1ba";
 }
-i.icon-diagonal-arrow-alt:before {
+.icon-diagonal-arrow-alt:before {
 	content: "\e1bb";
 }
-i.icon-door-open:before {
+.icon-door-open:before {
 	content: "\e1bc";
 }
-i.icon-download-alt:before {
+.icon-download-alt:before {
 	content: "\e1bd";
 }
-i.icon-download:before {
+.icon-download:before {
 	content: "\e1be";
 }
-i.icon-drop:before {
+.icon-drop:before {
 	content: "\e1bf";
 }
-i.icon-eco:before {
+.icon-eco:before {
 	content: "\e1c0";
 }
-i.icon-economy:before {
+.icon-economy:before {
 	content: "\e1c1";
 }
-i.icon-edit:before {
+.icon-edit:before {
 	content: "\e1c2";
 }
-i.icon-eject:before {
+.icon-eject:before {
 	content: "\e1c3";
 }
-i.icon-employee:before {
+.icon-employee:before {
 	content: "\e1c4";
 }
-i.icon-energy-saving-bulb:before {
+.icon-energy-saving-bulb:before {
 	content: "\e1c5";
 }
-i.icon-enter:before {
+.icon-enter:before {
 	content: "\e1c6";
 }
-i.icon-equalizer:before {
+.icon-equalizer:before {
 	content: "\e1c7";
 }
-i.icon-escape:before {
+.icon-escape:before {
 	content: "\e1c8";
 }
-i.icon-ethernet:before {
+.icon-ethernet:before {
 	content: "\e1c9";
 }
-i.icon-euro-bag:before {
+.icon-euro-bag:before {
 	content: "\e1ca";
 }
-i.icon-exit-fullscreen:before {
+.icon-exit-fullscreen:before {
 	content: "\e1cb";
 }
-i.icon-eye:before {
+.icon-eye:before {
 	content: "\e1cc";
 }
-i.icon-facebook-like:before {
+.icon-facebook-like:before {
 	content: "\e1cd";
 }
-i.icon-factory:before {
+.icon-factory:before {
 	content: "\e1ce";
 }
-i.icon-font:before {
+.icon-font:before {
 	content: "\e1cf";
 }
-i.icon-folders:before {
+.icon-folders:before {
 	content: "\e1d0";
 }
-i.icon-folder:before, i.icon-folder-close:before {
+.icon-folder:before, .icon-folder-close:before {
 	content: "\e1d1";
 }
-i.icon-folder-outline:before {
+.icon-folder-outline:before {
 	content: "\e1d2";
 }
-i.icon-folder-open:before {
+.icon-folder-open:before {
 	content: "\e1d3";
 }
-i.icon-flowerpot:before {
+.icon-flowerpot:before {
 	content: "\e1d4";
 }
-i.icon-flashlight:before {
+.icon-flashlight:before {
 	content: "\e1d5";
 }
-i.icon-flash:before {
+.icon-flash:before {
 	content: "\e1d6";
 }
-i.icon-flag:before {
+.icon-flag:before {
 	content: "\e1d7";
 }
-i.icon-flag-alt:before {
+.icon-flag-alt:before {
 	content: "\e1d8";
 }
-i.icon-firewire:before {
+.icon-firewire:before {
 	content: "\e1d9";
 }
-i.icon-firewall:before {
+.icon-firewall:before {
 	content: "\e1da";
 }
-i.icon-fire:before {
+.icon-fire:before {
 	content: "\e1db";
 }
-i.icon-fingerprint:before {
+.icon-fingerprint:before {
 	content: "\e1dc";
 }
-i.icon-filter:before {
+.icon-filter:before {
 	content: "\e1dd";
 }
-i.icon-filter-arrows:before {
+.icon-filter-arrows:before {
 	content: "\e1de";
 }
-i.icon-files:before {
+.icon-files:before {
 	content: "\e1df";
 }
-i.icon-file-cabinet:before {
+.icon-file-cabinet:before {
 	content: "\e1e0";
 }
-i.icon-female-symbol:before {
+.icon-female-symbol:before {
 	content: "\e1e1";
 }
-i.icon-footprints:before {
+.icon-footprints:before {
 	content: "\e1e2";
 }
-i.icon-hammer:before {
+.icon-hammer:before {
 	content: "\e1e3";
 }
-i.icon-hand-active-alt:before {
+.icon-hand-active-alt:before {
 	content: "\e1e4";
 }
-i.icon-forking:before {
+.icon-forking:before {
 	content: "\e1e5";
 }
-i.icon-hand-active:before {
+.icon-hand-active:before {
 	content: "\e1e6";
 }
-i.icon-hand-pointer-alt:before {
+.icon-hand-pointer-alt:before {
 	content: "\e1e7";
 }
-i.icon-hand-pointer:before {
+.icon-hand-pointer:before {
 	content: "\e1e8";
 }
-i.icon-handprint:before {
+.icon-handprint:before {
 	content: "\e1e9";
 }
-i.icon-handshake:before {
+.icon-handshake:before {
 	content: "\e1ea";
 }
-i.icon-handtool:before {
+.icon-handtool:before {
 	content: "\e1eb";
 }
-i.icon-hard-drive:before {
+.icon-hard-drive:before {
 	content: "\e1ec";
 }
-i.icon-help:before {
+.icon-help:before {
 	content: "\e1ed";
 }
-i.icon-graduate:before {
+.icon-graduate:before {
 	content: "\e1ee";
 }
-i.icon-gps:before {
+.icon-gps:before {
 	content: "\e1ef";
 }
-i.icon-help-alt:before {
+.icon-help-alt:before {
 	content: "\e1f0";
 }
-i.icon-height:before {
+.icon-height:before {
 	content: "\e1f1";
 }
-i.icon-globe:before {
+.icon-globe:before {
 	content: "\e1f2";
 }
-i.icon-hearts:before {
+.icon-hearts:before {
 	content: "\e1f3";
 }
-i.icon-globe-inverted-europe-africa:before {
+.icon-globe-inverted-europe-africa:before {
 	content: "\e1f4";
 }
-i.icon-headset:before {
+.icon-headset:before {
 	content: "\e1f5";
 }
-i.icon-globe-inverted-asia:before {
+.icon-globe-inverted-asia:before {
 	content: "\e1f6";
 }
-i.icon-headphones:before {
+.icon-headphones:before {
 	content: "\e1f7";
 }
-i.icon-globe-inverted-america:before {
+.icon-globe-inverted-america:before {
 	content: "\e1f8";
 }
-i.icon-hd:before {
+.icon-hd:before {
 	content: "\e1f9";
 }
-i.icon-globe-europe-africa:before,
-i.icon-globe-europe---africa:before {
+.icon-globe-europe-africa:before,
+.icon-globe-europe---africa:before {
 	content: "\e1fa";
 }
-i.icon-hat:before {
+.icon-hat:before {
 	content: "\e1fb";
 }
-i.icon-globe-asia:before {
+.icon-globe-asia:before {
 	content: "\e1fc";
 }
-i.icon-globe-alt:before {
+.icon-globe-alt:before {
 	content: "\e1fd";
 }
-i.icon-hard-drive-alt:before {
+.icon-hard-drive-alt:before {
 	content: "\e1fe";
 }
-i.icon-glasses:before {
+.icon-glasses:before {
 	content: "\e1ff";
 }
-i.icon-gift:before {
+.icon-gift:before {
 	content: "\e200";
 }
-i.icon-handtool-alt:before {
+.icon-handtool-alt:before {
 	content: "\e201";
 }
-i.icon-geometry:before {
+.icon-geometry:before {
 	content: "\e202";
 }
-i.icon-game:before {
+.icon-game:before {
 	content: "\e203";
 }
-i.icon-fullscreen:before {
+.icon-fullscreen:before {
 	content: "\e204";
 }
-i.icon-fullscreen-alt:before {
+.icon-fullscreen-alt:before {
 	content: "\e205";
 }
-i.icon-frame:before {
+.icon-frame:before {
 	content: "\e206";
 }
-i.icon-frame-alt:before {
+.icon-frame-alt:before {
 	content: "\e207";
 }
-i.icon-camera-roll:before {
+.icon-camera-roll:before {
 	content: "\e208";
 }
-i.icon-bookmark:before {
+.icon-bookmark:before {
 	content: "\e209";
 }
-i.icon-bill:before {
+.icon-bill:before {
 	content: "\e20a";
 }
-i.icon-baby-stroller:before {
+.icon-baby-stroller:before {
 	content: "\e20b";
 }
-i.icon-alarm-clock:before {
+.icon-alarm-clock:before {
 	content: "\e20c";
 }
-i.icon-addressbook:before,
-i.icon-adressbook:before {
+.icon-addressbook:before,
+.icon-adressbook:before {
 	content: "\e20d";
 }
-i.icon-add:before {
+.icon-add:before {
 	content: "\e20e";
 }
-i.icon-activity:before {
+.icon-activity:before {
 	content: "\e20f";
 }
-i.icon-untitled:before {
+.icon-untitled:before {
 	content: "\e210";
 }
-i.icon-glasses:before {
+.icon-glasses:before {
 	content: "\e211";
 }
-i.icon-camcorder:before {
+.icon-camcorder:before {
 	content: "\e212";
 }
-i.icon-calendar:before {
+.icon-calendar:before {
 	content: "\e213";
 }
-i.icon-calendar-alt:before {
+.icon-calendar-alt:before {
 	content: "\e214";
 }
-i.icon-calculator:before {
+.icon-calculator:before {
 	content: "\e215";
 }
-i.icon-bus:before {
+.icon-bus:before {
 	content: "\e216";
 }
-i.icon-burn:before {
+.icon-burn:before {
 	content: "\e217";
 }
-i.icon-bulleted-list:before {
+.icon-bulleted-list:before {
 	content: "\e218";
 }
-i.icon-bug:before {
+.icon-bug:before {
 	content: "\e219";
 }
-i.icon-brush:before {
+.icon-brush:before {
 	content: "\e21a";
 }
-i.icon-brush-alt:before {
+.icon-brush-alt:before {
 	content: "\e21b";
 }
-i.icon-brush-alt-2:before {
+.icon-brush-alt-2:before {
 	content: "\e21c";
 }
-i.icon-browser-window:before {
+.icon-browser-window:before {
 	content: "\e21d";
 }
-i.icon-briefcase:before {
+.icon-briefcase:before {
 	content: "\e21e";
 }
-i.icon-brick:before {
+.icon-brick:before {
 	content: "\e21f";
 }
-i.icon-brackets:before {
+.icon-brackets:before {
 	content: "\e220";
 }
-i.icon-box:before {
+.icon-box:before {
 	content: "\e221";
 }
-i.icon-box-open:before {
+.icon-box-open:before {
 	content: "\e222";
 }
-i.icon-box-alt:before {
+.icon-box-alt:before {
 	content: "\e223";
 }
-i.icon-books:before {
+.icon-books:before {
 	content: "\e224";
 }
-i.icon-billboard:before {
+.icon-billboard:before {
 	content: "\e225";
 }
-i.icon-bills-dollar:before {
+.icon-bills-dollar:before {
 	content: "\e226";
 }
-i.icon-bills-euro:before {
+.icon-bills-euro:before {
 	content: "\e227";
 }
-i.icon-bills-pound:before {
+.icon-bills-pound:before {
 	content: "\e228";
 }
-i.icon-bills-yen:before {
+.icon-bills-yen:before {
 	content: "\e229";
 }
-i.icon-bills:before {
+.icon-bills:before {
 	content: "\e22a";
 }
-i.icon-binarycode:before {
+.icon-binarycode:before {
 	content: "\e22b";
 }
-i.icon-binoculars:before {
+.icon-binoculars:before {
 	content: "\e22c";
 }
-i.icon-bird:before {
+.icon-bird:before {
 	content: "\e22d";
 }
-i.icon-birthday-cake:before {
+.icon-birthday-cake:before {
 	content: "\e22e";
 }
-i.icon-blueprint:before {
+.icon-blueprint:before {
 	content: "\e22f";
 }
-i.icon-block:before {
+.icon-block:before {
 	content: "\e230";
 }
-i.icon-bluetooth:before {
+.icon-bluetooth:before {
 	content: "\e231";
 }
-i.icon-boat-shipping:before {
+.icon-boat-shipping:before {
 	content: "\e232";
 }
-i.icon-bomb:before {
+.icon-bomb:before {
 	content: "\e233";
 }
-i.icon-book-alt-2:before {
+.icon-book-alt-2:before {
 	content: "\e234";
 }
-i.icon-bones:before {
+.icon-bones:before {
 	content: "\e235";
 }
-i.icon-book-alt:before {
+.icon-book-alt:before {
 	content: "\e236";
 }
-i.icon-book:before {
+.icon-book:before {
 	content: "\e237";
 }
-i.icon-bill-yen:before {
+.icon-bill-yen:before {
 	content: "\e238";
 }
-i.icon-award:before {
+.icon-award:before {
 	content: "\e239";
 }
-i.icon-bill-pound:before {
+.icon-bill-pound:before {
 	content: "\e23a";
 }
-i.icon-autofill:before {
+.icon-autofill:before {
 	content: "\e23b";
 }
-i.icon-bill-euro:before {
+.icon-bill-euro:before {
 	content: "\e23c";
 }
-i.icon-auction-hammer:before {
+.icon-auction-hammer:before {
 	content: "\e23d";
 }
-i.icon-bill-dollar:before {
+.icon-bill-dollar:before {
 	content: "\e23e";
 }
-i.icon-attachment:before {
+.icon-attachment:before {
 	content: "\e23f";
 }
-i.icon-bell:before {
+.icon-bell:before {
 	content: "\e240";
 }
-i.icon-article:before {
+.icon-article:before {
 	content: "\e241";
 }
-i.icon-bell-off:before {
+.icon-bell-off:before {
 	content: "\e242";
 }
-i.icon-art-easel:before {
+.icon-art-easel:before {
 	content: "\e243";
 }
-i.icon-beer-glass:before {
+.icon-beer-glass:before {
 	content: "\e244";
 }
-i.icon-arrow-up:before {
+.icon-arrow-up:before {
 	content: "\e245";
 }
-i.icon-battery-low:before {
+.icon-battery-low:before {
 	content: "\e246";
 }
-i.icon-arrow-right:before {
+.icon-arrow-right:before {
 	content: "\e247";
 }
-i.icon-battery-full:before {
+.icon-battery-full:before {
 	content: "\e248";
 }
-i.icon-arrow-left:before {
+.icon-arrow-left:before {
 	content: "\e249";
 }
-i.icon-bars:before {
+.icon-bars:before {
 	content: "\e24a";
 }
-i.icon-arrow-down:before {
+.icon-arrow-down:before {
 	content: "\e24b";
 }
-i.icon-barcode:before {
+.icon-barcode:before {
 	content: "\e24c";
 }
-i.icon-arrivals:before {
+.icon-arrivals:before {
 	content: "\e24d";
 }
-i.icon-bar-chart:before {
+.icon-bar-chart:before {
 	content: "\e24e";
 }
-i.icon-application-window:before {
+.icon-application-window:before {
 	content: "\e24f";
 }
-i.icon-band-aid:before {
+.icon-band-aid:before {
 	content: "\e250";
 }
-i.icon-application-window-alt:before {
+.icon-application-window-alt:before {
 	content: "\e251";
 }
-i.icon-ball:before {
+.icon-ball:before {
 	content: "\e252";
 }
-i.icon-application-error:before {
+.icon-application-error:before {
 	content: "\e253";
 }
-i.icon-badge-restricted:before {
+.icon-badge-restricted:before {
 	content: "\e254";
 }
-i.icon-app:before {
+.icon-app:before {
 	content: "\e255";
 }
-i.icon-badge-remove:before {
+.icon-badge-remove:before {
 	content: "\e256";
 }
-i.icon-anchor:before {
+.icon-anchor:before {
 	content: "\e257";
 }
-i.icon-badge-count:before {
+.icon-badge-count:before {
 	content: "\e258";
 }
-i.icon-alt:before {
+.icon-alt:before {
 	content: "\e259";
 }
-i.icon-badge-add:before {
+.icon-badge-add:before {
 	content: "\e25a";
 }
-i.icon-alert:before {
+.icon-alert:before {
 	content: "\e25b";
 }
-i.icon-backspace:before {
+.icon-backspace:before {
 	content: "\e25c";
 }
-i.icon-alert-alt:before {
+.icon-alert-alt:before {
 	content: "\e25d";
 }
-i.icon-section:before {
+.icon-section:before {
     content: "\e24f";
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the content type editor icon picker
  */
-function IconPickerController($scope, $http, $sce, localizationService, iconHelper) {
+function IconPickerController($scope, localizationService, iconHelper) {
 
     var vm = this;
 
@@ -42,19 +42,11 @@ function IconPickerController($scope, $http, $sce, localizationService, iconHelp
         vm.loading = true;
 
         setTitle();
-    
-        iconHelper.getAllIcons()
-            .then(icons => {
-                vm.icons = icons;
-                vm.loading = false;
 
-                iconHelper.getLegacyIcons()
-                    .then(icons => {
-                        if(icons && icons.length > 0) {
-                            vm.icons = icons.concat(vm.icons);
-                        }
-                    });
-            });
+        iconHelper.getIcons().then(function (icons) {
+            vm.icons = icons;
+            vm.loading = false;
+        });
 
         // set a default color if nothing is passed in
         vm.color = $scope.model.color ? findColor($scope.model.color) : vm.colors.find(x => x.default);
@@ -96,7 +88,7 @@ function IconPickerController($scope, $http, $sce, localizationService, iconHelp
     }
 
     function submit() {
-        if ($scope.model && $scope.model.submit) {            
+        if ($scope.model && $scope.model.submit) {
             $scope.model.submit($scope.model);
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -45,10 +45,10 @@
 
                 <div class="umb-control-group" ng-show="!vm.loading && filtered.length > 0 ">
                     <ul class="umb-iconpicker" ng-class="vm.color.value" ng-show="vm.icons">
-                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: searchTerm | orderBy:'name') track by $id(icon)">
-                            <button type="button" title="{{icon.name}}" ng-click="vm.selectIcon(icon.name, vm.color.value)">
-                                <umb-icon class="umb-iconpicker-svg {{icon.name}} large" icon="{{icon.name}}" svg-string="icon.svgString"></umb-icon>
-                                <span class="sr-only"><localize key="buttons_select">Select</localize> {{icon.name}}</span>
+                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: searchTerm) track by $id(icon)">
+                            <button type="button" title="{{icon}}" ng-click="vm.selectIcon(icon, vm.color.value)">
+                                <i class="{{icon}} large" aria-hidden="true"></i>
+                                <span class="sr-only"><localize key="buttons_select">Select</localize> {{icon}}</span>
                             </button>
                         </li>
                     </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -69,9 +69,9 @@
                                     prevent-default>
                                 Last Updated
                                 <i class="umb-table-head__icon icon"  aria-hidden="true" ng-class="{'icon-navigation-up': isSortDirection('updateDate', 'asc'), 'icon-navigation-down': isSortDirection('updateDate', 'desc')}"></i>
-                            </button>                           
+                            </button>
                         </div>
-               
+
                     </div>
                 </div>
                 <div class="umb-table-body">
@@ -79,15 +79,15 @@
 
                         <div class="umb-table-cell">
                             <i ng-show="item.selected" class="umb-table-body__icon umb-table-body__checkicon icon-check" aria-hidden="true"></i>
-                            <i class="{{item.icon}}" aria-hidden="true" ng-if="!item.thumbnail && item.extension != 'svg' && !item.selected"></i><i class="icon-picture"  aria-hidden="true" ng-if="item.thumbnail && !item.selected"></i>
+                            <i class="{{item.icon}}" class="umb-table-body__icon" aria-hidden="true" ng-if="!item.thumbnail && item.extension != 'svg' && !item.selected"></i><i class="icon-picture"  aria-hidden="true" ng-if="item.thumbnail && !item.selected"></i>
                         </div>
                         <div class="umb-table-cell  umb-table__name">
-                  
+
                             <ins ng-show="item.isFolder" ng-class="{'-locked': item.selected || !item.file || !item.thumbnail}" ng-click="clickItemName(item, $event, $index)" class="icon-navigation-right"></ins> <span data-src="{{item.value.src}}" class="item-name">{{item.name}}</span>
                         </div>
                         <div class="umb-table-cell">
                             <span class="muted small" style="font-size:0.8em">{{item.updateDate | date:'medium'}}</span>
-                        </div>           
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
@@ -1,5 +1,5 @@
 <button type="button" class="btn-reset umb-outline blockelement-labelblock-editor blockelement__draggable-element"
-        ng-click="block.edit()"
+        ng-click="api.editBlock(block, block.hideContentInOverlay, index, parentForm)"
         ng-focus="block.focus"
         ng-class="{ '--active': block.active, '--error': parentForm.$invalid && valFormManager.isShowingValidation() }"
         val-server-property-class="">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
@@ -1,5 +1,5 @@
 <button type="button" class="btn-reset umb-outline blockelement-labelblock-editor blockelement__draggable-element"
-        ng-click="api.editBlock(block, block.hideContentInOverlay, index, parentForm)"
+        ng-click="block.edit()"
         ng-focus="block.focus"
         ng-class="{ '--active': block.active, '--error': parentForm.$invalid && valFormManager.isShowingValidation() }"
         val-server-property-class="">


### PR DESCRIPTION
Reverting parts of helveticons.less and other parts from the umb-icon PR to ensure backwards compatibility

---
_This item has been added to our backlog [AB#8567](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8567)_