### PR TITLE
Ensure that upload file in the MediaPicker is returned instead of las…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -330,7 +330,7 @@ angular.module("umbraco")
                             var images = _.rest($scope.images, $scope.images.length - files.length);
                             images.forEach(image => selectMedia(image));
                         } else {
-                            var image = $scope.images[$scope.images.length - 1];
+                            var image = _.sortBy($scope.images, 'id').reverse()[0];
                             clickHandler(image);
                         }
                     });


### PR DESCRIPTION
…t file in folder

When you use another sorting for Media items than the default (we sort Media-items automatically by name alphabetically when they are created/uploaded), the onUploadComplete function doesn't return the last the last uploaded file. Instead is returns the last filename. By sorting the files by Id, it ensures that the last added file is returned instead of the last file in the list.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
