### PR TITLE
Help drawer adjustments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -21,7 +21,7 @@
                                     <span class="umb-help-list-item__title">{{ tour.name }}</span>
                                 </div>
                                 <div>
-                                    <umb-button  button-style="primary" size="xxs" type="button" label="Start" action="vm.startTour(tour)"></umb-button>
+                                    <umb-button button-style="primary" size="xxs" type="button" label="Start" action="vm.startTour(tour)"></umb-button>
                                 </div>
                             </div>
                         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -106,50 +106,50 @@
                                 </span>
                                 <span class="umb-help-list-item__description">{{topic.description}}</span>
                             </span>
-                    </a>
-                </li>
-            </ul>
-        </div>
+                        </a>
+                    </li>
+                </ul>
+            </div>
 
-        <!--  Umbraco tv content -->
-        <div class="umb-help-section" data-element="help-videos" ng-if="vm.hasAccessToSettings">
-            <h5 class="umb-help-section__title" ng-if="vm.videos.length > 0">
-                <localize key="general_videos">Videos</localize>
-            </h5>
-            <ul class="umb-help-list">
-                <li class="umb-help-list-item" ng-repeat="video in vm.videos track by $index">
-                <a class="umb-help-list-item__content" data-element="help-article-{{video.title}}" target="_blank" ng-href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
-                        <i class="umb-help-list-item__icon icon-tv-old" aria-hidden="true"></i>
-                        <span class="umb-help-list-item__title">{{video.title}}</span>
-                        <i class="umb-help-list-item__open-icon icon-out" aria-hidden="true"></i>
-                    </a>
-                </li>
-            </ul>
-        </div>
+            <!--  Umbraco tv content -->
+            <div class="umb-help-section" data-element="help-videos" ng-if="vm.hasAccessToSettings">
+                <h5 class="umb-help-section__title" ng-if="vm.videos.length > 0">
+                    <localize key="general_videos">Videos</localize>
+                </h5>
+                <ul class="umb-help-list">
+                    <li class="umb-help-list-item" ng-repeat="video in vm.videos track by $index">
+                    <a class="umb-help-list-item__content" data-element="help-article-{{video.title}}" target="_blank" ng-href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                            <i class="umb-help-list-item__icon icon-tv-old" aria-hidden="true"></i>
+                            <span class="umb-help-list-item__title">{{video.title}}</span>
+                            <i class="umb-help-list-item__open-icon icon-out" aria-hidden="true"></i>
+                        </a>
+                    </li>
+                </ul>
+            </div>
 
-        <!--  Links -->
-        <div class="umb-help-section" data-element="help-links" ng-if="vm.hasAccessToSettings">
-            <a data-element="help-link-umbraco-tv" class="umb-help-badge" target="_blank" href="https://umbraco.tv?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
-                <i class="umb-help-badge__icon icon-tv-old" aria-hidden="true"></i>
-                <div class="umb-help-badge__title">
-                    <localize key="help_umbracoTv">Visit umbraco.tv</localize>
-                </div>
-                <small>
-                    <localize key="help_theBestUmbracoVideoTutorials">The best Umbraco video tutorials</localize>
-                </small>
-            </a>
+            <!--  Links -->
+            <div class="umb-help-section" data-element="help-links" ng-if="vm.hasAccessToSettings">
+                <a data-element="help-link-umbraco-tv" class="umb-help-badge" target="_blank" href="https://umbraco.tv?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                    <i class="umb-help-badge__icon icon-tv-old" aria-hidden="true"></i>
+                    <div class="umb-help-badge__title">
+                        <localize key="help_umbracoTv">Visit umbraco.tv</localize>
+                    </div>
+                    <small>
+                        <localize key="help_theBestUmbracoVideoTutorials">The best Umbraco video tutorials</localize>
+                    </small>
+                </a>
 
-            <a data-element="help-link-our-umbraco" class="umb-help-badge" target="_blank" href="https://our.umbraco.com?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=our">
-                <i class="umb-help-badge__icon icon-favorite" aria-hidden="true"></i>
+                <a data-element="help-link-our-umbraco" class="umb-help-badge" target="_blank" href="https://our.umbraco.com?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=our">
+                    <i class="umb-help-badge__icon icon-favorite" aria-hidden="true"></i>
 
