### PR TITLE
Fix disabled upload button in media picker on initial open

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -133,7 +133,8 @@ angular.module("umbraco")
                         entityResource.getById($scope.lastOpenedNode, "media")
                             .then(ensureWithinStartNode, gotoStartNode);
                     } else {
-                        gotoStartNode();
+                        entityResource.getById($scope.startNodeId, "media")
+                            .then(gotoStartNode);
                     }
                 } else {
                     // if a target is specified, go look it up - generally this target will just contain ids not the actual full
@@ -350,7 +351,7 @@ angular.module("umbraco")
                     gotoFolder({ id: $scope.lastOpenedNode || $scope.startNodeId, name: "Media", icon: "icon-folder", path: node.path });
                     return true;
                 } else {
-                    gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });
+                    gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder", path: node.path });
                     return false;
                 }
             }
@@ -366,8 +367,8 @@ angular.module("umbraco")
                 return false;
             }
 
-            function gotoStartNode() {
-                gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder" });
+            function gotoStartNode(node) {
+                gotoFolder({ id: $scope.startNodeId, name: "Media", icon: "icon-folder", path: node.path });
             }
 
             function openDetailsDialog() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/8076

### Description

See original issue for more details - how to test:

- Create a media picker that **has a start node assigned**
- Open the media picker, the upload button should not be greyed out

The issue was caused by the `hasStartNode` check failing, because the `node.path` only contains the start node ID on initial load.

When it is not an intial load, a different method is used which populates the whole node path. I have copied this to resolve the issue.

https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js#L358



<!-- Thanks for contributing to Umbraco CMS! -->
