### PR TITLE
Add Root<T> and Breadcrumbs extension methods for IPublishedContent

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1155,8 +1155,8 @@ namespace Umbraco.Web
                                     { "NodeTypeAlias", n.ContentType.Alias },
                                     { "CreateDate", n.CreateDate },
                                     { "UpdateDate", n.UpdateDate },
-                                    { "CreatorName", n.CreatorName },
-                                    { "WriterName", n.WriterName },
+                                    { "CreatorName", n.CreatorName(services.UserService) },
+                                    { "WriterName", n.WriterName(services.UserService) },
                                     { "Url", n.Url() }
                                 };
 

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1271,13 +1271,35 @@ namespace Umbraco.Web
         #region Axes: custom
 
         /// <summary>
-        /// Gets the root content for this content.
+        /// Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" />.
         /// </summary>
         /// <param name="content">The content.</param>
-        /// <returns>The 'site' content ie AncestorOrSelf(1).</returns>
+        /// <returns>
+        /// The root content (ancestor or self at level 1) for the specified <paramref name="content" />.
+        /// </returns>
+        /// <remarks>
+        /// This is the same as calling <see cref="Umbraco.Web.PublishedContentExtensions.AncestorOrSelf(IPublishedContent, int)" /> with <c>maxLevel</c> set to 1.
+        /// </remarks>
         public static IPublishedContent Root(this IPublishedContent content)
         {
             return content.AncestorOrSelf(1);
+        }
+
+        /// <summary>
+        /// Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the specified content type <typeparamref name="T" />.
+        /// </summary>
+        /// <typeparam name="T">The content type.</typeparam>
+        /// <param name="content">The content.</param>
+        /// <returns>
+        /// The root content (ancestor or self at level 1) for the specified <paramref name="content" /> of content type <typeparamref name="T" />.
+        /// </returns>
+        /// <remarks>
+        /// This is the same as calling <see cref="Umbraco.Web.PublishedContentExtensions.AncestorOrSelf{T}(IPublishedContent, int)" /> with <c>maxLevel</c> set to 1.
+        /// </remarks>
+        public static T Root<T>(this IPublishedContent content)
+            where T : class, IPublishedContent
+        {
+            return content.AncestorOrSelf<T>(1);
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -814,6 +814,64 @@ namespace Umbraco.Web
 
         #endregion
 
+        #region Axes: breadcrumbs
+
+        /// <summary>
+        /// Gets the breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" />.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="andSelf">Indicates whether the specified content should be included.</param>
+        /// <returns>
+        /// The breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" />.
+        /// </returns>
+        public static IEnumerable<IPublishedContent> Breadcrumbs(this IPublishedContent content, bool andSelf = true)
+        {
+            return content.AncestorsOrSelf(andSelf, null).Reverse();
+        }
+
+        /// <summary>
+        /// Gets the breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" /> at a level higher or equal to <paramref name="minLevel" />.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="minLevel">The minimum level.</param>
+        /// <param name="andSelf">Indicates whether the specified content should be included.</param>
+        /// <returns>
+        /// The breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" /> at a level higher or equal to <paramref name="minLevel" />.
+        /// </returns>
+        public static IEnumerable<IPublishedContent> Breadcrumbs(this IPublishedContent content, int minLevel, bool andSelf = true)
+        {
+            return content.AncestorsOrSelf(andSelf, n => n.Level >= minLevel).Reverse();
+        }
+
+        /// <summary>
+        /// Gets the breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" /> at a level higher or equal to the specified root content type <typeparamref name="T" />.
+        /// </summary>
+        /// <typeparam name="T">The root content type.</typeparam>
+        /// <param name="content">The content.</param>
+        /// <param name="andSelf">Indicates whether the specified content should be included.</param>
+        /// <returns>
+        /// The breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" /> at a level higher or equal to the specified root content type <typeparamref name="T" />.
+        /// </returns>
+        public static IEnumerable<IPublishedContent> Breadcrumbs<T>(this IPublishedContent content, bool andSelf = true)
+            where T : class, IPublishedContent
+        {
+            static IEnumerable<IPublishedContent> TakeUntil(IEnumerable<IPublishedContent> source, Func<IPublishedContent, bool> predicate)
+            {
+                foreach (var item in source)
+                {
+                    yield return item;
+                    if (predicate(item))
+                    {
+                        yield break;
+                    }
+                }
+            }
+
+            return TakeUntil(content.AncestorsOrSelf(andSelf, null), n => n is T).Reverse();
+        }
+
+        #endregion
+
         #region Axes: descendants, descendants-or-self
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This adds a generic `Root<T>` extension method to `IPublishedContent` to get the root content in a specific (ModelsBuilder generated) content type, e.g. to get the `Home` content in a Razor master view:

```cshtml
@{
    var home = Model.Root<Home>();
}
```

It also adds a `Breadcrumbs` extension method that basically gets the ancestors in reverse order, until a specific level or content type is found and with/without itself:

```cshtml
@foreach (var breadcrumb in Model.Breadcrumbs<Home>())
{
    <a href="@breadcrumb.Url()">@breadcrumb.Name</a>
}
```

I've also fixed the obsolete usage of both `CreatorName` and `WriterName` properties (https://github.com/umbraco/Umbraco-CMS/pull/7544) with the extension methods, which was very easy, as the `IUserService` was already available 🎉 