### PR TITLE
Reverts button type change in media edit

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -59,7 +59,7 @@
 
                     <!-- label-key="buttons_save" -->
                     <umb-button alias="save"
-                                type="button"
+                                type="submit"
                                 button-style="success"
                                 state="page.saveButtonState"
                                 label-key="{{page.submitButtonLabelKey}}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9600 

### Description
Per the discussion on #9600, changing the button type broke the click event (since there's no handler defined for the button, and changing from submit means no more default form submit action). This change reverts the button type back to `submit`

This does mean the issue raised in #9019 is also reverted, but we can find a more appropriate way to fix.
