### PR TITLE
Remove deprecated ReplaceLineBreaksForHtml

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Editors/TextString.cshtml
@@ -5,7 +5,7 @@
 @if (Model.editor.config.markup != null)
 {
     string markup = Model.editor.config.markup.ToString();
-    markup = markup.Replace("#value#", Html.ReplaceLineBreaksForHtml(HttpUtility.HtmlEncode((string)Model.value.ToString())).ToString());
+    markup = markup.Replace("#value#", Html.ReplaceLineBreaks((string)Model.value.ToString()).ToString());
 
     if (Model.editor.config.style != null)
     {


### PR DESCRIPTION
ReplaceLineBreaksForHtml is deprecated and the alternative ReplaceLineBreaks includes HtmlEncode.

This update will remove an error in Visual Studio.