### PR TITLE
V8 - Show that underlying item is used on the info tab

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IRelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRelationRepository.cs
@@ -30,6 +30,8 @@ namespace Umbraco.Core.Persistence.Repositories
 
         IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int childId, long pageIndex, int pageSize, out long totalRecords, int[] relationTypes, params Guid[] entityTypes);
 
+        IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildIds(int[] childIds, long pageIndex, int pageSize, out long totalRecords, int[] relationTypes, params Guid[] entityTypes);
+
         IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes);
 
         IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords, int[] relationTypes, params Guid[] entityTypes);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -212,9 +212,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 
                 sql.WhereAny(s => s.WhereIn<RelationDto>(rel => rel.ParentId, childIds),
                     s => s.WhereNotIn<NodeDto>(node => node.NodeId, childIds));
-               // sql.WhereAny( < RelationDto >)(s => s.Where<RelationDto, NodeDto>())
-              //  sql.Where<RelationDto, NodeDto>((rel, node) => rel.ParentId == childId || node.NodeId != childId);
-
+               
                 if (relationTypes != null && relationTypes.Any())
                 {
                     sql.WhereIn<RelationDto>(rel => rel.RelationType, relationTypes);

--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -221,6 +221,17 @@ namespace Umbraco.Core.Services
         IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildId(int id, long pageIndex, int pageSize, out long totalChildren, string[] relationTypes, params UmbracoObjectTypes[] entityTypes);
 
         /// <summary>
+        /// Returns paged parent entities for a related child ids
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="pageSize"></param>
+        /// <param name="totalChildren"></param>
+        /// <param name="relationTypes">A list of relation types to filter</param>
+        /// <returns></returns>
+        IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildIds(int[] ids, long pageIndex, int pageSize, out long totalChildren, string[] relationTypes, params UmbracoObjectTypes[] entityTypes);
+
+        /// <summary>
         /// Returns paged child entities for a related parent id
         /// </summary>
         /// <param name="id"></param>

--- a/src/Umbraco.Core/Services/Implement/RelationService.cs
+++ b/src/Umbraco.Core/Services/Implement/RelationService.cs
@@ -294,6 +294,17 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildIds(int[] ids, long pageIndex, int pageSize, out long totalChildren,
+            string[] relationTypes, params UmbracoObjectTypes[] entityTypes)
+        {
+            var relationTypeIds = this.GetRelationTypeIdsFromAliases(relationTypes);
+
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _relationRepository.GetPagedParentEntitiesByChildIds(ids, pageIndex, pageSize, out totalChildren, relationTypeIds, entityTypes.Select(x => x.GetGuid()).ToArray());
+            }
+        }
+
         /// <inheritdoc />
         public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int id, long pageIndex, int pageSize, out long totalChildren, params UmbracoObjectTypes[] entityTypes)
         {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
@@ -43,29 +43,28 @@
 
             $q.all([loadContentRelations(), loadMediaRelations(), loadMemberRelations()]).then(function () {
                 
+                if (vm.hasContentReferences && vm.hasMediaReferences && vm.hasMemberReferences) {
+                    vm.loading = false;
+                } else {
+                    var descendantsPromises = [];
 
-                if (!vm.hasContentReferences) {
-                    trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.contentOptions.entityType)
-                        .then(function(data) {
-                            vm.hasContentReferencesInDescendants = data;
-                        });
+                    if (!vm.hasContentReferences) {
+                        descendantsPromises.push(checkContentDescendantsUsage());
+                    }
+
+                    if (!vm.hasMediaReferences) {
+                        descendantsPromises.push(checkMediaDescendantsUsage());
+                    }
+
+                    if (!vm.hasMemberReferences) {
+                        descendantsPromises.push(checkMemberDescendantsUsage())
+                    }
+
+                    $q.all(descendantsPromises).then(function() {
+                        vm.loading = false;
+                    });
+
                 }
-
-                if (!vm.hasMediaReferences) {
-                    trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.mediaOptions.entityType)
-                        .then(function (data) {
-                            vm.hasMediaReferencesInDescendants = data;
-                        });
-                }
-
-                if (!vm.hasMemberReferences) {
-                    trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.memberOptions.entityType)
-                        .then(function (data) {
-                            vm.hasMemberReferencesInDescendants = data;
-                        });
-                }
-
-                vm.loading = false;
             });
 
            
