### PR TITLE
Fix mis-spelt "occurred"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -179,7 +179,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
 
                     //show a ysod dialog
                     if (Umbraco.Sys.ServerVariables["isDebuggingEnabled"] === true) {
-                        const error = { errorMsg: 'An error occured', data: response.data };
+                        const error = { errorMsg: 'An error occurred', data: response.data };
                         // TODO: All YSOD handling should be done with an interceptor
                         overlayService.ysod(error);
                     }
@@ -294,7 +294,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                         }
                         else if (Umbraco.Sys.ServerVariables["isDebuggingEnabled"] === true) {
                             //show a ysod dialog
-                            const error = { errorMsg: 'An error occured', data: response.data };
+                            const error = { errorMsg: 'An error occurred', data: response.data };
                             // TODO: All YSOD handling should be done with an interceptor
                             overlayService.ysod(error);
                         }

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -443,9 +443,9 @@ namespace Umbraco.Web.Editors
             }
             catch (Exception ex)
             {
-                Logger.Error<UsersController>(ex, "An error occured in a custom event handler while inviting the user");
+                Logger.Error<UsersController>(ex, "An error occurred in a custom event handler while inviting the user");
                 throw new HttpResponseException(
-                    Request.CreateNotificationValidationErrorResponse($"An error occured inviting the user (check logs for more info): {ex.Message}"));
+                    Request.CreateNotificationValidationErrorResponse($"An error occurred inviting the user (check logs for more info): {ex.Message}"));
             }
 
             // If the event is handled then no need to send the email


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below


### Description

Mis-spelt "occurred" in the error messages that get thrown in the back office

This might seem trivial, but this error message bugs me everyyyyyy time!
