### PR TITLE
Track ng-repeat with id instead of label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -1,6 +1,6 @@
 ﻿<div>
     <ng-form name="tabbedContentForm">
-        <div class="umb-group-panel" retrive-dom-element="registerPropertyGroup(element[0], attributes.appAnchor)" data-app-anchor="{{group.id}}" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs track by group.label">
+        <div class="umb-group-panel" retrive-dom-element="registerPropertyGroup(element[0], attributes.appAnchor)" data-app-anchor="{{group.id}}" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs track by group.id">
 
             <div class="umb-group-panel__header">
                 <div id="group-{{group.id}}">{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
@@ -2,7 +2,7 @@
     <ng-form name="elementTypeContentForm">
         <div class="umb-group-panel"
              data-element="group-{{group.alias}}"
-             ng-repeat="group in vm.model.variants[0].tabs track by group.label">
+             ng-repeat="group in vm.model.variants[0].tabs track by group.id">
 
             <div class="umb-group-panel__header">
                 <div id="group-{{group.id}}">{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-member-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-member-node-info.html
@@ -1,7 +1,7 @@
 <div class="umb-package-details">
     <div class="umb-package-details__main-content">
 
-        <umb-box data-element="node-info-membership" ng-repeat="group in node.tabs| filter: {properties:{view:'readonlyvalue'}} track by group.label">
+        <umb-box data-element="node-info-membership" ng-repeat="group in node.tabs| filter: {properties:{view:'readonlyvalue'}} track by group.id">
 
             <div class="umb-group-panel__header">
                 <div>{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/apps/content/content.html
@@ -1,5 +1,5 @@
 <div class="form-horizontal" ng-controller="Umbraco.Editors.Media.Apps.ContentController as vm">
-    <div class="umb-group-panel" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs | filter: { hide : '!' + true } track by group.label">
+    <div class="umb-group-panel" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs | filter: { hide : '!' + true } track by group.id">
 
         <div class="umb-group-panel__header">
             <div>{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
@@ -1,6 +1,6 @@
 <div class="form-horizontal" ng-controller="Umbraco.Editors.Member.Apps.ContentController as vm">
 
-    <div class="umb-group-panel" ng-repeat="group in content.tabs track by group.label">
+    <div class="umb-group-panel" ng-repeat="group in content.tabs track by group.id">
 
         <div class="umb-group-panel__header">
             <div>{{ group.label }}</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9291 

### Description
The error is caused by multiple groups having the same label. I changed the loop to use `group.id` for tracking. I did a search to see if there were any other components using label for tracking and found `umb-tabbed-content` using it too.

To reproduce:
1) Set your backoffice language to Dutch - nl.
2) Go to Settings (Instellingen) -> Member types (Ledentypes)
3) Add another group called `Eigenschappen` and put a text field in it.
4) Create/Edit a member
