### PR TITLE
Bugfix: Updated tour skip-step condition to the new format after umb-icon

### DIFF
--- a/src/Umbraco.Web.UI/config/BackOfficeTours/getting-started.json
+++ b/src/Umbraco.Web.UI/config/BackOfficeTours/getting-started.json
@@ -312,7 +312,7 @@
                 "event": "click",
                 "eventElement": "#tree [data-element='tree-item-templates'] [data-element='tree-item-expand']",
                 "view": "templatetree",
-                "skipStepIfVisible": "#tree [data-element='tree-item-templates'] > div > button[data-element=tree-item-expand].icon-navigation-down"
+                "skipStepIfVisible": "#tree [data-element='tree-item-templates'] > div > button[data-element=tree-item-expand] span.icon-navigation-down"
             },
             {
                 "element": "#tree [data-element='tree-item-templates'] [data-element='tree-item-Home Page']",


### PR DESCRIPTION
Fix for issue found in https://github.com/umbraco/Umbraco-CMS/pull/9008#issuecomment-702565353 which was backtracked down to v8.

This fixes the issue about "Render in template"

It seems like an issue since https://github.com/umbraco/Umbraco-CMS/pull/5606.

Basically the issue is that the class `icon-navigation-down` is now set on the `umb-icon` instead of directly on the `button`

# Test
- Run the tour "Render in template" in a setup without starter kit
  - Ensure the template folder is open when the tour is started (E.g. by running the first tours)
