### PR TITLE
Netcore: Ensure unit tests are runnable on linux

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
@@ -12,6 +12,6 @@ namespace Umbraco.Core.Configuration.Models
 
         public uint CachedNameLength { get; set; } = 8;
 
-        public string CacheFolder { get; set; } = Path.Combine("..", "Umbraco", "MediaCache");
+        public string CacheFolder { get; set; } = Path.Combine("..", "umbraco", "mediacache");
     }
 }

--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -5,10 +5,10 @@ namespace Umbraco.Core.Configuration.Models
     /// <summary>
     ///     Represents the models builder configuration.
     /// </summary>
-    public class ModelsBuilderSettings 
+    public class ModelsBuilderSettings
     {
         // TODO: This should not go into App_Data - that folder isn't really a real thing anymore
-        public static string DefaultModelsDirectory => "~/App_Data/Models";
+        public static string DefaultModelsDirectory => "~/umbraco/models";
 
         /// <summary>
         ///     Gets a value indicating whether the whole models experience is enabled.

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/CoreXml/RenamedRootNavigatorTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/CoreXml/RenamedRootNavigatorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Runtime.InteropServices;
+using System.Xml;
 using System.Xml.XPath;
 using NUnit.Framework;
 using Umbraco.Core.Xml.XPath;
@@ -18,10 +19,10 @@ namespace Umbraco.Tests.CoreXml
 </root>");
             var nav = doc.CreateNavigator();
             var xml = nav.OuterXml;
-            Assert.AreEqual(@"<root foo=""bar"">
+            Assert.AreEqual(EnsureNativeLineEndings(@"<root foo=""bar"">
   <a></a>
   <b x=""1""></b>
-</root>".CrLf(), xml);
+</root>"), xml);
         }
 
         [Test]
@@ -34,10 +35,10 @@ namespace Umbraco.Tests.CoreXml
 </xx:root>");
             var nav = doc.CreateNavigator();
             var xml = nav.OuterXml;
-            Assert.AreEqual(@"<xx:root foo=""bar"" xmlns:xx=""uri"">
+            Assert.AreEqual(EnsureNativeLineEndings(@"<xx:root foo=""bar"" xmlns:xx=""uri"">
   <a></a>
   <b x=""1""></b>
-</xx:root>".CrLf(), xml);
+</xx:root>"), xml);
         }
 
         [Test]
@@ -50,10 +51,16 @@ namespace Umbraco.Tests.CoreXml
 </root>");
             var nav = new RenamedRootNavigator(doc.CreateNavigator(), "test");
             var xml = nav.OuterXml;
-            Assert.AreEqual(@"<test foo=""bar"">
+            Assert.AreEqual(EnsureNativeLineEndings(@"<test foo=""bar"">
   <a></a>
   <b x=""1""></b>
-</test>".CrLf(), xml);
+</test>"), xml);
+        }
+
+        private string EnsureNativeLineEndings(string text)
+        {
+            var useCrLf = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return useCrLf ? text.CrLf() : text.Lf();
         }
 
         [Test]
@@ -66,10 +73,10 @@ namespace Umbraco.Tests.CoreXml
 </xx:root>");
             var nav = new RenamedRootNavigator(doc.CreateNavigator(), "test");
             var xml = nav.OuterXml;
-            Assert.AreEqual(@"<xx:test foo=""bar"" xmlns:xx=""uri"">
+            Assert.AreEqual(EnsureNativeLineEndings(@"<xx:test foo=""bar"" xmlns:xx=""uri"">
   <a></a>
   <b x=""1""></b>
-</xx:test>".CrLf(), xml);
+</xx:test>"), xml);
         }
 
         [Test]

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Packaging/PackageExtractionTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Packaging/PackageExtractionTests.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Tests.Packaging
 
         private static FileInfo GetTestPackagePath(string packageName)
         {
-            const string testPackagesDirName = "Umbraco.Core\\Packaging\\Packages";
+            var testPackagesDirName = Path.Combine("Umbraco.Core","Packaging","Packages");
             var testDir = TestContext.CurrentContext.TestDirectory.Split("bin")[0];
             var path = Path.Combine(testDir, testPackagesDirName, packageName);
             return new FileInfo(path);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HealthChecks/HealthCheckResultsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HealthChecks/HealthCheckResultsTests.cs
@@ -137,7 +137,7 @@ namespace Umbraco.Tests.Web.HealthChecks
             var results = new HealthCheckResults(checks);
 
             var resultAsMarkdown = results.ResultsAsMarkDown(HealthCheckNotificationVerbosity.Summary);
-            Assert.IsTrue(resultAsMarkdown.IndexOf("Result: 'Success'\r\n") > -1);
+            Assert.IsTrue(resultAsMarkdown.IndexOf("Result: 'Success'" + Environment.NewLine) > -1);
         }
 
         [Test]
@@ -151,8 +151,8 @@ namespace Umbraco.Tests.Web.HealthChecks
             var results = new HealthCheckResults(checks);
 
             var resultAsMarkdown = results.ResultsAsMarkDown(HealthCheckNotificationVerbosity.Detailed);
-            Assert.IsFalse(resultAsMarkdown.IndexOf("Result: 'Success'\r\n") > -1);
-            Assert.IsTrue(resultAsMarkdown.IndexOf("Result: 'Success', Message: 'First check was successful'\r\n") > -1);
+            Assert.IsFalse(resultAsMarkdown.IndexOf("Result: 'Success'" + Environment.NewLine) > -1);
+            Assert.IsTrue(resultAsMarkdown.IndexOf("Result: 'Success', Message: 'First check was successful'" + Environment.NewLine) > -1);
         }
     }
 }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Tests.Common/Builders/StylesheetBuilderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Tests.Common/Builders/StylesheetBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using NUnit.Framework;
 using Umbraco.Core.Routing;
 using Umbraco.Tests.Common.Builders;
@@ -24,7 +25,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Tests.Common.Builders
                 .Build();
 
             // Assert
-            Assert.AreEqual("\\css\\styles.css", stylesheet.Path);
+            Assert.AreEqual(Path.DirectorySeparatorChar + Path.Combine("css", "styles.css"), stylesheet.Path);
             Assert.AreEqual(testContent, stylesheet.Content);
         }
     }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Common
             var viewResult = await sut.Index() as ViewResult;
             var fileName = GetViewName(viewResult, Path.DirectorySeparatorChar.ToString());
 
-            var views = GetUiFiles(new[] { "Umbraco", "UmbracoInstall" });
+            var views = GetUiFiles(new[] { "umbraco", "UmbracoInstall" });
             Assert.True(views.Contains(fileName), $"Expected {fileName} to exist, but it didn't");
         }
 
@@ -63,7 +63,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Common
             var viewResult = sut.Index() as ViewResult;
             var fileName = GetViewName(viewResult);
 
-            var views = GetUiFiles(new[] { "Umbraco", "UmbracoBackOffice" });
+            var views = GetUiFiles(new[] { "umbraco", "UmbracoBackOffice" });
 
             Assert.True(views.Contains(fileName), $"Expected {fileName} to exist, but it didn't");
         }
@@ -85,7 +85,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Common
 
             var viewResult = await sut.Default() as ViewResult;
             var fileName = GetViewName(viewResult);
-            var views = GetUiFiles(new[] { "Umbraco", "UmbracoBackOffice" });
+            var views = GetUiFiles(new[] { "umbraco", "UmbracoBackOffice" });
 
             Assert.True(views.Contains(fileName), $"Expected {fileName} to exist, but it didn't");
         }
@@ -94,7 +94,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Common
         [Test]
         public void LanguageFilesAreLowercase()
         {
-            var files = GetUiFiles(new[] { "Umbraco", "config", "lang" });
+            var files = GetUiFiles(new[] { "umbraco", "config", "lang" });
             foreach (var fileName in files)
             {
                 Assert.AreEqual(fileName.ToLower(), fileName,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Macros/MacroParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Macros/MacroParserTests.cs
@@ -323,7 +323,7 @@ test"">
 <!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2
 test"" /> -->
 <ins>Macro alias: <strong>Map</strong></ins></div>
-<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+<p>asdfasdf</p>".NoCrLf(), result.NoCrLf());
         }
 
         [Test]


### PR DESCRIPTION
- Changes small things to ensure the tests are runnable on linux.. 

If tests passes on buildserver, we know the unit tests can be executed on both windows and linux

### Changes
- The umbraco folder needs to be lowercase
- We can't force test results to be CRLF, but the line endings must be native
- Can't use hardcode directory separators + Line endings
