### PR TITLE
Review: Break text in item-picker cards

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/card.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/card.less
@@ -159,6 +159,7 @@
         justify-content: center;
         flex-direction: column;
         background-color: transparent;
+        word-break: break-word;
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/8702

Break(Linebreak..) the text in item picker so long text doesn't go on top of each other.

![image](https://user-images.githubusercontent.com/6791648/94553060-32f18a00-0258-11eb-94e6-8d4bd0aede7d.png)


---
_This item has been added to our backlog [AB#8609](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8609)_