### PR TITLE
Remove orderBy filter for languages/variants

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-navigation.html
@@ -23,7 +23,7 @@
                         class="umb-language-picker__dropdown-item"
                         ng-class="{'umb-language-picker__dropdown-item--current': language.active}"
                         ng-click="selectLanguage(language)"
-                        ng-repeat="language in languages | orderBy:'name'"
+                        ng-repeat="language in languages"
                     >
                     <span class="sr-only">
                         <localize key="visuallyHiddenTexts_switchLanguage">Switch language to</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -51,7 +51,7 @@
 
                     <umb-dropdown ng-if="vm.dropdownOpen" class="umb-variant-switcher" ng-class="{'--has-sub-variants': vm.hasSubVariants === true}" on-close="vm.dropdownOpen = false" umb-keyboard-list>
                         <umb-dropdown-item
-                            ng-repeat-start="entry in vm.variantMenu | orderBy:'variant.displayName' track by entry.key"
+                            ng-repeat-start="entry in vm.variantMenu track by entry.key"
                             class="umb-variant-switcher__item"
                             ng-class="{'--current': entry.variant === editor.content, '--active': entry.variant.active && vm.dropdownOpen, '--error': entry.variant.active !== true && entry.variant.hasError, '--state-notCreated':entry.variant.state==='NotCreated' && entry.variant.name == null, '--state-draft':entry.variant.state==='Draft' || (entry.variant.state==='NotCreated' && entry.variant.name != null)}"
                         >

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -36,7 +36,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="language in vm.languages | orderBy:'name' track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
+                    <tr ng-repeat="language in vm.languages track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
                         <td>
                             <i class="icon-globe" style="color: #BBBABF; margin-right: 5px;"></i>
                             <span>{{ language.name }}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes regressions introduced in PRs #9006 and #9007.

### Description
As per https://github.com/umbraco/Umbraco-CMS/pull/9006#issuecomment-708682932, the languages/variants were correctly sorted alphabetically, but with the default language first. This reverts the custom `orderBy` filters in the AngularJS views and ensures the ordering retrieved from the server is used instead.

This ordering is done on the server in the `LanguageMapDefinition`, so even though the `ILanguageRepository` always returns the languages sorted on ID (which can be different per environment), this ensures the first is always the default and the rest is sorted on name:

https://github.com/umbraco/Umbraco-CMS/blob/b29fd4ada3c1eb7a703c3a3a0131ecfa990c3f97/src/Umbraco.Web/Models/Mapping/LanguageMapDefinition.cs#L41-L56