### PR TITLE
Fix typo

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1439,7 +1439,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="elementDoesNotSupport">Dette benyttes ikke for en Element-type</key>
     <key alias="propertyHasChanges">Du har lavet ændringer til denne egenskab. Er du sikker på at du vil kassere dem?</key>
     <key alias="displaySettingsHeadline">Visning</key>
-    <key alias="displaySettingsLabelOnTop">Label hen over (fuld brede)</key>
+    <key alias="displaySettingsLabelOnTop">Label hen over (fuld bredde)</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Tilføj sprog</key>


### PR DESCRIPTION
Missing "d" in "bredde" single "d" is used as an action while two "d" is used for measurements