### PR TITLE
Add new "umb-confirm-remove" directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmaction.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmaction.directive.js
@@ -5,6 +5,7 @@
 @scope
 
 @description
+<p><b>OBSOLETE!!! - Please use <umb-confirm-remove> instead :-)</b></p>
 <p>Use this directive to toggle a confirmation prompt for an action.
 The prompt consists of a checkmark and a cross to confirm or cancel the action.
 The prompt can be opened in four direction up, down, left or right.</p>

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmremove.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmremove.directive.js
@@ -10,15 +10,13 @@ The prompt can be opened in four direction up, down, left or right.</p>
 <h3>Markup example</h3>
 <pre>
     <div ng-controller="My.Controller as vm">
-        <div class="my-action" style="position:relative;">
-            <umb-confirm-action
-                show="vm.promptIsVisible"
-                direction="left"
-                on-delete="vm.showPrompt()"
-                on-confirm="vm.ConfirmRemove()"
-                on-cancel="vm.hidePrompt()">
-            </umb-confirm-action>
-        </div>
+        <umb-confirm-remove
+            show="vm.promptIsVisible"
+            direction="left"
+            on-delete="vm.showPrompt()"
+            on-confirm="vm.ConfirmRemove()"
+            on-cancel="vm.hidePrompt()">
+        </umb-confirm-remove>
     </div>
 </pre>
 <h3>Controller example</h3>

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmremove.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmremove.directive.js
@@ -1,0 +1,98 @@
+/**
+@ngdoc directive
+@name umbraco.directives.directive:umbConfirmRemove
+@restrict E
+@scope
+@description
+<p>Use this directive to toggle a confirmation prompt for an action.
+The prompt consists of a checkmark and a cross to confirm or cancel the action.
+The prompt can be opened in four direction up, down, left or right.</p>
+<h3>Markup example</h3>
+<pre>
+    <div ng-controller="My.Controller as vm">
+        <div class="my-action" style="position:relative;">
+            <umb-confirm-action
+                show="vm.promptIsVisible"
+                direction="left"
+                on-delete="vm.showPrompt()"
+                on-confirm="vm.ConfirmRemove()"
+                on-cancel="vm.hidePrompt()">
+            </umb-confirm-action>
+        </div>
+    </div>
+</pre>
+<h3>Controller example</h3>
+<pre>
+    (function () {
+        "use strict";
+        function Controller() {
+            var vm = this;
+            vm.promptIsVisible = false;
+            vm.ConfirmRemove = ConfirmRemove;
+            vm.showPrompt = showPrompt;
+            vm.hidePrompt = hidePrompt;
+            function ConfirmRemove() {
+                // confirm logic here
+            }
+            function showPrompt() {
+                vm.promptIsVisible = true;
+            }
+            function hidePrompt() {
+                vm.promptIsVisible = false;
+            }
+        }
+        angular.module("umbraco").controller("My.Controller", Controller);
+    })();
+</pre>
+@param {string} direction The direction the prompt opens ("up", "down", "left", "right").
+@param {callback} onConfirm Callback when the checkmark is clicked.
+@param {callback} onCancel Callback when the cross is clicked.
+**/
+
+(function () {
+    'use strict';
+
+    function ConfirmRemove() {
+
+        function link(scope, el, attr, ctrl) {
+
+            scope.clickButton = function (event) {
+                if (scope.onDelete) {
+                    scope.onDelete({ $event: event });
+                }
+            }
+
+            scope.clickConfirm = function () {
+                if (scope.onConfirm) {
+                    scope.onConfirm();
+                }
+            };
+
+            scope.clickCancel = function () {
+                if (scope.onCancel) {
+                    scope.onCancel();
+                }
+            };
+
+        }
+
+        var directive = {
+            restrict: 'E',
+            replace: true,
+            templateUrl: 'views/components/umb-confirm-remove.html',
+            scope: {
+                direction: "@",
+                show: "<",
+                onDelete: "&?",
+                onConfirm: "&",
+                onCancel: "&"
+            },
+            link: link
+        };
+
+        return directive;
+    }
+
+    angular.module('umbraco.directives').directive('umbConfirmRemove', ConfirmRemove);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmremove.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbconfirmremove.directive.js
@@ -81,6 +81,7 @@ The prompt can be opened in four direction up, down, left or right.</p>
             scope: {
                 direction: "@",
                 show: "<",
+                cssClass: "@?",
                 onDelete: "&?",
                 onConfirm: "&",
                 onCancel: "&"

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -119,6 +119,7 @@
 @import "components/umb-list-view-settings.less";
 @import "components/umb-table.less";
 @import "components/umb-confirm-action.less";
+@import "components/umb-confirm-remove.less";
 @import "components/umb-keyboard-shortcuts-overview.less";
 @import "components/umb-checkbox-list.less";
 @import "components/umb-form-check.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-remove.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-remove.less
@@ -1,6 +1,7 @@
 //WRAPPER 
 .umb_confirm-remove {
     display: inline-block;
+    position: relative;
 }
 
 // OVERLAY

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-remove.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-confirm-remove.less
@@ -1,0 +1,136 @@
+//WRAPPER 
+.umb_confirm-remove {
+    display: inline-block;
+}
+
+// OVERLAY
+.umb_confirm-remove__overlay {
+    position: absolute;
+    z-index: 999999;
+    display: flex;
+}
+
+// positions
+.umb_confirm-remove__overlay.-top {
+    top: -50px;
+    right: auto;
+    bottom: auto;
+    left: 0;
+    animation: fadeInUp 0.2s;
+    flex-direction: column;
+
+    .umb_confirm-remove__overlay-action {
+        margin-bottom: 5px;
+    }
+
+    .umb_confirm-remove__overlay-action.-confirm {
+        order: 1;
+    }
+
+    .umb_confirm-remove__overlay-action.-cancel {
+        order: 2;
+    }
+
+}
+
+.umb_confirm-remove__overlay.-right {
+    top: 0;
+    right: -50px;
+    bottom: auto;
+    left: auto;
+    animation: fadeInLeft 0.2s;
+    flex-direction: row;
+
+    .umb_confirm-remove__overlay-action {
+        margin-left: 5px;
+    }
+
+    .umb_confirm-remove__overlay-action.-confirm {
+        order: 2;
+    }
+
+    .umb_confirm-remove__overlay-action.-cancel {
+        order: 1;
+    }
+}
+
+.umb_confirm-remove__overlay.-bottom {
+    top: auto;
+    right: auto;
+    bottom: -50px;
+    left: 0;
+    animation: fadeInDown 0.2s;
+    flex-direction: column;
+
+    .umb_confirm-remove__overlay-action {
+        margin-top: 5px;
+    }
+
+    .umb_confirm-remove__overlay-action.-confirm {
+        order: 2;
+    }
+
+    .umb_confirm-remove__overlay-action.-cancel {
+        order: 1;
+    }
+}
+
+.umb_confirm-remove__overlay.-left {
+    top: 0;
+    right: auto;
+    bottom: auto;
+    left: -50px;
+    animation: fadeInRight 0.2s;
+    flex-direction: row;
+
+    .umb_confirm-remove__overlay-action {
+        margin-right: 5px;
+    }
+
+    .umb_confirm-remove__overlay-action.-confirm {
+        order: 1;
+    }
+
+    .umb_confirm-remove__overlay-action.-cancel {
+        order: 2;
+    }
+}
+
+// BUTTONS
+.umb_confirm-remove__overlay-action {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: @white;
+  border-radius: 40px;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.umb_confirm-remove__overlay-action:hover {
+  text-decoration: none;
+  color: @white;
+}
+
+// confirm button
+.umb_confirm-remove__overlay-action.-confirm {
+  background: @white;
+  color: @green !important;
+}
+
+.umb_confirm-remove__overlay-action.-confirm:hover {
+    color: @green !important;
+}
+
+// cancel button
+.umb_confirm-remove__overlay-action.-cancel {
+  background: @white;
+  color: @red !important;
+}
+
+.umb_confirm-remove__overlay-action.-cancel:hover {
+    color: @red !important;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
@@ -12,13 +12,13 @@
             <span ng-repeat="tag in vm.viewModel track by $index" class="label label-primary tag" ng-keyup="vm.onKeyUpOnTag(tag, $event)" tabindex="0">
                 <span ng-bind-html="tag"></span>
 
-                <i class="icon-trash" ng-click="vm.showPrompt($index, tag)" localize="title" title="@buttons_deleteTag"></i>
-
-                <umb-confirm-action ng-if="vm.promptIsVisible === $index"
-                                    direction="left"
-                                    on-confirm="vm.removeTag(tag)"
-                                    on-cancel="vm.hidePrompt()">
-                </umb-confirm-action>
+                <umb-confirm-remove
+                    show="vm.promptIsVisible === $index"
+                    direction="left"
+                    on-delete="vm.showPrompt($index, tag)"
+                    on-confirm="vm.removeTag(tag)"
+                    on-cancel="vm.hidePrompt()">
+                </umb-confirm-remove>
             </span>
 
             <input type="text"

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-remove.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-remove.html
@@ -1,0 +1,29 @@
+<div class="umb_confirm-remove">
+    <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)">
+        <i class="icon-trash" aria-hidden="true"></i>
+        <span class="sr-only">Delete</span>
+    </button>
+
+    <div class="umb_confirm-remove__overlay" ng-class="{
+        '-top': direction === 'top',
+        '-right': direction === 'right',
+        '-bottom': direction === 'bottom',
+        '-left': direction === 'left'}" on-outside-click="clickCancel()" ng-if="show">
+
+        <button type="button" class="umb_confirm-remove__overlay-action -confirm btn-reset" ng-click="clickConfirm()"
+            localize="title" title="@buttons_confirmActionConfirm">
+            <i class="icon-check" aria-hidden="true"></i>
+            <span class="sr-only">
+                <localize key="buttons_confirmActionConfirm">Confirm</localize>
+            </span>
+        </button>
+
+        <button type="button" class="umb_confirm-remove__overlay-action -cancel btn-reset" ng-click="clickCancel()"
+            localize="title" title="@buttons_confirmActionCancel">
+            <i class="icon-delete" aria-hidden="true"></i>
+            <span class="sr-only">
+                <localize key="buttons_confirmActionCancel">Cancel</localize>
+            </span>
+        </button>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-remove.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-remove.html
@@ -1,6 +1,6 @@
-<div class="umb_confirm-remove">
+<div class="umb_confirm-remove" ng-class="cssClass">
     <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)" aria-haspopup="{{show}}">
-        <umb-icon class="icon-trash" aria-hidden="true"></umb-icon>
+        <umb-icon icon="icon-trash" class="icon-trash" aria-hidden="true"></umb-icon>
         <span class="sr-only">Delete</span>
     </button>
 
@@ -12,7 +12,7 @@
 
         <button type="button" class="umb_confirm-remove__overlay-action -confirm btn-reset" ng-click="clickConfirm()"
             localize="title" title="@buttons_confirmActionConfirm">
-            <umb-icon class="icon-check" aria-hidden="true"></umb-icon>
+            <umb-icon icon="icon-check" class="icon-check" aria-hidden="true"></umb-icon>
             <span class="sr-only">
                 <localize key="buttons_confirmActionConfirm">Confirm</localize>
             </span>
@@ -20,7 +20,7 @@
 
         <button type="button" class="umb_confirm-remove__overlay-action -cancel btn-reset" ng-click="clickCancel()"
             localize="title" title="@buttons_confirmActionCancel">
-            <umb-icon class="icon-delete" aria-hidden="true"></umb-icon>
+            <umb-icon icon="icon-delete" class="icon-delete" aria-hidden="true"></umb-icon>
             <span class="sr-only">
                 <localize key="buttons_confirmActionCancel">Cancel</localize>
             </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-remove.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm-remove.html
@@ -1,6 +1,6 @@
 <div class="umb_confirm-remove">
-    <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)">
-        <i class="icon-trash" aria-hidden="true"></i>
+    <button ng-if="onDelete" type="button" class="btn-reset" ng-click="clickButton($event)" aria-haspopup="{{show}}">
+        <umb-icon class="icon-trash" aria-hidden="true"></umb-icon>
         <span class="sr-only">Delete</span>
     </button>
 
@@ -12,7 +12,7 @@
 
         <button type="button" class="umb_confirm-remove__overlay-action -confirm btn-reset" ng-click="clickConfirm()"
             localize="title" title="@buttons_confirmActionConfirm">
-            <i class="icon-check" aria-hidden="true"></i>
+            <umb-icon class="icon-check" aria-hidden="true"></umb-icon>
             <span class="sr-only">
                 <localize key="buttons_confirmActionConfirm">Confirm</localize>
             </span>
@@ -20,7 +20,7 @@
 
         <button type="button" class="umb_confirm-remove__overlay-action -cancel btn-reset" ng-click="clickCancel()"
             localize="title" title="@buttons_confirmActionCancel">
-            <i class="icon-delete" aria-hidden="true"></i>
+            <umb-icon class="icon-delete" aria-hidden="true"></umb-icon>
             <span class="sr-only">
                 <localize key="buttons_confirmActionCancel">Cancel</localize>
             </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -101,13 +101,14 @@
                     </ng-form>
 
                     <div class="umb-group-builder__group-remove" ng-if="!sortingMode && canRemoveGroup(tab)">
-                        <i class="icon-trash" ng-click="togglePrompt(tab)"></i>
-                        <umb-confirm-action
+                        <umb-confirm-remove
                             ng-if="tab.deletePrompt"
+                            show="tab.deletePrompt"
                             direction="left"
+                            on-delete="togglePrompt(tab)"
                             on-confirm="removeGroup($index)"
                             on-cancel="hidePrompt(tab)">
-                        </umb-confirm-action>
+                        </umb-confirm-remove>
                     </div>
 
                 </div>
@@ -266,15 +267,14 @@
 
                                     <!-- delete property -->
                                     <div ng-if="!property.locked" class="umb-group-builder__property-action">
-                                        <button aria-label="Delete property" class="btn-icon" ng-click="togglePrompt(property)">
-                                            <umb-icon icon="icon-trash" class="icon-trash"></umb-icon>
-                                        </button>
-                                        <umb-confirm-action
+                                        <umb-confirm-remove
                                             ng-if="property.deletePrompt"
+                                            show="property.deletePrompt"
                                             direction="left"
+                                            on-delete="togglePrompt(property)"
                                             on-confirm="deleteProperty(tab, $index)"
                                             on-cancel="hidePrompt(property)">
-                                        </umb-confirm-action>
+                                        </umb-confirm-remove>
                                     </div>
 
                                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -268,8 +268,8 @@
                                     <!-- delete property -->
                                     <div ng-if="!property.locked" class="umb-group-builder__property-action">
                                         <umb-confirm-remove
-                                            ng-if="property.deletePrompt"
                                             show="property.deletePrompt"
+                                            css-class="flex justify-center"
                                             direction="left"
                                             on-delete="togglePrompt(property)"
                                             on-confirm="deleteProperty(tab, $index)"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -100,13 +100,13 @@
                                    </div>
 
                                     <div class="cell-tools-remove row-tool">
-                                        <button class="icon-trash btn-reset" ng-click="togglePrompt(row)" type="button"></button>
-                                        <umb-confirm-action
-                                            ng-if="row.deletePrompt"
+                                        <umb-confirm-remove
+                                            show="row.deletePrompt"
                                             direction="left"
+                                            on-delete="togglePrompt(row)"
                                             on-confirm="removeRow(section, $index)"
                                             on-cancel="hidePrompt(row)">
-                                        </umb-confirm-action>
+                                        </umb-confirm-remove>
                                     </div>
 
                                </div>
@@ -215,12 +215,14 @@
                                                                           </div>
 
                                                                           <div class="umb-control-tool">
-                                                                              <button class="umb-control-tool-icon icon-trash btn-reset" ng-click="togglePrompt(control)" type="button"></button>
-                                                                              <umb-confirm-action ng-if="control.deletePrompt"
-                                                                                                  direction="left"
-                                                                                                  on-confirm="removeControl(area, $index)"
-                                                                                                  on-cancel="hidePrompt(control)">
-                                                                              </umb-confirm-action>
+
+                                                                            <umb-confirm-remove
+                                                                                show="control.deletePrompt"
+                                                                                direction="left"
+                                                                                on-delete="togglePrompt(control)"
+                                                                                on-confirm="removeControl(area, $index)"
+                                                                                on-cancel="hidePrompt(control)">
+                                                                            </umb-confirm-remove>
                                                                           </div>
 
                                                                       </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.html
@@ -36,14 +36,13 @@
                    <umb-checkbox ng-if="layout.isSystem === 1" model="layout.selected"></umb-checkbox>
 
                    <div class="list-view-layout__remove" ng-if="layout.isSystem !== 1">
-                       <button type="button" class="btn-icon" ng-click="vm.showPrompt(layout)" aria-label="Remove">
-                           <i class="icon-trash" aria-hidden="true"></i>
-                       </button>
-                       <umb-confirm-action ng-if="layout.deletePrompt"
-                                           direction="left"
-                                           on-confirm="vm.removeLayout($index, layout)"
-                                           on-cancel="vm.hidePrompt(layout)">
-                       </umb-confirm-action>
+                        <umb-confirm-remove
+                            show="layout.deletePrompt"
+                            direction="left"
+                            on-delete="vm.showPrompt(layout)"
+                            on-confirm="vm.removeLayout($index, layout)"
+                            on-cancel="vm.hidePrompt(layout)">
+                        </umb-confirm-remove>
                    </div>
                </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -10,18 +10,16 @@
 
           <div class="icon-wrapper">
               <i class="icon icon-navigation handle" aria-hidden="true" localize="title" title="@general_move"></i>
-  
+
               <div class="umb-multiple-textbox__confirm" ng-show="model.value.length > model.config.min">
-                  <button type="button" class="umb-multiple-textbox__confirm-action" ng-click="showPrompt($index, item)" localize="title" title="@content_removeTextBox">
-                      <i class="icon-trash" aria-hidden="true"></i>
-                  </button>
-  
-                  <umb-confirm-action
-                      ng-if="promptIsVisible === $index"
-                      direction="left"
-                      on-confirm="remove($index)"
-                      on-cancel="hidePrompt()">
-                  </umb-confirm-action>
+                    <umb-confirm-remove
+                        ng-if="promptIsVisible === $index"
+                        show="promptIsVisible === $index"
+                        direction="left"
+                        on-delete="showPrompt($index, item)"
+                        on-confirm="remove($index)"
+                        on-cancel="hidePrompt()">
+                    </umb-confirm-remove>
               </div>
           </div>
       </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -10,10 +10,8 @@
 
           <div class="icon-wrapper">
               <i class="icon icon-navigation handle" aria-hidden="true" localize="title" title="@general_move"></i>
-
               <div class="umb-multiple-textbox__confirm" ng-show="model.value.length > model.config.min">
                     <umb-confirm-remove
-                        ng-if="promptIsVisible === $index"
                         show="promptIsVisible === $index"
                         direction="left"
                         on-delete="showPrompt($index, item)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Unfortunately the changes that got merged with #8198 broke forms and probably other packages and therefore the changes got reverted. Therefore I have now been redoing the changes in a new directive called "umb-confirm-remove" instead.

~~I will mark the umb-confirm-action directive as being obsolete and still need to do some further enhancments before this one is ready for review. But got the primary stuff sorted.~~

**Update**: @nul800sebastiaan Ok, so this one is ready for being reviewed :-) Basically I've copy/pasted the changes that was originally made in umb-confirm-action into this directive and ensured it looks and acts as expected the different places where it's being used and I've added an "Obsoleted" text to the documentation for the old directive as well.

Let me know if you have any comments 👍 