### PR TITLE
ContextDialog: Accessibility improvements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umbcontextdialog/umb-context-dialog.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umbcontextdialog/umb-context-dialog.html
@@ -1,6 +1,12 @@
-<div id="dialog" class="umb-modalcolumn fill shadow" on-outside-click="outSideClick()">
+<div id="dialog"
+     class="umb-modalcolumn fill shadow"
+     on-outside-click="outSideClick()"
+     role="dialog"
+     aria-labelledby="contextdialog-title"
+     aria-describedby="contextdialog-description">
     <div class="umb-modalcolumn-header">
-        <h1>{{dialogTitle}}</h1>
+        <h1 id="contextdialog-title">{{dialogTitle}}</h1>
+        <p id="contextdialog-description" class="sr-only">Perform action {{dialogTitle}} on node {{currentNode.name}}</p>
     </div>
     <div class="umb-modalcolumn-body" ng-include="view"></div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umbcontextdialog/umb-context-dialog.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umbcontextdialog/umb-context-dialog.html
@@ -6,7 +6,9 @@
      aria-describedby="contextdialog-description">
     <div class="umb-modalcolumn-header">
         <h1 id="contextdialog-title">{{dialogTitle}}</h1>
-        <p id="contextdialog-description" class="sr-only">Perform action {{dialogTitle}} on node {{currentNode.name}}</p>
+        <p id="contextdialog-description" class="sr-only">
+            <localize key="visuallyHiddenTexts_contextDialogDescription" tokens="[dialogTitle,currentNode.name]">Perform action {{dialogTitle}} on the {{currentNode.name}} node</localize>
+        </p>
     </div>
     <div class="umb-modalcolumn-body" ng-include="view"></div>
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2278,6 +2278,7 @@ To manage your website, simply open the Umbraco back office and start adding con
       <key alias="hasTranslation">Has translation</key>
       <key alias="noTranslation">Missing translation</key>
       <key alias="dictionaryListCaption">Dictionary items</key>
+      <key alias="contextDialogDescription">Perform action %0% on the %1% node</key>
   </area>
   <area alias="references">
     <key alias="tabName">References</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2300,6 +2300,7 @@ To manage your website, simply open the Umbraco back office and start adding con
       <key alias="hasTranslation">Has translation</key>
       <key alias="noTranslation">Missing translation</key>
       <key alias="dictionaryListCaption">Dictionary items</key>
+      <key alias="contextDialogDescription">Perform action %0% on the %1% node</key>
   </area>
   <area alias="references">
     <key alias="tabName">References</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have improved the accessibility of the context dialog overlay adding `role="dialog`, ´aria-labelledby´, `aria-describedby` and a description text + of course added keys in the languages files for `en` and `en_us`.

I would have loved to add the focus lock as well but in it's current state it's not quite ready yet - I will give it a try again once I've finished the #8522, which contain some changes that takes view changes into account. View changes are exactly the issue here - The current focus lock is not aware if something change state and becomes visible. But once it's fixed I'll give this another shot :-)