### PR TITLE
Accessibilty: set the html lang element

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -1,4 +1,5 @@
-﻿@using Umbraco.Core
+﻿@using System.Globalization
+@using Umbraco.Core
 @using ClientDependency.Core
 @using ClientDependency.Core.Mvc
 @using Umbraco.Core.Composing
@@ -27,7 +28,7 @@
 
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="@CultureInfo.CurrentCulture.Name">
 <head>
     <base href="@Model.GlobalSettings.Path.EnsureEndsWith('/')" />
     <meta charset="utf-8">


### PR DESCRIPTION
I have created this PR to ensure the lang element is set based on the user's culture when the page is loaded.

This is important for screen readers, it ensures the correct pronunciation of the words.  This YouTube video demonstrates the importance of setting the language https://www.youtube.com/watch?v=QwOoU8T24UY#