### PR TITLE
Block list editor validation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -26,11 +26,11 @@
             </div>
         </div>
 
-        <button ng-if="vm.loading !== true"
+        <button type="button"
                 id="{{vm.model.alias}}"
-                type="button"
                 class="btn-reset umb-block-list__create-button umb-outline"
                 ng-class="{ '--disabled': vm.availableBlockTypes.length === 0 }"
+                ng-if="vm.loading !== true"
                 ng-click="vm.showCreateDialog(vm.layout.length, $event)">
             <localize key="grid_addElement">Add content</localize>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -38,13 +38,13 @@
         <input type="hidden" name="minCount" ng-model="vm.layout" val-server="minCount" />
         <input type="hidden" name="maxCount" ng-model="vm.layout" val-server="maxCount" />
 
-        <div ng-messages="vm.propertyForm.minCount.$error">
+        <div ng-messages="vm.propertyForm.minCount.$error" show-validation-on-submit>
             <div class="help text-error" ng-message="minCount">
                 <localize key="validation_entriesShort" tokens="[vm.validationLimit.min, vm.validationLimit.min - vm.layout.length]" watch-tokens="true">Minimum %0% entries, needs <strong>%1%</strong> more.</localize>
             </div>
             <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.minCount.errorMsg">></span>
         </div>
-        <div ng-messages="vm.propertyForm.maxCount.$error">
+        <div ng-messages="vm.propertyForm.maxCount.$error" show-validation-on-submit>
             <div class="help text-error" ng-message="maxCount">
                 <localize key="validation_entriesExceed" tokens="[vm.validationLimit.max, vm.layout.length - vm.validationLimit.max]" watch-tokens="true">Maximum %0% entries, <strong>%1%</strong> too many.</localize>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -35,17 +35,50 @@
             <localize key="grid_addElement">Add content</localize>
         </button>
 
+        <div class="umb-contentpicker__min-max-help" ng-if="vm.validationLimit && (vm.validationLimit.max > 1 || vm.validationLimit.min > 0)">
+
+            <!-- Both min and max items -->
+            <span ng-if="vm.validationLimit.min && vm.validationLimit.max && vm.validationLimit.min !== vm.validationLimit.max">
+                <span ng-if="vm.layout.length < vm.validationLimit.max">Add between {{vm.validationLimit.min}} and {{vm.validationLimit.max}} items</span>
+                <span ng-if="vm.layout.length > vm.validationLimit.max">
+                    <localize key="validation_maxCount">You can only have</localize> {{vm.validationLimit.max}} <localize key="validation_itemsSelected"> items selected</localize>
+                </span>
+            </span>
+
+            <!-- Equal min and max -->
+            <span ng-if="vm.validationLimit.min && vm.validationLimit.max && vm.validationLimit.min === vm.validationLimit.max">
+                <span ng-if="vm.layout.length < vm.validationLimit.max">Add {{vm.validationLimit.min - vm.layout.length}} item(s)</span>
+                <span ng-if="vm.layout.length > vm.validationLimit.max">
+                    <localize key="validation_maxCount">You can only have</localize> {{vm.validationLimit.max}} <localize key="validation_itemsSelected"> items selected</localize>
+                </span>
+            </span>
+
+            <!-- Only max -->
+            <span ng-if="!vm.validationLimit.min && vm.validationLimit.max">
+                <span ng-if="vm.layout.length < vm.validationLimit.max">Add up to {{vm.validationLimit.max}} items</span>
+                <span ng-if="vm.layout.length > vm.validationLimit.max">
+                    <localize key="validation_maxCount">You can only have</localize> {{vm.validationLimit.max}} <localize key="validation_itemsSelected">items selected</localize>
+                </span>
+            </span>
+
+            <!-- Only min -->
+            <span ng-if="vm.validationLimit.min && !vm.validationLimit.max && vm.layout.length < vm.validationLimit.min">
+                Add at least {{vm.validationLimit.min}} item(s)
+            </span>
+
+        </div>
+
         <input type="hidden" name="minCount" ng-model="vm.layout" val-server="minCount" />
         <input type="hidden" name="maxCount" ng-model="vm.layout" val-server="maxCount" />
 
         <div ng-messages="vm.propertyForm.minCount.$error" show-validation-on-submit>
-            <div class="help text-error" ng-message="minCount">
+            <div class="help" ng-message="minCount">
                 <localize key="validation_entriesShort" tokens="[vm.validationLimit.min, vm.validationLimit.min - vm.layout.length]" watch-tokens="true">Minimum %0% entries, needs <strong>%1%</strong> more.</localize>
             </div>
             <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.minCount.errorMsg">></span>
         </div>
         <div ng-messages="vm.propertyForm.maxCount.$error" show-validation-on-submit>
-            <div class="help text-error" ng-message="maxCount">
+            <div class="help" ng-message="maxCount">
                 <localize key="validation_entriesExceed" tokens="[vm.validationLimit.max, vm.layout.length - vm.validationLimit.max]" watch-tokens="true">Maximum %0% entries, <strong>%1%</strong> too many.</localize>
             </div>
             <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.maxCount.errorMsg"></span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.PropertyEditors.ContentPickerController" class="umb-property-editor umb-contentpicker">
 
