### PR TITLE
Do not save media items when hitting enter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -59,7 +59,7 @@
 
                     <!-- label-key="buttons_save" -->
                     <umb-button alias="save"
-                                type="submit"
+                                type="button"
                                 button-style="success"
                                 state="page.saveButtonState"
                                 label-key="{{page.submitButtonLabelKey}}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

For whatever reason the "Save" button on media items is of type "submit". This causes the editor to save automatically if you hit enter after loading the editor:

![edit-media-prevent-enter-submit](https://user-images.githubusercontent.com/7405322/94841967-0c2f8100-041b-11eb-977e-8a3074e86ce8.gif)

For content items, the "Save" button is of type "button", which prevents this behavior... so I have changed the "Save" button on media items to be of type "button" as well.