### PR TITLE
use umb-outline for umb-block-card

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -7,11 +7,12 @@ umb-block-card {
     background-color: white;
     border-radius: @doubleBorderRadius;
     box-shadow: 0 1px 2px rgba(0,0,0,.2);
-    overflow: hidden;
 
     transition: box-shadow 120ms;
 
     cursor: pointer;
+
+    .umb-outline();
 
     &:hover {
         box-shadow: 0 1px 3px rgba(@ui-action-type-hover, .5);
@@ -60,6 +61,9 @@ umb-block-card {
         background-size: cover;
         background-position: 50% 50%;
         background-repeat: no-repeat;
+        
+        border-top-left-radius: @doubleBorderRadius;
+        border-top-right-radius: @doubleBorderRadius;
 
         &.--error {
             border: 2px solid @errorBackground;
@@ -85,6 +89,8 @@ umb-block-card {
         background-color: #fff;
         padding-top: 10px;
         padding-bottom: 11px;// 10 + 1 to compentiate for the -1 substraction in margin-bottom.
+        border-bottom-left-radius: @doubleBorderRadius;
+        border-bottom-right-radius: @doubleBorderRadius;
 
         &.--error {
             background-color: @errorBackground;


### PR DESCRIPTION
Use umb-outline for a more visible focus outline.

The default one was stuck behind some parts, so it was hard to see.

![image](https://user-images.githubusercontent.com/6791648/96737372-e532f200-13bd-11eb-8cd4-f0725167af02.png)


---
_This item has been added to our backlog [AB#9004](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/9004)_