### PR TITLE
NetCore: updated some code to match linting rules 

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -1,4 +1,8 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -13,6 +17,7 @@ using Umbraco.Core.Sync;
 using Umbraco.Infrastructure.Configuration.Extensions;
 using Umbraco.Infrastructure.HealthCheck;
 using Umbraco.Web.HealthCheck;
+using Umbraco.Web.HealthCheck.NotificationMethods;
 
 namespace Umbraco.Infrastructure.HostedServices
 {
@@ -31,6 +36,19 @@ namespace Umbraco.Infrastructure.HostedServices
         private readonly ILogger<HealthCheckNotifier> _logger;
         private readonly IProfilingLogger _profilingLogger;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthCheckNotifier"/> class.
+        /// </summary>
+        /// <param name="healthChecksSettings">The configuration for health check settings.</param>
+        /// <param name="healthChecks">The collection of healthchecks.</param>
+        /// <param name="notifications">The collection of healthcheck notification methods.</param>
+        /// <param name="runtimeState">Representation of the state of the Umbraco runtime.</param>
+        /// <param name="serverRegistrar">Provider of server registrations to the distributed cache.</param>
+        /// <param name="mainDom">Representation of the main application domain.</param>
+        /// <param name="scopeProvider">Provides scopes for database operations.</param>
+        /// <param name="logger">The typed logger.</param>
+        /// <param name="profilingLogger">The profiling logger.</param>
+        /// <param name="cronTabParser">Parser of crontab expressions.</param>
         public HealthCheckNotifier(
             IOptions<HealthChecksSettings> healthChecksSettings,
             HealthCheckCollection healthChecks,
@@ -42,8 +60,9 @@ namespace Umbraco.Infrastructure.HostedServices
             ILogger<HealthCheckNotifier> logger,
             IProfilingLogger profilingLogger,
             ICronTabParser cronTabParser)
-            : base(healthChecksSettings.Value.Notification.Period,
-                   healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
+            : base(
+                healthChecksSettings.Value.Notification.Period,
+                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
         {
             _healthChecksSettings = healthChecksSettings.Value;
             _healthChecks = healthChecks;
@@ -88,25 +107,25 @@ namespace Umbraco.Infrastructure.HostedServices
             // Ensure we use an explicit scope since we are running on a background thread and plugin health
             // checks can be making service/database calls so we want to ensure the CallContext/Ambient scope
             // isn't used since that can be problematic.
-            using (var scope = _scopeProvider.CreateScope())
+            using (IScope scope = _scopeProvider.CreateScope())
             using (_profilingLogger.DebugDuration<HealthCheckNotifier>("Health checks executing", "Health checks complete"))
             {
                 // Don't notify for any checks that are disabled, nor for any disabled just for notifications.
-                var disabledCheckIds = _healthChecksSettings.Notification.DisabledChecks
+                Guid[] disabledCheckIds = _healthChecksSettings.Notification.DisabledChecks
                         .Select(x => x.Id)
                     .Union(_healthChecksSettings.DisabledChecks
                         .Select(x => x.Id))
                     .Distinct()
                     .ToArray();
 
-                var checks = _healthChecks
+                IEnumerable<Core.HealthCheck.HealthCheck> checks = _healthChecks
                     .Where(x => disabledCheckIds.Contains(x.Id) == false);
 
                 var results = new HealthCheckResults(checks);
                 results.LogResults();
 
                 // Send using registered notification methods that are enabled.
-                foreach (var notificationMethod in _notifications.Where(x => x.Enabled))
+                foreach (IHealthCheckNotificationMethod notificationMethod in _notifications.Where(x => x.Enabled))
                 {
                     await notificationMethod.SendAsync(results);
                 }

--- a/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -24,7 +27,24 @@ namespace Umbraco.Infrastructure.HostedServices
         private readonly IServerRegistrar _serverRegistrar;
         private readonly IHttpClientFactory _httpClientFactory;
 
-        public KeepAlive(IRequestAccessor requestAccessor, IMainDom mainDom, IOptions<KeepAliveSettings> keepAliveSettings, ILogger<KeepAlive> logger, IProfilingLogger profilingLogger, IServerRegistrar serverRegistrar, IHttpClientFactory httpClientFactory)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeepAlive"/> class.
+        /// </summary>
+        /// <param name="requestAccessor">Accessor for the current request.</param>
+        /// <param name="mainDom">Representation of the main application domain.</param>
+        /// <param name="keepAliveSettings">The configuration for keep alive settings.</param>
+        /// <param name="logger">The typed logger.</param>
+        /// <param name="profilingLogger">The profiling logger.</param>
+        /// <param name="serverRegistrar">Provider of server registrations to the distributed cache.</param>
+        /// <param name="httpClientFactory">Factory for <see cref="HttpClient" /> instances.</param>
+        public KeepAlive(
+            IRequestAccessor requestAccessor,
+            IMainDom mainDom,
+            IOptions<KeepAliveSettings> keepAliveSettings,
+            ILogger<KeepAlive> logger,
+            IProfilingLogger profilingLogger,
+            IServerRegistrar serverRegistrar,
+            IHttpClientFactory httpClientFactory)
             : base(TimeSpan.FromMinutes(5), DefaultDelay)
         {
             _requestAccessor = requestAccessor;
@@ -79,8 +99,8 @@ namespace Umbraco.Infrastructure.HostedServices
                     }
 
                     var request = new HttpRequestMessage(HttpMethod.Get, keepAlivePingUrl);
-                    var httpClient = _httpClientFactory.CreateClient();
-                    await httpClient.SendAsync(request);
+                    HttpClient httpClient = _httpClientFactory.CreateClient();
+                    _ = await httpClient.SendAsync(request);
                 }
                 catch (Exception ex)
                 {

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -13,44 +16,54 @@ namespace Umbraco.Infrastructure.HostedServices
     /// </remarks>
     public abstract class RecurringHostedServiceBase : IHostedService, IDisposable
     {
+        /// <summary>
+        /// The default delay to use for recurring tasks for the first run after application start-up if no alternative is configured.
+        /// </summary>
         protected static readonly TimeSpan DefaultDelay = TimeSpan.FromMinutes(3);
 
         private readonly TimeSpan _period;
         private readonly TimeSpan _delay;
         private Timer _timer;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecurringHostedServiceBase"/> class.
+        /// </summary>
+        /// <param name="period">Timepsan representing how often the task should recur.</param>
+        /// <param name="delay">Timespan represeting the initial delay after application start-up before the first run of the task occurs.</param>
         protected RecurringHostedServiceBase(TimeSpan period, TimeSpan delay)
         {
             _period = period;
             _delay = delay;
         }
 
+        /// <inheritdoc/>
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _timer = new Timer(ExecuteAsync, null, (int)_delay.TotalMilliseconds, (int)_period.TotalMilliseconds);
             return Task.CompletedTask;
         }
 
-        public async void ExecuteAsync(object state)
-        {
+        /// <summary>
+        /// Executes the task.
+        /// </summary>
+        /// <param name="state">The task state.</param>
+        public async void ExecuteAsync(object state) =>
             // Delegate work to method returning a task, that can be called and asserted in a unit test.
             // Without this there can be behaviour where tests pass, but an error within them causes the test
             // running process to crash.
             // Hat-tip: https://stackoverflow.com/a/14207615/489433
             await PerformExecuteAsync(state);
-        }
 
         internal abstract Task PerformExecuteAsync(object state);
 
+        /// <inheritdoc/>
         public Task StopAsync(CancellationToken cancellationToken)
         {
             _timer?.Change(Timeout.Infinite, 0);
             return Task.CompletedTask;
         }
 
-        public void Dispose()
-        {
-            _timer?.Dispose();
-        }
+        /// <inheritdoc/>
+        public void Dispose() => _timer?.Dispose();
     }
 }

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -20,6 +23,10 @@ namespace Umbraco.Infrastructure.HostedServices.ServerRegistration
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionProcessTask"/> class.
         /// </summary>
+        /// <param name="runtimeState">Representation of the state of the Umbraco runtime.</param>
+        /// <param name="messenger">Service broadcasting cache notifications to registered servers.</param>
+        /// <param name="logger">The typed logger.</param>
+        /// <param name="globalSettings">The configuration for global settings.</param>
         public InstructionProcessTask(IRuntimeState runtimeState, IServerMessenger messenger, ILogger<InstructionProcessTask> logger, IOptions<GlobalSettings> globalSettings)
             : base(globalSettings.Value.DatabaseServerMessenger.TimeBetweenSyncOperations, TimeSpan.FromMinutes(1))
         {
@@ -28,11 +35,11 @@ namespace Umbraco.Infrastructure.HostedServices.ServerRegistration
             _logger = logger;
         }
 
-        internal override async Task PerformExecuteAsync(object state)
+        internal override Task PerformExecuteAsync(object state)
         {
             if (_runtimeState.Level != RuntimeLevel.Run)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             try
@@ -43,6 +50,8 @@ namespace Umbraco.Infrastructure.HostedServices.ServerRegistration
             {
                 _logger.LogError(e, "Failed (will repeat).");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,11 +21,16 @@ namespace Umbraco.Infrastructure.HostedServices.ServerRegistration
         private readonly IServerRegistrationService _serverRegistrationService;
         private readonly IRequestAccessor _requestAccessor;
         private readonly ILogger<TouchServerTask> _logger;
-        private GlobalSettings _globalSettings;
+        private readonly GlobalSettings _globalSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchServerTask"/> class.
         /// </summary>
+        /// <param name="runtimeState">Representation of the state of the Umbraco runtime.</param>
+        /// <param name="serverRegistrationService">Services for server registrations.</param>
+        /// <param name="requestAccessor">Accessor for the current request.</param>
+        /// <param name="logger">The typed logger.</param>
+        /// <param name="globalSettings">The configuration for global settings.</param>
         public TouchServerTask(IRuntimeState runtimeState, IServerRegistrationService serverRegistrationService, IRequestAccessor requestAccessor, ILogger<TouchServerTask> logger, IOptions<GlobalSettings> globalSettings)
             : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
         {
@@ -33,18 +41,18 @@ namespace Umbraco.Infrastructure.HostedServices.ServerRegistration
             _globalSettings = globalSettings.Value;
         }
 
-        internal override async Task PerformExecuteAsync(object state)
+        internal override Task PerformExecuteAsync(object state)
         {
             if (_runtimeState.Level != RuntimeLevel.Run)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             var serverAddress = _requestAccessor.GetApplicationUrl()?.ToString();
             if (serverAddress.IsNullOrWhiteSpace())
             {
                 _logger.LogWarning("No umbracoApplicationUrl for service (yet), skip.");
-                return;
+                return Task.CompletedTask;
             }
 
             try
@@ -57,6 +65,8 @@ namespace Umbraco.Infrastructure.HostedServices.ServerRegistration
             {
                 _logger.LogError(ex, "Failed to update server record in database.");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Tests.Common/Builders/AuditEntryBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/AuditEntryBuilder.cs
@@ -1,5 +1,7 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
-using System.Globalization;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
 
@@ -7,7 +9,8 @@ namespace Umbraco.Tests.Common.Builders
 {
     public class AuditEntryBuilder : AuditEntryBuilder<object>
     {
-        public AuditEntryBuilder() : base(null)
+        public AuditEntryBuilder()
+            : base(null)
         {
         }
     }
@@ -34,8 +37,57 @@ namespace Umbraco.Tests.Common.Builders
         private DateTime? _eventDateUtc = null;
         private int? _performingUserId = null;
 
-        public AuditEntryBuilder(TParent parentBuilder) : base(parentBuilder)
+        public AuditEntryBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
+        }
+
+        public AuditEntryBuilder<TParent> WithAffectedDetails(string affectedDetails)
+        {
+            _affectedDetails = affectedDetails;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithAffectedUserId(int affectedUserId)
+        {
+            _affectedUserId = affectedUserId;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithEventDetails(string eventDetails)
+        {
+            _eventDetails = eventDetails;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithEventType(string eventType)
+        {
+            _eventType = eventType;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithPerformingDetails(string performingDetails)
+        {
+            _performingDetails = performingDetails;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithPerformingIp(string performingIp)
+        {
+            _performingIp = performingIp;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithEventDate(DateTime eventDateUtc)
+        {
+            _eventDateUtc = eventDateUtc;
+            return this;
+        }
+
+        public AuditEntryBuilder<TParent> WithPerformingUserId(int performingUserId)
+        {
+            _performingUserId = performingUserId;
+            return this;
         }
 
         DateTime? IWithCreateDateBuilder.CreateDate
@@ -68,22 +120,20 @@ namespace Umbraco.Tests.Common.Builders
             set => _updateDate = value;
         }
 
-
-
         public override IAuditEntry Build()
         {
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
-            var deleteDate = _deleteDate ?? null;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
+            DateTime? deleteDate = _deleteDate ?? null;
             var affectedDetails = _affectedDetails ?? Guid.NewGuid().ToString();
             var affectedUserId = _affectedUserId ?? -1;
             var eventDetails = _eventDetails ?? Guid.NewGuid().ToString();
             var eventType = _eventType ?? "umbraco/user";
             var performingDetails = _performingDetails ?? Guid.NewGuid().ToString();
             var performingIp = _performingIp ?? "127.0.0.1";
-            var eventDateUtc = _eventDateUtc ?? DateTime.UtcNow;
+            DateTime eventDateUtc = _eventDateUtc ?? DateTime.UtcNow;
             var performingUserId = _performingUserId ?? -1;
 
             return new AuditEntry

--- a/src/Umbraco.Tests.Common/Builders/BuilderBase.cs
+++ b/src/Umbraco.Tests.Common/Builders/BuilderBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders

--- a/src/Umbraco.Tests.Common/Builders/ChildBuilderBase.cs
+++ b/src/Umbraco.Tests.Common/Builders/ChildBuilderBase.cs
@@ -1,18 +1,14 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 namespace Umbraco.Tests.Common.Builders
 {
     public abstract class ChildBuilderBase<TParent, TType> : BuilderBase<TType>
     {
         private readonly TParent _parentBuilder;
 
-        protected ChildBuilderBase(TParent parentBuilder)
-        {
-            _parentBuilder = parentBuilder;
-        }
+        protected ChildBuilderBase(TParent parentBuilder) => _parentBuilder = parentBuilder;
 
-        public TParent Done()
-        {
-            return _parentBuilder;
-        }
-
+        public TParent Done() => _parentBuilder;
     }
 }

--- a/src/Umbraco.Tests.Common/Builders/ConfigurationEditorBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ConfigurationEditorBuilder.cs
@@ -1,7 +1,8 @@
-using System.Collections.Generic;
-using Umbraco.Core;
-using Umbraco.Core.PropertyEditors;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
 
+using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Tests.Common.Builders
 {
@@ -9,7 +10,8 @@ namespace Umbraco.Tests.Common.Builders
     {
         private IDictionary<string, object> _defaultConfiguration;
 
-        public ConfigurationEditorBuilder(TParent parentBuilder) : base(parentBuilder)
+        public ConfigurationEditorBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -21,7 +23,7 @@ namespace Umbraco.Tests.Common.Builders
 
         public override IConfigurationEditor Build()
         {
-            var defaultConfiguration  = _defaultConfiguration ?? new Dictionary<string, object>();
+            IDictionary<string, object> defaultConfiguration  = _defaultConfiguration ?? new Dictionary<string, object>();
 
             return new ConfigurationEditor()
             {

--- a/src/Umbraco.Tests.Common/Builders/ContentBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentBuilder.cs
@@ -1,11 +1,14 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Umbraco.Core.Models;
-using Umbraco.Tests.Common.Builders.Interfaces;
-using Umbraco.Tests.Common.Builders.Extensions;
-using Umbraco.Tests.Testing;
 using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Tests.Common.Builders.Extensions;
+using Umbraco.Tests.Common.Builders.Interfaces;
+using Umbraco.Tests.Testing;
 
 namespace Umbraco.Tests.Common.Builders
 {
@@ -44,7 +47,7 @@ namespace Umbraco.Tests.Common.Builders
         private bool? _trashed;
         private CultureInfo _cultureInfo;
         private IContentType _contentType;
-        private IDictionary<string, string> _cultureNames = new Dictionary<string, string>();
+        private readonly IDictionary<string, string> _cultureNames = new Dictionary<string, string>();
         private object _propertyValues;
         private string _propertyValuesCulture;
         private string _propertyValuesSegment;
@@ -105,11 +108,11 @@ namespace Umbraco.Tests.Common.Builders
         {
             var id = _id ?? 0;
             var versionId = _versionId ?? 0;
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var parentId = _parentId ?? -1;
-            var parent = _parent ?? null;
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            IContent parent = _parent ?? null;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? Guid.NewGuid().ToString();
             var creatorId = _creatorId ?? 0;
             var level = _level ?? 1;
@@ -126,7 +129,7 @@ namespace Umbraco.Tests.Common.Builders
                 throw new InvalidOperationException("A content item cannot be constructed without providing a content type. Use AddContentType() or WithContentType().");
             }
 
-            var contentType = _contentType ?? _contentTypeBuilder.Build();
+            IContentType contentType = _contentType ?? _contentTypeBuilder.Build();
 
             Content content;
             if (parent != null)
@@ -149,7 +152,7 @@ namespace Umbraco.Tests.Common.Builders
             content.SortOrder = sortOrder;
             content.Trashed = trashed;
 
-            foreach (var cultureName in _cultureNames)
+            foreach (KeyValuePair<string, string> cultureName in _cultureNames)
             {
                 content.SetCultureName(cultureName.Value, cultureName.Key);
             }
@@ -158,8 +161,8 @@ namespace Umbraco.Tests.Common.Builders
             {
                 if (_propertyDataBuilder != null)
                 {
-                    var propertyData = _propertyDataBuilder.Build();
-                    foreach (var keyValuePair in propertyData)
+                    IDictionary<string, object> propertyData = _propertyDataBuilder.Build();
+                    foreach (KeyValuePair<string, object> keyValuePair in propertyData)
                     {
                         content.SetValue(keyValuePair.Key, keyValuePair.Value);
                     }
@@ -175,47 +178,44 @@ namespace Umbraco.Tests.Common.Builders
             return content;
         }
 
-        public static Content CreateBasicContent(IContentType contentType, int id = 0)
-        {
-            return new ContentBuilder()
+        public static Content CreateBasicContent(IContentType contentType, int id = 0) =>
+            new ContentBuilder()
                 .WithId(id)
                 .WithContentType(contentType)
                 .WithName("Home")
                 .Build();
-        }
 
-        public static Content CreateSimpleContent(IContentType contentType)
-        {
-            return new ContentBuilder()
+        public static Content CreateSimpleContent(IContentType contentType) =>
+            new ContentBuilder()
                 .WithContentType(contentType)
                 .WithName("Home")
                 .WithPropertyValues(new
-                    {
-                        title = "Welcome to our Home page",
-                        bodyText = "This is the welcome message on the first page",
-                        author = "John Doe"
-                    })
+                {
+                    title = "Welcome to our Home page",
+                    bodyText = "This is the welcome message on the first page",
+                    author = "John Doe"
+                })
                 .Build();
-        }
 
-        public static Content CreateSimpleContent(IContentType contentType, string name, int parentId = -1, string culture = null, string segment = null)
-        {
-            return new ContentBuilder()
+        public static Content CreateSimpleContent(IContentType contentType, string name, int parentId = -1, string culture = null, string segment = null) =>
+            new ContentBuilder()
                 .WithContentType(contentType)
                 .WithName(name)
                 .WithParentId(parentId)
-                .WithPropertyValues(new
+                .WithPropertyValues(
+                    new
                     {
                         title = "Welcome to our Home page",
                         bodyText = "This is the welcome message on the first page",
                         author = "John Doe"
-                    }, culture, segment)
+                    },
+                    culture,
+                    segment)
                 .Build();
-        }
 
         public static Content CreateSimpleContent(IContentType contentType, string name, IContent parent, string culture = null, string segment = null, bool setPropertyValues = true)
         {
-            var builder = new ContentBuilder()
+            ContentBuilder builder = new ContentBuilder()
                 .WithContentType(contentType)
                 .WithName(name)
                 .WithParent(parent);
@@ -228,15 +228,18 @@ namespace Umbraco.Tests.Common.Builders
 
             if (setPropertyValues)
             {
-                builder = builder.WithPropertyValues(new
-                {
-                    title = name + " Subpage",
-                    bodyText = "This is a subpage",
-                    author = "John Doe"
-                }, culture, segment);
+                builder = builder.WithPropertyValues(
+                    new
+                    {
+                        title = name + " Subpage",
+                        bodyText = "This is a subpage",
+                        author = "John Doe"
+                    },
+                    culture,
+                    segment);
             }
 
-            var content = builder.Build();
+            Content content = builder.Build();
 
             content.ResetDirtyProperties(false);
 
@@ -247,7 +250,7 @@ namespace Umbraco.Tests.Common.Builders
         {
             var list = new List<Content>();
 
-            for (int i = 0; i < amount; i++)
+            for (var i = 0; i < amount; i++)
             {
                 var name = "Textpage No-" + i;
                 var content = new Content(name, parentId, contentType) { CreatorId = 0, WriterId = 0 };
@@ -269,14 +272,15 @@ namespace Umbraco.Tests.Common.Builders
 
             return list;
         }
-        public static Content CreateTextpageContent(IContentType contentType, string name, int parentId)
-        {
-            return new ContentBuilder()
+
+        public static Content CreateTextpageContent(IContentType contentType, string name, int parentId) =>
+            new ContentBuilder()
                 .WithId(0)
                 .WithContentType(contentType)
                 .WithName(name)
                 .WithParentId(parentId)
-                .WithPropertyValues(new
+                .WithPropertyValues(
+                    new
                     {
                         title = name + " textpage",
                         bodyText = string.Format("This is a textpage based on the {0} ContentType", contentType.Alias),
@@ -284,7 +288,6 @@ namespace Umbraco.Tests.Common.Builders
                         description = "This is the meta description for a textpage"
                     })
                 .Build();
-        }
 
         public static IEnumerable<Content> CreateMultipleTextpageContent(IContentType contentType, int parentId, int amount)
         {
@@ -293,7 +296,7 @@ namespace Umbraco.Tests.Common.Builders
             for (var i = 0; i < amount; i++)
             {
                 var name = "Textpage No-" + i;
-                var content = new ContentBuilder()
+                Content content = new ContentBuilder()
                     .WithName(name)
                     .WithParentId(parentId)
                     .WithContentType(contentType)
@@ -314,7 +317,7 @@ namespace Umbraco.Tests.Common.Builders
 
         public static Content CreateAllTypesContent(IContentType contentType, string name, int parentId)
         {
-            var content = new ContentBuilder()
+            Content content = new ContentBuilder()
                 .WithName(name)
                 .WithParentId(parentId)
                 .WithContentType(contentType)

--- a/src/Umbraco.Tests.Common/Builders/ContentItemSaveBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentItemSaveBuilder.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
 using System.Linq;
-using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
 using Umbraco.Web.Models.ContentEditing;
 
@@ -29,8 +31,8 @@ namespace Umbraco.Tests.Common.Builders
             var id = _id ?? 0;
             var parentId = _parentId ?? -1;
             var contentTypeAlias = _contentTypeAlias ?? null;
-            var action = _action ?? ContentSaveAction.Save;
-            var variants = _variantBuilders.Select(x => x.Build());
+            ContentSaveAction action = _action ?? ContentSaveAction.Save;
+            IEnumerable<ContentVariantSave> variants = _variantBuilders.Select(x => x.Build());
 
             return new TestContentItemSave()
             {
@@ -47,6 +49,7 @@ namespace Umbraco.Tests.Common.Builders
             get => _id;
             set => _id = value;
         }
+
         int? IWithParentIdBuilder.ParentId
         {
             get => _parentId;

--- a/src/Umbraco.Tests.Common/Builders/ContentPropertyBasicBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentPropertyBasicBuilder.cs
@@ -1,4 +1,7 @@
-﻿using Umbraco.Tests.Common.Builders.Interfaces;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Tests.Common.Builders.Interfaces;
 using Umbraco.Web.Models.ContentEditing;
 
 namespace Umbraco.Tests.Common.Builders
@@ -31,9 +34,9 @@ namespace Umbraco.Tests.Common.Builders
         public ContentPropertyBasicBuilder<TParent> WithValue(object value)
         {
             _value = value;
-
             return this;
         }
+
         int? IWithIdBuilder.Id
         {
             get => _id;

--- a/src/Umbraco.Tests.Common/Builders/ContentTypeBaseBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentTypeBaseBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Collections.Generic;
 using Umbraco.Core.Models;
@@ -26,7 +29,8 @@ namespace Umbraco.Tests.Common.Builders
             IWithIconBuilder,
             IWithThumbnailBuilder,
             IWithTrashedBuilder,
-            IWithIsContainerBuilder where TParent : IBuildContentTypes
+            IWithIsContainerBuilder
+        where TParent : IBuildContentTypes
     {
         private int? _id;
         private Guid? _key;
@@ -48,7 +52,8 @@ namespace Umbraco.Tests.Common.Builders
 
         protected IShortStringHelper ShortStringHelper => new DefaultShortStringHelper(new DefaultShortStringHelperConfig());
 
-        public ContentTypeBaseBuilder(TParent parentBuilder) : base(parentBuilder)
+        public ContentTypeBaseBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -88,7 +93,7 @@ namespace Umbraco.Tests.Common.Builders
 
         protected void BuildPropertyGroups(ContentTypeCompositionBase contentType, IEnumerable<PropertyGroup> propertyGroups)
         {
-            foreach (var propertyGroup in propertyGroups)
+            foreach (PropertyGroup propertyGroup in propertyGroups)
             {
                 contentType.PropertyGroups.Add(propertyGroup);
             }
@@ -99,7 +104,7 @@ namespace Umbraco.Tests.Common.Builders
             if (propertyTypeIdsIncrementingFrom.HasValue)
             {
                 var i = propertyTypeIdsIncrementingFrom.Value;
-                foreach (var propertyType in contentType.PropertyTypes)
+                foreach (IPropertyType propertyType in contentType.PropertyTypes)
                 {
                     propertyType.Id = ++i;
                 }
@@ -112,12 +117,12 @@ namespace Umbraco.Tests.Common.Builders
             // and ensure there are no clashes).
             contentType.Id = seedId;
             var itemid = seedId + 1;
-            foreach (var propertyGroup in contentType.PropertyGroups)
+            foreach (PropertyGroup propertyGroup in contentType.PropertyGroups)
             {
                 propertyGroup.Id = itemid++;
             }
 
-            foreach (var propertyType in contentType.PropertyTypes)
+            foreach (IPropertyType propertyType in contentType.PropertyTypes)
             {
                 propertyType.Id = itemid++;
             }

--- a/src/Umbraco.Tests.Common/Builders/ContentTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentTypeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
@@ -12,21 +15,23 @@ namespace Umbraco.Tests.Common.Builders
             IWithPropertyTypeIdsIncrementingFrom,
             IBuildPropertyTypes
     {
-        private List<PropertyGroupBuilder<ContentTypeBuilder>> _propertyGroupBuilders = new List<PropertyGroupBuilder<ContentTypeBuilder>>();
-        private List<PropertyTypeBuilder<ContentTypeBuilder>> _noGroupPropertyTypeBuilders = new List<PropertyTypeBuilder<ContentTypeBuilder>>();
-        private List<TemplateBuilder> _templateBuilders = new List<TemplateBuilder>();
-        private List<ContentTypeSortBuilder> _allowedContentTypeBuilders = new List<ContentTypeSortBuilder>();
+        private readonly List<PropertyGroupBuilder<ContentTypeBuilder>> _propertyGroupBuilders = new List<PropertyGroupBuilder<ContentTypeBuilder>>();
+        private readonly List<PropertyTypeBuilder<ContentTypeBuilder>> _noGroupPropertyTypeBuilders = new List<PropertyTypeBuilder<ContentTypeBuilder>>();
+        private readonly List<TemplateBuilder> _templateBuilders = new List<TemplateBuilder>();
+        private readonly List<ContentTypeSortBuilder> _allowedContentTypeBuilders = new List<ContentTypeSortBuilder>();
 
         private int? _propertyTypeIdsIncrementingFrom;
         private int? _defaultTemplateId;
         private ContentVariation? _contentVariation;
         private PropertyTypeCollection _propertyTypeCollection;
 
-        public ContentTypeBuilder() : base(null)
+        public ContentTypeBuilder()
+            : base(null)
         {
         }
 
-        public ContentTypeBuilder(ContentBuilder parentBuilder) : base(parentBuilder)
+        public ContentTypeBuilder(ContentBuilder parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -78,10 +83,10 @@ namespace Umbraco.Tests.Common.Builders
 
         public override IContentType Build()
         {
-            var contentVariation = _contentVariation ?? ContentVariation.Nothing;
+            ContentVariation contentVariation = _contentVariation ?? ContentVariation.Nothing;
 
             ContentType contentType;
-            var parent = GetParent();
+            IContentTypeComposition parent = GetParent();
             if (parent != null)
             {
                 contentType = new ContentType(ShortStringHelper, (IContentType)parent, GetAlias());
@@ -113,7 +118,7 @@ namespace Umbraco.Tests.Common.Builders
 
             if (_propertyTypeCollection != null)
             {
-                var propertyGroup = new PropertyGroupBuilder()
+                PropertyGroup propertyGroup = new PropertyGroupBuilder()
                     .WithName("Content")
                     .WithSortOrder(1)
                     .WithPropertyTypeCollection(_propertyTypeCollection)
@@ -153,7 +158,7 @@ namespace Umbraco.Tests.Common.Builders
 
         public static ContentType CreateSimpleContentType2(string alias, string name, IContentType parent = null, bool randomizeAliases = false, string propertyGroupName = "Content")
         {
-            var builder = CreateSimpleContentTypeHelper(alias, name, parent, randomizeAliases: randomizeAliases, propertyGroupName: propertyGroupName);
+            ContentTypeBuilder builder = CreateSimpleContentTypeHelper(alias, name, parent, randomizeAliases: randomizeAliases, propertyGroupName: propertyGroupName);
 
             builder.AddPropertyType()
                 .WithAlias(RandomAlias("gen", randomizeAliases))
@@ -167,14 +172,12 @@ namespace Umbraco.Tests.Common.Builders
             return (ContentType)builder.Build();
         }
 
-        public static ContentType CreateSimpleContentType(string alias = null, string name = null, IContentType parent = null, PropertyTypeCollection propertyTypeCollection = null, bool randomizeAliases = false, string propertyGroupName = "Content", bool mandatoryProperties = false, int defaultTemplateId = 0)
-        {
-            return (ContentType)CreateSimpleContentTypeHelper(alias, name, parent, propertyTypeCollection, randomizeAliases, propertyGroupName, mandatoryProperties, defaultTemplateId).Build();
-        }
+        public static ContentType CreateSimpleContentType(string alias = null, string name = null, IContentType parent = null, PropertyTypeCollection propertyTypeCollection = null, bool randomizeAliases = false, string propertyGroupName = "Content", bool mandatoryProperties = false, int defaultTemplateId = 0) =>
+            (ContentType)CreateSimpleContentTypeHelper(alias, name, parent, propertyTypeCollection, randomizeAliases, propertyGroupName, mandatoryProperties, defaultTemplateId).Build();
 
         public static ContentTypeBuilder CreateSimpleContentTypeHelper(string alias = null, string name = null, IContentType parent = null, PropertyTypeCollection propertyTypeCollection = null,  bool randomizeAliases = false, string propertyGroupName = "Content", bool mandatoryProperties = false, int defaultTemplateId = 0)
         {
-            var builder = new ContentTypeBuilder()
+            ContentTypeBuilder builder = new ContentTypeBuilder()
                 .WithAlias(alias ?? "simple")
                 .WithName(name ?? "Simple Page")
                 .WithParentContentType(parent);
@@ -228,9 +231,9 @@ namespace Umbraco.Tests.Common.Builders
 
         public static ContentType CreateSimpleTagsContentType(string alias, string name, IContentType parent = null, bool randomizeAliases = false, string propertyGroupName = "Content", int defaultTemplateId = 1)
         {
-            var contentType = CreateSimpleContentType(alias, name, parent, randomizeAliases: randomizeAliases, propertyGroupName: propertyGroupName, defaultTemplateId: defaultTemplateId);
+            ContentType contentType = CreateSimpleContentType(alias, name, parent, randomizeAliases: randomizeAliases, propertyGroupName: propertyGroupName, defaultTemplateId: defaultTemplateId);
 
-            var propertyType = new PropertyTypeBuilder()
+            PropertyType propertyType = new PropertyTypeBuilder()
                 .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.Tags)
                 .WithValueStorageType(ValueStorageType.Nvarchar)
                 .WithAlias(RandomAlias("tags", randomizeAliases))

--- a/src/Umbraco.Tests.Common/Builders/ContentTypeSortBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentTypeSortBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Extensions;
@@ -15,7 +18,8 @@ namespace Umbraco.Tests.Common.Builders
         private string _alias;
         private int? _sortOrder;
 
-        public ContentTypeSortBuilder() : base(null)
+        public ContentTypeSortBuilder()
+            : base(null)
         {
         }
 
@@ -44,7 +48,7 @@ namespace Umbraco.Tests.Common.Builders
             set => _alias = value;
         }
 
-        int? IWithSortOrderBuilder.SortOrder   
+        int? IWithSortOrderBuilder.SortOrder
         {
             get => _sortOrder;
             set => _sortOrder = value;

--- a/src/Umbraco.Tests.Common/Builders/ContentVariantSaveBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/ContentVariantSaveBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Umbraco.Tests.Common.Builders.Interfaces;
@@ -10,16 +13,28 @@ namespace Umbraco.Tests.Common.Builders
         IWithNameBuilder,
         IWithCultureInfoBuilder
     {
-        private List<ContentPropertyBasicBuilder<ContentVariantSaveBuilder<TParent>>> _propertyBuilders = new List<ContentPropertyBasicBuilder<ContentVariantSaveBuilder<TParent>>>();
-
+        private readonly List<ContentPropertyBasicBuilder<ContentVariantSaveBuilder<TParent>>> _propertyBuilders = new List<ContentPropertyBasicBuilder<ContentVariantSaveBuilder<TParent>>>();
 
         private string _name;
         private CultureInfo _cultureInfo;
         private bool? _save = null;
         private bool? _publish = null;
 
-        public ContentVariantSaveBuilder(TParent parentBuilder) : base(parentBuilder)
+        public ContentVariantSaveBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
+        }
+
+        public ContentVariantSaveBuilder<TParent> WithSave(bool save)
+        {
+            _save = save;
+            return this;
+        }
+
+        public ContentVariantSaveBuilder<TParent> WithPublish(bool publish)
+        {
+            _publish = publish;
+            return this;
         }
 
         public ContentPropertyBasicBuilder<ContentVariantSaveBuilder<TParent>> AddProperty()
@@ -35,7 +50,7 @@ namespace Umbraco.Tests.Common.Builders
             var culture = _cultureInfo?.Name ?? null;
             var save = _save ?? true;
             var publish = _publish ?? true;
-            var properties = _propertyBuilders.Select(x => x.Build());
+            IEnumerable<ContentPropertyBasic> properties = _propertyBuilders.Select(x => x.Build());
 
             return new ContentVariantSave()
             {

--- a/src/Umbraco.Tests.Common/Builders/DataEditorBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/DataEditorBuilder.cs
@@ -1,7 +1,9 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Umbraco.Core.Logging;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
@@ -10,11 +12,12 @@ namespace Umbraco.Tests.Common.Builders
 {
     public class DataEditorBuilder<TParent> : ChildBuilderBase<TParent, IDataEditor>
     {
-        private ConfigurationEditorBuilder<DataEditorBuilder<TParent>> _explicitConfigurationEditorBuilder;
-        private DataValueEditorBuilder<DataEditorBuilder<TParent>> _explicitValueEditorBuilder;
+        private readonly ConfigurationEditorBuilder<DataEditorBuilder<TParent>> _explicitConfigurationEditorBuilder;
+        private readonly DataValueEditorBuilder<DataEditorBuilder<TParent>> _explicitValueEditorBuilder;
         private IDictionary<string, object> _defaultConfiguration;
 
-        public DataEditorBuilder(TParent parentBuilder) : base(parentBuilder)
+        public DataEditorBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
             _explicitConfigurationEditorBuilder = new ConfigurationEditorBuilder<DataEditorBuilder<TParent>>(this);
             _explicitValueEditorBuilder = new DataValueEditorBuilder<DataEditorBuilder<TParent>>(this);
@@ -34,17 +37,16 @@ namespace Umbraco.Tests.Common.Builders
 
         public override IDataEditor Build()
         {
-            var defaultConfiguration = _defaultConfiguration ?? new Dictionary<string, object>();
-            var explicitConfigurationEditor = _explicitConfigurationEditorBuilder.Build();
-            var explicitValueEditor = _explicitValueEditorBuilder.Build();
+            IDictionary<string, object> defaultConfiguration = _defaultConfiguration ?? new Dictionary<string, object>();
+            IConfigurationEditor explicitConfigurationEditor = _explicitConfigurationEditorBuilder.Build();
+            IDataValueEditor explicitValueEditor = _explicitValueEditorBuilder.Build();
 
             return new DataEditor(
                 NullLoggerFactory.Instance,
                 Mock.Of<IDataTypeService>(),
                 Mock.Of<ILocalizationService>(),
                 Mock.Of<ILocalizedTextService>(),
-                Mock.Of<IShortStringHelper>()
-            )
+                Mock.Of<IShortStringHelper>())
             {
                 DefaultConfiguration = defaultConfiguration,
                 ExplicitConfigurationEditor = explicitConfigurationEditor,

--- a/src/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Core.Serialization;
@@ -20,7 +23,7 @@ namespace Umbraco.Tests.Common.Builders
             IWithPathBuilder,
             IWithSortOrderBuilder
     {
-        private DataEditorBuilder<DataTypeBuilder> _dataEditorBuilder;
+        private readonly DataEditorBuilder<DataTypeBuilder> _dataEditorBuilder;
         private int? _id;
         private int? _parentId;
         private Guid? _key;
@@ -35,10 +38,7 @@ namespace Umbraco.Tests.Common.Builders
         private ValueStorageType? _databaseType;
         private int? _sortOrder;
 
-        public DataTypeBuilder()
-        {
-            _dataEditorBuilder = new DataEditorBuilder<DataTypeBuilder>(this);
-        }
+        public DataTypeBuilder() => _dataEditorBuilder = new DataEditorBuilder<DataTypeBuilder>(this);
 
         public DataTypeBuilder WithDatabaseType(ValueStorageType databaseType)
         {
@@ -46,25 +46,22 @@ namespace Umbraco.Tests.Common.Builders
             return this;
         }
 
-        public DataEditorBuilder<DataTypeBuilder> AddEditor()
-        {
-            return _dataEditorBuilder;
-        }
+        public DataEditorBuilder<DataTypeBuilder> AddEditor() => _dataEditorBuilder;
 
         public override DataType Build()
         {
-            var editor = _dataEditorBuilder.Build();
+            Core.PropertyEditors.IDataEditor editor = _dataEditorBuilder.Build();
             var parentId = _parentId ?? -1;
             var id = _id ?? 1;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
-            var deleteDate = _deleteDate ?? null;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
+            DateTime? deleteDate = _deleteDate ?? null;
             var name = _name ?? Guid.NewGuid().ToString();
             var level = _level ?? 0;
             var path = _path ?? $"-1,{id}";
             var creatorId = _creatorId ?? 1;
-            var databaseType = _databaseType ?? ValueStorageType.Ntext;
+            ValueStorageType databaseType = _databaseType ?? ValueStorageType.Ntext;
             var sortOrder = _sortOrder ?? 0;
             var serializer = new ConfigurationEditorJsonSerializer();
 

--- a/src/Umbraco.Tests.Common/Builders/DataValueEditorBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/DataValueEditorBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Moq;
 using Umbraco.Core.PropertyEditors;
@@ -13,7 +16,8 @@ namespace Umbraco.Tests.Common.Builders
         private bool? _hideLabel;
         private string _valueType;
 
-        public DataValueEditorBuilder(TParent parentBuilder) : base(parentBuilder)
+        public DataValueEditorBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -52,8 +56,7 @@ namespace Umbraco.Tests.Common.Builders
                 Mock.Of<IDataTypeService>(),
                 Mock.Of<ILocalizationService>(),
                 Mock.Of<ILocalizedTextService>(),
-                Mock.Of<IShortStringHelper>()
-            )
+                Mock.Of<IShortStringHelper>())
             {
                 Configuration = configuration,
                 View = view,

--- a/src/Umbraco.Tests.Common/Builders/DictionaryItemBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/DictionaryItemBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -57,12 +60,12 @@ namespace Umbraco.Tests.Common.Builders
 
         public override DictionaryItem Build()
         {
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
-            var deleteDate = _deleteDate ?? null;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
+            DateTime? deleteDate = _deleteDate ?? null;
             var id = _id ?? 1;
-            var key = _key ?? Guid.NewGuid();
-            var parentId = _parentId ?? null;
+            Guid key = _key ?? Guid.NewGuid();
+            Guid? parentId = _parentId ?? null;
             var itemKey = _itemKey ?? Guid.NewGuid().ToString();
 
             var result = new DictionaryItem(itemKey)

--- a/src/Umbraco.Tests.Common/Builders/DictionaryTranslationBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/DictionaryTranslationBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
@@ -12,7 +15,7 @@ namespace Umbraco.Tests.Common.Builders
             IWithDeleteDateBuilder,
             IWithKeyBuilder
     {
-        private LanguageBuilder<DictionaryTranslationBuilder> _languageBuilder;
+        private readonly LanguageBuilder<DictionaryTranslationBuilder> _languageBuilder;
         private DateTime? _createDate;
         private DateTime? _deleteDate;
         private int? _id;
@@ -20,15 +23,11 @@ namespace Umbraco.Tests.Common.Builders
         private DateTime? _updateDate;
         private string _value;
 
-        public DictionaryTranslationBuilder() : base(null)
-        {
-            _languageBuilder = new LanguageBuilder<DictionaryTranslationBuilder>(this);
-        }
+        public DictionaryTranslationBuilder()
+            : base(null) => _languageBuilder = new LanguageBuilder<DictionaryTranslationBuilder>(this);
 
-        public DictionaryTranslationBuilder(DictionaryItemBuilder parentBuilder) : base(parentBuilder)
-        {
-            _languageBuilder = new LanguageBuilder<DictionaryTranslationBuilder>(this);
-        }
+        public DictionaryTranslationBuilder(DictionaryItemBuilder parentBuilder)
+            : base(parentBuilder) => _languageBuilder = new LanguageBuilder<DictionaryTranslationBuilder>(this);
 
         public LanguageBuilder<DictionaryTranslationBuilder> AddLanguage() => _languageBuilder;
 
@@ -40,11 +39,11 @@ namespace Umbraco.Tests.Common.Builders
 
         public override IDictionaryTranslation Build()
         {
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
-            var deleteDate = _deleteDate ?? null;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
+            DateTime? deleteDate = _deleteDate ?? null;
             var id = _id ?? 1;
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
 
             var result = new DictionaryTranslation(
                 _languageBuilder.Build(),

--- a/src/Umbraco.Tests.Common/Builders/DocumentEntitySlimBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/DocumentEntitySlimBuilder.cs
@@ -1,4 +1,8 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models.Entities;
 using Umbraco.Tests.Common.Builders.Interfaces;
 
@@ -75,9 +79,9 @@ namespace Umbraco.Tests.Common.Builders
         public override DocumentEntitySlim Build()
         {
             var id = _id ?? 1;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? Guid.NewGuid().ToString();
             var creatorId = _creatorId ?? 1;
             var level = _level ?? 1;
@@ -111,8 +115,8 @@ namespace Umbraco.Tests.Common.Builders
 
             if (_additionalDataBuilder != null)
             {
-                var additionalData = _additionalDataBuilder.Build();
-                foreach (var kvp in additionalData)
+                IDictionary<string, object> additionalData = _additionalDataBuilder.Build();
+                foreach (KeyValuePair<string, object> kvp in additionalData)
                 {
                     documentEntitySlim.AdditionalData.Add(kvp.Key, kvp.Value);
                 }

--- a/src/Umbraco.Tests.Common/Builders/EntitySlimBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/EntitySlimBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using Umbraco.Core.Models.Entities;
 using Umbraco.Tests.Common.Builders.Interfaces;
 

--- a/src/Umbraco.Tests.Common/Builders/Extensions/BuilderExtensions.cs
+++ b/src/Umbraco.Tests.Common/Builders/Extensions/BuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Globalization;
 using Umbraco.Core.Models;

--- a/src/Umbraco.Tests.Common/Builders/Extensions/ContentItemSaveBuilderExtensions.cs
+++ b/src/Umbraco.Tests.Common/Builders/Extensions/ContentItemSaveBuilderExtensions.cs
@@ -1,11 +1,12 @@
-﻿using System.Linq;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using Umbraco.Core.Models;
 
 namespace Umbraco.Tests.Common.Builders.Extensions
 {
     public static class ContentItemSaveBuilderExtensions
     {
-
         public static ContentItemSaveBuilder WithContent(this ContentItemSaveBuilder builder, IContent content)
         {
             builder.WithId(content.Id);
@@ -13,43 +14,39 @@ namespace Umbraco.Tests.Common.Builders.Extensions
 
             if (content.CultureInfos.Count == 0)
             {
-                var variantBuilder = builder.AddVariant();
+                ContentVariantSaveBuilder<ContentItemSaveBuilder> variantBuilder = builder.AddVariant();
                 variantBuilder.WithName(content.Name);
 
-                foreach (var contentProperty in content.Properties)
+                foreach (IProperty contentProperty in content.Properties)
                 {
                     AddInvariantProperty(variantBuilder, contentProperty);
                 }
             }
             else
             {
-                foreach (var contentCultureInfos in content.CultureInfos)
+                foreach (ContentCultureInfos contentCultureInfos in content.CultureInfos)
                 {
-                    var variantBuilder = builder.AddVariant();
+                    ContentVariantSaveBuilder<ContentItemSaveBuilder> variantBuilder = builder.AddVariant();
 
                     variantBuilder.WithName(contentCultureInfos.Name);
                     variantBuilder.WithCultureInfo(contentCultureInfos.Culture);
 
-                    foreach (var contentProperty in content.Properties)
+                    foreach (IProperty contentProperty in content.Properties)
                     {
                         AddInvariantProperty(variantBuilder, contentProperty);
                     }
                 }
             }
 
-
-
             return builder;
         }
 
-        private static void AddInvariantProperty(ContentVariantSaveBuilder<ContentItemSaveBuilder> variantBuilder, IProperty contentProperty)
-        {
+        private static void AddInvariantProperty(ContentVariantSaveBuilder<ContentItemSaveBuilder> variantBuilder, IProperty contentProperty) =>
             variantBuilder
                 .AddProperty()
                 .WithId(contentProperty.Id)
                 .WithAlias(contentProperty.Alias)
                 .WithValue(contentProperty.GetValue())
                 .Done();
-        }
     }
 }

--- a/src/Umbraco.Tests.Common/Builders/Extensions/ContentTypeBuilderExtensions.cs
+++ b/src/Umbraco.Tests.Common/Builders/Extensions/ContentTypeBuilderExtensions.cs
@@ -1,13 +1,15 @@
-﻿using Umbraco.Core;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Core;
 using Umbraco.Core.Models;
 
 namespace Umbraco.Tests.Common.Builders.Extensions
 {
     public static class ContentTypeBuilderExtensions
     {
-        public static ContentType BuildSimpleContentType(this ContentTypeBuilder builder)
-        {
-            return (ContentType)builder
+        public static ContentType BuildSimpleContentType(this ContentTypeBuilder builder) =>
+            (ContentType)builder
                 .WithId(10)
                 .WithAlias("textPage")
                 .WithName("Text Page")
@@ -64,11 +66,9 @@ namespace Umbraco.Tests.Common.Builders.Extensions
                     .WithSortOrder(9)
                     .Done()
                 .Build();
-        }
 
-        public static MediaType BuildImageMediaType(this MediaTypeBuilder builder)
-        {
-            return (MediaType)builder
+        public static MediaType BuildImageMediaType(this MediaTypeBuilder builder) =>
+            (MediaType)builder
                 .WithId(10)
                 .WithAlias(Constants.Conventions.MediaTypes.Image)
                 .WithName("Image")
@@ -77,11 +77,9 @@ namespace Umbraco.Tests.Common.Builders.Extensions
                 .WithPropertyTypeIdsIncrementingFrom(200)
                 .WithMediaPropertyGroup()
                 .Build();
-        }
 
-        public static MemberType BuildSimpleMemberType(this MemberTypeBuilder builder)
-        {
-            return (MemberType)builder
+        public static MemberType BuildSimpleMemberType(this MemberTypeBuilder builder) =>
+            (MemberType)builder
                 .WithId(10)
                 .WithAlias("memberType")
                 .WithName("Member type")
@@ -105,6 +103,5 @@ namespace Umbraco.Tests.Common.Builders.Extensions
                 .WithMemberCanEditProperty("title", true)
                 .WithMemberCanViewProperty("bodyText", true)
                 .Build();
-        }
     }
 }

--- a/src/Umbraco.Tests.Common/Builders/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Tests.Common/Builders/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Extensions
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Extensions
 {
     public static class StringExtensions
     {

--- a/src/Umbraco.Tests.Common/Builders/GenericCollectionBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/GenericCollectionBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,14 +11,12 @@ namespace Umbraco.Tests.Common.Builders
     {
         private readonly IList<T> _collection;
 
-        public GenericCollectionBuilder(TBuilder parentBuilder) : base(parentBuilder)
-        {
-            _collection = new List<T>();
-        }        
+        public GenericCollectionBuilder(TBuilder parentBuilder)
+            : base(parentBuilder) => _collection = new List<T>();
 
         public override IEnumerable<T> Build()
         {
-            var collection = _collection?.ToList() ?? Enumerable.Empty<T>();
+            IEnumerable<T> collection = _collection?.ToList() ?? Enumerable.Empty<T>();
             return collection;
         }
 

--- a/src/Umbraco.Tests.Common/Builders/GenericDictionaryBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/GenericDictionaryBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 
 namespace Umbraco.Tests.Common.Builders
@@ -7,17 +10,12 @@ namespace Umbraco.Tests.Common.Builders
     {
         private readonly IDictionary<TKey, TValue> _dictionary;
 
-        public GenericDictionaryBuilder(TBuilder parentBuilder) : base(parentBuilder)
-        {
-            _dictionary = new Dictionary<TKey, TValue>();
-        }        
+        public GenericDictionaryBuilder(TBuilder parentBuilder)
+            : base(parentBuilder) => _dictionary = new Dictionary<TKey, TValue>();
 
-        public override IDictionary<TKey, TValue> Build()
-        {
-            return _dictionary == null
+        public override IDictionary<TKey, TValue> Build() => _dictionary == null
                 ? new Dictionary<TKey, TValue>()
                 : new Dictionary<TKey, TValue>(_dictionary);
-        }
 
         public GenericDictionaryBuilder<TBuilder, TKey, TValue> WithKeyValue(TKey key, TValue value)
         {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IAccountBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IAccountBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IAccountBuilder : IWithLoginBuilder,
                                        IWithEmailBuilder,

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IBuildContentTypes.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IBuildContentTypes.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IBuildContentTypes
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IBuildPropertyGroups.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IBuildPropertyGroups.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IBuildPropertyGroups
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IBuildPropertyTypes.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IBuildPropertyTypes.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IBuildPropertyTypes
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithAliasBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithAliasBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithAliasBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithCreateDateBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithCreateDateBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithCreatorIdBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithCreatorIdBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithCultureInfoBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithCultureInfoBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System.Globalization;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces
 {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithDeleteDateBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithDeleteDateBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithDescriptionBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithDescriptionBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithDescriptionBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithEmailBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithEmailBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithEmailBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithFailedPasswordAttemptsBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithFailedPasswordAttemptsBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithFailedPasswordAttemptsBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIconBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIconBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithIconBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIdBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIdBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithIdBuilder

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIsApprovedBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIsApprovedBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+﻿// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithIsApprovedBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIsContainerBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIsContainerBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithIsContainerBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIsLockedOutBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithIsLockedOutBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces
 {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithKeyBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithKeyBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLastLoginDateBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLastLoginDateBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLastPasswordChangeDateBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLastPasswordChangeDateBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLevelBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLevelBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithLevelBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLoginBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithLoginBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithLoginBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithNameBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithNameBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithNameBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithParentContentTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithParentContentTypeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using Umbraco.Core.Models;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithParentIdBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithParentIdBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithParentIdBuilder

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithPathBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithPathBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithPathBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithPropertyTypeIdsIncrementingFrom.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithPropertyTypeIdsIncrementingFrom.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithPropertyTypeIdsIncrementingFrom
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithPropertyValues.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithPropertyValues.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithPropertyValues

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithSortOrderBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithSortOrderBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithSortOrderBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithSupportsPublishing.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithSupportsPublishing.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithThumbnailBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithThumbnailBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithThumbnailBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithTrashedBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithTrashedBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Tests.Common.Builders.Interfaces
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Tests.Common.Builders.Interfaces
 {
     public interface IWithTrashedBuilder
     {

--- a/src/Umbraco.Tests.Common/Builders/Interfaces/IWithUpdateDateBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/Interfaces/IWithUpdateDateBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 
 namespace Umbraco.Tests.Common.Builders.Interfaces

--- a/src/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Globalization;
 using Umbraco.Core.Configuration.Models;
@@ -8,7 +11,8 @@ namespace Umbraco.Tests.Common.Builders
 {
     public class LanguageBuilder : LanguageBuilder<object>
     {
-        public LanguageBuilder() : base(null)
+        public LanguageBuilder()
+            : base(null)
         {
         }
     }
@@ -33,7 +37,8 @@ namespace Umbraco.Tests.Common.Builders
         private Guid? _key;
         private DateTime? _updateDate;
 
-        public LanguageBuilder(TParent parentBuilder) : base(parentBuilder)
+        public LanguageBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -63,13 +68,13 @@ namespace Umbraco.Tests.Common.Builders
 
         public override ILanguage Build()
         {
-            var cultureInfo = _cultureInfo ?? CultureInfo.GetCultureInfo("en-US");
+            CultureInfo cultureInfo = _cultureInfo ?? CultureInfo.GetCultureInfo("en-US");
             var cultureName = _cultureName ?? cultureInfo.EnglishName;
             var globalSettings = new GlobalSettings { DefaultUILanguage = cultureInfo.Name };
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
-            var deleteDate = _deleteDate ?? null;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
+            DateTime? deleteDate = _deleteDate ?? null;
             var fallbackLanguageId = _fallbackLanguageId ?? null;
             var isDefault = _isDefault ?? false;
             var isMandatory = _isMandatory ?? false;

--- a/src/Umbraco.Tests.Common/Builders/MacroBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MacroBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +18,7 @@ namespace Umbraco.Tests.Common.Builders
             IWithAliasBuilder,
             IWithNameBuilder
     {
-        private List<MacroPropertyBuilder> _propertyBuilders = new List<MacroPropertyBuilder>();
+        private readonly List<MacroPropertyBuilder> _propertyBuilders = new List<MacroPropertyBuilder>();
 
         private int? _id;
         private Guid? _key;
@@ -78,7 +81,7 @@ namespace Umbraco.Tests.Common.Builders
             var id = _id ?? 1;
             var name = _name ?? Guid.NewGuid().ToString();
             var alias = _alias ?? name.ToCamelCase();
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var useInEditor = _useInEditor ?? false;
             var cacheDuration = _cacheDuration ?? 0;
             var cacheByPage = _cacheByPage ?? false;
@@ -90,7 +93,7 @@ namespace Umbraco.Tests.Common.Builders
 
             var macro = new Macro(shortStringHelper, id, key, useInEditor, cacheDuration, alias, name, cacheByPage, cacheByMember, dontRender, macroSource);
 
-            foreach (var property in _propertyBuilders.Select(x => x.Build()))
+            foreach (IMacroProperty property in _propertyBuilders.Select(x => x.Build()))
             {
                 macro.Properties.Add(property);
             }

--- a/src/Umbraco.Tests.Common/Builders/MacroPropertyBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MacroPropertyBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Extensions;
@@ -20,7 +23,8 @@ namespace Umbraco.Tests.Common.Builders
         private int? _sortOrder;
         private string _editorAlias;
 
-        public MacroPropertyBuilder(MacroBuilder parentBuilder) : base(parentBuilder)
+        public MacroPropertyBuilder(MacroBuilder parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -28,20 +32,20 @@ namespace Umbraco.Tests.Common.Builders
         {
             _editorAlias = editorAlias;
             return this;
-        }        
+        }
 
         public override IMacroProperty Build()
         {
             var id = _id ?? 1;
             var name = _name ?? Guid.NewGuid().ToString();
             var alias = _alias ?? name.ToCamelCase();
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var sortOrder = _sortOrder ?? 0;
             var editorAlias = _editorAlias ?? string.Empty;
 
             return new MacroProperty(id, key, alias, name, sortOrder, editorAlias);
         }
-        
+
         int? IWithIdBuilder.Id
         {
             get => _id;

--- a/src/Umbraco.Tests.Common/Builders/MediaBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MediaBuilder.cs
@@ -1,8 +1,12 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
-using Umbraco.Core.Models;
-using Umbraco.Tests.Common.Builders.Interfaces;
-using Umbraco.Tests.Common.Builders.Extensions;
+using System.Collections.Generic;
 using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Tests.Common.Builders.Extensions;
+using Umbraco.Tests.Common.Builders.Interfaces;
 using Umbraco.Tests.Testing;
 
 namespace Umbraco.Tests.Common.Builders
@@ -68,10 +72,10 @@ namespace Umbraco.Tests.Common.Builders
         public override Media Build()
         {
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var parentId = _parentId ?? -1;
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? Guid.NewGuid().ToString();
             var creatorId = _creatorId ?? 0;
             var level = _level ?? 1;
@@ -87,7 +91,7 @@ namespace Umbraco.Tests.Common.Builders
                 throw new InvalidOperationException("A media item cannot be constructed without providing a media type. Use AddMediaType() or WithMediaType().");
             }
 
-            var mediaType = _mediaType ?? _mediaTypeBuilder.Build();
+            IMediaType mediaType = _mediaType ?? _mediaTypeBuilder.Build();
 
             var media = new Media(name, parentId, mediaType)
             {
@@ -106,8 +110,8 @@ namespace Umbraco.Tests.Common.Builders
             {
                 if (_propertyDataBuilder != null)
                 {
-                    var propertyData = _propertyDataBuilder.Build();
-                    foreach (var keyValuePair in propertyData)
+                    IDictionary<string, object> propertyData = _propertyDataBuilder.Build();
+                    foreach (KeyValuePair<string, object> keyValuePair in propertyData)
                     {
                         media.SetValue(keyValuePair.Key, keyValuePair.Value);
                     }
@@ -123,35 +127,27 @@ namespace Umbraco.Tests.Common.Builders
             return media;
         }
 
-        public static Media CreateSimpleMedia(IMediaType mediaType, string name, int parentId, int id = 0)
-        {
-            return new MediaBuilder()
+        public static Media CreateSimpleMedia(IMediaType mediaType, string name, int parentId, int id = 0) =>
+            new MediaBuilder()
                 .WithId(id)
                 .WithName(name)
                 .WithMediaType(mediaType)
                 .WithParentId(parentId)
                 .WithPropertyValues(new
-                    {
-                        title = name + " Subpage",
-                        bodyText = "This is a subpage",
-                        author = "John Doe"
-                    })
+                {
+                    title = name + " Subpage",
+                    bodyText = "This is a subpage",
+                    author = "John Doe"
+                })
                 .Build();
-        }
 
-        public static Media CreateMediaImage(IMediaType mediaType, int parentId)
-        {
-            return CreateMediaImage(mediaType, parentId, "/media/test-image.png");
-        }
+        public static Media CreateMediaImage(IMediaType mediaType, int parentId) =>
+            CreateMediaImage(mediaType, parentId, "/media/test-image.png");
 
-        public static Media CreateMediaImageWithCrop(IMediaType mediaType, int parentId)
-        {
-            return CreateMediaImage(mediaType, parentId, "{src: '/media/test-image.png', crops: []}");
-        }
+        public static Media CreateMediaImageWithCrop(IMediaType mediaType, int parentId) =>
+            CreateMediaImage(mediaType, parentId, "{src: '/media/test-image.png', crops: []}");
 
-        private static Media CreateMediaImage(IMediaType mediaType, int parentId, string fileValue)
-        {
-            return new MediaBuilder()
+        private static Media CreateMediaImage(IMediaType mediaType, int parentId, string fileValue) => new MediaBuilder()
                 .WithMediaType(mediaType)
                 .WithName("Test Image")
                 .WithParentId(parentId)
@@ -163,20 +159,14 @@ namespace Umbraco.Tests.Common.Builders
                     .WithKeyValue(Constants.Conventions.Media.Extension, "png")
                     .Done()
                 .Build();
-        }
 
-        public static Media CreateMediaFolder(IMediaType mediaType, int parentId)
-        {
-            return new MediaBuilder()
+        public static Media CreateMediaFolder(IMediaType mediaType, int parentId) => new MediaBuilder()
                 .WithMediaType(mediaType)
                 .WithName("Test Folder")
                 .WithParentId(parentId)
                 .Build();
-        }
 
-        public static Media CreateMediaFile(IMediaType mediaType, int parentId)
-        {
-            return new MediaBuilder()
+        public static Media CreateMediaFile(IMediaType mediaType, int parentId) => new MediaBuilder()
                 .WithMediaType(mediaType)
                 .WithName("Test File")
                 .WithParentId(parentId)
@@ -186,7 +176,6 @@ namespace Umbraco.Tests.Common.Builders
                     .WithKeyValue(Constants.Conventions.Media.Extension, "png")
                     .Done()
                 .Build();
-        }
 
         int? IWithIdBuilder.Id
         {
@@ -247,6 +236,7 @@ namespace Umbraco.Tests.Common.Builders
             get => _sortOrder;
             set => _sortOrder = value;
         }
+
         int? IWithParentIdBuilder.ParentId
         {
             get => _parentId;

--- a/src/Umbraco.Tests.Common/Builders/MediaTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MediaTypeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
@@ -11,20 +14,22 @@ namespace Umbraco.Tests.Common.Builders
         : ContentTypeBaseBuilder<MediaBuilder, IMediaType>,
             IWithPropertyTypeIdsIncrementingFrom
     {
-        private List<PropertyGroupBuilder<MediaTypeBuilder>> _propertyGroupBuilders = new List<PropertyGroupBuilder<MediaTypeBuilder>>();
+        private readonly List<PropertyGroupBuilder<MediaTypeBuilder>> _propertyGroupBuilders = new List<PropertyGroupBuilder<MediaTypeBuilder>>();
         private int? _propertyTypeIdsIncrementingFrom;
 
-        public MediaTypeBuilder() : base(null)
+        public MediaTypeBuilder()
+            : base(null)
         {
         }
 
-        public MediaTypeBuilder(MediaBuilder parentBuilder) : base(parentBuilder)
+        public MediaTypeBuilder(MediaBuilder parentBuilder)
+            : base(parentBuilder)
         {
         }
 
         public MediaTypeBuilder WithMediaPropertyGroup()
         {
-            var builder = new PropertyGroupBuilder<MediaTypeBuilder>(this)
+            PropertyGroupBuilder<MediaTypeBuilder> builder = new PropertyGroupBuilder<MediaTypeBuilder>(this)
                 .WithId(99)
                 .WithName("Media")
                 .WithSortOrder(1)
@@ -82,7 +87,7 @@ namespace Umbraco.Tests.Common.Builders
         public override IMediaType Build()
         {
             MediaType mediaType;
-            var parent = GetParent();
+            IContentTypeComposition parent = GetParent();
             if (parent != null)
             {
                 mediaType = new MediaType(ShortStringHelper, (IMediaType)parent, GetAlias());
@@ -122,7 +127,7 @@ namespace Umbraco.Tests.Common.Builders
         public static MediaType CreateSimpleMediaType(string alias, string name, IMediaType parent = null, bool randomizeAliases = false, string propertyGroupName = "Content")
         {
             var builder = new MediaTypeBuilder();
-            var mediaType = builder
+            IMediaType mediaType = builder
                 .WithAlias(alias)
                 .WithName(name)
                 .WithParentContentType(parent)
@@ -156,20 +161,16 @@ namespace Umbraco.Tests.Common.Builders
             return (MediaType)mediaType;
         }
 
-        public static MediaType CreateImageMediaType(string alias = Constants.Conventions.MediaTypes.Image)
-        {
-            return CreateImageMediaType(alias ?? "Image", Constants.PropertyEditors.Aliases.UploadField, -90);
-        }
+        public static MediaType CreateImageMediaType(string alias = Constants.Conventions.MediaTypes.Image) =>
+            CreateImageMediaType(alias ?? "Image", Constants.PropertyEditors.Aliases.UploadField, -90);
 
-        public static MediaType CreateImageMediaTypeWithCrop(string alias = Constants.Conventions.MediaTypes.Image)
-        {
-            return CreateImageMediaType(alias ?? "Image", Constants.PropertyEditors.Aliases.ImageCropper, 1043);
-        }
+        public static MediaType CreateImageMediaTypeWithCrop(string alias = Constants.Conventions.MediaTypes.Image) =>
+            CreateImageMediaType(alias ?? "Image", Constants.PropertyEditors.Aliases.ImageCropper, 1043);
 
         private static MediaType CreateImageMediaType(string alias, string imageFieldPropertyEditorAlias, int imageFieldDataTypeId)
         {
             var builder = new MediaTypeBuilder();
-            var mediaType = builder
+            IMediaType mediaType = builder
                 .WithAlias(alias)
                 .WithName("Image")
                 .AddPropertyGroup()
@@ -222,7 +223,7 @@ namespace Umbraco.Tests.Common.Builders
         public static MediaType CreateVideoMediaType()
         {
             var builder = new MediaTypeBuilder();
-            var mediaType = builder
+            IMediaType mediaType = builder
                 .WithAlias("video")
                 .WithName("Video")
                 .AddPropertyGroup()
@@ -237,7 +238,7 @@ namespace Umbraco.Tests.Common.Builders
                         .WithAlias("videoFile")
                         .WithName("Video file")
                         .WithSortOrder(1)
-                        .Done()                   
+                        .Done()
                     .Done()
                 .Build();
 

--- a/src/Umbraco.Tests.Common/Builders/MemberBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MemberBuilder.cs
@@ -1,8 +1,11 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
-using Umbraco.Core.Models;
-using Umbraco.Tests.Common.Builders.Interfaces;
-using Umbraco.Tests.Common.Builders.Extensions;
 using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Tests.Common.Builders.Extensions;
+using Umbraco.Tests.Common.Builders.Interfaces;
 
 namespace Umbraco.Tests.Common.Builders
 {
@@ -95,9 +98,9 @@ namespace Umbraco.Tests.Common.Builders
         public override Member Build()
         {
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? Guid.NewGuid().ToString();
             var creatorId = _creatorId ?? 0;
             var level = _level ?? 1;
@@ -110,16 +113,16 @@ namespace Umbraco.Tests.Common.Builders
             var failedPasswordAttempts = _failedPasswordAttempts ?? 0;
             var isApproved = _isApproved ?? false;
             var isLockedOut = _isLockedOut ?? false;
-            var lastLockoutDate = _lastLockoutDate ?? DateTime.Now;
-            var lastLoginDate = _lastLoginDate ?? DateTime.Now;
-            var lastPasswordChangeDate = _lastPasswordChangeDate ?? DateTime.Now;
+            DateTime lastLockoutDate = _lastLockoutDate ?? DateTime.Now;
+            DateTime lastLoginDate = _lastLoginDate ?? DateTime.Now;
+            DateTime lastPasswordChangeDate = _lastPasswordChangeDate ?? DateTime.Now;
 
             if (_memberTypeBuilder is null && _memberType is null)
             {
                 throw new InvalidOperationException("A member cannot be constructed without providing a member type. Use AddMemberType() or WithMemberType().");
             }
 
-            var memberType = _memberType ?? _memberTypeBuilder.Build();
+            IMemberType memberType = _memberType ?? _memberTypeBuilder.Build();
 
             var member = new Member(name, email, username, rawPasswordValue, memberType)
             {
@@ -137,7 +140,7 @@ namespace Umbraco.Tests.Common.Builders
             if (_propertyIdsIncrementingFrom.HasValue)
             {
                 var i = _propertyIdsIncrementingFrom.Value;
-                foreach (var property in member.Properties)
+                foreach (IProperty property in member.Properties)
                 {
                     property.Id = ++i;
                 }
@@ -157,8 +160,8 @@ namespace Umbraco.Tests.Common.Builders
 
             if (_additionalDataBuilder != null)
             {
-                var additionalData = _additionalDataBuilder.Build();
-                foreach (var kvp in additionalData)
+                IDictionary<string, object> additionalData = _additionalDataBuilder.Build();
+                foreach (KeyValuePair<string, object> kvp in additionalData)
                 {
                     member.AdditionalData.Add(kvp.Key, kvp.Value);
                 }
@@ -166,8 +169,8 @@ namespace Umbraco.Tests.Common.Builders
 
             if (_propertyDataBuilder != null)
             {
-                var propertyData = _propertyDataBuilder.Build();
-                foreach (var kvp in propertyData)
+                IDictionary<string, object> propertyData = _propertyDataBuilder.Build();
+                foreach (KeyValuePair<string, object> kvp in propertyData)
                 {
                     member.SetValue(kvp.Key, kvp.Value);
                 }
@@ -178,7 +181,7 @@ namespace Umbraco.Tests.Common.Builders
             return member;
         }
 
-        public static IEnumerable<IMember> CreateSimpleMembers(IMemberType memberType, int amount, Action<int, IMember> onCreating = null)
+        public static IEnumerable<IMember> CreateSimpleMembers(IMemberType memberType, int amount)
         {
             var list = new List<IMember>();
 
@@ -186,12 +189,11 @@ namespace Umbraco.Tests.Common.Builders
             {
                 var name = "Member No-" + i;
 
-                var builder = new MemberBuilder()
+                MemberBuilder builder = new MemberBuilder()
                     .WithMemberType(memberType)
                     .WithName(name)
                     .WithEmail("test" + i + "@test.com")
                     .WithLogin("test" + i, "test" + i);
-
 
                 builder = builder
                     .AddPropertyData()
@@ -205,9 +207,10 @@ namespace Umbraco.Tests.Common.Builders
 
             return list;
         }
+
         public static Member CreateSimpleMember(IMemberType memberType, string name, string email, string password, string username, Guid? key = null)
         {
-            var builder = new MemberBuilder()
+            MemberBuilder builder = new MemberBuilder()
                 .WithMemberType(memberType)
                 .WithName(name)
                 .WithEmail(email)
@@ -236,7 +239,7 @@ namespace Umbraco.Tests.Common.Builders
             for (var i = 0; i < amount; i++)
             {
                 var name = "Member No-" + i;
-                var member = new MemberBuilder()
+                Member member = new MemberBuilder()
                     .WithMemberType(memberType)
                     .WithName(name)
                     .WithEmail("test" + i + "@test.com")

--- a/src/Umbraco.Tests.Common/Builders/MemberGroupBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MemberGroupBuilder.cs
@@ -1,4 +1,8 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
+using System.Collections.Generic;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
 
@@ -32,9 +36,9 @@ namespace Umbraco.Tests.Common.Builders
         public override MemberGroup Build()
         {
             var id = _id ?? 1;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? Guid.NewGuid().ToString();
             var creatorId = _creatorId ?? 1;
 
@@ -50,8 +54,8 @@ namespace Umbraco.Tests.Common.Builders
 
             if (_additionalDataBuilder != null)
             {
-                var additionalData = _additionalDataBuilder.Build();
-                foreach (var kvp in additionalData)
+                IDictionary<string, object> additionalData = _additionalDataBuilder.Build();
+                foreach (KeyValuePair<string, object> kvp in additionalData)
                 {
                     memberGroup.AdditionalData.Add(kvp.Key, kvp.Value);
                 }

--- a/src/Umbraco.Tests.Common/Builders/MemberTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/MemberTypeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
@@ -11,22 +14,24 @@ namespace Umbraco.Tests.Common.Builders
         : ContentTypeBaseBuilder<MemberBuilder, IMemberType>,
             IWithPropertyTypeIdsIncrementingFrom
     {
-        private List<PropertyGroupBuilder<MemberTypeBuilder>> _propertyGroupBuilders = new List<PropertyGroupBuilder<MemberTypeBuilder>>();
-        private Dictionary<string, bool> _memberCanEditProperties = new Dictionary<string, bool>();
-        private Dictionary<string, bool> _memberCanViewProperties = new Dictionary<string, bool>();
+        private readonly List<PropertyGroupBuilder<MemberTypeBuilder>> _propertyGroupBuilders = new List<PropertyGroupBuilder<MemberTypeBuilder>>();
+        private readonly Dictionary<string, bool> _memberCanEditProperties = new Dictionary<string, bool>();
+        private readonly Dictionary<string, bool> _memberCanViewProperties = new Dictionary<string, bool>();
         private int? _propertyTypeIdsIncrementingFrom;
 
-        public MemberTypeBuilder() : base(null)
+        public MemberTypeBuilder()
+            : base(null)
         {
         }
 
-        public MemberTypeBuilder(MemberBuilder parentBuilder) : base(parentBuilder)
+        public MemberTypeBuilder(MemberBuilder parentBuilder)
+            : base(parentBuilder)
         {
         }
 
         public MemberTypeBuilder WithMembershipPropertyGroup()
         {
-            var builder = new PropertyGroupBuilder<MemberTypeBuilder>(this)
+            PropertyGroupBuilder<MemberTypeBuilder> builder = new PropertyGroupBuilder<MemberTypeBuilder>(this)
                 .WithId(99)
                 .WithName(Constants.Conventions.Member.StandardPropertiesGroupName)
                 .AddPropertyType()
@@ -118,12 +123,12 @@ namespace Umbraco.Tests.Common.Builders
             BuildPropertyGroups(memberType, _propertyGroupBuilders.Select(x => x.Build()));
             BuildPropertyTypeIds(memberType, _propertyTypeIdsIncrementingFrom);
 
-            foreach (var kvp in _memberCanEditProperties)
+            foreach (KeyValuePair<string, bool> kvp in _memberCanEditProperties)
             {
                 memberType.SetMemberCanEditProperty(kvp.Key, kvp.Value);
             }
 
-            foreach (var kvp in _memberCanViewProperties)
+            foreach (KeyValuePair<string, bool> kvp in _memberCanViewProperties)
             {
                 memberType.SetMemberCanViewProperty(kvp.Key, kvp.Value);
             }
@@ -136,7 +141,7 @@ namespace Umbraco.Tests.Common.Builders
         public static MemberType CreateSimpleMemberType(string alias = null, string name = null)
         {
             var builder = new MemberTypeBuilder();
-            var memberType = builder
+            IMemberType memberType = builder
                 .WithAlias(alias)
                 .WithName(name)
                 .AddPropertyGroup()
@@ -160,8 +165,8 @@ namespace Umbraco.Tests.Common.Builders
                         .Done()
                     .Done()
                 .Build();
-  
-            // Ensure that nothing is marked as dirty
+
+            // Ensure that nothing is marked as dirty.
             memberType.ResetDirtyProperties(false);
 
             return (MemberType)memberType;

--- a/src/Umbraco.Tests.Common/Builders/PropertyBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/PropertyBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
@@ -38,16 +41,16 @@ namespace Umbraco.Tests.Common.Builders
         public override IProperty Build()
         {
             var id = _id ?? 1;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
 
             if (_propertyTypeBuilder is null && _propertyType is null)
             {
                 throw new InvalidOperationException("A property cannot be constructed without providing a property type. Use AddPropertyType() or WithPropertyType().");
             }
 
-            var propertyType = _propertyType ?? _propertyTypeBuilder.Build();
+            IPropertyType propertyType = _propertyType ?? _propertyTypeBuilder.Build();
 
             // Needs to be within collection to support publishing.
             var propertyTypeCollection = new PropertyTypeCollection(true, new[] { propertyType });

--- a/src/Umbraco.Tests.Common/Builders/PropertyGroupBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/PropertyGroupBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +11,8 @@ namespace Umbraco.Tests.Common.Builders
 {
     public class PropertyGroupBuilder : PropertyGroupBuilder<NullPropertyGroupBuilderParent>
     {
-        public PropertyGroupBuilder() : base(null)
+        public PropertyGroupBuilder()
+            : base(null)
         {
         }
     }
@@ -26,7 +30,8 @@ namespace Umbraco.Tests.Common.Builders
             IWithUpdateDateBuilder,
             IWithNameBuilder,
             IWithSortOrderBuilder,
-            IWithSupportsPublishing where TParent: IBuildPropertyGroups
+            IWithSupportsPublishing
+        where TParent : IBuildPropertyGroups
     {
         private readonly List<PropertyTypeBuilder<PropertyGroupBuilder<TParent>>> _propertyTypeBuilders = new List<PropertyTypeBuilder<PropertyGroupBuilder<TParent>>>();
 
@@ -39,7 +44,8 @@ namespace Umbraco.Tests.Common.Builders
         private bool? _supportsPublishing;
         private PropertyTypeCollection _propertyTypeCollection;
 
-        public PropertyGroupBuilder(TParent parentBuilder) : base(parentBuilder)
+        public PropertyGroupBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -59,9 +65,9 @@ namespace Umbraco.Tests.Common.Builders
         public override PropertyGroup Build()
         {
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? Guid.NewGuid().ToString();
             var sortOrder = _sortOrder ?? 0;
             var supportsPublishing = _supportsPublishing ?? false;
@@ -74,7 +80,7 @@ namespace Umbraco.Tests.Common.Builders
             else
             {
                 propertyTypeCollection = new PropertyTypeCollection(supportsPublishing);
-                foreach (var propertyType in _propertyTypeBuilders.Select(x => x.Build()))
+                foreach (PropertyType propertyType in _propertyTypeBuilders.Select(x => x.Build()))
                 {
                     propertyTypeCollection.Add(propertyType);
                 }

--- a/src/Umbraco.Tests.Common/Builders/PropertyTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/PropertyTypeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core;
 using Umbraco.Core.Models;
@@ -9,7 +12,8 @@ namespace Umbraco.Tests.Common.Builders
 {
     public class PropertyTypeBuilder : PropertyTypeBuilder<NullPropertyTypeBuilderParent>
     {
-        public PropertyTypeBuilder() : base(null)
+        public PropertyTypeBuilder()
+            : base(null)
         {
         }
     }
@@ -28,7 +32,8 @@ namespace Umbraco.Tests.Common.Builders
             IWithUpdateDateBuilder,
             IWithSortOrderBuilder,
             IWithDescriptionBuilder,
-            IWithSupportsPublishing where TParent : IBuildPropertyTypes
+            IWithSupportsPublishing
+        where TParent : IBuildPropertyTypes
     {
         private int? _id;
         private Guid? _key;
@@ -49,7 +54,8 @@ namespace Umbraco.Tests.Common.Builders
         private bool? _supportsPublishing;
         private ContentVariation? _variations;
 
-        public PropertyTypeBuilder(TParent parentBuilder) : base(parentBuilder)
+        public PropertyTypeBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -100,23 +106,23 @@ namespace Umbraco.Tests.Common.Builders
         public override PropertyType Build()
         {
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var propertyEditorAlias = _propertyEditorAlias ?? Constants.PropertyEditors.Aliases.TextBox;
-            var valueStorageType = _valueStorageType ?? ValueStorageType.Nvarchar;
+            ValueStorageType valueStorageType = _valueStorageType ?? ValueStorageType.Nvarchar;
             var name = _name ?? Guid.NewGuid().ToString();
             var alias = _alias ?? name.ToCamelCase();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var sortOrder = _sortOrder ?? 0;
             var dataTypeId = _dataTypeId ?? -88;
             var description = _description ?? string.Empty;
-            var propertyGroupId = _propertyGroupId ?? null;
+            Lazy<int> propertyGroupId = _propertyGroupId ?? null;
             var mandatory = _mandatory ?? false;
             var mandatoryMessage = _mandatoryMessage ?? string.Empty;
             var validationRegExp = _validationRegExp ?? string.Empty;
             var validationRegExpMessage = _validationRegExpMessage ?? string.Empty;
             var supportsPublishing = _supportsPublishing ?? false;
-            var variations = _variations ?? ContentVariation.Nothing;
+            ContentVariation variations = _variations ?? ContentVariation.Nothing;
 
             var shortStringHelper = new DefaultShortStringHelper(new DefaultShortStringHelperConfig());
 
@@ -142,7 +148,7 @@ namespace Umbraco.Tests.Common.Builders
 
             return propertyType;
         }
-        
+
         int? IWithIdBuilder.Id
         {
             get => _id;

--- a/src/Umbraco.Tests.Common/Builders/RelationBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/RelationBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
@@ -55,9 +58,9 @@ namespace Umbraco.Tests.Common.Builders
             var id = _id ?? 0;
             var parentId = _parentId ?? 0;
             var childId = _childId ?? 0;
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var comment = _comment ?? string.Empty;
 
             if (_relationTypeBuilder == null && _relationType == null)
@@ -65,7 +68,7 @@ namespace Umbraco.Tests.Common.Builders
                 throw new InvalidOperationException("Cannot construct a Relation without a RelationType.  Use AddRelationType() or WithRelationType().");
             }
 
-            var relationType = _relationType ?? _relationTypeBuilder.Build();
+            IRelationType relationType = _relationType ?? _relationTypeBuilder.Build();
 
             return new Relation(parentId, childId, relationType)
                 {

--- a/src/Umbraco.Tests.Common/Builders/RelationTypeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/RelationTypeBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using Umbraco.Core.Models;
 using Umbraco.Tests.Common.Builders.Interfaces;
 
@@ -25,11 +28,13 @@ namespace Umbraco.Tests.Common.Builders
         private Guid? _parentObjectType;
         private DateTime? _updateDate;
 
-        public RelationTypeBuilder() : base(null)
+        public RelationTypeBuilder()
+            : base(null)
         {
         }
 
-        public RelationTypeBuilder(RelationBuilder parentBuilder) : base(parentBuilder)
+        public RelationTypeBuilder(RelationBuilder parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -55,14 +60,14 @@ namespace Umbraco.Tests.Common.Builders
         {
             var alias = _alias ?? Guid.NewGuid().ToString();
             var name = _name ?? Guid.NewGuid().ToString();
-            var parentObjectType = _parentObjectType ?? null;
-            var childObjectType = _childObjectType ?? null;
+            Guid? parentObjectType = _parentObjectType ?? null;
+            Guid? childObjectType = _childObjectType ?? null;
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var isBidirectional = _isBidirectional ?? false;
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
-            var deleteDate = _deleteDate ?? null;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
+            DateTime? deleteDate = _deleteDate ?? null;
 
             return new RelationType(name, alias, isBidirectional, parentObjectType, childObjectType)
             {

--- a/src/Umbraco.Tests.Common/Builders/StylesheetBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/StylesheetBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using Umbraco.Core.Models;
 
 namespace Umbraco.Tests.Common.Builders

--- a/src/Umbraco.Tests.Common/Builders/TemplateBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/TemplateBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using Umbraco.Core.Models;
 using Umbraco.Core.Strings;
@@ -28,11 +31,13 @@ namespace Umbraco.Tests.Common.Builders
         private string _masterTemplateAlias;
         private Lazy<int> _masterTemplateId;
 
-        public TemplateBuilder() : base(null)
+        public TemplateBuilder()
+            : base(null)
         {
         }
 
-        public TemplateBuilder(ContentTypeBuilder parentBuilder) : base(parentBuilder)
+        public TemplateBuilder(ContentTypeBuilder parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -53,16 +58,16 @@ namespace Umbraco.Tests.Common.Builders
         public override ITemplate Build()
         {
             var id = _id ?? 0;
-            var key = _key ?? Guid.NewGuid();
+            Guid key = _key ?? Guid.NewGuid();
             var name = _name ?? Guid.NewGuid().ToString();
             var alias = _alias ?? name.ToCamelCase();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var path = _path ?? $"-1,{id}";
             var content = _content;
             var isMasterTemplate = _isMasterTemplate ?? false;
             var masterTemplateAlias = _masterTemplateAlias ?? string.Empty;
-            var masterTemplateId = _masterTemplateId ?? new Lazy<int>(() => -1);
+            Lazy<int> masterTemplateId = _masterTemplateId ?? new Lazy<int>(() => -1);
 
             var shortStringHelper = new DefaultShortStringHelper(new DefaultShortStringHelperConfig());
 
@@ -82,13 +87,11 @@ namespace Umbraco.Tests.Common.Builders
             return template;
         }
 
-        public static Template CreateTextPageTemplate(string alias = "textPage")
-        {
-            return (Template)new TemplateBuilder()
+        public static Template CreateTextPageTemplate(string alias = "textPage") =>
+            (Template)new TemplateBuilder()
                 .WithAlias(alias)
                 .WithName("Text page")
                 .Build();
-        }
 
         int? IWithIdBuilder.Id
         {

--- a/src/Umbraco.Tests.Common/Builders/TreeBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/TreeBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using Umbraco.Core;
 using Umbraco.Tests.Common.Builders.Interfaces;
 using Umbraco.Web.Trees;
@@ -54,7 +57,7 @@ namespace Umbraco.Tests.Common.Builders
             var sectionAlias = _sectionAlias ?? Constants.Applications.Content;
             var group = _group ?? string.Empty;
             var title = _title ?? string.Empty;
-            var treeUse = _treeUse ?? TreeUse.Main;
+            TreeUse treeUse = _treeUse ?? TreeUse.Main;
             var isSingleNode = _isSingleNode ?? false;
 
             return new Tree(sortOrder, sectionAlias, group, alias, title, treeUse, typeof(SampleTreeController), isSingleNode);

--- a/src/Umbraco.Tests.Common/Builders/UserBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/UserBuilder.cs
@@ -1,16 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core.Configuration.Models;
 using Umbraco.Core.Models.Membership;
-using Umbraco.Tests.Common.Builders.Interfaces;
 using Umbraco.Tests.Common.Builders.Extensions;
+using Umbraco.Tests.Common.Builders.Interfaces;
 
 namespace Umbraco.Tests.Common.Builders
 {
     public class UserBuilder : UserBuilder<object>
     {
-        public UserBuilder() : base(null)
+        public UserBuilder()
+            : base(null)
         {
         }
     }
@@ -48,7 +52,8 @@ namespace Umbraco.Tests.Common.Builders
         private int[] _startMediaIds;
         private readonly List<UserGroupBuilder<UserBuilder<TParent>>> _userGroupBuilders = new List<UserGroupBuilder<UserBuilder<TParent>>>();
 
-        public UserBuilder(TParent parentBuilder) : base(parentBuilder)
+        public UserBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
@@ -124,11 +129,6 @@ namespace Umbraco.Tests.Common.Builders
             return this;
         }
 
-        /// <summary>
-        /// Will suffix the name, email and username for testing
-        /// </summary>
-        /// <param name="suffix"></param>
-        /// <returns></returns>
         public UserBuilder<TParent> WithSuffix(string suffix)
         {
             _suffix = suffix;
@@ -147,9 +147,9 @@ namespace Umbraco.Tests.Common.Builders
             var id = _id ?? 0;
             var defaultLang = _defaultLang ?? "en";
             var globalSettings = new GlobalSettings { DefaultUILanguage = defaultLang };
-            var key = _key ?? Guid.NewGuid();
-            var createDate = _createDate ?? DateTime.Now;
-            var updateDate = _updateDate ?? DateTime.Now;
+            Guid key = _key ?? Guid.NewGuid();
+            DateTime createDate = _createDate ?? DateTime.Now;
+            DateTime updateDate = _updateDate ?? DateTime.Now;
             var name = _name ?? "TestUser" + _suffix;
             var language = _language ?? globalSettings.DefaultUILanguage;
             var username = _username ?? "TestUser" + _suffix;
@@ -158,14 +158,14 @@ namespace Umbraco.Tests.Common.Builders
             var failedPasswordAttempts = _failedPasswordAttempts ?? 0;
             var isApproved = _isApproved ?? false;
             var isLockedOut = _isLockedOut ?? false;
-            var lastLockoutDate = _lastLockoutDate ?? DateTime.Now;
-            var lastLoginDate = _lastLoginDate ?? DateTime.Now;
-            var lastPasswordChangeDate = _lastPasswordChangeDate ?? DateTime.Now;
+            DateTime lastLockoutDate = _lastLockoutDate ?? DateTime.Now;
+            DateTime lastLoginDate = _lastLoginDate ?? DateTime.Now;
+            DateTime lastPasswordChangeDate = _lastPasswordChangeDate ?? DateTime.Now;
             var comments = _comments ?? string.Empty;
             var sessionTimeout = _sessionTimeout ?? 0;
             var startContentIds = _startContentIds ?? new[] { -1 };
             var startMediaIds = _startMediaIds ?? new[] { -1 };
-            var groups = _userGroupBuilders.Select(x => x.Build());
+            IEnumerable<IUserGroup> groups = _userGroupBuilders.Select(x => x.Build());
 
             var result = new User(
                 globalSettings,
@@ -190,7 +190,7 @@ namespace Umbraco.Tests.Common.Builders
                 StartContentIds = startContentIds,
                 StartMediaIds = startMediaIds,
             };
-            foreach (var readOnlyUserGroup in groups)
+            foreach (IUserGroup readOnlyUserGroup in groups)
             {
                 result.AddGroup(readOnlyUserGroup.ToReadOnlyGroup());
             }
@@ -205,7 +205,7 @@ namespace Umbraco.Tests.Common.Builders
             for (var i = 0; i < amount; i++)
             {
                 var name = "User No-" + i;
-                var user = new UserBuilder()
+                User user = new UserBuilder()
                     .WithName(name)
                     .WithEmail("test" + i + "@test.com")
                     .WithLogin("test" + i, "test" + i)
@@ -221,15 +221,13 @@ namespace Umbraco.Tests.Common.Builders
             return list;
         }
 
-        public static User CreateUser(string suffix = "")
-        {
-            return new UserBuilder()
+        public static User CreateUser(string suffix = "") =>
+            new UserBuilder()
                 .WithIsApproved(true)
                 .WithName("TestUser" + suffix)
                 .WithLogin("TestUser" + suffix, "testing")
                 .WithEmail("test" + suffix + "@test.com")
                 .Build();
-        }
 
         int? IWithIdBuilder.Id
         {

--- a/src/Umbraco.Tests.Common/Builders/UserGroupBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/UserGroupBuilder.cs
@@ -1,16 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Strings;
-using Umbraco.Tests.Common.Builders.Interfaces;
 using Umbraco.Tests.Common.Builders.Extensions;
+using Umbraco.Tests.Common.Builders.Interfaces;
 
 namespace Umbraco.Tests.Common.Builders
 {
     public class UserGroupBuilder : UserGroupBuilder<object>
     {
-        public UserGroupBuilder() : base(null)
+        public UserGroupBuilder()
+            : base(null)
         {
         }
     }
@@ -33,15 +37,16 @@ namespace Umbraco.Tests.Common.Builders
         private int? _startMediaId;
         private int? _userCount;
 
-        public UserGroupBuilder(TParent parentBuilder) : base(parentBuilder)
+        public UserGroupBuilder(TParent parentBuilder)
+            : base(parentBuilder)
         {
         }
 
         /// <summary>
-        /// Will suffix the name and alias for testing
+        /// Will suffix the name, email and username for testing.
         /// </summary>
-        /// <param name="suffix"></param>
-        /// <returns></returns>
+        /// <param name="suffix">Suffix to add to user group properties.</param>
+        /// <returns>Current builder instance.</returns>
         public UserGroupBuilder<TParent> WithSuffix(string suffix)
         {
             _suffix = suffix;
@@ -84,9 +89,8 @@ namespace Umbraco.Tests.Common.Builders
             return this;
         }
 
-        public IReadOnlyUserGroup BuildReadOnly(IUserGroup userGroup)
-        {
-            return Mock.Of<IReadOnlyUserGroup>(x =>
+        public IReadOnlyUserGroup BuildReadOnly(IUserGroup userGroup) =>
+            Mock.Of<IReadOnlyUserGroup>(x =>
                 x.Permissions == userGroup.Permissions &&
                 x.Alias == userGroup.Alias &&
                 x.Icon == userGroup.Icon &&
@@ -95,7 +99,6 @@ namespace Umbraco.Tests.Common.Builders
                 x.StartMediaId == userGroup.StartMediaId &&
                 x.AllowedSections == userGroup.AllowedSections &&
                 x.Id == userGroup.Id);
-        }
 
         public override IUserGroup Build()
         {
@@ -109,10 +112,12 @@ namespace Umbraco.Tests.Common.Builders
 
             var shortStringHelper = new DefaultShortStringHelper(new DefaultShortStringHelperConfig());
 
-            var userGroup = new UserGroup(shortStringHelper, userCount, alias, name, _permissions, icon);
-            userGroup.Id = id;
-            userGroup.StartContentId = startContentId;
-            userGroup.StartMediaId = startMediaId;
+            var userGroup = new UserGroup(shortStringHelper, userCount, alias, name, _permissions, icon)
+            {
+                Id = id,
+                StartContentId = startContentId,
+                StartMediaId = startMediaId
+            };
 
             foreach (var section in _allowedSections)
             {
@@ -122,15 +127,13 @@ namespace Umbraco.Tests.Common.Builders
             return userGroup;
         }
 
-        public static UserGroup CreateUserGroup(string alias = "testGroup", string name = "Test Group", string suffix = "", string[] permissions = null, string[] allowedSections = null)
-        {
-            return (UserGroup)new UserGroupBuilder()
+        public static UserGroup CreateUserGroup(string alias = "testGroup", string name = "Test Group", string suffix = "", string[] permissions = null, string[] allowedSections = null) =>
+            (UserGroup)new UserGroupBuilder()
                 .WithAlias(alias + suffix)
                 .WithName(name + suffix)
                 .WithPermissions(permissions ?? new[] { "A", "B", "C" })
                 .WithAllowedSections(allowedSections ?? new[] { "content", "media" })
                 .Build();
-        }
 
         int? IWithIdBuilder.Id
         {

--- a/src/Umbraco.Tests.Common/Builders/XmlDocumentBuilder.cs
+++ b/src/Umbraco.Tests.Common/Builders/XmlDocumentBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System.Xml;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Xml;
 
 namespace Umbraco.Tests.Common.Builders
 {

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/KeepAliveTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/KeepAliveTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -23,12 +26,12 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
     {
         private Mock<HttpMessageHandler> _mockHttpMessageHandler;
 
-        private const string _applicationUrl = "https://mysite.com";
+        private const string ApplicationUrl = "https://mysite.com";
 
         [Test]
         public async Task Does_Not_Execute_When_Not_Enabled()
         {
-            var sut = CreateKeepAlive(enabled: false);
+            KeepAlive sut = CreateKeepAlive(enabled: false);
             await sut.PerformExecuteAsync(null);
             VerifyKeepAliveRequestNotSent();
         }
@@ -36,7 +39,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Server_Role_Is_Replica()
         {
-            var sut = CreateKeepAlive(serverRole: ServerRole.Replica);
+            KeepAlive sut = CreateKeepAlive(serverRole: ServerRole.Replica);
             await sut.PerformExecuteAsync(null);
             VerifyKeepAliveRequestNotSent();
         }
@@ -44,7 +47,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Server_Role_Is_Unknown()
         {
-            var sut = CreateKeepAlive(serverRole: ServerRole.Unknown);
+            KeepAlive sut = CreateKeepAlive(serverRole: ServerRole.Unknown);
             await sut.PerformExecuteAsync(null);
             VerifyKeepAliveRequestNotSent();
         }
@@ -52,7 +55,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Not_Main_Dom()
         {
-            var sut = CreateKeepAlive(isMainDom: false);
+            KeepAlive sut = CreateKeepAlive(isMainDom: false);
             await sut.PerformExecuteAsync(null);
             VerifyKeepAliveRequestNotSent();
         }
@@ -60,7 +63,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Executes_And_Calls_Ping_Url()
         {
-            var sut = CreateKeepAlive();
+            KeepAlive sut = CreateKeepAlive();
             await sut.PerformExecuteAsync(null);
             VerifyKeepAliveRequestSent();
         }
@@ -76,7 +79,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             };
 
             var mockRequestAccessor = new Mock<IRequestAccessor>();
-            mockRequestAccessor.Setup(x => x.GetApplicationUrl()).Returns(new Uri(_applicationUrl));
+            mockRequestAccessor.Setup(x => x.GetApplicationUrl()).Returns(new Uri(ApplicationUrl));
 
             var mockServerRegistrar = new Mock<IServerRegistrar>();
             mockServerRegistrar.Setup(x => x.GetCurrentServerRole()).Returns(serverRole);
@@ -99,26 +102,25 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
             mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
-            return new KeepAlive(mockRequestAccessor.Object, mockMainDom.Object, Options.Create(settings),
-                mockLogger.Object, mockProfilingLogger.Object, mockServerRegistrar.Object, mockHttpClientFactory.Object);
+            return new KeepAlive(
+                mockRequestAccessor.Object,
+                mockMainDom.Object,
+                Options.Create(settings),
+                mockLogger.Object,
+                mockProfilingLogger.Object,
+                mockServerRegistrar.Object,
+                mockHttpClientFactory.Object);
         }
 
-        private void VerifyKeepAliveRequestNotSent()
-        {
-            VerifyKeepAliveRequestSentTimes(Times.Never());
-        }
+        private void VerifyKeepAliveRequestNotSent() => VerifyKeepAliveRequestSentTimes(Times.Never());
 
-        private void VerifyKeepAliveRequestSent()
-        {
-            VerifyKeepAliveRequestSentTimes(Times.Once());
-        }
+        private void VerifyKeepAliveRequestSent() => VerifyKeepAliveRequestSentTimes(Times.Once());
 
-        private void VerifyKeepAliveRequestSentTimes(Times times)
-        {
-            _mockHttpMessageHandler.Protected().Verify("SendAsync",
+        private void VerifyKeepAliveRequestSentTimes(Times times) => _mockHttpMessageHandler.Protected()
+            .Verify(
+                "SendAsync",
                 times,
-                ItExpr.Is<HttpRequestMessage>(x => x.RequestUri.ToString() == $"{_applicationUrl}/api/keepalive/ping"),
+                ItExpr.Is<HttpRequestMessage>(x => x.RequestUri.ToString() == $"{ApplicationUrl}/api/keepalive/ping"),
                 ItExpr.IsAny<CancellationToken>());
-        }
     }
 }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ScheduledPublishingTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ScheduledPublishingTests.cs
@@ -1,15 +1,16 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Core;
-using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
 using Umbraco.Core.Sync;
 using Umbraco.Infrastructure.HostedServices;
 using Umbraco.Web;
-using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 {
@@ -22,7 +23,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Not_Enabled()
         {
-            var sut = CreateScheduledPublishing(enabled: false);
+            ScheduledPublishing sut = CreateScheduledPublishing(enabled: false);
             await sut.PerformExecuteAsync(null);
             VerifyScheduledPublishingNotPerformed();
         }
@@ -34,7 +35,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [TestCase(RuntimeLevel.BootFailed)]
         public async Task Does_Not_Execute_When_Runtime_State_Is_Not_Run(RuntimeLevel runtimeLevel)
         {
-            var sut = CreateScheduledPublishing(runtimeLevel: runtimeLevel);
+            ScheduledPublishing sut = CreateScheduledPublishing(runtimeLevel: runtimeLevel);
             await sut.PerformExecuteAsync(null);
             VerifyScheduledPublishingNotPerformed();
         }
@@ -42,7 +43,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Server_Role_Is_Replica()
         {
-            var sut = CreateScheduledPublishing(serverRole: ServerRole.Replica);
+            ScheduledPublishing sut = CreateScheduledPublishing(serverRole: ServerRole.Replica);
             await sut.PerformExecuteAsync(null);
             VerifyScheduledPublishingNotPerformed();
         }
@@ -50,7 +51,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Server_Role_Is_Unknown()
         {
-            var sut = CreateScheduledPublishing(serverRole: ServerRole.Unknown);
+            ScheduledPublishing sut = CreateScheduledPublishing(serverRole: ServerRole.Unknown);
             await sut.PerformExecuteAsync(null);
             VerifyScheduledPublishingNotPerformed();
         }
@@ -58,7 +59,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Does_Not_Execute_When_Not_Main_Dom()
         {
-            var sut = CreateScheduledPublishing(isMainDom: false);
+            ScheduledPublishing sut = CreateScheduledPublishing(isMainDom: false);
             await sut.PerformExecuteAsync(null);
             VerifyScheduledPublishingNotPerformed();
         }
@@ -66,7 +67,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Executes_And_Performs_Scheduled_Publishing()
         {
-            var sut = CreateScheduledPublishing();
+            ScheduledPublishing sut = CreateScheduledPublishing();
             await sut.PerformExecuteAsync(null);
             VerifyScheduledPublishingPerformed();
         }
@@ -106,23 +107,21 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 
             var mockBackOfficeSecurityFactory = new Mock<IBackOfficeSecurityFactory>();
 
-            return new ScheduledPublishing(mockRunTimeState.Object, mockMainDom.Object, mockServerRegistrar.Object, _mockContentService.Object,
-                mockUmbracoContextFactory.Object, _mockLogger.Object, mockServerMessenger.Object, mockBackOfficeSecurityFactory.Object);
+            return new ScheduledPublishing(
+                mockRunTimeState.Object,
+                mockMainDom.Object,
+                mockServerRegistrar.Object,
+                _mockContentService.Object,
+                mockUmbracoContextFactory.Object,
+                _mockLogger.Object,
+                mockServerMessenger.Object,
+                mockBackOfficeSecurityFactory.Object);
         }
 
-        private void VerifyScheduledPublishingNotPerformed()
-        {
-            VerifyScheduledPublishingPerformed(Times.Never());
-        }
+        private void VerifyScheduledPublishingNotPerformed() => VerifyScheduledPublishingPerformed(Times.Never());
 
-        private void VerifyScheduledPublishingPerformed()
-        {
-            VerifyScheduledPublishingPerformed(Times.Once());
-        }
+        private void VerifyScheduledPublishingPerformed() => VerifyScheduledPublishingPerformed(Times.Once());
 
-        private void VerifyScheduledPublishingPerformed(Times times)
-        {
-            _mockContentService.Verify(x => x.PerformScheduledPublish(It.IsAny<DateTime>()), times);
-        }
+        private void VerifyScheduledPublishingPerformed(Times times) => _mockContentService.Verify(x => x.PerformScheduledPublish(It.IsAny<DateTime>()), times);
     }
 }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTaskTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTaskTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -22,7 +25,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.ServerRe
         [TestCase(RuntimeLevel.BootFailed)]
         public async Task Does_Not_Execute_When_Runtime_State_Is_Not_Run(RuntimeLevel runtimeLevel)
         {
-            var sut = CreateInstructionProcessTask(runtimeLevel: runtimeLevel);
+            InstructionProcessTask sut = CreateInstructionProcessTask(runtimeLevel: runtimeLevel);
             await sut.PerformExecuteAsync(null);
             VerifyMessengerNotSynced();
         }
@@ -30,7 +33,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.ServerRe
         [Test]
         public async Task Executes_And_Touches_Server()
         {
-            var sut = CreateInstructionProcessTask();
+            InstructionProcessTask sut = CreateInstructionProcessTask();
             await sut.PerformExecuteAsync(null);
             VerifyMessengerSynced();
         }
@@ -49,19 +52,10 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.ServerRe
             return new InstructionProcessTask(mockRunTimeState.Object, _mockDatabaseServerMessenger.Object, mockLogger.Object, Options.Create(settings));
         }
 
-        private void VerifyMessengerNotSynced()
-        {
-            VerifyMessengerSyncedTimes(Times.Never());
-        }
+        private void VerifyMessengerNotSynced() => VerifyMessengerSyncedTimes(Times.Never());
 
-        private void VerifyMessengerSynced()
-        {
-            VerifyMessengerSyncedTimes(Times.Once());
-        }
+        private void VerifyMessengerSynced() => VerifyMessengerSyncedTimes(Times.Once());
 
-        private void VerifyMessengerSyncedTimes(Times times)
-        {
-            _mockDatabaseServerMessenger.Verify(x => x.Sync(), times);
-        }
+        private void VerifyMessengerSyncedTimes(Times times) => _mockDatabaseServerMessenger.Verify(x => x.Sync(), times);
     }
 }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/TempFileCleanupTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/TempFileCleanupTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -15,12 +18,12 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
     public class TempFileCleanupTests
     {
         private Mock<IIOHelper> _mockIOHelper;
-        private string _testPath = Path.Combine(TestContext.CurrentContext.TestDirectory.Split("bin")[0], "App_Data", "TEMP");
+        private readonly string _testPath = Path.Combine(TestContext.CurrentContext.TestDirectory.Split("bin")[0], "App_Data", "TEMP");
 
         [Test]
         public async Task Does_Not_Execute_When_Not_Main_Dom()
         {
-            var sut = CreateTempFileCleanup(isMainDom: false);
+            TempFileCleanup sut = CreateTempFileCleanup(isMainDom: false);
             await sut.PerformExecuteAsync(null);
             VerifyFilesNotCleaned();
         }
@@ -28,7 +31,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
         [Test]
         public async Task Executes_And_Cleans_Files()
         {
-            var sut = CreateTempFileCleanup();
+            TempFileCleanup sut = CreateTempFileCleanup();
             await sut.PerformExecuteAsync(null);
             VerifyFilesCleaned();
         }
@@ -50,19 +53,10 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             return new TempFileCleanup(_mockIOHelper.Object, mockMainDom.Object, mockLogger.Object);
         }
 
-        private void VerifyFilesNotCleaned()
-        {
-            VerifyFilesCleaned(Times.Never());
-        }
+        private void VerifyFilesNotCleaned() => VerifyFilesCleaned(Times.Never());
 
-        private void VerifyFilesCleaned()
-        {
-            VerifyFilesCleaned(Times.Once());
-        }
+        private void VerifyFilesCleaned() => VerifyFilesCleaned(Times.Once());
 
-        private void VerifyFilesCleaned(Times times)
-        {
-            _mockIOHelper.Verify(x => x.CleanFolder(It.Is<DirectoryInfo>(y => y.FullName == _testPath), It.IsAny<TimeSpan>()), times);
-        }
+        private void VerifyFilesCleaned(Times times) => _mockIOHelper.Verify(x => x.CleanFolder(It.Is<DirectoryInfo>(y => y.FullName == _testPath), It.IsAny<TimeSpan>()), times);
     }
 }


### PR DESCRIPTION
I've restricted amends here to just code we've added in the .NET Core transition to avoid issues with merges from the V8 branch.  Have covered:

- The new hosted services
- The unit test model builders

Warning count before: 34216
After: 34031
Resolved: 185...baby steps!