### PR TITLE
Fix sign-in for users with many groups or content or media start nodes

### DIFF
--- a/src/Umbraco.Core/Security/AuthenticationExtensions.cs
+++ b/src/Umbraco.Core/Security/AuthenticationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -47,14 +47,14 @@ namespace Umbraco.Core.Security
             {
                 try
                 {
-                    //create the Umbraco user identity
+                    //create the Umbraco user identity 
                     var identity = new UmbracoBackOfficeIdentity(ticket);
 
                     //set the principal object
                     var principal = new GenericPrincipal(identity, identity.Roles);
 
                     //It is actually not good enough to set this on the current app Context and the thread, it also needs
-                    // to be set explicitly on the HttpContext.Current !! This is a strange web api thing that is actually
+                    // to be set explicitly on the HttpContext.Current !! This is a strange web api thing that is actually 
                     // an underlying fault of asp.net not propogating the User correctly.
                     if (HttpContext.Current != null)
                     {
@@ -107,7 +107,7 @@ namespace Umbraco.Core.Security
                 if (backOfficeIdentity != null) return backOfficeIdentity;
             }
 
-            //Otherwise convert to a UmbracoBackOfficeIdentity if it's auth'd and has the back office session
+            //Otherwise convert to a UmbracoBackOfficeIdentity if it's auth'd and has the back office session            
             var claimsIdentity = user.Identity as ClaimsIdentity;
             if (claimsIdentity != null && claimsIdentity.IsAuthenticated && claimsIdentity.HasClaim(x => x.Type == Constants.Security.SessionIdClaimType))
             {
@@ -116,7 +116,7 @@ namespace Umbraco.Core.Security
                     return UmbracoBackOfficeIdentity.FromClaimsIdentity(claimsIdentity);
                 }
                 catch (InvalidOperationException)
-                {
+                {                    
                 }
             }
 
@@ -124,11 +124,11 @@ namespace Umbraco.Core.Security
         }
 
         /// <summary>
-        /// This will return the current back office identity.
+        /// This will return the current back office identity. 
         /// </summary>
         /// <param name="http"></param>
-        /// <param name="authenticateRequestIfNotFound">
-        /// If set to true and a back office identity is not found and not authenticated, this will attempt to authenticate the
+        /// <param name="authenticateRequestIfNotFound"> 
+        /// If set to true and a back office identity is not found and not authenticated, this will attempt to authenticate the 
         /// request just as is done in the Umbraco module and then set the current identity if it is valid.
         /// Just like in the UmbracoModule, if this is true then the user's culture will be assigned to the request.
         /// </param>
@@ -142,21 +142,21 @@ namespace Umbraco.Core.Security
 
             //If it's already a UmbracoBackOfficeIdentity
             var backOfficeIdentity = GetUmbracoIdentity(http.User);
-            if (backOfficeIdentity != null) return backOfficeIdentity;
+            if (backOfficeIdentity != null) return backOfficeIdentity;            
 
             if (authenticateRequestIfNotFound == false) return null;
 
-            //even if authenticateRequestIfNotFound is true we cannot continue if the request is actually authenticated
+            //even if authenticateRequestIfNotFound is true we cannot continue if the request is actually authenticated 
             // which would mean something strange is going on that it is not an umbraco identity.
             if (http.User.Identity.IsAuthenticated) return null;
 
             //So the user is not authed but we've been asked to do the auth if authenticateRequestIfNotFound = true,
             // which might occur in old webforms style things or for routes that aren't included as a back office request.
             // in this case, we are just reverting to authing using the cookie.
-
-            // TODO: Even though this is in theory legacy, we have legacy bits laying around and we'd need to do the auth based on
+            
+            // TODO: Even though this is in theory legacy, we have legacy bits laying around and we'd need to do the auth based on 
             // how the Module will eventually do it (by calling in to any registered authenticators).
-
+            
             var ticket = http.GetUmbracoAuthTicket();
             if (http.AuthenticateCurrentRequest(ticket, true))
             {
@@ -167,11 +167,11 @@ namespace Umbraco.Core.Security
         }
 
         /// <summary>
-        /// This will return the current back office identity.
+        /// This will return the current back office identity. 
         /// </summary>
         /// <param name="http"></param>
         /// <param name="authenticateRequestIfNotFound">
-        /// If set to true and a back office identity is not found and not authenticated, this will attempt to authenticate the
+        /// If set to true and a back office identity is not found and not authenticated, this will attempt to authenticate the 
         /// request just as is done in the Umbraco module and then set the current identity if it is valid
         /// </param>
         /// <returns>
@@ -204,7 +204,7 @@ namespace Umbraco.Core.Security
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static FormsAuthenticationTicket UmbracoLoginWebApi(this HttpResponseMessage response, IUser user)
         {
-            throw new NotSupportedException("This method is not supported and should not be used, it has been removed in Umbraco 7.4");
+            throw new NotSupportedException("This method is not supported and should not be used, it has been removed in Umbraco 7.4");            
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace Umbraco.Core.Security
             if (http == null) throw new ArgumentNullException("http");
             new HttpContextWrapper(http).UmbracoLogout();
         }
-
+        
         /// <summary>
         /// This will force ticket renewal in the OWIN pipeline
         /// </summary>
@@ -252,19 +252,19 @@ namespace Umbraco.Core.Security
 
             if (http == null) throw new ArgumentNullException("http");
             if (userdata == null) throw new ArgumentNullException("userdata");
-
+            
             var userDataString = JsonConvert.SerializeObject(userdata);
             return CreateAuthTicketAndCookie(
-                http,
-                userdata.Username,
-                userDataString,
+                http, 
+                userdata.Username, 
+                userDataString, 
                 //use the configuration timeout - this is the same timeout that will be used when renewing the ticket.
-                GlobalSettings.TimeOutInMinutes,
+                GlobalSettings.TimeOutInMinutes, 
                 //Umbraco has always persisted it's original cookie for 1 day so we'll keep it that way
-                1440,
+                1440, 
                 UmbracoConfig.For.UmbracoSettings().Security.AuthCookieName,
                 UmbracoConfig.For.UmbracoSettings().Security.AuthCookieDomain);
-        }
+        }        
 
         /// <summary>
         /// returns the number of seconds the user has until their auth session times out
