### PR TITLE
use v8 branch as default for API Docs

### DIFF
--- a/src/ApiDocs/docfx.json
+++ b/src/ApiDocs/docfx.json
@@ -50,6 +50,7 @@
     ],
     "globalMetadata": {
       "_appTitle": "Umbraco c# Api docs",
+      "branch": "v8/contrib",
       "_enableSearch": true,
       "_disableContribution": false
     },


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9152
### Description
Issue with generation of DocFX is that the url is always based on branch on which it was build, it means if branch is not public or was removed the link will be incorrect, to avoid that I think the best solution is to use v8/contrib branch which in most of cases will be containing the code describe with API Docs.