### PR TITLE
9176: Fix editing labels and added functionality to edit colors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -81,8 +81,8 @@
         let colorPickerInstance = null;
         let labels = {};
 
-        ctrl.$onInit = function() {
-            
+        ctrl.$onInit = function () {
+
             // load the separate css for the editor to avoid it blocking our js loading
             assetsService.loadCss("lib/spectrum/spectrum.css", $scope);
 
@@ -95,7 +95,12 @@
                 // init color picker
                 grabElementAndRun();
             });
+        }
 
+        ctrl.$onChanges = function (changes) {
+            if (colorPickerInstance && changes.ngModel) {
+                colorPickerInstance.spectrum("set", changes.ngModel.currentValue);
+            }
         }
 
         function grabElementAndRun() {
@@ -167,7 +172,7 @@
         // Spectrum events: https://seballot.github.io/spectrum/#events
 
         function setUpCallbacks() {
-            
+
             if (colorPickerInstance) {
 
                 // bind hook for beforeShow

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -104,6 +104,20 @@
 // --------------------------------------------------
 
 /* pre-value editor */
+.umb-prevalues-multivalues.umb-colors {
+    max-width: 600px;
+    width: 100%;
+    min-width: 66.6%;
+
+    @media (min-width: 1101px) and (max-width: 1300px), (max-width: 930px) {
+        max-width: none;
+    }
+
+    .umb-overlay__form & {
+        width: 100%;
+    }
+}
+
 .control-group.color-picker-preval {
     .thumbnail {
         width: 34px;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/colorpicker.prevalues.html
@@ -1,4 +1,4 @@
-<div class="umb-property-editor umb-prevalues-multivalues" ng-controller="Umbraco.PrevalueEditors.MultiColorPickerController as vm">
+<div class="umb-property-editor umb-prevalues-multivalues umb-colors" ng-controller="Umbraco.PrevalueEditors.MultiColorPickerController as vm">
     <div class="control-group  umb-prevalues-multivalues__add color-picker-preval">
         <div class="umb-prevalues-multivalues__left">
 
@@ -14,7 +14,9 @@
             <input type="text" name="newLabel" ng-model="newLabel" focus-when="{{focusOnNew}}" class="umb-property-editor color-label" localize="placeholder" placeholder="@general_label" ng-show="vm.labelEnabled" />
         </div>
         <div class="umb-prevalues-multivalues__right">
-            <button type="button" class="btn btn-info add" ng-click="vm.add($event)"><localize key="general_add">Add</localize></button>
+            <button type="button" class="btn btn-info add" ng-if="vm.editItem == null" ng-click="vm.add($event)"><localize key="general_add">Add</localize></button>
+            <button type="button" class="btn btn-info add" ng-if="vm.editItem != null" ng-click="vm.add($event)"><localize key="general_update">Update</localize></button>
+            <button type="button" class="btn btn-link" ng-if="vm.editItem != null" ng-click="vm.cancel($event)"><localize key="general_cancel">Cancel</localize></button>
         </div>
     </div>
     <div ui-sortable="sortableOptions" ng-model="model.value">
@@ -24,11 +26,11 @@
                 <div class="thumbnail span1" hex-bg-color="{{item.value}}" hex-bg-orig="transparent"></div>
                 <div class="color-picker-prediv">
                     <pre>#{{item.value}}</pre>
-                    <span ng-bind="item.label" ng-if="!labelEnabled"></span>
-                    <input type="text" ng-if="labelEnabled" ng-model="item.label" val-server="item_{{$index}}" required />
+                    <span ng-bind="item.label" ng-if="vm.labelEnabled"></span>
                 </div>
             </div>
             <div class="umb-prevalues-multivalues__right">
+                <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.edit(item, $event)"><localize key="general_edit">Edit</localize></button>
                 <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove(item, $event)"><localize key="general_remove">Remove</localize></button>
             </div>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -5,12 +5,15 @@
 
         vm.add = add;
         vm.remove = remove;
+        vm.edit = edit;
+        vm.cancel = cancel;
 
         vm.show = show;
         vm.hide = hide;
         vm.change = change;
 
         vm.labelEnabled = false;
+        vm.editItem = null;
 
         //NOTE: We need to make each color an object, not just a string because you cannot 2-way bind to a primitive.
         var defaultColor = "000000";
@@ -105,14 +108,21 @@
 
             if ($scope.newColor) {
                 var newLabel = validLabel($scope.newLabel) ? $scope.newLabel : $scope.newColor;
-                var exists = _.find($scope.model.value, function(item) {
-                    return item.value.toUpperCase() === $scope.newColor.toUpperCase() || item.label.toUpperCase() === newLabel.toUpperCase();
+                var exists = _.find($scope.model.value, function (item) {
+                    return item != vm.editItem && (item.value.toUpperCase() === $scope.newColor.toUpperCase() || item.label.toUpperCase() === newLabel.toUpperCase());
                 });
                 if (!exists) {
-                    $scope.model.value.push({
-                        value: $scope.newColor,
-                        label: newLabel
-                    });
+                    if (vm.editItem == null) {
+                        $scope.model.value.push({
+                            value: $scope.newColor,
+                            label: newLabel
+                        });
+                    } else {
+                        vm.editItem.value = $scope.newColor;
+                        vm.editItem.label = newLabel;
+                        vm.editItem = null;
+                    }
+                    
                     $scope.newLabel = "";
                     $scope.hasError = false;
                     $scope.focusOnNew = true;
@@ -123,6 +133,23 @@
                 // there was an error, do the highlight (will be set back by the directive)
                 $scope.hasError = true;
             }
+        }
+
+        function edit(item, evt) {
+            evt.preventDefault();
+
+            vm.editItem = item;
+
+            $scope.newColor = item.value;
+            $scope.newLabel = item.label;
+        }
+
+        function cancel(evt) {
+            evt.preventDefault();
+
+            vm.editItem = null;
+            $scope.newColor = defaultColor;
+            $scope.newLabel = defaultLabel;
         }
 
         $scope.sortableOptions = {


### PR DESCRIPTION
Fixes #9176 
Can be tested by going to a color picker and using the edit buttons to edit the colors and labels.

![c68a425d29cbbc142a75ef544b8f53a6](https://user-images.githubusercontent.com/11466511/96224850-7e15d780-0f90-11eb-88ca-c7de7fd996cf.gif)
