### PR TITLE
Make index, settings and layout props available for labels

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -104,8 +104,8 @@
          */
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
-                // We are just using the data model, since its a key/value object that is live synced. (if we need to add additional vars, we could make a shallow copy and apply those.)
-                return blockObject.labelInterpolator(blockObject.data);
+                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}}, blockObject.data);
+                return blockObject.labelInterpolator(labelVars);
             }
             return blockObject.content.contentTypeName;
         }

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -104,7 +104,7 @@
          */
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
-                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}}, blockObject.data);
+                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": blockObject.index || 0}, blockObject.data);
                 return blockObject.labelInterpolator(labelVars);
             }
             return blockObject.content.contentTypeName;

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -104,7 +104,7 @@
          */
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
-                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": blockObject.index || 0}, blockObject.data);
+                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
                 return blockObject.labelInterpolator(labelVars);
             }
             return blockObject.content.contentTypeName;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -243,6 +243,9 @@
             block.showSettings = block.config.settingsElementTypeKey != null;
             block.showCopy = vm.supportCopy && block.config.contentElementTypeKey != null;// if we have content, otherwise it doesn't make sense to copy.
 
+
+            // Index is set by umbblocklistblock component and kept up to date by it.
+            block.index = 0;
             block.setParentForm = function (parentForm) {
                 this._parentForm = parentForm;
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -29,7 +29,7 @@
         }
     );
 
-    function BlockListBlockController($scope, $compile, $element, umbRequestHelper) {
+    function BlockListBlockController($scope, $compile, $element) {
         var model = this;
 
         model.$onInit = function () {
@@ -43,6 +43,9 @@
 
             // let the Block know about its form
             model.block.setParentForm(model.parentForm);
+
+            // let the Block know about the current index
+            model.block.index = model.index;
 
             $scope.block = model.block;
             $scope.api = model.api;
@@ -68,7 +71,12 @@
         // We need to watch for changes on primitive types and upate the $scope values.
         model.$onChanges = function (changes) {
             if (changes.index) {
-                $scope.index = changes.index.currentValue;
+                var index = changes.index.currentValue;
+                $scope.index = index;
+
+                // let the Block know about the current index:
+                model.block.index = index;
+                model.block.updateLabel();
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/8689

Make properties from Block settings available for the Block label on $settings.

**Test notes**
Use {{$settings.myprop}} in a label.

Test that the label does not fail for Blocks created before settings ElementType has been added for a Block.
— create a block with only Content-ElementType.
- create content of it.
- add Settings ElementType to your block (settings should have a property with alias "myProp")
- write a label like this. {{$settings.myProp}}
- view previously created content, and notice that no errors appear in the console.

Use {{$index}} in a label.
Test that the index is correct on init. When reordering and for nested Block Editors.

### Note
The index starts from 1 as opposed to a zero based index so that it is more editor friendly

---
_This item has been added to our backlog [AB#9064](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/9064)_