### PR TITLE
Styling all code elements in backoffice UI docs

### DIFF
--- a/src/Umbraco.Web.UI.Docs/umb-docs.css
+++ b/src/Umbraco.Web.UI.Docs/umb-docs.css
@@ -2,9 +2,9 @@
 html {
     font-family: 'Segoe UI', Tahoma, Helvetica, sans-serif;
 }
+
 body {
     font-family: 'Segoe UI', Tahoma, Helvetica, sans-serif;
-
 }
 
 .container, .navbar-static-top .container, .navbar-fixed-top .container, .navbar-fixed-bottom .container {
@@ -29,8 +29,27 @@ body {
     color: inherit;
 }
 
-.content code {
+a:hover {
+    text-decoration: none;
+    color: rgba(0, 0, 0, .8);
+}
+
+.content p code {
+    font-size: 85%;
     font-family: inherit;
+    background-color: #f7f7f9;
+    padding: 0px 3px;
+    border: 1px solid #e1e1e8;
+    color: #d14;
+    white-space: nowrap;
+}
+
+.header img {
+    width: 50px;
+}
+
+.breadcrumb {
+    background-color: #f7f7f7;
 }
 
 .navbar .container{
@@ -66,14 +85,6 @@ body {
     background-color: #ccc;
 }
 
-.breadcrumb {
-    background-color: #f7f7f7;
-}
-
-a:hover {
-    text-decoration: none;
-    color: rgba(0,0,0,.8);
-}
 .nav-list > .active > a, .nav-list > .active > a:hover, .nav-list > .active > a:focus,
 .form-search > .nav-list > .active > a, .form-search > .nav-list > .active > a:hover, .form-search > .nav-list > .active > a:focus {
     color: #f36f21;
@@ -95,17 +106,4 @@ a:hover {
 
 .form-search > ul.nav > li.module > a:hover{
     color: #fff;
-}
-
-.header img {
-    width: 50px;
-}
-
-.content .methods code {
-    border: 1px solid #e1e1e8;
-    background-color: #f7f7f9;
-    padding: 0px 3px;
-    font-size: 85%;
-    color: #d14;
-    white-space: nowrap;
 }


### PR DESCRIPTION
As highlighted by @abjerner in #9160 there's no styling for `<code>` blocks in the Umbraco backoffice docs styles. Well, there is, but it's only for method info.

This change makes sure all `<code>` blocks in the "content" section of a docs page are formatted correctly. I feel this is more future proof than specifically targeting which section of the page the block appears in.

I cleaned up some of the styles whilst I was at it too...