### PR TITLE
NetCore: Fix wrong version of Smidge in nuspec + Updated to official 3.2.0

### DIFF
--- a/build/NuSpecs/UmbracoCms.Web.nuspec
+++ b/build/NuSpecs/UmbracoCms.Web.nuspec
@@ -30,8 +30,8 @@
                 <dependency id="Microsoft.CodeAnalysis.CSharp" version="[3.7.0,3.999999)" />
                 <dependency id="MiniProfiler.AspNetCore.Mvc" version="[4.2.1,4.999999)" />
                 <dependency id="NETStandard.Library" version="[2.0.3,2.999999)" />
-                <dependency id="Smidge" version="[3.1.1,3.999999)" />
-                <dependency id="Smidge.Nuglify" version="[2.0.0,2.999999)" />
+                <dependency id="Smidge" version="[3.2.0,3.999999)" />
+                <dependency id="Smidge.Nuglify" version="[3.2.0,3.999999)" />
                 <dependency id="SixLabors.ImageSharp.Web" version="[1.0.0,1.999999)" />
                 <dependency id="HtmlSanitizer" version="[5.0.353,5.999999)" />
             </group>

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -26,8 +26,8 @@
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
       <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0" />
-      <PackageReference Include="Smidge" Version="3.2.0-build.244" />
-      <PackageReference Include="Smidge.Nuglify" Version="3.2.0-build.244" />
+      <PackageReference Include="Smidge" Version="3.2.0" />
+      <PackageReference Include="Smidge.Nuglify" Version="3.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Fix wrong version of `Smidge.Nuglify` in nuspec file
- Updated `Smidge` and  `Smidge.Nuglify` from build version of 3.2.0 to the official 3.2.0 on nuget