@@ -480,7 +480,7 @@ namespace Umbraco.Core.Security
 
             //ensure http only, this should only be able to be accessed via the server
             cookie.HttpOnly = true;
-
+				
             http.Response.Cookies.Set(cookie);
 
             return ticket;

--- a/src/Umbraco.Core/Security/AuthenticationExtensions.cs
+++ b/src/Umbraco.Core/Security/AuthenticationExtensions.cs
@@ -360,11 +360,13 @@ namespace Umbraco.Core.Security
         /// <returns>Encrypted Base64 string representation of the auth ticket.</returns>
         public static string EncryptFormsAuthTicketWithMachineKey(FormsAuthenticationTicket authTicket, string purpose = BackOfficeCookieAuthenticationProvider.EncryptionPurpose)
         {
-            using var memoryStream = new MemoryStream();
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(memoryStream, authTicket);
-            var protectedBytes = MachineKey.Protect(memoryStream.ToArray(), purpose);
-            return Convert.ToBase64String(protectedBytes);
+            using (var memoryStream = new MemoryStream())
+            {
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(memoryStream, authTicket);
+                var protectedBytes = MachineKey.Protect(memoryStream.ToArray(), purpose);
+                return Convert.ToBase64String(protectedBytes);
+            }
         }
 
         /// <summary>
