### PR TITLE
Ensure it is possible to replace media via drag and drop

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
@@ -10,25 +10,29 @@
 function umbFileUpload() {
     return {
         restrict: "A",
-        scope: true,        //create a new scope
+        scope: true, // create a new scope
         link: function (scope, el, attrs) {
             el.on('change', function (event) {
                 var files = event.target.files;
-                //emit event upward
+                // emit event upward
                 scope.$emit("filesSelected", { files: files });
-                //clear the element value - this allows us to pick the same file again and again
+                // clear the element value - this allows us to pick the same file again and again
                 el.val('');
-            });
-
-            el.on('drag dragstart dragend dragover dragenter dragleave drop', function (e) {
-                e.preventDefault();
-                e.stopPropagation();
+            })
+            .on('drag dragstart dragend dragover dragenter dragleave drop', function (event) {
+                event.preventDefault();
+                event.stopPropagation();
             })
             .on('dragover dragenter', function () {
                 scope.$emit("isDragover", { value: true });
             })
             .on('dragleave dragend drop', function () {
                 scope.$emit("isDragover", { value: false });
+            })
+            .on('drop', function (event) {
+                var files = event.originalEvent.dataTransfer.files;
+
+                scope.$emit("filesSelected", { files: files });
             });
         }
     };

--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -60,6 +60,7 @@
                     <!-- label-key="buttons_save" -->
                     <umb-button alias="save"
                                 type="button"
+                                action="save()"
                                 button-style="success"
                                 state="page.saveButtonState"
                                 label-key="{{page.submitButtonLabelKey}}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9342

### Description
This PR make some changes to this previous PR https://github.com/umbraco/Umbraco-CMS/pull/8390 where it seems the `onFilesSelected` function in `umbPropertyFileUpload` component wasn't triggered after in drop event via drag and drop, but triggered via the change event, when clicking the button.

However with latest changes in `v8/contrib` I did need to change the save button in media back to `type="submit"` to save the media, which was changed in this PR https://github.com/umbraco/Umbraco-CMS/pull/9019

