### PR TITLE
Make models builder properties virtual to allow mocking

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/Building/TextBuilder.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Building/TextBuilder.cs
@@ -246,7 +246,7 @@ namespace Umbraco.ModelsBuilder.Embedded.Building
             WriteGeneratedCodeAttribute(sb, "\t\t");
             sb.AppendFormat("\t\t[ImplementPropertyType(\"{0}\")]\n", property.Alias);
 
-            sb.Append("\t\tpublic ");
+            sb.Append("\t\tpublic virtual ");
             WriteClrType(sb, property.ClrTypeName);
 
             sb.AppendFormat(" {0} => ",
@@ -307,14 +307,14 @@ namespace Umbraco.ModelsBuilder.Embedded.Building
 
             if (mixinStatic)
             {
-                sb.Append("\t\tpublic ");
+                sb.Append("\t\tpublic virtual ");
                 WriteClrType(sb, property.ClrTypeName);
                 sb.AppendFormat(" {0} => {1}(this);\n",
                     property.ClrName, MixinStaticGetterName(property.ClrName));
             }
             else
             {
-                sb.Append("\t\tpublic ");
+                sb.Append("\t\tpublic virtual ");
                 WriteClrType(sb, property.ClrTypeName);
                 sb.AppendFormat(" {0} => this.Value",
                     property.ClrName);

--- a/src/Umbraco.Tests/ModelsBuilder/BuilderTests.cs
+++ b/src/Umbraco.Tests/ModelsBuilder/BuilderTests.cs
@@ -97,7 +97,7 @@ namespace Umbraco.Web.PublishedModels
 
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute(""Umbraco.ModelsBuilder.Embedded"", """ + version + @""")]
 		[ImplementPropertyType(""prop1"")]
-		public string Prop1 => this.Value<string>(""prop1"");
+		public virtual string Prop1 => this.Value<string>(""prop1"");
 	}
 }
 ";
@@ -212,7 +212,7 @@ namespace Umbraco.Web.PublishedModels
 
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute(""Umbraco.ModelsBuilder.Embedded"", """ + version + @""")]
 		[ImplementPropertyType(""foo"")]
-		public global::System.Collections.Generic.IEnumerable<global::Foo> Foo => this.Value<global::System.Collections.Generic.IEnumerable<global::Foo>>(""foo"");
+		public virtual global::System.Collections.Generic.IEnumerable<global::Foo> Foo => this.Value<global::System.Collections.Generic.IEnumerable<global::Foo>>(""foo"");
 	}
 }
 ";


### PR DESCRIPTION
When trying to unit test using models builder models, we are unable to mock these without writing a lot of code - https://our.umbraco.com/forum/using-umbraco-and-getting-started/81058-unit-testing-moq-mocking-for-umbraco-models-builder-object

Making the properties virtual will mean we can mock them using something like Moq with no additional code. 

**Testing**
I have updated the unit tests to reflect the virtual property change.

Thanks
Matt