### PR TITLE
Replaced <i> with umb-icon directive in languages overview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -647,3 +647,8 @@ input[type=checkbox]:checked + .input-label--small {
   background-color: @green-l3;
   text-decoration: none;
 }
+
+.language-icon {
+    color: #BBBABF;
+    margin-right: 5px;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -38,7 +38,7 @@
                 <tbody>
                     <tr ng-repeat="language in vm.languages | orderBy:'name' track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
                         <td>
-                           <umb-icon icon="icon-globe" class="language-icon" aria-hidden="true"></umb-icon>
+                           <umb-icon icon="icon-globe" class="language-icon"></umb-icon>
                             <span>{{ language.name }}</span>
                         </td>
                         <td>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overview.html
@@ -38,7 +38,7 @@
                 <tbody>
                     <tr ng-repeat="language in vm.languages | orderBy:'name' track by language.id" ng-click="vm.editLanguage(language)" style="cursor: pointer;">
                         <td>
-                            <i class="icon-globe" style="color: #BBBABF; margin-right: 5px;"></i>
+                           <umb-icon icon="icon-globe" class="language-icon" aria-hidden="true"></umb-icon>
                             <span>{{ language.name }}</span>
                         </td>
                         <td>


### PR DESCRIPTION
Hi,

I have replaced `<i>` with an `umb-icon` in the languages overview screen

![image](https://user-images.githubusercontent.com/3941753/102334278-648c0e80-3f86-11eb-87ab-67b794cffef2.png)


Poornima