### PR TITLE
Make RTE toolbar sticky

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -35,6 +35,11 @@
     box-sizing: border-box;
 }
 
+.umb-rte .mce-top-part {
+	position: sticky;
+	top: 0;
+}
+
 /* make sure the menu wraps */
 .umb-rte .mce-top-part.mce-container div {
     white-space: normal;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #9315

### Description
CSS update to the RTE toolbar to make it sticky. Now if the RTE area is larger than the viewport, as you scroll down the RTE toolbar will remain sticky to the content area meaning you don't have to scroll back up to access it.

To test, create an RTE in "classic" mode then enter a lot of content that forces it scroll beyond the view port height. When you scroll down, the RTE toolbar should now stick to the top of the viewport.