### PR TITLE
Allow local links and query strings in Markdown editor links

### DIFF
--- a/src/Umbraco.Tests/Templates/HtmlLocalLinkParserTests.cs
+++ b/src/Umbraco.Tests/Templates/HtmlLocalLinkParserTests.cs
@@ -90,5 +90,62 @@ namespace Umbraco.Tests.Templates
                 Assert.AreEqual(result, output);
             }
         }
+
+        //All the same as with non-markdown
+        [TestCase("", "")]
+        [TestCase("hello href=\"{localLink:1234}\" world ", "hello href=\"/my-test-url\" world ")]
+        [TestCase("hello href=\"{localLink:umb://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ", "hello href=\"/my-test-url\" world ")]
+        [TestCase("hello href=\"{localLink:umb://document/9931BDE0AAC34BABB838909A7B47570E}\" world ", "hello href=\"/my-test-url\" world ")]
+        [TestCase("hello href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\" world ", "hello href=\"/media/1001/my-image.jpg\" world ")]
+        //this one has an invalid char so won't match
+        [TestCase("hello href=\"{localLink:umb^://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ", "hello href=\"{localLink:umb^://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ")]
+        [TestCase("hello href=\"{localLink:umb://document-type/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ", "hello href=\"#\" world ")]
+        //Markdown specific cases
+        [TestCase("hello [a]({localLink:1234}) world ", "hello [a](/my-test-url) world ")]
+        [TestCase("hello [a]({localLink:umb://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E}) world ", "hello [a](/my-test-url) world ")]
+        [TestCase(" [1]: {localLink:umb://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E} ", " [1]: /my-test-url ")]
+        public void ParseLocalLinksMarkdown(string input, string result)
+        {
+            //setup a mock URL provider which we'll use for testing
+            var contentUrlProvider = new Mock<IUrlProvider>();
+            contentUrlProvider
+                .Setup(x => x.GetUrl(It.IsAny<UmbracoContext>(), It.IsAny<IPublishedContent>(), It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<Uri>()))
+                .Returns(UrlInfo.Url("/my-test-url"));
+            var contentType = new PublishedContentType(Guid.NewGuid(), 666, "alias", PublishedItemType.Content, Enumerable.Empty<string>(), Enumerable.Empty<PublishedPropertyType>(), ContentVariation.Nothing);
+            var publishedContent = new Mock<IPublishedContent>();
+            publishedContent.Setup(x => x.Id).Returns(1234);
+            publishedContent.Setup(x => x.ContentType).Returns(contentType);
+
+            var mediaType = new PublishedContentType(Guid.NewGuid(), 777, "image", PublishedItemType.Media, Enumerable.Empty<string>(), Enumerable.Empty<PublishedPropertyType>(), ContentVariation.Nothing);
+            var media = new Mock<IPublishedContent>();
+            media.Setup(x => x.ContentType).Returns(mediaType);
+            var mediaUrlProvider = new Mock<IMediaUrlProvider>();
+            mediaUrlProvider.Setup(x => x.GetMediaUrl(It.IsAny<UmbracoContext>(), It.IsAny<IPublishedContent>(), It.IsAny<string>(), It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<Uri>()))
+                .Returns(UrlInfo.Url("/media/1001/my-image.jpg"));
+
+            var umbracoContextAccessor = new TestUmbracoContextAccessor();
+
+            var umbracoContextFactory = TestUmbracoContextFactory.Create(
+                urlProvider: contentUrlProvider.Object,
+                mediaUrlProvider: mediaUrlProvider.Object,
+                umbracoContextAccessor: umbracoContextAccessor);
+
+            using (var reference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>()))
+            {
+                var contentCache = Mock.Get(reference.UmbracoContext.Content);
+                contentCache.Setup(x => x.GetById(It.IsAny<int>())).Returns(publishedContent.Object);
+                contentCache.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(publishedContent.Object);
+
+                var mediaCache = Mock.Get(reference.UmbracoContext.Media);
+                mediaCache.Setup(x => x.GetById(It.IsAny<int>())).Returns(media.Object);
+                mediaCache.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(media.Object);
+
+                var linkParser = new HtmlLocalLinkParser(umbracoContextAccessor);
+
+                var output = linkParser.EnsureInternalLinks(input, false, true);
+
+                Assert.AreEqual(result, output);
+            }
+        }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -15,12 +15,12 @@ function MarkdownEditorController($scope, $element, assetsService, editorService
     function openMediaPicker(callback) {
         var mediaPicker = {
             disableFolderSelect: true,
-            submit: function(model) {
+            submit: function (model) {
                 var selectedImagePath = model.selection[0].image;
                 callback(selectedImagePath);
                 editorService.close();
             },
-            close: function() {
+            close: function () {
                 editorService.close();
             }
         };
@@ -30,11 +30,15 @@ function MarkdownEditorController($scope, $element, assetsService, editorService
     function openLinkPicker(callback) {
         var linkPicker = {
             hideTarget: true,
-            submit: function(model) {
-                callback(model.target.url, model.target.name);
+            submit: function (model) {
+                var url = model.target.url;
+                if (model.target.udi) {
+                    url = "{localLink:" + model.target.udi + "}";
+                }
+                callback(url + model.target.anchor, model.target.name);
                 editorService.close();
             },
-            close: function() {
+            close: function () {
                 editorService.close();
             }
         };

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             var sourceString = source.ToString();
 
             // ensures string is parsed for {localLink} and URLs are resolved correctly
-            sourceString = _localLinkParser.EnsureInternalLinks(sourceString, preview);
+            sourceString = _localLinkParser.EnsureInternalLinks(sourceString, preview, true);
             sourceString = _urlParser.EnsureUrls(sourceString);
 
             return sourceString;

--- a/src/Umbraco.Web/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Web/Templates/HtmlLocalLinkParser.cs
@@ -43,6 +43,7 @@ namespace Umbraco.Web.Templates
         /// </summary>
         /// <param name="text"></param>
         /// <param name="preview"></param>
+        /// <param name="markdown">Indicates the text in Markdown rather than HTML</param>
         /// <returns></returns>
         public string EnsureInternalLinks(string text, bool preview, bool markdown = false)
         {
@@ -62,7 +63,6 @@ namespace Umbraco.Web.Templates
         /// Parses the string looking for the {localLink} syntax and updates them to their correct links.
         /// </summary>
         /// <param name="text"></param>
-        /// <param name="urlProvider"></param>
         /// <returns></returns>
         public string EnsureInternalLinks(string text)
         {
@@ -73,7 +73,7 @@ namespace Umbraco.Web.Templates
         /// Parses the string looking for the {localLink} syntax and updates them to their correct links.
         /// </summary>
         /// <param name="text"></param>
-        /// <param name="urlProvider"></param>
+        /// <param name="markdown">Indicates the text in Markdown rather than HTML</param>
         /// <returns></returns>
         private string EnsureInternalLinksInternal(string text, bool markdown)
         {

--- a/src/Umbraco.Web/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Web/Templates/HtmlLocalLinkParser.cs
@@ -13,8 +13,13 @@ namespace Umbraco.Web.Templates
     /// </summary>
     public sealed class HtmlLocalLinkParser
     {
+        private static readonly Regex LocalUdiPattern = new Regex(@"[/]?(?:\{|\%7B)localLink:(?<udi>[a-zA-Z0-9-://]+)(?:\}|\%7D)",
+            RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex LocalLinkPattern = new Regex(@"href=""[/]?(?:\{|\%7B)localLink:([a-zA-Z0-9-://]+)(?:\}|\%7D)",
+        private static readonly Regex LocalLinkPattern = new Regex(@"(?<prefix>href="")" + LocalUdiPattern,
+            RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+
+        private static readonly Regex LocalLinkMarkdownPattern = new Regex(@"(?:" + LocalLinkPattern + @")|(?:(?<prefix>\[[0-9]+\]:\s*)" + LocalUdiPattern + @")|(?:(?<prefix>\[[^\]]+\]\()" + LocalUdiPattern + @")",
             RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
@@ -24,9 +29,9 @@ namespace Umbraco.Web.Templates
             _umbracoContextAccessor = umbracoContextAccessor;
         }
 
-        internal IEnumerable<Udi> FindUdisFromLocalLinks(string text)
+        internal IEnumerable<Udi> FindUdisFromLocalLinks(string text, bool markdown = false)
         {
-            foreach ((int? intId, GuidUdi udi, string tagValue) in FindLocalLinkIds(text))
+            foreach ((int? intId, GuidUdi udi, string tagValue, string format) in FindLocalLinkIds(text, markdown))
             {
                 if (udi != null)
                     yield return udi; // In v8, we only care abuot UDIs
@@ -39,17 +44,17 @@ namespace Umbraco.Web.Templates
         /// <param name="text"></param>
         /// <param name="preview"></param>
         /// <returns></returns>
-        public string EnsureInternalLinks(string text, bool preview)
+        public string EnsureInternalLinks(string text, bool preview, bool markdown = false)
         {
             if (_umbracoContextAccessor.UmbracoContext == null)
                 throw new InvalidOperationException("Could not parse internal links, there is no current UmbracoContext");
 
             if (!preview)
-                return EnsureInternalLinks(text);
+                return EnsureInternalLinksInternal(text, markdown);
 
             using (_umbracoContextAccessor.UmbracoContext.ForcedPreview(preview)) // force for URL provider
             {
-                return EnsureInternalLinks(text);
+                return EnsureInternalLinksInternal(text, markdown);
             }
         }
 
@@ -61,12 +66,23 @@ namespace Umbraco.Web.Templates
         /// <returns></returns>
         public string EnsureInternalLinks(string text)
         {
+            return EnsureInternalLinksInternal(text, false);
+        }
+
+        /// <summary>
+        /// Parses the string looking for the {localLink} syntax and updates them to their correct links.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="urlProvider"></param>
+        /// <returns></returns>
+        private string EnsureInternalLinksInternal(string text, bool markdown)
+        {
             if (_umbracoContextAccessor.UmbracoContext == null)
                 throw new InvalidOperationException("Could not parse internal links, there is no current UmbracoContext");
 
             var urlProvider = _umbracoContextAccessor.UmbracoContext.UrlProvider;
 
-            foreach((int? intId, GuidUdi udi, string tagValue) in FindLocalLinkIds(text))
+            foreach((int? intId, GuidUdi udi, string tagValue, string format) in FindLocalLinkIds(text, markdown))
             {
                 if (udi != null)
                 {
@@ -79,39 +95,40 @@ namespace Umbraco.Web.Templates
                     if (newLink == null)
                         newLink = "#";
 
-                    text = text.Replace(tagValue, "href=\"" + newLink);
+                    text = text.Replace(tagValue, string.Format(format, newLink));
                 }
                 else if (intId.HasValue)
                 {
                     var newLink = urlProvider.GetUrl(intId.Value);
-                    text = text.Replace(tagValue, "href=\"" + newLink);
+                    text = text.Replace(tagValue, string.Format(format, newLink));
                 }
             }
 
             return text;
         }
 
-        private IEnumerable<(int? intId, GuidUdi udi, string tagValue)> FindLocalLinkIds(string text)
+        private IEnumerable<(int? intId, GuidUdi udi, string tagValue, string format)> FindLocalLinkIds(string text, bool markdown)
         {
             // Parse internal links
-            var tags = LocalLinkPattern.Matches(text);
+            var tags = (markdown ? LocalLinkMarkdownPattern : LocalLinkPattern).Matches(text);
             foreach (Match tag in tags)
             {
                 if (tag.Groups.Count > 0)
                 {
-                    var id = tag.Groups[1].Value; //.Remove(tag.Groups[1].Value.Length - 1, 1);
-
+                    var id = tag.Groups["udi"].Value; //.Remove(tag.Groups[1].Value.Length - 1, 1);
+                    var prefix = tag.Groups["prefix"]?.Value;
+                    var format = $"{prefix}{{0}}";
                     //The id could be an int or a UDI
                     if (Udi.TryParse(id, out var udi))
                     {
                         var guidUdi = udi as GuidUdi;
                         if (guidUdi != null)
-                            yield return (null, guidUdi, tag.Value);
+                            yield return (null, guidUdi, tag.Value, format);
                     }
 
                     if (int.TryParse(id, out var intId))
                     {
-                        yield return (intId, null, tag.Value);
+                        yield return (intId, null, tag.Value, format);
                     }
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR has the following changes:
 - Query/hash part no longer ignored
 - If a local URL is selected, picker uses the `localLink` syntax
 - The localLink logic is fixed to identify markdown, not just HTML
 - Unit tests for amended localLink logic

To test:
 - add a markdown editor control to a document type
 - render the contents of the markdown editor in the page template
 - insert a _local_ link using the link button in the markdown control (by browsing the tree)
 - enter a hash or query string
 - the link will be entered in the markdown with the `{localLink:[udi]}` syntax seen in links added to the RTE.
 - when viewing the rendered page, the link should render with the actual URL (with the query/hash still intact)
 

<!-- Thanks for contributing to Umbraco CMS! -->
