### PR TITLE
Ensure that TaskScheduler.Default is used anywhere that ContinueWith is used, adds more debug logging to MainDom operations

### DIFF
--- a/src/Umbraco.Core/Logging/LoggingTaskExtension.cs
+++ b/src/Umbraco.Core/Logging/LoggingTaskExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Umbraco.Core.Logging
@@ -14,7 +15,12 @@ namespace Umbraco.Core.Logging
         /// </summary>
         public static Task LogErrors(this Task task, Action<string, Exception> logMethod)
         {
-            return task.ContinueWith(t => LogErrorsInner(t, logMethod), TaskContinuationOptions.OnlyOnFaulted);
+            return task.ContinueWith(
+                t => LogErrorsInner(t, logMethod),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                TaskScheduler.Default);
         }
 
         /// <summary>
@@ -26,7 +32,10 @@ namespace Umbraco.Core.Logging
         /// </summary>
         public static Task LogErrorsWaitable(this Task task, Action<string, Exception> logMethod)
         {
-            return task.ContinueWith(t => LogErrorsInner(t, logMethod));
+            return task.ContinueWith(
+                t => LogErrorsInner(t, logMethod),
+                // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                TaskScheduler.Default);
         }
 
         private static void LogErrorsInner(Task task, Action<string, Exception> logAction)

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -119,7 +119,12 @@ namespace Umbraco.Core.Runtime
 
             // Create a long running task (dedicated thread)
             // to poll to check if we are still the MainDom registered in the DB
-            return Task.Factory.StartNew(ListeningLoop, _cancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            return Task.Factory.StartNew(
+                ListeningLoop,
+                _cancellationTokenSource.Token,
+                TaskCreationOptions.LongRunning,
+                // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                TaskScheduler.Default); 
 
         }
 
@@ -147,12 +152,6 @@ namespace Umbraco.Core.Runtime
                     continue;
                 }
 
-                if (!_dbFactory.Configured)
-                {
-                    // if we aren't configured, we just keep looping since we can't query the db
-                    continue;
-                }
-
                 lock (_locker)
                 {
                     // If cancellation has been requested we will just exit. Depending on timing of the shutdown,
@@ -160,7 +159,11 @@ namespace Umbraco.Core.Runtime
                     // the other MainDom is taking to startup. In this case the db row will just be deleted and the
                     // new MainDom will just take over.
                     if (_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        _logger.Debug<SqlMainDomLock>("Task canceled, exiting loop");
                         return;
+                    }
+                        
 
                     using var db = _dbFactory.CreateDatabase();
                     using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
@@ -184,8 +187,10 @@ namespace Umbraco.Core.Runtime
                         // We need to keep on listening unless we've been notified by our own AppDomain to shutdown since
                         // we don't want to shutdown resources controlled by MainDom inadvertently. We'll just keep listening otherwise.
                         if (_cancellationTokenSource.IsCancellationRequested)
+                        {
+                            _logger.Debug<SqlMainDomLock>("Task canceled, exiting loop");
                             return;
-
+                        }
                     }
                     finally
                     {
@@ -369,6 +374,8 @@ namespace Umbraco.Core.Runtime
                 {
                     lock (_locker)
                     {
+                        _logger.Debug<SqlMainDomLock>($"{nameof(SqlMainDomLock)} Disposing...");
+
                         // immediately cancel all sub-tasks, we don't want them to keep querying
                         _cancellationTokenSource.Cancel();
                         _cancellationTokenSource.Dispose();

--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -1380,7 +1380,11 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 {
                     _collectTask = null;
                 }
-            }, TaskContinuationOptions.ExecuteSynchronously);
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+            TaskScheduler.Default);
             // ReSharper restore InconsistentlySynchronizedField
 
             return task;

--- a/src/Umbraco.Web/PublishedCache/NuCache/SnapDictionary.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/SnapDictionary.cs
@@ -380,7 +380,11 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 {
                     _collectTask = null;
                 }
-            }, TaskContinuationOptions.ExecuteSynchronously);
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+            TaskScheduler.Default);
             // ReSharper restore InconsistentlySynchronizedField
 
             return task;

