### PR TITLE
9238: Fixed invalid multi url picker label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
@@ -47,7 +47,7 @@
 
             <!-- Only max -->
             <span ng-if="!model.config.minNumber && model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber"><localize key="addUpTo">Add up to</localize> {{model.config.maxNumber}} <localize key="validation_urls">url(s)</localize></span>
+                <span ng-if="renderModel.length < model.config.maxNumber"><localize key="validation_addUpTo">Add up to</localize> {{model.config.maxNumber}} <localize key="validation_urls">url(s)</localize></span>
                 <span ng-if="renderModel.length > model.config.maxNumber">
                     <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_urlsSelected">url(s) selected</localize>
                 </span>


### PR DESCRIPTION
Issue: https://github.com/umbraco/Umbraco-CMS/issues/9238

A simple fix by having the localization key point to the validation section (which is where the key is actually located instead of the default section).

How to check:
- Create a new data type 'Multi Url Picker' with a maximum.
- Add the data type to a page and check it out.