### PR TITLE
Get CodeQL to only scan the relevant directories

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,9 @@ name: "Code scanning - action"
 
 on:
   push:
-    branches: [v8/contrib]
+    branches: [v8/contrib,v8/dev]
   pull_request:
     # The branches below must be a subset of the branches above
-    # SJ: Don't run on PR branches for now
-    # branches: [v8/contrib]
   schedule:
     - cron: '0 7 * * 2'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,16 @@
 name: "Code scanning - action"
-
+paths-ignore: 
+  - node_modules
+  - Umbraco.TestData
+  - Umbraco.Tests
+  - Umbraco.Tests.AcceptanceTest
+  - Umbraco.Tests.Benchmarks
+  - bin
+paths:
+  - src 
 on:
   push:
-    branches: [v8/none]
+    branches: [v8/contrib]
   pull_request:
     # The branches below must be a subset of the branches above
     # SJ: Don't run on PR branches for now

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,5 @@
 name: "Code scanning - action"
-paths-ignore: 
-  - node_modules
-  - Umbraco.TestData
-  - Umbraco.Tests
-  - Umbraco.Tests.AcceptanceTest
-  - Umbraco.Tests.Benchmarks
-  - bin
-paths:
-  - src 
+
 on:
   push:
     branches: [v8/contrib]
@@ -59,3 +51,13 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      paths-ignore: 
+        - node_modules
+        - Umbraco.TestData
+        - Umbraco.Tests
+        - Umbraco.Tests.AcceptanceTest
+        - Umbraco.Tests.Benchmarks
+        - bin
+      paths:
+        - src 
+

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,13 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
+    
+    - name: configure Pagefile
+      uses: al-cheb/configure-pagefile-action@v1.2
+      with:
+          minimum-size: 8GB
+          maximum-size: 32GB
+          
     - run: |
         echo "Run Umbraco-CMS build"
         pwsh -command .\build\build.ps1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,13 +51,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-      paths-ignore: 
-        - node_modules
-        - Umbraco.TestData
-        - Umbraco.Tests
-        - Umbraco.Tests.AcceptanceTest
-        - Umbraco.Tests.Benchmarks
-        - bin
-      paths:
-        - src 
+      with:
+        config-file: ./.github/codeql-config.yml
+
 

--- a/.github/workflows/codeql-config.yml
+++ b/.github/workflows/codeql-config.yml
@@ -1,0 +1,10 @@
+name: "CodeQL config"
+paths-ignore: 
+  - node_modules
+  - Umbraco.TestData
+  - Umbraco.Tests
+  - Umbraco.Tests.AcceptanceTest
+  - Umbraco.Tests.Benchmarks
+  - bin
+paths:
+  - src   


### PR DESCRIPTION
Turns out this was failing on at least the `node_modules` directory, so we'll try to ignore directories that are not relevant for building a release.