### PR TITLE
Don't log query result to avoid confusion

### DIFF
--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -445,14 +445,14 @@ namespace Umbraco.Core.Migrations.Install
             }
 
             //Execute the Create Table sql
-            var created = _database.Execute(new Sql(createSql));
-                    _logger.Info<DatabaseSchemaCreator>("Create Table {TableName} ({Created}): \n {Sql}", tableName, created, createSql);
+            _database.Execute(new Sql(createSql));
+            _logger.Info<DatabaseSchemaCreator>("Create Table {TableName}: \n {Sql}", tableName, createSql);
 
             //If any statements exists for the primary key execute them here
             if (string.IsNullOrEmpty(createPrimaryKeySql) == false)
             {
-                var createdPk = _database.Execute(new Sql(createPrimaryKeySql));
-                _logger.Info<DatabaseSchemaCreator>("Create Primary Key ({CreatedPk}):\n {Sql}", createdPk, createPrimaryKeySql);
+                _database.Execute(new Sql(createPrimaryKeySql));
+                _logger.Info<DatabaseSchemaCreator>("Create Primary Key:\n {Sql}", createPrimaryKeySql);
             }
 
             if (SqlSyntax.SupportsIdentityInsert() && tableDefinition.Columns.Any(x => x.IsIdentity))
@@ -469,24 +469,24 @@ namespace Umbraco.Core.Migrations.Install
             //Loop through index statements and execute sql
             foreach (var sql in indexSql)
             {
-                var createdIndex = _database.Execute(new Sql(sql));
-                _logger.Info<DatabaseSchemaCreator>("Create Index ({CreatedIndex}):\n {Sql}", createdIndex, sql);
+                _database.Execute(new Sql(sql));
+                _logger.Info<DatabaseSchemaCreator>("Create Index:\n {Sql}", sql);
             }
 
             //Loop through foreignkey statements and execute sql
             foreach (var sql in foreignSql)
             {
-                var createdFk = _database.Execute(new Sql(sql));
-                _logger.Info<DatabaseSchemaCreator>("Create Foreign Key ({CreatedFk}):\n {Sql}", createdFk, sql);
+                _database.Execute(new Sql(sql));
+                _logger.Info<DatabaseSchemaCreator>("Create Foreign Key:\n {Sql}", sql);
             }
 
             if (overwrite)
             {
-                        _logger.Info<Database>("Table {TableName} was recreated", tableName);
+                _logger.Info<Database>("Table {TableName} was recreated", tableName);
             }
             else
             {
-                        _logger.Info<Database>("New table {TableName} was created", tableName);
+                _logger.Info<Database>("New table {TableName} was created", tableName);
 
             }
         }


### PR DESCRIPTION
The query result will always be -1, as the result is the amount of rows affected, but that is not applicable in these create queries. This may cause confusion as devs may wonder why for example 'CreatedIndex' is -1. This also seemed to be the only place where we actually use the result of `database.Execute`.

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7108

### Description
Logging these parameters leads to confusion, so let's remove them. Logging the name of the created indexes and keys requires some rework of the code and I'm not sure it's really needed at this point, as the SQL already contains the name if needed.

#### Test notes

- Run the site on a clean database or without database
- Ensure the database is constructed correctly and the log entries do not contain the removed parameters
