### PR TITLE
Speed up indexing for Media and reduce memory use by reducing array allocations and caching writer name look up.

### DIFF
--- a/src/Umbraco.Examine/MediaValueSetBuilder.cs
+++ b/src/Umbraco.Examine/MediaValueSetBuilder.cs
@@ -10,6 +10,8 @@ using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.PropertyEditors.ValueConverters;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
+using Umbraco.Core.Scoping;
+using Umbraco.Core.Models.Membership;
 
 namespace Umbraco.Examine
 {
@@ -18,19 +20,39 @@ namespace Umbraco.Examine
         private readonly UrlSegmentProviderCollection _urlSegmentProviders;
         private readonly IUserService _userService;
         private readonly ILogger _logger;
+        private readonly IScopeProvider _scopeProvider;
+        private static readonly object[] _negativeOneArray = new object[] { -1 };
+        private static readonly object[] _doubleQuestionMarkArray = new object[] { "??" };
 
         public MediaValueSetBuilder(PropertyEditorCollection propertyEditors,
             UrlSegmentProviderCollection urlSegmentProviders,
-            IUserService userService, ILogger logger)
+            IUserService userService, ILogger logger,
+            IScopeProvider scopeProvider)
             : base(propertyEditors, false)
         {
             _urlSegmentProviders = urlSegmentProviders;
             _userService = userService;
             _logger = logger;
+            _scopeProvider = scopeProvider;
         }
 
         /// <inheritdoc />
         public override IEnumerable<ValueSet> GetValueSets(params IMedia[] media)
