### PR TITLE
9153: Only show the cultures of the node in preview

### DIFF
--- a/src/Umbraco.Web/Editors/PreviewController.cs
+++ b/src/Umbraco.Web/Editors/PreviewController.cs
@@ -26,7 +26,6 @@ namespace Umbraco.Web.Editors
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly ILocalizationService _localizationService;
         private readonly IIconService _iconService;
-        private readonly IDomainService _domainService;
 
         [Obsolete("Use the constructor that injects IIconService.")]
         public PreviewController(
@@ -40,8 +39,7 @@ namespace Umbraco.Web.Editors
                 publishedSnapshotService,
                 umbracoContextAccessor,
                 localizationService,
-                Current.IconService,
-                Current.Services.DomainService)
+                Current.IconService)
         {
 
         }
@@ -52,8 +50,7 @@ namespace Umbraco.Web.Editors
             IPublishedSnapshotService publishedSnapshotService,
             IUmbracoContextAccessor umbracoContextAccessor,
             ILocalizationService localizationService,
-            IIconService iconService,
-            IDomainService domainService)
+            IIconService iconService)
         {
             _features = features;
             _globalSettings = globalSettings;
@@ -61,7 +58,6 @@ namespace Umbraco.Web.Editors
             _umbracoContextAccessor = umbracoContextAccessor;
             _localizationService = localizationService;
             _iconService = iconService;
-            _domainService = domainService;
         }
 
         [UmbracoAuthorize(redirectToUmbracoLogin: true)]


### PR DESCRIPTION
Fixes #9153 

This uses the .Cultures of the content node instead of always using all the languages on the website.

I tested it the following way:

1. Using the Umbraco starter kit.
2. Set the People document type to Varies by Culture.
3. Add another language to the website.
4. Add two domains to the root node.
5. Preview the people node and see 2 languages listed in preview modes.
6. Preview the products node and see that no languages are shown.

Now, this will work most of the time, but there is one situation where this doesn't work. If I make the People document Varies by Culture then you'll also have 2 versions of the children under there (Like Matt Brailsford), but those 2 languages will not show up in the language selector for the preview version. This is because .Cultures only returns a single language in that case. I can probably work around it with domains, but I think the issue lays deeper within Umbraco for that. Also see this issue that is related to it: https://github.com/umbraco/Umbraco-CMS/issues/8466

Please let me know if you would still want this PR through even with the problem that I explain above here.