### PR TITLE
Adds polling function to the Logviewer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -48,7 +48,14 @@
                             </div>
 
                         </div>
-
+                        <div class="flex">
+                            <!-- Polling Button -->
+                            <umb-button-group default-button="vm.polling.defaultButton"
+                                              sub-buttons="vm.polling.subButtons"
+                                              icon="{{ vm.polling.defaultButton.icon }}"
+                                              direction="down">
+                            </umb-button-group>
+                        </div>
                         <div class="flex search-box">
                             <div class="flex-auto">
                                 <!-- Search/expression filter -->

--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -53,7 +53,8 @@
                             <umb-button-group default-button="vm.polling.defaultButton"
                                               sub-buttons="vm.polling.subButtons"
                                               icon="{{ vm.polling.defaultButton.icon }}"
-                                              direction="down">
+                                              direction="down"
+                                              float="right">
                             </umb-button-group>
                         </div>
                         <div class="flex search-box">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2324,6 +2324,17 @@ To manage your website, simply open the Umbraco back office and start adding con
       <key alias="findLogsWithNamespace">Find Logs with Namespace</key>
       <key alias="findLogsWithMachineName">Find Logs with Machine Name</key>
       <key alias="open">Open</key>
+      <key alias="polling">Polling</key>
+      <key alias="every2">Every 2 seconds</key>
+      <key alias="every5">Every 5 seconds</key>
+      <key alias="every10">Every 10 seconds</key>
+      <key alias="every20">Every 20 seconds</key>
+      <key alias="every30">Every 30 seconds</key>
+      <key alias="pollingEvery2">Polling every 2s</key>
+      <key alias="pollingEvery5">Polling every 5s</key>
+      <key alias="pollingEvery10">Polling every 10s</key>
+      <key alias="pollingEvery20">Polling every 20s</key>
+      <key alias="pollingEvery30">Polling every 30s</key>
   </area>
   <area alias="clipboard">
     <key alias="labelForCopyAllEntries">Copy %0%</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2346,6 +2346,17 @@ To manage your website, simply open the Umbraco back office and start adding con
       <key alias="findLogsWithNamespace">Find Logs with Namespace</key>
       <key alias="findLogsWithMachineName">Find Logs with Machine Name</key>
       <key alias="open">Open</key>
+      <key alias="polling">Polling</key>
+      <key alias="every2">Every 2 seconds</key>
+      <key alias="every5">Every 5 seconds</key>
+      <key alias="every10">Every 10 seconds</key>
+      <key alias="every20">Every 20 seconds</key>
+      <key alias="every30">Every 30 seconds</key>
+      <key alias="pollingEvery2">Polling every 2s</key>
+      <key alias="pollingEvery5">Polling every 5s</key>
+      <key alias="pollingEvery10">Polling every 10s</key>
+      <key alias="pollingEvery20">Polling every 20s</key>
+      <key alias="pollingEvery30">Polling every 30s</key>
   </area>
   <area alias="clipboard">
     <key alias="labelForCopyAllEntries">Copy %0%</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
A thing I have been missing from the Diplo Tracelog viewer package, is the ability to have the log viewer poll for changes and update automatically.

So I added this functionality.

As you can see in the gif, you can poll every 2, 5, 10, 20 and 30 seconds, and it will keep any open log items open, upon loading more log items.

![jadEt6DcC1](https://user-images.githubusercontent.com/3726467/94846582-a7c3f000-0421-11eb-8cc1-86a9559e1a95.gif)

To test, open two browser windows with umbraco in them. In the first one go to the logviewer, and start polling. Open one of the log items.

In the other window, do some stuff that triggers logging, like logging in, publishing content etc.

Verify that the log items update, and the open log items keeps being open, when new items are added.