@@ -107,6 +106,27 @@
                 .then(function (data) {
                     vm.memberReferences = data;
                     vm.hasMemberReferences = data.items.length > 0;
+                });
+        }
+
+        function checkContentDescendantsUsage() {
+           return trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.contentOptions.entityType)
+                .then(function (data) {
+                    vm.hasContentReferencesInDescendants = data;
+                });
+        }
+
+        function checkMediaDescendantsUsage() {
+            return trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.mediaOptions.entityType)
+                .then(function (data) {
+                    vm.hasMediaReferencesInDescendants = data;
+                });
+        }
+
+        function checkMemberDescendantsUsage() {
+            return trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.memberOptions.entityType)
+                .then(function (data) {
+                    vm.hasMemberReferencesInDescendants = data;
                 });
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
@@ -23,16 +23,19 @@
         vm.contentOptions = {};
         vm.contentOptions.entityType = "DOCUMENT";
         vm.hasContentReferences = false;
+        vm.hasContentReferencesInDescendants = false;
 
         vm.changeMediaPageNumber = changeMediaPageNumber;
         vm.mediaOptions = {};
         vm.mediaOptions.entityType = "MEDIA";
         vm.hasMediaReferences = false;
+        vm.hasMediaReferencesInDescendants = false;
 
         vm.changeMemberPageNumber = changeMemberPageNumber;
         vm.memberOptions = {};
         vm.memberOptions.entityType = "MEMBER";
         vm.hasMemberReferences = false;
+        vm.hasMemberReferencesInDescendants = false;
 
         vm.$onInit = onInit;
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
@@ -42,6 +42,29 @@
         function onInit() {
 
             $q.all([loadContentRelations(), loadMediaRelations(), loadMemberRelations()]).then(function () {
+                
+
+                if (!vm.hasContentReferences) {
+                    trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.contentOptions.entityType)
+                        .then(function(data) {
+                            vm.hasContentReferencesInDescendants = data;
+                        });
+                }
+
+                if (!vm.hasMediaReferences) {
+                    trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.mediaOptions.entityType)
+                        .then(function (data) {
+                            vm.hasMediaReferencesInDescendants = data;
+                        });
+                }
+
+                if (!vm.hasMemberReferences) {
+                    trackedReferencesResource.hasReferencesInDescendants(vm.id, vm.memberOptions.entityType)
+                        .then(function (data) {
+                            vm.hasMemberReferencesInDescendants = data;
+                        });
+                }
+
                 vm.loading = false;
             });
 

--- a/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
@@ -96,7 +96,7 @@ function trackedReferencesResource($q, $http, umbRequestHelper) {
                         "HasReferencesInChildNode",
                         {
                             id: id,
-                            entitytype: entitype,
+                            entityType: entityType
                         }
                     )),
                 "Failed to check for references in child nodes");

--- a/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
@@ -64,6 +64,43 @@ function trackedReferencesResource($q, $http, umbRequestHelper) {
                         }
                     )),
                 "Failed to retrieve usages for entity of id " + id);
