### PR TITLE
V8/feature/ab9079 use tree for element type pickers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -249,6 +249,7 @@ body.touch .umb-tree {
     > .umb-tree-item__inner > i.icon,
     > .umb-tree-item__inner > a {
         cursor: not-allowed;
+        opacity: 0.4;
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.html
@@ -28,9 +28,8 @@
                                     </div>
                                 </div>
 
-                                <div class="umb-control-group">
+                                <div class="umb-control-group" ng-if="vm.enableSearh">
                                     <umb-tree-search-box
-                                        ng-if="vm.enableSearh"
                                         hide-search-callback="vm.hideSearch"
                                         search-callback="vm.onSearchResults"
                                         search-from-id="{{vm.searchInfo.searchFromId}}"
@@ -94,6 +93,15 @@
                         label-key="general_close"
                         shortcut="esc"
                         action="vm.close()">
+                    </umb-button>
+
+                    <umb-button
+                        ng-if="model.extraActions"
+                        ng-repeat="action in model.extraActions track by $index"
+                        type="button"
+                        button-style="{{action.style || 'link'}}"
+                        label-key="{{action.labelKey}}"
+                        action="action.action()">
                     </umb-button>
 
                     <umb-button

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
@@ -128,8 +128,12 @@
                             style: "primary",
                             labelKey: "blockEditor_labelcreateNewElementType",
                             action: function () {
-                                editorService.close();
-                                vm.createElementTypeAndCallback(vm.addBlockFromElementTypeKey);
+                                vm.createElementTypeAndCallback((documentTypeKey) => {
+                                    vm.addBlockFromElementTypeKey(documentTypeKey);
+
+                                    // At this point we will close the contentTypePicker.
+                                    editorService.close();
+                                });
                             }
                         }
                     ]
@@ -144,6 +148,7 @@
                 create: true,
                 infiniteMode: true,
                 isElement: true,
