### PR TITLE
Fix styling of search icon in search filter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-search-filter.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-search-filter.less
@@ -18,6 +18,8 @@ html .umb-search-filter {
         margin: 0;
     }
 
+    // "icon-search" class it kept for backward compatibility
+    .umb-icon, 
     .icon-search {
         color: #d8d7d9;
         position: absolute;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9541

### Description
This PR fixes some styling issues with search icon inside search filter after the `<umb-search-filter>` component has been introduced and changed to `<umb-icon>` inside search filter component, where the `icon-search` was removed. I have kept to old class so it still looks nice if packages used the old markup.

It seems a bit unnecessary to have the `w-100` class here
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/less/components/umb-search-filter.less#L6-L8 since we already have the utility class here https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/less/utilities/_width.less#L24

but removing this + the `html` selector in the component styling, it seems the styling in forms.less is prioritized, so the padding was overwritten by forms.less styling.
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/less/components/umb-search-filter.less#L14-L19

We can look at this in another PR. For now this should fix these styling issues.

**Icon Picker**
![image](https://user-images.githubusercontent.com/2919859/104124007-935f8f80-534e-11eb-8291-ebbf91b7c9db.png)

**DataType Picker**
![image](https://user-images.githubusercontent.com/2919859/104124034-bd18b680-534e-11eb-96a8-4ee1ca614794.png)

