### PR TITLE
fixes 8924, Always clear both

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -208,6 +208,13 @@ umb-property:last-of-type .umb-control-group {
     .control-description {
         display: block;
         clear: both;
+        overflow-wrap: break-word;
+    }
+
+    &::after {
+        content: '';
+        display: block;
+        clear: both;
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/8924

+ added word-break for description to avoid having long words in description overlapping the property controls.

---
_This item has been added to our backlog [AB#8649](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8649)_