### PR TITLE
Fixes regression issue with property values being updated in content repositories

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -919,6 +919,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 }
                 else
                 {
+                    // TODO: we can speed this up: Use BulkInsert and then do one SELECT to re-retrieve the property data inserted with assigned IDs.
+                    // This is a perfect thing to benchmark with Benchmark.NET to compare perf between Nuget releases.
                     Database.Insert(propertyDataDto);
                 }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -863,6 +863,75 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         }
 
+        /// <summary>
+        /// Inserts property values for the content entity
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="publishedVersionId"></param>
+        /// <param name="edited"></param>
+        /// <param name="editedCultures"></param>
+        /// <remarks>
+        /// Used when creating a new entity
+        /// </remarks>
+        protected void InsertPropertyValues(TEntity entity, int publishedVersionId, out bool edited, out HashSet<string> editedCultures)
+        {
+            // persist the property data
+            var propertyDataDtos = PropertyFactory.BuildDtos(entity.ContentType.Variations, entity.VersionId, publishedVersionId, entity.Properties, LanguageRepository, out edited, out editedCultures);
+            foreach (var propertyDataDto in propertyDataDtos)
+            {
+                Database.Insert(propertyDataDto);
+            }
+            // TODO: we can speed this up: Use BulkInsert and then do one SELECT to re-retrieve the property data inserted with assigned IDs.
+            // This is a perfect thing to benchmark with Benchmark.NET to compare perf between Nuget releases.
+        }
+
+        /// <summary>
+        /// Used to atomically replace the property values for the entity version specified
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="versionId"></param>
+        /// <param name="publishedVersionId"></param>
+        /// <param name="edited"></param>
+        /// <param name="editedCultures"></param>
+        protected void ReplacePropertyValues(TEntity entity, int versionId, int publishedVersionId, out bool edited, out HashSet<string> editedCultures)
+        {
+            // Replace the property data.
+            // Lookup the data to update with a UPDLOCK (using ForUpdate()) this is because we need to be atomic
+            // and handle DB concurrency. Doing a clear and then re-insert is prone to concurrency issues.
+
+            var propDataSql = SqlContext.Sql().Select("*").From<PropertyDataDto>().Where<PropertyDataDto>(x => x.VersionId == versionId).ForUpdate();
+            var existingPropData = Database.Fetch<PropertyDataDto>(propDataSql);
+            var propertyTypeToPropertyData = new Dictionary<(int propertyTypeId, int versionId), PropertyDataDto>();
+            var existingPropDataIds = new List<int>();
+            foreach (var p in existingPropData)
+            {
+                existingPropDataIds.Add(p.Id);
+                propertyTypeToPropertyData[(p.PropertyTypeId, p.VersionId)] = p;
+            }
+            var propertyDataDtos = PropertyFactory.BuildDtos(entity.ContentType.Variations, entity.VersionId, publishedVersionId, entity.Properties, LanguageRepository, out edited, out editedCultures);
+            foreach (var propertyDataDto in propertyDataDtos)
+            {
+                // Check if this already exists and update, else insert a new one
+                if (propertyTypeToPropertyData.TryGetValue((propertyDataDto.PropertyTypeId, propertyDataDto.VersionId), out var propData))
+                {
+                    propertyDataDto.Id = propData.Id;
+                    Database.Update(propertyDataDto);
+                }
+                else
+                {
+                    Database.Insert(propertyDataDto);
+                }
+
+                // track which ones have been processed
+                existingPropDataIds.Remove(propertyDataDto.Id);
+            }
+            // For any remaining that haven't been processed they need to be deleted
+            if (existingPropDataIds.Count > 0)
+            {
+                Database.Execute(SqlContext.Sql().Delete<PropertyDataDto>().WhereIn<PropertyDataDto>(x => x.Id, existingPropDataIds));
+            }
+        }
+
         private class NodeIdKey
         {
             [Column("id")]

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MediaRepository.cs
@@ -219,7 +219,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override void PersistNewItem(IMedia entity)
         {
-            var media = (Models.Media) entity;
             entity.AddingEntity();
 
             // ensure unique name on the same level
@@ -274,17 +273,15 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             contentVersionDto.NodeId = nodeDto.NodeId;
             contentVersionDto.Current = true;
             Database.Insert(contentVersionDto);
-            media.VersionId = contentVersionDto.Id;
+            entity.VersionId = contentVersionDto.Id;
 
             // persist the media version dto
             var mediaVersionDto = dto.MediaVersionDto;
-            mediaVersionDto.Id = media.VersionId;
+            mediaVersionDto.Id = entity.VersionId;
             Database.Insert(mediaVersionDto);
 
             // persist the property data
-            var propertyDataDtos = PropertyFactory.BuildDtos(media.ContentType.Variations, media.VersionId, 0, entity.Properties, LanguageRepository, out _, out _);
-            foreach (var propertyDataDto in propertyDataDtos)
-                Database.Insert(propertyDataDto);
+            InsertPropertyValues(entity, 0, out _, out _);
 
             // set tags
             SetEntityTags(entity, _tagRepository);
@@ -298,10 +295,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override void PersistUpdatedItem(IMedia entity)
         {
-            var media = (Models.Media) entity;
-
             // update
-            media.UpdatingEntity();
+            entity.UpdatingEntity();
 
             // ensure unique name on the same level
             entity.Name = EnsureUniqueNodeName(entity.ParentId, entity.Name, entity.Id);
@@ -339,11 +334,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             Database.Update(mediaVersionDto);
 
             // replace the property data
-            var deletePropertyDataSql = SqlContext.Sql().Delete<PropertyDataDto>().Where<PropertyDataDto>(x => x.VersionId == media.VersionId);
-            Database.Execute(deletePropertyDataSql);
-            var propertyDataDtos = PropertyFactory.BuildDtos(media.ContentType.Variations, media.VersionId, 0, entity.Properties, LanguageRepository, out _, out _);
-            foreach (var propertyDataDto in propertyDataDtos)
-                Database.Insert(propertyDataDto);
+            ReplacePropertyValues(entity, entity.VersionId, 0, out _, out _);
 
             SetEntityTags(entity, _tagRepository);
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -245,8 +245,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
             entity.AddingEntity();
 
-            var member = (Member) entity;
-
             // ensure that strings don't contain characters that are invalid in xml
             // TODO: do we really want to keep doing this here?
             entity.SanitizeEntityPropertiesForXmlStorage();
@@ -304,7 +302,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             contentVersionDto.NodeId = nodeDto.NodeId;
             contentVersionDto.Current = true;
             Database.Insert(contentVersionDto);
-            member.VersionId = contentVersionDto.Id;
+            entity.VersionId = contentVersionDto.Id;
 
             // persist the member dto
             dto.NodeId = nodeDto.NodeId;
@@ -321,9 +319,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             Database.Insert(dto);
 
             // persist the property data
-            var propertyDataDtos = PropertyFactory.BuildDtos(member.ContentType.Variations, member.VersionId, 0, entity.Properties, LanguageRepository, out _, out _);
-            foreach (var propertyDataDto in propertyDataDtos)
-                Database.Insert(propertyDataDto);
+            InsertPropertyValues(entity, 0, out _, out _);
 
             SetEntityTags(entity, _tagRepository);
 
@@ -335,11 +331,9 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         }
 
         protected override void PersistUpdatedItem(IMember entity)
-        {
-            var member = (Member) entity;
-
+        {   
             // update
-            member.UpdatingEntity();
+            entity.UpdatingEntity();
 
             // ensure that strings don't contain characters that are invalid in xml
             // TODO: do we really want to keep doing this here?
@@ -385,27 +379,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             if (changedCols.Count > 0)
                 Database.Update(dto, changedCols);
 
-            // Replace the property data
-            // Lookup the data to update with a UPDLOCK (using ForUpdate()) this is because we have another method that doesn't take an explicit WriteLock
-            // in SetLastLogin which is called very often and we want to avoid the lock timeout for the explicit lock table but we still need to ensure atomic
-            // operations between that method and this one. 
-
-            var propDataSql = SqlContext.Sql().Select("*").From<PropertyDataDto>().Where<PropertyDataDto>(x => x.VersionId == member.VersionId).ForUpdate();
-            var existingPropData = Database.Fetch<PropertyDataDto>(propDataSql).ToDictionary(x => x.PropertyTypeId);
-            var propertyDataDtos = PropertyFactory.BuildDtos(member.ContentType.Variations, member.VersionId, 0, entity.Properties, LanguageRepository, out _, out _);
-            foreach (var propertyDataDto in propertyDataDtos)
-            {
-                // Check if this already exists and update, else insert a new one
-                if (existingPropData.TryGetValue(propertyDataDto.PropertyTypeId, out var propData))
-                {
-                    propertyDataDto.Id = propData.Id;
-                    Database.Update(propertyDataDto);
-                }
-                else
-                {
-                    Database.Insert(propertyDataDto);
-                }
-            }   
+            ReplacePropertyValues(entity, entity.VersionId, 0, out _, out _);
 
             SetEntityTags(entity, _tagRepository);
 

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -1538,6 +1538,48 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Can_Update_Content_Property_Values()
+        {
+            IContentType contentType = MockedContentTypes.CreateSimpleContentType();
+            ServiceContext.ContentTypeService.Save(contentType);
+            IContent content = MockedContent.CreateSimpleContent(contentType, "hello");
+            content.SetValue("title", "title of mine");
+            content.SetValue("bodyText", "hello world");
+            ServiceContext.ContentService.SaveAndPublish(content);
+
+            // re-get
+            content = ServiceContext.ContentService.GetById(content.Id);
+            content.SetValue("title", "another title of mine");          // Change a value
+            content.SetValue("bodyText", null);                          // Clear a value
+            ServiceContext.ContentService.SaveAndPublish(content);
+
+            // re-get
+            content = ServiceContext.ContentService.GetById(content.Id);
+            Assert.AreEqual("another title of mine", content.GetValue("title"));
+            Assert.IsNull(content.GetValue("bodyText"));
+
+            content.SetValue("title", "new title");
+            content.SetValue("bodyText", "new body text");
+            ServiceContext.ContentService.Save(content);                // new non-published version
+
+            // re-get
+            content = ServiceContext.ContentService.GetById(content.Id);
+            content.SetValue("title", null);                            // Clear a value
+            content.SetValue("bodyText", null);                         // Clear a value
+            ServiceContext.ContentService.Save(content);                // saving non-published version
+
+            // re-get
+            content = ServiceContext.ContentService.GetById(content.Id);
+            Assert.IsNull(content.GetValue("title"));                   // Test clearing the value worked with the non-published version
+            Assert.IsNull(content.GetValue("bodyText"));
+
+            // make sure that the published version remained the same
+            var publishedContent = ServiceContext.ContentService.GetVersion(content.PublishedVersionId);
+            Assert.AreEqual("another title of mine", publishedContent.GetValue("title"));
+            Assert.IsNull(publishedContent.GetValue("bodyText"));
+        }
+
+        [Test]
         public void Can_Bulk_Save_Content()
         {
             // Arrange

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -1551,15 +1551,18 @@ namespace Umbraco.Tests.Services
             content = ServiceContext.ContentService.GetById(content.Id);
             content.SetValue("title", "another title of mine");          // Change a value
             content.SetValue("bodyText", null);                          // Clear a value
+            content.SetValue("author", "new author");                    // Add a value
             ServiceContext.ContentService.SaveAndPublish(content);
 
             // re-get
             content = ServiceContext.ContentService.GetById(content.Id);
             Assert.AreEqual("another title of mine", content.GetValue("title"));
             Assert.IsNull(content.GetValue("bodyText"));
+            Assert.AreEqual("new author", content.GetValue("author"));
 
             content.SetValue("title", "new title");
             content.SetValue("bodyText", "new body text");
+            content.SetValue("author", "new author text");
             ServiceContext.ContentService.Save(content);                // new non-published version
 
             // re-get
@@ -1572,11 +1575,13 @@ namespace Umbraco.Tests.Services
             content = ServiceContext.ContentService.GetById(content.Id);
             Assert.IsNull(content.GetValue("title"));                   // Test clearing the value worked with the non-published version
             Assert.IsNull(content.GetValue("bodyText"));
+            Assert.AreEqual("new author text", content.GetValue("author"));
 
             // make sure that the published version remained the same
             var publishedContent = ServiceContext.ContentService.GetVersion(content.PublishedVersionId);
             Assert.AreEqual("another title of mine", publishedContent.GetValue("title"));
             Assert.IsNull(publishedContent.GetValue("bodyText"));
+            Assert.AreEqual("new author", publishedContent.GetValue("author"));
         }
 
         [Test]

--- a/src/Umbraco.Tests/Services/MediaServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MediaServiceTests.cs
@@ -26,6 +26,28 @@ namespace Umbraco.Tests.Services
     [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, PublishedRepositoryEvents = true)]
     public class MediaServiceTests : TestWithSomeContentBase
     {
+        [Test]
+        public void Can_Update_Media_Property_Values()
+        {
+            IMediaType mediaType = MockedContentTypes.CreateSimpleMediaType("test", "Test");
+            ServiceContext.MediaTypeService.Save(mediaType);
+            IMedia media = MockedMedia.CreateSimpleMedia(mediaType, "hello", -1);
+            media.SetValue("title", "title of mine");
+            media.SetValue("bodyText", "hello world");
+            ServiceContext.MediaService.Save(media);
+
+            // re-get
+            media = ServiceContext.MediaService.GetById(media.Id);
+            media.SetValue("title", "another title of mine");          // Change a value
+            media.SetValue("bodyText", null);                          // Clear a value
+            ServiceContext.MediaService.Save(media);
+
+            // re-get
+            media = ServiceContext.MediaService.GetById(media.Id);
+            Assert.AreEqual("another title of mine", media.GetValue("title"));
+            Assert.IsNull(media.GetValue("bodyText"));
+        }
+
         /// <summary>
         /// Used to list out all ambiguous events that will require dispatching with a name
         /// </summary>

--- a/src/Umbraco.Tests/Services/MediaServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MediaServiceTests.cs
@@ -40,12 +40,14 @@ namespace Umbraco.Tests.Services
             media = ServiceContext.MediaService.GetById(media.Id);
             media.SetValue("title", "another title of mine");          // Change a value
             media.SetValue("bodyText", null);                          // Clear a value
+            media.SetValue("author", "new author");                    // Add a value
             ServiceContext.MediaService.Save(media);
 
             // re-get
             media = ServiceContext.MediaService.GetById(media.Id);
             Assert.AreEqual("another title of mine", media.GetValue("title"));
             Assert.IsNull(media.GetValue("bodyText"));
+            Assert.AreEqual("new author", media.GetValue("author"));
         }
 
         /// <summary>

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -49,22 +49,25 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
-        public void Can_Update_Member_Property_Value()
+        public void Can_Update_Member_Property_Values()
         {
             IMemberType memberType = MockedContentTypes.CreateSimpleMemberType();
             ServiceContext.MemberTypeService.Save(memberType);
             IMember member = MockedMember.CreateSimpleMember(memberType, "hello", "helloworld@test123.com", "hello", "hello");
             member.SetValue("title", "title of mine");
+            member.SetValue("bodyText", "hello world");
             ServiceContext.MemberService.Save(member);
 
             // re-get
             member = ServiceContext.MemberService.GetById(member.Id);
-            member.SetValue("title", "another title of mine");
+            member.SetValue("title", "another title of mine");          // Change a value
+            member.SetValue("bodyText", null);                          // Clear a value
             ServiceContext.MemberService.Save(member);
 
             // re-get
             member = ServiceContext.MemberService.GetById(member.Id);
             Assert.AreEqual("another title of mine", member.GetValue("title"));
+            Assert.IsNull(member.GetValue("bodyText"));
         }
 
         [Test]

--- a/src/Umbraco.Tests/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests/Services/MemberServiceTests.cs
@@ -62,12 +62,14 @@ namespace Umbraco.Tests.Services
             member = ServiceContext.MemberService.GetById(member.Id);
             member.SetValue("title", "another title of mine");          // Change a value
             member.SetValue("bodyText", null);                          // Clear a value
+            member.SetValue("author", "new author");                    // Add a value
             ServiceContext.MemberService.Save(member);
 
             // re-get
             member = ServiceContext.MemberService.GetById(member.Id);
             Assert.AreEqual("another title of mine", member.GetValue("title"));
             Assert.IsNull(member.GetValue("bodyText"));
+            Assert.AreEqual("new author", member.GetValue("author"));
         }
 
         [Test]

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -269,6 +269,14 @@ namespace Umbraco.Web.Search
                         DeleteIndexForEntity(c4.Id, false);
                     }
                     break;
+                case MessageType.RefreshByPayload:
+                    var payload = (MemberCacheRefresher.JsonPayload[])args.MessageObject;
+                    var members = payload.Select(x => _services.MemberService.GetById(x.Id));
+                    foreach(var m in members)
+                    {
+                        ReIndexForMember(m);
+                    }
+                    break;
                 case MessageType.RefreshAll:
                 case MessageType.RefreshByJson:
                 default:
@@ -746,6 +754,6 @@ namespace Umbraco.Web.Search
         }
         #endregion
 
