### PR TITLE
Remove private toBool methods and use Object extension method instead

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -648,20 +648,6 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
             else if (options.orderDirection === "desc") {
                 options.orderDirection = "Descending";
             }
-            
-            //converts the value to a js bool
-            function toBool(v) {
-                if (Utilities.isNumber(v)) {
-                    return v > 0;
-                }
-                if (Utilities.isString(v)) {
-                    return v === "true";
-                }
-                if (typeof v === "boolean") {
-                    return v;
-                }
-                return false;
-            }
 
             return umbRequestHelper.resourcePromise(
                 $http.get(
@@ -675,7 +661,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                             pageSize: options.pageSize,
                             orderBy: options.orderBy,
                             orderDirection: options.orderDirection,
-                            orderBySystemField: toBool(options.orderBySystemField),
+                            orderBySystemField: Object.toBoolean(options.orderBySystemField),
                             filter: options.filter,
                             cultureName: options.cultureName
                         })),

--- a/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/media.resource.js
@@ -344,20 +344,6 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 options.orderDirection = "Descending";
             }
 
-            //converts the value to a js bool
-            function toBool(v) {
-                if (Utilities.isNumber(v)) {
-                    return v > 0;
-                }
-                if (Utilities.isString(v)) {
-                    return v === "true";
-                }
-                if (typeof v === "boolean") {
-                    return v;
-                }
-                return false;
-            }
-
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl(
@@ -369,7 +355,7 @@ function mediaResource($q, $http, umbDataFormatter, umbRequestHelper) {
                             { pageSize: options.pageSize },
                             { orderBy: options.orderBy },
                             { orderDirection: options.orderDirection },
-                            { orderBySystemField: toBool(options.orderBySystemField) },
+                            { orderBySystemField: Object.toBoolean(options.orderBySystemField) },
                             { filter: options.filter }
                         ])),
                 'Failed to retrieve children for media item ' + parentId);

--- a/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
@@ -51,26 +51,12 @@ function memberResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 options.orderDirection = "Descending";
             }
 
-            //converts the value to a js bool
-            function toBool(v) {
-                if (Utilities.isNumber(v)) {
-                    return v > 0;
-                }
-                if (Utilities.isString(v)) {
-                    return v === "true";
-                }
-                if (typeof v === "boolean") {
-                    return v;
-                }
-                return false;
-            }
-
             var params = [
                 { pageNumber: options.pageNumber },
                 { pageSize: options.pageSize },
                 { orderBy: options.orderBy },
                 { orderDirection: options.orderDirection },
-                { orderBySystemField: toBool(options.orderBySystemField) },
+                { orderBySystemField: Object.toBoolean(options.orderBySystemField) },
                 { filter: options.filter }
             ];
             if (memberTypeAlias != null) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed we have re-invented the wheel several places to check for a truthy value by creating private `toBool()` methods.
However we already have the extension method `toBoolean()` on `Object`, which already is used most places.
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/lib/umbraco/Extensions.js#L340-L357

It might be a breaking change as the current implementation return `true` for numeric values greather than 0, where I think the `Object.toBoolean()` works similar to `Convert.ToBoolean()` in .NET although it also handle null and undefined values by returning false for these values.

Furthermore with the current implementation a string value `True` or `TRUE` would be handle as false since it only match on `true` value.