### PR TITLE
Netcore: Enable session

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MacroRenderingController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MacroRenderingController.cs
@@ -24,11 +24,6 @@ namespace Umbraco.Web.BackOffice.Controllers
     /// <summary>
     /// API controller to deal with Macro data
     /// </summary>
-    /// <remarks>
-    /// Note that this implements IRequiresSessionState which will enable HttpContext.Session - generally speaking we don't normally
-    /// enable this for webapi controllers, however since this controller is used to render macro content and macros can access
-    /// Session, we don't want it to throw null reference exceptions.
-    /// </remarks>
     [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
     public class MacroRenderingController : UmbracoAuthorizedJsonController
     {

--- a/src/Umbraco.Web.BackOffice/Extensions/BackOfficeApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/Extensions/BackOfficeApplicationBuilderExtensions.cs
@@ -35,6 +35,9 @@ namespace Umbraco.Extensions
             app.UseImageSharp();
             app.UseStaticFiles();
 
+            // Must be called after UseRouting and before UseEndpoints
+            app.UseSession();
+
             if (!app.UmbracoCanBoot()) return app;
 
             app.UseEndpoints(endpoints =>

--- a/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
@@ -248,7 +248,6 @@ namespace Umbraco.Extensions
             {
                 options.Cookie.Name = "UMB_SESSION";
                 options.Cookie.HttpOnly = true;
-                options.IdleTimeout = TimeSpan.FromSeconds(60);
             });
 
             // Add supported databases

--- a/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
@@ -241,6 +241,16 @@ namespace Umbraco.Extensions
             if (container is null) throw new ArgumentNullException(nameof(container));
             if (entryAssembly is null) throw new ArgumentNullException(nameof(entryAssembly));
 
+            // Add service session
+            // This can be overwritten by the user by adding their own call to AddSession
+            // since the last call of AddSession take precedence
+            services.AddSession(options =>
+            {
+                options.Cookie.Name = "UMB_SESSION";
+                options.Cookie.HttpOnly = true;
+                options.IdleTimeout = TimeSpan.FromSeconds(60);
+            });
+
             // Add supported databases
             services.AddUmbracoSqlCeSupport();
             services.AddUmbracoSqlServerSupport();


### PR DESCRIPTION
I enabled session by adding the session service and middleware. 

This is to replace the previous use of IRequiresSessionState since this is no longer a thing in net core

The way this is implemented now means that the session will be available everywhere HttpContext is, unfortunately, I was not able to find a way to enable/disable session for specific controllers. 

In regards to customizing session for users, this should still be possible by calling AddSession on services after using AddUmbraco, because the last call to AddSession is the one that's used. 

Setting session up to use redis, database or memory cache, should also be possible adding whatever implementation of IDistributedCache to the service collection before adding session I.E
```c#
services.AddUmbraco();
services.AddDistributedMemoryCache();
services.AddSession();
```

At least this is my understanding of this, I'd love to hear feedback if there are any issues or suggestions.