### PR TITLE
Replace obsolete usages with injected services in UmbracoHelper

### DIFF
--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -141,7 +141,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderTemplate(int contentId, int? altTemplateId = null)
         {
-            return ComponentRenderer.RenderTemplate(contentId, altTemplateId);
+            return _componentRenderer.RenderTemplate(contentId, altTemplateId);
         }
 
         #region RenderMacro
@@ -153,7 +153,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, null);
+            return _componentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, null);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias, object parameters)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters?.ToDictionary<object>());
+            return _componentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters?.ToDictionary<object>());
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Umbraco.Web
         /// <returns></returns>
         public IHtmlString RenderMacro(string alias, IDictionary<string, object> parameters)
         {
-            return ComponentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters);
+            return _componentRenderer.RenderMacro(AssignedContentItem?.Id ?? 0, alias, parameters);
         }
 
         #endregion
@@ -212,7 +212,7 @@ namespace Umbraco.Web
         /// Returns the ICultureDictionary for access to dictionary items
         /// </summary>
         public ICultureDictionary CultureDictionary => _cultureDictionary
-            ?? (_cultureDictionary = CultureDictionaryFactory.CreateDictionary());
+            ?? (_cultureDictionary = _cultureDictionaryFactory.CreateDictionary());
 
         #endregion
 
