### PR TITLE
Composition: Refactor search box to use umb-search-filter directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -17,17 +17,15 @@
                 <umb-box-content>
 
                     <div class="umb-control-group">
-                        <div class="form-search">
-                            <i class="icon-search"></i>
-                            <input type="text"
-                                   style="width: 100%"
-                                   ng-model="searchTerm"
-                                   class="umb-search-field search-query input-block-level"
-                                   localize="placeholder"
-                                   placeholder="@placeholders_filter"
-                                   umb-auto-focus
-                                   no-dirty-check />
-                        </div>
+
+                        <umb-search-filter
+                            input-id="composition-search"
+                            model="searchTerm"
+                            label-key="placeholders_filter"
+                            text="Type to filter..."
+                            auto-focus="true">
+                        </umb-search-filter>
+
                     </div>
 
                     <div class="umb-control-group">
@@ -113,7 +111,7 @@
         </umb-editor-footer>
 
         </form>
-        
+
     </umb-editor-view>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have changed the search box to use the `<umb-search-filter>` directive in order to keep things DRY and ensure any potential fixes in regards to semantics, styling accessibility etc. only needs to be done in one place.

**Edit:** Please hold on merging this PR until #9037 has been merged since I decided to refactor a few things in the directive that needs to be in the core before this change is merged. Once the changes to the directive has been merged I need to tweak this PR a little bit as well - Cheers 👍 
