### PR TITLE
umb-search-filter: Convert i to use umb-icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbsearchfilter.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbsearchfilter.directive.js
@@ -75,7 +75,8 @@
             labelKey: "@?",
             onChange: "&?",
             autoFocus: "<?",
-            preventSubmitOnEnter: "<?"
+            preventSubmitOnEnter: "<?",
+            cssClass: "@?"
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -177,6 +177,7 @@
 @import "components/umb-range-slider.less";
 @import "components/umb-number.less";
 @import "components/umb-tags-editor.less";
+@import "components/umb-search-filter.less";
 
 @import "components/buttons/umb-button.less";
 @import "components/buttons/umb-button-group.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-search-filter.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-search-filter.less
@@ -1,0 +1,28 @@
+html .umb-search-filter {
+    position: relative;
+    height: 30px;
+
+    &__input {
+        padding-left: 30px;
+        padding-right: 6px;
+        width: 190px;
+        margin: 0;
+
+        &.w-100 {
+            width: 100%;
+        }
+
+        &.mb-15 {
+            margin-bottom: 15px;
+        }
+    }
+
+    .icon-search {
+        color: #d8d7d9;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 10px;
+        margin: auto 0;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html
@@ -21,6 +21,7 @@
                         label-key="placeholders_search"
                         text="Type to search"
                         on-change="vm.searchTermChanged()"
+                        css-class="w-100"
                         auto-focus="true"
                     >
                     </umb-search-filter>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
@@ -22,6 +22,7 @@
                         model="vm.searchTerm"
                         label-key="placeholders_filter"
                         text="Type to filter..."
+                        css-class="w-100"
                         on-change="vm.filterItems()"
                         auto-focus="true"
                     >

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
@@ -1,7 +1,7 @@
 <div class="umb-control-group -no-border">
     <div class="form-search form-search-filter">
         <label for="{{vm.inputId}}" class="sr-only">{{vm.text}}</label>
-        <i class="icon-search" aria-hidden="true"></i>
+        <umb-icon icon="icon-search" class="icon-search"></umb-icon>
         <input
                 ng-if="vm.preventSubmitOnEnter"
                 id="{{vm.inputId}}"

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
@@ -1,5 +1,5 @@
 <div class="umb-control-group -no-border">
-    <div class="form-search form-search-filter">
+    <div class="umb-search-filter">
         <label for="{{vm.inputId}}" class="sr-only">{{vm.text}}</label>
         <umb-icon icon="icon-search" class="icon-search"></umb-icon>
         <input
@@ -8,7 +8,7 @@
                 type="text"
                 ng-change="vm.change()"
                 ng-model="vm.model"
-                class="umb-search-field search-query search-input input-block-level {{vm.cssClass}}"
+                class="umb-search-filter__input {{vm.cssClass}}"
                 placeholder="{{vm.text}}"
                 umb-auto-focus="{{vm.autoFocus === true}}"
                 prevent-enter-submit
@@ -20,7 +20,7 @@
                 type="text"
                 ng-change="vm.change()"
                 ng-model="vm.model"
-                class="umb-search-field search-query search-input input-block-level"
+                class="umb-search-filter__input {{vm.cssClass}}"
                 placeholder="{{vm.text}}"
                 umb-auto-focus="{{vm.autoFocus === true}}"
                 no-dirty-check />

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
@@ -8,7 +8,7 @@
                 type="text"
                 ng-change="vm.change()"
                 ng-model="vm.model"
-                class="umb-search-field search-query search-input input-block-level"
+                class="umb-search-field search-query search-input input-block-level {{vm.cssClass}}"
                 placeholder="{{vm.text}}"
                 umb-auto-focus="{{vm.autoFocus === true}}"
                 prevent-enter-submit

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -30,7 +30,7 @@
 
             <umb-editor-sub-header-section ng-if="vm.dashboard.urlTrackerDisabled === false">
 
-                <ng-form class="form-search -no-margin-bottom pull-right" novalidate>
+                <ng-form novalidate>
                     <div class="inner-addon left-addon">
                         <umb-search-filter
                             input-id="redirect-search"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I had a look around in the backoffice and was suprised to see that the `<umb-search-filter>` directive was not being used more since I had a vague memory that I switced some of the old patterns to use this directive - Turns out I was wrong. So some more PR's changing those patterns to use the `<umb-search-filter>` will be incoming 😄 

**Update:** The directive has also been extended to accept a css-class parameter, since I foresee we might need it in some scenarios 😃 

**Update 2:** I realised that we needed to add some more "scoped" styling for the directive since currently we would run into issues with using CSS modifiers in other context - Therefore the 3 places where the directive is being used already has also been updated.

Therefore I want to start out by changing the `<i>` to `<umb-icon>` in the directive so we get it out of the box with the other incoming PR's 👍 