### PR TITLE
Add support for unattended installs

### DIFF
--- a/src/Umbraco.Core/Exceptions/UnattendedInstallException.cs
+++ b/src/Umbraco.Core/Exceptions/UnattendedInstallException.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Core.Exceptions
+{
+    /// <summary>
+    /// An exception that is thrown if an unattended installation occurs.
+    /// </summary>
+    [Serializable]
+    public class UnattendedInstallException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnattendedInstallException" /> class.
+        /// </summary>
+        public UnattendedInstallException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnattendedInstallException" /> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public UnattendedInstallException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnattendedInstallException" /> class with a specified error message
+        /// and a reference to the inner exception which is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The inner exception, or null.</param>
+        public UnattendedInstallException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnattendedInstallException" /> class.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected UnattendedInstallException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Core/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseBuilder.cs
@@ -446,11 +446,9 @@ namespace Umbraco.Core.Migrations.Install
 
                 var schemaResult = ValidateSchema();
                 var hasInstalledVersion = schemaResult.DetermineHasInstalledVersion();
-                //var installedSchemaVersion = schemaResult.DetermineInstalledVersion();
-                //var hasInstalledVersion = !installedSchemaVersion.Equals(new Version(0, 0, 0));
 
-                //If Configuration Status is empty and the determined version is "empty" its a new install - otherwise upgrade the existing
-                if (string.IsNullOrEmpty(_globalSettings.ConfigurationStatus) && !hasInstalledVersion)
+                //If the determined version is "empty" its a new install - otherwise upgrade the existing
+                if (!hasInstalledVersion)
                 {
                     if (_runtime.Level == RuntimeLevel.Run)
                         throw new Exception("Umbraco is already configured!");

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -21,8 +21,13 @@ namespace Umbraco.Core.Migrations.Install
 
         public DatabaseSchemaCreator(IUmbracoDatabase database, ILogger logger)
         {
-            _database = database;
-            _logger = logger;
+            _database = database ?? throw new ArgumentNullException(nameof(database));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            if (_database?.SqlContext?.SqlSyntax == null)
+            {
+                throw new InvalidOperationException("No SqlContext has been assigned to the database");
+            }
         }
 
         private ISqlSyntaxProvider SqlSyntax => _database.SqlContext.SqlSyntax;

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaCreator.cs
@@ -143,7 +143,7 @@ namespace Umbraco.Core.Migrations.Install
 
         internal DatabaseSchemaResult ValidateSchema(IEnumerable<Type> orderedTables)
         {
-            var result = new DatabaseSchemaResult(SqlSyntax);
+            var result = new DatabaseSchemaResult();
 
             result.IndexDefinitions.AddRange(SqlSyntax.GetDefinedIndexes(_database)
                 .Select(x => new DbIndexDefinition(x)));

--- a/src/Umbraco.Core/Migrations/Install/DatabaseSchemaResult.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseSchemaResult.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
-using Umbraco.Core.Persistence.SqlSyntax;
 
 namespace Umbraco.Core.Migrations.Install
 {
@@ -12,7 +12,7 @@ namespace Umbraco.Core.Migrations.Install
     /// </summary>
     internal class DatabaseSchemaResult
     {
-        public DatabaseSchemaResult(ISqlSyntaxProvider sqlSyntax)
+        public DatabaseSchemaResult()
         {
             Errors = new List<Tuple<string, string>>();
             TableDefinitions = new List<TableDefinition>();

--- a/src/Umbraco.Core/Persistence/UmbracoDatabaseExtensions.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabaseExtensions.cs
@@ -48,6 +48,9 @@ namespace Umbraco.Core.Persistence
         /// <returns></returns>
         public static DatabaseSchemaResult ValidateSchema(this IUmbracoDatabase database, ILogger logger)
         {
+            if (database is null) throw new ArgumentNullException(nameof(database));
+            if (logger is null) throw new ArgumentNullException(nameof(logger));
+
             var dbSchema = new DatabaseSchemaCreator(database, logger);
             var databaseSchemaValidationResult = dbSchema.ValidateSchema();            
             return databaseSchemaValidationResult;
@@ -61,6 +64,9 @@ namespace Umbraco.Core.Persistence
         /// <returns></returns>
         public static bool IsUmbracoInstalled(this IUmbracoDatabase database, ILogger logger)
         {
+            if (database is null) throw new ArgumentNullException(nameof(database));
+            if (logger is null) throw new ArgumentNullException(nameof(logger));
+
             var databaseSchemaValidationResult = database.ValidateSchema(logger);
             return databaseSchemaValidationResult.DetermineHasInstalledVersion();
         }

--- a/src/Umbraco.Core/Persistence/UmbracoDatabaseExtensions.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabaseExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Linq;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Migrations.Install;
 
 namespace Umbraco.Core.Persistence
 {
@@ -10,5 +13,57 @@ namespace Umbraco.Core.Persistence
             if (asDatabase == null) throw new Exception("oops: database.");
             return asDatabase;
         }
+
+        /// <summary>
+        /// Returns true if the database contains the specified table
+        /// </summary>
+        /// <param name="database"></param>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        public static bool HasTable(this IUmbracoDatabase database, string tableName)
+        {
+            try
+            {
+                return database.SqlContext.SqlSyntax.GetTablesInSchema(database).Any(table => table.InvariantEquals(tableName));
+            }
+            catch (Exception)
+            {
+                return false; // will occur if the database cannot connect
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the database contains no tables
+        /// </summary>
+        /// <param name="database"></param>
+        /// <returns></returns>
+        public static bool IsDatabaseEmpty(this IUmbracoDatabase database)
+            => database.SqlContext.SqlSyntax.GetTablesInSchema(database).Any() == false;
+
+        /// <summary>
+        /// Returns the <see cref="DatabaseSchemaResult"/> for the database
+        /// </summary>
+        /// <param name="database"></param>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        public static DatabaseSchemaResult ValidateSchema(this IUmbracoDatabase database, ILogger logger)
+        {
+            var dbSchema = new DatabaseSchemaCreator(database, logger);
+            var databaseSchemaValidationResult = dbSchema.ValidateSchema();            
+            return databaseSchemaValidationResult;
+        }
+
+        /// <summary>
+        /// Returns true if Umbraco database tables are detected to be installed
+        /// </summary>
+        /// <param name="database"></param>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        public static bool IsUmbracoInstalled(this IUmbracoDatabase database, ILogger logger)
+        {
+            var databaseSchemaValidationResult = database.ValidateSchema(logger);
+            return databaseSchemaValidationResult.DetermineHasInstalledVersion();
+        }
+
     }
 }

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -174,6 +174,7 @@ namespace Umbraco.Core.Runtime
                 // determine our runtime level
                 DetermineRuntimeLevel(databaseFactory, ProfilingLogger);
 
+
                 // get composers, and compose
                 var composerTypes = ResolveComposerTypes(typeLoader);
 
@@ -260,16 +261,17 @@ namespace Umbraco.Core.Runtime
 
             using (var database = databaseFactory.CreateDatabase())
             {
-                var isDatabaseEmpty = databaseFactory.SqlContext.SqlSyntax.GetTablesInSchema(database).Any() == false;
+                var hasUmbracoTables = database.IsUmbracoInstalled(Logger);
 
-                // database is not empty, assume Umbraco is already installed
-                if (isDatabaseEmpty == false) return;
+                // database has umbraco tables, assume Umbraco is already installed
+                if (hasUmbracoTables) return;
 
                 // all conditions fulfilled, do the install
                 Logger.Info<CoreRuntime>("Starting unattended install.");
-                database.BeginTransaction();
+                
                 try
                 {
+                    database.BeginTransaction();
                     var creator = new DatabaseSchemaCreator(database, Logger);
                     creator.InitializeDatabaseSchema();
                     database.CompleteTransaction();

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -336,7 +336,7 @@ namespace Umbraco.Core.Runtime
             {
                 try
                 {
-                    _state.DetermineRuntimeLevel(databaseFactory, profilingLogger);
+                    _state.DetermineRuntimeLevel(databaseFactory);
 
                     profilingLogger.Debug<CoreRuntime>("Runtime level: {RuntimeLevel} - {RuntimeLevelReason}", _state.Level, _state.Reason);
 

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading;
 using System.Web;
 using System.Web.Hosting;
 using Umbraco.Core.Cache;
@@ -10,6 +12,7 @@ using Umbraco.Core.Exceptions;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Logging.Serilog;
+using Umbraco.Core.Migrations.Install;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Mappers;
 using Umbraco.Core.Sync;
@@ -149,7 +152,7 @@ namespace Umbraco.Core.Runtime
                 {
                     MainDom = new MainDom(Logger, new MainDomSemaphoreLock(Logger));
                 }
-                
+
 
                 // create the composition
                 composition = new Composition(register, typeLoader, ProfilingLogger, _state, configs);
@@ -157,6 +160,9 @@ namespace Umbraco.Core.Runtime
 
                 // run handlers
                 RuntimeOptions.DoRuntimeEssentials(composition, appCaches, typeLoader, databaseFactory);
+
+                // determines if unattended install is enabled and performs it if required
+                DoUnattendedInstall(databaseFactory);
 
                 // register runtime-level services
                 // there should be none, really - this is here "just in case"
@@ -175,7 +181,7 @@ namespace Umbraco.Core.Runtime
                 using (ProfilingLogger.DebugDuration<CoreRuntime>("Scanning enable/disable composer attributes"))
                 {
                     enableDisableAttributes = typeLoader.GetAssemblyAttributes(typeof(EnableComposerAttribute), typeof(DisableComposerAttribute));
-                }   
+                }
 
                 var composers = new Composers(composition, composerTypes, enableDisableAttributes, ProfilingLogger);
                 composers.Compose();
@@ -223,6 +229,62 @@ namespace Umbraco.Core.Runtime
             }
 
             return _factory;
+        }
+
+        private void DoUnattendedInstall(IUmbracoDatabaseFactory databaseFactory)
+        {
+            // unattended install is not enabled
+            if (RuntimeOptions.InstallUnattended == false) return;
+
+            var localVersion = UmbracoVersion.LocalVersion; // the local, files, version
+            var codeVersion = _state.SemanticVersion; // the executing code version
+
+            // local version and code version is not equal, an unattended install cannot be performed
+            if (localVersion != codeVersion) return;
+
+            // no connection string set
+            if (databaseFactory.Configured == false) return;
+
+            var tries = 5;
+            var connect = false;
+            for (var i = 0;;)
+            {
+                connect = databaseFactory.CanConnect;
+                if (connect || ++i == tries) break;
+                Logger.Debug<CoreRuntime>("Could not immediately connect to database, trying again.");
+                Thread.Sleep(1000);
+            }
+
+            // could not connect to the database
+            if (connect == false) return;
+
+            using (var database = databaseFactory.CreateDatabase())
+            {
+                var isDatabaseEmpty = databaseFactory.SqlContext.SqlSyntax.GetTablesInSchema(database).Any() == false;
+
+                // database is not empty, assume Umbraco is already installed
+                if (isDatabaseEmpty == false) return;
+
+                // all conditions fulfilled, do the install
+                Logger.Info<CoreRuntime>("Starting unattended install.");
+                database.BeginTransaction();
+                try
+                {
+                    var creator = new DatabaseSchemaCreator(database, Logger);
+                    creator.InitializeDatabaseSchema();
+                    database.CompleteTransaction();
+                    Logger.Info<CoreRuntime>("Unattended install completed.");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error<CoreRuntime>(ex, "Error during unattended install.");
+                    database.AbortTransaction();
+
+                    throw new UnattendedInstallException(
+                        "The database configuration failed with the following message: " + ex.Message
+                        + "\n Please check log file for additional information (can be found in '/App_Data/Logs/')");
+                }
+            }
         }
 
         protected virtual void ConfigureUnhandledException()

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -174,7 +174,6 @@ namespace Umbraco.Core.Runtime
                 // determine our runtime level
                 DetermineRuntimeLevel(databaseFactory, ProfilingLogger);
 
-
                 // get composers, and compose
                 var composerTypes = ResolveComposerTypes(typeLoader);
 
@@ -329,8 +328,8 @@ namespace Umbraco.Core.Runtime
             }
         }
 
-        // internal for tests
-        internal void DetermineRuntimeLevel(IUmbracoDatabaseFactory databaseFactory, IProfilingLogger profilingLogger)
+        // internal/virtual for tests (i.e. hack, do not port to netcore)
+        internal virtual void DetermineRuntimeLevel(IUmbracoDatabaseFactory databaseFactory, IProfilingLogger profilingLogger)
         {
             using (var timer = profilingLogger.DebugDuration<CoreRuntime>("Determining runtime level.", "Determined."))
             {

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -27,6 +27,7 @@ namespace Umbraco.Core.Runtime
         private readonly UmbracoDatabaseFactory _dbFactory;
         private bool _errorDuringAcquiring;
         private object _locker = new object();
+        private bool _hasTable = false;
 
         public SqlMainDomLock(ILogger logger)
         {
@@ -37,14 +38,14 @@ namespace Umbraco.Core.Runtime
             _dbFactory = new UmbracoDatabaseFactory(
                Constants.System.UmbracoConnectionName,
                _logger,
-               new Lazy<IMapperCollection>(() => new Persistence.Mappers.MapperCollection(Enumerable.Empty<BaseMapper>())));
+               new Lazy<IMapperCollection>(() => new MapperCollection(Enumerable.Empty<BaseMapper>())));
         }
 
         public async Task<bool> AcquireLockAsync(int millisecondsTimeout)
         {
             if (!_dbFactory.Configured)
             {
-                // if we aren't configured, then we're in an install state, in which case we have no choice but to assume we can acquire
+                // if we aren't configured then we're in an install state, in which case we have no choice but to assume we can acquire
                 return true;
             }
 
@@ -58,6 +59,14 @@ namespace Umbraco.Core.Runtime
             var tempId = Guid.NewGuid().ToString();
 
             using var db = _dbFactory.CreateDatabase();
+
+            _hasTable = db.HasTable(Constants.DatabaseSchema.Tables.KeyValue);
+            if (!_hasTable)
+            {
+                // the Db does not contain the required table, we must be in an install state we have no choice but to assume we can acquire
+                return true;
+            }
+
             using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
 
             try
@@ -162,10 +171,22 @@ namespace Umbraco.Core.Runtime
                     {
                         _logger.Debug<SqlMainDomLock>("Task canceled, exiting loop");
                         return;
-                    }
-                        
+                    }   
 
                     using var db = _dbFactory.CreateDatabase();
+
+                    if (!_hasTable)
+                    {
+                        // re-check if its still false, we don't want to re-query once we know its there since this
+                        // loop needs to use minimal resources
+                        _hasTable = db.HasTable(Constants.DatabaseSchema.Tables.KeyValue);
+                        if (!_hasTable)
+                        {
+                            // the Db does not contain the required table, we just keep looping since we can't query the db
+                            continue;
+                        }
+                    }
+
                     using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
                     try
                     {

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -401,7 +401,7 @@ namespace Umbraco.Core.Runtime
                         _cancellationTokenSource.Cancel();
                         _cancellationTokenSource.Dispose();
 
-                        if (_dbFactory.Configured)
+                        if (_dbFactory.Configured && _hasTable)
                         {
                             using var db = _dbFactory.CreateDatabase();
                             using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);

--- a/src/Umbraco.Core/RuntimeOptions.cs
+++ b/src/Umbraco.Core/RuntimeOptions.cs
@@ -47,14 +47,12 @@ namespace Umbraco.Core
         /// </summary>
         /// <remarks>
         /// <para>By default, when a database connection string is configured and it is possible to connect to
-        /// the database, but the database is empty, the runtime enters the BootFailed level. If this options
-        /// is set to true, it enters the Install level instead.</para>
-        /// <para>It is then up to the implementor, that is setting this value, to take over the installation
-        /// sequence.</para>
+        /// the database, but the database is empty, the runtime enters the <c>Install</c> level. If this options
+        /// is set to <c>false</c>, it enters the <c>BootFailed</c> level instead.</para>
         /// </remarks>
         public static bool InstallEmptyDatabase
         {
-            get => _installEmptyDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallEmptyDatabase", false);
+            get => _installEmptyDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallEmptyDatabase", true);
             set => _installEmptyDatabase  = value;
         }
 
@@ -63,12 +61,13 @@ namespace Umbraco.Core
         /// </summary>
         /// <remarks>
         /// <para>By default, when a database connection string is configured and it is possible to connect to
-        /// the database, but the database is empty, an unattended install will be performed. If this options
-        /// is set to <c>false</c>, it enters the Install level instead.</para>
+        /// the database, but the database is empty, the runtime enters the <c>Install</c> level.
+        /// If this option is set to <c>true</c> an unattended install will be performed and the runtime enters
+        /// the <c>Run</c> level.</para>
         /// </remarks>
         public static bool InstallUnattended
         {
-            get => _installUnattended ?? BoolSetting("Umbraco.Core.RuntimeState.InstallUnattended", true);
+            get => _installUnattended ?? BoolSetting("Umbraco.Core.RuntimeState.InstallUnattended", false);
             set => _installUnattended = value;
         }
 

--- a/src/Umbraco.Core/RuntimeOptions.cs
+++ b/src/Umbraco.Core/RuntimeOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Configuration;
 using System.Runtime.CompilerServices;
 using Umbraco.Core.Cache;
@@ -42,14 +43,8 @@ namespace Umbraco.Core
             set => _installMissingDatabase = value;
         }
 
-        /// <summary>
-        /// Gets a value indicating whether the runtime should enter Install level when the database is empty.
-        /// </summary>
-        /// <remarks>
-        /// <para>By default, when a database connection string is configured and it is possible to connect to
-        /// the database, but the database is empty, the runtime enters the <c>Install</c> level. If this options
-        /// is set to <c>false</c>, it enters the <c>BootFailed</c> level instead.</para>
-        /// </remarks>
+        [Obsolete("This setting is no longer used and will be removed in future versions. If a database connection string is configured and the database is empty Umbraco will be installed during the installation sequence.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool InstallEmptyDatabase
         {
             get => _installEmptyDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallEmptyDatabase", true);

--- a/src/Umbraco.Core/RuntimeOptions.cs
+++ b/src/Umbraco.Core/RuntimeOptions.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Core
         private static List<Action<Composition, AppCaches, TypeLoader, IUmbracoDatabaseFactory>> _onEssentials;
         private static bool? _installMissingDatabase;
         private static bool? _installEmptyDatabase;
+        private static bool? _installUnattended;
 
         // reads a boolean appSetting
         private static bool BoolSetting(string key, bool missing) => ConfigurationManager.AppSettings[key]?.InvariantEquals("true") ?? missing;
@@ -37,8 +38,8 @@ namespace Umbraco.Core
         /// </remarks>
         public static bool InstallMissingDatabase
         {
-            get => _installEmptyDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallMissingDatabase", false);
-            set => _installEmptyDatabase = value;
+            get => _installMissingDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallMissingDatabase", false);
+            set => _installMissingDatabase = value;
         }
 
         /// <summary>
@@ -53,8 +54,22 @@ namespace Umbraco.Core
         /// </remarks>
         public static bool InstallEmptyDatabase
         {
-            get => _installMissingDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallEmptyDatabase", false);
-            set => _installMissingDatabase = value;
+            get => _installEmptyDatabase ?? BoolSetting("Umbraco.Core.RuntimeState.InstallEmptyDatabase", false);
+            set => _installEmptyDatabase  = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether unattended installs are enabled.
+        /// </summary>
+        /// <remarks>
+        /// <para>By default, when a database connection string is configured and it is possible to connect to
+        /// the database, but the database is empty, an unattended install will be performed. If this options
+        /// is set to <c>false</c>, it enters the Install level instead.</para>
+        /// </remarks>
+        public static bool InstallUnattended
+        {
+            get => _installUnattended ?? BoolSetting("Umbraco.Core.RuntimeState.InstallUnattended", true);
+            set => _installUnattended = value;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/RuntimeState.cs
+++ b/src/Umbraco.Core/RuntimeState.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Data.SqlServerCe;
 using System.Threading;
 using System.Web;
 using Semver;
@@ -123,16 +126,15 @@ namespace Umbraco.Core
         /// <summary>
         /// Determines the runtime level.
         /// </summary>
-        public void DetermineRuntimeLevel(IUmbracoDatabaseFactory databaseFactory, ILogger logger)
+        public void DetermineRuntimeLevel(IUmbracoDatabaseFactory databaseFactory)
         {
             var localVersion = UmbracoVersion.LocalVersion; // the local, files, version
             var codeVersion = SemanticVersion; // the executing code version
-            var connect = false;
-
+            
             if (localVersion == null)
             {
                 // there is no local version, we are not installed
-                logger.Debug<RuntimeState>("No local version, need to install Umbraco.");
+                _logger.Debug<RuntimeState>("No local version, need to install Umbraco.");
                 Level = RuntimeLevel.Install;
                 Reason = RuntimeLevelReason.InstallNoVersion;
                 return;
@@ -142,13 +144,13 @@ namespace Umbraco.Core
             {
                 // there *is* a local version, but it does not match the code version
                 // need to upgrade
-                logger.Debug<RuntimeState>("Local version '{LocalVersion}' < code version '{CodeVersion}', need to upgrade Umbraco.", localVersion, codeVersion);
+                _logger.Debug<RuntimeState>("Local version '{LocalVersion}' < code version '{CodeVersion}', need to upgrade Umbraco.", localVersion, codeVersion);
                 Level = RuntimeLevel.Upgrade;
                 Reason = RuntimeLevelReason.UpgradeOldVersion;
             }
             else if (localVersion > codeVersion)
             {
-                logger.Warn<RuntimeState>("Local version '{LocalVersion}' > code version '{CodeVersion}', downgrading is not supported.", localVersion, codeVersion);
+                _logger.Warn<RuntimeState>("Local version '{LocalVersion}' > code version '{CodeVersion}', downgrading is not supported.", localVersion, codeVersion);
 
                 // in fact, this is bad enough that we want to throw
                 Reason = RuntimeLevelReason.BootFailedCannotDowngrade;
@@ -158,108 +160,139 @@ namespace Umbraco.Core
             {
                 // local version *does* match code version, but the database is not configured
                 // install - may happen with Deploy/Cloud/etc
-                logger.Debug<RuntimeState>("Database is not configured, need to install Umbraco.");
+                _logger.Debug<RuntimeState>("Database is not configured, need to install Umbraco.");
                 Level = RuntimeLevel.Install;
                 Reason = RuntimeLevelReason.InstallNoDatabase;
                 return;
             }
 
-            // else, keep going,
-            // anything other than install wants a database - see if we can connect
-            // (since this is an already existing database, assume localdb is ready)
-            var tries = RuntimeOptions.InstallMissingDatabase ? 2 : 5;
-            for (var i = 0;;)
+            // Check the database state, whether we can connect or if it's in an upgrade or empty state, etc...
+
+            switch (GetUmbracoDatabaseState(databaseFactory))
             {
-                connect = databaseFactory.CanConnect;
-                if (connect || ++i == tries) break;
-                logger.Debug<RuntimeState>("Could not immediately connect to database, trying again.");
-                Thread.Sleep(1000);
+                case UmbracoDatabaseState.CannotConnect:
+                    {
+                        // cannot connect to configured database, this is bad, fail
+                        _logger.Debug<RuntimeState>("Could not connect to database.");
+
+                        if (RuntimeOptions.InstallMissingDatabase)
+                        {
+                            // ok to install on a configured but missing database
+                            Level = RuntimeLevel.Install;
+                            Reason = RuntimeLevelReason.InstallMissingDatabase;
+                            return;
+                        }
+
+                        // else it is bad enough that we want to throw
+                        Reason = RuntimeLevelReason.BootFailedCannotConnectToDatabase;
+                        throw new BootFailedException("A connection string is configured but Umbraco could not connect to the database.");
+                    }
+                case UmbracoDatabaseState.NotInstalled:
+                    {
+                        // ok to install on an empty database
+                        Level = RuntimeLevel.Install;
+                        Reason = RuntimeLevelReason.InstallEmptyDatabase;
+                        return;
+                    }
+                case UmbracoDatabaseState.NeedsUpgrade:
+                    {
+                        // the db version does not match... but we do have a migration table
+                        // so, at least one valid table, so we quite probably are installed & need to upgrade
+
+                        // although the files version matches the code version, the database version does not
+                        // which means the local files have been upgraded but not the database - need to upgrade
+                        _logger.Debug<RuntimeState>("Has not reached the final upgrade step, need to upgrade Umbraco.");
+                        Level = RuntimeLevel.Upgrade;
+                        Reason = RuntimeLevelReason.UpgradeMigrations;
+                    }
+                    break;
+                case UmbracoDatabaseState.Ok:
+                default:
+                    {
+                        // if we already know we want to upgrade, exit here
+                        if (Level == RuntimeLevel.Upgrade)
+                            return;
+
+                        // the database version matches the code & files version, all clear, can run
+                        Level = RuntimeLevel.Run;
+                        Reason = RuntimeLevelReason.Run;
+                    }
+                    break;
             }
+        }
 
-            if (connect == false)
-            {
-                // cannot connect to configured database, this is bad, fail
-                logger.Debug<RuntimeState>("Could not connect to database.");
+        private enum UmbracoDatabaseState
+        {
+            Ok,
+            CannotConnect,
+            NotInstalled,
+            NeedsUpgrade
+        }
 
-                if (RuntimeOptions.InstallMissingDatabase)
-                {
-                    // ok to install on a configured but missing database
-                    Level = RuntimeLevel.Install;
-                    Reason = RuntimeLevelReason.InstallMissingDatabase;
-                    return;
-                }
-
-                // else it is bad enough that we want to throw
-                Reason = RuntimeLevelReason.BootFailedCannotConnectToDatabase;
-                throw new BootFailedException("A connection string is configured but Umbraco could not connect to the database.");
-            }
-
-            // if we already know we want to upgrade,
-            // still run EnsureUmbracoUpgradeState to get the states
-            // (v7 will just get a null state, that's ok)
-
-            // else
-            // look for a matching migration entry - bypassing services entirely - they are not 'up' yet
-            bool noUpgrade;
+        private UmbracoDatabaseState GetUmbracoDatabaseState(IUmbracoDatabaseFactory databaseFactory)
+        {
             try
             {
-                noUpgrade = EnsureUmbracoUpgradeState(databaseFactory, logger);
+                if (!TryDbConnect(databaseFactory))
+                {
+                    return UmbracoDatabaseState.CannotConnect;
+                }
+
+                // no scope, no service - just directly accessing the database
+                using (var database = databaseFactory.CreateDatabase())
+                {
+                    if (!database.IsUmbracoInstalled(_logger))
+                    {
+                        return UmbracoDatabaseState.NotInstalled;
+                    }
+
+                    if (DoesUmbracoRequireUpgrade(database))
+                    {
+                        return UmbracoDatabaseState.NeedsUpgrade;
+                    }
+                }
+
+                return UmbracoDatabaseState.Ok;
             }
             catch (Exception e)
             {
-                // can connect to the database but cannot check the upgrade state... oops
-                logger.Warn<RuntimeState>(e, "Could not check the upgrade state.");
-
-                if (RuntimeOptions.InstallEmptyDatabase)
-                {
-                    // ok to install on an empty database
-                    Level = RuntimeLevel.Install;
-                    Reason = RuntimeLevelReason.InstallEmptyDatabase;
-                    return;
-                }
+                // can connect to the database so cannot check the upgrade state... oops
+                _logger.Warn<RuntimeState>(e, "Could not check the upgrade state.");
 
                 // else it is bad enough that we want to throw
                 Reason = RuntimeLevelReason.BootFailedCannotCheckUpgradeState;
                 throw new BootFailedException("Could not check the upgrade state.", e);
             }
-
-            // if we already know we want to upgrade, exit here
-            if (Level == RuntimeLevel.Upgrade)
-                return;
-
-            if (noUpgrade)
-            {
-                // the database version matches the code & files version, all clear, can run
-                Level = RuntimeLevel.Run;
-                Reason = RuntimeLevelReason.Run;
-                return;
-            }
-
-            // the db version does not match... but we do have a migration table
-            // so, at least one valid table, so we quite probably are installed & need to upgrade
-
-            // although the files version matches the code version, the database version does not
-            // which means the local files have been upgraded but not the database - need to upgrade
-            logger.Debug<RuntimeState>("Has not reached the final upgrade step, need to upgrade Umbraco.");
-            Level = RuntimeLevel.Upgrade;
-            Reason = RuntimeLevelReason.UpgradeMigrations;
         }
 
-        protected virtual bool EnsureUmbracoUpgradeState(IUmbracoDatabaseFactory databaseFactory, ILogger logger)
+        private bool TryDbConnect(IUmbracoDatabaseFactory databaseFactory)
+        {
+            // anything other than install wants a database - see if we can connect
+            // (since this is an already existing database, assume localdb is ready)
+            bool canConnect;
+            var tries = RuntimeOptions.InstallMissingDatabase ? 2 : 5;
+            for (var i = 0; ;)
+            {
+                canConnect = databaseFactory.CanConnect;
+                if (canConnect || ++i == tries) break;
+                _logger.Debug<RuntimeState>("Could not immediately connect to database, trying again.");
+                Thread.Sleep(1000);
+            }
+
+            return canConnect;
+        }
+
+        private bool DoesUmbracoRequireUpgrade(IUmbracoDatabase database)
         {
             var upgrader = new Upgrader(new UmbracoPlan());
             var stateValueKey = upgrader.StateValueKey;
 
-            // no scope, no service - just directly accessing the database
-            using (var database = databaseFactory.CreateDatabase())
-            {
-                CurrentMigrationState = KeyValueService.GetValue(database, stateValueKey);
-                FinalMigrationState = upgrader.Plan.FinalState;
-            }
+            CurrentMigrationState = KeyValueService.GetValue(database, stateValueKey);
+            FinalMigrationState = upgrader.Plan.FinalState;
 
-            logger.Debug<RuntimeState>("Final upgrade state is {FinalMigrationState}, database contains {DatabaseState}", FinalMigrationState, CurrentMigrationState ?? "<null>");
+            _logger.Debug<RuntimeState>("Final upgrade state is {FinalMigrationState}, database contains {DatabaseState}", FinalMigrationState, CurrentMigrationState ?? "<null>");
 
-            return CurrentMigrationState == FinalMigrationState;
+            return CurrentMigrationState != FinalMigrationState;
         }
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -129,6 +129,7 @@
     -->
     <Compile Include="AssemblyExtensions.cs" />
     <Compile Include="Constants-SqlTemplates.cs" />
+    <Compile Include="Exceptions\UnattendedInstallException.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\ContentTypeDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyDataDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyTypeDto80.cs" />

--- a/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
+++ b/src/Umbraco.Tests/Runtimes/StandaloneTests.cs
@@ -75,7 +75,7 @@ namespace Umbraco.Tests.Runtimes
             coreRuntime.Compose(composition);
 
             // determine actual runtime level
-            runtimeState.DetermineRuntimeLevel(databaseFactory, logger);
+            runtimeState.DetermineRuntimeLevel(databaseFactory);
             Console.WriteLine(runtimeState.Level);
             // going to be Install BUT we want to force components to be there (nucache etc)
             runtimeState.Level = RuntimeLevel.Run;

--- a/src/Umbraco.Web/Install/InstallHelper.cs
+++ b/src/Umbraco.Web/Install/InstallHelper.cs
@@ -145,7 +145,7 @@ namespace Umbraco.Web.Install
                     return true;
                 }
 
-                return _databaseBuilder.HasSomeNonDefaultUser() == false;
+                return _databaseBuilder.IsUmbracoInstalled() == false;
             }
         }
 

--- a/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
@@ -12,6 +12,7 @@ using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Migrations.Install;
+using Umbraco.Core.Persistence;
 using Umbraco.Core.Services;
 using Umbraco.Web.Install.Models;
 
@@ -124,32 +125,94 @@ namespace Umbraco.Web.Install.InstallSteps
         {
             get
             {
-                return RequiresExecution(null)
-              //the user UI
-                ? "user"
-              //the continue install UI
-              : "continueinstall";
+                return ShowView()
+                    // the user UI
+                    ? "user"
+                    // continue install UI
+                    : "continueinstall";
             }
+        }
+
+        private InstallState GetInstallState()
+        {
+            var installState = InstallState.Unknown;
+
+            var databaseSettings = ConfigurationManager.ConnectionStrings[Constants.System.UmbracoConnectionName];
+
+            var hasVersion = !_globalSettings.ConfigurationStatus.IsNullOrWhiteSpace();
+            if (hasVersion)
+            {
+                installState = InstallState.HasVersion;
+            }
+
+            var hasConnString = databaseSettings != null && _databaseBuilder.IsDatabaseConfigured;
+            if (hasConnString)
+            {
+                installState = (installState | InstallState.HasConnectionString) & ~InstallState.Unknown;
+            }
+
+            var connStringConfigured = hasConnString ? _databaseBuilder.IsConnectionStringConfigured(databaseSettings) : false;
+            if (connStringConfigured)
+            {
+                installState = (installState | InstallState.ConnectionStringConfigured) & ~InstallState.Unknown;
+            }
+
+            var canConnect = connStringConfigured ? DbConnectionExtensions.IsConnectionAvailable(databaseSettings.ConnectionString, databaseSettings.ProviderName) : false;
+            if (canConnect)
+            {
+                installState = (installState | InstallState.CanConnect) & ~InstallState.Unknown;
+            }
+
+            var umbracoInstalled = canConnect ? _databaseBuilder.IsUmbracoInstalled() : false;
+            if (umbracoInstalled)
+            {
+                installState = (installState | InstallState.UmbracoInstalled) & ~InstallState.Unknown;
+            }
+
+            var hasNonDefaultUser = umbracoInstalled ? _databaseBuilder.HasSomeNonDefaultUser() : false;
+            if (hasNonDefaultUser)
+            {
+                installState = (installState | InstallState.HasNonDefaultUser) & ~InstallState.Unknown;
+            }
+
+            return installState;
+        }
+
+        private bool ShowView()
+        {
+            var installState = GetInstallState();
+
+            return installState.HasFlag(InstallState.Unknown)
+                || !installState.HasFlag(InstallState.UmbracoInstalled);
         }
 
         public override bool RequiresExecution(UserModel model)
         {
-            //now we have to check if this is really a new install, the db might be configured and might contain data
-            var databaseSettings = ConfigurationManager.ConnectionStrings[Constants.System.UmbracoConnectionName];
+            var installState = GetInstallState();
 
-            //if there's already a version then there should def be a user but in some cases someone may have
-            // left a version number in there but cleared out their db conn string, in that case, it's really a new install.
-            if (_globalSettings.ConfigurationStatus.IsNullOrWhiteSpace() == false && databaseSettings != null) return false;
+            if (installState.HasFlag(InstallState.Unknown))
+            {
+                // In this one case when it's a brand new install and nothing has been configured, make sure the
+                // back office cookie is cleared so there's no old cookies lying around causing problems
+                _http.ExpireCookie(Current.Configs.Settings().Security.AuthCookieName);
+            }
 
-            // if Umbraco is already installed there's already users in the database, skip this step
-            if (_databaseBuilder.IsConnectionStringConfigured(databaseSettings) && _databaseBuilder.IsDatabaseConfigured && _databaseBuilder.IsUmbracoInstalled())
-                return _databaseBuilder.HasSomeNonDefaultUser() == false;
+            return installState.HasFlag(InstallState.Unknown)
+                || !installState.HasFlag(InstallState.HasNonDefaultUser);
+        }
 
-            // In this one case when it's a brand new install and nothing has been configured, make sure the
-            // back office cookie is cleared so there's no old cookies lying around causing problems
-            _http.ExpireCookie(Current.Configs.Settings().Security.AuthCookieName);
-
-            return true;
+        [Flags]
+        private enum InstallState : short
+        {
+            // This is an easy way to avoid 0 enum assignment and not worry about
+            // manual calcs. https://www.codeproject.com/Articles/396851/Ending-the-Great-Debate-on-Enum-Flags
+            Unknown = 1,
+            HasVersion = 1 << 1,
+            HasConnectionString = 1 << 2,
+            ConnectionStringConfigured = 1 << 3,
+            CanConnect = 1 << 4,
+            UmbracoInstalled = 1 << 5,
+            HasNonDefaultUser = 1 << 6
         }
     }
 }

--- a/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
@@ -141,14 +141,15 @@ namespace Umbraco.Web.Install.InstallSteps
             // left a version number in there but cleared out their db conn string, in that case, it's really a new install.
             if (_globalSettings.ConfigurationStatus.IsNullOrWhiteSpace() == false && databaseSettings != null) return false;
 
-            if (_databaseBuilder.IsConnectionStringConfigured(databaseSettings) && _databaseBuilder.IsDatabaseConfigured)
-                return _databaseBuilder.IsUmbracoInstalled() == false;
+            // if Umbraco is already installed there's already users in the database, skip this step
+            if (_databaseBuilder.IsConnectionStringConfigured(databaseSettings) && _databaseBuilder.IsDatabaseConfigured && _databaseBuilder.IsUmbracoInstalled())
+                return _databaseBuilder.HasSomeNonDefaultUser() == false;
 
             // In this one case when it's a brand new install and nothing has been configured, make sure the
             // back office cookie is cleared so there's no old cookies lying around causing problems
             _http.ExpireCookie(Current.Configs.Settings().Security.AuthCookieName);
 
-                return true;
+            return true;
         }
     }
 }

--- a/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/NewInstallStep.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Web.Install.InstallSteps
             if (_globalSettings.ConfigurationStatus.IsNullOrWhiteSpace() == false && databaseSettings != null) return false;
 
             if (_databaseBuilder.IsConnectionStringConfigured(databaseSettings) && _databaseBuilder.IsDatabaseConfigured)
-                return _databaseBuilder.HasSomeNonDefaultUser() == false;
+                return _databaseBuilder.IsUmbracoInstalled() == false;
 
             // In this one case when it's a brand new install and nothing has been configured, make sure the
             // back office cookie is cleared so there's no old cookies lying around causing problems

--- a/src/Umbraco.Web/UmbracoApplication.cs
+++ b/src/Umbraco.Web/UmbracoApplication.cs
@@ -31,6 +31,8 @@ namespace Umbraco.Web
             // Determine if we should use the sql main dom or the default
             var appSettingMainDomLock = ConfigurationManager.AppSettings[Constants.AppSettings.MainDomLock];
 
+            // TODO: Can we automatically and consistently determine we're running on Azure without this app setting?
+
             var mainDomLock = appSettingMainDomLock == "SqlMainDomLock"
                 ? (IMainDomLock)new SqlMainDomLock(logger)
                 : new MainDomSemaphoreLock(logger);


### PR DESCRIPTION
To enable unattended install the `Umbraco.Core.ConfigurationStatus` app setting needs to have the current version and the `umbracoDbDSN` connection string needs to be configured. Then on boot we'll check if the database is empty (has no tables) and if it is, the database schema and default data will be created.

The unattended install can be disabled by adding an app setting `Umbraco.Core.RuntimeState.InstallUnattended` with the value `false`. Umbraco will then fail to boot if the version and connection string is present but the database is empty.

Note: You will not be able to login to Umbraco since no password has been set for the default user, you either need to have an external login provider configured or setting a password in some other way.

---
_This item has been added to our backlog [AB#9632](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/9632)_