+        },
+
+        /**
+         * @ngdoc method
+         * @name umbraco.resources.trackedReferencesResource#hasReferencesInChildNodes
+        * @methodOf umbraco.resources.trackedReferencesResource
+         *
+         * @description
+         * Checks 
+         *
+         * ##usage
+         * <pre>         
+         * trackedReferencesResource.hasReferencesInDescendants(1,'MEDIA')
+         *    .then(function(data) {
+         *        console.log(data);
+         *    });
+         * </pre>
+         *
+         * @param {int} id Id of the  item to query for tracked references
+         * @param {string} entityType  the type of tracked entity (default : DOCUMENT). Possible values DOCUMENT, MEDIA
+         * @returns {Promise} resourcePromise object.
+         *
+         */
+        hasReferencesInDescendants: function (id, entityType) {
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "trackedReferencesApiBaseUrl",
+                        "HasReferencesInChildNode",
+                        {
+                            id: id,
+                            entitytype: entitype,
+                        }
+                    )),
+                "Failed to check for references in child nodes");
+
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
@@ -93,7 +93,7 @@ function trackedReferencesResource($q, $http, umbRequestHelper) {
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "trackedReferencesApiBaseUrl",
-                        "HasReferencesInChildNode",
+                        "HasReferencesInDescendants",
                         {
                             id: id,
                             entityType: entityType

--- a/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
@@ -54,7 +54,7 @@
 
         <umb-box>
             <umb-box-content>
-                <localize key="references_labelUsedInContentDescendants">One of the underlying items is being used in content item</localize>
+                <localize key="references_labelUsedInContentDescendants">One or more of this item's descendants is being used in a content item.</localize>
             </umb-box-content>
         </umb-box>
     </div>
@@ -102,7 +102,7 @@
 
         <umb-box>
             <umb-box-content>
-                <localize key="references_labelUsedInMemberDescendants">One of the underlying items is being used in a member</localize>
+                <localize key="references_labelUsedInMemberDescendants">One or more of this item's descendants is being used in a a member</localize>
             </umb-box-content>
         </umb-box>
     </div>
@@ -150,7 +150,7 @@
 
         <umb-box>
             <umb-box-content>
-                <localize key="references_labelUsedInMediaDescendants">One of the underlying items is being used in a media item</localize>
+                <localize key="references_labelUsedInMediaDescendants">One or more of this item's descendants is being used in a media item</localize>
             </umb-box-content>
         </umb-box>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
@@ -47,6 +47,18 @@
         </div>
     </div>
 
+    <div ng-if="vm.hasContentReferencesInDescendants">
+        <h5 class="mt0" style="margin-bottom: 20px;">
+            <localize key="references_labelUsedByDocuments">Used in Documents</localize>
+        </h5>
+
+        <umb-box>
+            <umb-box-content>
+                <localize key="references_labelUsedInContentDescendants">One of the underlying items is being used in content item</localize>
+            </umb-box-content>
+        </umb-box>
+    </div>
+
     <!-- Members -->
     <div ng-if="vm.hasMemberReferences > 0">
 
@@ -83,6 +95,18 @@
         </div>
     </div>
 
+    <div ng-if="vm.hasMemberReferencesInDescendants">
+        <h5 class="mt0" style="margin-bottom: 20px;">
+            <localize key="references_labelUsedByMembers">Used in Members</localize>
+        </h5>
+
+        <umb-box>
+            <umb-box-content>
+                <localize key="references_labelUsedInMemberDescendants">One of the underlying items is being used in a member</localize>
+            </umb-box-content>
+        </umb-box>
+    </div>
+
     <!-- Media -->
     <div ng-if="vm.hasMediaReferences">
 
@@ -117,6 +141,18 @@
                             on-change="vm.changeMediaPageNumber(pageNumber)">
             </umb-pagination>
         </div>
+    </div>
+
+    <div ng-if="vm.hasMediaReferencesInDescendants">
+        <h5 class="mt0" style="margin-bottom: 20px;">
+            <localize key="references_labelUsedByMedia">Used in Media</localize>
+        </h5>
+
+        <umb-box>
+            <umb-box-content>
+                <localize key="references_labelUsedInMediaDescendants">One of the underlying items is being used in a media item</localize>
+            </umb-box-content>
+        </umb-box>
     </div>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
@@ -1,6 +1,6 @@
 ﻿<umb-load-indicator ng-if="vm.loading === true"></umb-load-indicator>
 
-<umb-box ng-if="(vm.hasContentReferences === false) && (vm.hasMediaReferences === false) && (vm.hasMemberReferences === false) && vm.loading === false">
+<umb-box ng-if="(vm.hasContentReferences === false) && (vm.hasContentReferencesInDescendants === false) && (vm.hasMediaReferences === false) && (vm.hasMediaReferencesInDescendants === false) && (vm.hasMemberReferences === false) && (vm.hasMemberReferencesInDescendants === false) && vm.loading === false">
     <umb-box-header title-key="references_tabName"></umb-box-header>
     <umb-box-content>
         <umb-empty-state size="small">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2292,9 +2292,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="labelUsedByDocuments">Used in Documents</key>
     <key alias="labelUsedByMembers">Used in Members</key>
     <key alias="labelUsedByMedia">Used in Media</key>
-      <key alias="labelUsedInMediaDescendants">One of the underlying items is being used in a media item</key>
-      <key alias="labelUsedInContentDescendants">One of the underlying items is being used in a content item</key>
-      <key alias="labelUsedInMemberDescendants">One of the underlying items is being used in a member</key>
+      <key alias="labelUsedInMediaDescendants">One or more of this item's descendants is being used in a media item</key>
+      <key alias="labelUsedInContentDescendants">One or more of this item's descendants is being used in a content item</key>
+      <key alias="labelUsedInMemberDescendants">One or more of this item's descendants is being used in a member</key>
   </area>
   <area alias="logViewer">
       <key alias="deleteSavedSearch">Delete Saved Search</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2292,6 +2292,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="labelUsedByDocuments">Used in Documents</key>
     <key alias="labelUsedByMembers">Used in Members</key>
     <key alias="labelUsedByMedia">Used in Media</key>
+      <key alias="labelUsedInMediaDescendants">One of the underlying items is being used in a media item</key>
+      <key alias="labelUsedInContentDescendants">One of the underlying items is being used in a content item</key>
+      <key alias="labelUsedInMemberDescendants">One of the underlying items is being used in a member</key>
   </area>
   <area alias="logViewer">
       <key alias="deleteSavedSearch">Delete Saved Search</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2314,6 +2314,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="labelUsedByDocuments">Used in Documents</key>
     <key alias="labelUsedByMembers">Used in Members</key>
     <key alias="labelUsedByMedia">Used in Media</key>
+      <key alias="labelUsedInMediaDescendants">One of the underlying items is being used in a media item</key>
+      <key alias="labelUsedInContentDescendants">One of the underlying items is being used in a content item</key>
+      <key alias="labelUsedInMemberDescendants">One of the underlying items is being used in a member</key>
   </area>
   <area alias="logViewer">
       <key alias="deleteSavedSearch">Delete Saved Search</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2314,9 +2314,9 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="labelUsedByDocuments">Used in Documents</key>
     <key alias="labelUsedByMembers">Used in Members</key>
     <key alias="labelUsedByMedia">Used in Media</key>
-      <key alias="labelUsedInMediaDescendants">One of the underlying items is being used in a media item</key>
-      <key alias="labelUsedInContentDescendants">One of the underlying items is being used in a content item</key>
-      <key alias="labelUsedInMemberDescendants">One of the underlying items is being used in a member</key>
+      <key alias="labelUsedInMediaDescendants">One or more of this item's descendants is being used in a media item</key>
+      <key alias="labelUsedInContentDescendants">One or more of this item's descendants is being used in a content item</key>
+      <key alias="labelUsedInMemberDescendants">One or more of this item's descendants is being used in a member</key>
   </area>
   <area alias="logViewer">
       <key alias="deleteSavedSearch">Delete Saved Search</key>

--- a/src/Umbraco.Web/Editors/TrackedReferencesController.cs
+++ b/src/Umbraco.Web/Editors/TrackedReferencesController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Umbraco.Core;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration;
@@ -58,6 +59,7 @@ namespace Umbraco.Web.Editors
             };
         }
 
