### PR TITLE
Fix save buttons not working when using non-live models builder

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -176,7 +176,7 @@
                     hotKeyWhenHidden: true,
                     labelKey: vm.submitButtonKey,
                     letter: "S",
-                    type: "submit",
+                    type: "button",
                     handler: function () { vm.save(); }
                 };
                 vm.page.subButtons = [{

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -176,7 +176,6 @@
                     hotKeyWhenHidden: true,
                     labelKey: vm.submitButtonKey,
                     letter: "S",
-                    type: "button",
                     handler: function () { vm.save(); }
                 };
                 vm.page.subButtons = [{

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -190,7 +190,7 @@
                     hotKeyWhenHidden: true,
                     labelKey: vm.saveButtonKey,
                     letter: "S",
-                    type: "submit",
+                    type: "button",
                     handler: function () { vm.save(); }
                 };
                 vm.page.subButtons = [{

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -190,7 +190,6 @@
                     hotKeyWhenHidden: true,
                     labelKey: vm.saveButtonKey,
                     letter: "S",
-                    type: "button",
                     handler: function () { vm.save(); }
                 };
                 vm.page.subButtons = [{

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -111,7 +111,6 @@
                     hotKeyWhenHidden: true,
                     labelKey: vm.saveButtonKey,
                     letter: "S",
-                    type: "button",
                     handler: function () { vm.save(); }
                 };
                 vm.page.subButtons = [{

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -111,7 +111,7 @@
                     hotKeyWhenHidden: true,
                     labelKey: vm.saveButtonKey,
                     letter: "S",
-                    type: "submit",
+                    type: "button",
                     handler: function () { vm.save(); }
                 };
                 vm.page.subButtons = [{


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9286

### Description

See original issue for full details. The buttons work again when the type is set to "button", which is the default (as shown below) so the types in the PR can be safely removed.

https://github.com/umbraco/Umbraco-CMS/blob/e9e8a0354ddb36d12ebdecddf0569132dc96f4be/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js#L128
