### PR TITLE
Bugfix: Add null check for null converted treenode icon so .startsWith does not throw

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js
@@ -135,7 +135,7 @@ function treeService($q, treeResource, iconHelper, notificationsService, eventsS
                 if (treeNode.iconIsClass === undefined || treeNode.iconIsClass) {
                     var converted = iconHelper.convertFromLegacyTreeNodeIcon(treeNode);
                     treeNode.cssClass = standardCssClass + " " + converted;
-                    if (converted.startsWith('.')) {
+                    if (converted && converted.startsWith('.')) {
                         //its legacy so add some width/height
                         treeNode.style = "height:16px;width:16px;";
                     }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes 

### Description

Adds a check so ensure the converted treenode icon is not undefined before calling converted.startswith(.) which will throw.
This issue causes  the content/settings/media trees not to work. No way to fix the issue from the cms

