### PR TITLE
Block list action z index

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.html
@@ -8,6 +8,7 @@
         <i class="icon {{block.content.icon}}" aria-hidden="true"></i>
         <span class="name">{{block.label}}</span>
     </button>
+
     <div class="blockelement-inlineblock-editor__inner" ng-class="{'--singleGroup':block.content.variants[0].tabs.length === 1}" ng-if="block.active === true">
         <umb-element-editor-content model="block.content"></umb-element-editor-content>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -9,7 +9,7 @@
             <div ng-repeat="layout in vm.layout track by layout.$block.key">
 
                 <button type="button"
-                        class="btn-reset umb-block-list__block--create-button"
+                        class="btn-reset umb-block-list__block-create-button"
                         ng-click="vm.showCreateDialog($index, $event)"
                         ng-controller="Umbraco.PropertyEditors.BlockListPropertyEditor.CreateButtonController as inlineCreateButtonCtrl"
                         ng-mousemove="inlineCreateButtonCtrl.onMouseMove($event)">
@@ -60,6 +60,5 @@
         view="vm.blockTypePicker.view"
         model="vm.blockTypePicker">
     </umb-overlay>
-
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
@@ -11,7 +11,8 @@
 .umb-block-list__wrapper {
     position: relative;
     max-width: 1024px;
-    > .ui-sortable > .ui-sortable-helper > .umb-block-list__block > .umb-block-list__block--content > * {
+
+    > .ui-sortable > .ui-sortable-helper > .umb-block-list__block > .umb-block-list__block-content > * {
         box-shadow: 0px 5px 10px 0 rgba(0,0,0,.2);
     }
 }
@@ -20,7 +21,7 @@
     position: relative;
     width: 100%;
 
-    > .umb-block-list__block--actions {
+    > .umb-block-list__block-actions {
         opacity: 0;
         transition: opacity 120ms;
 
@@ -33,8 +34,7 @@
     &:focus,
     &:focus-within,
     &.--active {
-
-        > .umb-block-list__block--actions {
+        > .umb-block-list__block-actions {
             opacity: 1;
         }
     }
@@ -43,6 +43,7 @@
         ng-form.ng-invalid-val-server-match-content > & {
             border: 2px solid @formErrorText;
             border-radius: @baseBorderRadius;
+
             &::after {
                 content: "!";
                 position: absolute;
@@ -61,12 +62,12 @@
                 color: @errorText;
                 border: 2px solid @white;
                 font-weight: 900;
-    
                 animation-duration: 1.4s;
                 animation-iteration-count: infinite;
-                animation-name: umb-block-list__block--content--badge-bounce;
+                animation-name: umb-block-list__block-content--badge-bounce;
                 animation-timing-function: ease;
-                @keyframes umb-block-list__block--content--badge-bounce {
+
+                @keyframes umb-block-list__block-content--badge-bounce {
                     0%   { transform: translateY(0); }
                     20%  { transform: translateY(-6px); }
                     40%  { transform: translateY(0); }
@@ -78,10 +79,12 @@
         }
     }
 }
-ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-block-list__block--actions {
+
+ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-block-list__block-actions {
     opacity: 1;
 }
-.umb-block-list__block--actions {
+
+.umb-block-list__block-actions {
     position: absolute;
     z-index: 999999;
     top: 10px;
@@ -91,15 +94,18 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
     border-radius: 16px;
     padding-left: 5px;
     padding-right: 5px;
+
     .action {
         position: relative;
         display: inline-block;
         color: @ui-action-discreet-type;
         font-size: 18px;
         padding: 5px;
+
         &:hover {
             color: @ui-action-discreet-type-hover;
         }
+
         > .__error-badge {
             position: absolute;
             top: -2px;
@@ -117,13 +123,14 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
             display: none;
             font-weight: 900;
         }
+
         &.--error > .__error-badge {
             display: block;
-
             animation-duration: 1.4s;
             animation-iteration-count: infinite;
             animation-name: umb-block-list__action--badge-bounce;
             animation-timing-function: ease;
+
             @keyframes umb-block-list__action--badge-bounce {
                 0%   { transform: translateY(0); }
                 20%  { transform: translateY(-4px); }
@@ -132,13 +139,11 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
                 70%  { transform: translateY(0); }
                 100% { transform: translateY(0); }
             }
-
         }
     }
 }
 
-.umb-block-list__block--content {
-
+.umb-block-list__block-content {
     > div {
         position: relative;
         width: 100%;
@@ -147,15 +152,13 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
         border-radius: @baseBorderRadius;
         box-sizing: border-box;
     }
-
 }
 
 .blockelement__draggable-element {
     cursor: grab;
 }
 
-
-.umb-block-list__block--create-button {
+.umb-block-list__block-create-button {
     position: absolute;
     width: 100%;
     z-index: 1;
@@ -178,11 +181,11 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
         right: 0;
         left: 0;
         height: 2px;
-        animation: umb-block-list__block--create-button_before 400ms ease-in-out alternate infinite;
+        animation: umb-block-list__block-create-button--before 400ms ease-in-out alternate infinite;
         transform: scaleX(.99);
         transition: transform 240ms ease-out;
 
-        @keyframes umb-block-list__block--create-button_before {
+        @keyframes umb-block-list__block-create-button--before {
             0%   { opacity: 1; }
             100% { opacity: 0.5; }
         }
@@ -207,10 +210,9 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
         box-shadow: 0 0 0 2px rgba(255, 255, 255, .96);
         transform: scale(0);
         transition: transform 240ms ease-in;
-        
-        animation: umb-block-list__block--create-button__plus 400ms ease-in-out alternate infinite;
+        animation: umb-block-list__block-create-button__plus 400ms ease-in-out alternate infinite;
 
-        @keyframes umb-block-list__block--create-button__plus {
+        @keyframes umb-block-list__block-create-button__plus {
             0%   { color: rgba(@blueMid, 1); }
             100% { color: rgba(@blueMid, 0.8); }
         }
@@ -229,6 +231,7 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
         &::before {
             transform: scaleX(1);
         }
+
         > .__plus {
             transform: scale(1);
             transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.275);
@@ -236,6 +239,7 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
         }
     }
 }
+
 .umb-block-list__create-button {
     position: relative;
     display: flex;
@@ -249,17 +253,17 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
     padding: 5px 15px;
     box-sizing: border-box;
     border-radius: @baseBorderRadius;
-}
 
-.umb-block-list__create-button:hover {
-    color: @ui-action-discreet-type-hover;
-    border-color: @ui-action-discreet-border-hover;
-    text-decoration: none;
-}
+    &:hover {
+        color: @ui-action-discreet-type-hover;
+        border-color: @ui-action-discreet-border-hover;
+        text-decoration: none;
+    }
 
-.umb-block-list__create-button.--disabled,
-.umb-block-list__create-button.--disabled:hover {
-    color: @gray-7;
-    border-color: @gray-7;
-    cursor: default;
+    &.--disabled,
+    &.--disabled:hover {
+        color: @gray-7;
+        border-color: @gray-7;
+        cursor: default;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
@@ -83,7 +83,7 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
 }
 .umb-block-list__block--actions {
     position: absolute;
-    z-index:999999999;// We always want to be on top of custom view, but we need to make sure we still are behind relevant Umbraco CMS UI. ToDo: Needs further testing.
+    z-index: 999999;
     top: 10px;
     right: 10px;
     font-size: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-row.html
@@ -2,7 +2,7 @@
     <div class="umb-block-list__block" ng-class="{'--active':vm.layout.$block.active, '--show-validation': vm.layout.$block.showValidation === true}">
 
         <umb-block-list-block stylesheet="{{::vm.layout.$block.config.stylesheet}}"
-                              class="umb-block-list__block--content"
+                              class="umb-block-list__block-content"
                               ng-class="{'blockelement__draggable-element': vm.layout.$block.config.stylesheet}"
                               view="{{vm.layout.$block.view}}"
                               api="vm.blockEditorApi"
@@ -11,7 +11,7 @@
                               parent-form="vm.blockRowForm">
         </umb-block-list-block>
 
-        <div class="umb-block-list__block--actions">
+        <div class="umb-block-list__block-actions">
             <button type="button" class="btn-reset umb-outline action --settings" localize="title" title="actions_editSettings"
                     ng-click="vm.blockEditorApi.openSettingsForBlock(vm.layout.$block, vm.index, vm.blockRowForm);"
                     ng-class="{ '--error': vm.blockRowForm.$error.valServerMatchSettings && vm.valFormManager.isShowingValidation() }"
@@ -22,6 +22,7 @@
                 </span>
                 <div class="__error-badge">!</div>
             </button>
+
             <button type="button" class="btn-reset umb-outline action --copy" localize="title" title="actions_copy"
                     ng-click="vm.blockEditorApi.copyBlock(vm.layout.$block);"
                     ng-if="vm.layout.$block.showCopy === true">
@@ -30,6 +31,7 @@
                     <localize key="general_copy">Copy</localize>
                 </span>
             </button>
+
             <button type="button" class="btn-reset umb-outline action --delete" localize="title" title="actions_delete"
                     ng-click="vm.blockEditorApi.requestDeleteBlock(vm.layout.$block);">
                 <i class="icon icon-trash" aria-hidden="true"></i>


### PR DESCRIPTION
The actions (appearing to the right hand side of block list editors on hover) clash with other UI elements, such as the publish actions menu.

<img width="919" alt="Screenshot 2020-12-09 at 22 23 01" src="https://user-images.githubusercontent.com/16511093/101695953-3f227080-3a6d-11eb-9032-43ead7a8bd9b.png">

There is an insanely high `z-index` value set here to ensure they always stay on top of all custom + Umbraco styles loaded.

I have reduced the `z-index` to a more sensible level, inline with the similar `umb-confirm-action` component to avoid the clashes. Now it looks like this:

<img width="760" alt="Screenshot 2020-12-09 at 22 29 08" src="https://user-images.githubusercontent.com/16511093/101696452-08008f00-3a6e-11eb-97b0-01114233c1b1.png">

_(I also cleaned up some of the CSS here, maybe want to review with whitespace ignored)_