### PR TITLE
Replaced <i> with umb-icon in umb-node-preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -1,6 +1,6 @@
 <div class="umb-node-preview" ng-class="{'umb-node-preview--sortable': sortable, 'umb-node-preview--unpublished': published === false }">
     <div class="flex"> <!-- div keeps icon and nodename from wrapping -->
-        <umb-icon ng-if="icon" icon="{{icon}}" class="umb-node-preview__icon {{icon}}" aria-hidden="true"></umb-icon>
+        <umb-icon ng-if="icon" icon="{{icon}}" class="umb-node-preview__icon {{icon}}"></umb-icon>
         <div class="umb-node-preview__content">
 
             <div class="umb-node-preview__name" ng-attr-title="{{nodeNameTitle}}">{{ name }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -1,6 +1,6 @@
 <div class="umb-node-preview" ng-class="{'umb-node-preview--sortable': sortable, 'umb-node-preview--unpublished': published === false }">
     <div class="flex"> <!-- div keeps icon and nodename from wrapping -->
-        <i ng-if="icon" class="umb-node-preview__icon {{ icon }}" aria-hidden="true"></i>
+        <umb-icon ng-if="icon" icon="{{icon}}" class="umb-node-preview__icon {{icon}}" aria-hidden="true"></umb-icon>
         <div class="umb-node-preview__content">
 
             <div class="umb-node-preview__name" ng-attr-title="{{nodeNameTitle}}">{{ name }}</div>


### PR DESCRIPTION
Another `umb-icon` from me. I have replaced the `<i>` with `umb-icon` in `umb-node-preview` . This is quite a sweeping change as the `umb-node-preview` is used in many many places. Would recommend testing the following
1) Info content apps in content, media, members
2) Icons in grid editor config
3) icons in content picker in content edit
4) icons for user groups in users section
