### PR TITLE
Returning response from downloadFile promise

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbrequesthelper.service.js
@@ -18,7 +18,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
          *
          * @param {string} a virtual path, if this is already an absolute path it will just be returned, if this is a relative path an exception will be thrown
          */
-        convertVirtualToAbsolutePath: function(virtualPath) {
+        convertVirtualToAbsolutePath: function (virtualPath) {
             if (virtualPath.startsWith("/")) {
                 return virtualPath;
             }
@@ -136,7 +136,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                 };
 
                 // if "opts" is a promise, we set "err.errorMsg" to be that promise
-                if (typeof(opts) == "object" && typeof(opts.then) == "function") {
+                if (typeof (opts) == "object" && typeof (opts.then) == "function") {
                     err.errorMsg = opts;
                 }
 
@@ -339,7 +339,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                 // and setting the Content-type manually will not set this boundary parameter. For whatever reason, setting the Content-type to 'undefined'
                 // will force the request to automatically populate the headers properly including the boundary parameter.
                 headers: { 'Content-Type': undefined },
-                transformRequest: function(data) {
+                transformRequest: function (data) {
                     var formData = new FormData();
                     //add the json data
                     if (Utilities.isArray(data)) {
@@ -359,9 +359,9 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                     return formData;
                 },
                 data: jsonData
-            }).then(function(response) {
+            }).then(function (response) {
                 return $q.resolve(response);
-            }, function(response) {
+            }, function (response) {
                 return $q.reject(response);
             });
         },
@@ -377,7 +377,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
          * @param {string} httpPath the path (url) to the resource being downloaded
          * @returns {Promise} http promise object.
          */
-        downloadFile : function (httpPath) {
+        downloadFile: function (httpPath) {
 
             /**
              * Based on an implementation here: web.student.tuwien.ac.at/~e0427417/jsdownload.html
@@ -471,7 +471,7 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
                         window.open(httpPath, '_blank', '');
                     }
 
-                    return $q.resolve();
+                    return $q.resolve(response);
 
                 }, function (response) {
 
@@ -484,4 +484,5 @@ function umbRequestHelper($http, $q, notificationsService, eventsService, formHe
         }
     };
 }
+
 angular.module('umbraco.services').factory('umbRequestHelper', umbRequestHelper);


### PR DESCRIPTION
When working with the `umbrequesthelper.downloadFile` in the backoffice it would be handy to be able to access the response object, e.g. to check values from the response headers. Currently this function doesn't return anything...

This change makes the function return the `response` object on success. The `error` promise already returns the `response` so it's a little unclear why `success` doesn't too...

This change also brings it inline with the other methods in this helper.

The impact is thankfully minimal and won't won't break any existing implementations as promise parameters are optional.