### PR TITLE
Added a check for the ExternalLogin table to the ExternalLoginTableUs…

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_9_0/ExternalLoginTableUserData.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_9_0/ExternalLoginTableUserData.cs
@@ -14,7 +14,15 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_9_0
         /// </summary>
         public override void Migrate()
         {
-            AddColumn<ExternalLoginDto>(Constants.DatabaseSchema.Tables.ExternalLogin, "userData");
+            if (!TableExists(Constants.DatabaseSchema.Tables.ExternalLogin))
+            {
+                // We may need to create the table if the database was upgraded from a previous release prior to 7.2.x(!)
+
+                Create.Table<ExternalLoginDto>(true).Do();
+            } else
+            {
+                AddColumn<ExternalLoginDto>(Constants.DatabaseSchema.Tables.ExternalLogin, "userData");
+            }
         }
     }
 }


### PR DESCRIPTION
…erData migration

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9288 

### Description

This PR simply adds a check to the `ExternalLoginTableUserData` Migration in the V_8_9_0 collection.  I'm not fully decided this is the best place for it, or whether we should be using the TableValidation to mark missing tables for creation further up the migration chain as more of a catch-all?

Comments requested, I'll happily update the PR to accommodate any changes requested

As for testing, you need to start with a pre-v7 database to upgrade.  Unfortunately I don't have a fairly vanilla one to go by.