### PR TITLE
Add Link and BeginLink extension methods

### DIFF
--- a/src/Umbraco.Web/Mvc/DisposableTagScope.cs
+++ b/src/Umbraco.Web/Mvc/DisposableTagScope.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Mvc;
+using Umbraco.Core;
+
+namespace Umbraco.Web.Mvc
+{
+    /// <summary>
+    /// Class for creating HTML elements with seperate start and end tags.
+    /// </summary>
+    /// <seealso cref="Umbraco.Web.Mvc.IDisposableTagScope" />
+    public class DisposableTagScope : IDisposableTagScope
+    {
+        #region Fields
+
+        /// <summary>
+        /// The tag builder.
+        /// </summary>
+        private readonly TagBuilder tagBuilder;
+
+        /// <summary>
+        /// Indicates whether the tag is started.
+        /// </summary>
+        private bool started = false;
+
+        /// <summary>
+        /// Indicates whether this instance is disposed.
+        /// </summary>
+        private bool disposed = false;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the view context.
+        /// </summary>
+        /// <value>
+        /// The view context.
+        /// </value>
+        protected ViewContext ViewContext { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisposableTagScope" /> class.
+        /// </summary>
+        /// <param name="viewContext">The view context.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <exception cref="System.ArgumentNullException">viewContext</exception>
+        public DisposableTagScope(ViewContext viewContext, string tagName, object htmlAttributes = null)
+        {
+            this.ViewContext = viewContext ?? throw new ArgumentNullException(nameof(viewContext));
+
+            var tagBuilder = new TagBuilder(tagName);
+            var htmlAttributesDictionary = htmlAttributes as IDictionary<string, object> ?? HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes);
+            htmlAttributesDictionary.RemoveAll(kvp => kvp.Value == null);
+            tagBuilder.MergeAttributes(htmlAttributesDictionary);
+
+            this.tagBuilder = tagBuilder;
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="DisposableTagScope" /> class.
+        /// </summary>
+        ~DisposableTagScope() => this.Dispose(false);
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Writes the start tag.
+        /// </summary>
+        /// <returns>
+        /// The current instance as <see cref="IDisposable" />.
+        /// </returns>
+        public virtual IDisposable Start()
+        {
+            if (!this.started)
+            {
+                this.started = true;
+
+                this.WriteStartTag();
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Writes the start tag.
+        /// </summary>
+        protected void WriteStartTag()
+        {
+            this.ViewContext.Writer.Write(this.tagBuilder.ToString(TagRenderMode.StartTag));
+        }
+
+        /// <summary>
+        /// Writes the end tag.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the end tag was written; otherwise, <c>false</c>.
+        /// </returns>
+        public virtual bool End()
+        {
+            if (this.started)
+            {
+                this.started = false;
+
+                this.WriteEndTag();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Writes the end tag.
+        /// </summary>
+        protected void WriteEndTag()
+        {
+            this.ViewContext.Writer.Write(this.tagBuilder.ToString(TagRenderMode.EndTag));
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                this.disposed = true;
+
+                if (disposing)
+                {
+                    while (this.End())
+                    {
+                        // Ensure all end tags are written
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Umbraco.Web/Mvc/Html/BeginLinkExtensions.cs
+++ b/src/Umbraco.Web/Mvc/Html/BeginLinkExtensions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Web.Mvc;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.Mvc.Html
+{
+    /// <summary>
+    /// Provides support for rendering a link/anchor with seperate start/end tags.
+    /// </summary>
+    public static class BeginLinkExtensions
+    {
+        /// <summary>
+        /// Begins the link/anchor tag.
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="link">The link.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <returns>
+        /// The link/anchor tag.
+        /// </returns>
+        /// <remarks>
+        /// The link start and end tag is not rendered when <paramref name="link" /> is <c>null</c>.
+        /// </remarks>
+        /// <example>
+        /// @using (Html.BeginLink(Model.Button, new { @class = "button" }))
+        /// {
+        ///     <i class="fab fa-umbraco"></i> Example text
+        /// }
+        /// </example>
+        public static IDisposable BeginLink(this HtmlHelper htmlHelper, Link link, object htmlAttributes = null)
+        {
+            if (link == null)
+            {
+                return null;
+            }
+
+            return htmlHelper.BeginLink(link.Url, LinkExtensions.GetAttributes(htmlAttributes, link));
+        }
+
+        /// <summary>
+        /// Begins the link/anchor tag.
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="href">The URL of the link.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <returns>
+        /// The link/anchor tag.
+        /// </returns>
+        /// <example>
+        /// @using (Html.BeginLink(Model.Url, new { @class = "button" }))
+        /// {
+        ///     <i class="fab fa-umbraco"></i> Example text
+        /// }
+        /// </example>
+        public static IDisposable BeginLink(this HtmlHelper htmlHelper, string href, object htmlAttributes = null)
+        {
+            return new DisposableTagScope(htmlHelper.ViewContext, "a", LinkExtensions.GetAttributes(htmlAttributes, href)).Start();
+        }
+    }
+}

--- a/src/Umbraco.Web/Mvc/Html/BeginTagScopeExtensions.cs
+++ b/src/Umbraco.Web/Mvc/Html/BeginTagScopeExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System.Web.Mvc;
+
+namespace Umbraco.Web.Mvc.Html
+{
+    /// <summary>
+    /// Provides support for rendering tag scopes (tags with seperate start/end tags).
+    /// </summary>
+    public static class BeginTagScopeExtensions
+    {
+        /// <summary>
+        /// Begins the tag scope (only writes the start/end tag when <paramref name="start" /> is set to <c>true</c> or <see cref="IDisposableTagScope.Start" /> is called).
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <param name="start">If set to <c>true</c>, directly writes the start tag.</param>
+        /// <returns>
+        /// The tag scope, which automatically writes the end tag for an open start tag when disposed.
+        /// </returns>
+        /// <example>
+        /// @using (Html.BeginTagScope("strong", new { @class = "root-node" }, Model.Parent == null)) {}
+        ///
+        /// @using (var list = Html.BeginTagScope("dl", new { @class = "contact-details" }))
+        /// {
+        ///     if (!string.IsNullOrEmpty(Model.Telephone))
+        ///     {
+        ///         list.Start();
+        ///
+        ///         <dt>Telephone</dt>
+        ///         <dd>@Model.Telephone</dd>
+        ///     }
+        ///
+        ///     if (!string.IsNullOrEmpty(Model.Email))
+        ///     {
+        ///         list.Start();
+        ///
+        ///         <dt>Email</dt>
+        ///         <dd>@Model.Email</dd>
+        ///     }
+        /// }
+        /// </example>
+        public static IDisposableTagScope BeginTagScope(this HtmlHelper htmlHelper, string tagName, object htmlAttributes = null, bool start = false)
+        {
+            var disposableTagScope = new DisposableTagScope(htmlHelper.ViewContext, tagName, htmlAttributes);
+            if (start)
+            {
+                disposableTagScope.Start();
+            }
+
+            return disposableTagScope;
+        }
+    }
+}

--- a/src/Umbraco.Web/Mvc/Html/LinkExtensions.cs
+++ b/src/Umbraco.Web/Mvc/Html/LinkExtensions.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web;
+using System.Web.Mvc;
+using Umbraco.Core;
+using Umbraco.Web.Models;
+
+namespace Umbraco.Web.Mvc.Html
+{
+    /// <summary>
+    /// Provides support for rendering link/anchor tags.
+    /// </summary>
+    public static class LinkExtensions
+    {
+        /// <summary>
+        /// Returns a link/anchor tag by using the specified <paramref name="link" />, <paramref name="text" /> and <paramref name="htmlAttributes" />.
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="link">The link.</param>
+        /// <param name="text">The text of the link.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <returns>
+        /// The link/anchor tag.
+        /// </returns>
+        /// <remarks>
+        /// The link is not rendered when <paramref name="link" /> is <c>null</c>.
+        /// </remarks>
+        /// <example>
+        /// @Html.Link(Model.Button, htmlAttributes: new { @class = "button" })
+        /// </example>
+        public static IHtmlString Link(this HtmlHelper htmlHelper, Link link, string text = null, object htmlAttributes = null)
+        {
+            if (link == null)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                text = link.Name;
+            }
+
+            return htmlHelper.Link(link, _ => new HtmlString(HttpUtility.HtmlEncode(text)), htmlAttributes);
+        }
+
+        /// <summary>
+        /// Returns a link/anchor tag by using the specified <paramref name="link" />, <paramref name="template" /> and <paramref name="htmlAttributes" />.
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="link">The link.</param>
+        /// <param name="template">The template.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <returns>
+        /// The link/anchor tag.
+        /// </returns>
+        /// <remarks>
+        /// The link is not rendered when <paramref name="link" /> is <c>null</c>.
+        /// </remarks>
+        /// <example>
+        /// @Html.Link(Model.Button, @<text><i class="fab fa-umbraco"></i> @item.Name</text>, new { @class = "button" })
+        /// </example>
+        public static IHtmlString Link(this HtmlHelper htmlHelper, Link link, Func<Link, IHtmlString> template, object htmlAttributes = null)
+        {
+            if (link == null)
+            {
+                return null;
+            }
+
+            return htmlHelper.Link(link.Url, _ => template(link), GetAttributes(htmlAttributes, link));
+        }
+
+        /// <summary>
+        /// Returns a link/anchor tag by using the specified <paramref name="href" />, <paramref name="text" /> and <paramref name="htmlAttributes" />.
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="href">The URL of the link.</param>
+        /// <param name="text">The text of the link.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <returns>
+        /// The link/anchor tag.
+        /// </returns>
+        /// <example>
+        /// @Html.Link(Model.Url, "Example text", new { @class = "button" })
+        /// </example>
+        public static IHtmlString Link(this HtmlHelper htmlHelper, string href, string text, object htmlAttributes = null)
+        {
+            return htmlHelper.Link(href, _ => new HtmlString(HttpUtility.HtmlEncode(text)), htmlAttributes);
+        }
+
+        /// <summary>
+        /// Returns a link/anchor tag by using the specified <paramref name="href" />, <paramref name="template" /> and <paramref name="htmlAttributes" />.
+        /// </summary>
+        /// <param name="htmlHelper">The HTML helper.</param>
+        /// <param name="href">The URL of the link.</param>
+        /// <param name="template">The template.</param>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <returns>
+        /// The link/anchor tag.
+        /// </returns>
+        /// <example>
+        /// @Html.Link(Model.Url, @<text><i class="fab fa-umbraco"></i> Example text</text>, new { @class = "button" })
+        /// </example>
+        public static IHtmlString Link(this HtmlHelper htmlHelper, string href, Func<string, IHtmlString> template, object htmlAttributes = null)
+        {
+            var linkTag = new TagBuilder("a")
+            {
+                InnerHtml = template(href).ToHtmlString()
+            };
+
+            var htmlAttributesDictionary = GetAttributes(htmlAttributes, href);
+            linkTag.MergeAttributes(htmlAttributesDictionary);
+
+            return htmlHelper.Raw(linkTag.ToString());
+        }
+
+        /// <summary>
+        /// Gets the attributes.
+        /// </summary>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <param name="link">The link.</param>
+        /// <returns>
+        /// The merged HTML attributes.
+        /// </returns>
+        internal static IDictionary<string, object> GetAttributes(object htmlAttributes, Link link)
+        {
+            var htmlAttributesDictionary = htmlAttributes as IDictionary<string, object> ?? HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes);
+
+            if (!htmlAttributesDictionary.ContainsKey("target") &&
+                link.Target is var linkTarget &&
+                !string.IsNullOrWhiteSpace(linkTarget))
+            {
+                htmlAttributesDictionary["target"] = linkTarget;
+            }
+
+            return htmlAttributesDictionary;
+        }
+
+        /// <summary>
+        /// Gets the attributes.
+        /// </summary>
+        /// <param name="htmlAttributes">The HTML attributes.</param>
+        /// <param name="href">The href.</param>
+        /// <returns>
+        /// The merged HTML attributes.
+        /// </returns>
+        internal static IDictionary<string, object> GetAttributes(object htmlAttributes, string href)
+        {
+            var htmlAttributesDictionary = htmlAttributes as IDictionary<string, object> ?? HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes);
+
+            if (!htmlAttributesDictionary.ContainsKey("rel") &&
+                htmlAttributesDictionary.TryGetValue("target", out var target) &&
+                target != null &&
+                target.ToString().Equals("_blank", StringComparison.OrdinalIgnoreCase))
+            {
+                htmlAttributesDictionary["rel"] = "noopener";
+            }
+
+            if (!string.IsNullOrWhiteSpace(href))
+            {
+                htmlAttributesDictionary["href"] = href;
+            }
+
+            htmlAttributesDictionary.RemoveAll(kvp => kvp.Value == null);
+
+            return htmlAttributesDictionary;
+        }
+    }
+}

--- a/src/Umbraco.Web/Mvc/IDisposableTagScope.cs
+++ b/src/Umbraco.Web/Mvc/IDisposableTagScope.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Umbraco.Web.Mvc
+{
+    /// <summary>
+    /// Represents a disposable tag scope.
+    /// </summary>
+    /// <seealso cref="System.IDisposable" />
+    public interface IDisposableTagScope : IDisposable
+    {
+        /// <summary>
+        /// Writes the start tag.
+        /// </summary>
+        /// <returns>
+        /// The current instance as <see cref="IDisposable" />.
+        /// </returns>
+        IDisposable Start();
+
+        /// <summary>
+        /// Writes the end tag.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the end tag was written; otherwise, <c>false</c>.
+        /// </returns>
+        bool End();
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -244,8 +244,11 @@
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />
     <Compile Include="Models\PublishedContent\HybridVariationContextAccessor.cs" />
     <Compile Include="Models\TemplateQuery\QueryConditionExtensions.cs" />
+    <Compile Include="Mvc\DisposableTagScope.cs" />
+    <Compile Include="Mvc\Html\BeginTagScopeExtensions.cs" />
     <Compile Include="Mvc\Html\LinkExtensions.cs" />
     <Compile Include="Mvc\HttpUmbracoFormRouteStringException.cs" />
+    <Compile Include="Mvc\IDisposableTagScope.cs" />
     <Compile Include="Mvc\ModelBindingExceptionFilter.cs" />
     <Compile Include="Mvc\StatusCodeFilterAttribute.cs" />
     <Compile Include="Mvc\SurfaceControllerTypeCollectionBuilder.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Models\PublishedContent\HybridVariationContextAccessor.cs" />
     <Compile Include="Models\TemplateQuery\QueryConditionExtensions.cs" />
     <Compile Include="Mvc\DisposableTagScope.cs" />
+    <Compile Include="Mvc\Html\BeginLinkExtensions.cs" />
     <Compile Include="Mvc\Html\BeginTagScopeExtensions.cs" />
     <Compile Include="Mvc\Html\LinkExtensions.cs" />
     <Compile Include="Mvc\HttpUmbracoFormRouteStringException.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Models\Mapping\MapperContextExtensions.cs" />
     <Compile Include="Models\PublishedContent\HybridVariationContextAccessor.cs" />
     <Compile Include="Models\TemplateQuery\QueryConditionExtensions.cs" />
+    <Compile Include="Mvc\Html\LinkExtensions.cs" />
     <Compile Include="Mvc\HttpUmbracoFormRouteStringException.cs" />
     <Compile Include="Mvc\ModelBindingExceptionFilter.cs" />
     <Compile Include="Mvc\StatusCodeFilterAttribute.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Similar to PR https://github.com/umbraco/Umbraco-CMS/pull/8840, this adds additional `HtmlHelper` extension methods to render links (`<a href=""></a>`) in Razor views, either using the Umbraco `Link` model or only a URL and text.

The `Link` extension methods that accept a `Link` model automatically use the URL, name and even target (open in new tab or window) to generate the link. When the target is set to `_blank`, it automatically adds `rel="noopener"` (unless there's already a `rel` attribute added to the `htmlAttributes` parameter), [avoiding performance and security issues](https://web.dev/external-anchors-use-rel-noopener/). Whenever the `Link` is `null`, nothing will be rendered, so no additional null-checks have to be added to the views. It even allows using a Razor template (with the `Link` assigned to the special `item` variable):
```cshtml
@Html.Link(Model.Button, htmlAttributes: new { @class = "button" })
@Html.Link(Model.Button, @<text><i class="fab fa-umbraco"></i> @item.Name</text>, new { @class = "button" })
```

The overloads that accept a URL and text work very similar:
```cshtml
@Html.Link(Model.Url, "Example text", new { @class = "button" })
@Html.Link(Model.Url, @<text><i class="fab fa-umbraco"></i> Example text</text>, new { @class = "button" })
```

----

Whenever you need to wrap the link around more HTML, you can use the `BeginLink` extension methods and wrap it in a `using` block (just like `BeginForm`). If the `Link` is `null`, the link is not rendered, but the content within is.

```cshtml
@using (Html.BeginLink(Model.Button, new { @class = "button" }))
{
    <i class="fab fa-umbraco"></i> Example text
}

@using (Html.BeginLink(Model.Url, new { @class = "button" }))
{
    <i class="fab fa-umbraco"></i> Example text
}
```

-----

The `BeginLink` uses a `DisposableTagScope` to render the start and end tags using an `IDisposable`. Because this can be used in very useful ways, I've added a bonus extension method: `BeginTagScope` 🎉 This allows conditionally rendering start/end tags by using a conditional attribute or manually calling the `Start` (or `End`) methods:

```cshtml
@using (Html.BeginTagScope("strong", new { @class = "root-node" }, Model.Parent == null)) {}
```

```cshtml
@using (var list = Html.BeginTagScope("dl", new { @class = "contact-details" }))
{
    if (!string.IsNullOrEmpty(Model.Telephone))
    {
        list.Start();

        <dt>Telephone</dt>
        <dd>@Model.Telephone</dd>
    }

    if (!string.IsNullOrEmpty(Model.Email))
    {
        list.Start();

        <dt>Email</dt>
        <dd>@Model.Email</dd>
    }
}
```