### PR TITLE
Make blockConfigModel optional

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -2,7 +2,7 @@
     <div class="__showcase"
         ng-class="{'--error':vm.elementTypeModel === null}"
         ng-style="{'background-color': vm.blockConfigModel ? vm.blockConfigModel.backgroundColor : '', 'background-image': vm.styleBackgroundImage}">
-        <i ng-if="vm.blockConfigModel && vm.blockConfigModel.thumbnail == null" class="__icon {{ vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block' }}" ng-attr-style="{{'color:'+vm.blockConfigModel.iconColor+' !important'}}" aria-hidden="true"></i>
+        <i ng-if="vm.blockConfigModel == null || vm.blockConfigModel.thumbnail == null" class="__icon {{ vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block' }}" ng-attr-style="{{'color:'+vm.blockConfigModel.iconColor+' !important'}}" aria-hidden="true"></i>
     </div>
     <div class="__info" ng-if="vm.elementTypeModel !== null">
         <div class="__name" ng-bind="vm.elementTypeModel.name"></div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,8 +1,8 @@
 
     <div class="__showcase"
         ng-class="{'--error':vm.elementTypeModel === null}"
-        ng-style="{'background-color':vm.blockConfigModel.backgroundColor, 'background-image': vm.styleBackgroundImage}">
-        <i ng-if="vm.blockConfigModel.thumbnail == null" class="__icon {{ vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block' }}" ng-attr-style="{{'color:'+vm.blockConfigModel.iconColor+' !important'}}" aria-hidden="true"></i>
+        ng-style="{'background-color': vm.blockConfigModel ? vm.blockConfigModel.backgroundColor : '', 'background-image': vm.styleBackgroundImage}">
+        <i ng-if="vm.blockConfigModel && vm.blockConfigModel.thumbnail == null" class="__icon {{ vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block' }}" ng-attr-style="{{'color:'+vm.blockConfigModel.iconColor+' !important'}}" aria-hidden="true"></i>
     </div>
     <div class="__info" ng-if="vm.elementTypeModel !== null">
         <div class="__name" ng-bind="vm.elementTypeModel.name"></div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -9,7 +9,7 @@
             controllerAs: "vm",
             transclude: true,
             bindings: {
-                blockConfigModel: "<",
+                blockConfigModel: "<?",
                 elementTypeModel: "<"
             }
         });
@@ -35,7 +35,7 @@
         }
 
         vm.updateThumbnail = function () {
-            if (vm.blockConfigModel.thumbnail == null || vm.blockConfigModel.thumbnail === "") {
+            if (vm.blockConfigModel == null || vm.blockConfigModel.thumbnail == null || vm.blockConfigModel.thumbnail === "") {
                 vm.styleBackgroundImage = "none";
                 return;
             }


### PR DESCRIPTION
Make ```<umb-block-card>``` work without blockConfigModel as we need that for pasting a list of items.

Fixes this issue:

![image](https://user-images.githubusercontent.com/6791648/96733102-5f14ac80-13b9-11eb-81fb-4903e1561199.png)

test-notes:

Copy all items of a Block List Property Editor, go to "Add content" and go to the clipboard.

---
_This item has been added to our backlog [AB#9001](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/9001)_