### PR TITLE
Prevents templates being created when adding DocTypes through the block list config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
@@ -141,6 +141,7 @@
             const editor = {
                 create: true,
                 infiniteMode: true,
+                noTemplate: true,
                 isElement: true,
                 submit: function (model) {
                     loadElementTypes().then( function () {


### PR DESCRIPTION
Fixes #8646 

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8646

### Description
I added the noTemplate property to the model used for creating the document type.

To test:
Create a block list, add a block, add a new doctype for the block. Verify that no templates are being created for the new doctype.