### PR TITLE
Allow to close list view settings overlay via esc shortcut

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings-overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-list-view-settings-overlay.html
@@ -23,7 +23,8 @@
             <umb-button 
                 type="button" 
                 button-style="link" 
-                label-key="general_close" 
+                label-key="general_close"
+                shortcut="esc"
                 action="model.close()">
             </umb-button>
             <umb-button


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add the `shortcut="esc"` to close button, so it is possible to close overlay via `esc` key.

![4yGE94AtHn](https://user-images.githubusercontent.com/2919859/95439103-75e9e680-0957-11eb-8aa9-8b6b60b557cf.gif)
