### PR TITLE
V8: Fix bug where allowing culture variation would delete content from element types #7471

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -448,8 +448,14 @@ AND umbracoNode.id <> @id",
                     // The composed property is only considered segment variant when the base content type is also segment variant.
                     // Example: Culture variant content type with a Culture+Segment variant property type will become ContentVariation.Culture
                     var target = newContentTypeVariation & composedPropertyType.Variations;
+                    // Determine the previous variation
+                    // We have to compare with the old content type variation because the composed property might already have changed
+                    // Example: A property with variations in an element type with variations is used in a document without
+                    //          when you enable variations the property has already enabled variations from the element type,
+                    //          but it's still a change from nothing because the document did not have variations, but it does now.
+                    var from = oldContentTypeVariation & composedPropertyType.Variations;
 
-                    propertyTypeVariationChanges[composedPropertyType.Id] = (composedPropertyType.Variations, target);
+                    propertyTypeVariationChanges[composedPropertyType.Id] = (from, target);
                 }
             }
 

--- a/src/Umbraco.Tests/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -14,6 +14,7 @@ using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;
 using Umbraco.Web.Models.ContentEditing;
+using Content = Umbraco.Core.Models.Content;
 
 namespace Umbraco.Tests.Persistence.Repositories
 {
@@ -1004,6 +1005,88 @@ namespace Umbraco.Tests.Persistence.Repositories
                 // Assert
                 Assert.That(result, Is.False);
                 Assert.That(result2, Is.True);
+            }
+        }
+
+        [Test]
+        public void Can_Update_Variation_Of_Element_Type_Property()
+        {
+            var provider = TestObjects.GetScopeProvider(Logger);
+            using (var scope = provider.CreateScope())
+            {
+                ContentTypeRepository repository;
+                var contentRepository = CreateRepository((IScopeAccessor) provider, out repository);
+
+                // Create elementType
+                var elementType = new ContentType(-1)
+                {
+                    Alias = "elementType",
+                    Name = "Element type",
+                    Description = "Element type to use as compositions",
+                    Icon = ".sprTreeDoc3",
+                    Thumbnail = "doc.png",
+                    SortOrder = 1,
+                    CreatorId = 0,
+                    Trashed = false,
+                    IsElement = true,
+                    Variations = ContentVariation.Nothing
+                };
+
+                var contentCollection = new PropertyTypeCollection(true);
+                contentCollection.Add(new PropertyType("test", ValueStorageType.Ntext)
+                {
+                    Alias = "title",
+                    Name = "Title",
+                    Description = "",
+                    Mandatory = false,
+                    SortOrder = 1,
+                    DataTypeId = Constants.DataTypes.Textbox,
+                    LabelOnTop = true,
+                    Variations = ContentVariation.Nothing
+                });
+                elementType.PropertyGroups.Add(new PropertyGroup(contentCollection) {Name = "Content", SortOrder = 1});
+                elementType.ResetDirtyProperties(false);
+                elementType.SetDefaultTemplate(new Template("ElementType", "elementType"));
+                repository.Save(elementType);
+
+                // Create the basic "home" doc type that uses element type as comp
+                var docType = new ContentType(-1)
+                {
+                    Alias = "home",
+                    Name = "Home",
+                    Description = "Home containing elementType",
+                    Icon = ".sprTreeDoc3",
+                    Thumbnail = "doc.png",
+                    SortOrder = 1,
+                    CreatorId = 0,
+                    Trashed = false,
+                    Variations = ContentVariation.Nothing
+                };
+                var comp = new List<IContentTypeComposition>();
+                comp.Add(elementType);
+                docType.ContentTypeComposition = comp;
+                repository.Save(docType);
+
+                // Create "home" content
+                var content = new Content("Home", -1, docType){Level = 1, SortOrder = 1, CreatorId = 0, WriterId = 0};
+                object obj = new {title = "test title"};
+                content.PropertyValues(obj);
+                content.ResetDirtyProperties(false);
+                contentRepository.Save(content);
+
+                // Update variation on element type
+                elementType.Variations = ContentVariation.Culture;
+                elementType.PropertyTypes.First().Variations = ContentVariation.Culture;
+                repository.Save(elementType);
+
+                // Update variation on doc type
+                docType.Variations = ContentVariation.Culture;
+                repository.Save(docType);
+
+                // Re fetch renewedContent and make sure that the culture has been set.
+                var renewedContent = ServiceContext.ContentService.GetById(content.Id);
+                var hasCulture = renewedContent.Properties["title"].Values.First().Culture != null;
+                Assert.That(hasCulture, Is.True);
             }
         }
 


### PR DESCRIPTION
This should fix the bug where if you allowed varying culture in a composition and property field, that property field would be lost in any content using the property type. 

The underlying issue was that when we were checking for a change in variation we only looked at the previous state of the property type, however, when you're using it in an element type, the element type and property type can allow variation, while the document type you're using it in as a composition does not allow it. When you later allow variation in you document type the property type will already allow variation (because it's allowed in the element type), and therefore we did not copy the property data to a new column that has a language ID associated with it, causing this bug.

We now also check the source document type for variation when changing variation for composed property types.

I've also made a unit tests that hit this issue. 

fixes #7471 

### Testing: 
1. Ensure the project is empty
2. Create an element type with a text property
3. Create a document type with root access, that uses the element type as a composition
4. Create a root content node and add some text to the property
5. Enable variants on the element type and the text property
6. Enable variants on the doc type
7. Ensure the content in the text property still exists in the root content node.

I've tried to fiddle around to find any side effects of this change, but couldn't find any, would be helpful to try and fiddle around with changing culture settings as well. 
