### PR TITLE
Use ace xml mode for package actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -29,14 +29,17 @@ function dependencies() {
                 "./node_modules/ace-builds/src-min-noconflict/snippets/javascript.js",
                 "./node_modules/ace-builds/src-min-noconflict/snippets/css.js",
                 "./node_modules/ace-builds/src-min-noconflict/snippets/json.js",
+                "./node_modules/ace-builds/src-min-noconflict/snippets/xml.js",
                 "./node_modules/ace-builds/src-min-noconflict/theme-chrome.js",
                 "./node_modules/ace-builds/src-min-noconflict/mode-razor.js",
                 "./node_modules/ace-builds/src-min-noconflict/mode-javascript.js",
                 "./node_modules/ace-builds/src-min-noconflict/mode-css.js",
+                "./node_modules/ace-builds/src-min-noconflict/mode-json.js",
+                "./node_modules/ace-builds/src-min-noconflict/mode-xml.js",
                 "./node_modules/ace-builds/src-min-noconflict/worker-javascript.js",
                 "./node_modules/ace-builds/src-min-noconflict/worker-css.js",
-                "./node_modules/ace-builds/src-min-noconflict/mode-json.js",
-                "./node_modules/ace-builds/src-min-noconflict/worker-json.js"
+                "./node_modules/ace-builds/src-min-noconflict/worker-json.js",
+                "./node_modules/ace-builds/src-min-noconflict/worker-xml.js"
             ],
             "base": "./node_modules/ace-builds"
         },

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.controller.js
@@ -39,6 +39,23 @@
 
         vm.versionRegex = /^(\d+\.)(\d+\.)(\*|\d+)$/;
 
+        vm.aceOption = {
+            mode: "xml",
+            theme: "chrome",
+            showPrintMargin: false,
+            advanced: {
+                fontSize: '14px',
+                enableSnippets: true,
+                enableBasicAutocompletion: true,
+                enableLiveAutocompletion: false
+            },
+            onLoad: function (_editor) {
+                vm.editor = _editor;
+
+                vm.editor.setValue(vm.package.actions);
+            }
+        };
+
         function onInit() {
 
             if (create) {

--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -275,7 +275,10 @@
                             <div>
                                 <a href="" ng-href="https://our.umbraco.com/documentation/Reference/Packaging/" target="_blank" rel="noopener">Documentation</a>
                                 <div>
-                                    <textarea class="umb-property-editor" rows="10" ng-model="vm.package.actions"></textarea>
+                                    <div data-element="package-actions"
+                                         umb-ace-editor="vm.aceOption"
+                                         model="vm.package.actions">
+                                    </div>
                                 </div>
                             </div>
                         </umb-control-group>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At the moment package actions input in packages section is a simple textarea. However since package actions at the moment is in xml format, is would be great to use the xml mode in ace editor.
https://our.umbraco.com/documentation/Extending/Packages/Package-Actions/

![image](https://user-images.githubusercontent.com/2919859/95018145-08d80780-065e-11eb-8b25-317730eec9ac.png)
