### PR TITLE
Make JsonLogViewer public to allow changing log directory

### DIFF
--- a/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
+++ b/src/Umbraco.Core/Logging/Viewer/JsonLogViewer.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.IO;
 
 namespace Umbraco.Core.Logging.Viewer
 {
-    internal class JsonLogViewer : LogViewerSourceBase
+    public class JsonLogViewer : LogViewerSourceBase
     {
         private readonly string _logsPath;
         private readonly ILogger _logger;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7908.

### Description
As described in #7908, changing the log directory in serilog.config breaks the log viewer in the backoffice. Making the `JsonLogViewer` class public allows user code to change the `logsPath` so the log viewer works again.

#### Testing steps:

- Change the value of `serilog:write-to:File.path` in config/serilog.config to something else than the default (e.g.: `%BASEDIR%\App_Data\LogsTest\UmbracoTraceLog.%MACHINENAME%..json`
- Create a new Composer, replacing the default LogViewer with a new one with the file path changed, e.g.:
```
public class ChangeLogPathComposer : IUserComposer
{
    public void Compose(Composition composition)
    {
        composition.SetLogViewer(_ => new JsonLogViewer(composition.Logger, logsPath: IOHelper.MapPath("~/App_Data/LogsTest")));
    }
}
```
- (Optional) Delete the contents of the default folder (~/App_Data/Logs) to trigger an error if the logs are loaded incorrectly (otherwise it will just show the wrong log files)
- Start the site and open the log viewer in the backoffice. Verify that it works and shows the correct logs.

### Notes:

- The hardcoded path was already fixed in #8281 
- The Composer needs to use `IOHelper.MapPath`, is this desired, or should we call this method on the input in the constructor of `JsonLogViewer`?
- After this is merged, I will have a look at updating the docs to document this.
