### PR TITLE
Iconpicker: Switch to umb-search-filter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -18,17 +18,13 @@
             <umb-box-content>
 
                 <div class="umb-control-group">
-                    <div class="form-search">
-                        <umb-icon icon="icon-search" class="icon-search"></umb-icon>
-                        <input type="text"
-                                style="width: 100%"
-                                ng-model="searchTerm"
-                                class="umb-search-field search-query input-block-level"
-                                localize="placeholder"
-                                placeholder="@placeholders_filter"
-                                umb-auto-focus
-                                no-dirty-check />
-                    </div>
+                    <umb-search-filter
+                        input-id="icon-search"
+                        model="searchTerm"
+                        label-key="placeholders_filter"
+                        text="Type to filter..."
+                        auto-focus="true">
+                    </umb-search-filter>
                 </div>
 
                 <div class="umb-control-group">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR changes the search markup to use the `<umb-search-filter>` ensuring the markup is aligned throughout the entire backoffice.

**Edit:** Please hold on merging this PR until #9037 has been merged since I decided to refactor a few things in the directive that needs to be in the core before this change is merged. Once the changes to the directive has been merged I need to tweak this PR a little bit as well - Cheers 👍 
