### PR TITLE
Combine background image and background color in block card

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,8 +1,8 @@
-
+<div>
     <div class="__showcase"
-        ng-class="{'--error':vm.elementTypeModel === null}"
-        ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.styleBackgroundImage}">
-        <i ng-if="vm.blockConfigModel.thumbnail == null" class="__icon {{ vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block' }}" ng-attr-style="{{'color:'+vm.blockConfigModel.iconColor+' !important'}}" aria-hidden="true"></i>
+         ng-class="{'--error':vm.elementTypeModel === null}"
+         ng-style="{'background-color': (vm.styleBackgroundImage === 'none' ? vm.blockConfigModel.backgroundColor : 'transparent'), 'background-image': vm.styleBackgroundImage}">
+        <i ng-if="vm.blockConfigModel.thumbnail == null" class="__icon {{ vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block' }}" ng-attr-style="{{'color:' + vm.blockConfigModel.iconColor + ' !important'}}" aria-hidden="true"></i>
     </div>
     <div class="__info" ng-if="vm.elementTypeModel !== null">
         <div class="__name" ng-bind="vm.elementTypeModel.name"></div>
@@ -14,4 +14,4 @@
     </div>
 
     <ng-transclude></ng-transclude>
-
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -20,19 +20,18 @@
         vm.styleBackgroundImage = "none";
 
         var unwatch = $scope.$watch("vm.blockConfigModel.thumbnail", (newValue, oldValue) => {
-            if(newValue !== oldValue) {
+            if (newValue !== oldValue) {
                 vm.updateThumbnail();
             }
         });
 
         vm.$onInit = function () {
-
             vm.updateThumbnail();
+        };
 
-        }
         vm.$onDestroy = function () {
             unwatch();
-        }
+        };
 
         vm.updateThumbnail = function () {
             if (vm.blockConfigModel.thumbnail == null || vm.blockConfigModel.thumbnail === "") {
@@ -44,8 +43,9 @@
             if (path.toLowerCase().endsWith(".svg") === false) {
                 path += "?upscale=false&width=400";
             }
-            vm.styleBackgroundImage = 'url(\''+path+'\')';
-        }
+
+            vm.styleBackgroundImage = `linear-gradient(0deg, ${vm.blockConfigModel.backgroundColor}, ${vm.blockConfigModel.backgroundColor}), url(${path})`;
+        };
 
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
@@ -1,13 +1,6 @@
-<div
-    class="umb-block-list-block-configuration"
-    ng-controller="Umbraco.PropertyEditors.BlockList.BlockConfigurationController as vm"
-    >
+<div class="umb-block-list-block-configuration" ng-controller="Umbraco.PropertyEditors.BlockList.BlockConfigurationController as vm">
 
-    <div
-        class="umb-block-card-grid"
-        ui-sortable="vm.sortableOptions"
-        ng-model="model.value"
-        >
+    <div class="umb-block-card-grid" ui-sortable="vm.sortableOptions" ng-model="model.value">
 
         <umb-block-card
             block-config-model="block"
@@ -23,7 +16,7 @@
             </div>
         </umb-block-card>
 
-        <button id="{{model.alias}}" type="button" class="btn-reset __add-button" ng-click="vm.openAddDialog($event)">
+        <button type="button" id="{{model.alias}}" class="btn-reset __add-button" ng-click="vm.openAddDialog($event)">
             <localize key="general_add">Add</localize>
         </button>
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR allow to combine background image (thumbnail) and background color in block list editor using `linear-gradient` as in the example here: https://stackoverflow.com/a/36679903

https://caniuse.com/mdn-css_types_image_gradient_linear-gradient

![iLIYi38Dei](https://user-images.githubusercontent.com/2919859/95254086-a4fd3c80-081f-11eb-928d-e0d2517c0e71.gif)