--- a/src/Umbraco.Web/Scheduling/BackgroundTaskRunner.cs
+++ b/src/Umbraco.Web/Scheduling/BackgroundTaskRunner.cs
@@ -756,9 +756,17 @@ namespace Umbraco.Web.Scheduling
                 lock (_locker)
                 {
                     if (_runningTask != null)
-                        _runningTask.ContinueWith(_ => StopImmediate());
+                    {
+                        _runningTask.ContinueWith(
+                            _ => StopImmediate(),
+                            // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                            TaskScheduler.Default);
+                    }   
                     else
+                    {
                         StopImmediate();
+                    }
+                        
                 }
             }
 

--- a/src/Umbraco.Web/Scheduling/TaskAndFactoryExtensions.cs
+++ b/src/Umbraco.Web/Scheduling/TaskAndFactoryExtensions.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Web.Scheduling
     {
         #region Task Extensions
 
+        // TODO: Not used, is this used in Deploy or something?
         static void SetCompletionSource<TResult>(TaskCompletionSource<TResult> completionSource, Task task)
         {
             if (task.IsFaulted)
@@ -16,6 +17,7 @@ namespace Umbraco.Web.Scheduling
                 completionSource.SetResult(default(TResult));
         }
 
+        // TODO: Not used, is this used in Deploy or something?
         static void SetCompletionSource<TResult>(TaskCompletionSource<TResult> completionSource, Task<TResult> task)
         {
             if (task.IsFaulted)
@@ -24,17 +26,33 @@ namespace Umbraco.Web.Scheduling
                 completionSource.SetResult(task.Result);
         }
 
+        // TODO: Not used, is this used in Deploy or something?
         public static Task ContinueWithTask(this Task task, Func<Task, Task> continuation)
         {
             var completionSource = new TaskCompletionSource<object>();
-            task.ContinueWith(atask => continuation(atask).ContinueWith(atask2 => SetCompletionSource(completionSource, atask2)));
+            task.ContinueWith(atask => continuation(atask).ContinueWith(
+                    atask2 => SetCompletionSource(completionSource, atask2),
+                    // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                    TaskScheduler.Default),
+                // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                TaskScheduler.Default);
             return completionSource.Task;
         }
 
+        // TODO: Not used, is this used in Deploy or something?
         public static Task ContinueWithTask(this Task task, Func<Task, Task> continuation, CancellationToken token)
         {
             var completionSource = new TaskCompletionSource<object>();
-            task.ContinueWith(atask => continuation(atask).ContinueWith(atask2 => SetCompletionSource(completionSource, atask2), token), token);
+            task.ContinueWith(atask => continuation(atask).ContinueWith(
+                    atask2 => SetCompletionSource(completionSource, atask2),
+                    token,
+                    TaskContinuationOptions.None,
+                    // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                    TaskScheduler.Default),
+                token,
+                TaskContinuationOptions.None,
+                // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                TaskScheduler.Default);
             return completionSource.Task;
         }
 

--- a/src/Umbraco.Web/WebApi/HttpActionContextExtensions.cs
+++ b/src/Umbraco.Web/WebApi/HttpActionContextExtensions.cs
@@ -89,7 +89,9 @@ namespace Umbraco.Web.WebApi
                         throw x.Exception;
                     }
                     result = x.ConfigureAwait(false).GetAwaiter().GetResult();
-                });
+                },
+                // Must explicitly specify this, see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html
+                TaskScheduler.Default);
             task.Wait();
 
             if (result == null)


### PR DESCRIPTION
Ensure that TaskScheduler.Default is used anywhere that ContinueWith is used and adds more debug logging to MainDom operations.

ContinueWith should always have `TaskScheduler.Default` explicitly declared. There's a few instances in the codebase where this is not the case. It hasn't caused problems in the past that we know about but it is the safe thing to do. For more reading see https://blog.stephencleary.com/2013/10/continuewith-is-dangerous-too.html

This adds a little bit more debug logging to MainDom. This is for debugging purposes only because there's one known site where MainDom shuts down without the application being shutdown and without any SqlMainDomLock logging taking place which is truly odd. 

## Testing

* Configure your site to use SqlMainDomLock
* Add this logging config to your serilog.config
   ```
   <add key="serilog:minimum-level:override:Umbraco.Core.Runtime.MainDom" value="Debug" />
   <add key="serilog:minimum-level:override:Umbraco.Core.Runtime.SqlMainDomLock" value="Debug" />
   ```
* Test restarting your running app by bumping the web.config, etc... 
* Check the logs during restart MainDom should show it's being signaled, shutdown and acquired each time like normal