### PR TITLE
Linkpicker: Convert a to button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
@@ -107,9 +107,9 @@
 
                     <div class="umb-control-group">
                         <h5><localize key="defaultdialogs_linkToMedia">Link to media</localize></h5>
-                        <a href ng-click="switchToMediaPicker()" class="btn">
+                        <button type="button" ng-click="switchToMediaPicker()" class="btn">
                             <localize key="defaultdialogs_selectMedia">Select media</localize>
-                        </a>
+                        </button>
                     </div>
 
                 </umb-box-content>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
@nul800sebastiaan We need to put a hold on the party - Turns out there were more `<a>` with an empty `href` - Only it's just set without a value some places. More PR's incoming - Fixed this one by converting `<a>` to `<button>`. 👍 