### PR TITLE
Fix void element of umb-checkbox component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logviewer/search.html
@@ -38,7 +38,11 @@
                                 <umb-dropdown class="pull-left" ng-if="vm.page.showLevelFilter" on-close="vm.page.showLevelFilter = false;">
                                     <umb-dropdown-item ng-repeat="level in vm.logLevels" class="dropdown-item">
                                         <div class="flex items-center">
-                                        <umb-checkbox input-id="loglevel-{{$index}}" name="loglevel" model="level.selected" on-change="vm.setLogLevelFilter(level)" />
+                                            <umb-checkbox input-id="loglevel-{{$index}}"
+                                                          name="loglevel"
+                                                          model="level.selected"
+                                                          on-change="vm.setLogLevelFilter(level)">
+                                            </umb-checkbox>
                                             <label for="loglevel-{{$index}}">
                                                 <umb-badge size="s" color="{{level.logTypeColor}}">{{level.name}}</umb-badge>
                                             </label>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Angular elements are custom HTML elements, which are not meant to be void elements (self-closing) although it did seem to work in previous Angular versions.

I already fixed this issue in https://github.com/umbraco/Umbraco-CMS/commit/12a4dbc7052aad1e0018396be27be82feb5b7827#diff-144204f44d67201e4a96574595d21b13 but is seems this was reverted when merging https://github.com/umbraco/Umbraco-CMS/pull/8213

In the case it only cause some addtional spacing in the logviewer filter.

**Current**

![image](https://user-images.githubusercontent.com/2919859/94999168-e8557200-05b7-11eb-9676-04726c2f263f.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/94999181-f905e800-05b7-11eb-9a57-c6e517091c8b.png)
