### PR TITLE
Replace jQuery trim() using vanilla JS

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -687,7 +687,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
             if (e.nameExp) {
                 var newValue = e.nameExp({ value });
-                if (newValue && (newValue = $.trim(newValue))) {
+                if (newValue && (newValue = newValue.trim())) {
                     value = newValue;
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -352,7 +352,7 @@
                         item["$index"] = (idx + 1);
 
                         var newName = contentType.nameExp(item);
-                        if (newName && (newName = $.trim(newName))) {
+                        if (newName && (newName = newName.trim())) {
                             name = newName;
                         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed we have a few references using jQuery trim method `$.trim(string)`, but there is no need to use this in modern browsers, where we can just use vanilla `trim()` method, which already is use most places.
http://youmightnotneedjquery.com/#trim