### PR TITLE
Creating a "System" content type breaks Umbraco

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/BackOffice/ContentTypeModelValidatorBase.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/BackOffice/ContentTypeModelValidatorBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Umbraco.Core;
@@ -24,6 +25,13 @@ namespace Umbraco.ModelsBuilder.Embedded.BackOffice
         {
             //don't do anything if we're not enabled
             if (!_config.Enable) yield break;
+
+            //list of reserved/disallowed aliases for content/media/member types - more can be added as the need arises
+            var reservedModelAliases = new[] { "system" };
+            if(reservedModelAliases.Contains(model.Alias, StringComparer.OrdinalIgnoreCase))
+            {
+                yield return new ValidationResult($"The model alias {model.Alias} is a reserved term and cannot be used", new[] { "Alias" });
+            }
 
             var properties = model.Groups.SelectMany(x => x.Properties)
                 .Where(x => x.Inherited == false)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Creating a content type named "System" has the quite unintended side effect of breaking Umbraco entirely:

![image](https://user-images.githubusercontent.com/7405322/94789554-5857d280-03d5-11eb-9baa-4ecce29cece4.png)

This was achieved with ModelsBuilder in `PureLive` (default) mode:

1. Create the content type "System" - an empty content type is fine.
2. Reload the backoffice.

This PR adds validation to prevent this specific case of unfortunate content type naming; it looks like this when you attempt to create a "System" content type:

![image](https://user-images.githubusercontent.com/7405322/94789768-a53ba900-03d5-11eb-87ba-b9f3a85c3187.png)

There are likely other cases to be found down the road, and once found we can add them to the `reservedModelAliases` collection in the validator.