### PR TITLE
Do not show cryptic confirm dialog when editing group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -23,7 +23,9 @@
         vm.openContentPicker = openContentPicker;
         vm.openMediaPicker = openMediaPicker;
         vm.openUserPicker = openUserPicker;
-        vm.removeSelectedItem = removeSelectedItem;
+        vm.removeSection = removeSection;
+        vm.removeAssignedPermissions = removeAssignedPermissions;
+        vm.removeUser = removeUser;
         vm.clearStartNode = clearStartNode;
         vm.save = save;
         vm.openGranularPermissionsPicker = openGranularPermissionsPicker;
@@ -281,28 +283,33 @@
 
         }
 
-        function removeSelectedItem(index, selection) {
-            if (selection && selection.length > 0) {
+        function removeSection(index) {
+            vm.userGroup.sections.splice(index, 1);
+        }
 
-                const dialog = {
-                    view: "views/users/views/overlays/remove.html",
-                    username: selection[index].username,
-                    userGroupName: vm.userGroup.name.toLowerCase(),
-                    submitButtonLabelKey: "defaultdialogs_yesRemove",
-                    submitButtonStyle: "danger",
+        function removeAssignedPermissions(index) {
+            vm.userGroup.assignedPermissions.splice(index, 1);
+        }
 
-                    submit: function () {
-                        selection.splice(index, 1);
+        function removeUser(index) {
+            const dialog = {
+                view: "views/users/views/overlays/remove.html",
+                username: vm.userGroup.users[index].username,
+                userGroupName: vm.userGroup.name.toLowerCase(),
+                submitButtonLabelKey: "defaultdialogs_yesRemove",
+                submitButtonStyle: "danger",
 
-                        overlayService.close();
-                    },
-                    close: function () {
-                        overlayService.close();
-                    }
-                };
+                submit: function () {
+                    vm.userGroup.users.splice(index, 1);
 
-                overlayService.open(dialog);
-            }
+                    overlayService.close();
+                },
+                close: function () {
+                    overlayService.close();
+                }
+            };
+
+            overlayService.open(dialog);
         }
 
         function clearStartNode(type) {

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.html
@@ -35,7 +35,7 @@
                                                           icon="section.icon"
                                                           name="section.name"
                                                           allow-remove="true"
-                                                          on-remove="vm.removeSelectedItem($index, vm.userGroup.sections)">
+                                                          on-remove="vm.removeSection($index)">
                                         </umb-node-preview>
 
                                         <button type="button"
@@ -115,7 +115,7 @@
                                                           name="node.name"
                                                           permissions="node.allowedPermissions"
                                                           allow-remove="true"
-                                                          on-remove="vm.removeSelectedItem($index, vm.userGroup.assignedPermissions)"
+                                                          on-remove="vm.removeAssignedPermissions($index)"
                                                           allow-edit="true"
                                                           on-edit="vm.setPermissionsForNode(node)">
                                         </umb-node-preview>
@@ -143,7 +143,7 @@
                                                       name="user.name"
                                                       avatars="user.avatars"
                                                       allow-remove="true"
-                                                      on-remove="vm.removeSelectedItem($index, vm.userGroup.users)">
+                                                      on-remove="vm.removeUser($index)">
                                     </umb-user-preview>
 
                                     <button type="button"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9036

### Description

Looks like #8739 was a tad too eager in showing confirmation dialogs. It resulted in somewhat cryptic dialogs when removing sections or granular permissions from a user group:

![image](https://user-images.githubusercontent.com/7405322/94961495-0a39f080-04f5-11eb-82e6-cf95532eb247.png)

![image](https://user-images.githubusercontent.com/7405322/94961454-f8584d80-04f4-11eb-9eb1-544ed9d27462.png)

This PR ensures that we retain the confirmation dialog when removing users from groups, but avoid showing confirmation dialogs when removing sections or granular permissions:

![group-delete-items-after](https://user-images.githubusercontent.com/7405322/94961592-39e8f880-04f5-11eb-9ddd-dbac99933e67.gif)
