### PR TITLE
Remove CSS: bottom offset in umb-grid.less

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -829,7 +829,6 @@
             position: absolute;
             width: 100%;
             left: 0;
-            bottom: -25px;
             padding-top: 15px;
         }
 


### PR DESCRIPTION
Hello Umbraco World 👋

### Prerequisites

- [x] I have added steps to test this contribution in the description below

closes 9182

### Description
This PR removes a single line of css that hard-coded the position of the label. 
This made the text display over the icons if the text spanned multiple lines. 

Before Change:
![beforeChange](https://user-images.githubusercontent.com/1050133/96735103-7f456b00-13bb-11eb-9b4b-ed50a50006ec.png)

After Change:
![afterChange](https://user-images.githubusercontent.com/1050133/96734990-5e7d1580-13bb-11eb-81f5-935d00d10882.png)