+        {
+            Dictionary<int, object[]> creatorIds;
+
+            // We can lookup all of the creator/writer names at once which can save some
+            // processing below instead of one by one.
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                creatorIds = _userService.GetProfilesById(media.Select(x => x.CreatorId).ToArray())
+                    .ToDictionary(x => x.Id, x => new object[] { x.Name });
+                scope.Complete();
+            }
+
+            return GetValueSetsEnumerable(media, creatorIds);
+        }
+        public  IEnumerable<ValueSet> GetValueSetsEnumerable(IMedia[] media, Dictionary<int, object[]> creatorIds)
         {
             foreach (var m in media)
             {
@@ -39,7 +61,7 @@ namespace Umbraco.Examine
                 var umbracoFilePath = string.Empty;
                 var umbracoFile = string.Empty;
 
-                var umbracoFileSource  = m.GetValue<string>(Constants.Conventions.Media.File);
+                var umbracoFileSource = m.GetValue<string>(Constants.Conventions.Media.File);
 
                 if (umbracoFileSource.DetectIsJson())
                 {
@@ -76,7 +98,7 @@ namespace Umbraco.Examine
                     {"icon", m.ContentType.Icon?.Yield() ?? Enumerable.Empty<string>()},
                     {"id", new object[] {m.Id}},
                     {UmbracoExamineIndex.NodeKeyFieldName, new object[] {m.Key}},
-                    {"parentID", new object[] {m.Level > 1 ? m.ParentId : -1}},
+                    {"parentID", m.Level > 1 ? new object[] {m.ParentId } : _negativeOneArray},
                     {"level", new object[] {m.Level}},
                     {"creatorID", new object[] {m.CreatorId}},
                     {"sortOrder", new object[] {m.SortOrder}},
@@ -86,7 +108,7 @@ namespace Umbraco.Examine
                     {"urlName", urlValue?.Yield() ?? Enumerable.Empty<string>()},
                     {"path", m.Path?.Yield() ?? Enumerable.Empty<string>()},
                     {"nodeType", m.ContentType.Id.ToString().Yield() },
-                    {"creatorName", (m.GetCreatorProfile(_userService)?.Name ?? "??").Yield()},
+                   {"creatorName", creatorIds.TryGetValue(m.CreatorId, out var creatorProfile) ? creatorProfile : _doubleQuestionMarkArray },
                     {UmbracoExamineIndex.UmbracoFileFieldName, umbracoFile.Yield()}
                 };
 

--- a/src/Umbraco.Examine/MemberValueSetBuilder.cs
+++ b/src/Umbraco.Examine/MemberValueSetBuilder.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Examine
         {
         }
 
+        private static readonly object[] _negativeOneArray = new object[] { -1 };
         /// <inheritdoc />
         public override IEnumerable<ValueSet> GetValueSets(params IMember[] members)
         {
@@ -25,7 +26,7 @@ namespace Umbraco.Examine
                     {"icon", m.ContentType.Icon?.Yield() ?? Enumerable.Empty<string>()},
                     {"id", new object[] {m.Id}},
                     {UmbracoExamineIndex.NodeKeyFieldName, new object[] {m.Key}},
-                    {"parentID", new object[] {m.Level > 1 ? m.ParentId : -1}},
+                    {"parentID", m.Level > 1 ? new object[] { m.ParentId} :_negativeOneArray},
                     {"level", new object[] {m.Level}},
                     {"creatorID", new object[] {m.CreatorId}},
                     {"sortOrder", new object[] {m.SortOrder}},

--- a/src/Umbraco.Tests/PublishedContent/PublishedMediaTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedMediaTests.cs
@@ -117,7 +117,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void Ensure_Children_Sorted_With_Examine()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
@@ -146,7 +146,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void Do_Not_Find_In_Recycle_Bin()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
@@ -194,7 +194,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void Children_With_Examine()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
@@ -222,7 +222,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void Descendants_With_Examine()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
@@ -250,7 +250,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void DescendantsOrSelf_With_Examine()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,
@@ -278,7 +278,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void Ancestors_With_Examine()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
 
             using (var luceneDir = new RandomIdRamDirectory())
@@ -304,7 +304,7 @@ namespace Umbraco.Tests.PublishedContent
         [Test]
         public void AncestorsOrSelf_With_Examine()
         {
-            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var rebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,

--- a/src/Umbraco.Tests/UmbracoExamine/IndexInitializer.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/IndexInitializer.cs
@@ -49,9 +49,9 @@ namespace Umbraco.Tests.UmbracoExamine
             return contentIndexDataSource;
         }
 
-        public static MediaIndexPopulator GetMediaIndexRebuilder(PropertyEditorCollection propertyEditors, IMediaService mediaService)
+        public static MediaIndexPopulator GetMediaIndexRebuilder(PropertyEditorCollection propertyEditors, IMediaService mediaService, IScopeProvider scopeProvider)
         {
-            var mediaValueSetBuilder = new MediaValueSetBuilder(propertyEditors, new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }), GetMockUserService(), GetMockLogger());
+            var mediaValueSetBuilder = new MediaValueSetBuilder(propertyEditors, new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }), GetMockUserService(), GetMockLogger(), scopeProvider);
             var mediaIndexDataSource = new MediaIndexPopulator(null, mediaService, mediaValueSetBuilder);
             return mediaIndexDataSource;
         }

--- a/src/Umbraco.Tests/UmbracoExamine/IndexTest.cs
+++ b/src/Umbraco.Tests/UmbracoExamine/IndexTest.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Tests.UmbracoExamine
         public void Rebuild_Index()
         {
             var contentRebuilder = IndexInitializer.GetContentIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockContentService(), ScopeProvider, false);
-            var mediaRebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService());
+            var mediaRebuilder = IndexInitializer.GetMediaIndexRebuilder(Factory.GetInstance<PropertyEditorCollection>(), IndexInitializer.GetMockMediaService(), ScopeProvider);
 
             using (var luceneDir = new RandomIdRamDirectory())
             using (var indexer = IndexInitializer.GetUmbracoIndexer(ProfilingLogger, luceneDir,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A
### Description
What?
Reduce memory allocations and save on profile lookups for writerId and creator Id while indexing.
Reuse arrays that are commonly instantiated. Retrieve the names for writers for media indexing the same way this is being done for content.

Why?
Save memory, database, improve performance.

How to test?
Existing tests pass.