@@ -375,13 +377,15 @@ namespace Umbraco.Core.Security
         /// <returns>A FormsAuthenticationTicket stored in the encrypted string if valid. Otherwise an exception is throw.</returns>
         public static FormsAuthenticationTicket DecryptFormsAuthTicketWithMachineKey(string encryptedText, string purpose = BackOfficeCookieAuthenticationProvider.EncryptionPurpose)
         {
-            using var memStream = new MemoryStream();
-            var protectedBytes = Convert.FromBase64String(encryptedText);
-            var unprotectedBytes = MachineKey.Unprotect(protectedBytes, purpose);
-            memStream.Write(unprotectedBytes, 0, unprotectedBytes.Length);
-            memStream.Seek(0, SeekOrigin.Begin);
-            var formatter = new BinaryFormatter();
-            return formatter.Deserialize(memStream) as FormsAuthenticationTicket;
+            using (var memStream = new MemoryStream())
+            {
+                var protectedBytes = Convert.FromBase64String(encryptedText);
+                var unprotectedBytes = MachineKey.Unprotect(protectedBytes, purpose);
+                memStream.Write(unprotectedBytes, 0, unprotectedBytes.Length);
+                memStream.Seek(0, SeekOrigin.Begin);
+                var formatter = new BinaryFormatter();
+                return formatter.Deserialize(memStream) as FormsAuthenticationTicket;
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Security/AuthenticationExtensions.cs
+++ b/src/Umbraco.Core/Security/AuthenticationExtensions.cs
@@ -302,7 +302,7 @@ namespace Umbraco.Core.Security
         public static FormsAuthenticationTicket GetUmbracoAuthTicket(this HttpContextBase http)
         {
             if (http == null) throw new ArgumentNullException(nameof(http));
-            var owinContext = http.ApplicationInstance.Context.GetOwinContext();
+            var owinContext = http.GetOwinContext();
             return GetUmbracoAuthTicket(owinContext);
         }
 

--- a/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
+++ b/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Core.Security
 {
     public class BackOfficeCookieAuthenticationProvider : CookieAuthenticationProvider
     {
+        public const string EncryptionPurpose = "UmbracoAuthTicket";
         private readonly ApplicationContext _appCtx;
 
         [Obsolete("Use the ctor specifying all dependencies")]
@@ -50,7 +51,7 @@ namespace Umbraco.Core.Security
                     : Guid.NewGuid();
 
                 backOfficeIdentity.UserData.SessionId = session.ToString();
-            }            
+            }
 
             base.ResponseSignIn(context);
         }
@@ -113,7 +114,7 @@ namespace Umbraco.Core.Security
                 return;
             }
             await base.ValidateIdentity(context);
-        }        
+        }
 
         /// <summary>
         /// Ensures that the user has a valid session id

--- a/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
+++ b/src/Umbraco.Core/Security/BackOfficeCookieAuthenticationProvider.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Core.Security
                     : Guid.NewGuid();
 
                 backOfficeIdentity.UserData.SessionId = session.ToString();
-            }
+            }            
 
             base.ResponseSignIn(context);
         }
@@ -114,7 +114,7 @@ namespace Umbraco.Core.Security
                 return;
             }
             await base.ValidateIdentity(context);
-        }
+        }        
 
         /// <summary>
         /// Ensures that the user has a valid session id

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -69,6 +69,9 @@
     </Reference>
     <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+        <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Security.4.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>

--- a/src/Umbraco.Tests/Web/Controllers/UsersControllerTests.cs
+++ b/src/Umbraco.Tests/Web/Controllers/UsersControllerTests.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Tests.Web.Controllers
                     .Returns(new[] { Mock.Of<IUserGroup>(group => group.Id == 123 && group.Alias == "writers" && group.Name == "Writers") });
                 userServiceMock.Setup(service => service.GetUserGroupsByAlias(It.IsAny<string[]>()))
                     .Returns(new[] { Mock.Of<IUserGroup>(group => group.Id == 123 && group.Alias == "writers" && group.Name == "Writers") });
-                userServiceMock.Setup(service => service.GetUserById(It.IsAny<int>()))
+                userServiceMock.Setup(service => service.GetUserById(It.Is<int>(x => x == 1234)))
                     .Returns(new User(1234, "Test", "test@test.com", "test@test.com", "", new List<IReadOnlyUserGroup>(), new int[0], new int[0]));
                 
                 //we need to manually apply automapper mappings with the mocked applicationcontext

