### PR TITLE
Accessibility (keyboard navigation): The 'Content' drop down menu opens automatically when tabbing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigationitem.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigationitem.directive.js
@@ -4,8 +4,13 @@
     function UmbEditorNavigationItemController($scope, $element, $attrs) {
         
         var vm = this;
-        
-        vm.clicked = function() {
+
+        vm.close = function () {
+            vm.expanded = false;
+        };
+
+        vm.clicked = function () {
+            vm.expanded = vm.item.anchors && vm.item.anchors.length > 1 && !vm.expanded;
             vm.onOpen({item:vm.item});
         };
         

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-editor-navigation-item.less
@@ -93,7 +93,7 @@
         .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
     }
 
-    &:focus-within > &__anchor_dropdown,
+    & > &__anchor_dropdown.is-expanded,
     &:hover > &__anchor_dropdown {
         visibility: visible;
         opacity: 1;

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -1,21 +1,23 @@
 <button data-element="sub-view-{{vm.item.alias}}"
-   type="button"
-   ng-click="vm.clicked()"
-   hotkey="{{::vm.hotkey}}"
-   hotkey-when-hidden="true"
-   ng-class="{'is-active': vm.item.active, '-has-error': vm.item.hasError}"
-   ng-disabled="vm.item.disabled"
-   class="umb-sub-views-nav-item__action umb-outline umb-outline--thin">
+        type="button"
+        ng-click="vm.clicked()"
+        hotkey="{{::vm.hotkey}}"
+        hotkey-when-hidden="true"
+        ng-class="{'is-active': vm.item.active, '-has-error': vm.item.hasError }"
+        ng-disabled="vm.item.disabled"
+        class="umb-sub-views-nav-item__action umb-outline umb-outline--thin"
+        aria-haspopup="{{ vm.item.anchors && vm.item.anchors.length > 1 }}"
+        aria-expanded="{{ vm.expanded }}">
     <i class="icon {{ vm.item.icon }}" aria-hidden="true"></i>
     <span class="umb-sub-views-nav-item-text">{{ vm.item.name }}</span>
     <div ng-show="vm.item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>
     <div ng-show="!vm.item.badge" class="badge -type-alert --error-badge">!</div>
 </button>
 
-<ul class="dropdown-menu umb-sub-views-nav-item__anchor_dropdown" ng-if="vm.item.anchors && vm.item.anchors.length > 1">
-    <li ng-repeat="anchor in vm.item.anchors" ng-class="{'is-active': vm.item.active && anchor.active}">
+<umb-dropdown on-close="vm.close()" umb-keyboard-list class="umb-sub-views-nav-item__anchor_dropdown" ng-class="{'is-expanded': vm.expanded}" ng-if="vm.item.anchors && vm.item.anchors.length > 1">
+    <umb-dropdown-item ng-repeat="anchor in vm.item.anchors" ng-class="{'is-active': vm.item.active && anchor.active}">
         <a href="#group-{{anchor.id}}" ng-click="vm.anchorClicked(anchor, $event)" prevent-default>
             <span class="sr-only"><localize key="visuallyHiddenTexts_jumpTo">Jump to</localize></span> {{anchor.label}} <span class="sr-only"><localize key="visuallyHiddenTexts_group"> group</localize></span>
         </a>
-    </li>
-</ul>
+    </umb-dropdown-item>
+</umb-dropdown>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -14,7 +14,7 @@
     <div ng-show="!vm.item.badge" class="badge -type-alert --error-badge">!</div>
 </button>
 
-<umb-dropdown on-close="vm.close()" umb-keyboard-list class="umb-sub-views-nav-item__anchor_dropdown" ng-class="{'is-expanded': vm.expanded}" ng-if="vm.item.anchors && vm.item.anchors.length > 1">
+<umb-dropdown on-close="vm.close()" deep-blur="vm.close()" umb-keyboard-list class="umb-sub-views-nav-item__anchor_dropdown" ng-class="{'is-expanded': vm.expanded}" ng-if="vm.item.anchors && vm.item.anchors.length > 1">
     <umb-dropdown-item ng-repeat="anchor in vm.item.anchors" ng-class="{'is-active': vm.item.active && anchor.active}">
         <a href="#group-{{anchor.id}}" ng-click="vm.anchorClicked(anchor, $event)" prevent-default>
             <span class="sr-only"><localize key="visuallyHiddenTexts_jumpTo">Jump to</localize></span> {{anchor.label}} <span class="sr-only"><localize key="visuallyHiddenTexts_group"> group</localize></span>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://trello.com/c/pd2QnSjI/17-the-content-drop-down-menu-opens-automatically-when-tabbing

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
The drop down for 'Content' (within the 'Content' tab) opens when user is tabbing through. 

This behaviour differs from all other drop downs on the CMS (that remain closed until user opens).

I replaced the custom markup with the umb-dropdown directive, but also allowed the existing hover functionality to remain.

![keyboard-content-dropdown](https://user-images.githubusercontent.com/3120611/97784836-2f278f00-1b99-11eb-8499-648a34fdfac4.gif)

To test:
Open up a content node and tab from the name field over to the content tab. Tabbing again will take you to the next tab (Info) rather than entering the dropdown. Hit space/enter to open while the Content tab button is selected. Then tabbing will take you into the dropdown menu.

Hitting Esc or tabbing past the bottom item in the dropdown will close the dropdown.

The Content button will now be announced as expanded/collapsed when using a screen reader.

Hover and click functionality is maintained.

<!-- Thanks for contributing to Umbraco CMS! -->
