### PR TITLE
Add pagination to icon picker

### DIFF
--- a/src/Umbraco.Core/Services/IIconService.cs
+++ b/src/Umbraco.Core/Services/IIconService.cs
@@ -13,9 +13,15 @@ namespace Umbraco.Core.Services
         IconModel GetIcon(string iconName);
 
         /// <summary>
-        /// Gets a list of all svg icons found at at the global icons path.
+        /// Gets a list of all svg icons found at the global icons path.
         /// </summary>
         /// <returns></returns>
         IList<IconModel> GetAllIcons();
+
+        /// <summary>
+        /// Gets a paged list of svg icons found at the global icons path.
+        /// </summary>
+        /// <returns></returns>
+        IList<IconModel> GetPagedIcons(int pageNumber, int pageSize, string filter = "");
     }
 }

--- a/src/Umbraco.Core/Services/IIconService.cs
+++ b/src/Umbraco.Core/Services/IIconService.cs
@@ -22,6 +22,6 @@ namespace Umbraco.Core.Services
         /// Gets a paged list of svg icons found at the global icons path.
         /// </summary>
         /// <returns></returns>
-        IList<IconModel> GetPagedIcons(int pageNumber, int pageSize, string filter = "");
+        IList<IconModel> GetPagedIcons(int pageIndex, int pageSize, out long totalRecords, string filter = "");
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -292,6 +292,13 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                     $http.get(Umbraco.Sys.ServerVariables.umbracoUrls.iconApiBaseUrl + 'GetPagedIcons', qry)
                     , 'Failed to retrieve icons')
                     .then(icons => {
+
+                        if (icons) {
+                            icons.items.forEach(icon => {
+                                this.defineIcon(icon.Name, icon.SvgString);
+                            });
+                        }
+
                         resolve(icons);
                     })
                     .catch(err => {
@@ -351,7 +358,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
         /** Creates a icon object, and caches it in a runtime cache */
         defineIcon: function(name, svg) {
             var icon = iconCache.find(x => x.name === name);
-            if(icon === undefined) {
+            if (icon === undefined) {
                 icon = {
                     name: name,
                     svgString: $sce.trustAsHtml(svg)

--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -224,8 +224,8 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                  }
             });
         },
-
-        /** Gets all the available icons in the backoffice icon folder and returns them as an array of IconModels */
+        
+         /** Gets all the available icons in the backoffice icon folder and returns them as an array of IconModels */
          getAllIcons: function() {
             return $q((resolve, reject) => {
                 if(allIconsRequested === false) {
@@ -247,6 +247,60 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                 } else {
                     resolve(iconCache);
                 }
+            });
+        },
+
+        getPagedIcons: function (options) {
+
+            var defaults = {
+                pageSize: 100,
+                pageNumber: 1,
+                filter: '',
+                orderDirection: "Ascending",
+                orderBy: "Name"
+            };
+            if (options === undefined) {
+                options = {};
+            }
+
+            // overwrite the defaults if there are any specified
+            Utilities.extend(defaults, options);
+
+            // now copy back to the options we will use
+            options = defaults;
+
+            // change asc/desc
+            if (options.orderDirection === "asc") {
+                options.orderDirection = "Ascending";
+            }
+            else if (options.orderDirection === "desc") {
+                options.orderDirection = "Descending";
+            }
+
+            var params = [
+                { pageNumber: options.pageNumber },
+                { pageSize: options.pageSize },
+                { orderBy: options.orderBy },
+                { orderDirection: options.orderDirection },
+                { filter: options.filter }
+            ];
+
+            var qry = umbRequestHelper.dictionaryToQueryString(params);
+
+            return $q((resolve, reject) => {
+                umbRequestHelper.resourcePromise(
+                    $http.get(Umbraco.Sys.ServerVariables.umbracoUrls.iconApiBaseUrl + 'GetPagedIcons', qry)
+                    , 'Failed to retrieve icons')
+                    .then(icons => {
+                        icons.forEach(icon => {
+                            this.defineIcon(icon.Name, icon.SvgString);
+                        });
+
+                        resolve(iconCache);
+                    })
+                    .catch(err => {
+                        console.warn(err);
+                    });
             });
         },
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -292,14 +292,7 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                     $http.get(Umbraco.Sys.ServerVariables.umbracoUrls.iconApiBaseUrl + 'GetPagedIcons', qry)
                     , 'Failed to retrieve icons')
                     .then(icons => {
-
-                        if (icons) {
-                            icons.items.forEach(icon => {
-                                this.defineIcon(icon.Name, icon.SvgString);
-                            });
-                        }
-
-                        resolve(iconCache);
+                        resolve(icons);
                     })
                     .catch(err => {
                         console.warn(err);

--- a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js
@@ -292,9 +292,12 @@ function iconHelper($http, $q, $sce, $timeout, umbRequestHelper) {
                     $http.get(Umbraco.Sys.ServerVariables.umbracoUrls.iconApiBaseUrl + 'GetPagedIcons', qry)
                     , 'Failed to retrieve icons')
                     .then(icons => {
-                        icons.forEach(icon => {
-                            this.defineIcon(icon.Name, icon.SvgString);
-                        });
+
+                        if (icons) {
+                            icons.items.forEach(icon => {
+                                this.defineIcon(icon.Name, icon.SvgString);
+                            });
+                        }
 
                         resolve(iconCache);
                     })

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
@@ -10,6 +10,9 @@ function IconPickerController($scope, localizationService, iconHelper) {
 
     var vm = this;
 
+    vm.options = {};
+
+    vm.changePageNumber = changePageNumber;
     vm.selectIcon = selectIcon;
     vm.selectColor = selectColor;
     vm.submit = submit;
@@ -43,7 +46,22 @@ function IconPickerController($scope, localizationService, iconHelper) {
 
         setTitle();
 
-        iconHelper.getAllIcons()
+        loadIcons();
+
+        // set a default color if nothing is passed in
+        vm.color = $scope.model.color ? findColor($scope.model.color) : vm.colors.find(x => x.default);
+
+        // if an icon is passed in - preselect it
+        vm.icon = $scope.model.icon ? $scope.model.icon : undefined;
+    }
+
+    function changePageNumber(pageNumber) {
+        vm.options.pageNumber = pageNumber;
+        loadIcons();
+    }
+
+    function loadIcons() {
+        iconHelper.getPagedIcons(vm.options)
             .then(icons => {
                 vm.icons = icons;
 
@@ -61,13 +79,6 @@ function IconPickerController($scope, localizationService, iconHelper) {
                         vm.loading = false;
                     });
             });
-
-        // set a default color if nothing is passed in
-        vm.color = $scope.model.color ? findColor($scope.model.color) : vm.colors.find(x => x.default);
-
-
-        // if an icon is passed in - preselect it
-        vm.icon = $scope.model.icon ? $scope.model.icon : undefined;
     }
 
     function setTitle() {
@@ -96,7 +107,7 @@ function IconPickerController($scope, localizationService, iconHelper) {
     }
 
     function close() {
-        if($scope.model && $scope.model.close) {
+        if ($scope.model && $scope.model.close) {
             $scope.model.close();
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
@@ -69,21 +69,24 @@ function IconPickerController($scope, localizationService, iconHelper) {
     function loadIcons() {
         iconHelper.getPagedIcons(vm.options)
             .then(icons => {
-                vm.icons = icons.items || [];
+                vm.icons = icons;
+                console.log("loadIcons", vm.icons);
 
                 // Get's legacy icons, removes duplicates then maps them to IconModel
-                iconHelper.getIcons()
-                    .then(icons => {
-                        if (icons && icons.length > 0) {
-                            let legacyIcons = icons
-                                .filter(icon => !vm.icons.find(x => x.name == icon))
-                                .map(icon => { return { name: icon, svgString: null }; });
+                //iconHelper.getIcons()
+                //    .then(icons => {
+                //        if (icons && icons.length > 0) {
+                //            let legacyIcons = icons
+                //                .filter(icon => !vm.icons.find(x => x.name == icon))
+                //                .map(icon => { return { name: icon, svgString: null }; });
 
-                            vm.icons = legacyIcons.concat(vm.icons);
-                        }
+                //            vm.icons = legacyIcons.concat(vm.icons);
+                //        }
 
-                        vm.loading = false;
-                    });
+                //        vm.loading = false;
+                //    });
+
+                vm.loading = false;
             });
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
@@ -10,13 +10,19 @@ function IconPickerController($scope, localizationService, iconHelper) {
 
     var vm = this;
 
-    vm.options = {};
-
     vm.changePageNumber = changePageNumber;
     vm.selectIcon = selectIcon;
     vm.selectColor = selectColor;
     vm.submit = submit;
     vm.close = close;
+
+    vm.options = {
+        pageNumber: 1,
+        pageSize: 100,
+        totalItems: 0,
+        totalPages: 0,
+        filter: ''
+    };
 
     vm.colors = [
         { name: "Black", value: "color-black", default: true },
@@ -52,7 +58,7 @@ function IconPickerController($scope, localizationService, iconHelper) {
         vm.color = $scope.model.color ? findColor($scope.model.color) : vm.colors.find(x => x.default);
 
         // if an icon is passed in - preselect it
-        vm.icon = $scope.model.icon ? $scope.model.icon : undefined;
+        vm.icon = $scope.model.icon ? $scope.model.icon : null;
     }
 
     function changePageNumber(pageNumber) {
@@ -63,7 +69,7 @@ function IconPickerController($scope, localizationService, iconHelper) {
     function loadIcons() {
         iconHelper.getPagedIcons(vm.options)
             .then(icons => {
-                vm.icons = icons;
+                vm.icons = icons.items || [];
 
                 // Get's legacy icons, removes duplicates then maps them to IconModel
                 iconHelper.getIcons()

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -20,7 +20,7 @@
                 <div class="umb-control-group">
                     <umb-search-filter
                         input-id="icon-search"
-                        model="searchTerm"
+                        model="vm.options.filter"
                         label-key="placeholders_filter"
                         text="Type to filter..."
                         css-class="w-100"
@@ -40,9 +40,9 @@
 
                 <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
-                <div class="umb-control-group" ng-show="!vm.loading && filtered.length > 0 ">
-                    <ul class="umb-iconpicker" ng-class="vm.color.value" ng-show="vm.icons">
-                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: searchTerm | orderBy:'name') track by $id(icon)">
+                <div class="umb-control-group" ng-show="!vm.loading && vm.icons.length > 0 ">
+                    <ul class="umb-iconpicker" ng-class="vm.color.value">
+                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in vm.icons track by $id(icon)">
                             <button type="button" title="{{icon.name}}" ng-click="vm.selectIcon(icon.name, vm.color.value)">
                                 <umb-icon class="umb-iconpicker-svg {{icon.name}} large" icon="{{icon.name}}"></umb-icon>
                                 <span class="sr-only"><localize key="buttons_select">Select</localize> {{icon.name}}</span>
@@ -51,11 +51,19 @@
                     </ul>
                 </div>
 
-                <umb-empty-state
-                    ng-if="filtered.length === 0"
-                    position="center">
+                <umb-empty-state ng-if="vm.icons.length === 0"
+                                 position="center">
                     <localize key="defaultdialogs_noIconsFound">No icons were found.</localize>
                 </umb-empty-state>
+
+                <!-- Pagination -->
+                <!--<div class="flex justify-center">
+                    <umb-pagination ng-if="model.relations.totalPages"
+                                    page-number="model.relations.pageNumber"
+                                    total-pages="model.relations.totalPages"
+                                    on-change="vm.changePageNumber(pageNumber)">
+                    </umb-pagination>
+                </div>-->
 
             </umb-box-content>
         </umb-box>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -40,9 +40,9 @@
 
                 <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
-                <div class="umb-control-group" ng-show="!vm.loading && vm.icons.length > 0 ">
+                <div class="umb-control-group" ng-show="!vm.loading && vm.icons.items.length > 0 ">
                     <ul class="umb-iconpicker" ng-class="vm.color.value">
-                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in vm.icons track by $id(icon)">
+                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in vm.icons.items track by $id(icon)">
                             <button type="button" title="{{icon.name}}" ng-click="vm.selectIcon(icon.name, vm.color.value)">
                                 <umb-icon class="umb-iconpicker-svg {{icon.name}} large" icon="{{icon.name}}"></umb-icon>
                                 <span class="sr-only"><localize key="buttons_select">Select</localize> {{icon.name}}</span>
@@ -51,19 +51,19 @@
                     </ul>
                 </div>
 
-                <umb-empty-state ng-if="vm.icons.length === 0"
+                <umb-empty-state ng-if="vm.icons.totalItems === 0"
                                  position="center">
                     <localize key="defaultdialogs_noIconsFound">No icons were found.</localize>
                 </umb-empty-state>
 
                 <!-- Pagination -->
-                <!--<div class="flex justify-center">
-                    <umb-pagination ng-if="model.relations.totalPages"
-                                    page-number="model.relations.pageNumber"
-                                    total-pages="model.relations.totalPages"
+                <div class="flex justify-center">
+                    <umb-pagination ng-if="model.icons.totalPages"
+                                    page-number="model.icons.pageNumber"
+                                    total-pages="model.icons.totalPages"
                                     on-change="vm.changePageNumber(pageNumber)">
                     </umb-pagination>
-                </div>-->
+                </div>
 
             </umb-box-content>
         </umb-box>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -58,9 +58,9 @@
 
                 <!-- Pagination -->
                 <div class="flex justify-center">
-                    <umb-pagination ng-if="model.icons.totalPages"
-                                    page-number="model.icons.pageNumber"
-                                    total-pages="model.icons.totalPages"
+                    <umb-pagination ng-if="vm.icons.totalPages"
+                                    page-number="vm.icons.pageNumber"
+                                    total-pages="vm.icons.totalPages"
                                     on-change="vm.changePageNumber(pageNumber)">
                     </umb-pagination>
                 </div>

--- a/src/Umbraco.Web/Editors/IconController.cs
+++ b/src/Umbraco.Web/Editors/IconController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Mvc;
@@ -27,12 +28,34 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
-        /// Gets a list of all svg icons found at at the global icons path.
+        /// Gets a list of all svg icons found at the global icons path.
         /// </summary>
         /// <returns></returns>
         public IList<IconModel> GetAllIcons()
         {
             return _iconService.GetAllIcons();
+        }
+
+        /// <summary>
+        /// Gets a paged result of svg icons found at the global icons path.
+        /// </summary>
+        /// <returns></returns>
+        public PagedResult<IconModel> GetPagedIcons(
+            int pageNumber = 1,
+            int pageSize = 100,
+            string filter = "")
+        {
+            if (pageSize <= 0 || pageNumber <= 0)
+            {
+                return new PagedResult<IconModel>(0, pageNumber, pageSize);
+            }
+
+            var icons = _iconService.GetPagedIcons(pageNumber - 1, pageSize, out long totalRecords, null, filter);
+
+            return new PagedResult<IconModel>(totalRecords, pageNumber, pageSize)
+            {
+                Items = icons
+            };
         }
     }
 }

--- a/src/Umbraco.Web/Editors/IconController.cs
+++ b/src/Umbraco.Web/Editors/IconController.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Web.Editors
                 return new PagedResult<IconModel>(0, pageNumber, pageSize);
             }
 
-            var icons = _iconService.GetPagedIcons(pageNumber - 1, pageSize, out long totalRecords, null, filter);
+            var icons = _iconService.GetPagedIcons(pageNumber - 1, pageSize, out long totalRecords, filter);
 
             return new PagedResult<IconModel>(totalRecords, pageNumber, pageSize)
             {

--- a/src/Umbraco.Web/Services/IconService.cs
+++ b/src/Umbraco.Web/Services/IconService.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Web.Services
         }
 
         /// <inheritdoc />
-        public IList<IconModel> GetPagedIcons(int pageNumber, int pageSize, string filter = "")
+        public IList<IconModel> GetPagedIcons(int pageIndex, int pageSize, out long totalRecords, string filter = "")
         {
             var icons = new List<IconModel>();
             var iconNames = GetIconNames();
@@ -49,7 +49,7 @@ namespace Umbraco.Web.Services
                 ? iconNames.Where(x => x.Name.InvariantContains(filter))
                 : iconNames;
 
-            filtered.OrderBy(f => f.Name).Skip(pageSize * (pageNumber - 1)).Take(pageSize).ToList().ForEach(iconInfo =>
+            filtered.OrderBy(f => f.Name).Skip(pageSize * pageIndex).Take(pageSize).ToList().ForEach(iconInfo =>
             {
                 var icon = GetIcon(iconInfo);
 
@@ -58,6 +58,8 @@ namespace Umbraco.Web.Services
                     icons.Add(icon);
                 }
             });
+
+            totalRecords = icons.Count;
 
             return icons;
         }

--- a/src/Umbraco.Web/Services/IconService.cs
+++ b/src/Umbraco.Web/Services/IconService.cs
@@ -24,10 +24,32 @@ namespace Umbraco.Web.Services
         public IList<IconModel> GetAllIcons()
         {
             var icons = new List<IconModel>();
-            var directory = new DirectoryInfo(IOHelper.MapPath($"{_globalSettings.IconsPath}/"));
-            var iconNames = directory.GetFiles("*.svg");
+            var iconNames = GetIconNames();
 
             iconNames.OrderBy(f => f.Name).ToList().ForEach(iconInfo =>
+            {
+                var icon = GetIcon(iconInfo);
+
+                if (icon != null)
+                {
+                    icons.Add(icon);
+                }
+            });
+
+            return icons;
+        }
+
+        /// <inheritdoc />
+        public IList<IconModel> GetPagedIcons(int pageNumber, int pageSize, string filter = "")
+        {
+            var icons = new List<IconModel>();
+            var iconNames = GetIconNames();
+
+            var filtered = !string.IsNullOrEmpty(filter)
+                ? iconNames.Where(x => x.Name.InvariantContains(filter))
+                : iconNames;
+
+            filtered.OrderBy(f => f.Name).Skip(pageSize * (pageNumber - 1)).Take(pageSize).ToList().ForEach(iconInfo =>
             {
                 var icon = GetIcon(iconInfo);
 
@@ -46,6 +68,18 @@ namespace Umbraco.Web.Services
             return string.IsNullOrWhiteSpace(iconName)
                 ? null
                 : CreateIconModel(iconName.StripFileExtension(), IOHelper.MapPath($"{_globalSettings.IconsPath}/{iconName}.svg"));
+        }
+
+        /// <summary>
+        /// Gets svg icon names from directory
+        /// </summary>
+        /// <returns></returns>
+        private FileInfo[] GetIconNames()
+        {
+            var directory = new DirectoryInfo(IOHelper.MapPath($"{_globalSettings.IconsPath}/"));
+            var iconNames = directory.GetFiles("*.svg");
+
+            return iconNames;
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9352

### Description
When having a lot of icons, either font icons of SVG icons, the icon picker can be slow and cause memory issues, because a lot of icons is rendered and filtered in the DOM. Instead we should fetch a paged list of icons, e.g. 100 per page.