### PR TITLE
9178 - V7 - Allow editors with multiple media start nodes to pick media items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -17,6 +17,7 @@ angular.module("umbraco")
             $scope.cropSize = dialogOptions.cropSize;
             $scope.lastOpenedNode = localStorageService.get("umbLastOpenedMediaNodeId");
             $scope.lockedFolder = true;
+            $scope.showChilds = false;
 
             var userStartNodes = [];
 
@@ -66,6 +67,12 @@ angular.module("umbraco")
             function onInit() {
                 userService.getCurrentUser().then(function (userData) {
                     userStartNodes = userData.startMediaIds;
+
+                    if (userStartNodes && userStartNodes.length > 1) {
+                        // if there is more than one start node, this needs to be true, so all folders are shown in media picker
+                        // otherwise the media grid will filter them out
+                        $scope.showChilds = true;
+                    }
 
                     if ($scope.startNodeId !== -1) {
                         entityResource.getById($scope.startNodeId, "media")


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #9178 

### Description

With this fix editors with multiple media startnodes (not at root level) are able to pick media items.

Steps for reproducing and testing can be found in the related issue.

I tested with other media picker startnodes configurations and everything seems to be fine
