### PR TITLE
Remove build warnings for internal classes

### DIFF
--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Web.Compose
         public static DatabaseServerMessengerOptions GetDefaultOptions(IFactory factory)
         {
             var logger = factory.GetInstance<ILogger>();
-            var indexRebuilder = factory.GetInstance<IndexRebuilder>();
+            var backgroundIndexRebuilder = factory.GetInstance<BackgroundIndexRebuilder>();
 
             return new DatabaseServerMessengerOptions
             {
@@ -61,7 +61,7 @@ namespace Umbraco.Web.Compose
                     //rebuild indexes if the server is not synced
                     // NOTE: This will rebuild ALL indexes including the members, if developers want to target specific
                     // indexes then they can adjust this logic themselves.
-                    () => { ExamineComponent.RebuildIndexes(indexRebuilder, logger, false, 5000); }
+                    () => { backgroundIndexRebuilder.RebuildIndexes(false, 5000); }
                 }
             };
         }

--- a/src/Umbraco.Web/Editors/DashboardController.cs
+++ b/src/Umbraco.Web/Editors/DashboardController.cs
@@ -18,6 +18,7 @@ using Umbraco.Core.Persistence;
 using Umbraco.Core.Services;
 using Umbraco.Core.Dashboards;
 using Umbraco.Web.Services;
+using Umbraco.Core.Mapping;
 
 namespace Umbraco.Web.Editors
 {
@@ -35,8 +36,8 @@ namespace Umbraco.Web.Editors
         /// <summary>
         /// Initializes a new instance of the <see cref="DashboardController"/> with all its dependencies.
         /// </summary>
-        public DashboardController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, IDashboardService dashboardService, UmbracoHelper umbracoHelper)
-            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
+        public DashboardController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, IDashboardService dashboardService, UmbracoHelper umbracoHelper, UmbracoMapper umbracoMapper)
+            : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper, umbracoMapper)
         {
             _dashboardService = dashboardService;
         }

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -518,7 +518,7 @@ namespace Umbraco.Web.Editors
         /// <param name="userSave"></param>
         /// <returns></returns>
         [OutgoingEditorModelEvent]
