### PR TITLE
V8/feature/ab9263 refine media types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbpropertyfileupload.directive.js
@@ -85,7 +85,7 @@
 
         /** Called when the component has linked all elements, this is when the form controller is available */
         function postLink() {
-            
+
         }
 
         function initialize() {
@@ -186,7 +186,7 @@
                         });
                     }
                 }
-                
+
             }
         }
 
@@ -325,7 +325,8 @@
              */
             onFilesChanged: "&",
             onInit: "&",
-            required: "="
+            required: "=",
+            acceptFileExt: "<?"
         },
         transclude: true,
         controllerAs: 'vm',

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbsinglefileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbsinglefileupload.directive.js
@@ -9,19 +9,24 @@
 *  is required because the only way to reset an upload control is to replace it's html.
 **/
 function umbSingleFileUpload($compile) {
+
+    // cause we have the same template twice I choose to extract it to its own variable:
+    var innerTemplate = "<input type='file' umb-file-upload accept='{{acceptFileExt}}'/>";
+
     return {
         restrict: "E",
         scope: {
-            rebuild: "="
+            rebuild: "=",
+            acceptFileExt: "<?"
         },
         replace: true,
-        template: "<div><input type='file' umb-file-upload /></div>",
-        link: function (scope, el, attrs) {
+        template: "<div>"+innerTemplate+"</div>",
+        link: function (scope, el) {
 
             scope.$watch("rebuild", function (newVal, oldVal) {
                 if (newVal && newVal !== oldVal) {
                     //recompile it!
-                    el.html("<input type='file' umb-file-upload />");
+                    el.html(innerTemplate);
                     $compile(el.contents())(scope);
                 }
             });

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
@@ -6,9 +6,9 @@
         <div class="fileinput-button umb-upload-button-big" ng-hide="vm.files.length > 0">
             <i class="icon icon-page-up" aria-hidden="true"></i>
             <p><localize key="media_clickToUpload">Click to upload</localize></p>
-            <umb-single-file-upload></umb-single-file-upload>
+            <umb-single-file-upload accept-file-ext="vm.acceptFileExt"></umb-single-file-upload>
         </div>
-        
+
         <div ng-if="vm.files.length > 0">
             <div ng-if="!vm.hideSelection">
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -11,7 +11,7 @@
      *
     */
     function fileUploadController($scope, fileManager) {
-        
+
         $scope.fileChanged = onFileChanged;
         //declare a special method which will be called whenever the value has changed from the server
         $scope.model.onValueChanged = onValueChanged;
@@ -38,12 +38,12 @@
                 files: []
             });
         }
-        
+
     };
 
     angular.module("umbraco")
         .controller('Umbraco.PropertyEditors.FileUploadController', fileUploadController)
-        .run(function (mediaHelper, umbRequestHelper, assetsService) {
+        .run(function (mediaHelper) {
             if (mediaHelper && mediaHelper.registerFileResolver) {
 
                 //NOTE: The 'entity' can be either a normal media entity or an "entity" returned from the entityResource

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -16,6 +16,9 @@
         //declare a special method which will be called whenever the value has changed from the server
         $scope.model.onValueChanged = onValueChanged;
 
+
+        $scope.fileExtensionsString = $scope.model.config.fileExtensions.map(x => "."+x.value).join(",");
+
         /**
          * Called when the file selection value changes
          * @param {any} value

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.controller.js
@@ -17,7 +17,7 @@
         $scope.model.onValueChanged = onValueChanged;
 
 
-        $scope.fileExtensionsString = $scope.model.config.fileExtensions.map(x => "."+x.value).join(",");
+        $scope.fileExtensionsString = $scope.model.config.fileExtensions ? $scope.model.config.fileExtensions.map(x => "."+x.value).join(",") : "";
 
         /**
          * Called when the file selection value changes

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -4,6 +4,7 @@
                               property-alias="{{model.alias}}"
                               value="model.value"
                               required="model.validation.mandatory"
-                              on-files-selected="fileChanged(value)">
+                              on-files-selected="fileChanged(value)"
+                              accept-file-ext="'.jpg,.png'">
     </umb-property-file-upload>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/fileupload/fileupload.html
@@ -5,6 +5,6 @@
                               value="model.value"
                               required="model.validation.mandatory"
                               on-files-selected="fileChanged(value)"
-                              accept-file-ext="'.jpg,.png'">
+                              accept-file-ext="fileExtensionsString">
     </umb-property-file-upload>
 </div>

--- a/src/Umbraco.Web/PropertyEditors/FileExtensionConfigItem.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileExtensionConfigItem.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    public class FileExtensionConfigItem : IFileExtensionConfigItem
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/FileUploadConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileUploadConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    /// <summary>
+    /// Represents the configuration for the file upload address value editor.
+    /// </summary>
+    public class FileUploadConfiguration
+    {
+
+        [ConfigurationField("fileExtensions", "Accepted file extensions", "multivalues")]
+        public List<ValueListItem> FileExtensions { get; set; } = new List<ValueListItem>();
+
+        public class ValueListItem
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("value")]
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/FileUploadConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileUploadConfiguration.cs
@@ -8,19 +8,11 @@ namespace Umbraco.Web.PropertyEditors
     /// <summary>
     /// Represents the configuration for the file upload address value editor.
     /// </summary>
-    public class FileUploadConfiguration
+    public class FileUploadConfiguration : IFileExtensionsConfig
     {
 
         [ConfigurationField("fileExtensions", "Accepted file extensions", "multivalues")]
-        public List<ValueListItem> FileExtensions { get; set; } = new List<ValueListItem>();
-
-        public class ValueListItem
-        {
-            [JsonProperty("id")]
-            public int Id { get; set; }
-
-            [JsonProperty("value")]
-            public string Value { get; set; }
-        }
+        //public List<FileExtensionConfigItem> FileExtensions { get; set; } = new List<FileExtensionConfigItem>();
+        List<IFileExtensionConfigItem> IFileExtensionsConfig.FileExtensions { get; set; } = new List<FileExtensionConfigItem>();
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/FileUploadConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileUploadConfiguration.cs
@@ -10,6 +10,6 @@ namespace Umbraco.Web.PropertyEditors
     {
 
         [ConfigurationField("fileExtensions", "Accepted file extensions", "multivalues")]
-        List<FileExtensionConfigItem> IFileExtensionsConfig.FileExtensions { get; set; } = new List<FileExtensionConfigItem>();
+        public List<FileExtensionConfigItem> FileExtensions { get; set; } = new List<FileExtensionConfigItem>();
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/FileUploadConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileUploadConfigurationEditor.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.PropertyEditors;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    /// <summary>
+    /// Represents the configuration editor for the file upload value editor.
+    /// </summary>
+    public class FileUploadConfigurationEditor : ConfigurationEditor<FileUploadConfiguration>
+    {
+
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/FileUploadPropertyEditor.cs
@@ -32,6 +32,10 @@ namespace Umbraco.Web.PropertyEditors
             _uploadAutoFillProperties = new UploadAutoFillProperties(_mediaFileSystem, logger, contentSection);
         }
 
+
+        /// <inheritdoc />
+        protected override IConfigurationEditor CreateConfigurationEditor() => new FileUploadConfigurationEditor();
+
         /// <summary>
         /// Creates the corresponding property value editor.
         /// </summary>

--- a/src/Umbraco.Web/PropertyEditors/IFileExtensionConfig.cs
+++ b/src/Umbraco.Web/PropertyEditors/IFileExtensionConfig.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Umbraco.Web.PropertyEditors;
+
+namespace Umbraco.Core.PropertyEditors
+{
+    /// <summary>
+    /// Marker interface for any editor configuration that supports defining file extensions
+    /// </summary>
+    public interface IFileExtensionsConfig
+    {
+        List<IFileExtensionConfigItem> FileExtensions { get; set; }
+    }
+}

--- a/src/Umbraco.Web/PropertyEditors/IFileExtensionConfigItem.cs
+++ b/src/Umbraco.Web/PropertyEditors/IFileExtensionConfigItem.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Web.PropertyEditors
+{
+    public interface IFileExtensionConfigItem
+    {
+        int Id { get; set; }
+
+        string Value { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -258,6 +258,8 @@
     <Compile Include="PropertyEditors\BlockListPropertyEditor.cs" />
     <Compile Include="Compose\NestedContentPropertyComposer.cs" />
     <Compile Include="PropertyEditors\ComplexEditorValidator.cs" />
+    <Compile Include="PropertyEditors\FileUploadConfiguration.cs" />
+    <Compile Include="PropertyEditors\FileUploadConfigurationEditor.cs" />
     <Compile Include="PropertyEditors\ParameterEditors\MultipleMediaPickerParameterEditor.cs" />
     <Compile Include="PropertyEditors\RichTextEditorPastedImages.cs" />
     <Compile Include="PropertyEditors\Validation\ComplexEditorElementTypeValidationResult.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -257,6 +257,9 @@
     <Compile Include="PropertyEditors\BlockListConfigurationEditor.cs" />
     <Compile Include="PropertyEditors\BlockListPropertyEditor.cs" />
     <Compile Include="Compose\NestedContentPropertyComposer.cs" />
+    <Compile Include="PropertyEditors\IFileExtensionsItem.cs" />
+    <Compile Include="PropertyEditors\FileExtensionsItem.cs" />
+    <Compile Include="PropertyEditors\IFileExtensionConfig.cs" />
     <Compile Include="PropertyEditors\ComplexEditorValidator.cs" />
     <Compile Include="PropertyEditors\FileUploadConfiguration.cs" />
     <Compile Include="PropertyEditors\FileUploadConfigurationEditor.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -257,8 +257,8 @@
     <Compile Include="PropertyEditors\BlockListConfigurationEditor.cs" />
     <Compile Include="PropertyEditors\BlockListPropertyEditor.cs" />
     <Compile Include="Compose\NestedContentPropertyComposer.cs" />
-    <Compile Include="PropertyEditors\IFileExtensionsItem.cs" />
-    <Compile Include="PropertyEditors\FileExtensionsItem.cs" />
+    <Compile Include="PropertyEditors\IFileExtensionConfigItem.cs" />
+    <Compile Include="PropertyEditors\FileExtensionConfigItem.cs" />
     <Compile Include="PropertyEditors\IFileExtensionConfig.cs" />
     <Compile Include="PropertyEditors\ComplexEditorValidator.cs" />
     <Compile Include="PropertyEditors\FileUploadConfiguration.cs" />


### PR DESCRIPTION
This PR adds the ability to define accepted file extensions for FileUpload and use these to determine Media Type for File Uploads.

Prepare:
Create new Media Type (named "Video") with new File Upload Data type for umbracoFile-property.
Set the accepted file extensions for this new data type to ex.: mov and mp4

Create another set that takes mp3 name it "Sound".

Test Notes:
* General testing that uploaded files are made of the Media Type that fits the file extension.
* Test creating new items through create menu, see the you can only pick files that matches the file extension.
* Test that Media Type "File" still can pick any file.
* Test dragging files of these new types get creates as the defined media type.
* Check that image files that are not define by any media type are created as media.
* Check that folders and other files still works as before.