### PR TITLE
Support dependency injection for Examine IDirectoryFactory

### DIFF
--- a/src/Umbraco.Examine/LuceneIndexCreator.cs
+++ b/src/Umbraco.Examine/LuceneIndexCreator.cs
@@ -17,6 +17,12 @@ namespace Umbraco.Examine
     /// </summary>
     public abstract class LuceneIndexCreator : IIndexCreator
     {
+
+        private readonly IFactory _factory;
+        public LuceneIndexCreator(IFactory factory)
+        {
+            _factory = factory ?? throw new System.ArgumentNullException(nameof(factory));
+        }
         public abstract IEnumerable<IIndex> Create();
 
         /// <summary>
@@ -40,7 +46,7 @@ namespace Umbraco.Examine
                 //this should be a fully qualified type
                 var factoryType = TypeFinder.GetTypeByName(configuredDirectoryFactory);
                 if (factoryType == null) throw new NullReferenceException("No directory type found for value: " + configuredDirectoryFactory);
-                var directoryFactory = (IDirectoryFactory)Activator.CreateInstance(factoryType);
+                var directoryFactory = (IDirectoryFactory)_factory.GetInstance(factoryType);
                 return directoryFactory.CreateDirectory(dirInfo);
             }
 

--- a/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
+++ b/src/Umbraco.Web/Search/UmbracoIndexesCreator.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Analysis.Standard;
 using Examine.LuceneEngine;
 using Examine;
 using Umbraco.Core;
+using Umbraco.Core.Composing;
 
 namespace Umbraco.Web.Search
 {
@@ -15,12 +16,14 @@ namespace Umbraco.Web.Search
     /// </summary>
     public class UmbracoIndexesCreator : LuceneIndexCreator, IUmbracoIndexesCreator
     {
+
         // TODO: we should inject the different IValueSetValidator so devs can just register them instead of overriding this class?
 
         public UmbracoIndexesCreator(IProfilingLogger profilingLogger,
             ILocalizationService languageService,
             IPublicAccessService publicAccessService,
-            IMemberService memberService, IUmbracoIndexConfig umbracoIndexConfig)
+            IMemberService memberService, IUmbracoIndexConfig umbracoIndexConfig,
+            IFactory factory) : base(factory)
         {
             ProfilingLogger = profilingLogger ?? throw new System.ArgumentNullException(nameof(profilingLogger));
             LanguageService = languageService ?? throw new System.ArgumentNullException(nameof(languageService));


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A

### Description
What?
Retrieve new IDirectoryFactory instances from the container instead of using Activator.

Why?
Allow registering IDirectoryFactory instances with dependencies

How to test?
Case 1
Use a ICoreComposer to register an IDirectoryFactory with dependencies.
Set the registered IDirectoryFactory in web.config for key "Umbraco.Examine.LuceneDirectoryFactory"
Boot Umbraco.

Case 2
Set a built in Examine IDirectoryFactory in web.config for key "Umbraco.Examine.LuceneDirectoryFactory"
Existing IDirectoryFactory loads without having to be registered in code with the IOC container.
