### PR TITLE
Review: Always show action buttons in delete dialogs & enable once checked

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/delete.html
@@ -111,7 +111,7 @@
                     </div>
 
 
-                <umb-confirm ng-if="vm.confirmed || vm.hasReferences === false"
+                <umb-confirm confirm-disabled="!(vm.confirmed || vm.hasReferences === false)"
                              on-confirm="vm.performDelete"
                              on-cancel="vm.cancel"
                              confirm-button-style="danger"

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/delete.html
@@ -30,7 +30,7 @@
 
                 <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}"></umb-checkbox>
 
-                <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
+                <umb-confirm confirm-disabled="!confirmed" confirm-label-key="delete" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
                 </umb-confirm>
             </div>
         </ng-switch>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/delete.html
@@ -26,7 +26,7 @@
 
                 <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}"></umb-checkbox>
 
-                <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
+                <umb-confirm confirm-disabled="!confirmed" confirm-label-key="delete" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
                 </umb-confirm>
             </div>
         </ng-switch>

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/delete.html
@@ -15,7 +15,7 @@
 
         <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}"></umb-checkbox>
 
-        <umb-confirm ng-if="confirmed" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
+        <umb-confirm confirm-disabled="!confirmed" confirm-label-key="delete" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
         </umb-confirm>
 
 


### PR DESCRIPTION
This PR always shows the dialog actions, so the user always can cancel the dialog.

Now the delete-action button says delete to be explicit and it's disabled until the user has checked the checkbox.

![image](https://user-images.githubusercontent.com/6791648/94563801-7f909180-0267-11eb-9ca9-f0c401285dda.png)


---
_This item has been added to our backlog [AB#8615](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8615)_