### PR TITLE
Including ModelsBuilder.Umbraco in list of external Models Builders

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
@@ -20,14 +21,11 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
     {
         public void Compose(Composition composition)
         {
-            var isLegacyModelsBuilderInstalled = IsLegacyModelsBuilderInstalled();
-
-
             composition.Configs.Add<IModelsBuilderConfig>(() => new ModelsBuilderConfig());
 
-            if (isLegacyModelsBuilderInstalled)
+            if (IsExternalModelsBuilderInstalled() == true)
             {
-                ComposeForLegacyModelsBuilder(composition);
+                ComposeForExternalModelsBuilder(composition);
                 return;
             }
 
@@ -45,22 +43,35 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
                 ComposeForDefaultModelsFactory(composition);
         }
 
-        private static bool IsLegacyModelsBuilderInstalled()
+        private static bool IsExternalModelsBuilderInstalled()
         {
-            Assembly legacyMbAssembly = null;
+            var assemblyNames = new[]
+            {
+                "Umbraco.ModelsBuider",
+                "ModelsBuilder.Umbraco"
+            };
+
             try
             {
-                legacyMbAssembly = Assembly.Load("Umbraco.ModelsBuilder");
+                foreach (var name in assemblyNames)
+                {
+                    var assembly = Assembly.Load(name);
+
+                    if (assembly != null)
+                    {
+                        return true;
+                    }
+                }
             }
-            catch (System.Exception)
+            catch (Exception)
             {
                 //swallow exception, DLL must not be there
             }
 
-            return legacyMbAssembly != null;
+            return false;
         }
 
-        private void ComposeForLegacyModelsBuilder(Composition composition)
+        private void ComposeForExternalModelsBuilder(Composition composition)
         {
             composition.Logger.Info<ModelsBuilderComposer>("ModelsBuilder.Embedded is disabled, the external ModelsBuilder was detected.");
             composition.Components().Append<DisabledModelsBuilderComponent>();


### PR DESCRIPTION
As part of the [Community Models Builder Team](https://github.com/modelsbuilder)'s work we will be releasing a new version of Models Builder.

We cannot continue using the `Umbraco.ModelsBuilder` namespace, for many obvious reasons, and so we'll be introducing a new namespace: `ModelsBuilder.Umbraco`. This offers the flexibility we need to drive the project in the direction we want.

Umbraco identifies whether to use the built in "Embedded" Models Builder or the "legacy" / external one by scanning for the `Umbraco.ModelsBuilder` assembly...

Longer term I think we need a better way of registering a Models Builder, but for now this change adds the new namespace to the list treated as external.