-        public async Task<UserDisplay> PostSaveUser(UserSave userSave)
+        public UserDisplay PostSaveUser(UserSave userSave)
         {
             if (userSave == null) throw new ArgumentNullException("userSave");
 

--- a/src/Umbraco.Web/Macros/MacroRenderer.cs
+++ b/src/Umbraco.Web/Macros/MacroRenderer.cs
@@ -26,8 +26,9 @@ namespace Umbraco.Web.Macros
         private readonly ILocalizedTextService _textService;
         private readonly AppCaches _appCaches;
         private readonly IMacroService _macroService;
+        private readonly IUserService _userService;
 
-        public MacroRenderer(IProfilingLogger plogger, IUmbracoContextAccessor umbracoContextAccessor, IContentSection contentSection, ILocalizedTextService textService, AppCaches appCaches, IMacroService macroService)
+        public MacroRenderer(IProfilingLogger plogger, IUmbracoContextAccessor umbracoContextAccessor, IContentSection contentSection, ILocalizedTextService textService, AppCaches appCaches, IMacroService macroService, IUserService userService)
         {
             _plogger = plogger ?? throw new ArgumentNullException(nameof(plogger));
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
@@ -35,6 +36,7 @@ namespace Umbraco.Web.Macros
             _textService = textService;
             _appCaches = appCaches ?? throw new ArgumentNullException(nameof(appCaches));
             _macroService = macroService ?? throw new ArgumentNullException(nameof(macroService));
+            _userService = userService;
         }
 
         #region MacroContent cache
@@ -208,7 +210,7 @@ namespace Umbraco.Web.Macros
             if (m == null)
                 throw new InvalidOperationException("No macro found by alias " + macroAlias);
 
-            var page = new PublishedContentHashtableConverter(content);
+            var page = new PublishedContentHashtableConverter(content, _userService);
 
             var macro = new MacroModel(m);
 

--- a/src/Umbraco.Web/Macros/PublishedContentHashtableConverter.cs
+++ b/src/Umbraco.Web/Macros/PublishedContentHashtableConverter.cs
@@ -6,6 +6,7 @@ using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Web.Composing;
 using Umbraco.Web.Editors;
@@ -29,14 +30,14 @@ namespace Umbraco.Web.Macros
         /// that the PublishedRequest takes into account how a template is assigned during the routing process whereas
         /// with an IPublishedContent item, the template id is assigned purely based on the default.
         /// </remarks>
-        internal PublishedContentHashtableConverter(PublishedRequest frequest)
+        internal PublishedContentHashtableConverter(PublishedRequest frequest, IUserService userService)
         {
             if (!frequest.HasPublishedContent)
                 throw new ArgumentException("Document request has no node.", nameof(frequest));
 
             PopulatePageData(frequest.PublishedContent.Id,
                 frequest.PublishedContent.Name, frequest.PublishedContent.ContentType.Id, frequest.PublishedContent.ContentType.Alias,
-                frequest.PublishedContent.WriterName, frequest.PublishedContent.CreatorName, frequest.PublishedContent.CreateDate, frequest.PublishedContent.UpdateDate,
+                frequest.PublishedContent.WriterName(userService), frequest.PublishedContent.CreatorName(userService), frequest.PublishedContent.CreateDate, frequest.PublishedContent.UpdateDate,
                 frequest.PublishedContent.Path, frequest.PublishedContent.Parent?.Id ?? -1);
 
             if (frequest.HasTemplate)
@@ -52,13 +53,13 @@ namespace Umbraco.Web.Macros
         /// Initializes a new instance of the page for a published document
         /// </summary>
         /// <param name="doc"></param>
-        internal PublishedContentHashtableConverter(IPublishedContent doc)
+        internal PublishedContentHashtableConverter(IPublishedContent doc, IUserService userService)
         {
             if (doc == null) throw new ArgumentNullException(nameof(doc));
 
             PopulatePageData(doc.Id,
                 doc.Name, doc.ContentType.Id, doc.ContentType.Alias,
-                doc.WriterName, doc.CreatorName, doc.CreateDate, doc.UpdateDate,
+                doc.WriterName(userService), doc.CreatorName(userService), doc.CreateDate, doc.UpdateDate,
                 doc.Path, doc.Parent?.Id ?? -1);
 
             if (doc.TemplateId.HasValue)
@@ -69,16 +70,6 @@ namespace Umbraco.Web.Macros
 
             PopulateElementData(doc);
         }
-
-        /// <summary>
-        /// Initializes a new instance of the page for a content.
-        /// </summary>
-        /// <param name="content">The content.</param>
-        /// <param name="variationContextAccessor"></param>
-        /// <remarks>This is for <see cref="MacroRenderingController"/> usage only.</remarks>
-        internal PublishedContentHashtableConverter(IContent content, IVariationContextAccessor variationContextAccessor)
-            : this(new PagePublishedContent(content, variationContextAccessor))
-        { }
 
         #endregion
 

--- a/src/Umbraco.Web/Mvc/MinifyJavaScriptResultAttribute.cs
+++ b/src/Umbraco.Web/Mvc/MinifyJavaScriptResultAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System.IO;
+using System.Web.Mvc;
 using System.Web.UI;
 using ClientDependency.Core;
 using ClientDependency.Core.CompositeFiles;
@@ -29,7 +30,7 @@ namespace Umbraco.Web.Mvc
             //minify the result
             var result = jsResult.Script;
             var minifier = new JSMin();
-            var minified = minifier.Minify(result);
+            var minified = minifier.Minify(new StringReader(result));
             jsResult.Script = minified;
         }
 

--- a/src/Umbraco.Web/PropertyEditors/TagsDataController.cs
+++ b/src/Umbraco.Web/PropertyEditors/TagsDataController.cs
@@ -17,6 +17,13 @@ namespace Umbraco.Web.PropertyEditors
     [PluginController("UmbracoApi")]
     public class TagsDataController : UmbracoAuthorizedApiController
     {
+        private readonly ITagQuery _tagQuery;
+
+        public TagsDataController(ITagQuery tagQuery)
+        {
+           _tagQuery = tagQuery;
+        }
+
         /// <summary>
         /// Returns all tags matching tagGroup, culture and an optional query
         /// </summary>
@@ -28,7 +35,7 @@ namespace Umbraco.Web.PropertyEditors
         {
             if (culture == string.Empty) culture = null;
 
-            var result = Umbraco.TagQuery.GetAllTags(tagGroup, culture);
+            var result = _tagQuery.GetAllTags(tagGroup, culture);
 
             
             if (!query.IsNullOrWhiteSpace())

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1155,8 +1155,8 @@ namespace Umbraco.Web
                                     { "NodeTypeAlias", n.ContentType.Alias },
                                     { "CreateDate", n.CreateDate },
                                     { "UpdateDate", n.UpdateDate },
-                                    { "CreatorName", n.CreatorName },
-                                    { "WriterName", n.WriterName },
+                                    { "CreatorName", n.CreatorName(services.UserService) },
+                                    { "WriterName", n.WriterName(services.UserService) },
                                     { "Url", n.Url() }
                                 };
 

--- a/src/Umbraco.Web/Routing/ContentFinderByConfigured404.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByConfigured404.cs
@@ -1,3 +1,4 @@
+using Examine;
 using System.Globalization;
 using System.Linq;
 using Umbraco.Core;
@@ -16,12 +17,14 @@ namespace Umbraco.Web.Routing
         private readonly ILogger _logger;
         private readonly IEntityService _entityService;
         private readonly IContentSection _contentConfigSection;
+        private readonly IExamineManager _examineManager;
 
-        public ContentFinderByConfigured404(ILogger logger, IEntityService entityService, IContentSection contentConfigSection)
+        public ContentFinderByConfigured404(ILogger logger, IEntityService entityService, IContentSection contentConfigSection, IExamineManager examineManager)
         {
             _logger = logger;
             _entityService = entityService;
             _contentConfigSection = contentConfigSection;
+            _examineManager = examineManager;
         }
 
         /// <summary>
@@ -62,7 +65,7 @@ namespace Umbraco.Web.Routing
             var error404 = NotFoundHandlerHelper.GetCurrentNotFoundPageId(
                 _contentConfigSection.Error404Collection.ToArray(),
                 _entityService,
-                new PublishedContentQuery(frequest.UmbracoContext.PublishedSnapshot, frequest.UmbracoContext.VariationContextAccessor),
+                new PublishedContentQuery(frequest.UmbracoContext.PublishedSnapshot, frequest.UmbracoContext.VariationContextAccessor, _examineManager),
                 errorCulture);
 
             IPublishedContent content = null;

--- a/src/Umbraco.Web/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Web/Routing/PublishedRouter.cs
@@ -195,7 +195,7 @@ namespace Umbraco.Web.Routing
 
             // assign the legacy page back to the request
             // handlers like default.aspx will want it and most macros currently need it
-            frequest.LegacyContentHashTable = new PublishedContentHashtableConverter(frequest);
+            frequest.LegacyContentHashTable = new PublishedContentHashtableConverter(frequest, _services.UserService);
 
             return true;
         }
@@ -235,7 +235,7 @@ namespace Umbraco.Web.Routing
 
             // assign the legacy page back to the docrequest
             // handlers like default.aspx will want it and most macros currently need it
-            request.LegacyContentHashTable = new PublishedContentHashtableConverter(request);
+            request.LegacyContentHashTable = new PublishedContentHashtableConverter(request, _services.UserService);
             
         }
 

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Web.Runtime
             composition.Register<IPublishedContentQuery>(factory =>
             {
                 var umbCtx = factory.GetInstance<IUmbracoContextAccessor>();
-                return new PublishedContentQuery(umbCtx.UmbracoContext.PublishedSnapshot, factory.GetInstance<IVariationContextAccessor>());
+                return new PublishedContentQuery(umbCtx.UmbracoContext.PublishedSnapshot, factory.GetInstance<IVariationContextAccessor>(), factory.GetInstance<IExamineManager>());
             }, Lifetime.Request);
             composition.Register<ITagQuery, TagQuery>(Lifetime.Request);
 

--- a/src/Umbraco.Web/Trees/TreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/TreeControllerBase.cs
@@ -15,7 +15,6 @@ using Umbraco.Core.Services;
 using Umbraco.Web.Models.Trees;
 using Umbraco.Web.WebApi;
 using Umbraco.Web.WebApi.Filters;
-using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Trees
 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There is a bunch of obsolete usage going on internally in the core. I have tried to root some of them with this PR - the ones that are non-breaking and "safe" to do. There probably are loads more that could be safely fixed, but I reckon it's best to do this in baby steps 😄 