### PR TITLE
Remove double editorService.close()

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.controller.js
@@ -39,7 +39,6 @@ function memberGroupPicker($scope, editorService, memberGroupResource){
                     // no new groups selected
                     editorService.close();
                 }
-                editorService.close();
             },
             close: function() {
                 editorService.close();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9299

### Description

See original issue for detailed info.

`editorService.close()` is being hit twice because it exists inside both if/else and outside the statements.