### PR TITLE
Use trim method as trim isn't a property

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -353,7 +353,7 @@ Use this directive to construct a header inside the main editor window.
             }
 
             function SetPageTitle(title) {
-                    scope.$emit("$changeTitle", title);
+                scope.$emit("$changeTitle", title);
             }
 
             $rootScope.$on('$setAccessibleHeader', function (event, isNew, editorFor, nameLocked, name, contentTypeName, setTitle) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -341,16 +341,15 @@ Use this directive to construct a header inside the main editor window.
                         }
 
                     }
-                    scope.accessibility.a11yMessageVisible = !isEmptyOrSpaces(scope.accessibility.a11yMessage);
-                    scope.accessibility.a11yNameVisible = !isEmptyOrSpaces(scope.accessibility.a11yName);
+
+                    scope.accessibility.a11yMessageVisible = !isNullOrWhitespace(scope.accessibility.a11yMessage);
+                    scope.accessibility.a11yNameVisible = !isNullOrWhitespace(scope.accessibility.a11yName);
 
                 });
             }
 
-
-
-           function isEmptyOrSpaces(str) {
-               return str === null || str===undefined || str.trim ==='';
+            function isNullOrWhitespace(str) {
+               return str === null || str === undefined || str.trim() === '';
             }
 
             function SetPageTitle(title) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -342,10 +342,14 @@ Use this directive to construct a header inside the main editor window.
 
                     }
 
-                    scope.accessibility.a11yMessageVisible = !Utilities.isNullOrWhitespace(scope.accessibility.a11yMessage);
-                    scope.accessibility.a11yNameVisible = !Utilities.isNullOrWhitespace(scope.accessibility.a11yName);
+                    scope.accessibility.a11yMessageVisible = !isNullOrWhitespace(scope.accessibility.a11yMessage);
+                    scope.accessibility.a11yNameVisible = !isNullOrWhitespace(scope.accessibility.a11yName);
 
                 });
+            }
+
+            function isNullOrWhitespace(str) {
+               return str === null || str === undefined || str.trim() === '';
             }
 
             function SetPageTitle(title) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -342,14 +342,10 @@ Use this directive to construct a header inside the main editor window.
 
                     }
 
-                    scope.accessibility.a11yMessageVisible = !isNullOrWhitespace(scope.accessibility.a11yMessage);
-                    scope.accessibility.a11yNameVisible = !isNullOrWhitespace(scope.accessibility.a11yName);
+                    scope.accessibility.a11yMessageVisible = !Utilities.isNullOrWhitespace(scope.accessibility.a11yMessage);
+                    scope.accessibility.a11yNameVisible = !Utilities.isNullOrWhitespace(scope.accessibility.a11yName);
 
                 });
-            }
-
-            function isNullOrWhitespace(str) {
-               return str === null || str === undefined || str.trim() === '';
             }
 
             function SetPageTitle(title) {

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -70,6 +70,14 @@
 
     const isScope = obj => obj && obj.$evalAsync && obj.$watch;
 
+    const isNullOrEmpty = val => {
+        return isUndefined(val) || !val;
+    }
+
+    const isNullOrWhitespace = val => {
+        return isNullOrEmpty(val) || val.trim() === '';
+    }
+
     const toJsonReplacer = (key, value) => {
         var val = value;      
         if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
@@ -82,7 +90,8 @@
           val = '$SCOPE';
         }      
         return val;
-      }
+    }
+
     /**
      * Equivalent to angular.toJson
      */
@@ -126,6 +135,8 @@
         isString: isString,
         isNumber: isNumber,
         isObject: isObject,
+        isNullOrEmpty: isNullOrEmpty,
+        isNullOrWhitespace: isNullOrWhitespace,
         fromJson: fromJson,
         toJson: toJson,
         forEach: forEach

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -72,11 +72,11 @@
 
     const isNullOrEmpty = val => {
         return isUndefined(val) || !val;
-    };
+    }
 
     const isNullOrWhitespace = val => {
         return isNullOrEmpty(val) || val.trim() === '';
-    };
+    }
 
     const toJsonReplacer = (key, value) => {
         var val = value;      
@@ -90,7 +90,7 @@
           val = '$SCOPE';
         }      
         return val;
