### PR TITLE
8719 - Show block item alias when no element description is present

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -7,6 +7,7 @@
     <div class="__info" ng-if="vm.elementTypeModel !== null">
         <div class="__name" ng-bind="vm.elementTypeModel.name"></div>
         <div class="__subname" ng-if="vm.elementTypeModel.description" ng-bind="vm.elementTypeModel.description"></div>
+        <div class="__subname" ng-if="!vm.elementTypeModel.description">({{vm.elementTypeModel.alias}})</div>
     </div>
     <div class="__info --error" ng-if="vm.elementTypeModel === null">
         <div class="__name"><localize key="blockEditor_elementTypeDoesNotExistHeadline">Other</localize></div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [8719](https://github.com/umbraco/Umbraco-CMS/issues/8719)

### Description

Adds the Block alias in parenthesis below the Block name if there is no element description present.  This allows blocks that have the same name/icon to be selected by the editor.  

See the screenshot below.  The first block has an element description.  The second block doesn't so it displays the alias.

![BlockEditorAlias](https://user-images.githubusercontent.com/167112/97063470-c450d500-1554-11eb-8d7c-fef2a8d799b1.PNG)

