### PR TITLE
Unhelpful unsupported property message in Block Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/notsupported/notsupported.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/notsupported/notsupported.html
@@ -1,3 +1,3 @@
 <div class="umb-property-editor umb-property-editor--notsupported">
-    <localize key="errors_errorPropertyEditorNotSupportedInElementTypes" tokens="[model.label, model.editor]"></localize>
+    <localize key="blockEditor_propertyEditorNotSupported" tokens="[model.label, model.editor]"></localize>
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
@@ -700,7 +700,6 @@
         <key alias="tableColMergeLeft">Symudwch y cyrchwr ar ochr chwith y ddwy gell yr ydych eisiau cyfuno</key>
         <key alias="tableSplitNotSplittable">Ni allwch hollti cell sydd heb ei gyfuno.</key>
         <key alias="propertyHasErrors">Mae gan briodwedd hon gwallau</key>
-        <key alias="errorPropertyEditorNotSupportedInElementTypes">Priodwedd '%0%' yn defnyddio'r golygydd '%1%' sydd ddim yn cael ei gefnogi mewn Mathau o Elfen.</key>
         <key alias="xsltErrorHeader">Gwall yn y ffynhonnell XSLT</key>
         <key alias="xsltErrorText">Nid yw'r XSLTwedi'i achub gan ei fod yn cynnwys gwall(au)</key>
         <key alias="missingPropertyEditorErrorMessage">Mae gwall ffurfwedd gyda'r math o ddata sy'n cael ei ddefnyddio ar gyfer y priodwedd yma, gwiriwch y fath o ddata</key>
