### PR TITLE
Itempicker: Fix filter check

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/itempicker/itempicker.html
@@ -1,5 +1,5 @@
 <div ng-controller="Umbraco.Overlays.ItemPickerOverlay" class="umb-itempicker">
-    <div class="form-search" ng-if="model.filter" style="margin-bottom: 15px;">
+    <div class="form-search" ng-if="model.filter !== false" style="margin-bottom: 15px;">
         <i class="icon-search" aria-hidden="true"></i>
         <input type="text"
                ng-model="searchTerm"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
@nul800sebastiaan This PR fixes the issue where the search filter was not being displayed when used in the "template" context - Since the model is not immutable it's not enough to assume that the filter should be displayed or hidden if model.filter is true or false since it can also be undefined. Therefore it's now changed from `ng-if="model.filter"` to `ng-if="model.filter !== false` 👍 

**Before**
![item-picker-template-before](https://user-images.githubusercontent.com/1932158/95665136-b317c980-0b4d-11eb-8c7b-354ef0c87f2e.png)

**After**
![item-picker-template-after](https://user-images.githubusercontent.com/1932158/95665139-b90daa80-0b4d-11eb-911c-4abca08189a3.png)
