### PR TITLE
Add an override for GetMostRecentRedirectUrl to allow for culture

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IRedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRedirectUrlRepository.cs
@@ -43,6 +43,14 @@ namespace Umbraco.Core.Persistence.Repositories
         IRedirectUrl GetMostRecentUrl(string url);
 
         /// <summary>
+        /// Gets the most recent redirect URL corresponding to an Umbraco redirect URL route.
+        /// </summary>
+        /// <param name="url">The Umbraco redirect URL route.</param>
+        /// <param name="culture">The culture the domain is associated with</param>
+        /// <returns>The most recent redirect URL corresponding to the route.</returns>
+        IRedirectUrl GetMostRecentUrl(string url, string culture);
+
+        /// <summary>
         /// Gets all redirect URLs for a content item.
         /// </summary>
         /// <param name="contentKey">The content unique key.</param>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -208,5 +208,17 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
             var rules = result.Items.Select(Map);
             return rules;
         }
+
+        public IRedirectUrl GetMostRecentUrl(string url, string culture)
+        {
+            if (string.IsNullOrWhiteSpace(culture)) return GetMostRecentUrl(url);
+            var urlHash = url.GenerateHash<SHA1>();
+            var sql = GetBaseQuery(false)
+                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.Culture == culture.ToLower())
+                .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
+            var dtos = Database.Fetch<RedirectUrlDto>(sql);
+            var dto = dtos.FirstOrDefault();
+            return dto == null ? null : Map(dto);
+        }
     }
 }

--- a/src/Umbraco.Core/Services/IRedirectUrlService.cs
+++ b/src/Umbraco.Core/Services/IRedirectUrlService.cs
@@ -49,6 +49,14 @@ namespace Umbraco.Core.Services
         IRedirectUrl GetMostRecentRedirectUrl(string url);
 
         /// <summary>
+        /// Gets the most recent redirect URLs corresponding to an Umbraco redirect URL route.
+        /// </summary>
+        /// <param name="url">The Umbraco redirect URL route.</param>
+        /// <param name="culture">The culture of the request.</param>
+        /// <returns>The most recent redirect URLs corresponding to the route.</returns>
+        IRedirectUrl GetMostRecentRedirectUrl(string url, string culture);
+
+        /// <summary>
         /// Gets all redirect URLs for a content item.
         /// </summary>
         /// <param name="contentKey">The content unique key.</param>

--- a/src/Umbraco.Core/Services/Implement/RedirectUrlService.cs
+++ b/src/Umbraco.Core/Services/Implement/RedirectUrlService.cs
@@ -108,5 +108,15 @@ namespace Umbraco.Core.Services.Implement
                 return _redirectUrlRepository.SearchUrls(searchTerm, pageIndex, pageSize, out total);
             }
         }
+
+        public IRedirectUrl GetMostRecentRedirectUrl(string url, string culture)
+        {
+            if (string.IsNullOrWhiteSpace(culture)) return GetMostRecentRedirectUrl(url);
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _redirectUrlRepository.GetMostRecentUrl(url, culture);
+            }
+
+        }
     }
 }

--- a/src/Umbraco.Tests/Services/RedirectUrlServiceTests.cs
+++ b/src/Umbraco.Tests/Services/RedirectUrlServiceTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Core.Cache;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+
+using Umbraco.Core.Persistence.Repositories;
+using Umbraco.Core.Persistence.Repositories.Implement;
+using Umbraco.Core.Scoping;
+using Umbraco.Tests.Testing;
+
+namespace Umbraco.Tests.Services
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+    public class RedirectUrlServiceTests : TestWithSomeContentBase
+    {
+        private IContent _testPage;
+        private IContent _altTestPage;
+        private string _url = "blah";
+        private string _cultureA = "en";
+        private string _cultureB = "de";
+        public override void CreateTestData()
+        {
+            base.CreateTestData();
+
+            var provider = TestObjects.GetScopeProvider(Logger);
+            using (var scope = provider.CreateScope())
+            {
+                var repository = new RedirectUrlRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger>());
+                var rootContent = ServiceContext.ContentService.GetRootContent().FirstOrDefault();
+                var subPages = ServiceContext.ContentService.GetPagedChildren(rootContent.Id, 0, 2, out _).ToList();
+                _testPage = subPages[0];
+                _altTestPage = subPages[1];
+
+                repository.Save(new RedirectUrl
+                {
+                    ContentKey = _testPage.Key,
+                    Url = _url,
+                    Culture = _cultureA
+                });
+                repository.Save(new RedirectUrl
+                {
+                    ContentKey = _altTestPage.Key,
+                    Url = _url,
+                    Culture = _cultureB
+                });
+                scope.Complete();
+            }
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+
+        [Test]
+        public void Can_Get_Most_Recent_RedirectUrl()
+        {
+            var redirectUrlService = ServiceContext.RedirectUrlService;
+            var redirect = redirectUrlService.GetMostRecentRedirectUrl(_url);
+            Assert.AreEqual(redirect.ContentId, _altTestPage.Id);
+
+        }
+
+        [Test]
+        public void Can_Get_Most_Recent_RedirectUrl_With_Culture()
+        {
+            var redirectUrlService = ServiceContext.RedirectUrlService;
+            var redirect = redirectUrlService.GetMostRecentRedirectUrl(_url, _cultureA);
+            Assert.AreEqual(redirect.ContentId, _testPage.Id);
+
+        }
+
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Services\MemberGroupServiceTests.cs" />
     <Compile Include="Services\MediaTypeServiceTests.cs" />
     <Compile Include="Services\PropertyValidationServiceTests.cs" />
+    <Compile Include="Services\RedirectUrlServiceTests.cs" />
     <Compile Include="Templates\HtmlLocalLinkParserTests.cs" />
     <Compile Include="TestHelpers\RandomIdRamDirectory.cs" />
     <Compile Include="Testing\Objects\TestDataSource.cs" />

--- a/src/Umbraco.Web/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByRedirectUrl.cs
@@ -36,7 +36,9 @@ namespace Umbraco.Web.Routing
                 ? frequest.Domain.ContentId + DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.Uri.GetAbsolutePathDecoded())
                 : frequest.Uri.GetAbsolutePathDecoded();
 
-            var redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(route);
+
+
+            var redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(route, frequest.Culture.Name);
 
             if (redirectUrl == null)
             {


### PR DESCRIPTION
Prerequisites
[@ ] I have added steps to test this contribution in the description below
If there's an existing issue for this PR then this fixes #8568

Description
The issue #8568 describes how the RedirectUrl Content Finder doesn't take into account the culture of the request, so if multiple urls that are the same exist in different cultures it returns the first one.

This is addressed by passing in the identified culture from the request through to the RedirectUrlService and the RedirectUrlRepository. In addition more unit tests were added for the following classe:

* RedirectUrlRepository
* RedirectUrlService