### PR TITLE
Speed up boot time by not loading draft data from nucache on replica servers

### DIFF
--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -95,7 +95,7 @@ namespace Umbraco.Tests.Scoping
                 ScopeProvider,
                 documentRepository, mediaRepository, memberRepository,
                 DefaultCultureAccessor,
-                new DatabaseDataSource(),
+                new DatabaseDataSource(new DatabaseDataSourceConfiguration()),
                 Factory.GetInstance<IGlobalSettings>(),
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),

--- a/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
@@ -66,7 +66,7 @@ namespace Umbraco.Tests.Services
                 ScopeProvider,
                 documentRepository, mediaRepository, memberRepository,
                 DefaultCultureAccessor,
-                new DatabaseDataSource(),
+                new DatabaseDataSource(new DatabaseDataSourceConfiguration()),
                 Factory.GetInstance<IGlobalSettings>(),
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.DictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/BTree.DictionaryOfPropertyDataSerializer.cs
@@ -51,6 +51,11 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         public void WriteTo(IDictionary<string, PropertyData[]> value, Stream stream)
         {
             // write properties count
+            if (value == null)
+            {
+                PrimitiveSerializer.Int32.WriteTo(0, stream);
+                return;
+            }
             PrimitiveSerializer.Int32.WriteTo(value.Count, stream);
 
             // write each property

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/DatabaseDataSourceConfiguration.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/DatabaseDataSourceConfiguration.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    public class DatabaseDataSourceConfiguration
+    {
+        public DatabaseDataSourceConfiguration(bool publishedContentOnly = false)
+        {
+            PublishedContentOnly = publishedContentOnly;
+        }
+        public bool PublishedContentOnly { get; private set; }
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core;
+﻿using System.Configuration;
+using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Web.PublishedCache.NuCache.DataSource;
 
@@ -11,6 +12,16 @@ namespace Umbraco.Web.PublishedCache.NuCache
             base.Compose(composition);
 
             // register the NuCache database data source
+            var disallowUnpublishedContent = ConfigurationManager.AppSettings["Umbraco.Web.PublishedCache.NuCache.NoUnpublishedContentData"];
+            if (disallowUnpublishedContent == "true")
+            {
+                var dataSourceConfig = new DatabaseDataSourceConfiguration(true);
+                composition.RegisterUnique<DatabaseDataSourceConfiguration>(dataSourceConfig);
+            }
+            else
+            {
+                composition.RegisterUnique<DatabaseDataSourceConfiguration, DatabaseDataSourceConfiguration>();
+            }
             composition.Register<IDataSource, DatabaseDataSource>();
 
             // register the NuCache published snapshot service

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -39,8 +39,10 @@ namespace Umbraco.Web.PublishedCache.NuCache
             {
                 // add one property per property type - this is required, for the indexing to work
                 // if contentData supplies pdatas, use them, else use null
-                contentData.Properties.TryGetValue(propertyType.Alias, out var pdatas); // else will be null
-                properties[i++] =new Property(propertyType, this, pdatas, _publishedSnapshotAccessor);
+                if (contentData.Properties != null && contentData.Properties.TryGetValue(propertyType.Alias, out var pdatas))
+                {
+                    properties[i++] = new Property(propertyType, this, pdatas, _publishedSnapshotAccessor);
+                }// else will be null
             }
             PropertiesArray = properties;
         }

--- a/src/Umbraco.Web/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Web/Routing/PublishedRouter.cs
@@ -534,13 +534,13 @@ namespace Umbraco.Web.Routing
             {
                 // bad redirect - log and display the current page (legacy behavior)
                 _logger.Debug<PublishedRouter>("FollowInternalRedirects: Failed to redirect to id={InternalRedirectId}: value is not an int nor a GuidUdi.",
-                    request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId).GetSourceValue());
+                    request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId)?.GetSourceValue());
             }
 
             if (internalRedirectNode == null)
             {
                 _logger.Debug<PublishedRouter>("FollowInternalRedirects: Failed to redirect to id={InternalRedirectId}: no such published document.",
-                    request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId).GetSourceValue());
+                    request.PublishedContent.GetProperty(Constants.Conventions.Content.InternalRedirectId)?.GetSourceValue());
             }
             else if (internalRedirectId == request.PublishedContent.Id)
             {

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -266,6 +266,7 @@
     <Compile Include="PropertyEditors\Validation\ValidationResultConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\BlockEditorConverter.cs" />
     <Compile Include="PropertyEditors\ValueConverters\BlockListPropertyValueConverter.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\DatabaseDataSourceConfiguration.cs" />
     <Compile Include="PublishedCache\NuCache\PublishedSnapshotServiceOptions.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenObj.cs" />
     <Compile Include="PublishedCache\NuCache\Snap\GenRef.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes 

### Description
What?
Add an option to not load the draft data (for content, media still loaded) from cmsContentNu for replica servers. On replica servers no one should be updating content or previewing so no need to load this data. An improvement to this would be to only load unpublished data on demand so the main server does not have to load draft data at startup either.

Why?
Faster boot up times by reducing the amount of joins made and data transferred, save on memory as unused draft data is not being kept in memory.

How to test:
Add to AppSettings
`<add key="Umbraco.Web.PublishedCache.NuCache.NoUnpublishedContentData" value = "true"/>`
Published content should load / render as normal. Preview content will have null values for Property Data.

