### PR TITLE
Noemivdp patch 1 - Add AllowedChildrenEventManager

### DIFF
--- a/src/Umbraco.Web/Editors/AllowedChildrenEventArgs.cs
+++ b/src/Umbraco.Web/Editors/AllowedChildrenEventArgs.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.Editors
+{
+    public sealed class AllowedChildrenEventArgs<T> : AllowedChildrenEventArgs
+    {
+        private readonly AllowedChildrenEventArgs _baseArgs;
+        private T _model;
+
+        public AllowedChildrenEventArgs(AllowedChildrenEventArgs baseArgs)
+            : base(baseArgs.Model, baseArgs.UmbracoContext, baseArgs.ContentId)
+        {
+            _baseArgs = baseArgs;
+            Model = (T)baseArgs.Model;
+            ContentId = baseArgs.ContentId;
+        }
+
+        public AllowedChildrenEventArgs(T model, UmbracoContext umbracoContext, int? contentId)
+            : base(model, umbracoContext,contentId)
+        {
+            Model = model;
+            ContentId = contentId;
+        }
+
+        public new T Model
+        {
+            get => _model;
+            set
+            {
+                _model = value;
+                if (_baseArgs != null)
+                    _baseArgs.Model = _model;
+            }
+        }
+    }
+
+    public class AllowedChildrenEventArgs : EventArgs
+    {
+        public AllowedChildrenEventArgs(object model, UmbracoContext umbracoContext, int? contentId)
+        {
+            Model = model;
+            ContentId = contentId;
+            UmbracoContext = umbracoContext;
+        }
+
+        public object Model { get; set; }
+        public int? ContentId { get; set; }
+        public UmbracoContext UmbracoContext { get; }
+    }
+}

--- a/src/Umbraco.Web/Editors/AllowedChildrenEventManager.cs
+++ b/src/Umbraco.Web/Editors/AllowedChildrenEventManager.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Web.Http.Filters;
+using Umbraco.Core.Dashboards;
+using Umbraco.Core.Events;
+using Umbraco.Web.Models.ContentEditing;
+namespace Umbraco.Web.Editors
+{
+    public sealed class AllowedChildrenEventManager
+    {
+        public static event TypedEventHandler<HttpActionExecutedContext, AllowedChildrenEventArgs<System.Collections.Generic.IEnumerable<Umbraco.Web.Models.ContentEditing.ContentTypeBasic>>> SendingAllowedChildrenModel;
+
+        private static void OnSendingAllowedChildrenModel(HttpActionExecutedContext sender, AllowedChildrenEventArgs<System.Collections.Generic.IEnumerable<Umbraco.Web.Models.ContentEditing.ContentTypeBasic>> e)
+        {
+            var handler = SendingAllowedChildrenModel;
+            handler?.Invoke(sender, e);
+        }
+        /// <summary>
+        /// Emit the Event
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        internal static void EmitEvent(HttpActionExecutedContext sender, AllowedChildrenEventArgs e)
+        {
+               OnSendingAllowedChildrenModel(sender, new AllowedChildrenEventArgs<System.Collections.Generic.IEnumerable<Umbraco.Web.Models.ContentEditing.ContentTypeBasic>>(e));
+        }
+    }
+}

--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -468,6 +468,7 @@ namespace Umbraco.Web.Editors
         /// Returns the allowed child content type objects for the content item id passed in
         /// </summary>
         /// <param name="contentId"></param>
