### PR TITLE
run JS unit test in development script

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/test.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/test.js
@@ -23,7 +23,6 @@ function runUnitTestServer() {
         autoWatch: true,
         port: 9999,
         singleRun: false,
-        browsers: ['ChromeDebugging'],
         keepalive: true
     })
     .start();

--- a/src/Umbraco.Web.UI.Client/gulpfile.js
+++ b/src/Umbraco.Web.UI.Client/gulpfile.js
@@ -6,11 +6,11 @@
     * ===========
     * This is now using Gulp 4, each child task is now a child function in its own corresponding file.
     *
-    * To add a new task, simply add a new task file to gulp/tasks folder, add a require statement below to include the one or more methods 
+    * To add a new task, simply add a new task file to gulp/tasks folder, add a require statement below to include the one or more methods
     * and then add the exports command to add the new item into the task menu.
     */
 
-const { src, dest, series, parallel, lastRun } = require('gulp');
+const { series, parallel } = require('gulp');
 
 const config = require('./gulp/config');
 const { setDevelopmentMode, setTestMode } = require('./gulp/modes');
@@ -28,9 +28,9 @@ config.compile.current = config.compile.build;
 // These Exports are the new way of defining Tasks in Gulp 4.x
 // ***********************************************************
 exports.build = series(parallel(dependencies, js, less, views), testUnit);
-exports.dev = series(setDevelopmentMode, parallel(dependencies, js, less, views), watchTask);
+exports.dev = series(setDevelopmentMode, parallel(dependencies, js, less, views), runUnitTestServer, watchTask);
 exports.watch = series(watchTask);
-// 
+//
 exports.runTests = series(setTestMode, series(js, testUnit));
 exports.runUnit = series(setTestMode, series(js, runUnitTestServer), watchTask);
 exports.testE2e = series(setTestMode, parallel(testE2e));


### PR DESCRIPTION
This PR makes the JS Unit test server run when you run the dev npm script, in this way it becomes more clear if Unit Tests are broken.

---
_This item has been added to our backlog [AB#8663](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/8663)_