### PR TITLE
Ensure that upload file(s) in the MediaPicker is returned

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -327,10 +327,10 @@ angular.module("umbraco")
                 gotoFolder($scope.currentFolder).then(function () {
                     $timeout(function () {
                         if ($scope.multiPicker) {
-                            var images = _.rest($scope.images, $scope.images.length - files.length);
+                            var images = _.rest(_.sortBy($scope.images, 'id'), $scope.images.length - files.length);
                             images.forEach(image => selectMedia(image));
                         } else {
-                            var image = $scope.images[$scope.images.length - 1];
+                            var image = _.sortBy($scope.images, 'id')[$scope.images.length - 1];
                             clickHandler(image);
                         }
                     });


### PR DESCRIPTION
The onUploadComplete function returns the last files that are added to a mediafolder. While this works correct by default and in most situations, it doesn't work as expected when a diffrent sorting is used for Media-items. For example, we've added events to sort Media-items automatically by name alphabetically when they are created/uploaded to keep them better organised. 
By sorting the $scope.files array by the Id-property, it ensures that the function returns the uploaded files, instead of the last files in the folder.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
