### PR TITLE
Allow the login logo to be customisable via the umbracoSettings config file

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -40,6 +40,9 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         [ConfigurationProperty("loginBackgroundImage")]
         internal InnerTextConfigurationElement<string> LoginBackgroundImage => GetOptionalTextElement("loginBackgroundImage", string.Empty);
 
+        [ConfigurationProperty("loginLogoImage")]
+        internal InnerTextConfigurationElement<string> LoginLogoImage => GetOptionalTextElement("loginLogoImage", string.Empty);
+
         string IContentSection.NotificationEmailAddress => Notifications.NotificationEmailAddress;
 
         bool IContentSection.DisableHtmlEmail => Notifications.DisableHtmlEmail;
@@ -61,5 +64,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         bool IContentSection.ShowDeprecatedPropertyEditors => ShowDeprecatedPropertyEditors;
 
         string IContentSection.LoginBackgroundImage => LoginBackgroundImage;
+
+        string IContentSection.LoginLogoImage => LoginLogoImage;
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
@@ -32,5 +32,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         bool ShowDeprecatedPropertyEditors { get; }
 
         string LoginBackgroundImage { get; }
+
+        string LoginLogoImage { get; }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -47,6 +47,7 @@
         vm.externalLoginInfo = externalLoginInfo;
         vm.resetPasswordCodeInfo = resetPasswordCodeInfo;
         vm.backgroundImage = Umbraco.Sys.ServerVariables.umbracoSettings.loginBackgroundImage;
+        vm.loginLogoImage = Umbraco.Sys.ServerVariables.umbracoSettings.loginLogoImage;
         vm.usernameIsEmail = Umbraco.Sys.ServerVariables.umbracoSettings.usernameIsEmail;
 
         vm.$onInit = onInit;

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -5,7 +5,7 @@
         <div class="login-overlay__background-image" ng-style="{'background-image': 'url('+vm.backgroundImage+')'}"></div>
 
         <div class="login-overlay__logo">
-            <img src="assets/img/application/umbraco_logo_white.svg">
+            <img src="{{ vm.loginLogoImage }}">
         </div>
 
         <div ng-show="vm.invitedUser != null" class="umb-login-container">

--- a/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
@@ -187,6 +187,9 @@
     <!-- You can specify your own background image for the login screen here. This path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/login.jpg -->
     <loginBackgroundImage>assets/img/login.jpg</loginBackgroundImage>
 
+    <!-- You can specify your own logo image for the login screen here. This path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/application/umbraco_logo_white.svg -->
+    <loginLogoImage>assets/img/application/umbraco_logo_white2.svg</loginLogoImage>
+
   </content>
 
   <security>

--- a/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.Release.config
@@ -188,7 +188,7 @@
     <loginBackgroundImage>assets/img/login.jpg</loginBackgroundImage>
 
     <!-- You can specify your own logo image for the login screen here. This path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/application/umbraco_logo_white.svg -->
-    <loginLogoImage>assets/img/application/umbraco_logo_white2.svg</loginLogoImage>
+    <loginLogoImage>assets/img/application/umbraco_logo_white.svg</loginLogoImage>
 
   </content>
 

--- a/src/Umbraco.Web.UI/config/umbracoSettings.config
+++ b/src/Umbraco.Web.UI/config/umbracoSettings.config
@@ -187,6 +187,9 @@
     <!-- You can specify your own background image for the login screen here. This path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/login.jpg -->
     <loginBackgroundImage>assets/img/login.jpg</loginBackgroundImage>
 
+    <!-- You can specify your own logo image for the login screen here. This path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/application/umbraco_logo_white.svg -->
+    <loginLogoImage>assets/img/application/umbraco_logo_white.svg</loginLogoImage>
+
   </content>
 
   <security>

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Web.Editors
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl", "iconApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "canSendRequiredEmail", "usernameIsEmail"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "canSendRequiredEmail", "usernameIsEmail", "loginLogoImage"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}
@@ -355,6 +355,7 @@ namespace Umbraco.Web.Editors
                         {"cssPath", IOHelper.ResolveUrl(SystemDirectories.Css).TrimEnd('/')},
                         {"allowPasswordReset", Current.Configs.Settings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  Current.Configs.Settings().Content.LoginBackgroundImage},
+                        {"loginLogoImage",  Current.Configs.Settings().Content.LoginLogoImage},
                         {"showUserInvite", EmailSender.CanSendRequiredEmail},
                         {"canSendRequiredEmail", EmailSender.CanSendRequiredEmail},
                         {"showAllowSegmentationForDocumentTypes", false},


### PR DESCRIPTION
### Prerequisites

- [x ] I have added steps to test this contribution in the description below

This enables the functionality highlighted in issue #9078 

### Description
The requirement for the associated issue was to allow the logo image on the Umbraco login page to be customisable, therefore the same functionality has been used as per the login background image to allow the login logo image to be specified in the umbracoSettings.config file.

A screenshot of this in action is shown here:

![image](https://user-images.githubusercontent.com/6841903/96045324-b4a50280-0e69-11eb-9f44-4a8374e46358.png)

A screenshot of the new config item is shown here:

![image](https://user-images.githubusercontent.com/6841903/96045764-588eae00-0e6a-11eb-90f7-5c8e99a0c5dc.png)

The link for my Our account is https://our.umbraco.com/members/ukdiverboi/