### PR TITLE
Add support for unattended upgrades (and custom boot failed error page)

### DIFF
--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -13,6 +13,7 @@ using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Logging.Serilog;
 using Umbraco.Core.Migrations.Install;
+using Umbraco.Core.Migrations.Upgrade;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Mappers;
 using Umbraco.Core.Sync;
@@ -189,6 +190,16 @@ namespace Umbraco.Core.Runtime
                 // create the factory
                 _factory = Current.Factory = composition.CreateFactory();
 
+                // if level is Run and reason is UpgradeMigrations, that means we need to perform an unattended upgrade
+                if (_state.Reason == RuntimeLevelReason.UpgradeMigrations && _state.Level == RuntimeLevel.Run)
+                {
+                    // do the upgrade
+                    DoUnattendedUpgrade(_factory.GetInstance<DatabaseBuilder>());
+
+                    // upgrade is done, set reason to Run
+                    _state.Reason = RuntimeLevelReason.Run;
+                }
+
                 // create & initialize the components
                 _components = _factory.GetInstance<ComponentCollection>();
                 _components.Initialize();
@@ -286,6 +297,17 @@ namespace Umbraco.Core.Runtime
                         + "\n Please check log file for additional information (can be found in '/App_Data/Logs/')");
                 }
             }
+        }
+
+        private void DoUnattendedUpgrade(DatabaseBuilder databaseBuilder)
+        {
+            var plan = new UmbracoPlan();
+            Logger.Info<CoreRuntime>("Starting unattended upgrade.");
+            var result = databaseBuilder.UpgradeSchemaAndData(plan);
+            Logger.Info<CoreRuntime>("Unattended upgrade completed.");
+
+            if (result.Success == false)
+                throw new UnattendedInstallException("An error occurred while running the unattended upgrade.\n" + result.Message);
         }
 
         protected virtual void ConfigureUnhandledException()

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -302,12 +302,12 @@ namespace Umbraco.Core.Runtime
         private void DoUnattendedUpgrade(DatabaseBuilder databaseBuilder)
         {
             var plan = new UmbracoPlan();
-            Logger.Info<CoreRuntime>("Starting unattended upgrade.");
-            var result = databaseBuilder.UpgradeSchemaAndData(plan);
-            Logger.Info<CoreRuntime>("Unattended upgrade completed.");
-
-            if (result.Success == false)
-                throw new UnattendedInstallException("An error occurred while running the unattended upgrade.\n" + result.Message);
+            using (ProfilingLogger.TraceDuration<CoreRuntime>("Starting unattended upgrade.", "Unattended upgrade completed."))
+            {
+                var result = databaseBuilder.UpgradeSchemaAndData(plan);
+                if (result.Success == false)
+                    throw new UnattendedInstallException("An error occurred while running the unattended upgrade.\n" + result.Message);
+            }
         }
 
         protected virtual void ConfigureUnhandledException()

--- a/src/Umbraco.Core/RuntimeOptions.cs
+++ b/src/Umbraco.Core/RuntimeOptions.cs
@@ -23,6 +23,7 @@ namespace Umbraco.Core
         private static bool? _installMissingDatabase;
         private static bool? _installEmptyDatabase;
         private static bool? _installUnattended;
+        private static bool? _upgradeUnattended;
 
         // reads a boolean appSetting
         private static bool BoolSetting(string key, bool missing) => ConfigurationManager.AppSettings[key]?.InvariantEquals("true") ?? missing;
