### PR TITLE
Fix SQL parameters in GetNewChildSortOrder

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -910,7 +910,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             var sql = template.Sql(NodeObjectTypeId, parentId);
             var sortOrder = Database.ExecuteScalar<int?>(sql);
 
-            return sortOrder.HasValue ? sortOrder.Value + 1 : first;
+            return (sortOrder + 1) ?? first;
         }
 
         protected virtual NodeDto GetParentNodeDto(int parentId)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8359.

### Description
Because the `NodeObjectTypeId` of the current implementing repository (`DocumentRepository`, `MediaRepository` and `MemberRepository`) ended up in the SQL template of the base class/method `ContentRepositoryBase.GetNewChildSortOrder()`, the sort order was only correctly returned for the repository that did the first database query (as that cached the SQL template).

This PR moves the `NodeObjectTypeId` to an SQL parameter and removes the `first` parameter from the SQL query (as that was also incorrectly cached in the template). This ensures the sort order is correctly retrieved from the database for all repositories and if none are found, the correct first sort order/number is returned.