-        
+
     }
 }


### PR DESCRIPTION
Fixes #9095 - caused by #8525 with changes here https://github.com/umbraco/Umbraco-CMS/pull/8525/files#diff-2ab7be5e592894a2e3dfac615d7a94a5ae6ab11e1948312fb515749caca04b79R12 because the ExamineComponent.MemberCacheRefresherUpdated event wasn't updated to handle the RefreshByPayload message type

Fixes #9093 - caused by #8525 with changes here https://github.com/umbraco/Umbraco-CMS/pull/8525/files#diff-0f4c2578706d75656978e4cccd48671380730283de0ec98f0d8e79ef7d7d0ef7R388. The problem was a change to the Member Repository that was not taking into account removed property values. The change was required because the previous way that content properties were persisted was not done atomically and was unsafe with high DB concurrency. This change was also required because a new member service method was added to deal with high concurrency issues which requires this other operation to be isolated correctly. It is not possible without a serializable transaction (which we don't use) to delete a bunch of rows and then re-add them since this is not isolated from other DB operations and weird things can happen along with deadlocks. To fix this we use a SELECT statement with an UPDLOCK hint on the rows returned and then either Insert, Update (or Delete) was is required based on the existing data compared to the data we're saving. The missing part here was the Delete part.

This has been fixed and the method to do this moved to the underlying ContentRepositoryBase so it can be re-used by the DocumentRepository and the MediaRepository because both of those are prone to the same concurrency problem and were also trying to just clear rows and re-insert which is unsafe. These repositories now also use this same shared method. I have also moved the logic for inserting property value rows to a shared method when new documents, media or members is created. I've put a TODO there because we can speed that operation up but would like to run some benchmarks on that before we do (that's for a later date).

I've added tests for the ContentService, MediaService and MemberService to ensure that property values can all be added, cleared, updated. 

## Testing

Ensure that #9093 and #9095 problems are fixed and that all tests pass