### PR TITLE
Add confirmation dialog to media picker "remove all entries" action

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker/mediapicker.controller.js
@@ -1,7 +1,7 @@
 //this controller simply tells the dialogs service to open a mediaPicker window
 //with a specified callback, this callback will receive an object with a selection on it
 angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerController",
-    function ($scope, entityResource, mediaHelper, $timeout, userService, localizationService, editorService, angularHelper) {
+    function ($scope, entityResource, mediaHelper, $timeout, userService, localizationService, editorService, angularHelper, overlayService) {
 
         var vm = this;
 
@@ -242,10 +242,22 @@ angular.module('umbraco').controller("Umbraco.PropertyEditors.MediaPickerControl
         }
 
         function removeAllEntries() {
-            $scope.mediaItems.length = 0;// AngularJS way to empty the array.
-            $scope.ids.length = 0;// AngularJS way to empty the array.
-            sync();
-            setDirty();
+            localizationService.localizeMany(["content_nestedContentDeleteAllItems", "general_delete"]).then(function (data) {
+                overlayService.confirmDelete({
+                    title: data[1],
+                    content: data[0],
+                    close: function () {
+                        overlayService.close();
+                    },
+                    submit: function () {
+                        $scope.mediaItems.length = 0;// AngularJS way to empty the array.
+                        $scope.ids.length = 0;// AngularJS way to empty the array.
+                        sync();
+                        setDirty();
+                        overlayService.close();
+                    }
+                });
+            });
         }
 
         var removeAllEntriesAction = {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you attempt to remove all items of a Nested Content or Block Editor property (by use of the property actions), you're asked to confirm this. However, this is not the case when you do the same for a Media Picker:

![propery-actions-media-picker-before](https://user-images.githubusercontent.com/7405322/95342544-d4f81e80-08b7-11eb-80ad-1a4e2c22029b.gif)

This PR adds the same confirmation dialog to Media Picker:

![propery-actions-media-picker-after](https://user-images.githubusercontent.com/7405322/95342590-e0e3e080-08b7-11eb-944e-56ae442c1054.gif)

