### PR TITLE
Fix link localization  in EnsureInternalLinks

### DIFF
--- a/src/Umbraco.Web/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Web/Templates/HtmlLocalLinkParser.cs
@@ -65,6 +65,7 @@ namespace Umbraco.Web.Templates
                 throw new InvalidOperationException("Could not parse internal links, there is no current UmbracoContext");
 
             var urlProvider = _umbracoContextAccessor.UmbracoContext.UrlProvider;
+            var culture = Thread.CurrentThread.CurrentCulture.Name;
 
             foreach((int? intId, GuidUdi udi, string tagValue) in FindLocalLinkIds(text))
             {
@@ -72,7 +73,7 @@ namespace Umbraco.Web.Templates
                 {
                     var newLink = "#";
                     if (udi.EntityType == Constants.UdiEntityType.Document)
-                        newLink = urlProvider.GetUrl(udi.Guid);
+                        newLink = urlProvider.GetUrl(udi.Guid, UrlMode.Default, culture);
                     else if (udi.EntityType == Constants.UdiEntityType.Media)
                         newLink = urlProvider.GetMediaUrl(udi.Guid);
 
@@ -83,7 +84,7 @@ namespace Umbraco.Web.Templates
                 }
                 else if (intId.HasValue)
                 {
-                    var newLink = urlProvider.GetUrl(intId.Value);
+                    var newLink = urlProvider.GetUrl(intId.Value, UrlMode.Default, culture);
                     text = text.Replace(tagValue, "href=\"" + newLink);
                 }
             }


### PR DESCRIPTION
url provider caches resolved fragments, resulting in localized url's not returning expected. 

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
