### PR TITLE
Check path with "," to get descendants

### DIFF
--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -228,8 +228,8 @@ namespace Umbraco.Core.Models
                 return true;
             }
 
-            //is it descendant?
-            var descendant = startNodePaths.Any(x => path.StartsWith(x));
+            //is it descendant? (add "," to path to check for descendant to prevent ie. 11310 as descendant of 1131)
+            var descendant = startNodePaths.Any(x => path.StartsWith(x + ","));
             if (descendant)
             {
                 hasPathAccess = true;


### PR DESCRIPTION
### Prerequisites
- [X] I have added steps to test this contribution in the description below

This PR fixes https://github.com/umbraco/Umbraco-CMS/issues/8292

### Description
A backenduser with the startnode 1130 for his group in the backend would also see any other root nodes that start with 1130 (11301, 11302, etc.). Adding a comma to the path, getting the root nodes, fixes this.

To reproduce this issue:
1. Create a backend root-node with a user that has access to only this node.
2. Add some fake content in the DB to create another node that starts with this root-node ID 
(
declare @newId as int = ((id of root in step 1) * 10) - 1

set identity_insert umbracoNode on
insert into umbraconode(id, trashed, parentid, nodeuser, level,path, sortOrder, uniqueID,text, nodeObjectType, createDate)
values (@newId, 0, -1,  0, 1, '-1, 11470', 0, newid(), 'fakee', 'B796F64C-1F99-4FFB-B886-4BF4BC011A9C', getdate())
set identity_insert umbracoNode off
)
3. Create another backend root-node, the Id for the new root will be the first created node * 10 (ie. 1147 and 11470).
4. Login with the specific user that has access to only root node 1. Without the PR, both items will show, with this PR, only the first item will show.