@@ -225,7 +225,7 @@ namespace Umbraco.Web
         /// <returns>True if the current user has access or if the current document isn't protected</returns>
         public bool MemberHasAccess(string path)
         {
-            return MembershipHelper.MemberHasAccess(path);
+            return _membershipHelper.MemberHasAccess(path);
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace Umbraco.Web
         /// <returns>True is the current user is logged in</returns>
         public bool MemberIsLoggedOn()
         {
-            return MembershipHelper.IsLoggedIn();
+            return _membershipHelper.IsLoggedIn();
         }
 
         #endregion
@@ -275,7 +275,7 @@ namespace Umbraco.Web
 
         public IPublishedContent Member(Guid id)
         {
-            return MembershipHelper.GetById(id);
+            return _membershipHelper.GetById(id);
         }
 
         public IPublishedContent Member(object id)
@@ -291,18 +291,18 @@ namespace Umbraco.Web
 
         public IPublishedContent Member(int id)
         {
-            return MembershipHelper.GetById(id);
+            return _membershipHelper.GetById(id);
         }
 
         public IPublishedContent Member(string id)
         {
             var asInt = id.TryConvertTo<int>();
-            return asInt ? MembershipHelper.GetById(asInt.Result) : MembershipHelper.GetByProviderKey(id);
+            return asInt ? _membershipHelper.GetById(asInt.Result) : _membershipHelper.GetByProviderKey(id);
         }
 
         public IEnumerable<IPublishedContent> Members(IEnumerable<int> ids)
         {
-            return MembershipHelper.GetByIds(ids);
+            return _membershipHelper.GetByIds(ids);
         }
 
         public IEnumerable<IPublishedContent> Members(IEnumerable<string> ids)
@@ -312,7 +312,7 @@ namespace Umbraco.Web
 
         public IEnumerable<IPublishedContent> Members(IEnumerable<Guid> ids)
         {
-            return MembershipHelper.GetByIds(ids);
+            return _membershipHelper.GetByIds(ids);
         }
 
         public IEnumerable<IPublishedContent> Members(IEnumerable<Udi> ids)
@@ -337,7 +337,7 @@ namespace Umbraco.Web
 
         public IEnumerable<IPublishedContent> Members(params Guid[] ids)
         {
-            return MembershipHelper.GetByIds(ids);
+            return _membershipHelper.GetByIds(ids);
         }
 
         public IEnumerable<IPublishedContent> Members(params Udi[] ids)
@@ -367,11 +367,11 @@ namespace Umbraco.Web
         private IPublishedContent ContentForObject(object id)
         {
             if (ConvertIdObjectToInt(id, out var intId))
-                return ContentQuery.Content(intId);
+                return _publishedContentQuery.Content(intId);
             if (ConvertIdObjectToGuid(id, out var guidId))
-                return ContentQuery.Content(guidId);
+                return _publishedContentQuery.Content(guidId);
             if (ConvertIdObjectToUdi(id, out var udiId))
-                return ContentQuery.Content(udiId);
+                return _publishedContentQuery.Content(udiId);
             return null;
         }
 
@@ -382,7 +382,7 @@ namespace Umbraco.Web
         /// <returns>The content, or null of the content item is not in the cache.</returns>
         public IPublishedContent Content(int id)
         {
-            return ContentQuery.Content(id);
+            return _publishedContentQuery.Content(id);
         }
 
         /// <summary>
@@ -392,7 +392,7 @@ namespace Umbraco.Web
         /// <returns>The content, or null of the content item is not in the cache.</returns>
         public IPublishedContent Content(Guid id)
         {
-            return ContentQuery.Content(id);
+            return _publishedContentQuery.Content(id);
         }
 
         /// <summary>
@@ -407,12 +407,12 @@ namespace Umbraco.Web
 
         public IPublishedContent Content(Udi id)
         {
-            return ContentQuery.Content(id);
+            return _publishedContentQuery.Content(id);
         }
 
         public IPublishedContent ContentSingleAtXPath(string xpath, params XPathVariable[] vars)
         {
-            return ContentQuery.ContentSingleAtXPath(xpath, vars);
+            return _publishedContentQuery.ContentSingleAtXPath(xpath, vars);
         }
 
         /// <summary>
@@ -434,7 +434,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing content, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Content(params Udi[] ids)
         {
-            return ids.Select(id => ContentQuery.Content(id)).WhereNotNull();
+            return ids.Select(id => _publishedContentQuery.Content(id)).WhereNotNull();
         }
 
         /// <summary>
@@ -445,16 +445,16 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing content, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Content(params GuidUdi[] ids)
         {
-            return ids.Select(id => ContentQuery.Content(id));
+            return ids.Select(id => _publishedContentQuery.Content(id));
         }
 
         private IEnumerable<IPublishedContent> ContentForObjects(IEnumerable<object> ids)
         {
             var idsA = ids.ToArray();
             if (ConvertIdsObjectToInts(idsA, out var intIds))
-                return ContentQuery.Content(intIds);
+                return _publishedContentQuery.Content(intIds);
             if (ConvertIdsObjectToGuids(idsA, out var guidIds))
-                return ContentQuery.Content(guidIds);
+                return _publishedContentQuery.Content(guidIds);
             return Enumerable.Empty<IPublishedContent>();
         }
 
@@ -465,7 +465,7 @@ namespace Umbraco.Web
         /// <returns>The content items that were found in the cache.</returns>
         public IEnumerable<IPublishedContent> Content(params int[] ids)
         {
-            return ContentQuery.Content(ids);
+            return _publishedContentQuery.Content(ids);
         }
 
         /// <summary>
@@ -475,7 +475,7 @@ namespace Umbraco.Web
         /// <returns>The content items that were found in the cache.</returns>
         public IEnumerable<IPublishedContent> Content(params Guid[] ids)
         {
-            return ContentQuery.Content(ids);
+            return _publishedContentQuery.Content(ids);
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing content, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Content(IEnumerable<Udi> ids)
         {
-            return ids.Select(id => ContentQuery.Content(id)).WhereNotNull();
+            return ids.Select(id => _publishedContentQuery.Content(id)).WhereNotNull();
         }
 
         /// <summary>
@@ -518,7 +518,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing content, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Content(IEnumerable<GuidUdi> ids)
         {
-            return ids.Select(id => ContentQuery.Content(id));
+            return ids.Select(id => _publishedContentQuery.Content(id));
         }
 
         /// <summary>
@@ -540,22 +540,22 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing content, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Content(IEnumerable<int> ids)
         {
-            return ContentQuery.Content(ids);
+            return _publishedContentQuery.Content(ids);
         }
 
         public IEnumerable<IPublishedContent> ContentAtXPath(string xpath, params XPathVariable[] vars)
         {
-            return ContentQuery.ContentAtXPath(xpath, vars);
+            return _publishedContentQuery.ContentAtXPath(xpath, vars);
         }
 
         public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars)
         {
-            return ContentQuery.ContentAtXPath(xpath, vars);
+            return _publishedContentQuery.ContentAtXPath(xpath, vars);
         }
 
         public IEnumerable<IPublishedContent> ContentAtRoot()
         {
-            return ContentQuery.ContentAtRoot();
+            return _publishedContentQuery.ContentAtRoot();
         }
 
         internal static bool ConvertIdObjectToInt(object id, out int intId)
@@ -654,7 +654,7 @@ namespace Umbraco.Web
 
         public IPublishedContent Media(Guid id)
         {
-            return ContentQuery.Media(id);
+            return _publishedContentQuery.Media(id);
         }
 
         /// <summary>
@@ -675,17 +675,17 @@ namespace Umbraco.Web
         private IPublishedContent MediaForObject(object id)
         {
             if (ConvertIdObjectToInt(id, out var intId))
-                return ContentQuery.Media(intId);
+                return _publishedContentQuery.Media(intId);
             if (ConvertIdObjectToGuid(id, out var guidId))
-                return ContentQuery.Media(guidId);
+                return _publishedContentQuery.Media(guidId);
             if (ConvertIdObjectToUdi(id, out var udiId))
-                return ContentQuery.Media(udiId);
+                return _publishedContentQuery.Media(udiId);
             return null;
         }
 
         public IPublishedContent Media(int id)
         {
-            return ContentQuery.Media(id);
+            return _publishedContentQuery.Media(id);
         }
 
         public IPublishedContent Media(string id)
@@ -708,9 +708,9 @@ namespace Umbraco.Web
         {
             var idsA = ids.ToArray();
             if (ConvertIdsObjectToInts(idsA, out var intIds))
-                return ContentQuery.Media(intIds);
+                return _publishedContentQuery.Media(intIds);
             if (ConvertIdsObjectToGuids(idsA, out var guidIds))
-                return ContentQuery.Media(guidIds);
+                return _publishedContentQuery.Media(guidIds);
             return Enumerable.Empty<IPublishedContent>();
         }
 
@@ -722,7 +722,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing media, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Media(params int[] ids)
         {
-            return ContentQuery.Media(ids);
+            return _publishedContentQuery.Media(ids);
         }
 
         /// <summary>
@@ -745,7 +745,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing media, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Media(params Udi[] ids)
         {
-            return ids.Select(id => ContentQuery.Media(id)).WhereNotNull();
+            return ids.Select(id => _publishedContentQuery.Media(id)).WhereNotNull();
         }
 
         /// <summary>
@@ -756,7 +756,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing media, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Media(params GuidUdi[] ids)
         {
-            return ids.Select(id => ContentQuery.Media(id));
+            return ids.Select(id => _publishedContentQuery.Media(id));
         }
 
         /// <summary>
@@ -778,7 +778,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing media, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Media(IEnumerable<int> ids)
         {
-            return ContentQuery.Media(ids);
+            return _publishedContentQuery.Media(ids);
         }
 
         /// <summary>
@@ -789,7 +789,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing media, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Media(IEnumerable<Udi> ids)
         {
-            return ids.Select(id => ContentQuery.Media(id)).WhereNotNull();
+            return ids.Select(id => _publishedContentQuery.Media(id)).WhereNotNull();
         }
 
         /// <summary>
@@ -800,7 +800,7 @@ namespace Umbraco.Web
         /// <remarks>If an identifier does not match an existing media, it will be missing in the returned value.</remarks>
         public IEnumerable<IPublishedContent> Media(IEnumerable<GuidUdi> ids)
         {
-            return ids.Select(id => ContentQuery.Media(id));
+            return ids.Select(id => _publishedContentQuery.Media(id));
         }
 
         /// <summary>
@@ -816,7 +816,7 @@ namespace Umbraco.Web
 
         public IEnumerable<IPublishedContent> MediaAtRoot()
         {
-            return ContentQuery.MediaAtRoot();
+            return _publishedContentQuery.MediaAtRoot();
         }
 
         #endregion


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

47 of 123 (or roughly 40%) of the solution build warnings all originate from internal usages of `Obsolete` marked properties in `UmbracoHelper.cs`. 

![image](https://user-images.githubusercontent.com/7405322/94896916-db892f00-048e-11eb-98e7-efe48cd70fa6.png)

Since the relevant services are already injected into `UmbracoHelper`, I figure there is no reason not to use them directly and thus get rid of those warnings. So I have done just that. 

There are no noticeable changes to test. But in order to validate the change, you can use this template (it assumes the content being rendered has a published and render-able child). If the template renders successfully, everything works 😄 

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@{
  Layout = null;
}
<html>
  <body>
    <ul>
      <li>What does Culture Dictionary think the current culture is? <b>@Umbraco.CultureDictionary.Culture</b></li>
      <li>Does Membership Helper think I have access? <b>@Umbraco.MemberHasAccess(Model.Path)</b></li>
      <li>Does Membership Helper think I am logged in? <b>@Umbraco.MemberIsLoggedOn()</b></li>
      <li>What does Content Query think the current content name is? <b>@Umbraco.Content(Model.Id).Name</b></li>
    </ul>
    <p>
    Here is the Compoment Rendererer at work:
    </p>
    <xmp>
      @Umbraco.RenderTemplate(Model.FirstChild().Id)
    </xmp>
  </body>
</html>
```