--- a/src/Umbraco.Web/Security/Identity/FormsAuthenticationSecureDataFormat.cs
+++ b/src/Umbraco.Web/Security/Identity/FormsAuthenticationSecureDataFormat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Claims;
 using System.Web.Security;
 using Microsoft.Owin;
@@ -28,15 +28,15 @@ namespace Umbraco.Web.Security.Identity
         {
             var backofficeIdentity = (UmbracoBackOfficeIdentity)data.Identity;
             var userDataString = JsonConvert.SerializeObject(backofficeIdentity.UserData);
-
+            
             var ticket = new FormsAuthenticationTicket(
                 5,
                 data.Identity.Name,
-                data.Properties.IssuedUtc.HasValue
-                    ? data.Properties.IssuedUtc.Value.LocalDateTime
+                data.Properties.IssuedUtc.HasValue 
+                    ? data.Properties.IssuedUtc.Value.LocalDateTime 
                     : DateTime.Now,
-                data.Properties.ExpiresUtc.HasValue
-                    ? data.Properties.ExpiresUtc.Value.LocalDateTime
+                data.Properties.ExpiresUtc.HasValue 
+                    ? data.Properties.ExpiresUtc.Value.LocalDateTime 
                     : DateTime.Now.AddMinutes(_loginTimeoutMinutes),
                 data.Properties.IsPersistent,
                 userDataString,

--- a/src/Umbraco.Web/Security/Identity/FormsAuthenticationSecureDataFormat.cs
+++ b/src/Umbraco.Web/Security/Identity/FormsAuthenticationSecureDataFormat.cs
@@ -14,6 +14,7 @@ namespace Umbraco.Web.Security.Identity
     /// <summary>
     /// Custom secure format that uses the old FormsAuthentication format
     /// </summary>
+    [Obsolete("Replaced by MachineKeyEncryptedFormsAuthSecureDataFormat")]
     internal class FormsAuthenticationSecureDataFormat : ISecureDataFormat<AuthenticationTicket>
     {
         private readonly int _loginTimeoutMinutes;
@@ -27,15 +28,15 @@ namespace Umbraco.Web.Security.Identity
         {
             var backofficeIdentity = (UmbracoBackOfficeIdentity)data.Identity;
             var userDataString = JsonConvert.SerializeObject(backofficeIdentity.UserData);
-            
+
             var ticket = new FormsAuthenticationTicket(
                 5,
                 data.Identity.Name,
-                data.Properties.IssuedUtc.HasValue 
-                    ? data.Properties.IssuedUtc.Value.LocalDateTime 
+                data.Properties.IssuedUtc.HasValue
+                    ? data.Properties.IssuedUtc.Value.LocalDateTime
                     : DateTime.Now,
-                data.Properties.ExpiresUtc.HasValue 
-                    ? data.Properties.ExpiresUtc.Value.LocalDateTime 
+                data.Properties.ExpiresUtc.HasValue
+                    ? data.Properties.ExpiresUtc.Value.LocalDateTime
                     : DateTime.Now.AddMinutes(_loginTimeoutMinutes),
                 data.Properties.IsPersistent,
                 userDataString,

--- a/src/Umbraco.Web/Security/Identity/MachineKeyEncryptedFormsAuthSecureDataFormat.cs
+++ b/src/Umbraco.Web/Security/Identity/MachineKeyEncryptedFormsAuthSecureDataFormat.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Web.Security;
+using Microsoft.Owin.Security;
+using Newtonsoft.Json;
+using Umbraco.Core.Security;
+
+namespace Umbraco.Web.Security.Identity
+{
+    /// <summary>
+    /// An ISecureDataFormat that uses the old FormsAuthenticationTicket but encrypts ticket without relying on FormsAuthentication.
+    /// </summary>
+    /// <remarks>
+    /// FormsAuthentication.Decrypt has an upper limit on input length of 4k characters - the max size of a single cookie.
+    /// Umbraco however uses ChunkingCookieManager which supports longer cookie content, which it splits across multiple cookies.
+    /// FormsAuthentication encryption and decryption was replaced by MachineKey encryption. FormsAuthentication uses MachineKey anyway,
+    /// and using this key for encryption is important for load balanced scenarios, so this will keep working for people who already
+    /// had this configured.
+    /// </remarks>
+    internal class MachineKeyEncryptedFormsAuthSecureDataFormat : ISecureDataFormat<AuthenticationTicket>
+    {
+        private readonly int _loginTimeoutMinutes;
+
+        public MachineKeyEncryptedFormsAuthSecureDataFormat(int loginTimeoutMinutes)
+        {
+            _loginTimeoutMinutes = loginTimeoutMinutes;
+        }
+
+        public string Protect(AuthenticationTicket data)
+        {
+            var backofficeIdentity = (UmbracoBackOfficeIdentity)data.Identity;
+            var userDataString = JsonConvert.SerializeObject(backofficeIdentity.UserData);
+
+            var ticket = new FormsAuthenticationTicket(
+                5,
+                data.Identity.Name,
+                data.Properties.IssuedUtc?.LocalDateTime ?? DateTime.Now,
+                data.Properties.ExpiresUtc?.LocalDateTime
+                ?? DateTime.Now.AddMinutes(_loginTimeoutMinutes),
+                data.Properties.IsPersistent,
+                userDataString,
+                "/"
+            );
+
+            return AuthenticationExtensions.EncryptFormsAuthTicketWithMachineKey(ticket);
+        }
+
+        public AuthenticationTicket Unprotect(string protectedText)
+        {
+            FormsAuthenticationTicket ticket;
+            UmbracoBackOfficeIdentity identity;
+
+            try
+            {
+                ticket = AuthenticationExtensions.DecryptFormsAuthTicketWithMachineKey(protectedText);
+                if (ticket == null)
+                    return null;
+                identity = new UmbracoBackOfficeIdentity(ticket);
+            }
+            catch (Exception)
+            {
+                //if it cannot be created return null, will be due to serialization errors in user data most likely due to corrupt cookies or cookies
+                //for previous versions of Umbraco
+                return null;
+            }
+
+            var result = new AuthenticationTicket(identity, new AuthenticationProperties
+            {
+                ExpiresUtc = ticket.Expiration.ToUniversalTime(),
+                IssuedUtc = ticket.IssueDate.ToUniversalTime(),
+                IsPersistent = ticket.IsPersistent,
+                AllowRefresh = true
+            });
+
+            return result;
+        }
+    }
+}

--- a/src/Umbraco.Web/Security/Identity/UmbracoBackOfficeCookieAuthOptions.cs
+++ b/src/Umbraco.Web/Security/Identity/UmbracoBackOfficeCookieAuthOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Owin;
@@ -19,15 +19,15 @@ namespace Umbraco.Web.Security.Identity
 
         public UmbracoBackOfficeCookieAuthOptions()
             : this(UmbracoConfig.For.UmbracoSettings().Security, GlobalSettings.TimeOutInMinutes, GlobalSettings.UseSSL)
-        {
+        {            
         }
-
+        
         public UmbracoBackOfficeCookieAuthOptions(
             string[] explicitPaths,
             ISecuritySection securitySection,
             int loginTimeoutMinutes,
             bool forceSsl,
-            bool useLegacyFormsAuthDataFormat = true)
+            bool useLegacyFormsAuthDataFormat = true)            
         {
             LoginTimeoutMinutes = loginTimeoutMinutes;
             AuthenticationType = Constants.Security.BackOfficeAuthenticationType;
@@ -44,7 +44,7 @@ namespace Umbraco.Web.Security.Identity
             CookieName = securitySection.AuthCookieName;
             CookieHttpOnly = true;
             CookieSecure = forceSsl ? CookieSecureOption.Always : CookieSecureOption.SameAsRequest;
-            CookiePath = "/";
+            CookiePath = "/";            
 
             //Custom cookie manager so we can filter requests
             CookieManager = new BackOfficeCookieManager(new SingletonUmbracoContextAccessor(), explicitPaths);
@@ -89,6 +89,6 @@ namespace Umbraco.Web.Security.Identity
 
             return cookieOptions;
         }
-
+          
     }
 }

--- a/src/Umbraco.Web/Security/Identity/UmbracoBackOfficeCookieAuthOptions.cs
+++ b/src/Umbraco.Web/Security/Identity/UmbracoBackOfficeCookieAuthOptions.cs
@@ -19,15 +19,15 @@ namespace Umbraco.Web.Security.Identity
 
         public UmbracoBackOfficeCookieAuthOptions()
             : this(UmbracoConfig.For.UmbracoSettings().Security, GlobalSettings.TimeOutInMinutes, GlobalSettings.UseSSL)
-        {            
+        {
         }
-        
+
         public UmbracoBackOfficeCookieAuthOptions(
             string[] explicitPaths,
             ISecuritySection securitySection,
             int loginTimeoutMinutes,
             bool forceSsl,
-            bool useLegacyFormsAuthDataFormat = true)            
+            bool useLegacyFormsAuthDataFormat = true)
         {
             LoginTimeoutMinutes = loginTimeoutMinutes;
             AuthenticationType = Constants.Security.BackOfficeAuthenticationType;
@@ -35,7 +35,7 @@ namespace Umbraco.Web.Security.Identity
             if (useLegacyFormsAuthDataFormat)
             {
                 //If this is not explicitly set it will fall back to the default automatically
-                TicketDataFormat = new FormsAuthenticationSecureDataFormat(LoginTimeoutMinutes);
+                TicketDataFormat = new MachineKeyEncryptedFormsAuthSecureDataFormat(LoginTimeoutMinutes);
             }
 
             SlidingExpiration = true;
@@ -44,7 +44,7 @@ namespace Umbraco.Web.Security.Identity
             CookieName = securitySection.AuthCookieName;
             CookieHttpOnly = true;
             CookieSecure = forceSsl ? CookieSecureOption.Always : CookieSecureOption.SameAsRequest;
-            CookiePath = "/";            
+            CookiePath = "/";
 
             //Custom cookie manager so we can filter requests
             CookieManager = new BackOfficeCookieManager(new SingletonUmbracoContextAccessor(), explicitPaths);
@@ -89,6 +89,6 @@ namespace Umbraco.Web.Security.Identity
 
             return cookieOptions;
         }
-          
+
     }
 }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -342,6 +342,7 @@
     <Compile Include="Models\Mapping\MemberTreeNodeUrlResolver.cs" />
     <Compile Include="Models\Trees\ExportMember.cs" />
     <Compile Include="PropertyEditors\DropdownFlexiblePropertyEditor.cs" />
+    <Compile Include="Security\Identity\MachineKeyEncryptedFormsAuthSecureDataFormat.cs" />
     <Compile Include="Security\UmbracoAntiForgeryAdditionalDataProvider.cs" />
     <Compile Include="TourFilterResolver.cs" />
     <Compile Include="Editors\UserEditorAuthorizationHelper.cs" />

--- a/src/Umbraco.Web/WebApi/Filters/UmbracoUserTimeoutFilterAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/UmbracoUserTimeoutFilterAttribute.cs
@@ -18,13 +18,13 @@ namespace Umbraco.Web.WebApi.Filters
             //this can occur if an error has already occurred.
             if (actionExecutedContext.Response == null) return;
 
-            var httpContextAttempt = actionExecutedContext.Request.TryGetHttpContext();
-            if (httpContextAttempt.Success)
+            var owinContextAttempt = actionExecutedContext.Request.TryGetOwinContext();
+            if (owinContextAttempt.Success)
             {
-                var ticket = httpContextAttempt.Result.GetUmbracoAuthTicket();
+                var ticket = owinContextAttempt.Result.GetUmbracoAuthTicket();
                 if (ticket != null && ticket.Expired == false)
                 {
-                    var remainingSeconds = httpContextAttempt.Result.GetRemainingAuthSeconds();
+                    var remainingSeconds = ticket.GetRemainingAuthSeconds();
                     actionExecutedContext.Response.Headers.Add("X-Umb-User-Seconds", remainingSeconds.ToString(CultureInfo.InvariantCulture));
                 }
             }


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco-CMS/issues/7727

## Background

Umbraco's `BackOfficeCookieManager` inherits from a `ChunkingCookieManager` which allows authentication cookie values to grow to any size. This is useful when a user is assigned many groups, content or media starts nodes, or any other data that gets serialized into the auth cookie.

What `ChunkingCookieManager` does is quite simple - it splits values that are too long for a single cookie into multiple cookies. When you access a chunked cookie and not expect any chunking, all you will get back is what is called a header valued, e.g. "chunks:N".

## Description

There were two places that did not expect or allow chunked cookies, which is now fixed.

Firstly it was the custom `FormsAuthenticationSecureDataFormat` class, which is assigned to the `TicketDataFormat` of `UmbracoBackOfficeCookieAuthOptions`, essentially providing a string representation of the user identity. It relied on `FormsAuthentication.Encrypt` and `FormsAuthentication.Decrypt` to produce the string value.

When a user affected by this issue log in the following happened:

1. The `FormsAuthentication.Encrypt` method worked fine, it produced a very long encrypted string value
2. The long value got correctly split into chunks by the `ChunkingCookieManager`
3. Cookies were correctly sent back to Umbraco with subsequent request
4. The long cookie value was correctly reconstructed by the `ChunkingCookieManager`
5. The `FormsAuthentication.Decrypt` method failed to decrypt the value. Turns out it has an arbitrary upper limit to the input string of 4k (expecting a value from a single cookie).

To fix this problem a new class called `MachineKeyEncryptedFormsAuthSecureDataFormat` was created and is used instead of the `FormsAuthenticationSecureDataFormat`. This class replaced `FormsAuthentication.Encrypt` and `FormsAuthentication.Decrypt` with `MachineKey.Protect` and `MachineKey.Unprotect`. These methods do not have the upper limit on the encrypted string length so avoid that problem entirely. These methods work with a byte array, so a `BinaryFormatter` was used to serialize the `FormsAuthenticationTicket`. A Base64 encoding was used to turn the encrypted byte array into text.

Using the machine key for encryption has one important benefit: Umbraco Auth cookies will still work in load-balancing scenarios. In these scenarios people are used to set the same machine key on all nodes, and this encryption mechanism honours that contract, so no additional changes are needed - it will keep working.

This introduces a "non-public" breaking change in that the cookie value itself has its content formatted differently.

The second place that needed fixing was a couple of static helpers that extracted the `FormsAuthenticationTicket` from the cookie. These have been updated to properly understand chunked cookies and use the new serialization / deserialzation. Their public API did not change.

The only change that might have some impact here is that I had to add a reference to `Microsoft.Owin.Host.SystemWeb` to `Umbraco.Core`. `Umbraco.Core` already had other OWIN dll references and other project already referenced `Microsoft.Owin.Host.SystemWeb` so hopefully that is ok. The only reason this reference was added was for an extension method that allows you to obtain the OWIN context from a `HttpContentBase`. `OwinContext` is needed by the `ChunkingCookieManager` which reconstructs the chunked cookies.

## Reproducing the problem

1. Create an empty Umbraco site (or run Umbraco in the solution)
2. Create a test user
3. Create 20 user groups with a really long names and aliases (such as guids)
4. Assign these user groups to the user
5. Attempt to log in as the test user
6. Observe the login fails
7. Inspect the `PostLogin` request in browser console - observe chunked cookies were sent

When you run Umbraco with this fix is place, do the following:

1. Log in as the user - log in works
2. Inspect the `PostLogin` request in browser console - observe cookie is not chunked due to different formatting
3. Create 80 more users groups and assign them to the user
4. Log in
5. Observe log in still works
6. Inspect the `PostLogin` request in browser console - observe chunked cookies were sent

## Examples

Chunked cookie before applying the fix (login fails):
![image](https://user-images.githubusercontent.com/580850/102242815-c4d56e80-3efa-11eb-9a62-f99a868949d3.png)

Chunked cookie after applying the fix (login succeeds):
![image](https://user-images.githubusercontent.com/580850/102242616-88a20e00-3efa-11eb-9c7c-1466557b7572.png)

