### PR TITLE
Sort the variant picker entries by display name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -51,7 +51,7 @@
 
                     <umb-dropdown ng-if="vm.dropdownOpen" class="umb-variant-switcher" ng-class="{'--has-sub-variants': vm.hasSubVariants === true}" on-close="vm.dropdownOpen = false" umb-keyboard-list>
                         <umb-dropdown-item
-                            ng-repeat-start="entry in vm.variantMenu track by entry.key"
+                            ng-repeat-start="entry in vm.variantMenu | orderBy:'variant.displayName' track by entry.key"
                             class="umb-variant-switcher__item"
                             ng-class="{'--current': entry.variant === editor.content, '--active': entry.variant.active && vm.dropdownOpen, '--error': entry.variant.active !== true && entry.variant.hasError, '--state-notCreated':entry.variant.state==='NotCreated' && entry.variant.name == null, '--state-draft':entry.variant.state==='Draft' || (entry.variant.state==='NotCreated' && entry.variant.name != null)}"
                         >


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In the previous versions of Umbraco, the variant picker entries were sorted alphabetically:

![image](https://user-images.githubusercontent.com/7405322/94791814-71ae4e00-03d8-11eb-8396-718fe97e01d8.png)

Somewhere along the line this stopped working, leaving the variants to appear in a somewhat random order (I suspect by order of which the languages were created):

![image](https://user-images.githubusercontent.com/7405322/94792084-c782f600-03d8-11eb-8767-1dc732c84f0f.png)

This PR re-introduces the alphabetical sorting in the variant picker:

![image](https://user-images.githubusercontent.com/7405322/94791969-a5897380-03d8-11eb-8cf1-1b5c57a7ee24.png)