+        [HttpGet]
         public bool HasReferencesInDescendants(int id, string entityType)
         {
             return false;

--- a/src/Umbraco.Web/Editors/TrackedReferencesController.cs
+++ b/src/Umbraco.Web/Editors/TrackedReferencesController.cs
@@ -57,5 +57,10 @@ namespace Umbraco.Web.Editors
                 })
             };
         }
+
+        public bool HasReferencesInDescendants(int id, string entityType)
+        {
+            return false;
+        }
     }
 }

--- a/src/Umbraco.Web/Editors/TrackedReferencesController.cs
+++ b/src/Umbraco.Web/Editors/TrackedReferencesController.cs
@@ -62,11 +62,8 @@ namespace Umbraco.Web.Editors
         [HttpGet]
         public bool HasReferencesInDescendants(int id, string entityType)
         {
-            //this.Services.EntityService.GetChildren()
-            //var childCount = this.Services.ContentService.CountChildren(id);
             var currentEntity = this.Services.EntityService.Get(id);
-
-
+            
             if (currentEntity != null)
             {
                 var currentObjectType = ObjectTypes.GetUmbracoObjectType(currentEntity.NodeObjectType);
@@ -82,7 +79,6 @@ namespace Umbraco.Web.Editors
                 var currentPage = 0;
 
                 IEntitySlim[] entities;
-
 
                 do
                 {
@@ -104,8 +100,7 @@ namespace Umbraco.Web.Editors
 
                 } while (entities.Length == pageSize);
             }
-
-
+            
             return false;
         }
     }

