### PR TITLE
Fix : Member Info Content App looks broken

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -201,10 +201,6 @@ umb-property:last-of-type .umb-control-group {
 }
 .umb-control-group .control-header {
     
-    .control-label {
-        float: left;
-    }
-
     .control-description {
         display: block;
         clear: both;


### PR DESCRIPTION
The members info content app looks quite funny in the current `v8/contrib` branch. This PR fixes it. I am not sure whether there is a better way to fix this though!

![image](https://user-images.githubusercontent.com/3941753/94805705-ba6c0400-03e4-11eb-8fba-450827f728d9.png)
