### PR TITLE
Added documentation for umbControlGroup directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbcontrolgroup.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbcontrolgroup.directive.js
@@ -3,12 +3,12 @@
 * @name umbraco.directives.directive:umbControlGroup
 * @restrict E
 
-@param {string=} label The label for the control group field
-@param {string=} description The description for the control group field
-@param {boolean=} hideLabel Set to <code>true</code> to hide the label
-@param {string=} alias The alias of the field within the control group
-@param {string=} labelFor The alias of the field that the label is for, used for validation
-@param {boolean=} required Set to <code>true</code> to mark the field as required
+@param {string=} label The label for the control group field.
+@param {string=} description The description for the control group field.
+@param {boolean=} hideLabel Set to <code>true</code> to hide the label.
+@param {string=} alias The alias of the field within the control group.
+@param {string=} labelFor The alias of the field that the label is for, used for validation.
+@param {boolean=} required Set to <code>true</code> to mark the field as required.
 
 **/
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbcontrolgroup.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/html/umbcontrolgroup.directive.js
@@ -2,7 +2,16 @@
 * @ngdoc directive
 * @name umbraco.directives.directive:umbControlGroup
 * @restrict E
+
+@param {string=} label The label for the control group field
+@param {string=} description The description for the control group field
+@param {boolean=} hideLabel Set to <code>true</code> to hide the label
+@param {string=} alias The alias of the field within the control group
+@param {string=} labelFor The alias of the field that the label is for, used for validation
+@param {boolean=} required Set to <code>true</code> to mark the field as required
+
 **/
+
 angular.module("umbraco.directives.html")
   .directive('umbControlGroup', function (localizationService) {
     return {


### PR DESCRIPTION
I have added the metadata required to the `umbControlGroup` directive so that the attributes available can be listed in the backoffice documentation.

I did my best to give an accurate description of the purpose for each attribute, but this was inferred from how they are used in the code itself. Perhaps someone can double-check my understanding is correct, and propose any better descriptions if anything is unclear.