### PR TITLE
SqlMainDomLock will stop listening if Sql Server connection terminates

### DIFF
--- a/src/Umbraco.Core/Runtime/MainDom.cs
+++ b/src/Umbraco.Core/Runtime/MainDom.cs
@@ -144,8 +144,16 @@ namespace Umbraco.Core.Runtime
 
             _logger.Info<MainDom>("Acquiring.");
 
-            // Get the lock 
-            var acquired = _mainDomLock.AcquireLockAsync(LockTimeoutMilliseconds).GetAwaiter().GetResult();
+            // Get the lock
+            var acquired = false;
+            try
+            {
+                acquired = _mainDomLock.AcquireLockAsync(LockTimeoutMilliseconds).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.Error<MainDom>(ex, "Error while acquiring");
+            }
 
             if (!acquired)
             {

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NPoco;
+using System;
 using System.Data;
 using System.Data.SqlClient;
 using System.Diagnostics;
@@ -48,7 +49,9 @@ namespace Umbraco.Core.Runtime
             }
 
             if (!(_dbFactory.SqlContext.SqlSyntax is SqlServerSyntaxProvider sqlServerSyntaxProvider))
+            {
                 throw new NotSupportedException("SqlMainDomLock is only supported for Sql Server");
+            }   
 
             _sqlServerSyntax = sqlServerSyntaxProvider;
 
@@ -56,11 +59,13 @@ namespace Umbraco.Core.Runtime
 
             var tempId = Guid.NewGuid().ToString();
 
-            using var db = _dbFactory.CreateDatabase();
-            using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
+            IUmbracoDatabase db = null;
 
             try
             {
+                db = _dbFactory.CreateDatabase();
+                db.BeginTransaction(IsolationLevel.ReadCommitted);
+
                 try
                 {
                     // wait to get a write lock
@@ -101,7 +106,8 @@ namespace Umbraco.Core.Runtime
             }
             finally
             {
-                transaction.Complete();
+                db?.CompleteTransaction();
+                db?.Dispose();
             }
             
 
@@ -154,11 +160,11 @@ namespace Umbraco.Core.Runtime
                     // new MainDom will just take over.
                     if (_cancellationTokenSource.IsCancellationRequested)
                         return;
-
-                    using var db = _dbFactory.CreateDatabase();
-                    using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
+                    IUmbracoDatabase db = null;
                     try
                     {
+                        db = _dbFactory.CreateDatabase();
+                        db.BeginTransaction(IsolationLevel.ReadCommitted);
                         // get a read lock
                         _sqlServerSyntax.ReadLock(db, Constants.Locks.MainDom);
 
@@ -182,7 +188,8 @@ namespace Umbraco.Core.Runtime
                     }
                     finally
                     {
-                        transaction.Complete();
+                        db?.CompleteTransaction();
+                        db?.Dispose();
                     }
                 }
 
