### PR TITLE
Issue 8353 - Fix of issue that caused small screens labels alignment

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -818,6 +818,7 @@ legend + .control-group {
   // Labels on own row
   .form-horizontal .control-label {
     float:none;
+    text-align: inherit;
     width: 100%;
   }
   .form-horizontal .controls {

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -57,7 +57,8 @@ body {
 #installer {
     margin: auto;
     background: @white;
-    width: 750px;
+    width: 80%;
+    max-width: 750px;
     height: 600px;
     text-align: left;
     padding: 30px;


### PR DESCRIPTION
There's an existing issue for this PR see https://github.com/umbraco/Umbraco-CMS/issues/8353

To reproduce the issue reduce the issue on the install screen width to less than 767px and form labels are placed on a new line, however the labels are still right aligned.

![before](https://user-images.githubusercontent.com/985852/94960839-757ec500-04eb-11eb-903c-ae6c74c7bc8c.jpg)

With this fix it sets them back to default:

![after-fix](https://user-images.githubusercontent.com/985852/94960841-76175b80-04eb-11eb-96fe-6bbe52733e48.jpg)



