### PR TITLE
User group picker: Use <umb-search-filter> directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
@@ -17,16 +17,14 @@
             <umb-box>
                 <umb-box-content>
 
-                    <div class="form-search" style="margin-bottom: 15px;">
-                        <i class="icon-search"></i>
-                        <input type="text"
-                                ng-model="searchTerm"
-                                class="umb-search-field search-query input-block-level -full-width-input"
-                                localize="placeholder"
-                                placeholder="@placeholders_filter"
-                                umb-auto-focus
-                                no-dirty-check />
-                    </div>
+                    <umb-search-filter
+                        input-id="composition-search"
+                        model="searchTerm"
+                        label-key="placeholders_filter"
+                        text="Type to filter..."
+                        css-class="w-100 mb-15"
+                        auto-focus="true">
+                    </umb-search-filter>
 
                     <div class="umb-user-group-picker-list">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
I have replaced the search markup with the `<umb-search-filter>` directive making maintaining the search box easier not re-implementing the same markup pattern multiple times.

**Usergroup search field after the change has been made**
![usergroup-umb-search-filter](https://user-images.githubusercontent.com/1932158/96322052-e065eb00-1017-11eb-8465-45a4fac47324.png)
