### PR TITLE
Ensure the fallback value if value updates

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -171,7 +171,7 @@ Use this directive to render an umbraco button. The directive can be used to gen
                     vm.innerState = changes.state.currentValue;
                 }
                 if (changes.state.currentValue === 'success' || changes.state.currentValue === 'error') {
-                    // set the state back to 'init' after a success or error 
+                    // set the state back to 'init' after a success or error
                     $timeout(function () {
                         vm.innerState = 'init';
                     }, 2000);
@@ -194,6 +194,13 @@ Use this directive to render an umbraco button. The directive can be used to gen
             // watch for label key changes
             if(changes.labelKey && changes.labelKey.currentValue) {
                 setButtonLabel();
+            }
+
+            // watch for type changes
+            if(changes.type) {
+                if (!vm.type) {
+                    vm.type = "button";// set the default
+                }
             }
 
         }


### PR DESCRIPTION
If the type-value updates it might still be 'nothing' and therefore we should ensure it gets the fallback value.

Removes the issue of the publish button disappearing in the content editor.
And other places where we use the umb-button-group.