### PR TITLE
Unversion - Configure & control which versions are cleaned up

### DIFF
--- a/src/Umbraco.Tests/Services/UnversionServiceTests.cs
+++ b/src/Umbraco.Tests/Services/UnversionServiceTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Web.Unversion;
+using Moq;
+
+namespace Umbraco.Tests.Services
+{
+    [TestFixture]
+    public class UnversionServiceTests
+    {
+        [Test]
+        public void GetVersions_Returns_Right_Based_On_Date()
+        {
+
+            var config = new UnversionConfigEntry() { MaxDays = 10 };
+
+            List<IContent> versions = new List<IContent>()
+            {
+                GetVersionMock(1, new DateTime(2019, 12, 10)).Object, // should be deleted
+                GetVersionMock(2, new DateTime(2019, 12, 19)).Object, // should be deleted
+                GetVersionMock(3, new DateTime(2019, 12, 20)).Object, // should be kept
+            };
+
+            var logger = Mock.Of<ILogger>();
+            var service = new UnversionService(null, logger, null, null);
+
+            var res = service.GetVersionsToDelete(versions, config, new DateTime(2019, 12, 30));
+
+            // Should have two versions to remove
+            Assert.IsTrue(res.Count == 2);
+
+            Assert.IsTrue(res.Contains(1));
+            Assert.IsTrue(res.Contains(2));
+
+            // Ensure we have not removed the version we want to keep
+            Assert.IsFalse(res.Contains(3));
+        }
+
+        [Test]
+        public void GetVersions_Returns_Right_Based_Max_Count()
+        {
+            var config = new UnversionConfigEntry() { MaxCount = 5 };
+
+            List<IContent> versions = new List<IContent>()
+            {
+                GetVersionMock(10, new DateTime(2019, 12, 10)).Object, // should be kept
+                GetVersionMock(20, new DateTime(2019, 12, 19)).Object, // should be kept
+                GetVersionMock(30, new DateTime(2019, 12, 20)).Object, // should be kept
+                GetVersionMock(40, new DateTime(2019, 12, 10)).Object, // should be kept
+                GetVersionMock(50, new DateTime(2019, 12, 19)).Object, // should be kept
+                GetVersionMock(60, new DateTime(2019, 12, 20)).Object, // should be deleted
+                GetVersionMock(70, new DateTime(2019, 12, 10)).Object, // should be deleted
+                GetVersionMock(80, new DateTime(2019, 12, 19)).Object, // should be deleted
+                GetVersionMock(90, new DateTime(2019, 12, 20)).Object, // should be deleted
+            };
+
+            var logger = Mock.Of<ILogger>();
+            var service = new UnversionService(null, logger, null, null);
+
+            var res = service.GetVersionsToDelete(versions, config, new DateTime(2019, 12, 30));
+
+            // Has 4 extra versions to remove (leaving the 5 max items we want)
+            Assert.IsTrue(res.Count == 4);            
+
+            // Ensure the list of IDs does not contain the versions we want to keep
+            Assert.IsFalse(res.Contains(10));
+            Assert.IsFalse(res.Contains(20));
+            Assert.IsFalse(res.Contains(30));
+            Assert.IsFalse(res.Contains(40));
+            Assert.IsFalse(res.Contains(50));
+
+            // These ones should be deleted
+            Assert.IsTrue(res.Contains(60));
+            Assert.IsTrue(res.Contains(70));
+            Assert.IsTrue(res.Contains(80));
+            Assert.IsTrue(res.Contains(90));            
+        }
+
+        private Mock<IContent> GetVersionMock(int versionId, DateTime updateDate)
+        {
+            var mock = new Mock<IContent>();
+            mock.Setup(x => x.VersionId).Returns(versionId);
+            mock.Setup(x => x.UpdateDate).Returns(updateDate);
+            return mock;
+        }
+    }
+}

--- a/src/Umbraco.Tests/Services/UnversionServiceTests.cs
+++ b/src/Umbraco.Tests/Services/UnversionServiceTests.cs
@@ -111,9 +111,91 @@ namespace Umbraco.Tests.Services
             Assert.IsFalse(res.Contains(30));
 
             // These ones should be deleted
