### PR TITLE
Speed up deleting relationship by parent. (Speeds up publishing/ saving)

### DIFF
--- a/src/Umbraco.Core/Constants-SqlTemplates.cs
+++ b/src/Umbraco.Core/Constants-SqlTemplates.cs
@@ -14,7 +14,11 @@
                 public const string GetParentNode = "Umbraco.Core.VersionableRepository.GetParentNode";
                 public const string GetReservedId = "Umbraco.Core.VersionableRepository.GetReservedId";
             }
-
+            public static class RelationRepository
+            {
+                public const string DeleteByParentAll = "Umbraco.Core.RelationRepository.DeleteByParent";
+                public const string DeleteByParentIn = "Umbraco.Core.RelationRepository.DeleteByParentIn";
+            }
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -288,20 +288,21 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         {
             if (relationTypeAliases.Length > 0)
             {
-                var query = Sql().Delete<RelationDto>()
-                 .From<RelationDto>()
-                .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
-                .Where<RelationDto>(x => x.ParentId == parentId);
-                Database.Execute(query);
+                var template = SqlContext.Templates.Get(Constants.SqlTemplates.RelationRepository.DeleteByParentIn, tsql => Sql().Delete<RelationDto>()
+                  .From<RelationDto>()
+                 .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
+                 .Where<RelationDto>(x => x.ParentId == SqlTemplate.Arg<int>(nameof(parentId)))
+                 .WhereIn<RelationTypeDto>(x => x.Alias, SqlTemplate.ArgIn<string>(nameof(relationTypeAliases))));
+                Database.Execute(template.Sql(new { parentId, relationTypeAliases }));
             }
             else
             {
-                var query = Sql().Delete<RelationDto>()
+                
+                var template = SqlContext.Templates.Get(Constants.SqlTemplates.RelationRepository.DeleteByParentAll, tsql => Sql().Delete<RelationDto>()
                  .From<RelationDto>()
                 .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
-                .Where<RelationDto>(x => x.ParentId == parentId)
-                .WhereIn<RelationTypeDto>(x => x.Alias, relationTypeAliases);
-                Database.Execute(query);
+                .Where<RelationDto>(x => x.ParentId == SqlTemplate.Arg<int>(nameof(parentId))));
+                Database.Execute(template.Sql(new { parentId }));
             }
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -289,6 +289,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             if (relationTypeAliases.Length > 0)
             {
                 var query = Sql().Delete<RelationDto>()
+                 .From<RelationDto>()
                 .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
                 .Where<RelationDto>(x => x.ParentId == parentId);
                 Database.Execute(query);
@@ -296,6 +297,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             else
             {
                 var query = Sql().Delete<RelationDto>()
+                 .From<RelationDto>()
                 .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
                 .Where<RelationDto>(x => x.ParentId == parentId)
                 .WhereIn<RelationTypeDto>(x => x.Alias, relationTypeAliases);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -286,17 +286,21 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         
         public void DeleteByParent(int parentId, params string[] relationTypeAliases)
         {
-            var subQuery = Sql().Select<RelationDto>(x => x.Id)
-                .From<RelationDto>()
-                .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
-                .Where<RelationDto>(x => x.ParentId == parentId);
-
             if (relationTypeAliases.Length > 0)
             {
-                subQuery.WhereIn<RelationTypeDto>(x => x.Alias, relationTypeAliases);
+                var query = Sql().Delete<RelationDto>()
+                .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
+                .Where<RelationDto>(x => x.ParentId == parentId);
+                Database.Execute(query);
             }
-
-            Database.Execute(Sql().Delete<RelationDto>().WhereIn<RelationDto>(x => x.Id, subQuery));
+            else
+            {
+                var query = Sql().Delete<RelationDto>()
+                .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
+                .Where<RelationDto>(x => x.ParentId == parentId)
+                .WhereIn<RelationTypeDto>(x => x.Alias, relationTypeAliases);
+                Database.Execute(query);
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -291,8 +291,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 var template = SqlContext.Templates.Get(Constants.SqlTemplates.RelationRepository.DeleteByParentIn, tsql => Sql().Delete<RelationDto>()
                   .From<RelationDto>()
                  .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
-                 .Where<RelationDto>(x => x.ParentId == SqlTemplate.Arg<int>(nameof(parentId)))
-                 .WhereIn<RelationTypeDto>(x => x.Alias, SqlTemplate.ArgIn<string>(nameof(relationTypeAliases))));
+                 .Where<RelationDto>(x => x.ParentId == SqlTemplate.Arg<int>("parentId"))
+                 .WhereIn<RelationTypeDto>(x => x.Alias, SqlTemplate.ArgIn<string>("relationTypeAliases")));
                 Database.Execute(template.Sql(new { parentId, relationTypeAliases }));
             }
             else
@@ -301,7 +301,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 var template = SqlContext.Templates.Get(Constants.SqlTemplates.RelationRepository.DeleteByParentAll, tsql => Sql().Delete<RelationDto>()
                  .From<RelationDto>()
                 .InnerJoin<RelationTypeDto>().On<RelationDto, RelationTypeDto>(x => x.RelationType, x => x.Id)
-                .Where<RelationDto>(x => x.ParentId == SqlTemplate.Arg<int>(nameof(parentId))));
+                .Where<RelationDto>(x => x.ParentId == SqlTemplate.Arg<int>("parentId")));
                 Database.Execute(template.Sql(new { parentId }));
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes N/A

### Description
What?
Improve query for Delete relationship by parent.

Why?
Faster deletion of relationships = reduced time to publish.

How to test?
Existing tests pass. Existing relationships on existing content are removed when the content is saved.
Execution time should be reduced on sql server/ sql azure