-    };
+    }
 
     /**
      * Equivalent to angular.toJson
@@ -101,7 +101,7 @@
           pretty = pretty ? 2 : null;
         }
         return JSON.stringify(obj, toJsonReplacer, pretty);
-    };
+    }
 
     /**
      * Equivalent to angular.fromJson
@@ -111,7 +111,7 @@
             return val;
         }
         return JSON.parse(val);
-    };
+    }
 
     /**
      * Not equivalent to angular.forEach. But like the angularJS method this does not fail on null or undefined.
@@ -121,7 +121,7 @@
             return obj.forEach(iterator);
         }
         return obj;
-    };
+    }
 
     let _utilities = {
         noop: noop,

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -71,28 +71,29 @@
     const isScope = obj => obj && obj.$evalAsync && obj.$watch;
 
     const toJsonReplacer = (key, value) => {
-        var val = value;      
+        var val = value;
         if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
-          val = undefined;
+            val = undefined;
         } else if (isWindow(value)) {
-          val = '$WINDOW';
-        } else if (value &&  window.document === value) {
-          val = '$DOCUMENT';
+            val = '$WINDOW';
+        } else if (value && window.document === value) {
+            val = '$DOCUMENT';
         } else if (isScope(value)) {
-          val = '$SCOPE';
-        }      
+            val = '$SCOPE';
+        }
         return val;
-      }
+    };
+
     /**
      * Equivalent to angular.toJson
      */
     const toJson = (obj, pretty) => {
         if (isUndefined(obj)) return undefined;
         if (!isNumber(pretty)) {
-          pretty = pretty ? 2 : null;
+            pretty = pretty ? 2 : null;
         }
         return JSON.stringify(obj, toJsonReplacer, pretty);
-    }
+    };
 
     /**
      * Equivalent to angular.fromJson
@@ -102,7 +103,7 @@
             return val;
         }
         return JSON.parse(val);
-    }
+    };
 
     /**
      * Not equivalent to angular.forEach. But like the angularJS method this does not fail on null or undefined.
@@ -112,7 +113,7 @@
             return obj.forEach(iterator);
         }
         return obj;
-    }
+    };
 
     let _utilities = {
         noop: noop,

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -72,11 +72,11 @@
 
     const isNullOrEmpty = val => {
         return isUndefined(val) || !val;
-    }
+    };
 
     const isNullOrWhitespace = val => {
         return isNullOrEmpty(val) || val.trim() === '';
-    }
+    };
 
     const toJsonReplacer = (key, value) => {
         var val = value;      
@@ -90,7 +90,7 @@
           val = '$SCOPE';
         }      
         return val;
-    }
+    };
 
     /**
      * Equivalent to angular.toJson
@@ -101,7 +101,7 @@
           pretty = pretty ? 2 : null;
         }
         return JSON.stringify(obj, toJsonReplacer, pretty);
-    }
+    };
 
     /**
      * Equivalent to angular.fromJson
@@ -111,7 +111,7 @@
             return val;
         }
         return JSON.parse(val);
-    }
+    };
 
     /**
      * Not equivalent to angular.forEach. But like the angularJS method this does not fail on null or undefined.
@@ -121,7 +121,7 @@
             return obj.forEach(iterator);
         }
         return obj;
-    }
+    };
 
     let _utilities = {
         noop: noop,

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -70,14 +70,6 @@
 
     const isScope = obj => obj && obj.$evalAsync && obj.$watch;
 
-    const isNullOrEmpty = val => {
-        return isUndefined(val) || !val;
-    }
-
-    const isNullOrWhitespace = val => {
-        return isNullOrEmpty(val) || val.trim() === '';
-    }
-
     const toJsonReplacer = (key, value) => {
         var val = value;      
         if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
@@ -90,8 +82,7 @@
           val = '$SCOPE';
         }      
         return val;
-    }
-
+      }
     /**
      * Equivalent to angular.toJson
      */
@@ -135,8 +126,6 @@
         isString: isString,
         isNumber: isNumber,
         isObject: isObject,
-        isNullOrEmpty: isNullOrEmpty,
-        isNullOrWhitespace: isNullOrWhitespace,
         fromJson: fromJson,
         toJson: toJson,
         forEach: forEach


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed this PR https://github.com/umbraco/Umbraco-CMS/pull/8213 introduced a private method `isEmptyOrSpaces()` which use `trim` as property instead of `trim()` as a method.

I also renamed the function to `isNullOrWhitespace()`.

I considered adding this as a `String` prototype extension in [Extensions.js](https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/lib/umbraco/Extensions.js), but is seems to throw an error if called as `str.isNullOrWhitespace()` and `str` is `null`.

For now I have omitted this, but it could be useful as we use check for `null`, `undefined` and empty string in many part of the code.

```
if (!String.prototype.isNullOrEmpty) {

    /** isNullOrEmpty extension method for string*/
    String.prototype.isNullOrEmpty = function () {
        var s = this;
        return s === null || s === null || s === "";
    };
}

if (!String.prototype.isNullOrWhitespace) {

    /** isNullOrWhitespace extension method for string*/
    String.prototype.isNullOrWhitespace = function (value) {
        var s = this;
        return s.isNullOrEmpty() || s.trim().length < 1;
    };
}
```
