### PR TITLE
Macropicker view: Avoid weird double tabbing behavior

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macropicker/macropicker.html
@@ -30,9 +30,8 @@
                             </div>
 
                             <ul class="umb-card-grid -three-in-row">
-                                <li ng-repeat="availableItem in macros | orderBy:'name' | filter:searchTerm"
-                                    ng-click="selectMacro(availableItem)">
-                                    <button class="btn-reset umb-card-grid-item" title="{{availableItem.name}}">
+                                <li ng-repeat="availableItem in macros | orderBy:'name' | filter:searchTerm">
+                                    <button class="btn-reset umb-card-grid-item" title="{{availableItem.name}}" ng-click="selectMacro(availableItem)">
                                         <span>
                                             <i class="icon-settings-alt" aria-hidden="true"></i>
                                             {{availableItem.name}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I thought I had already addressed this with #8779 but apparently I somehow managed to forget it... doh! 🤦‍♂️ However this PR moves the click event from the `<li>` element to the `<button>` element where it belongs meaning we don't see the current weird "double tab" issue since the ng-aria band aid adds `role="button"` to the `<li>` element making that tabable as well 😬 