### PR TITLE
Conditionally show check icon if umb-tree-item is selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <umb-icon icon="{{node.icon}}" class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
+        <umb-icon icon="{{node.selected ? 'icon-check' : node.icon}}" class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below

Fixes #9209 

### Description

A regression caused by #9064 The tree views no longer show the green tick icon when you select an item.

The check icon was previously enabled/disabled by css (line 177 of `umb-tree.less`) which targeted `<i>`, but the icon now uses `<umb-icon>` so the CSS no longer targets it.

I've changed it so the icon is changed in the view if the node is selected rather than via CSS.

However I'm unsure if:

- This is the correct approach
- The icon needs to be green (it is on some views but isn't on others)

@MMasey @poornimanayar I would appreciate your input on this as I understand you have done alot of work on icons recently - thank you!

<!-- Thanks for contributing to Umbraco CMS! -->