-    <p ng-if="(renderModel|filter:{trashed:true}).length == 1"><localize key="contentPicker_pickedTrashedItem"></localize></p>
-    <p ng-if="(renderModel|filter:{trashed:true}).length > 1"><localize key="contentPicker_pickedTrashedItems"></localize></p>
+    <p ng-if="(renderModel|filter:{trashed:true}).length == 1"><localize key="contentPicker_pickedTrashedItem">You have picked a content item currently deleted or in the recycle bin</localize></p>
+    <p ng-if="(renderModel|filter:{trashed:true}).length > 1"><localize key="contentPicker_pickedTrashedItems">You have picked content items currently deleted or in the recycle bin</localize></p>
 
     <ng-form name="contentPickerForm">
 
@@ -19,14 +19,12 @@
             </umb-node-preview>
         </div>
 
-        <button
-            ng-show="model.config.multiPicker === true && renderModel.length < model.config.maxNumber || renderModel.length === 0 || !model.config.maxNumber"
-            type="button"
-            class="umb-node-preview-add"
-            ng-click="openCurrentPicker()"
-            id="{{model.alias}}"
-            aria-label="{{model.label}}: {{labels.general_add}}"
-        >
+        <button type="button"
+                class="umb-node-preview-add"
+                id="{{model.alias}}"
+                ng-show="model.config.multiPicker === true && renderModel.length < model.config.maxNumber || renderModel.length === 0 || !model.config.maxNumber"
+                ng-click="openCurrentPicker()"
+                aria-label="{{model.label}}: {{labels.general_add}}">
             <localize key="general_add">Add</localize>
             <span class="sr-only">...</span>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -68,12 +68,12 @@
         <input type="hidden" name="minCount" ng-model="renderModel" />
         <input type="hidden" name="maxCount" ng-model="renderModel" />
 
-        <div ng-messages="contentPickerForm.minCount.$error" show-validation-on-submit >
+        <div ng-messages="contentPickerForm.minCount.$error" show-validation-on-submit>
             <div class="help-inline" ng-message="minCount">
                 <localize key="validation_minCount">You need to add at least</localize> {{model.config.minNumber}} <localize key="validation_items">items</localize>
             </div>
         </div>
-        <div ng-messages="contentPickerForm.maxCount.$error" show-validation-on-submit >
+        <div ng-messages="contentPickerForm.maxCount.$error" show-validation-on-submit>
             <div class="help-inline" ng-message="maxCount">
                 <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_itemsSelected">items selected</localize>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
@@ -1,8 +1,10 @@
 ﻿<div ng-controller="Umbraco.PropertyEditors.MultiUrlPickerController" class="umb-property-editor umb-contentpicker">
+
     <p ng-if="(renderModel|filter:{trashed:true}).length == 1"><localize key="contentPicker_pickedTrashedItem">You have picked a content item currently deleted or in the recycle bin</localize></p>
     <p ng-if="(renderModel|filter:{trashed:true}).length > 1"><localize key="contentPicker_pickedTrashedItems">You have picked content items currently deleted or in the recycle bin</localize></p>
-
+    
     <ng-form name="multiUrlPickerForm">
+
         <div ui-sortable="sortableOptions" ng-model="renderModel">
             <umb-node-preview ng-repeat="link in renderModel"
                               icon="link.icon"
@@ -17,10 +19,11 @@
             </umb-node-preview>
         </div>
 
-        <button ng-show="!model.config.maxNumber || renderModel.length < model.config.maxNumber"
-            type="button"
-            class="umb-node-preview-add"
-            ng-click="openLinkPicker()">
+        <button type="button"
+                class="umb-node-preview-add"
+                id="{{model.alias}}"
+                ng-show="!model.config.maxNumber || renderModel.length < model.config.maxNumber"
+                ng-click="openLinkPicker()">
             <span class="sr-only">{{ model.label }}:</span>
             <localize key="general_add">Add</localize>
             <span class="sr-only">url</span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
@@ -28,7 +28,6 @@
 
         <div class="umb-contentpicker__min-max-help">
 
-
             <!-- Both min and max items -->
             <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber !== model.config.maxNumber">
                 <span ng-if="renderModel.length < model.config.maxNumber">Add between {{model.config.minNumber}} and {{model.config.maxNumber}} items</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9351

### Description
This PR makes some adjustments to Block List editor, so validation message first is shown on submit as with Content Picker property editor (used for both content picker and MNTP) and Multi URL Picker property editor.

The Block List editor also shows the hint messages like the other property editors.

I think it would be great if the localized message wasn't splitted in mutliple keys but a single key using a token or handled in controller to deal with the singular/plural message.

Maybe we could even have a shared directive/component or some angular templates to handle this and easier to re-use in the different property editors. Perhaps an option to overwrite the default message for each of these validation messages?

For now I think this is more consistent with e.g. Content Picker, MNTP and Multi URL Picker.

![image](https://user-images.githubusercontent.com/2919859/98593747-ea57d280-22d3-11eb-923b-9accc5e5eec5.png)
