### PR TITLE
Fixes #6089 JsDiff.diffWords in Rollback freezes browser

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.controller.js
@@ -2,7 +2,7 @@
     "use strict";
 
     function RollbackController($scope, contentResource, localizationService, assetsService, dateHelper, userService) {
-        
+
         var vm = this;
 
         vm.rollback = rollback;
@@ -56,7 +56,7 @@
                 });
 
             });
-            
+
         }
 
         function changeLanguage(language) {
@@ -103,7 +103,7 @@
                             var timestampFormatted = dateHelper.getLocalDate(version.versionDate, currentUser.locale, 'LLL');
                             version.displayValue = timestampFormatted + ' - ' + version.versionAuthorName;
                             return version;
-                        }); 
+                        });
                     });
                 });
         }
@@ -146,7 +146,7 @@
                     var diffProperty = {
                         "alias": property.alias,
                         "label": property.label,
-                        "diff": JsDiff.diffWords(property.value, oldProperty.value),
+                        "diff": (property.isObject) ? JsDiff.diffJson(property.value, oldProperty.value) : JsDiff.diffWords(property.value, oldProperty.value),
                         "isObject": (property.isObject || oldProperty.isObject) ? true : false
                     };
 
@@ -163,7 +163,7 @@
 
             const nodeId = $scope.model.node.id;
             const versionId = vm.previousVersion.versionId;
-            const culture = $scope.model.node.variants.length > 1 ? vm.currentVersion.language.culture : null;            
+            const culture = $scope.model.node.variants.length > 1 ? vm.currentVersion.language.culture : null;
 
             return contentResource.rollback(nodeId, versionId, culture)
                 .then(data => {


### PR DESCRIPTION
As described in #6089 a large-ish diff for the Grid (and also for any other prop editor that stores JSON data) will kill a browser tab if you try to roll back.

The suggestion there to have a look at `diffJson` was a good one and very easy to implement since we already detect items as being a json blob versus stored text. I tested this with 150 paragraphs of text from https://baconipsum.com/ and saved the node a few times. Trying to do a rollback definitely killed by browser tab. After this fix, selecting a version to roll back to is really fast.

This doesn't fix all of the problems, it is still slow when you have many words in a regular textarea/RTE/etc. So that's an improvement that could be made at a later stage by capping the amount of words to do a diff on or something else. I think for now this will help people enough to be useful though.