### PR TITLE
Re-use svg opener on the upload propertytype

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -6,10 +6,10 @@
         function link(scope, element, attrs, ctrl) {
 
             var evts = [];
-            
+
             function onInit() {
                 // If logged in user has access to the settings section
-                // show the open anchors - if the user doesn't have 
+                // show the open anchors - if the user doesn't have
                 // access, contentType is null, see MediaModelMapper
                 scope.allowOpen = scope.node.contentType !== null;
 
@@ -49,13 +49,7 @@
             };
 
             scope.openSVG = function () {
-                var popup = window.open('', '_blank');
-                var html = '<!DOCTYPE html><body><img src="' + scope.nodeUrl + '"/>' +
-                    '<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
-
-                popup.document.open();
-                popup.document.write(html);
-                popup.document.close();
+                mediaHelper.openSVG(scope.nodeUrl);
             }
 
             // watch for content updates - reload content when node is saved, published etc.

--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -3,7 +3,7 @@
 * @name umbraco.services.mediaHelper
 * @description A helper object used for dealing with media items
 **/
-function mediaHelper(umbRequestHelper, $log) {
+function mediaHelper(umbRequestHelper, $log, $location) {
 
     //container of fileresolvers
     var _mediaFileResolvers = {};
@@ -383,6 +383,28 @@ function mediaHelper(umbRequestHelper, $log) {
             var lowered = filePath.toLowerCase();
             var ext = lowered.substr(lowered.lastIndexOf(".") + 1);
             return ext;
+        },
+
+        /**
+         * @ngdoc function
+         * @name umbraco.services.mediaHelper#openSVG
+         * @methodOf umbraco.services.mediaHelper
+         * @function
+         *
+         * @description
+         * Opens up a new window for an SVG, rendered in an img tag so that any embedded scripts don't execute
+		 * Reference: https://www.w3.org/wiki/SVG_Security#SVG_as_image
+         *
+         * @param {string} svgUrl - the path to the svg file, ex /media/1234/my-image.svg
+         */
+		openSVG: function (svgUrl) {
+            var popup = window.open('', '_blank');
+            var html = '<!DOCTYPE html><body><img src="' + svgUrl + '"/>' +
+            	'<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
+
+            popup.document.open();
+            popup.document.write(html);
+            popup.document.close();
         }
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -91,6 +91,10 @@ function fileUploadController($scope, $element, $compile, imageHelper, fileManag
         };
     }
 
+    $scope.openSVG = function (svgUrl) {
+        mediaHelper.openSVG(svgUrl);
+    }
+
     //listen for clear files changes to set our model to be sent up to the server
     $scope.$watch("clearFiles", function (isCleared) {
         if (isCleared == true) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -1,12 +1,15 @@
 ﻿<div class="umb-editor umb-fileupload" ng-controller="Umbraco.PropertyEditors.FileUploadController">
-    
+
     <div ng-show="persistedFiles.length > 0">
         <ul class="thumbnails">
             <li class="span4 thumbnail" ng-repeat="file in persistedFiles">
-                <a href="{{file.file}}" target="_blank" ng-switch on="file.isImage">
+                <a ng-href="{{file.file}}" ng-click="openSVG(file.file)" ng-if="file.isImage && file.extension === 'svg'" prevent-default>
+                    <img ng-src="{{file.file}}" alt="{{file.file}}" />
+                </a>
+
+                <a href="{{file.file}}" target="_blank" ng-switch on="file.isImage" ng-if="file.extension !== 'svg'">
                     <img ng-src="{{file.thumbnail}}" ng-switch-when="true" alt="{{file.file}}" />
-                    <img ng-src="{{file.file}}" ng-switch-when="false" ng-if="file.extension == 'svg'" alt="{{file.file}}" />
-                    <span class="file-icon-wrap" ng-if="!file.isImage && file.extension != 'svg'">
+                    <span class="file-icon-wrap" ng-if="!file.isImage">
                         <span class="file-icon">
                             <i class="icon icon-document"></i>
                             <span>.{{file.extension}}</span>


### PR DESCRIPTION
Following the update in https://github.com/umbraco/Umbraco-CMS/pull/6137 we didn't upload the generic fileupload control, that is fixed in this PR.

You can test this by adding an upload datatype to one of your document types, uploading both a non-svg image and an svg image to that document and then click on the image. The svg image will open in a new tab and when you inspect it with your browser's dev tools you will see it's been wrapped in an `img` tag.

![image](https://user-images.githubusercontent.com/304656/94040592-6ef49d00-fdc9-11ea-9787-d932e7bce7e6.png)

This is reusing the exact same approach as was used in the umb-media-info directive (see previous PR https://github.com/umbraco/Umbraco-CMS/pull/6137).