### PR TITLE
Non-published content indexed in ExternalIndex

### DIFF
--- a/src/Umbraco.Examine/ContentIndexPopulator.cs
+++ b/src/Umbraco.Examine/ContentIndexPopulator.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Examine
     /// <summary>
     /// Performs the data lookups required to rebuild a content index
     /// </summary>
-    public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
+    public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex2>
     {
         private readonly IContentService _contentService;
         private readonly IValueSetBuilder<IContent> _contentValueSetBuilder;
@@ -56,6 +56,12 @@ namespace Umbraco.Examine
                 _publishedQuery = sqlContext.Query<IContent>().Where(x => x.Published);
             _publishedValuesOnly = publishedValuesOnly;
             _parentId = parentId;
+        }
+
+        public override bool IsRegistered(IUmbracoContentIndex2 index)
+        {
+            // check if it should populate based on published values
+            return _publishedValuesOnly == index.PublishedValuesOnly;
         }
 
         protected override void PopulateIndexes(IReadOnlyList<IIndex> indexes)

--- a/src/Umbraco.Examine/IUmbracoContentIndex.cs
+++ b/src/Umbraco.Examine/IUmbracoContentIndex.cs
@@ -2,6 +2,20 @@ using Examine;
 
 namespace Umbraco.Examine
 {
+    /// <summary>
+    /// Marker interface for indexes of Umbraco content
+    /// </summary>
+    /// <remarks>
+    /// This is a backwards compat change, in next major version remove the need for this and just have a single interface
+    /// </remarks>
+    public interface IUmbracoContentIndex2 : IUmbracoContentIndex
+    {
+        bool PublishedValuesOnly { get; }
+    }
+
+    /// <summary>
+    /// Marker interface for indexes of Umbraco content
+    /// </summary>
     public interface IUmbracoContentIndex : IIndex
     {
 

--- a/src/Umbraco.Examine/IndexPopulator.cs
+++ b/src/Umbraco.Examine/IndexPopulator.cs
@@ -13,9 +13,16 @@ namespace Umbraco.Examine
     {
         public override bool IsRegistered(IIndex index)
         {
-            if (base.IsRegistered(index)) return true;
-            return index is TIndex;
+            if (base.IsRegistered(index))
+                return true;
+
+            if (!(index is TIndex casted))
+                return false;
+
+            return IsRegistered(casted);
         }
+
+        public virtual bool IsRegistered(TIndex index) => true;
     }
 
     public abstract class IndexPopulator : IIndexPopulator

--- a/src/Umbraco.Examine/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine/UmbracoContentIndex.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Examine
     /// <summary>
     /// An indexer for Umbraco content and media
     /// </summary>
-    public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex
+    public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex2
     {
         public const string VariesByCultureFieldName = SpecialFieldPrefix + "VariesByCulture";
         protected ILocalizationService LanguageService { get; }


### PR DESCRIPTION
Fixes issue that the non-published content index populator is executing for the ExternalIndex

As mentioned in https://github.com/umbraco/Umbraco-CMS/pull/9010 the index populator for non-published items will always execute for the ExternalIndex that has a validator to declare that it does not support published items.

This fixes that issue.
