### PR TITLE
Enable auto-focus for confirm button in umb-confirm

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-confirm.html
@@ -15,7 +15,8 @@
                         button-style="{{confirmButtonStyle || 'primary'}}"
                         state="confirmButtonState"
                         disabled="confirmDisabled === true"
-                        label-key="{{confirmLabelKey || 'general_ok'}}">
+                        label-key="{{confirmLabelKey || 'general_ok'}}"
+                        auto-focus="true">
             </umb-button>
         </div>
 	</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #8945

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR enables `auto-focus` for confirm button (`OK` button) in `umb-confirm`.

This mainly enables autofocus for the contextual menu delete (see #8945), but also the Empty Recycle Bin confirmation.

<!-- Thanks for contributing to Umbraco CMS! -->