+        [OutgoingAllowedChildrenEvent]
         [UmbracoTreeAuthorize(Constants.Trees.DocumentTypes, Constants.Trees.Content)]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
         {

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Dashboards\PublishedStatusDashboard.cs" />
     <Compile Include="Dashboards\RedirectUrlDashboard.cs" />
     <Compile Include="Dashboards\SettingsDashboards.cs" />
+    <Compile Include="Editors\AllowedChildrenEventArgs.cs" />
+    <Compile Include="Editors\AllowedChildrenEventManager.cs" />
     <Compile Include="Editors\BackOfficePreviewModel.cs" />
     <Compile Include="Editors\ChallengeResult.cs" />
     <Compile Include="Editors\ElementTypeController.cs" />
@@ -380,6 +382,7 @@
     <Compile Include="Editors\Binders\BlueprintItemBinder.cs" />
     <Compile Include="UmbracoApplicationBase.cs" />
     <Compile Include="WebApi\Filters\HttpQueryStringModelBinder.cs" />
+    <Compile Include="WebApi\Filters\OutgoingAllowedChildrenEvent.cs" />
     <Compile Include="WebApi\HttpActionContextExtensions.cs" />
     <Compile Include="Models\ContentEditing\IContentSave.cs" />
     <Compile Include="WebApi\SerializeVersionAttribute.cs" />

--- a/src/Umbraco.Web/WebApi/Filters/OutgoingAllowedChildrenEvent.cs
+++ b/src/Umbraco.Web/WebApi/Filters/OutgoingAllowedChildrenEvent.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Umbraco.Core;
+using Umbraco.Web.Composing;
+using Umbraco.Web.Editors;
+using Umbraco.Web.Models.ContentEditing;
+
+namespace Umbraco.Web.WebApi.Filters
+    {
+        /// <summary>
+        /// Used to emit outgoing 'AllowedChildren' Event
+        /// Enable developers to modify the list of available items to create based on custom logic
+        /// </summary>
+        internal sealed class OutgoingAllowedChildrenEventAttribute : ActionFilterAttribute
+        {
+
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                if (actionExecutedContext.Response == null) return;
+            var actionArguments = actionExecutedContext.ActionContext.ActionArguments;
+            int? _contentId = -1;
+            if (actionArguments.ContainsKey("contentId"))
+            {
+                _contentId = actionArguments["contentId"] as int?;
+            }
+            var user = Current.UmbracoContext.Security.CurrentUser;
+                if (user == null) return;           
+
+                if (actionExecutedContext.Response.Content is ObjectContent objectContent)
+                {
+                    var model = objectContent.Value;
+
+                    if (model != null)
+                    {
+                        var args = new AllowedChildrenEventArgs(
+                            model,
+                            Current.UmbracoContext, _contentId);
+                        AllowedChildrenEventManager.EmitEvent(actionExecutedContext, args);
+                        objectContent.Value = args.Model;
+                    }
+                }
+
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+    }


### PR DESCRIPTION
Hi,

I would like more control over the rules of what types of documents can be created at different levels of the Umbraco content tree, for me having only off and on based on type is not enough.

I would like to be able to allow only Admins to create a certain type of page for example - my feeling is  people might have different needs for their site - so thought the ways to achieve this would be like in kind to EditorModel sending events.

In PR I've tried copy this so that there is 'AllowedChildrenEventManager' and an filter applied to GetAllowedChildren api to give choice for developers to handle and change allowed types based on code logic.

An example: 
Admin's no create BlogPosts - yes create a secret adminSettings - under Blog Section:

```
public class RegisterToAllowedChildrenEvent : IUserComposer
    {

        public void Compose(Core.Composing.Composition composition)
        {
            composition.Components().Append<RegisterToAllowedChildrenEventComponent>();
        }

        public class RegisterToAllowedChildrenEventComponent : IComponent
        {
            public void Initialize()
            {
                AllowedChildrenEventManager.SendingAllowedChildrenModel += AllowedChildrenEventManager_SendingAllowedChildrenModel;
            }

            private void AllowedChildrenEventManager_SendingAllowedChildrenModel(System.Web.Http.Filters.HttpActionExecutedContext sender, AllowedChildrenEventArgs<IEnumerable<Models.ContentEditing.ContentTypeBasic>> e)
            {
                var parentNode = e.UmbracoContext.Content.GetById(e.ContentId ?? -1);
                var currentUser = e.UmbracoContext.Security.CurrentUser;
                bool isAdmin = false;
                if (currentUser.IsAdmin())
                {
                    isAdmin = true;
                }
                if (isAdmin && parentNode.ContentType.Alias=="blog")
                {
                    List<Models.ContentEditing.ContentTypeBasic> allowedChildren = e.Model.ToList();
                    var blogPost = allowedChildren.FirstOrDefault(f => f.Alias == "blogpost");
                    allowedChildren.Remove(blogPost);
                    ContentTypeBasic adminOnlyType = new ContentTypeBasic()
                    {
                        Alias = "adminSettings",
                        Icon = "icon-settings",
                        Name = "Admin Only Settings"

                    };
                    allowedChildren.Add(adminOnlyType);
                    e.Model = allowedChildren;
                }
            }

            // terminate: runs once when Umbraco stops
            public void Terminate()
            {
                AllowedChildrenEventManager.SendingAllowedChildrenModel -= AllowedChildrenEventManager_SendingAllowedChildrenModel;
            }          
        }
    }
```
adminSettings need not be allowed under blog section.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
