### PR TITLE
adjust default size of umb-button-ellipsis and its apperance in umb-tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
@@ -4,10 +4,10 @@
     margin: 0 auto;
     cursor: pointer;
     border-radius: @baseBorderRadius;
-    color: black;
+    color: @ui-action-discreet-type;
     position: relative;
     opacity: 0.8;
-    transition: opacity .3s ease-out;
+    transition: opacity 120ms, color 120ms;
 
     &--absolute {
         position: absolute;
@@ -21,6 +21,10 @@
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+    }
+
+    &:hover {
+        color: @ui-action-discreet-type-hover;
     }
 
     .umb-button-ellipsis--tab,
@@ -47,6 +51,7 @@
     &__icon {
         color: inherit;
         flex-basis: 100%;
+        font-size: 12px;
 
         .umb-button-ellipsis--tab & {
             margin: 0 0 7px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree-root.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree-root.less
@@ -1,5 +1,7 @@
-.umb-tree-root {    
+.umb-tree-root {
     
+    border: 2px solid transparent;
+
     &-link {
         display: flex;
         align-items: center;

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -95,7 +95,6 @@ body.touch .umb-tree {
             position: relative;
             width: auto;
             height: auto;
-            margin: 0 5px 0 auto;
             overflow: visible;
             clip: auto;
         }
@@ -185,9 +184,10 @@ body.touch .umb-tree {
     flex: 0 0 auto;
     justify-content: flex-end;
     text-align: center;
-    margin: 0 5px 0 auto;
+    margin: 0 10px 0 auto;
     cursor: pointer;
     border-radius: @baseBorderRadius;
+    transition: background-color 120ms;
 
     .umb-button-ellipsis {
         padding: 3px 5px;
@@ -207,7 +207,7 @@ body.touch .umb-tree {
     }
 
     &:hover {
-        background: rgba(255, 255, 255, .5);
+        background-color: rgba(255, 255, 255, .8);
 
         i {
             background: @ui-active-type-hover;


### PR DESCRIPTION
changes the appearance of umb-button-ellipsis for a more balanced look. As well aligns its appearance in the tree

![image](https://user-images.githubusercontent.com/6791648/94456946-359aa380-01b4-11eb-94b9-bacf1be1b252.png)


---
_This item has been added to our backlog [AB#8585](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8585)_