### PR TITLE
Sort the languages in the global language selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -23,7 +23,7 @@
                         class="umb-language-picker__dropdown-item"
                         ng-class="{'umb-language-picker__dropdown-item--current': language.active}"
                         ng-click="selectLanguage(language)"
-                        ng-repeat="language in languages"
+                        ng-repeat="language in languages | orderBy:'name'"
                     >
                     <span class="sr-only">
                         <localize key="visuallyHiddenTexts_switchLanguage">Switch language to</localize>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is somewhat related to #9006 - the languages in the global language selector aren't sorted in any particular way:

![image](https://user-images.githubusercontent.com/7405322/94792950-05cce500-03da-11eb-8763-3fb493f333cd.png)

The languages used to be sorted alphabetically, which I think makes perfect sense...to this PR adds sorting to the language selector:

![image](https://user-images.githubusercontent.com/7405322/94792720-aa9af280-03d9-11eb-8c73-76defaaf9d28.png)