@@ -201,34 +208,47 @@ namespace Umbraco.Core.Runtime
 
             return Task.Run(() =>
             {
-                using var db = _dbFactory.CreateDatabase();
-
-                var watch = new Stopwatch();
-                watch.Start();
-                while (true)
+                try
                 {
-                    // poll very often, we need to take over as fast as we can
-                    // local testing shows the actual query to be executed from client/server is approx 300ms but would change depending on environment/IO
-                    Thread.Sleep(1000);
+                    using var db = _dbFactory.CreateDatabase();
 
-                    var acquired = TryAcquire(db, tempId, updatedTempId);
-                    if (acquired.HasValue)
-                        return acquired.Value;
-
-                    if (watch.ElapsedMilliseconds >= millisecondsTimeout)
+                    var watch = new Stopwatch();
+                    watch.Start();
+                    while (true)
                     {
-                        return AcquireWhenMaxWaitTimeElapsed(db);
+                        // poll very often, we need to take over as fast as we can
+                        // local testing shows the actual query to be executed from client/server is approx 300ms but would change depending on environment/IO
+                        Thread.Sleep(1000);
+
+                        var acquired = TryAcquire(db, tempId, updatedTempId);
+                        if (acquired.HasValue)
+                            return acquired.Value;
+
+                        if (watch.ElapsedMilliseconds >= millisecondsTimeout)
+                        {
+                            return AcquireWhenMaxWaitTimeElapsed(db);
+                        }
                     }
                 }
+                catch (Exception ex)
+                {
+                    _logger.Error<SqlMainDomLock>(ex, "An error occurred trying to acquire and waiting for existing SqlMainDomLock to shutdown");
+                    return false;
+                }
+                
             }, _cancellationTokenSource.Token);
         }
 
         private bool? TryAcquire(IUmbracoDatabase db, string tempId, string updatedTempId)
         {
-            using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
+            // Creates a separate transaction to the DB instance so we aren't allocating tons of new DB instances for each transaction
+            // since this is executed in a tight loop
+
+            ITransaction transaction = null;
 
             try
             {
+                transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
                 // get a read lock
                 _sqlServerSyntax.ReadLock(db, Constants.Locks.MainDom);
 
@@ -274,7 +294,8 @@ namespace Umbraco.Core.Runtime
             }
             finally
             {
-                transaction.Complete();
+                transaction?.Complete();
+                transaction?.Dispose();
             }
 
             return null; // continue
@@ -282,6 +303,9 @@ namespace Umbraco.Core.Runtime
 
         private bool AcquireWhenMaxWaitTimeElapsed(IUmbracoDatabase db)
         {
+            // Creates a separate transaction to the DB instance so we aren't allocating tons of new DB instances for each transaction
+            // since this is executed in a tight loop
+
             // if the timeout has elapsed, it either means that the other main dom is taking too long to shutdown,
             // or it could mean that the previous appdomain was terminated and didn't clear out the main dom SQL row
             // and it's just been left as an orphan row.
@@ -291,10 +315,12 @@ namespace Umbraco.Core.Runtime
 
             _logger.Debug<SqlMainDomLock>("Timeout elapsed, assuming orphan row, acquiring MainDom.");
 
-            using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
+            ITransaction transaction = null;
 
             try
             {
+                transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
+                
                 _sqlServerSyntax.WriteLock(db, Constants.Locks.MainDom);
 
                 // so now we update the row with our appdomain id
@@ -317,7 +343,8 @@ namespace Umbraco.Core.Runtime
             }
             finally
             {
-                transaction.Complete();
+                transaction?.Complete();
+                transaction?.Dispose();
             }
         }
 
@@ -368,11 +395,12 @@ namespace Umbraco.Core.Runtime
 
                         if (_dbFactory.Configured)
                         {
-                            using var db = _dbFactory.CreateDatabase();
-                            using var transaction = db.GetTransaction(IsolationLevel.ReadCommitted);
-
+                            IUmbracoDatabase db = null;
                             try
                             {
+                                db = _dbFactory.CreateDatabase();
+                                db.BeginTransaction(IsolationLevel.ReadCommitted);
+
                                 // get a write lock
                                 _sqlServerSyntax.WriteLock(db, Constants.Locks.MainDom);
 
@@ -399,7 +427,15 @@ namespace Umbraco.Core.Runtime
                             }
                             finally
                             {
-                                transaction.Complete();
+                                try
+                                {
+                                    db?.CompleteTransaction();
+                                    db?.Dispose();
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.Error<SqlMainDomLock>(ex, "Unexpected error during dispose when completing transaction.");
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
NOTE: This PR is targeting the 8.6 branch

Related to #8398 which ensured that if any Azure Sql transient errors occurred that SqlMainDomLock would not stop listening. This didn't take into account exception that occur when trying to create a transaction which can occur if the Sql server cannot be connected to at all - for example if the service is stopped or paused or if the sql user can no longer connect.

If this unhandled exception occurs, MainDom stops listening and shuts itself down which is not what we want to happen. This extends the work from #8398 to prevent MainDom from shutting down if Sql server can no longer be reached. This in theory shouldn't happen but it is in some installs which is impacting sites.

## Testing

Prior to this fix, do this:

* ensure you are using Sql Server for your DB
* enable sqlmaindomlock in appsettings `<add key="Umbraco.Core.MainDom.Lock" value="SqlMainDomLock"/>`
* run with the debugger attached
* put a breakpoint on MainDom.OnSignal
* open sql server management, right click on your server node and select "Pause" to pause the service
* your breakpoint will hit MainDom.OnSignal which means it will shutdown - this is unwanted behavior

With this fix applied

* repeat the steps (ensure you restart the Sql server service first!) and you will not see MainDom.OnSignal hit
* while you are still debugging, resume the Sql server service
* open the `ClientDependency.config` and add some whitespace and save the file - this will restart the site since it's a .net config file - MainDom.OnSignal will be hit - this is expected behavior

You will see a huge amount of errors in the logs, one every 2 seconds while the SQL server is unreachable. This is expected. 