+            Assert.IsTrue(res.Contains(40));
+            Assert.IsTrue(res.Contains(50));
+            Assert.IsTrue(res.Contains(60));
+            Assert.IsTrue(res.Contains(70));
+            Assert.IsTrue(res.Contains(80));
+            Assert.IsTrue(res.Contains(90));
+        }
+
+        [Test]
+        public void GetVersions_Returns_Right_Based_Min_Count_Greater_Than_Max_Count()
+        {
+            // We should always take biggest number & keep 5
+            var config = new UnversionConfigEntry() { MinCount = 5, MaxCount = 2 };
+
+            List<IContent> versions = new List<IContent>()
+            {
+                GetVersionMock(10, new DateTime(2019, 12, 10)).Object, // should be kept
+                GetVersionMock(20, new DateTime(2019, 12, 19)).Object, // should be kept
+                GetVersionMock(30, new DateTime(2019, 12, 20)).Object, // should be kept
+                GetVersionMock(40, new DateTime(2019, 12, 10)).Object, // should be kept
+                GetVersionMock(50, new DateTime(2019, 12, 19)).Object, // should be kept
+                GetVersionMock(60, new DateTime(2019, 12, 20)).Object, // should be deleted
+                GetVersionMock(70, new DateTime(2019, 12, 10)).Object, // should be deleted
+                GetVersionMock(80, new DateTime(2019, 12, 19)).Object, // should be deleted
+                GetVersionMock(90, new DateTime(2019, 12, 20)).Object, // should be deleted
+            };
+
+            var logger = Mock.Of<ILogger>();
+            var service = new UnversionService(null, logger, null, null);
+
+            var res = service.GetVersionsToDelete(versions, config, new DateTime(2019, 12, 30));
+
+            // Has 4 extra versions to remove (leaving the 5 min items we want)
+            Assert.IsTrue(res.Count == 4);
+
+            // Ensure the list of IDs does not contain the versions we want to keep
+            Assert.IsFalse(res.Contains(10));
+            Assert.IsFalse(res.Contains(20));
+            Assert.IsFalse(res.Contains(30));
             Assert.IsFalse(res.Contains(40));
             Assert.IsFalse(res.Contains(50));
+
+            // These ones should be deleted
             Assert.IsTrue(res.Contains(60));
+            Assert.IsTrue(res.Contains(70));
+            Assert.IsTrue(res.Contains(80));
+            Assert.IsTrue(res.Contains(90));
+        }
+
+        [Test]
+        public void GetVersions_Returns_Right_Based_Min_Count_Less_Than_Max_Count()
+        {
+            // We should always take biggest number & keep 6
+            var config = new UnversionConfigEntry() { MinCount = 2, MaxCount = 6 };
+
+            List<IContent> versions = new List<IContent>()
+            {
+                GetVersionMock(10, new DateTime(2019, 12, 10)).Object, // should be kept
+                GetVersionMock(20, new DateTime(2019, 12, 19)).Object, // should be kept
+                GetVersionMock(30, new DateTime(2019, 12, 20)).Object, // should be kept
+                GetVersionMock(40, new DateTime(2019, 12, 10)).Object, // should be kept
+                GetVersionMock(50, new DateTime(2019, 12, 19)).Object, // should be kept
+                GetVersionMock(60, new DateTime(2019, 12, 20)).Object, // should be kept
+                GetVersionMock(70, new DateTime(2019, 12, 10)).Object, // should be deleted
+                GetVersionMock(80, new DateTime(2019, 12, 19)).Object, // should be deleted
+                GetVersionMock(90, new DateTime(2019, 12, 20)).Object, // should be deleted
+            };
+
+            var logger = Mock.Of<ILogger>();
+            var service = new UnversionService(null, logger, null, null);
+
+            var res = service.GetVersionsToDelete(versions, config, new DateTime(2019, 12, 30));
+
+            // Has 3 extra versions to remove (leaving the 6 min items we want)
+            Assert.IsTrue(res.Count == 3);
+
+            // Ensure the list of IDs does not contain the versions we want to keep
+            Assert.IsFalse(res.Contains(10));
+            Assert.IsFalse(res.Contains(20));
+            Assert.IsFalse(res.Contains(30));
+            Assert.IsFalse(res.Contains(40));
+            Assert.IsFalse(res.Contains(50));
+            Assert.IsFalse(res.Contains(60));
+
+            // These ones should be deleted
             Assert.IsTrue(res.Contains(70));
             Assert.IsTrue(res.Contains(80));
             Assert.IsTrue(res.Contains(90));

--- a/src/Umbraco.Tests/Services/UnversionServiceTests.cs
+++ b/src/Umbraco.Tests/Services/UnversionServiceTests.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Moq;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Web.Unversion;
-using Moq;
 
 namespace Umbraco.Tests.Services
 {

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Services\MemberGroupServiceTests.cs" />
     <Compile Include="Services\MediaTypeServiceTests.cs" />
     <Compile Include="Services\PropertyValidationServiceTests.cs" />
+    <Compile Include="Services\UnversionServiceTests.cs" />
     <Compile Include="Templates\HtmlLocalLinkParserTests.cs" />
     <Compile Include="TestHelpers\RandomIdRamDirectory.cs" />
     <Compile Include="Testing\Objects\TestDataSource.cs" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -286,6 +286,7 @@
     <Content Include="Umbraco\Views\Preview\Index.cshtml" />
     <Content Include="Umbraco\Views\web.config" />
     <Content Include="Views\Partials\BlockList\Default.cshtml" />
+    <Content Include="Config\unversion.config" />
     <None Include="Web.Debug.config.transformed" />
     <None Include="web.Template.Debug.config">
       <DependentUpon>Web.Template.config</DependentUpon>

--- a/src/Umbraco.Web.UI/config/unversion.config
+++ b/src/Umbraco.Web.UI/config/unversion.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0"?>
+<unversionConfig>
+    <add docTypeAlias="newsPage" rootXpath="//newsIndex" maxDays="2" maxCount="10" />
+</unversionConfig>

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -302,6 +302,11 @@
     <Compile Include="UmbracoContextFactory.cs" />
     <Compile Include="UmbracoContextReference.cs" />
     <Compile Include="Mvc\UmbracoVirtualNodeByUdiRouteHandler.cs" />
+    <Compile Include="Unversion\IUnversionService.cs" />
+    <Compile Include="Unversion\UnversionComponent.cs" />
+    <Compile Include="Unversion\UnversionComposer.cs" />
+    <Compile Include="Unversion\UnversionConfig.cs" />
+    <Compile Include="Unversion\UnversionService.cs" />
     <Compile Include="ViewDataExtensions.cs" />
     <Compile Include="WebApi\Filters\AdminUsersAuthorizeAttribute.cs" />
     <Compile Include="WebApi\Filters\OnlyLocalRequestsAttribute.cs" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -307,6 +307,7 @@
     <Compile Include="Unversion\UnversionComposer.cs" />
     <Compile Include="Unversion\UnversionConfig.cs" />
     <Compile Include="Unversion\UnversionService.cs" />
+    <Compile Include="Unversion\UnversionTask.cs" />
     <Compile Include="ViewDataExtensions.cs" />
     <Compile Include="WebApi\Filters\AdminUsersAuthorizeAttribute.cs" />
     <Compile Include="WebApi\Filters\OnlyLocalRequestsAttribute.cs" />

--- a/src/Umbraco.Web/Unversion/IUnversionService.cs
+++ b/src/Umbraco.Web/Unversion/IUnversionService.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Core.Models;
+
+namespace Umbraco.Web.Unversion
+{
+    public interface IUnversionService
+    {
+        void Unversion(IContent content);
+    }
+}
+

--- a/src/Umbraco.Web/Unversion/UnversionComponent.cs
+++ b/src/Umbraco.Web/Unversion/UnversionComponent.cs
@@ -1,0 +1,35 @@
+﻿using Umbraco.Core.Composing;
+using Umbraco.Core.Events;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
+
+namespace Umbraco.Web.Unversion
+{
+    public class UnversionComponent : IComponent
+    {
+        private readonly IUnversionService unVersionService;
+
+        public UnversionComponent(IUnversionService _unVersionService)
+        {
+            unVersionService = _unVersionService;
+        }
+
+        public void Initialize()
+        {
+            ContentService.Published += ContentService_Published;
+        }
+
+        private void ContentService_Published(IContentService sender, ContentPublishedEventArgs e)
+        {
+            foreach (var content in e.PublishedEntities)
+            {
+                unVersionService.Unversion(content);
+            }
+        }
+
+        public void Terminate()
+        {
+            ContentService.Published -= ContentService_Published;
+        }
+    }
+}

--- a/src/Umbraco.Web/Unversion/UnversionComposer.cs
+++ b/src/Umbraco.Web/Unversion/UnversionComposer.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Composing;
+
+namespace Umbraco.Web.Unversion
+{
+    public class UnversionComposer : ICoreComposer
+    {
+        public void Compose(Composition composition)
+        {
+            composition.Register<IUnversionConfig, UnversionConfig>();
+            composition.Register<IUnversionService, UnversionService>();
+            composition.Components().Append<UnversionComponent>();
+        }
+    }
+}

--- a/src/Umbraco.Web/Unversion/UnversionConfig.cs
+++ b/src/Umbraco.Web/Unversion/UnversionConfig.cs
@@ -49,6 +49,7 @@ namespace Umbraco.Web.Unversion
                 {
                     var configEntry = new UnversionConfigEntry
                     {
+                        // If no doctype alias set on XML entry then its assume it's for all doctypes
                         DocTypeAlias = xmlConfigEntry.Attributes["docTypeAlias"] != null
                             ? xmlConfigEntry.Attributes["docTypeAlias"].Value
                             : AllDocumentTypesKey

--- a/src/Umbraco.Web/Unversion/UnversionConfig.cs
+++ b/src/Umbraco.Web/Unversion/UnversionConfig.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Web;
+using System.Xml;
+using Umbraco.Core.Logging;
+
+namespace Umbraco.Web.Unversion
+{
+    public class UnversionConfig : IUnversionConfig
+    {
+        public const string AllDocumentTypesKey = "$_ALL";
+        public IDictionary<string, List<UnversionConfigEntry>> ConfigEntries { get; set; }
+
+        private ILogger _logger;
+
+        public UnversionConfig(ILogger logger)
+        {
+            _logger = logger;
+
+            ConfigEntries = new Dictionary<string, List<UnversionConfigEntry>>();
+
+            try
+            {
+                var appPath = HttpRuntime.AppDomainAppPath;
+                var configFilePath = Path.Combine(appPath, @"config\unversion.config");
+                LoadXmlConfig(string.Concat(configFilePath));
+            }
+            catch (Exception e)
+            {
+                _logger.Error<UnversionConfig>(e, "Error when parsing unversion.config.");
+            }
+
+        }
+
+        private void LoadXmlConfig(string configPath)
+        {
+            if (!File.Exists(configPath))
+            {
+                _logger.Warn<UnversionConfig>("Couldn't find config file {configPath}", configPath);
+                return;
+            }
+
+            var xmlConfig = new XmlDocument();
+            xmlConfig.Load(configPath);
+
+            foreach (XmlNode xmlConfigEntry in xmlConfig.SelectNodes("/unversionConfig/add"))
+                if (xmlConfigEntry.NodeType == XmlNodeType.Element)
+                {
+                    var configEntry = new UnversionConfigEntry
+                    {
+                        DocTypeAlias = xmlConfigEntry.Attributes["docTypeAlias"] != null
+                            ? xmlConfigEntry.Attributes["docTypeAlias"].Value
+                            : AllDocumentTypesKey
+                    };
+
+                    if (xmlConfigEntry.Attributes["rootXpath"] != null)
+                        configEntry.RootXPath = xmlConfigEntry.Attributes["rootXpath"].Value;
+
+                    if (xmlConfigEntry.Attributes["maxDays"] != null)
+                        configEntry.MaxDays = Convert.ToInt32(xmlConfigEntry.Attributes["maxDays"].Value);
+
+                    if (xmlConfigEntry.Attributes["maxCount"] != null)
+                        configEntry.MaxCount = Convert.ToInt32(xmlConfigEntry.Attributes["maxCount"].Value);
+
+                    if (!ConfigEntries.ContainsKey(configEntry.DocTypeAlias))
+                        ConfigEntries.Add(configEntry.DocTypeAlias, new List<UnversionConfigEntry>());
+
+                    ConfigEntries[configEntry.DocTypeAlias].Add(configEntry);
+                }
+        }
+    }
+
+    public class UnversionConfigEntry
+    {
+        public UnversionConfigEntry()
+        {
+            MaxDays = MaxCount = int.MaxValue;
+        }
+
+        public string DocTypeAlias { get; set; }
+        public string RootXPath { get; set; }
+        public int MaxDays { get; set; }
+        public int MaxCount { get; set; }
+    }
+
+    public interface IUnversionConfig
+    {
+        IDictionary<string, List<UnversionConfigEntry>> ConfigEntries { get; }
+    }
+}

--- a/src/Umbraco.Web/Unversion/UnversionConfig.cs
+++ b/src/Umbraco.Web/Unversion/UnversionConfig.cs
@@ -63,6 +63,9 @@ namespace Umbraco.Web.Unversion
                     if (xmlConfigEntry.Attributes["maxCount"] != null)
                         configEntry.MaxCount = Convert.ToInt32(xmlConfigEntry.Attributes["maxCount"].Value);
 
+                    if (xmlConfigEntry.Attributes["minCount"] != null)
+                        configEntry.MinCount = Convert.ToInt32(xmlConfigEntry.Attributes["minCount"].Value);
+
                     if (!ConfigEntries.ContainsKey(configEntry.DocTypeAlias))
                         ConfigEntries.Add(configEntry.DocTypeAlias, new List<UnversionConfigEntry>());
 
@@ -75,13 +78,14 @@ namespace Umbraco.Web.Unversion
     {
         public UnversionConfigEntry()
         {
-            MaxDays = MaxCount = int.MaxValue;
+            MaxDays = MaxCount = MinCount = int.MaxValue;
         }
 
         public string DocTypeAlias { get; set; }
         public string RootXPath { get; set; }
         public int MaxDays { get; set; }
         public int MaxCount { get; set; }
+        public int MinCount { get; set; }
     }
 
     public interface IUnversionConfig

--- a/src/Umbraco.Web/Unversion/UnversionConfig.cs
+++ b/src/Umbraco.Web/Unversion/UnversionConfig.cs
@@ -79,7 +79,8 @@ namespace Umbraco.Web.Unversion
     {
         public UnversionConfigEntry()
         {
-            MaxDays = MaxCount = MinCount = int.MaxValue;
+            MaxDays = MaxCount = int.MaxValue;
+            MinCount = int.MinValue;
         }
 
         public string DocTypeAlias { get; set; }

--- a/src/Umbraco.Web/Unversion/UnversionService.cs
+++ b/src/Umbraco.Web/Unversion/UnversionService.cs
@@ -50,7 +50,6 @@ namespace Umbraco.Web.Unversion
 
                 // Check if RootXPath is configured
                 if (!string.IsNullOrEmpty(configEntry.RootXPath))
-                    // TODO: Fix in some otherway (Check with Soren on what he meant by this)
                     if (content.Level > 1 && content.ParentId > 0)
                     {
                         var ids = GetNodeIdsFromXpath(configEntry.RootXPath);

--- a/src/Umbraco.Web/Unversion/UnversionService.cs
+++ b/src/Umbraco.Web/Unversion/UnversionService.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Core.Logging;
+using System.Linq;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Web.Unversion
+{
+    public class UnversionService : IUnversionService
+    {
+        private readonly ILogger _logger;
+        private readonly IUmbracoContextFactory _context;
+        private readonly IContentService _contentService;
+        private IUnversionConfig _config;
+
+        public UnversionService(IUnversionConfig config, ILogger logger, IUmbracoContextFactory context, IContentService contentService)
+        {
+            _logger = logger;
+            _config = config;
+            _context = context;
+            _contentService = contentService;
+        }
+
+        public void Unversion(IContent content)
+        {
+            var configEntries = new List<UnversionConfigEntry>();
+
+            if (_config.ConfigEntries.ContainsKey(content.ContentType.Alias))
+                configEntries.AddRange(_config.ConfigEntries[content.ContentType.Alias]);
+
+            if (_config.ConfigEntries.ContainsKey(UnversionConfig.AllDocumentTypesKey))
+                configEntries.AddRange(_config.ConfigEntries[UnversionConfig.AllDocumentTypesKey]);
+
+            if (configEntries.Count <= 0)
+            {
+                _logger.Debug<UnversionService>("No unversion configuration found for type {alias}", content.ContentType.Alias);
+                return;
+            }
+
+            foreach (var configEntry in configEntries)
+            {
+                var isValid = true;
+
+                // Check the RootXPath if configured
+                if (!string.IsNullOrEmpty(configEntry.RootXPath))
+                    // TODO: Fix in some otherway
+                    if (content.Level > 1 && content.ParentId > 0)
+                    {
+                        var ids = GetNodeIdsFromXpath(configEntry.RootXPath);
+                        isValid = ids.Contains(content.ParentId);
+                    }
+
+                if (!isValid)
+                {
+                    _logger.Debug<UnversionService>("Configuration invalid, rootXPath must be {rootXPath}", configEntry.RootXPath);
+                    continue;
+                }
+
+                var allVersions = _contentService.GetVersionsSlim(content.Id, 0, int.MaxValue).ToList();
+
+                if (!allVersions.Any())
+                {
+                    _logger.Debug<UnversionService>("No versions of content {contentId} found", content.Id);
+                    continue;
+                }
+
+                var versionIdsToDelete = GetVersionsToDelete(allVersions, configEntry, DateTime.Now);
+
+                foreach (var vid in versionIdsToDelete)
+                {
+                    _logger.Debug<UnversionService>("Deleting version {versionId} of content {contentId}", vid, content.Id);
+                    _contentService.DeleteVersion(content.Id, vid, false);
+                }
+
+            }
+
+        }
+
+        /// <summary>
+        /// Iterates a list of IContent versions and returns items to be removed based on a configEntry.
+        /// </summary>
+        /// <param name="versions"></param>
+        /// <param name="configEntry"></param>
+        /// <param name="currentDateTime"></param>
+        /// <returns></returns>
+        public List<int> GetVersionsToDelete(List<IContent> versions, UnversionConfigEntry configEntry, DateTime currentDateTime)
+        {
+            var versionIdsToDelete = new List<int>();
+
+            var iterationCount = 0;
+
+
+            _logger.Debug<UnversionService>("Getting versions for config entry. {alias}, {maxCount}, {maxDays}, {rootXpath}", configEntry.DocTypeAlias, configEntry.MaxCount, configEntry.MaxDays, configEntry.RootXPath);
+
+            foreach (var version in versions)
+            {
+                iterationCount++;
+                _logger.Debug<UnversionService>("Comparing version {versionId}, iterationCount is {iterationCount}", version.VersionId, iterationCount);
+
+                // If we have a maxCount and the current iteration is above that max-count
+                if (configEntry.MaxCount > 0 && iterationCount > configEntry.MaxCount)
+                {
+                    _logger.Debug<UnversionService>("Remove version {versionId}, because iterationCount is {iterationCount} and max count is {maxCount}", version.VersionId, iterationCount, configEntry.MaxCount);
+                    versionIdsToDelete.Add(version.VersionId);
+                    // no need to compare dates since we've already added this version for deletion
+                    continue;
+                }
+
+                // If we have a max days and the current version is older
+                if (configEntry.MaxDays > 0 && configEntry.MaxDays != int.MaxValue)
+                {
+                    var dateRemoveBefore = currentDateTime.AddDays(0 - configEntry.MaxDays);
+                    if (version.UpdateDate < dateRemoveBefore)
+                    {
+                        _logger.Debug<UnversionService>("Remove version {versionId}, because version is updated {updateDate} and max days is {maxDays} (cutoff: {dateRemoveBefore})", version.VersionId, version.UpdateDate, configEntry.MaxDays, dateRemoveBefore);
+                        versionIdsToDelete.Add(version.VersionId);
+                    }
+                }
+
+            }
+
+            return versionIdsToDelete;
+
+        }
+
+        private List<int> GetNodeIdsFromXpath(string xpath)
+        {
+            using (var ctx = _context.EnsureUmbracoContext())
+            {
+                var nodes = ctx.UmbracoContext.Content.GetByXPath(xpath);
+
+                if (nodes == null)
+                    return new List<int>();
+
+                return nodes.Select(x => x.Id).ToList();
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Unversion/UnversionService.cs
+++ b/src/Umbraco.Web/Unversion/UnversionService.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using Umbraco.Core.Models;
-using Umbraco.Core.Logging;
 using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 
 namespace Umbraco.Web.Unversion

--- a/src/Umbraco.Web/Unversion/UnversionService.cs
+++ b/src/Umbraco.Web/Unversion/UnversionService.cs
@@ -104,7 +104,7 @@ namespace Umbraco.Web.Unversion
                 _logger.Debug<UnversionService>("Version:{VersionId} ContentUdi:{ContentUdi} IterationCount:{IterationCount}", version.VersionId, version.GetUdi(), iterationCount);
 
                 // If we have a minCount set and current iteration is LESS than min count
-                if(configEntry.MinCount > 0 && iterationCount < configEntry.MinCount)
+                if(configEntry.MinCount > 0 && iterationCount <= configEntry.MinCount)
                 {
                     // Do nothing apart from log it as we want to keep this version
                     _logger.Debug<UnversionService>("Keeping version {VersionId} for {ContentUdi} because item was required by MinCount. IterationCount: {IterationCount} MinValue: {MinCount}", version.VersionId, version.GetUdi(), iterationCount, configEntry.MinCount);
@@ -131,7 +131,19 @@ namespace Umbraco.Web.Unversion
                     {
                         _logger.Debug<UnversionService>("Mark this version to be removed {VersionId} for {ContentUdi} because version update date {UpdateDate} is less than the cuttoff date {DateRemoveBefore}", version.VersionId, version.GetUdi(), version.UpdateDate, dateRemoveBefore);
                         versionIdsToDelete.Add(version.VersionId);
+
+                        // Added to list stop carrying on
+                        continue;
                     }
+                }
+
+                // We have a mincount set and the iteration count is higher than the versions we want to keep
+                // AND we do NOT have MaxCount or MaxDays sets
+                // Thus we need to remove all other versions as we explicity only wanted to keep x min versions only
+                if(configEntry.MinCount > 0 && configEntry.MaxCount !> 0 && configEntry.MaxDays !> 0)
+                {
+                    _logger.Debug<UnversionService>("Mark this version to be removed {VersionId} for {ContentUdi} because we have all the versions we required for mincount and MaxDays nor MaxCount has been set in conjuction.", version.VersionId, version.GetUdi(), iterationCount, configEntry.MaxCount);
+                    versionIdsToDelete.Add(version.VersionId);
                 }
             }
 

--- a/src/Umbraco.Web/Unversion/UnversionService.cs
+++ b/src/Umbraco.Web/Unversion/UnversionService.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Web.Unversion
         private readonly IContentService _contentService;
         private IUnversionConfig _config;
 
+        // WB: Note do we want this service in Current.Services etc... ?!
         public UnversionService(IUnversionConfig config, ILogger logger, IUmbracoContextFactory context, IContentService contentService)
         {
             _logger = logger;

--- a/src/Umbraco.Web/Unversion/UnversionTask.cs
+++ b/src/Umbraco.Web/Unversion/UnversionTask.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Web.Scheduling;
+
+namespace Umbraco.Web.Unversion
+{
+
+    public class UnversionTask : RecurringTaskBase
+    {
+        private IRuntimeState _runtime;
+        private IProfilingLogger _logger;
+        private IContentService _contentService;
+        private IUnversionService _unversionService;
+
+        public UnversionTask(IBackgroundTaskRunner<RecurringTaskBase> runner, int delayBeforeWeStart, int howOftenWeRepeat, IRuntimeState runtime, IProfilingLogger logger, IContentService contentService, IUnversionService unversionService)
+            : base(runner, delayBeforeWeStart, howOftenWeRepeat)
+        {
+            _runtime = runtime;
+            _logger = logger;
+
+            _contentService = contentService;
+            _unversionService = unversionService;
+        }
+
+        public override bool PerformRun()
+        {
+            var allContent = new List<IContent>();
+
+            // Get all content nodes
+            // Worried this could be crap for performance...
+            var rootContent = _contentService.GetRootContent();
+            allContent.AddRange(rootContent);
+
+            // For each top level root node get its descendants
+            foreach (var rootNode in rootContent)
+            {
+                var pageIndex = 0;
+                var itemCount = 0;
+                long totalRecords;
+
+                // Keep paging through all descendants until we have no more to fetch
+                do
+                {
+                    var descendants = _contentService.GetPagedDescendants(rootNode.Id, pageIndex, 1, out totalRecords);
+
+                    pageIndex++;
+                    itemCount += descendants.Count();
+
+                    allContent.AddRange(descendants);
+                } while (itemCount < totalRecords);
+
+            }
+
+            // For each piece of content check if we need to unversion
+            foreach (var content in allContent)
+            {
+                _unversionService.Unversion(content);
+            }
+
+            // If we want to keep repeating - we need to return true
+            // But if we run into a problem/error & want to stop repeating - return false
+            return true;
+        }
+
+        public override bool IsAsync => false;
+    }
+}

--- a/src/Umbraco.Web/Unversion/UnversionTask.cs
+++ b/src/Umbraco.Web/Unversion/UnversionTask.cs
@@ -28,6 +28,12 @@ namespace Umbraco.Web.Unversion
 
         public override bool PerformRun()
         {
+            if (_runtime.ServerRole != Core.Sync.ServerRole.Master)
+            {
+                _logger.Debug<UnversionTask>("Unversion background task does not run when server role '{ServerRole}' is not Master", _runtime.ServerRole);
+                return true; // We return true to try again as the server role may change!
+            }
+
             var allContent = new List<IContent>();
 
             // Get all content nodes

--- a/src/Umbraco.Web/Unversion/UnversionTask.cs
+++ b/src/Umbraco.Web/Unversion/UnversionTask.cs
@@ -28,9 +28,9 @@ namespace Umbraco.Web.Unversion
 
         public override bool PerformRun()
         {
-            if (_runtime.ServerRole != Core.Sync.ServerRole.Master)
+            if (_runtime.ServerRole != Core.Sync.ServerRole.Master && _runtime.ServerRole != Core.Sync.ServerRole.Single)
             {
-                _logger.Debug<UnversionTask>("Unversion background task does not run when server role '{ServerRole}' is not Master", _runtime.ServerRole);
+                _logger.Debug<UnversionTask>("Unversion background task does not run when server role '{ServerRole}' is not Master or Single", _runtime.ServerRole);
                 return true; // We return true to try again as the server role may change!
             }
 


### PR DESCRIPTION
# Feature
This adds the ability to configure and determine how many versions of all document types to keep or to add more granular and specific rules.

This is done in a background task and is performed once a day every hour as opposed to the original Unversion package which is done via the published event of a content node.

## Note:
This is still **draft**. I need to finish the following:

- [ ] Documentation
- [ ] Ship a sensible example XML config file - perhaps with commented out rules
- [x] Add more unit tests for more configuration cases

### Thanks
A BIG thanks and kudos to @skttl to allowing us to the bulk of the Unversion source code into the CMS core codebase 👍 
Along with the original owners/writers of Unversion code @mattbrailsford & @leekelleher 
