### PR TITLE
Make toggle group labels clickable and aligned correctly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle-group.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-toggle-group.less
@@ -20,6 +20,12 @@
         justify-content: center;
         flex: 1 1 auto;
         cursor: pointer;
+
+        label {
+          padding: unset;
+          margin: unset;
+          pointer-events: none;
+        }
     }
 
     .umb-toggle-group-item--disabled .umb-toggle-group-item__toggle,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The changes in #8826 has unfortunately resulted in misaligned labels for toggle groups:

![image](https://user-images.githubusercontent.com/7405322/96337833-396e6700-108a-11eb-8518-ee78a0ca163e.png)

Also the checkbox label is no longer clickable - or rather, clicking it does not have any effect (because the label element swallows up the click event on the parent, which is supposed to be toggling the checkbox):

![toggle-group-before](https://user-images.githubusercontent.com/7405322/96337866-5dca4380-108a-11eb-9020-d3de6fbd7a97.gif)

This PR removes the additional padding and margin on the checkbox label, and ensures that it doesn't steal click events from the parent element:

![toggle-group-after](https://user-images.githubusercontent.com/7405322/96337869-602c9d80-108a-11eb-84a3-8fef1de8d229.gif)


