### PR TITLE
Casting tree controllers to TreeControllerBase

### DIFF
--- a/src/Umbraco.Web/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web/Trees/ApplicationTreeController.cs
@@ -205,7 +205,7 @@ namespace Umbraco.Web.Trees
         {
             if (tree == null) throw new ArgumentNullException(nameof(tree));
 
-            var controller = (TreeController) await GetApiControllerProxy(tree.TreeControllerType, "GetRootNode", querystring);
+            var controller = (TreeControllerBase) await GetApiControllerProxy(tree.TreeControllerType, "GetRootNode", querystring);
             var rootNode = controller.GetRootNode(querystring);
             if (rootNode == null)
                 throw new InvalidOperationException($"Failed to get root node for tree \"{tree.TreeAlias}\".");
@@ -226,7 +226,7 @@ namespace Umbraco.Web.Trees
             d["id"] = null;
             var proxyQuerystring = new FormDataCollection(d);
 
-            var controller = (TreeController) await GetApiControllerProxy(tree.TreeControllerType, "GetNodes", proxyQuerystring);
+            var controller = (TreeControllerBase) await GetApiControllerProxy(tree.TreeControllerType, "GetNodes", proxyQuerystring);
             return controller.GetNodes(id.ToInvariantString(), querystring);
         }
 


### PR DESCRIPTION
As described in #9357 you get a cast error when trying to register multiple trees in the same section and tree group without using the `[Tree(...)]` attribute to declare it.

To create a tree without using the attribute you must inherit from `TreeControllerBase` and not `TreeController` - here the logic expects `TreeController` and so breaks in cases when not inheriting from it.

It transpires the cast causing the error is actually unnecessary, as the methods being accessed are part of `TreeControllerBase` and being inherited by `TreeController` anyway, so changing to cast to `TreeControllerBase` seems like a nice solution.