### PR TITLE
Show badge in user state filter and icon in user group filter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-badge.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-badge.less
@@ -8,45 +8,88 @@
     border-radius: 100px;
 }
 
+.umb-badge__count {
+    display: flex;
+    width: 1rem;
+    height: 1rem;
+    line-height: 1;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+    font-size: 12px;
+}
+
 // Colors
 .umb-badge--primary {
     background-color: @blueDark;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@blueDark, 5%);
+    }
 }
 
 .umb-badge--secondary {
     background-color: @blueExtraDark;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@blueExtraDark, 8%);
+    }
 }
 
 .umb-badge--gray {
     background-color: @sand-2;
     color: @blueDark;
+
+    .umb-badge__count {
+        background-color: darken(@sand-2, 8%);
+    }
 }
 
 .umb-badge--danger {
     background-color: @red;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@red, 8%);
+    }
 }
 
 .umb-badge--info {
     background-color: @blue;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@blue, 8%);
+    }
 }
 
 .umb-badge--warning {
     background-color: @orange;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@orange, 8%);
+    }
 }
 
 .umb-badge--success {
     background-color: @green;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@green, 8%);
+    }
 }
 
 .umb-badge--dark {
     background-color: @grayDark;
     color: @white;
+
+    .umb-badge__count {
+        background-color: darken(@grayDark, 8%);
+    }
 }
 
 // Size

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -143,10 +143,17 @@
                     <umb-dropdown class="pull-right" ng-if="vm.page.showGroupFilter" on-close="vm.page.showGroupFilter = false;">
                         <umb-dropdown-item ng-repeat="userGroup in vm.userGroups" style="padding: 8px 20px 8px 16px;">
                             <div class="flex items-center">
-                                <umb-checkbox model="userGroup.selected"
-                                              on-change="vm.setUserGroupFilter(userGroup)"
-                                              text="{{ userGroup.name }}">
+                                <umb-checkbox input-id="usergroup-{{$index}}"
+                                              name="usergroup"
+                                              model="userGroup.selected"
+                                              on-change="vm.setUserGroupFilter(userGroup)">
                                 </umb-checkbox>
+                                <label for="usergroup-{{$index}}">
+                                    <span class="flex items-center">
+                                        <i class="{{userGroup.icon}}" aria-hidden="true"></i>
+                                        <span class="ml1">{{userGroup.name}}</span>
+                                    </span>
+                                </label>
                             </div>
                         </umb-dropdown-item>
                     </umb-dropdown>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -110,7 +110,6 @@
             </div>
 
             <div class="flex ml-auto">
-
                 <!-- State filter -->
                 <div class="umb-filter" ng-if="vm.userStatesFilter.length > 0">
                     <button type="button" class="btn btn-link dropdown-toggle umb-filter__toggle" ng-click="vm.toggleFilter('state')">
@@ -120,10 +119,16 @@
                     </button>
                     <umb-dropdown class="pull-right" ng-if="vm.page.showStatusFilter" on-close="vm.page.showStatusFilter = false;">
                         <umb-dropdown-item ng-repeat="userState in vm.userStatesFilter | filter:{ key: '!All'}" ng-show="userState.count > 0" style="padding: 8px 20px 8px 16px;">
-                            <umb-checkbox model="userState.selected"
-                                          on-change="vm.setUserStatesFilter(userState)"
-                                          text="{{ userState.name }} ({{userState.count}})">
-                            </umb-checkbox>
+                            <div class="flex items-center">
+                                <umb-checkbox input-id="userstate-{{$index}}"
+                                              name="userstate"
+                                              model="userState.selected"
+                                              on-change="vm.setUserStatesFilter(userState)">
+                                </umb-checkbox>
+                                <label for="userstate-{{$index}}">
+                                    <umb-badge size="s" color="{{userState.color}}">{{userState.name}} <span class="ml1 umb-badge__count">{{userState.count}}</span></umb-badge>
+                                </label>
+                            </div>
                         </umb-dropdown-item>
                     </umb-dropdown>
                 </div>
@@ -137,10 +142,12 @@
                     </button>
                     <umb-dropdown class="pull-right" ng-if="vm.page.showGroupFilter" on-close="vm.page.showGroupFilter = false;">
                         <umb-dropdown-item ng-repeat="userGroup in vm.userGroups" style="padding: 8px 20px 8px 16px;">
-                            <umb-checkbox model="userGroup.selected"
-                                          on-change="vm.setUserGroupFilter(userGroup)"
-                                          text="{{ userGroup.name }}">
-                            </umb-checkbox>
+                            <div class="flex items-center">
+                                <umb-checkbox model="userGroup.selected"
+                                              on-change="vm.setUserGroupFilter(userGroup)"
+                                              text="{{ userGroup.name }}">
+                                </umb-checkbox>
+                            </div>
                         </umb-dropdown-item>
                     </umb-dropdown>
                 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add a badge in user state filter similar to log level filter. Furthermore I have also added icons in user group filter. However I haven't used `<umb-icon>` here at the moment since with the latest changes this seems to be a be slow and these icons are first loaded quite a while after the user group filter has been opened.

![image](https://user-images.githubusercontent.com/2919859/95448786-25c55100-0964-11eb-8098-5f0ddb703de4.png)

![image](https://user-images.githubusercontent.com/2919859/95448869-42618900-0964-11eb-96df-43d47313a934.png)