--- a/src/Umbraco.Web/Editors/TrackedReferencesController.cs
+++ b/src/Umbraco.Web/Editors/TrackedReferencesController.cs
@@ -81,26 +81,26 @@ namespace Umbraco.Web.Editors
                 var pageSize = 1000;
                 var currentPage = 0;
 
-                IEntity[] entities;
+                IEntitySlim[] entities;
+
 
                 do
                 {
                     entities = this.Services.EntityService.GetPagedDescendants(id, currentObjectType, currentPage, pageSize, out _)
                         .ToArray();
 
-                    currentPage++;
+                    var ids = entities.Select(x => x.Id).ToArray();
 
-                    foreach (var descendant in entities)
+                    var relations =
+                        this.Services.RelationService.GetPagedParentEntitiesByChildIds(ids, 0, int.MaxValue, out _,
+                            relationTypes, objectType);
+
+                    if (relations.Any())
                     {
-                        var relations = Services.RelationService.GetPagedParentEntitiesByChildId(descendant.Id, 0,
-                            int.MaxValue, out _, relationTypes, objectType);
-
-                        if (relations.Any())
-                        {
-                            return true;
-                        }
+                        return true;
                     }
 
+                    currentPage++;
 
                 } while (entities.Length == pageSize);
             }

--- a/src/Umbraco.Web/Editors/TrackedReferencesController.cs
+++ b/src/Umbraco.Web/Editors/TrackedReferencesController.cs
@@ -78,12 +78,12 @@ namespace Umbraco.Web.Editors
                 var pageSize = 1000;
                 var currentPage = 0;
 
-                IEntitySlim[] entities;
+                var entities = new List<IEntitySlim>();
 
                 do
                 {
                     entities = this.Services.EntityService.GetPagedDescendants(id, currentObjectType, currentPage, pageSize, out _)
-                        .ToArray();
+                        .ToList();
 
                     var ids = entities.Select(x => x.Id).ToArray();
 
@@ -98,7 +98,7 @@ namespace Umbraco.Web.Editors
 
                     currentPage++;
 
-                } while (entities.Length == pageSize);
+                } while (entities.Count == pageSize);
             }
             
             return false;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8699

### Description

With this PR you can now see if one of the underlying items (descendants) is being used in content. It doesn't show which content items yet, that is for a future PR.

To have good performance I needed to introduce a new repository and service method.

For testing the default starter kit can be used

### Steps to test for media

1. Create a folder structure several levels deep in the media section. 
2. Upload some photo's in a sub folder
3. Link one of the photo's from content
4. On the top level folder check the info tab. It should indicate that one of the underlying items is in use.

### Steps to test for content
1. Create a content structure several levels deep in the content section. 
2. Link content on the lowest level in another page.
3. On the top level content item of the newly created content structure check the info tab. It should indicate that one of the underlying items is in use.

