### PR TITLE
Fix - user delete shows notifications twice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -458,8 +458,7 @@
 
         function performDelete() {
             usersResource.deleteNonLoggedInUser(vm.user.id).then(function (data) {
-                formHelper.showNotifications(data);
-                goToPage(vm.breadcrumbs[0]);
+               goToPage(vm.breadcrumbs[0]);
             }, function (error) {
                 vm.deleteNotLoggedInUserButtonState = "error";
                 formHelper.showNotifications(error.data);


### PR DESCRIPTION
Hi,

This PR fixes the issue mentioned in #8967 

When a backoffice user is deleted the notification is shown twice. This PR fixes it.

Poornima