### PR TITLE
Update umb-button directive parameter usage to reflect accurate imple…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -61,15 +61,15 @@ Use this directive to render an umbraco button. The directive can be used to gen
 @param {string=} state Set a progress state on the button ("init", "busy", "success", "error").
 @param {string=} shortcut Set a keyboard shortcut for the button ("ctrl+c").
 @param {string=} label Set the button label.
-@param {string=} labelKey Set a localization key to make a multi lingual button ("general_buttonText").
+@param {string=} labelKey Set a localization key to make a multi-lingual button ("general_buttonText").
 @param {string=} icon Set a button icon.
-@param {string=} size Set a button icon ("xs", "m", "l", "xl").
+@param {string=} size Set a button size ("xs", "m", "l", "xl").
 @param {boolean=} disabled Set to <code>true</code> to disable the button.
-@param {string=} addEllipsis Adds an ellipsis character (…) to the button label which means the button will open a dialog or prompt the user for more information.
-@param {string=} showCaret Shows a caret on the right side of the button label
-@param {string=} autoFocus add autoFocus to the button
-@param {string=} hasPopup Used to expose to the accessibility API whether the button will trigger a popup or not
-@param {string=]} isExpanded Used to add an aria-expanded attribute and expose whether the button has expanded a popup or not
+@param {boolean=} addEllipsis Adds an ellipsis character (…) to the button label which means the button will open a dialog or prompt the user for more information.
+@param {boolean=} showCaret Shows a caret on the right side of the button label
+@param {boolean=} autoFocus add autoFocus to the button
+@param {boolean=} hasPopup Used to expose to the accessibility API whether the button will trigger a popup or not
+@param {boolean=} isExpanded Used to add an aria-expanded attribute and expose whether the button controls collapsible content
 
 **/
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Whilst working on the umbSense tags for VS Code, using the API docs as a reference, it appears to me that the usage parameters for the umb-button directive are not totally accurate: https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbButton

I have updated them (along with some typos that were causing ambiguity in the docs) to reflect that properties like `isExpanded`, `hasPopup`, `addEllipsis` etc should really be expected as boolean inputs in the directive. If this is not the case/not consistent then I am happy to revert those changes - just let me know!

Thanks,
Laura
