### PR TITLE
[8977] prepending http to external links that have it missing

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 foreach (var dto in dtos)
                 {
                     var type = LinkType.External;
-                    var url = dto.Url;
+                    var url = dto.Url.StartsWith("http") ? dto.Url : "http://" + dto.Url;
 
                     if (dto.Udi != null)
                     {


### PR DESCRIPTION
### Prerequisites

https://github.com/umbraco/Umbraco-CMS/issues/8977

### Description
A conditional has been added. If a URL in the multiurl picker does not start with http, http:// is appended to the start of the URL string.

This is a fix for the issue here: https://github.com/umbraco/Umbraco-CMS/issues/8977

Steps to test: 
Create a link using Multi Url Picker data type, but don't inlcude http in the url.
The url when rendered on the page  should link to the external link.