@@ -2762,6 +2761,7 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
         <key alias="blockHasChanges">Rydych chi wedi gwneud newidiadau i'r cynnwys hwn. Wyt ti'n siŵr eich bod chi am eu taflu ei fwrdd?</key>
         <key alias="confirmCancelBlockCreationHeadline">Gwaredu cread?</key>
         <key alias="confirmCancelBlockCreationMessage"><![CDATA[Ydych chi'n siŵr eich bod chi'n am ganslo'r cread?]]></key>
+        <key alias="propertyEditorNotSupported">Priodwedd '%0%' yn defnyddio'r golygydd '%1%' sydd ddim yn cael ei gefnogi mewn Mathau o Elfen.</key>
     </area>
     <area alias="contentTemplatesDashboard">
         <key alias="whatHeadline">Beth yw Templedi Gynnwys</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
@@ -676,7 +676,6 @@
         <key alias="errorMandatoryWithoutTab">%0% yn faes ofynnol</key>
         <key alias="errorRegExp">%0% yn %1% mewn fformat annilys</key>
         <key alias="errorRegExpWithoutTab">%0% mewn fformat annilys</key>
-        <key alias="errorPropertyEditorNotSupportedInElementTypes">Briodwedd '%0%' yn defnyddio'r golygydd '%1%' sydd ddim wedi ei chynnal yn y teipiau elfen.</key>
     </area>
     <area alias="errors">
         <key alias="receivedErrorFromServer">Derbynwyd gwall o'r gweinydd</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
@@ -2761,7 +2761,7 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
         <key alias="blockHasChanges">Rydych chi wedi gwneud newidiadau i'r cynnwys hwn. Wyt ti'n siŵr eich bod chi am eu taflu ei fwrdd?</key>
         <key alias="confirmCancelBlockCreationHeadline">Gwaredu cread?</key>
         <key alias="confirmCancelBlockCreationMessage"><![CDATA[Ydych chi'n siŵr eich bod chi'n am ganslo'r cread?]]></key>
-        <key alias="propertyEditorNotSupported">Priodwedd '%0%' yn defnyddio'r golygydd '%1%' sydd ddim yn cael ei gefnogi mewn Mathau o Elfen.</key>
+        <key alias="propertyEditorNotSupported">Priodwedd '%0%' yn defnyddio'r golygydd '%1%' sydd ddim yn cael ei gefnogi mewn blociau.</key>
     </area>
     <area alias="contentTemplatesDashboard">
         <key alias="whatHeadline">Beth yw Templedi Gynnwys</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -611,7 +611,6 @@
     <key alias="tableColMergeLeft">Du skal stå til venstre for de 2 celler du ønsker at samle!</key>
     <key alias="tableSplitNotSplittable">Du kan ikke opdele en celle, som ikke allerede er delt.</key>
     <key alias="propertyHasErrors">Denne egenskab er ugyldig</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">Feltet %0% bruger editor %1% som ikke er supporteret for ElementTyper.</key>
   </area>
   <area alias="general">
     <key alias="about">Om</key>
@@ -1860,6 +1859,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Er du sikker på at du vil annullere oprettelsen.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Error!</key>
     <key alias="elementTypeDoesNotExistDescription">The ElementType of this block does not exist anymore</key>
+    <key alias="propertyEditorNotSupported">Feltet %0% bruger editor %1% som ikke er supporteret for ElementTyper.</key>
   </area>
   <area alias="preview">
     <key alias="endLabel">Afslut</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1859,7 +1859,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Er du sikker på at du vil annullere oprettelsen.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Error!</key>
     <key alias="elementTypeDoesNotExistDescription">The ElementType of this block does not exist anymore</key>
-    <key alias="propertyEditorNotSupported">Feltet %0% bruger editor %1% som ikke er supporteret for ElementTyper.</key>
+    <key alias="propertyEditorNotSupported">Feltet %0% bruger editor %1% som ikke er supporteret for blokke.</key>
   </area>
   <area alias="preview">
     <key alias="endLabel">Afslut</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -642,7 +642,6 @@
     <key alias="tableColMergeLeft">Please place cursor at the left of the two cells you wish to merge</key>
     <key alias="tableSplitNotSplittable">You cannot split a cell that hasn't been merged.</key>
     <key alias="propertyHasErrors">This property is invalid</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
   </area>
   <area alias="general">
     <key alias="about">About</key>
@@ -2512,6 +2511,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Are you sure you want to cancel the creation.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Error!</key>
     <key alias="elementTypeDoesNotExistDescription">The ElementType of this block does not exist anymore</key>
+    <key alias="propertyEditorNotSupported">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -625,7 +625,6 @@
     <key alias="errorMandatoryWithoutTab">%0% is a mandatory field</key>
     <key alias="errorRegExp">%0% at %1% is not in a correct format</key>
     <key alias="errorRegExpWithoutTab">%0% is not in a correct format</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
   </area>
   <area alias="errors">
     <key alias="receivedErrorFromServer">Received an error from the server</key>
@@ -643,6 +642,7 @@
     <key alias="tableColMergeLeft">Please place cursor at the left of the two cells you wish to merge</key>
     <key alias="tableSplitNotSplittable">You cannot split a cell that hasn't been merged.</key>
     <key alias="propertyHasErrors">This property is invalid</key>
+    <key alias="errorPropertyEditorNotSupportedInElementTypes">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
   </area>
   <area alias="general">
     <key alias="about">About</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2511,7 +2511,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Are you sure you want to cancel the creation.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Error!</key>
     <key alias="elementTypeDoesNotExistDescription">The ElementType of this block does not exist anymore</key>
-    <key alias="propertyEditorNotSupported">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
+    <key alias="propertyEditorNotSupported">Property '%0%' uses editor '%1%' which is not supported in blocks.</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -649,7 +649,6 @@
     <key alias="tableColMergeLeft">Please place cursor at the left of the two cells you wish to merge</key>
     <key alias="tableSplitNotSplittable">You cannot split a cell that hasn't been merged.</key>
     <key alias="propertyHasErrors">This property is invalid</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
   </area>
   <area alias="general">
     <key alias="options">Options</key>
@@ -2534,6 +2533,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Are you sure you want to cancel the creation.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Error!</key>
     <key alias="elementTypeDoesNotExistDescription">The ElementType of this block does not exist anymore</key>
+    <key alias="propertyEditorNotSupported">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2533,7 +2533,7 @@ To manage your website, simply open the Umbraco back office and start adding con
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Are you sure you want to cancel the creation.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Error!</key>
     <key alias="elementTypeDoesNotExistDescription">The ElementType of this block does not exist anymore</key>
-    <key alias="propertyEditorNotSupported">Property '%0%' uses editor '%1%' which is not supported in Element Types.</key>
+    <key alias="propertyEditorNotSupported">Property '%0%' uses editor '%1%' which is not supported in blocks.</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -650,7 +650,6 @@
     <key alias="tableColMergeLeft">Plaats de cursor links van de twee cellen die je wilt samenvoegen</key>
     <key alias="tableSplitNotSplittable">Je kunt een cel die is samengevoegd niet delen</key>
     <key alias="propertyHasErrors">Deze eigenschap is ongeldig</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">Eigenschap '%0%' gebruikt editor '%1%' die niet ondersteund wordt in Element Types.</key>
   </area>
   <area alias="general">
     <key alias="options">Opties</key>
@@ -2361,6 +2360,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
       <key alias="confirmCancelBlockCreationMessage"><![CDATA[Ben je zeker dat je deze wijzigingen wil verwerpen?]]></key>
       <key alias="elementTypeDoesNotExistHeadline">Fout!</key>
       <key alias="elementTypeDoesNotExistDescription">Het Elementtype van dit blok bestaat niet meer</key>
+      <key alias="propertyEditorNotSupported">Eigenschap '%0%' gebruikt editor '%1%' die niet ondersteund wordt in Element Types.</key>
     </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">Wat zijn Inhoudssjablonen?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -2360,7 +2360,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
       <key alias="confirmCancelBlockCreationMessage"><![CDATA[Ben je zeker dat je deze wijzigingen wil verwerpen?]]></key>
       <key alias="elementTypeDoesNotExistHeadline">Fout!</key>
       <key alias="elementTypeDoesNotExistDescription">Het Elementtype van dit blok bestaat niet meer</key>
-      <key alias="propertyEditorNotSupported">Eigenschap '%0%' gebruikt editor '%1%' die niet ondersteund wordt in Element Types.</key>
+      <key alias="propertyEditorNotSupported">Eigenschap '%0%' gebruikt editor '%1%' die niet ondersteund wordt in blokken.</key>
     </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">Wat zijn Inhoudssjablonen?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -648,7 +648,6 @@
     <key alias="tableColMergeLeft">Lütfen imleci birleştirmek istediğiniz iki hücrenin soluna yerleştirin</key>
     <key alias="tableSplitNotSplittable">Birleştirilmemiş bir hücreyi bölemezsiniz.</key>
     <key alias="propertyHasErrors">Bu özellik geçersiz</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">'%0%' özelliği, Öğe Türlerinde desteklenmeyen '%1%' düzenleyicisini kullanıyor.</key>
   </area>
   <area alias="general">
     <key alias="about">Hakkında</key>
@@ -2575,6 +2574,7 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Oluşturmayı iptal etmek istediğinizden emin misiniz.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Hata!</key>
     <key alias="elementTypeDoesNotExistDescription">Bu bloğun ElementType'ı artık mevcut değil</key>
+    <key alias="propertyEditorNotSupported">'%0%' özelliği, Öğe Türlerinde desteklenmeyen '%1%' düzenleyicisini kullanıyor.</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">İçerik Şablonları Nedir?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -2574,7 +2574,7 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="confirmCancelBlockCreationMessage"><![CDATA[Oluşturmayı iptal etmek istediğinizden emin misiniz.]]></key>
     <key alias="elementTypeDoesNotExistHeadline">Hata!</key>
     <key alias="elementTypeDoesNotExistDescription">Bu bloğun ElementType'ı artık mevcut değil</key>
-    <key alias="propertyEditorNotSupported">'%0%' özelliği, Öğe Türlerinde desteklenmeyen '%1%' düzenleyicisini kullanıyor.</key>
+    <key alias="propertyEditorNotSupported">'%0%' özelliği, bloklarda desteklenmeyen '%1%' düzenleyicisini kullanıyor.</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">İçerik Şablonları Nedir?</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -631,7 +631,6 @@
     <key alias="errorMandatoryWithoutTab">%0% zorunlu bir alandır</key>
     <key alias="errorRegExp">%1% konumunda %0% doğru biçimde değil</key>
     <key alias="errorRegExpWithoutTab">%0% doğru biçimde değil</key>
-    <key alias="errorPropertyEditorNotSupportedInElementTypes">'%0%' özelliği, Öğe Türlerinde desteklenmeyen '%1%' düzenleyicisini kullanıyor.</key>
   </area>
   <area alias="errors">
     <key alias="receivedErrorFromServer">Sunucudan bir hata aldı</key>
@@ -649,6 +648,7 @@
     <key alias="tableColMergeLeft">Lütfen imleci birleştirmek istediğiniz iki hücrenin soluna yerleştirin</key>
     <key alias="tableSplitNotSplittable">Birleştirilmemiş bir hücreyi bölemezsiniz.</key>
     <key alias="propertyHasErrors">Bu özellik geçersiz</key>
+    <key alias="errorPropertyEditorNotSupportedInElementTypes">'%0%' özelliği, Öğe Türlerinde desteklenmeyen '%1%' düzenleyicisini kullanıyor.</key>
   </area>
   <area alias="general">
     <key alias="about">Hakkında</key>


### PR DESCRIPTION
When adding a property like Nested Content to the block editor you get an error like this:

> Property XYZ uses editor Nested Content which is not supported in **Element Types**.

The exact reasons for this have been discussed in #8732 - I'm not going to argue here and now... ;-)

But this error message is rather unhelpful, and in many cases inaccurate. It is possible to put Nested Content properties inside Element Types as Nested Content itself uses elements!

I have updated all instances of this message to be more Block Editor specific. The message now reads:

> Property XYZ uses editor Nested Content which is not supported in **blocks**.