### PR TITLE
Ensure content wrapper is positioned to left in section without tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -171,13 +171,13 @@ body.umb-drawer-is-visible #mainwrapper{
 }
 
 @media (min-width: 1101px) {
-  #contentwrapper, #speechbubble {left: 360px;}
-  .emptySection #contentwrapper {left:0px;}
+  #contentwrapper, #speechbubble { left: 360px; } 
+  .emptySection #contentwrapper { left: 0 !important; }
 }
 
 //empty section modification
-.emptySection #speechbubble {left: 0;}
-.emptySection #navigation {display: none}
+.emptySection #speechbubble { left: 0; }
+.emptySection #navigation { display: none }
 
 .login-only #speechbubble {
     z-index: 10000;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8950

### Description
This PR a probably a temporary workaround, but it would be great to investigate further how to reset the inline left position on `contentwrapper`, when using the vertical size handle to change size of navigation panel and afterwards switch to another section without trees like packages, users, forms, etc.

It does seems there is still a tree in background but this is hidden here:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/less/application/grid.less#L180

For now the workaround in this PR seems to do the trick, where the left position with `!important` gets a higher priority than the inline left position.

![DMjlSMFH3U](https://user-images.githubusercontent.com/2919859/95238818-585b3680-080a-11eb-9aed-af9ab1a07dff.gif)
