### PR TITLE
Check if urls is null

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -315,7 +315,7 @@
 
             function updateCurrentUrls() {
                 // never show URLs for element types (if they happen to have been created in the content tree)
-                if (scope.node.isElement) {
+                if (scope.node.isElement || scope.node.urls === null) {
                     scope.currentUrls = null;
                     return;
                 }


### PR DESCRIPTION
Check if node.urls is null and set scope.currentUrls to null and return

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Related to issue #7215

### Description

When setting node urls to null using EditorModelEventManager.SendingContentModel += (sender, e) => e.Model.Urls = null; then urls box is shown if the node has variants. A check is now added to set scope.currentUrls to null same as for Elements.

To test create a component with the above-mentioned code and open a content node that has variants. The urls box should be hidden.
