### PR TITLE
Fix broken auto-focus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
@@ -10,19 +10,18 @@ angular.module("umbraco.directives")
                 }
             };
 
-            var enabled = true;
             //check if there's a value for the attribute, if there is and it's false then we conditionally don't
             //use auto focus.
             if (attrs.umbAutoFocus) {
                 attrs.$observe("umbAutoFocus", function (newVal) {
-                    enabled = (newVal === "false" || newVal === 0 || newVal === false) ? false : true;
+                    var enabled = (newVal === "false" || newVal === 0 || newVal === false) ? false : true;
+                    if (enabled) {
+                        $timeout(function() {
+                            update();
+                        });
+                    }
                 });
             }
 
-            if (enabled) {
-                $timeout(function() {
-                    update();
-                });
-            }
         };
 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Seems like #8799 broke the `umb-auto-focus` directive... it now assumes it's enabled by default, causing focus to be applied to all the wrong things out of order.

As an example: The data type selector should automatically be focused when it's opened, so you can start typing right away; but it's not:

![umb-auto-focus-before](https://user-images.githubusercontent.com/7405322/94787314-740da980-03d2-11eb-9071-7dc134aa8cf2.gif)

This PR fixes the directive, so it only applies focus if `umb-auto-focus` is actually meant to be applied (either by supplying `umb-auto-focus` without a value or by using `umb-auto-focus="true"`). Now the data type selector does receive focus automatically:

![umb-auto-focus-after](https://user-images.githubusercontent.com/7405322/94787493-ab7c5600-03d2-11eb-9fa1-bd6441946edb.gif)

