### PR TITLE
Add ellipsis to the Sort action in Content and Media

### DIFF
--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -135,7 +135,7 @@ namespace Umbraco.Web.Trees
 
                 //these two are the standard items
                 menu.Items.Add<ActionNew>(Services.TextService, opensDialog: true);
-                menu.Items.Add<ActionSort>(Services.TextService, true);
+                menu.Items.Add<ActionSort>(Services.TextService, true, opensDialog: true);
 
                 //filter the standard items
                 FilterUserAllowedMenuItems(menu, nodeActions);
@@ -235,7 +235,7 @@ namespace Umbraco.Web.Trees
             AddActionNode<ActionCreateBlueprintFromContent>(item, menu, opensDialog: true);
             AddActionNode<ActionMove>(item, menu, true, opensDialog: true);
             AddActionNode<ActionCopy>(item, menu, opensDialog: true);
-            AddActionNode<ActionSort>(item, menu, true);
+            AddActionNode<ActionSort>(item, menu, true, opensDialog: true);
             AddActionNode<ActionAssignDomain>(item, menu, opensDialog: true);
             AddActionNode<ActionRights>(item, menu, opensDialog: true);
             AddActionNode<ActionProtect>(item, menu, true, opensDialog: true);

--- a/src/Umbraco.Web/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web/Trees/MediaTreeController.cs
@@ -101,7 +101,7 @@ namespace Umbraco.Web.Trees
 
                 // root actions
                 menu.Items.Add<ActionNew>(Services.TextService, opensDialog: true);
-                menu.Items.Add<ActionSort>(Services.TextService, true);
+                menu.Items.Add<ActionSort>(Services.TextService, true, opensDialog: true);
                 menu.Items.Add(new RefreshNode(Services.TextService, true));
                 return menu;
             }
@@ -141,7 +141,7 @@ namespace Umbraco.Web.Trees
                 menu.Items.Add<ActionNew>(Services.TextService, opensDialog: true);
                 menu.Items.Add<ActionMove>(Services.TextService, opensDialog: true);
                 menu.Items.Add<ActionDelete>(Services.TextService, opensDialog: true);
-                menu.Items.Add<ActionSort>(Services.TextService);
+                menu.Items.Add<ActionSort>(Services.TextService, opensDialog: true);
                 menu.Items.Add(new RefreshNode(Services.TextService, true));
 
                 //set the default to create


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The Actions menu/dropdown in Content and Media contains a Sort link. It should end with an ellipsis ... because it opens a dialog just like the other items, like Move, Copy, Permissions.

To reproduce:
- Open the Content section
- Right-click on a content item and notice that Sort ends with an ellipsis ...
- Open the content item and click on the Actions dropdown in the top-right and notice that Sort ends with an ellipsis ...
- Reproduce these same steps in the Media section.


![image](https://user-images.githubusercontent.com/6131869/97791410-38811d80-1bd2-11eb-9aec-5362639d501d.png)
