### PR TITLE
9129 keep model value reference after empty

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -138,10 +138,10 @@
 
             // We need to ensure that the property model value is an object, this is needed for modelObject to recive a reference and keep that updated.
             if (typeof newVal !== 'object' || newVal === null) {// testing if we have null or undefined value or if the value is set to another type than Object.
-                newVal = {};
+                vm.model.value = newVal = {};
             }
 
-            modelObject.update(newVal, $scope);
+            modelObject.update(vm.model.value, $scope);
             onLoaded();
         }
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/9129

When server resets the value to a primative value (null or undefined, does not matter) we lose the reference between the BlockEditorModelObject and the Data Model of the Content. This update makes sure when resetting the value its bound on the model and that reference is parsed.

Read test notes on issue.