### PR TITLE
Introduce CachedPartial that takes a Func instead of an object

### DIFF
--- a/src/Umbraco.Web/CacheHelperExtensions.cs
+++ b/src/Umbraco.Web/CacheHelperExtensions.cs
@@ -36,16 +36,44 @@ namespace Umbraco.Web
             string cacheKey,
             ViewDataDictionary viewData = null)
         {
+            return appCaches.CachedPartialView(htmlHelper,
+                partialViewName,
+                () => model,
+                cachedSeconds,
+                cacheKey,
+                viewData);
+        }
+
+        /// <summary>
+        /// Outputs and caches a partial view in MVC
+        /// </summary>
+        /// <param name="appCaches"></param>
+        /// <param name="htmlHelper"></param>
+        /// <param name="partialViewName"></param>
+        /// <param name="builder"></param>
+        /// <param name="cachedSeconds"></param>
+        /// <param name="cacheKey">used to cache the partial view, this key could change if it is cached by page or by member</param>
+        /// <param name="viewData"></param>
+        /// <returns></returns>
+        public static IHtmlString CachedPartialView(
+            this AppCaches appCaches,
+            HtmlHelper htmlHelper,
+            string partialViewName,
+            Func<object> builder,
+            int cachedSeconds,
+            string cacheKey,
+            ViewDataDictionary viewData = null)
+        {
             //disable cached partials in debug mode: http://issues.umbraco.org/issue/U4-5940
             if (htmlHelper.ViewContext.HttpContext.IsDebuggingEnabled)
             {
                 // just return a normal partial view instead
-                return htmlHelper.Partial(partialViewName, model, viewData);
+                return htmlHelper.Partial(partialViewName, builder(), viewData);
             }
 
             return appCaches.RuntimeCache.GetCacheItem<IHtmlString>(
                 PartialViewCacheKey + cacheKey,
-                () => htmlHelper.Partial(partialViewName, model, viewData),
+                () => htmlHelper.Partial(partialViewName, builder(), viewData),
                 priority: CacheItemPriority.NotRemovable, //not removable, the same as macros (apparently issue #27610)
                 timeout: new TimeSpan(0, 0, 0, cachedSeconds));
         }

--- a/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Web
             ViewDataDictionary viewData = null,
             Func<object, ViewDataDictionary, string> contextualKeyBuilder = null)
         {
-            var cacheKey = BuildCacheKey(partialViewName, cacheByPage, cacheByMember);
+            var cacheKey = BuildCachedPartialCacheKey(partialViewName, cacheByPage, cacheByMember);
             if (contextualKeyBuilder != null)
             {
                 var contextualKey = contextualKeyBuilder(model, viewData);
@@ -101,7 +101,7 @@ namespace Umbraco.Web
             ViewDataDictionary viewData = null,
             Func<ViewDataDictionary, string> contextualKeyBuilder = null)
         {
-            var cacheKey = BuildCacheKey(partialViewName, cacheByPage, cacheByMember);
+            var cacheKey = BuildCachedPartialCacheKey(partialViewName, cacheByPage, cacheByMember);
             if (contextualKeyBuilder != null)
             {
                 var contextualKey = contextualKeyBuilder(viewData);
@@ -110,7 +110,7 @@ namespace Umbraco.Web
             return Current.AppCaches.CachedPartialView(htmlHelper, partialViewName, builder, cachedSeconds, cacheKey, viewData);
         }
 
-        private static string BuildCacheKey(
+        private static string BuildCachedPartialCacheKey(
             string partialViewName,
             bool cacheByPage = false,
             bool cacheByMember = false)
@@ -205,7 +205,7 @@ namespace Umbraco.Web
             if (string.IsNullOrWhiteSpace(actionName)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(actionName));
             if (surfaceType == null) throw new ArgumentNullException(nameof(surfaceType));
 
-            var routeVals = new RouteValueDictionary(new {area = ""});
+            var routeVals = new RouteValueDictionary(new { area = "" });
 
             var surfaceController = Current.SurfaceControllerTypes.SingleOrDefault(x => x == surfaceType);
             if (surfaceController == null)


### PR DESCRIPTION
This allows postponing the building of the model passed to the partial to when it is actually needed, as the model really only needs to be built when the partial is not in cache (and when the contextualKeyBuilder doesn't use the model as input). This can be a great performance improvement if building the model is very expensive.

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #7142.

### Description
See above.

Usage is similar to the existing `CachedPartial`, but then a Func is passed instead, e.g.:
```
@Html.CachedPartial("~/Views/Partials/Home/Hero.cshtml", () => HeroBuilder.Build(Model))
```

#### Testing notes
To test the difference between this and the regular `CachedPartial`, we need to verify whether the method is actually only called once.

- Make sure caching is enabled, so `debug="false"` in the web.config
- Take an existing usage of `CachedPartial` like `@Html.CachedPartial("~/Views/Partials/Home/Hero.cshtml", Model)` and verify that it works
- Replace with the usage with a Func that has a side effect like logging. For example:
```
@Html.CachedPartial("~/Views/Partials/Home/Hero.cshtml", () => {
    global::Umbraco.Web.Composing.Current.Logger.Warn(typeof(object), "Builder called");
    return Model;
})
```
- Refresh the page a few times and verify that the log entry only appears once.
