### PR TITLE
Get default culture comparable to the variant culture

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -699,7 +699,7 @@ namespace Umbraco.Web.Editors
 
             //The default validation language will be either: The default languauge, else if the content is brand new and the default culture is
             // not marked to be saved, it will be the first culture in the list marked for saving.
-            var defaultCulture = _allLangs.Value.Values.FirstOrDefault(x => x.IsDefault)?.CultureName;
+            var defaultCulture = _allLangs.Value.Values.FirstOrDefault(x => x.IsDefault)?.IsoCode;
             var cultureForInvariantErrors = CultureImpact.GetCultureForInvariantErrors(
                 contentItem.PersistedContent,
                 contentItem.Variants.Where(x => x.Save).Select(x => x.Culture).ToArray(),


### PR DESCRIPTION
This fixes issue #8936.  The testing steps are specified there.

The fix was correcting defaultCulture from using the culture's display name to is ISO name.  The one consideration I had to look into was to make sure the one other place default culture was used would handle it correctly.  This was on line 703 of ContentController where it called CultureImpact.GetCultureForInvariantErrors.  However in my debugging, the other values passed in, which would have been used if not equal to the default culture, were also in the ISO name format, not the display name format, and so this change probably fixes another potential bug in that call.

The unit tests all passed locally, and when running through the test scenario from the issue above, I was able to verify that the comparison was between two equivalent strings now.