### PR TITLE
Refactoring server names from Master to Primary

### DIFF
--- a/src/Umbraco.Core/Models/IServerRegistration.cs
+++ b/src/Umbraco.Core/Models/IServerRegistration.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Core.Models
         /// <summary>
         /// Gets or sets a value indicating whether the server is master.
         /// </summary>
+        [Obsolete("Replaced with IsPrimary. Will be removed from a future version.")]
         bool IsMaster { get; set; }
 
         /// <summary>

--- a/src/Umbraco.Core/Services/Implement/ServerRegistrationService.cs
+++ b/src/Umbraco.Core/Services/Implement/ServerRegistrationService.cs
@@ -81,9 +81,9 @@ namespace Umbraco.Core.Services.Implement
 
                 // default role is single server, but if registrations contain more
                 // than one active server, then role is master or replica
-#warning If peeps depend on ServerRole being master after this, then we're in trouble.
+                #warning Changing this to ServerRole.Primary will be a breaking change.
                 _currentServerRole = regs.Count(x => x.IsActive) > 1
-                    ? (server.IsMaster ? ServerRole.Primary : ServerRole.Replica)
+                    ? (server.IsMaster ? ServerRole.Master : ServerRole.Replica)
                     : ServerRole.Single;
 
                 scope.Complete();

--- a/src/Umbraco.Core/Services/Implement/ServerRegistrationService.cs
+++ b/src/Umbraco.Core/Services/Implement/ServerRegistrationService.cs
@@ -81,8 +81,9 @@ namespace Umbraco.Core.Services.Implement
 
                 // default role is single server, but if registrations contain more
                 // than one active server, then role is master or replica
+#warning If peeps depend on ServerRole being master after this, then we're in trouble.
                 _currentServerRole = regs.Count(x => x.IsActive) > 1
-                    ? (server.IsMaster ? ServerRole.Master : ServerRole.Replica)
+                    ? (server.IsMaster ? ServerRole.Primary : ServerRole.Replica)
                     : ServerRole.Single;
 
                 scope.Complete();

--- a/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
@@ -262,12 +262,9 @@ namespace Umbraco.Core.Sync
 
                     _lastPruned = _lastSync;
 
-                    switch (Current.RuntimeState.ServerRole)
+                    if (Current.RuntimeState.ServerRole.ShouldPrune())
                     {
-                        case ServerRole.Single:
-                        case ServerRole.Master:
-                            PruneOldInstructions(scope.Database);
-                            break;
+                        PruneOldInstructions(scope.Database);
                     }
 
                     scope.Complete();

--- a/src/Umbraco.Core/Sync/ServerRole.cs
+++ b/src/Umbraco.Core/Sync/ServerRole.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Core.Sync
+﻿using System;
+
+namespace Umbraco.Core.Sync
 {
     /// <summary>
     /// The role of a server in an application environment.
@@ -23,6 +25,27 @@
         /// <summary>
         /// In a multi-servers environment, the server is the master server.
         /// </summary>
-        Master = 3
+        [Obsolete("Replaced with ServerRole.Primary. Will be removed from a future version.")]
+        Master = 3,
+
+        /// <summary>
+        /// In a multi-servers environment, the server is the master server.
+        /// </summary>
+        Primary = 4
+    }
+
+    public static class ServerRoleExtensions
+    {
+        public static bool IsPrimary(this ServerRole role)
+        {
+            return role == ServerRole.Master
+                || role == ServerRole.Primary;
+        }
+
+        public static bool ShouldPrune(this ServerRole role)
+        {
+            return role.IsPrimary()
+                || role == ServerRole.Single;
+        }
     }
 }


### PR DESCRIPTION
This is as much work that can be done to fix #9088 in V8.

There's one usage of `ServerRole.Master` and quite a lot of `IsMaster` properties that can't be changed without breaking comptibility. Rest will have to be done to unicore. 🤷‍♂️

I've set up two identical websites and tested publishing from the primary one using the new enum value. Seems legit:

![image](https://user-images.githubusercontent.com/350918/96351817-57ee5580-10be-11eb-8004-f724933da4f1.png)

Docs have a sibling PR at https://github.com/umbraco/UmbracoDocs/pull/2779.