### PR TITLE
Update usage guidance for umb-breadcrumbs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbbreadcrumbs.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbbreadcrumbs.directive.js
@@ -13,7 +13,8 @@ Use this directive to generate a list of breadcrumbs.
         <umb-breadcrumbs
             ng-if="vm.ancestors && vm.ancestors.length > 0"
             ancestors="vm.ancestors"
-            entity-type="content">
+            entity-type="content"
+            on-open="clickBreadcrumb(ancestor)">
         </umb-breadcrumbs>
     </div>
 </pre>
@@ -32,6 +33,9 @@ Use this directive to generate a list of breadcrumbs.
                 vm.ancestors = ancestors;
             });
 
+            $scope.clickBreadcrumb = function(ancestor) {
+                // manipulate breadcrumb display
+            }
         }
 
         angular.module("umbraco").controller("My.Controller", Controller);
@@ -40,7 +44,7 @@ Use this directive to generate a list of breadcrumbs.
 
 @param {array} ancestors Array of ancestors
 @param {string} entityType The content entity type (member, media, content).
-@param {callback} Callback when an ancestor is clicked. It will override the default link behaviour.
+@param {callback=} onOpen Function callback when an ancestor is clicked. This will override the default link behaviour.
 **/
 
 (function () {


### PR DESCRIPTION
#4637 # Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Whilst creating tags for VS Code plugin (umbSense), the documentation on umb-breadcrumb is unclear at the API docs: https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBreadcrumbs. The property marked as "Callback" is actually referenced as `on-open`. E.g. from the [mini list view](https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html):

```
<umb-breadcrumbs
                ng-if="breadcrumb && breadcrumb.length > 0"
                ancestors="breadcrumb"
                entity-type="content"
                on-open="clickBreadcrumb(ancestor)">
</umb-breadcrumbs>
```

I have made the following changes to rectify this: 
- Reflect optional nature of the callback method in the functionality
- Show actual property name to reference in usage