### PR TITLE
Speed up publish content query and reduce memory use by reducing array allocations for PublishedContent properties

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -33,15 +33,16 @@ namespace Umbraco.Web.PublishedCache.NuCache
             _urlSegment = ContentData.UrlSegment;
             IsPreviewing = ContentData.Published == false;
 
-            var properties = new List<IPublishedProperty>();
+            var properties = new IPublishedProperty[_contentNode.ContentType.PropertyTypes.Count()];
+            int i =0;
             foreach (var propertyType in _contentNode.ContentType.PropertyTypes)
             {
                 // add one property per property type - this is required, for the indexing to work
                 // if contentData supplies pdatas, use them, else use null
                 contentData.Properties.TryGetValue(propertyType.Alias, out var pdatas); // else will be null
-                properties.Add(new Property(propertyType, this, pdatas, _publishedSnapshotAccessor));
+                properties[i++] =new Property(propertyType, this, pdatas, _publishedSnapshotAccessor);
             }
-            PropertiesArray = properties.ToArray();
+            PropertiesArray = properties;
         }
 
         private string GetProfileNameById(int id)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A

### Description
What?
Change from using a list to using an array when we know the size of the array in advance.
Why?
Speed up publish content query and reduce memory use by reducing array allocations for PublishedContent properties.

How to test?
Existing tests pass.