### PR TITLE
NetCore: Fixes registration issue

### DIFF
--- a/src/Umbraco.Core/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Core/ServiceCollectionExtensions.cs
@@ -12,6 +12,21 @@ namespace Umbraco.Core
             where TImplementing : class, TService
             => services.Replace(ServiceDescriptor.Singleton<TService, TImplementing>());
 
+        /// <summary>
+        /// Registers a unique service as a single instance implementing two interfaces.
+        /// </summary>
+        /// <remarks>
+        /// Hat-tip: https://stackoverflow.com/a/55402016/489433
+        /// </remarks>
+        public static void AddUnique<TService1, TService2, TImplementing>(this IServiceCollection services)
+            where TService1 : class
+            where TService2 : class
+            where TImplementing : class, TService1, TService2
+        {
+            services.Replace(ServiceDescriptor.Singleton<TService1, TImplementing>());
+            services.Replace(ServiceDescriptor.Singleton<TService2, TImplementing>(x => (TImplementing)x.GetService<TService1>()));
+        }
+
         public static void AddUnique<TImplementing>(this IServiceCollection services)
             where TImplementing : class
             => services.Replace(ServiceDescriptor.Singleton<TImplementing, TImplementing>());

--- a/src/Umbraco.Web.Common/Runtime/AspNetCoreComposer.cs
+++ b/src/Umbraco.Web.Common/Runtime/AspNetCoreComposer.cs
@@ -55,12 +55,10 @@ namespace Umbraco.Web.Common.Runtime
             composition.Services.AddUnique<IApplicationShutdownRegistry, AspNetCoreApplicationShutdownRegistry>();
 
             // The umbraco request lifetime
-            composition.Services.AddUnique<IUmbracoRequestLifetime, UmbracoRequestLifetime>();
-            composition.Services.AddUnique<IUmbracoRequestLifetimeManager, UmbracoRequestLifetime>();
+            composition.Services.AddUnique<IUmbracoRequestLifetime, IUmbracoRequestLifetimeManager, UmbracoRequestLifetime>();
 
-            //Password hasher
+            // Password hasher
             composition.Services.AddUnique<IPasswordHasher, AspNetCorePasswordHasher>();
-
 
             composition.Services.AddUnique<ICookieManager, AspNetCoreCookieManager>();
             composition.Services.AddTransient<IIpResolver, AspNetCoreIpResolver>();
@@ -75,7 +73,6 @@ namespace Umbraco.Web.Common.Runtime
 
             composition.Services.AddUnique<IMacroRenderer, MacroRenderer>();
             composition.Services.AddUnique<IMemberUserKeyProvider, MemberUserKeyProvider>();
-
 
             // register the umbraco context factory
             composition.Services.AddUnique<IUmbracoContextFactory, UmbracoContextFactory>();


### PR DESCRIPTION
Following the MSDI refactor, I found a problem where a singleton class's field was null when it had previously been set (specifically the `UmbracoRequestLifetime.RequestStart` event).

Tracked it down to the fact that this class has two interfaces, and the recent changes meant two implementations were getting registered, when I think there should be just one.

The amend in this PR resolves the issue and restores the expected behaviour.

For reference, previously (before the MSDI refactor), we had this:

```
composition.RegisterMultipleUnique<IUmbracoRequestLifetime, IUmbracoRequestLifetimeManager, UmbracoRequestLifetime>();
```