### PR TITLE
Fix missing icon shown for package actions group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -265,7 +265,7 @@
                 <div class="umb-expansion-panel">
                     <div class="umb-expansion-panel__header" ng-click="vm.actionsOpen = !vm.actionsOpen">
                         <div><localize key="packager_packageActions">Package Actions</localize></div>
-                        <umb-icon icon="vm.actionsOpen ? 'icon-navigation-up' : 'icon-navigation-down'" class="umb-expansion-panel__expand" ng-class="{'icon-navigation-down': !vm.actionsOpen, 'icon-navigation-up': vm.actionsOpen}">&nbsp;</umb-icon>
+                        <umb-icon icon="{{vm.actionsOpen ? 'icon-navigation-up' : 'icon-navigation-down'}}" class="umb-expansion-panel__expand" ng-class="{'icon-navigation-down': !vm.actionsOpen, 'icon-navigation-up': vm.actionsOpen}">&nbsp;</umb-icon>
                     </div>
                     <div class="umb-expansion-panel__content" ng-show="vm.actionsOpen">
                         <umb-control-group


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In https://github.com/umbraco/Umbraco-CMS/pull/5606 `<umb-icon>` component was adding and the icon in the icon in header of the expansion panels was replaced with `<umb-icon>`.

However for package actions it wasn't rendered correct, which this PR fixes.