### PR TITLE
Change to MemberHasAccess to return true for unprotected paths.

### DIFF
--- a/src/Umbraco.Web/Security/MembershipHelper.cs
+++ b/src/Umbraco.Web/Security/MembershipHelper.cs
@@ -119,7 +119,7 @@ namespace Umbraco.Web.Security
             {
                 pathsWithAccess.TryGetValue(path, out var hasAccess);
                 // if it's not found it's false anyways
-                result[path] = hasAccess;
+                result[path] = !pathsWithProtection.Contains(path) || hasAccess;
             }
             return result;
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

The method as it currently stands will only return true for a path that is protected _and_ the member has access. However, it should return true for paths which are also unprotected.

To test, call the method passing in paths of nodes which are unprotected. It should return false for all of these paths.

There are 3 possible scenarios that this method should deal with:
1. Node is unprotected
2. Node is protected and member does not have access
3. Node is protected and member does have access

At the moment the code only satisfies options 2 and 3.
