### PR TITLE
App header: Use umb-icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -14,7 +14,7 @@
                         <span class="sr-only">
                             <localize key="visuallyHiddenTexts_openBackofficeSearch">Open backoffice search</localize>...
                         </span>
-                        <i class="umb-app-header__action-icon icon-search" aria-hidden="true"></i>
+                        <umb-icon icon="icon-search" class="umb-app-header__action-icon icon-search"></umb-icon>
                     </button>
                 </li>
                 <li data-element="global-help" class="umb-app-header__action">
@@ -22,7 +22,7 @@
                         <span class="sr-only">
                             <localize key="visuallyHiddenTexts_openCloseBackofficeHelp">Open/Close backoffice help</localize>...
                         </span>
-                        <i class="umb-app-header__action-icon icon-help-alt" aria-hidden="true"></i>
+                        <umb-icon icon="icon-help-alt" class="umb-app-header__action-icon icon-help-alt"></umb-icon>
                     </button>
                 </li>
                 <li data-element="global-user" class="umb-app-header__action">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have converted the `<i>` icons to use the new and shiny `<umb-icon>` directive instead.