### PR TITLE
Add umb-icon to umb-tree-item and umb-tree-search-box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <i class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1" aria-hidden="true"></i>
+        <umb-icon icon="{{node.icon}}" class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1" aria-hidden="true"></umb-icon>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <umb-icon icon="{{node.icon}}" class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1" aria-hidden="true"></umb-icon>
+        <umb-icon icon="{{node.icon}}" class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
@@ -1,10 +1,10 @@
 <div class="form-search">
-    <i class="icon icon-search" ng-if="showSearch == 'false'" aria-hidden="true"></i>
+    <umb-icon icon="icon-search" class="icon icon-search" ng-if="showSearch == 'false'" aria-hidden="true"></umb-icon>
     <button type="button" class="btn-reset icon icon-arrow-left" ng-if="showSearch == 'true'" localize="title" title="@general_back" ng-click="hideSearch()"></button>
     <input type="text"
            ng-model="term"
            class="umb-search-field search-query -full-width-input"
-           placeholder="{{searchPlaceholderText}}"           
+           placeholder="{{searchPlaceholderText}}"
            umb-auto-focus="{{autoFocus ? 'true' : 'false'}}">
     <h4 ng-if="showSearch && searchFromName">
         <small><localize key="general_search">Search</localize>:&nbsp;</small>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-box.html
@@ -1,5 +1,5 @@
 <div class="form-search">
-    <umb-icon icon="icon-search" class="icon icon-search" ng-if="showSearch == 'false'" aria-hidden="true"></umb-icon>
+    <umb-icon icon="icon-search" class="icon icon-search" ng-if="showSearch == 'false'"></umb-icon>
     <button type="button" class="btn-reset icon icon-arrow-left" ng-if="showSearch == 'true'" localize="title" title="@general_back" ng-click="hideSearch()"></button>
     <input type="text"
            ng-model="term"


### PR DESCRIPTION
This PR updates the `umb-tree-item` and `umb-tree-search-box` views to use the `umb-icon` directive. 

![umb-tree-svg-update](https://user-images.githubusercontent.com/6573613/95017545-d1fbf480-0651-11eb-88c1-7d08a97c9870.gif)
