### PR TITLE
Make sure external links are not attempted to be opened inside preview iframe

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
@@ -85,6 +85,13 @@ var app = angular.module("umbraco.preview", ['umbraco.resources', 'umbraco.servi
                 .fail(function () { console.log("Could not connect to SignalR preview hub."); });
         }
 
+        function fixExternalLinks(iframe) {
+            // Make sure external links don't open inside the iframe
+            Array.from(iframe.contentDocument.getElementsByTagName("a"))
+                .filter(a => a.hostname !== location.hostname && !a.target)
+                .forEach(a => a.target = "_top");
+        }
+
         var isInit = getParameterByName("init");
         if (isInit === "true") {
             //do not continue, this is the first load of this new window, if this is passed in it means it's been
@@ -188,6 +195,7 @@ var app = angular.module("umbraco.preview", ['umbraco.resources', 'umbraco.servi
         $scope.onFrameLoaded = function (iframe) {
             $scope.frameLoaded = true;
             configureSignalR(iframe);
+            fixExternalLinks(iframe);
 
             $scope.currentCultureIso = $location.search().culture || null;
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #6960

### Description
As discussed in #6960, when attempting to open an external link in the same tab inside preview, a browser error is displayed. This is because the link is attempted to be opened inside the iframe, which will not be allowed for most external URLs.

This PR modifies all external links that did not have their target set already to open in the same browser window, outside the iframe. This is not 100% ideal UX, but as per the discussion in #6960, it's likely the best option for now.

#### Testing notes

- Place a link to an external page (without 'open in new tab' set). I used the About Us page of the Starter Kit.
- Preview the page and click the link. Verify that you do not get a browser error, but the link is opened instead.

I have also tested the following scenarios I could think of, and they all seem to work fine:

- Internal links should open in the iframe
- Links with a target set (e.g. `_blank`) should not have their behavior overwritten
- Special links like `mailto:` should keep working
- Pages without links should not result in browser errors