### PR TITLE
Adding a cache buster to the scoped stylesheet in Blocklist editor.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
@@ -353,9 +353,7 @@ angular.module('umbraco.services')
              * @param {string} url the original url without cache buster 
              * @returns {string} The url with the cache buster appended
              */
-            appendCacheBuster: function (url) {
-                return appendRnd(url);
-            }
+            appendCacheBuster: appendRnd
         };
 
         return service;

--- a/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/assets.service.js
@@ -339,6 +339,22 @@ angular.module('umbraco.services')
                 }
 
                 return promise;
+            },
+
+            /**
+             * @ngdoc method
+             * @name umbraco.services.assetsService#appendCacheBuster
+             * @methodOf umbraco.services.assetsService
+             *
+             * @description
+             * Appends the standard cache buster to an url
+             *
+             *
+             * @param {string} url the original url without cache buster 
+             * @returns {string} The url with the cache buster appended
+             */
+            appendCacheBuster: function (url) {
+                return appendRnd(url);
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -58,7 +58,7 @@
                     <style>
                     @import "{{$scope.stylesheet}}"
                     </style>
-                    <div ng-include="'${$scope.view}'"></div>
+                    <div ng-include="view"></div>
                 `;
                 $compile(shadowRoot)($scope);
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -29,7 +29,7 @@
         }
     );
 
-    function BlockListBlockController($scope, $compile, $element, umbRequestHelper) {
+    function BlockListBlockController($scope, $compile, $element, assetsService, umbRequestHelper) {
         var model = this;
 
         model.$onInit = function () {
@@ -49,26 +49,20 @@
             $scope.index = model.index;
             $scope.parentForm = model.parentForm;
             $scope.valFormManager = model.valFormManager;
+            $scope.view = assetsService.appendCacheBuster(model.view);
 
             if (model.stylesheet) {
-                var stylesheetUrl = model.stylesheet;
-                if (Umbraco.Sys.ServerVariables.application) {
-                    var rnd = Umbraco.Sys.ServerVariables.application.cacheBuster;
-                    var _op = (stylesheetUrl.indexOf("?") > 0) ? "&" : "?";
-                    stylesheetUrl = stylesheetUrl + _op + "umb__rnd=" + rnd;
-                }
-
                 var shadowRoot = $element[0].attachShadow({ mode: 'open' });
                 shadowRoot.innerHTML = `
                     <style>
-                    @import "${stylesheetUrl}"
+                    @import "${assetsService.appendCacheBuster(model.stylesheet)}"
                     </style>
-                    <div ng-include="'${model.view}'"></div>
+                    <div ng-include="'${$scope.view}'"></div>
                 `;
                 $compile(shadowRoot)($scope);
             }
             else {
-                $element.append($compile('<div ng-include="model.view"></div>')($scope));
+                $element.append($compile('<div ng-include="view"></div>')($scope));
             }
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -52,6 +52,7 @@
             $scope.view = assetsService.appendCacheBuster(model.view);
 
             if (model.stylesheet) {
+                $scope.stylesheet = assetsService.appendCacheBuster(model.stylesheet);
                 var shadowRoot = $element[0].attachShadow({ mode: 'open' });
                 shadowRoot.innerHTML = `
                     <style>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -56,7 +56,7 @@
                 var shadowRoot = $element[0].attachShadow({ mode: 'open' });
                 shadowRoot.innerHTML = `
                     <style>
-                    @import "${assetsService.appendCacheBuster(model.stylesheet)}"
+                    @import "{{$scope.stylesheet}}"
                     </style>
                     <div ng-include="'${$scope.view}'"></div>
                 `;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -51,10 +51,17 @@
             $scope.valFormManager = model.valFormManager;
 
             if (model.stylesheet) {
+                var stylesheetUrl = model.stylesheet;
+                if (Umbraco.Sys.ServerVariables.application) {
+                    var rnd = Umbraco.Sys.ServerVariables.application.cacheBuster;
+                    var _op = (stylesheetUrl.indexOf("?") > 0) ? "&" : "?";
+                    stylesheetUrl = stylesheetUrl + _op + "umb__rnd=" + rnd;
+                }
+
                 var shadowRoot = $element[0].attachShadow({ mode: 'open' });
                 shadowRoot.innerHTML = `
                     <style>
-                    @import "${model.stylesheet}"
+                    @import "${stylesheetUrl}"
                     </style>
                     <div ng-include="'${model.view}'"></div>
                 `;


### PR DESCRIPTION
Adding a cache buster to the scoped stylesheet in Blocklist editor.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #9079

### Description

This adds the standard cache buster used in the assets service, to the scoped stylesheet in the Blocklist editor blocks. This stylesheet is loaded separately from the rest of Umbraco's assets and will not be refreshed if the site has long cache timeouts for static resources.

Steps to test:
1. Make sure the site has long cache timeout for static resources:
`    <staticContent>
      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="365.00:00:00" />
    </staticContent>
`
1. Create a Block editor with a block that has a custom view and stylesheet configured.
1. Open a document in the backoffice with this editor, and watch the custom view and stylesheet load.
1. Edit both the stylesheet and the view
1. Reload the backoffice, and notice that the custom stylesheet is not updated since it is already cached by the browser.
1. Change the client dependency version number.
1. Reload the backoffice again, and the edits should now be visible.
