### PR TITLE
updates CSS selector to match latest

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -19,7 +19,7 @@
         yeah so this is a pain, but we must be super specific in targeting the mandatory property labels,
         otherwise all properties within a reqired, nested, nested content property will all appear mandatory
     */
-    > ng-form > .control-group > .umb-el-wrap > .control-header label:after {
+    .umb-property > ng-form > .control-group > .umb-el-wrap > .control-header label:after {
         content: '*';
         color: @red;
     }


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/8963

Makes the star(*) appear on mandatory fields of NC, as previously.

![image](https://user-images.githubusercontent.com/6791648/96837234-603feb00-1446-11eb-9793-b4201088a127.png)


---
_This item has been added to our backlog [AB#9010](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/9010)_