### PR TITLE
RTE Media picker deletes image if alternative text is changed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/mediaPicker/mediapicker.controller.js
@@ -94,7 +94,7 @@ angular.module("umbraco")
                     var id = $scope.target.udi ? $scope.target.udi : $scope.target.id
                     var altText = $scope.target.altText;
                     if (id) {
-                        entityResource.getById(id, "Media")
+                        mediaResource.getById(id)
                             .then(function (node) {
                                 $scope.target = node;
                                 if (ensureWithinStartNode(node)) {


### PR DESCRIPTION
Fixed bug #8254 described [here](https://github.com/umbraco/Umbraco-CMS/issues/8254).
Tested by adding an image to a rich text editor, then clicking on the image and changing the alternative text.