### PR TITLE
Installer: Starterkit - Convert <a> to <button>

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/starterkit.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/starterkit.html
@@ -10,13 +10,13 @@
 
     <ul class="thumbnails">
         <li class="span3" ng-repeat="pck in packages">
-            <a ng-click="setPackageAndContinue(pck.id)" class="thumbnail">
+            <button type="button" ng-click="setPackageAndContinue(pck.id)" class="btn-reset thumbnail">
                 <img ng-src="https://our.umbraco.com{{
                         pck.thumbnail
                     }}?width=170"
                      alt="{{ pck.name }}" />
                 <small>Install starter website</small>
-            </a>
+            </button>
         </li>
     </ul>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Noticed that we also had an `<a>` tag without an `href` attribute in the installer process where one picks the starterkit. Converted to `<button>` with this PR 👍 