### PR TITLE
umb-control-group directive: Fix styling issue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -276,7 +276,7 @@ label:not([for]) {
 }
 
 .controls-row {
-  padding-bottom: 5px;
+  padding-bottom: 5px; 
   margin-left: 240px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -276,7 +276,7 @@ label:not([for]) {
 }
 
 .controls-row {
-  padding-bottom: 5px; 
+  padding-bottom: 5px;
   margin-left: 240px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/html/umb-control-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/html/umb-control-group.html
@@ -8,7 +8,7 @@
                 </span>
                 <small ng-if="descriptionstring">{{descriptionstring}}</small>
             </label>
-            <div class="controls controls-row" ng-transclude></div>
+            <div class="controls" ng-transclude></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Prerequisites

- ✔ I have added steps to test this contribution in the description below

### Description
@bjarnef found this issue and we had a chat about whether it could be introduced by a former PR of mine but we figured out it was not but I of course got a bit curious to figure out what was going on and after a little digging it appears to be the use of `.controls-row` class that offsets the padding on the "Title" by 10 pixels. Removing the class appears to be fixing the issue.

Therefore I have simply removed this class and that seems to fix the issue - I have checked the view that appears when you right click on a content node and select "Do something else" and select "Permissions" and then choose a group to setup permissions for in the dropdown. I have checked it in the users section as well. Can't remember the actions to take to see it but it looked fine there as well.

**Before**
![control-group-before](https://user-images.githubusercontent.com/1932158/95025776-77cc5500-068c-11eb-8776-d03cce808c6b.png)

**After**
![control-group-after](https://user-images.githubusercontent.com/1932158/95025701-fa084980-068b-11eb-8260-5541d74a8392.png)