-                <div class="umb-help-badge__title">
-                    <localize key="help_umbracoForum">Visit our.umbraco.com</localize>
-                </div>
-                <small>
-                    <localize key="defaultdialogs_theFriendliestCommunity">The friendliest community</localize>
-                </small>
-            </a>
-        </div>
+                    <div class="umb-help-badge__title">
+                        <localize key="help_umbracoForum">Visit our.umbraco.com</localize>
+                    </div>
+                    <small>
+                        <localize key="defaultdialogs_theFriendliestCommunity">The friendliest community</localize>
+                    </small>
+                </a>
+            </div>
 
         </umb-drawer-content>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -2,8 +2,8 @@
     <umb-drawer-view>
 
         <umb-drawer-header
-            title="{{ vm.title }}"
-            description="{{ vm.subtitle }}">
+            title="{{vm.title}}"
+            description="{{vm.subtitle}}">
         </umb-drawer-header>
 
         <umb-drawer-content>
@@ -13,7 +13,6 @@
                 <h5>Need help editing current item '{{vm.nodeName}}' ?</h5>
 
                 <div class="umb-help-list">
-
 
                     <div ng-repeat="tour in vm.docTypeTours | orderBy:'groupOrder'">
                         <div data-element="tour-{{tour.alias}}" class="umb-help-list-item">
@@ -98,7 +97,7 @@
                 </h5>
                 <ul class="umb-help-list">
                     <li class="umb-help-list-item" ng-repeat="topic in vm.topics track by $index">
-                        <a class="umb-help-list-item__content" data-element="help-article-{{topic.name}}" target="_blank" ng-href="{{topic.url}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                        <a class="umb-help-list-item__content" data-element="help-article-{{topic.name}}" target="_blank" rel="noopener" href="" ng-href="{{topic.url}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
                             <span>
                                 <span class="umb-help-list-item__title">
                                     <span class="bold">{{topic.name}}</span>
@@ -118,7 +117,7 @@
                 </h5>
                 <ul class="umb-help-list">
                     <li class="umb-help-list-item" ng-repeat="video in vm.videos track by $index">
-                    <a class="umb-help-list-item__content" data-element="help-article-{{video.title}}" target="_blank" ng-href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                    <a class="umb-help-list-item__content" data-element="help-article-{{video.title}}" target="_blank" rel="noopener" href="" ng-href="{{video.link}}?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
                             <i class="umb-help-list-item__icon icon-tv-old" aria-hidden="true"></i>
                             <span class="umb-help-list-item__title">{{video.title}}</span>
                             <i class="umb-help-list-item__open-icon icon-out" aria-hidden="true"></i>
@@ -129,7 +128,7 @@
 
             <!--  Links -->
             <div class="umb-help-section" data-element="help-links" ng-if="vm.hasAccessToSettings">
-                <a data-element="help-link-umbraco-tv" class="umb-help-badge" target="_blank" href="https://umbraco.tv?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
+                <a data-element="help-link-umbraco-tv" class="umb-help-badge" target="_blank" rel="noopener" href="https://umbraco.tv?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=tv">
                     <i class="umb-help-badge__icon icon-tv-old" aria-hidden="true"></i>
                     <div class="umb-help-badge__title">
                         <localize key="help_umbracoTv">Visit umbraco.tv</localize>
@@ -139,7 +138,7 @@
                     </small>
                 </a>
 
-                <a data-element="help-link-our-umbraco" class="umb-help-badge" target="_blank" href="https://our.umbraco.com?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=our">
+                <a data-element="help-link-our-umbraco" class="umb-help-badge" target="_blank" rel="noopener" href="https://our.umbraco.com?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=our">
                     <i class="umb-help-badge__icon icon-favorite" aria-hidden="true"></i>
 
                     <div class="umb-help-badge__title">

--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.html
@@ -159,6 +159,7 @@
                 <umb-button
                     alias="close"
                     type="button"
+                    shortcut="esc"
                     button-style="link"
                     label-key="general_close"
                     action="vm.closeDrawer()">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR fixes a few issues in help drawer:

- Ensure help drawer can be closed via `esc` key.
- Adding `rel="noopener"` to anchor elements with `target="_blank"` for security reasons.