### PR TITLE
umb-tree-search-results directive view fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -155,6 +155,14 @@ body.touch .umb-tree {
         &-link {
             display: block;
         }
+
+        &-name {
+            display: flex;
+
+            &__text {
+                margin: 1px 0 0;
+            }
+        }
     }
 
     &-link {

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -1,6 +1,6 @@
 <div>
   <umb-empty-state ng-if="results.length === 0" position="{{emptySearchResultPosition}}">
-    <localize key="general_searchNoResult"></localize>
+    <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
   </umb-empty-state>
 
   <ul class="umb-tree">
@@ -8,13 +8,17 @@
       <ul class="umb-search-group">
         <li class="umb-search-group-item" ng-repeat="result in results">
           <div ng-class="{'umb-tree-node-checked' : result.selected}">
-            <a href class="umb-search-group-item-link" ng-class="{first:$first}" ng-click="selectResultCallback($event, result)">
-              <div class="umb-search-group-item-name">
-                <i class="icon umb-tree-icon sprTree {{result.icon}}"></i>
-                {{result.name}}
-              </div>
-              <small class="search-subtitle" ng-if="result.subTitle">{{result.subTitle}}</small>
-            </a>
+            <button type="button" class="btn-reset umb-search-group-item-link" ng-class="{first:$first}"
+                ng-click="selectResultCallback($event, result)">
+                <span class="umb-search-group-item-name">
+                    <umb-icon ng-if="result.selected" icon="icon-check" class="icon umb-tree-icon green sprTree icon-check">
+                    </umb-icon>
+                    <umb-icon ng-if="!result.selected" icon="{{result.icon}}" class="icon umb-tree-icon sprTree {{result.icon}}">
+                    </umb-icon>
+                    <span class="umb-search-group-item-name__text">{{ result.name }}</span>
+                </span>
+                <small class="search-subtitle" ng-if="result.subTitle">{{ result.subTitle }}</small>
+            </button>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have fixed the following
- Converted `<a>` to `<button`
- Added english fallback for "no search result" localization
- Changed `<i>` to use `<umb-icon>` - Please not an extra icon directive has been added to display the green checkmark when an item is checked. Previously this was handled using CSS on the `<i>` tag
- Some minor styling issues

** Where to find it **
The directive is being used in more places but one of them is in the "Copy" dialog on a node when using the search box.

![umb-tree-search-results](https://user-images.githubusercontent.com/1932158/94852324-042b0d80-042a-11eb-9c51-12cff3c96acc.png)