@@ -64,6 +65,15 @@ namespace Umbraco.Core
         {
             get => _installUnattended ?? BoolSetting("Umbraco.Core.RuntimeState.InstallUnattended", false);
             set => _installUnattended = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether unattended upgrade is enabled.
+        /// </summary>
+        public static bool UpgradeUnattended
+        {
+            get => _upgradeUnattended ?? BoolSetting("Umbraco.Core.RuntimeState.UpgradeUnattended", false);
+            set => _upgradeUnattended = value;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/RuntimeState.cs
+++ b/src/Umbraco.Core/RuntimeState.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Core
         {
             var localVersion = UmbracoVersion.LocalVersion; // the local, files, version
             var codeVersion = SemanticVersion; // the executing code version
-            
+
             if (localVersion == null)
             {
                 // there is no local version, we are not installed
@@ -202,7 +202,7 @@ namespace Umbraco.Core
                         // although the files version matches the code version, the database version does not
                         // which means the local files have been upgraded but not the database - need to upgrade
                         _logger.Debug<RuntimeState>("Has not reached the final upgrade step, need to upgrade Umbraco.");
-                        Level = RuntimeLevel.Upgrade;
+                        Level = RuntimeOptions.UpgradeUnattended ? RuntimeLevel.Run : RuntimeLevel.Upgrade;
                         Reason = RuntimeLevelReason.UpgradeMigrations;
                     }
                     break;

--- a/src/Umbraco.Web.UI.Client/src/views/errors/BootFailed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/errors/BootFailed.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Boot Failed</title>
+    <style>
+    @font-face {
+        font-family: Lato;
+        src: local("LatoLatin Regular"), local("LatoLatin-Regular"),
+            url(/umbraco/assets/fonts/lato/LatoLatin-Regular.woff2) format("woff2");
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        text-rendering: optimizeLegibility;
+    }
+    @font-face {
+        font-family: Lato;
+        src: local("LatoLatin Bold"), local("LatoLatin-Bold"),
+            url(/umbraco/assets/fonts/lato/LatoLatin-Bold.woff2) format("woff2");
+        font-style: normal;
+        font-weight: 700;
+        font-display: swap;
+        text-rendering: optimizeLegibility;
+    }
+    body {
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-position: 50%;
+        background-image: url(/umbraco/assets/img/login.jpg);
+        margin: 0;
+        padding: 0;
+        font-family: Lato, Helvetica Neue, Helvetica, Arial, sans-serif;
+        font-size: 15px;
+        line-height: 20px;
+        color: #000;
+        background-color: #f3f3f5;
+        -webkit-font-smoothing: antialiased;
+        font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+    }
+    .logo {
+        position: absolute;
+        top: 22px;
+        left: 25px;
+        width: 30px;
+        height: 30px;
+        z-index: 1;
+    }
+    .error-container {
+        display: grid;
+        justify-content: center;
+        align-content: center;
+        height: 100vh;
+    }
+    .error {
+        background: #fff;
+        padding: 30px;
+        max-width: 500px;
+        margin: auto 25px;
+        border-radius: 3px;
+    }
+    .error h1 {
+        font-size: 24px;
+        font-weight: 700;
+        margin-bottom: 20px;
+    }
+    </style>
+</head>
+<body>
+<main class="error-container">
+    <img src="/umbraco/assets/img/application/umbraco_logo_white.svg" class="logo">
+    <div class="error">
+        <h1>Boot Failed</h1>
+        <p>Umbraco failed to boot, if you are the owner of the website please see the log file for more details.</p>
+    </div>
+</main>
+</body>
+</html>

--- a/src/Umbraco.Web/Composing/ModuleInjector.cs
+++ b/src/Umbraco.Web/Composing/ModuleInjector.cs
@@ -35,7 +35,16 @@ namespace Umbraco.Web.Composing
                 catch { /* don't make it worse */ }
 
                 if (runtimeState?.BootFailedException != null)
-                    BootFailedException.Rethrow(runtimeState.BootFailedException);
+                {
+                    // if we throw the exception here the HttpApplication.Application_Error method will never be hit
+                    // and our custom error page will not be shown, so we need to wait for the request to begin
+                    // before we throw the exception.
+                    context.BeginRequest += (sender, args) =>
+                    {
+                        BootFailedException.Rethrow(runtimeState.BootFailedException);
+                    };
+                    return;
+                }
 
                 // else... throw what we have
                 throw;

--- a/src/Umbraco.Web/UmbracoApplication.cs
+++ b/src/Umbraco.Web/UmbracoApplication.cs
@@ -1,7 +1,10 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
+using System.IO;
 using System.Threading;
 using System.Web;
 using Umbraco.Core;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Logging.Serilog;
 using Umbraco.Core.Runtime;
@@ -21,6 +24,53 @@ namespace Umbraco.Web
             var runtime = new WebRuntime(this, logger, GetMainDom(logger));
 
             return runtime;
+        }
+
+        protected override void OnApplicationError(object sender, EventArgs evargs)
+        {
+            base.OnApplicationError(sender, evargs);
+
+            // if the exception is a BootFailedException we want to show a custom 500 page
+            if (Server.GetLastError() is BootFailedException)
+            {
+                // if the requested file exists on disk, clear the error and return
+                // this is needed to serve static files
+                if (File.Exists(Request.PhysicalPath))
+                {
+                    Server.ClearError();
+                    return;
+                }
+
+                // if the application is in debug mode we don't want to show the custom 500 page
+                if (Context.IsDebuggingEnabled) return;
+
+                // find the error file to show
+                var fileName = GetBootErrorFileName();
+
+                // if the file doesn't exist we return and a YSOD will be shown
+                if (File.Exists(fileName) == false) return;
+
+                Response.TrySkipIisCustomErrors = true;
+                Server.ClearError();
+                Response.Clear();
+
+                Response.StatusCode = 500;
+                Response.ContentType = "text/html";
+                Response.WriteFile(fileName);
+
+                CompleteRequest();
+            }
+        }
+
+        /// <summary>
+        /// Returns the absolute filename to the BootException html file.
+        /// </summary>
+        protected virtual string GetBootErrorFileName()
+        {
+            var fileName = Server.MapPath("~/config/errors/BootFailed.html");
+            if (File.Exists(fileName)) return fileName;
+
+            return Server.MapPath("~/umbraco/views/errors/BootFailed.html");
         }
 
         /// <summary>

--- a/src/Umbraco.Web/UmbracoApplicationBase.cs
+++ b/src/Umbraco.Web/UmbracoApplicationBase.cs
@@ -6,7 +6,6 @@ using System.Web.Hosting;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
-using Umbraco.Core.Logging.Serilog;
 
 namespace Umbraco.Web
 {

--- a/src/Umbraco.Web/UmbracoInjectedModule.cs
+++ b/src/Umbraco.Web/UmbracoInjectedModule.cs
@@ -357,15 +357,13 @@ namespace Umbraco.Web
                 // there's nothing we can do really
                 app.BeginRequest += (sender, args) =>
                 {
-                    // would love to avoid throwing, and instead display a customized Umbraco 500
-                    // page - however if we don't throw here, something else might go wrong, and
-                    // it's this later exception that would be reported. could not figure out how
-                    // to prevent it, either with httpContext.Response.End() or .ApplicationInstance
-                    // .CompleteRequest()
+                    // if we don't throw here, something else might go wrong,
+                    // and it's this later exception that would be reported.
 
                     // also, if something goes wrong with our DI setup, the logging subsystem may
                     // not even kick in, so here we try to give as much detail as possible
 
+                    // the exception is handled in UmbracoApplication which shows a custom error page
                     BootFailedException.Rethrow(Core.Composing.Current.RuntimeState.BootFailedException);
                 };
                 return;


### PR DESCRIPTION
There are two parts to this PR.

The first part is unattended upgrades, it's an opt-in feature and can be enabled by adding an app setting `Umbraco.Core.RuntimeState.UpgradeUnattended=true`.

In addition to the above setting the `Umbraco.Core.ConfigurationStatus` app setting must match the assembly version before unattended upgrades are run.

If the conditions are met, the Runtime level will be `Run` instead of `Upgrade`, this allows us to do run the migrations and continue with the normal boot when the migrations succeed without requiring to restart the application. 

The upgrade is run after Composers but before Components. This is because the migrations requires services that are registered in Composers and Components requires that Umbraco (and the database) is ready.

To test the unattended upgrade, a database with an older Umbraco version is needed (I've tested with an 8.0.0 database). Update the connection string to point to that database and update the required app settings as mentioned above, then start Umbraco as you normally would. Now instead of the seeing the upgrade page, Umbraco runs the migrations on startup and you should see the website instead. 

The second part of this PR is a custom error page for when a `BootFailedException` is thrown. The error page is a HTML file located in `~/umbraco/views/errors/BootFailed.html` it can be overwritten by creating a file `~/config/errors/BootFailed.html` (not sure about the location).

There are multiple ways to test the error page, some of them are

* Configure an invalid connection string
* Have unattended upgrades enabled and add an migration that throws an exception
* Throw an exception in a Composer or Component
* Recursive dependencies in a Component

Note that the error page is only shown if debugging is disabled by setting `/configuration/system.web/compilation/@debug` to `false` in `web.config`. Not sure if we should also check the `customErrors/@mode`?

The error page could use some love, right now it's a copy of the login page

![image](https://user-images.githubusercontent.com/379886/101749804-72491c00-3ace-11eb-8c37-e5678e9a9456.png)

**NOTE this PR targets the `v8/feature/unattended-install` branch since it relies on changes made there**

---
_This item has been added to our backlog [AB#9755](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/9755)_