### PR TITLE
create enviroment configuration through install script

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/README.md
+++ b/src/Umbraco.Tests.AcceptanceTest/README.md
@@ -4,24 +4,11 @@
 - NodeJS 12+
 - A running installed Umbraco on url: [https://localhost:44331](https://localhost:44331) (Default development port)
    - Install using a `SqlServer`/`LocalDb` as the tests execute too fast for `SqlCE` to handle.
-- User information in `cypress.env.json` (See [Getting started](#getting-started))
 
 ### Getting started
 The tests are located in the project/folder as `Umbraco.Tests.AcceptanceTests`. Make sure you run `npm install` in that folder, or let your IDE do that.
 
-Next, it is important that you create a new file in the root of the project called `cypress.env.json`.
-This file is already added to `.gitignore` and can contain values that are different for each developer machine.
-
-The file needs the following content:
-```
-{
-    "username": "<email for superadmin>",
-    "password": "<password for superadmin>"
-}
-```
-Replace the `<email for superadmin>` and `<password for superadmin>` placeholders with correct info.
-
-
+The script will ask you to enter the username and password for a superadmin user of your Umbraco CMS.
 
 ### Executing tests
 There are two npm scripts that can be used to execute the test:
@@ -32,3 +19,18 @@ There are two npm scripts that can be used to execute the test:
    - Executes the tests in a browser handled by a cypress application.
 
  In case of errors it is recommended to use the UI to debug.
+
+### Enviroment Configuration
+
+The enviroment configuration is begin setup by the npm installation script.
+This results in the creation of this file: `cypress.env.json`.
+This file is already added to `.gitignore` and can contain values that are different for each developer machine.
+
+The file has the following content:
+```
+{
+    "username": "<email for superadmin>",
+    "password": "<password for superadmin>"
+}
+```
+You can change this if you like or run the config script to reset the values, type "npm run config" in your terminal.

--- a/src/Umbraco.Tests.AcceptanceTest/config.js
+++ b/src/Umbraco.Tests.AcceptanceTest/config.js
@@ -3,11 +3,17 @@ const fs = require('fs');
 
 const properties = [
     {
+        description: 'Enter your superadmin username/email',
         name: 'username'
     },
     {
+        description: 'Enter your superadmin password',
         name: 'password',
         hidden: true
+    },
+    {
+        description: 'Enter CMS URL, or leave empty for default(https://localhost:44331)',
+        name: 'baseUrl'
     }
 ];
 
@@ -15,7 +21,6 @@ const properties = [
 const configPath = './cypress.env.json'
 
 console.log("Configure your test enviroment")
-console.log("Enter CMS superadmin credentials:")
 
 prompt.start();
 
@@ -24,7 +29,10 @@ prompt.get(properties, function (error, result) {
 
 var fileContent = `{
     "username": "${result.username}",
-    "password": "${result.password}"
+    "password": "${result.password}"${
+        result.baseUrl && `,
+    "baseUrl": "${result.baseUrl}"`
+    }
 }`;
 
     fs.writeFile(configPath, fileContent, function (error) {

--- a/src/Umbraco.Tests.AcceptanceTest/config.js
+++ b/src/Umbraco.Tests.AcceptanceTest/config.js
@@ -4,12 +4,14 @@ const fs = require('fs');
 const properties = [
     {
         description: 'Enter your superadmin username/email',
-        name: 'username'
+        name: 'username',
+        required: true
     },
     {
         description: 'Enter your superadmin password',
         name: 'password',
-        hidden: true
+        hidden: true,
+        required: true
     },
     {
         description: 'Enter CMS URL, or leave empty for default(https://localhost:44331)',

--- a/src/Umbraco.Tests.AcceptanceTest/config.js
+++ b/src/Umbraco.Tests.AcceptanceTest/config.js
@@ -1,17 +1,21 @@
 const prompt = require('prompt');
-fs = require('fs');
+const fs = require('fs');
 
 const properties = [
     {
-        name: 'superadmin username/email'
+        name: 'username'
     },
     {
-        name: 'superadmin password',
+        name: 'password',
         hidden: true
     }
 ];
 
-console.log("Configure your test enviroment:")
+
+const configPath = './cypress.env.json'
+
+console.log("Configure your test enviroment")
+console.log("Enter CMS superadmin credentials:")
 
 prompt.start();
 
@@ -23,10 +27,10 @@ var fileContent = `{
     "password": "${result.password}"
 }`;
 
-    fs.writeFile('cypress.env.json', fileContent, function (error) {
+    fs.writeFile(configPath, fileContent, function (error) {
         if (error) return console.error(error);
         console.log('Configuration saved');
-      });
+    });
 });
 
 function onError(error) {

--- a/src/Umbraco.Tests.AcceptanceTest/createEnviromentConfiguration.js
+++ b/src/Umbraco.Tests.AcceptanceTest/createEnviromentConfiguration.js
@@ -1,0 +1,35 @@
+const prompt = require('prompt');
+fs = require('fs');
+
+const properties = [
+    {
+        name: 'username'
+    },
+    {
+        name: 'password',
+        hidden: true
+    }
+];
+
+prompt.start();
+
+prompt.get(properties, function (error, result) {
+    if (error) { return onError(error); }
+
+    console.log('Saving...');
+
+var fileContent = `{
+    "username": "${result.username}",
+    "password": "${result.password}"
+}`;
+
+    fs.writeFile('cypress.env.json', fileContent, function (error) {
+        if (error) return console.error(error);
+        console.log('Saved');
+      });
+});
+
+function onError(error) {
+    console.error(error);
+    return true;
+}

--- a/src/Umbraco.Tests.AcceptanceTest/createEnviromentConfiguration.js
+++ b/src/Umbraco.Tests.AcceptanceTest/createEnviromentConfiguration.js
@@ -3,20 +3,20 @@ fs = require('fs');
 
 const properties = [
     {
-        name: 'username'
+        name: 'superadmin username/email'
     },
     {
-        name: 'password',
+        name: 'superadmin password',
         hidden: true
     }
 ];
+
+console.log("Configure your test enviroment:")
 
 prompt.start();
 
 prompt.get(properties, function (error, result) {
     if (error) { return onError(error); }
-
-    console.log('Saving...');
 
 var fileContent = `{
     "username": "${result.username}",
@@ -25,7 +25,7 @@ var fileContent = `{
 
     fs.writeFile('cypress.env.json', fileContent, function (error) {
         if (error) return console.error(error);
-        console.log('Saved');
+        console.log('Configuration saved');
       });
 });
 

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/plugins/index.js
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/plugins/index.js
@@ -18,4 +18,11 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  const baseUrl = config.env.baseUrl || null;
+
+  if (baseUrl) {
+    config.baseUrl = baseUrl;
+  }
+
+  return config;
 }

--- a/src/Umbraco.Tests.AcceptanceTest/package.json
+++ b/src/Umbraco.Tests.AcceptanceTest/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "postinstall": "node createEnviromentConfiguration.js",
-    "config": "node createEnviromentConfiguration.js",
+    "postinstall": "node postinstall.js",
+    "config": "node config.js",
     "test": "npx cypress run",
     "ui": "npx cypress open"
   },

--- a/src/Umbraco.Tests.AcceptanceTest/package.json
+++ b/src/Umbraco.Tests.AcceptanceTest/package.json
@@ -1,5 +1,7 @@
 {
   "scripts": {
+    "postinstall": "node createEnviromentConfiguration.js",
+    "config": "node createEnviromentConfiguration.js",
     "test": "npx cypress run",
     "ui": "npx cypress open"
   },
@@ -7,7 +9,8 @@
     "cross-env": "^7.0.2",
     "cypress": "^5.1.0",
     "ncp": "^2.0.0",
-    "umbraco-cypress-testhelpers": "^1.0.0-beta-50"
+    "umbraco-cypress-testhelpers": "^1.0.0-beta-50",
+    "prompt": "^1.0.0"
   },
   "dependencies": {
     "typescript": "^3.9.2"

--- a/src/Umbraco.Tests.AcceptanceTest/postinstall.js
+++ b/src/Umbraco.Tests.AcceptanceTest/postinstall.js
@@ -7,7 +7,7 @@ try {
     //file exists
     console.log("Skips configuration as file already exists, run 'npm run config' to change your configuration.");
   } else {
-    require('./createEnviromentConfiguration.js');
+    require('./config.js');
   }
 } catch(err) {
   console.error(err)

--- a/src/Umbraco.Tests.AcceptanceTest/postinstall.js
+++ b/src/Umbraco.Tests.AcceptanceTest/postinstall.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+const configPath = './cypress.env.json';
+
+try {
+  if (fs.existsSync(configPath)) {
+    //file exists
+    console.log("Skips configuration as file already exists, run 'npm run config' to change your configuration.");
+  } else {
+    require('./createEnviromentConfiguration.js');
+  }
+} catch(err) {
+  console.error(err)
+}


### PR DESCRIPTION
Ask user about username and password for the Umbraco User to be used for Cypress as part of the installation script.

This is how it will look running the npm installation script, which will result in an environment configuration file that contains the username and password.

![image](https://user-images.githubusercontent.com/6791648/94251734-3f59a800-ff23-11ea-9a7e-c0b4d7b2e9e7.png)



Test notes:

- Test that "npm i" askes for user credentials if NO cypress.env.json exist.
- Test that "npm i" DOES NOT askes for user credentials if the cypress.env.json already exist.
- Test that you can change credentials by running "npm run config"
- Test that baseUrl does not get set when leaving prompt question 'baseUrl' empty.
- Test that defining baseUrl in prompt gets set in cypress.env.json
- Test that cypress uses the environment baseUrl, if defined.
- Read the readme file