### PR TITLE
v8 - use ng-hide in validation directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/showvalidationonsubmit.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/showvalidationonsubmit.directive.js
@@ -11,6 +11,7 @@
             link: function (scope, element, attr, ctrl) {
 
                 var formMgr = ctrl.length > 1 ? ctrl[1] : null;
+                const hiddenClass = 'ng-hide';
 
                 //We can either get the form submitted status by the parent directive valFormManager
                 //or we can check upwards in the DOM for the css class... lets try both :)
@@ -18,17 +19,17 @@
                 //reset the status.
                 var submitted = element.closest(".show-validation").length > 0 || (formMgr && formMgr.showValidation);
                 if (!submitted) {
-                    element.hide();
+                    element[0].classList.add(hiddenClass);
                 }
 
                 var unsubscribe = [];
 
                 unsubscribe.push(scope.$on("formSubmitting", function (ev, args) {
-                    element.show();
+                    element[0].classList.remove(hiddenClass);
                 }));
 
                 unsubscribe.push(scope.$on("formSubmitted", function (ev, args) {
-                    element.hide();
+                    element[0].classList.add(hiddenClass);
                 }));
 
                 //no isolate scope to listen to element destroy


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is a left-over bit from work on #8894. In fiddling with that issue, I found that the showValidationOnSubmit directive used `.show()` and `.hide()` to control element visibility. That's all good until we want to change the visibility of the validation messages using the `ng-show` or `ng-hide` directive in a view. `.show()` and `.hide()` set an inline style attribute, which has higher specificity than the class added by `ng-show` or `ng-hide` so it's not possible to control the element visibility outside the events in validation directive.

To fix that, I've removed `.show()` and `.hide()` in favour of toggling the `ng-hide` class name on the outermost element. End result is the same (display property is set to `none!important' but it's done via a class rather than the style attribute, so isn't insanely specific. Also means that we're not mixing jQuery with Angular, which can (this PR as an example) cause unexpected behaviour.
