### PR TITLE
Reduce memory use of DefaultShortStringHelper using Span<T>

### DIFF
--- a/src/Umbraco.Core/Strings/Utf8ToAsciiConverter.cs
+++ b/src/Umbraco.Core/Strings/Utf8ToAsciiConverter.cs
@@ -19,16 +19,14 @@ namespace Umbraco.Core.Strings
         /// <param name="text">The text to convert.</param>
         /// <param name="fail">The character to use to replace characters that cannot properly be converted.</param>
         /// <returns>The converted text.</returns>
-        public static string ToAsciiString(string text, char fail = '?')
+        public static Span<char> ToAsciiString(ReadOnlySpan<char> input, char fail = '?')
         {
-            var input = text.ToCharArray();
-
             // this is faster although it uses more memory
             // but... we should be filtering short strings only...
 
-            var output = new char[input.Length * 3]; // *3 because of things such as OE
+            var output = new char[input.Length * 3].AsSpan(); // *3 because of things such as OE
             var len = ToAscii(input, output, fail);
-            return new string(output, 0, len);
+            return output.Slice(0, len);
 
             //var output = new StringBuilder(input.Length + 16); // default is 16, start with at least input length + little extra
             //ToAscii(input, output);
@@ -70,7 +68,7 @@ namespace Umbraco.Core.Strings
         /// <returns>The number of characters in the output array.</returns>
         /// <remarks>The caller must ensure that the output array is big enough.</remarks>
         /// <exception cref="OverflowException">The output array is not big enough.</exception>
-        private static int ToAscii(char[] input, char[] output, char fail = '?')
+        private static int ToAscii(ReadOnlySpan<char> input, Span<char> output, char fail = '?')
         {
             var opos = 0;
 
@@ -118,7 +116,7 @@ namespace Umbraco.Core.Strings
         /// <para>Input should contain Utf8 characters exclusively and NOT Unicode.</para>
         /// <para>Removes controls, normalizes whitespaces, replaces symbols by '?'.</para>
         /// </remarks>
-        private static void ToAscii(char[] input, int ipos, char[] output, ref int opos, char fail = '?')
+        private static void ToAscii(ReadOnlySpan<char> input, int ipos, Span<char> output, ref int opos, char fail = '?')
         {
             var c = input[ipos];
 

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -72,6 +72,9 @@
     <PackageReference Include="Serilog.Sinks.Map">
       <Version>1.0.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
     <PackageReference Include="Umbraco.Code">
       <Version>1.0.5</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Umbraco.Tests.Benchmarks/DefaultShortStringHelperBenchmark.cs
+++ b/src/Umbraco.Tests.Benchmarks/DefaultShortStringHelperBenchmark.cs
@@ -1,0 +1,78 @@
+﻿using BenchmarkDotNet.Attributes;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.Strings;
+using Umbraco.Tests.TestHelpers;
+
+namespace Umbraco.Tests.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class DefaultShortStringHelperBenchmark
+    {
+        DefaultShortStringHelper helper;
+        const string input = "0123 中文测试 中文测试 léger ZÔRG (2) a?? *x";
+        public DefaultShortStringHelperBenchmark()
+        {
+            var settings = SettingsForTests.GenerateMockUmbracoSettings();
+            var contentMock = Mock.Get(settings.RequestHandler);
+            contentMock.Setup(x => x.CharCollection).Returns(Enumerable.Empty<IChar>());
+            contentMock.Setup(x => x.ConvertUrlsToAscii).Returns(false);
+
+            helper = new DefaultShortStringHelper(new DefaultShortStringHelperConfig().WithDefault(settings));
+
+        }
+        [Benchmark]
+        public void CleanStringDefaultConfig()
+        {
+            var alias = helper.CleanStringForSafeAlias(input);
+            var filename = helper.CleanStringForSafeFileName(input);
+            var segment = helper.CleanStringForUrlSegment(input);
+        }
+
+
+        //Char[]
+        // * Summary *
+
+        //        BenchmarkDotNet = v0.11.3, OS = Windows 10.0.18362
+        //Intel Core i5-8265U CPU 1.60GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+        // [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0
+        //  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0
+
+
+        //                   Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+        //------------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
+        // CleanStringDefaultConfig | 5.839 us | 0.0319 us | 0.0298 us |      0.8850 |           - |           - |             2.73 KB |
+
+        //// * Legends *
+        //  Mean                : Arithmetic mean of all measurements
+        //  Error               : Half of 99.9% confidence interval
+        //  StdDev              : Standard deviation of all measurements
+        //  Gen 0/1k Op         : GC Generation 0 collects per 1k Operations
+        //  Gen 1/1k Op         : GC Generation 1 collects per 1k Operations
+        //  Gen 2/1k Op         : GC Generation 2 collects per 1k Operations
+        //  Allocated Memory/Op : Allocated memory per single operation(managed only, inclusive, 1KB = 1024B)
+        //  1 us                : 1 Microsecond(0.000001 sec)
+
+        //// * Diagnostic Output - MemoryDiagnoser *
+
+        //        Span<T>
+        // * Summary *
+
+//        BenchmarkDotNet=v0.11.3, OS=Windows 10.0.18362
+//Intel Core i5-8265U CPU 1.60GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+// [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0
+//  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0
+
+
+//                   Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+//------------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
+// CleanStringDefaultConfig | 7.144 us | 0.2048 us | 0.2192 us |      0.6790 |           - |           - |             2.11 KB |
+
+
+    }
+}

--- a/src/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
+++ b/src/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Config\QuickRunConfigAttribute.cs" />
     <Compile Include="Config\QuickRunWithMemoryDiagnoserConfigAttribute.cs" />
     <Compile Include="CtorInvokeBenchmarks.cs" />
+    <Compile Include="DefaultShortStringHelperBenchmark.cs" />
     <Compile Include="HexStringBenchmarks.cs" />
     <Compile Include="EnumeratorBenchmarks.cs" />
     <Compile Include="LinqCastBenchmarks.cs" />

--- a/src/Umbraco.Tests/Strings/DefaultShortStringHelperTests.cs
+++ b/src/Umbraco.Tests/Strings/DefaultShortStringHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -376,8 +377,8 @@ namespace Umbraco.Tests.Strings
         public void Utf8ToAsciiConverter()
         {
             const string str = "a\U00010F00z\uA74Ftéô";
-            var output = Core.Strings.Utf8ToAsciiConverter.ToAsciiString(str);
-            Assert.AreEqual("a?zooteo", output);
+            var output = Core.Strings.Utf8ToAsciiConverter.ToAsciiString(str.AsSpan());
+            Assert.AreEqual("a?zooteo", output.ToString());
         }
 
         [Test]

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -1286,7 +1286,7 @@
     </PropertyGroup>
     <ItemGroup>
       <!-- we want to exclude all facade references ?! -->
-      <FixedReferencePath Include="@(ReferencePath)" Condition="'%(ReferencePath.FileName)' != 'System.ValueTuple' and '%(ReferencePath.FileName)' != 'System.Net.Http'" />
+        <FixedReferencePath Include="@(ReferencePath)" Condition="'%(ReferencePath.FileName)' != 'System.ValueTuple' and '%(ReferencePath.FileName)' != 'System.Net.Http'  and '%(ReferencePath.FileName)' != 'Microsoft.Bcl.AsyncInterfaces' and '%(ReferencePath.FileName)' != 'System.Buffers' and '%(ReferencePath.FileName)' != 'System.Numerics.Vectors' and '%(ReferencePath.FileName)' != 'System.Runtime.CompilerServices.Unsafe'" />
     </ItemGroup>
     <Delete Files="$(TargetDir)$(TargetName).XmlSerializers.dll" ContinueOnError="true" />
     <!--


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A

### Description
What?
Reduce memory use for DefaultShortStringHelper by using `Span<T>`.

Why?
Reduce memory footprint of Umbraco. Many small changes like this could add up to cloud cost savings.

How to test?
Existing tests pass. Benchmark included.

Original
```
        //Char[]
        // * Summary *

        //        BenchmarkDotNet = v0.11.3, OS = Windows 10.0.18362
        //Intel Core i5-8265U CPU 1.60GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
        // [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0
        //  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0


        //                   Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
        //------------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
        // CleanStringDefaultConfig | 5.839 us | 0.0319 us | 0.0298 us |      0.8850 |           - |           - |             2.73 KB |

```
        `Span<T>`

```
//        BenchmarkDotNet=v0.11.3, OS=Windows 10.0.18362
//Intel Core i5-8265U CPU 1.60GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
// [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0
//  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4180.0


//                   Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
//------------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
// CleanStringDefaultConfig | 7.144 us | 0.2048 us | 0.2192 us |      0.6790 |           - |           - |             2.11 KB |
```

https://github.com/umbraco/Umbraco-CMS/pull/8909
<!-- Thanks for contributing to Umbraco CMS! -->
