### PR TITLE
Make Nested Content icons centered and same size as Block Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -91,9 +91,10 @@
         color:@ui-option-type-hover;
     }
 
-    i {
+    .umb-nested-content__item-icon {
         position: absolute;
-        margin-top: -1px;
+        margin-top: -3px;
+        font-size: 22px;
     }
 
     .umb-nested-content__item-name {
@@ -116,7 +117,7 @@
     transition: opacity 120ms ease-in-out;
     position: absolute;
     right: 0;
-    top: 3px;
+    top: 5px;
     padding: 5px;
     background-color: @white;
 }
@@ -167,7 +168,7 @@
 
 .umb-nested-content__icon .icon {
     display: block;
-    font-size: 16px !important;
+    font-size: 18px !important;
 }
 
 .umb-nested-content__icon--disabled {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -18,7 +18,7 @@
                              ng-hide="vm.singleMode"
                              umb-auto-focus="{{vm.currentNode.key === node.key ? 'true' : 'false'}}">
 
-                            <div class="umb-nested-content__heading"><i ng-if="vm.showIcons" class="icon" ng-class="vm.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-class="{'--has-icon': vm.showIcons}" ng-bind="vm.getName($index)"></span></div>
+                            <div class="umb-nested-content__heading"><i ng-if="vm.showIcons" class="icon umb-nested-content__item-icon" ng-class="vm.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-class="{'--has-icon': vm.showIcons}" ng-bind="vm.getName($index)"></span></div>
 
                             <div class="umb-nested-content__icons">
                                 <button type="button" class="umb-nested-content__icon umb-nested-content__icon--copy" title="{{vm.labels.copy_icon_title}}" ng-click="vm.clickCopy($event, node);" ng-if="vm.showCopy">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8922

### Description

As described in #8922, the Nested Content item icons have gone a bit askew:

![image](https://user-images.githubusercontent.com/7405322/94847761-4bfa6680-0423-11eb-94e3-07407f2afb62.png)

This PR centers them again, and also increases the icon sizes to match those of Block Editor:

![image](https://user-images.githubusercontent.com/7405322/94847709-3a18c380-0423-11eb-84d9-913ee479a612.png)
