### PR TITLE
Support more primitives in nucache

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
@@ -13,6 +13,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         private byte[] _bytes;
         private string _str;
         private readonly object _locker;
+        private bool _isDecompressed;
 
         /// <summary>
         /// Constructor
@@ -22,7 +23,8 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         {
             _locker = new object();
             _bytes = bytes;
-            _str = null;            
+            _str = null;
+            _isDecompressed = false;
         }
 
         public byte[] GetBytes()
@@ -30,6 +32,10 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             if (_bytes == null)
                 throw new InvalidOperationException("The bytes have already been expanded");
             return _bytes;
+        }
+        public bool IsDecompressed()
+        {
+            return _isDecompressed;
         }
 
         public override string ToString()
@@ -41,6 +47,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                 if (_bytes == null) throw new PanicException("Bytes have already been cleared");
                 _str = Encoding.UTF8.GetString(LZ4Pickler.Unpickle(_bytes));
                 _bytes = null;
+                _isDecompressed = true;
             }
             return _str;
         }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/LazyCompressedString.cs
@@ -33,10 +33,11 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                 throw new InvalidOperationException("The bytes have already been expanded");
             return _bytes;
         }
-        public bool IsDecompressed()
-        {
-            return _isDecompressed;
-        }
+        /// <summary>
+        /// Whether the bytes have been decompressed to a string. If true calling GetBytes() will throw InvalidOperationException.
+        /// </summary>
+        public bool IsDecompressed => _isDecompressed;
+        
 
         public override string ToString()
         {

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
@@ -48,17 +48,17 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 
         public ContentCacheDataModel Deserialize(int contentTypeId, string stringData, byte[] byteData)
         {
-            if (stringData != null)
+            if (byteData != null)
+            {
+                var content = MessagePackSerializer.Deserialize<ContentCacheDataModel>(byteData, _options);
+                Expand(contentTypeId, content);
+                return content;
+            }
+            else if (stringData != null)
             {
                 // NOTE: We don't really support strings but it's possible if manually used (i.e. tests)
                 var bin = Convert.FromBase64String(stringData);
                 var content = MessagePackSerializer.Deserialize<ContentCacheDataModel>(bin, _options);
-                Expand(contentTypeId, content);
-                return content;
-            }
-            else if (byteData != null)
-            {
-                var content = MessagePackSerializer.Deserialize<ContentCacheDataModel>(byteData, _options);
                 Expand(contentTypeId, content);
                 return content;
             }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
@@ -172,7 +172,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             }
             else if (value is LazyCompressedString lazyCompressedString)
             {
-                if (lazyCompressedString.IsDecompressed())
+                if (lazyCompressedString.IsDecompressed)
                 {
                     PrimitiveSerializer.Char.WriteTo(PrefixString, stream);
                     PrimitiveSerializer.String.WriteTo(lazyCompressedString, stream);

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
@@ -172,8 +172,16 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             }
             else if (value is LazyCompressedString lazyCompressedString)
             {
-                PrimitiveSerializer.Char.WriteTo(PrefixCompressedStringByteArray, stream);
-                PrimitiveSerializer.Bytes.WriteTo(lazyCompressedString.GetBytes(), stream);
+                if (lazyCompressedString.IsDecompressed())
+                {
+                    PrimitiveSerializer.Char.WriteTo(PrefixString, stream);
+                    PrimitiveSerializer.String.WriteTo(lazyCompressedString, stream);
+                }
+                else
+                {
+                    PrimitiveSerializer.Char.WriteTo(PrefixCompressedStringByteArray, stream);
+                    PrimitiveSerializer.Bytes.WriteTo(lazyCompressedString.GetBytes(), stream);
+                }
             }
             else if (value is sbyte signedByteValue)
             {

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
@@ -4,7 +4,7 @@ using CSharpTest.Net.Serialization;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    internal abstract class SerializerBase
+    public abstract class SerializerBase
     {
         private const char PrefixNull = 'N';
         private const char PrefixString = 'S';
@@ -18,6 +18,12 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         private const char PrefixByte = 'O';
         private const char PrefixByteArray = 'A';
         private const char PrefixCompressedStringByteArray = 'C';
+        private const char PrefixSignedByte = 'E';
+        private const char PrefixBool = 'M';
+        private const char PrefixGuid = 'G';
+        private const char PrefixTimeSpan = 'T';
+        private const char PrefixInt16 = 'Q';
+        private const char PrefixChar = 'R';
 
         protected string ReadString(Stream stream) => PrimitiveSerializer.String.ReadFrom(stream);
         protected int ReadInt(Stream stream) => PrimitiveSerializer.Int32.ReadFrom(stream);
@@ -86,6 +92,18 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                     return PrimitiveSerializer.DateTime.ReadFrom(stream);
                 case PrefixByteArray:
                     return PrimitiveSerializer.Bytes.ReadFrom(stream);
+                case PrefixSignedByte:
+                    return PrimitiveSerializer.SByte.ReadFrom(stream);
+                case PrefixBool:
+                    return PrimitiveSerializer.Boolean.ReadFrom(stream);
+                case PrefixGuid:
+                    return PrimitiveSerializer.Guid.ReadFrom(stream);
+                case PrefixTimeSpan:
+                    return PrimitiveSerializer.TimeSpan.ReadFrom(stream);
+                case PrefixInt16:
+                    return PrimitiveSerializer.Int16.ReadFrom(stream);
+                case PrefixChar:
+                    return PrimitiveSerializer.Char.ReadFrom(stream);
                 case PrefixCompressedStringByteArray:
                     return new LazyCompressedString(PrimitiveSerializer.Bytes.ReadFrom(stream));
                 default:
@@ -156,6 +174,36 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             {
                 PrimitiveSerializer.Char.WriteTo(PrefixCompressedStringByteArray, stream);
                 PrimitiveSerializer.Bytes.WriteTo(lazyCompressedString.GetBytes(), stream);
+            }
+            else if (value is sbyte signedByteValue)
+            {
+                PrimitiveSerializer.Char.WriteTo(PrefixSignedByte, stream);
+                PrimitiveSerializer.SByte.WriteTo(signedByteValue, stream);
+            }
+            else if (value is bool boolValue)
+            {
+                PrimitiveSerializer.Char.WriteTo(PrefixBool, stream);
+                PrimitiveSerializer.Boolean.WriteTo(boolValue, stream);
+            }
+            else if (value is Guid guidValue)
+            {
+                PrimitiveSerializer.Char.WriteTo(PrefixGuid, stream);
+                PrimitiveSerializer.Guid.WriteTo(guidValue, stream);
+            }
+            else if (value is TimeSpan timespanValue)
+            {
+                PrimitiveSerializer.Char.WriteTo(PrefixTimeSpan, stream);
+                PrimitiveSerializer.TimeSpan.WriteTo(timespanValue, stream);
+            }
+            else if (value is short int16Value)
+            {
+                PrimitiveSerializer.Char.WriteTo(PrefixInt16, stream);
+                PrimitiveSerializer.Int16.WriteTo(int16Value, stream);
+            }
+            else if (value is char charValue)
+            {
+                PrimitiveSerializer.Char.WriteTo(PrefixChar, stream);
+                PrimitiveSerializer.Char.WriteTo(charValue, stream);
             }
             else
                 throw new NotSupportedException("Value type " + value.GetType().FullName + " cannot be serialized.");

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/SerializerBase.cs
@@ -4,7 +4,7 @@ using CSharpTest.Net.Serialization;
 
 namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 {
-    public abstract class SerializerBase
+    internal abstract class SerializerBase
     {
         private const char PrefixNull = 'N';
         private const char PrefixString = 'S';


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes 

### Description
What?
Support serializing more primitives to nucache

Why?
More efficient to serialize.