+                noTemplate: true,
                 submit: function (model) {
                     loadElementTypes().then( function () {
                         callback(model.documentTypeKey);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
@@ -16,7 +16,7 @@
         }
     }
 
-    function BlockConfigurationController($scope, elementTypeResource, overlayService, localizationService, editorService, eventsService) {
+    function BlockConfigurationController($scope, elementTypeResource, overlayService, localizationService, editorService, eventsService, udiService) {
 
         var unsubscribe = [];
 
@@ -95,47 +95,46 @@
             }
         };
 
-        vm.openAddDialog = function ($event, entry) {
+        vm.openAddDialog = function () {
 
-            //we have to add the 'alias' property to the objects, to meet the data requirements of itempicker.
-            var selectedItems = Utilities.copy($scope.model.value).forEach((obj) => {
-                var elementType = vm.getElementTypeByKey(obj.contentElementTypeKey);
-                if(elementType) {
-                    obj.alias = elementType.alias;
-                    return obj;
-                }
-            });
+            localizationService.localize("blockEditor_headlineCreateBlock").then(function(localizedTitle) {
 
-            var availableItems = vm.getAvailableElementTypes()
-
-            localizationService.localizeMany(["blockEditor_headlineCreateBlock", "blockEditor_labelcreateNewElementType"]).then(function(localized) {
-
-                var elemTypeSelectorOverlay = {
-                    view: "itempicker",
-                    title: localized[0],
-                    availableItems: availableItems,
-                    selectedItems: selectedItems,
-                    createNewItem: {
-                        action: function() {
-                            overlayService.close();
-                            vm.createElementTypeAndCallback(vm.addBlockFromElementTypeKey);
-                        },
-                        icon: "icon-add",
-                        name: localized[1]
+                const contentTypePicker = {
+                    title: localizedTitle,
+                    section: "settings",
+                    treeAlias: "documentTypes",
+                    entityType: "documentType",
+                    isDialog: true,
+                    filter: function (node) {
+                        if (node.metaData.isElement === true) {
+                            var key = udiService.getKey(node.udi);
+                            // If a Block with this ElementType as content already exists, we will emit it as a posible option.
+                            return $scope.model.value.find(function (entry) {
+                                return key === entry.contentElementTypeKey;
+                            });
+                        }
+                        return true;
                     },
-                    position: "target",
-                    event: $event,
-                    size: availableItems.length < 7 ? "small" : "medium",
-                    submit: function (overlay) {
-                        vm.addBlockFromElementTypeKey(overlay.selectedItem.key);
-                        overlayService.close();
+                    filterCssClass: "not-allowed",
+                    select: function (node) {
+                        vm.addBlockFromElementTypeKey(udiService.getKey(node.udi));
+                        editorService.close();
                     },
                     close: function () {
-                        overlayService.close();
-                    }
+                        editorService.close();
+                    },
+                    extraActions: [
+                        {
+                            style: "primary",
+                            labelKey: "blockEditor_labelcreateNewElementType",
+                            action: function () {
+                                editorService.close();
+                                vm.createElementTypeAndCallback(vm.addBlockFromElementTypeKey);
+                            }
+                        }
+                    ]
                 };
-
-                overlayService.open(elemTypeSelectorOverlay);
+                editorService.treePicker(contentTypePicker);
 
             });
         };
@@ -160,7 +159,7 @@
 
         vm.addBlockFromElementTypeKey = function(key) {
 
-            var entry = {
+            var blockType = {
                 "contentElementTypeKey": key,
                 "settingsElementTypeKey": null,
                 "labelTemplate": "",
@@ -172,7 +171,10 @@
                 "thumbnail": null
             };
 
-            $scope.model.value.push(entry);
+            $scope.model.value.push(blockType);
+
+            vm.openBlockOverlay(blockType);
+
         };
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -160,6 +160,7 @@
                     filter: function (i) {
                         return !(i.name.indexOf(".html") !== -1);
                     },
+                    filterCssClass: "not-allowed",
                     select: function (node) {
                         const filepath = decodeURIComponent(node.id.replace(/\+/g, " "));
                         block.view = "~/" + filepath;
@@ -206,6 +207,7 @@
                     filter: function (i) {
                         return !(i.name.indexOf(".css") !== -1);
                     },
+                    filterCssClass: "not-allowed",
                     select: function (node) {
                         const filepath = decodeURIComponent(node.id.replace(/\+/g, " "));
                         block.stylesheet = "~/" + filepath;

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1825,7 +1825,7 @@ Mange hilsner fra Umbraco robotten
   </area>
   <area alias="blockEditor">
     <key alias="headlineCreateBlock">Vælg Element-Type</key>
-    <key alias="headlineAddSettingsElementType">Tilføj en indstillings afsnit</key>
+    <key alias="headlineAddSettingsElementType">Tilføj en indstillings Element-Type</key>
     <key alias="headlineAddCustomView">Tilføj visning</key>
     <key alias="headlineAddCustomStylesheet">Tilføj stylesheet</key>
     <key alias="headlineAddThumbnail">Vælg billede</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1824,12 +1824,12 @@ Mange hilsner fra Umbraco robotten
     <key alias="tooltipForPropertyActionsMenu">Åben egenskabshandlinger</key>
   </area>
   <area alias="blockEditor">
-    <key alias="headlineCreateBlock">Vælg Element-Type</key>
-    <key alias="headlineAddSettingsElementType">Tilføj en indstillings Element-Type</key>
+    <key alias="headlineCreateBlock">Vælg elementtype</key>
+    <key alias="headlineAddSettingsElementType">Tilføj en indstillings elementtype</key>
     <key alias="headlineAddCustomView">Tilføj visning</key>
     <key alias="headlineAddCustomStylesheet">Tilføj stylesheet</key>
     <key alias="headlineAddThumbnail">Vælg billede</key>
-    <key alias="labelcreateNewElementType">Opret ny Element-Type</key>
+    <key alias="labelcreateNewElementType">Opret ny elementtype</key>
     <key alias="labelCustomStylesheet">Overskriv stylesheet</key>
     <key alias="addCustomStylesheet">Tilføj stylesheet</key>
     <key alias="headlineEditorAppearance">Redigerings udseende</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1824,12 +1824,12 @@ Mange hilsner fra Umbraco robotten
     <key alias="tooltipForPropertyActionsMenu">Åben egenskabshandlinger</key>
   </area>
   <area alias="blockEditor">
-    <key alias="headlineCreateBlock">Opret ny blok</key>
+    <key alias="headlineCreateBlock">Vælg Element-Type</key>
     <key alias="headlineAddSettingsElementType">Tilføj en indstillings afsnit</key>
     <key alias="headlineAddCustomView">Tilføj visning</key>
     <key alias="headlineAddCustomStylesheet">Tilføj stylesheet</key>
     <key alias="headlineAddThumbnail">Vælg billede</key>
-    <key alias="labelcreateNewElementType">Opret ny</key>
+    <key alias="labelcreateNewElementType">Opret ny Element-Type</key>
     <key alias="labelCustomStylesheet">Overskriv stylesheet</key>
     <key alias="addCustomStylesheet">Tilføj stylesheet</key>
     <key alias="headlineEditorAppearance">Redigerings udseende</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2454,12 +2454,12 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="formsDescription">Create forms using an intuitive drag and drop interface. From simple contact forms that sends e-mails to advanced questionaires that integrate with CRM systems. Your clients will love it!</key>
   </area>
   <area alias="blockEditor">
-    <key alias="headlineCreateBlock">Create new block</key>
+    <key alias="headlineCreateBlock">Pick Element Type</key>
     <key alias="headlineAddSettingsElementType">Attach a settings section</key>
     <key alias="headlineAddCustomView">Select view</key>
     <key alias="headlineAddCustomStylesheet">Select stylesheet</key>
     <key alias="headlineAddThumbnail">Choose thumbnail</key>
-    <key alias="labelcreateNewElementType">Create new</key>
+    <key alias="labelcreateNewElementType">Create new Element Type</key>
     <key alias="labelCustomStylesheet">Custom stylesheet</key>
     <key alias="addCustomStylesheet">Add stylesheet</key>
     <key alias="headlineEditorAppearance">Editor apperance</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2455,7 +2455,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   </area>
   <area alias="blockEditor">
     <key alias="headlineCreateBlock">Pick Element Type</key>
-    <key alias="headlineAddSettingsElementType">Attach a settings section</key>
+    <key alias="headlineAddSettingsElementType">Attach a settings Element Type</key>
     <key alias="headlineAddCustomView">Select view</key>
     <key alias="headlineAddCustomStylesheet">Select stylesheet</key>
     <key alias="headlineAddThumbnail">Choose thumbnail</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2476,12 +2476,12 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="formsDescription">Create forms using an intuitive drag and drop interface. From simple contact forms that sends e-mails to advanced questionaires that integrate with CRM systems. Your clients will love it!</key>
   </area>
   <area alias="blockEditor">
-    <key alias="headlineCreateBlock">Create new block</key>
+    <key alias="headlineCreateBlock">Pick Element Type</key>
     <key alias="headlineAddSettingsElementType">Attach a settings section</key>
     <key alias="headlineAddCustomView">Select view</key>
     <key alias="headlineAddCustomStylesheet">Select stylesheet</key>
     <key alias="headlineAddThumbnail">Choose thumbnail</key>
-    <key alias="labelcreateNewElementType">Create new</key>
+    <key alias="labelcreateNewElementType">Create new Element Type</key>
     <key alias="labelCustomStylesheet">Custom stylesheet</key>
     <key alias="addCustomStylesheet">Add stylesheet</key>
     <key alias="headlineEditorAppearance">Editor apperance</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2477,7 +2477,7 @@ To manage your website, simply open the Umbraco back office and start adding con
   </area>
   <area alias="blockEditor">
     <key alias="headlineCreateBlock">Pick Element Type</key>
-    <key alias="headlineAddSettingsElementType">Attach a settings section</key>
+    <key alias="headlineAddSettingsElementType">Attach a settings Element Type</key>
     <key alias="headlineAddCustomView">Select view</key>
     <key alias="headlineAddCustomStylesheet">Select stylesheet</key>
     <key alias="headlineAddThumbnail">Choose thumbnail</key>


### PR DESCRIPTION
Use tree picker for Element Type Picking in Block List Prevalue Editor.

![image](https://user-images.githubusercontent.com/6791648/97726281-59ad1580-1acf-11eb-9539-5d35d980e2ca.png)


**test notes:**
Make a new Block from an existing ElementType.
Add Settings Element Type for Block, from an existing ElementType.
Make a new Block from an ElementType created in the flow. (use create new element type button in tree-picker)
Add Settings from an ElementType created in the flow. (use create new element type button in tree-picker)