### PR TITLE
Scale the preview iframe to fit the viewport

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
@@ -192,6 +192,7 @@ body {
 
 #demo-iframe-wrapper {
     transition: all 240ms cubic-bezier(0.165, 0.84, 0.44, 1);
+    flex-shrink:0;
 }
 
 .fullsize {

--- a/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
@@ -29,7 +29,28 @@ var app = angular.module("umbraco.preview", ['umbraco.resources', 'umbraco.servi
             window.addEventListener("keydown", handleFirstTab);
         }
 
+        var iframeWrapper = angular.element("#demo-iframe-wrapper");
+        var canvasDesignerPanel = angular.element("#canvasdesignerPanel");
+        
         window.addEventListener("keydown", handleFirstTab);
+        window.addEventListener("resize", scaleIframeWrapper);
+        iframeWrapper.on("transitionend", scaleIframeWrapper);
+
+        function scaleIframeWrapper() {
+            if ($scope.previewDevice.name == "fullsize") { // dont scale fullsize preview
+                iframeWrapper.css({"transform": ""});
+            }
+            else {
+                var wrapWidth = canvasDesignerPanel.width(); // width of the wrapper
+                var wrapHeight = canvasDesignerPanel.height();
+                var childWidth = iframeWrapper.width() + 30; // width of child iframe plus some space
+                var childHeight = iframeWrapper.height() + 30; // child height plus some space
+                var wScale = wrapWidth / childWidth;
+                var hScale = wrapHeight / childHeight;
+                var scale = Math.min(wScale,hScale,1);  // get the lowest ratio, but not higher than 1
+                iframeWrapper.css({"transform": "scale("+scale+")" });  // set scale
+            }
+        }
 
 
         //gets a real query string value


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes related, but not complete fix for #8673 and #8303 

### Description
This PR adds some automatic scaling of the preview iframe in the preview viewer, to make it fit the current viewport. This way you can preview your page as if it was shown in ie. a desktop sized browser window, but you don't need a window of the same size.

Modern browser dev tools (seen in Chrome, Edge and Firefox) does the same in responsive mode.

To test:
Open a node in the previewer, make sure your browser window is reasonably small. Change the viewmode in the bottom right corner, and notice how the iframe scales up and down when needed, to fit in your viewport. When in fullscreen, no scaling should be applied though.

![R1pzPilAEH](https://user-images.githubusercontent.com/3726467/95663309-801a0980-0b3e-11eb-981f-327dba13ed4d.gif)
