### PR TITLE
Align datatype sidebar box properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -803,9 +803,12 @@ legend + .control-group {
 
 // adjustments for properties tab
 .form-horizontal .block-form .control-label {
-  display: block;
-  float: none;
-  width: 100%;
+    display: block;
+    float: none;
+    width: 100%;
+}
+.form-horizontal .block-form .controls {
+    margin-left: 0;
 }
 
 //make sure buttons are always on top

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/edit.html
@@ -13,7 +13,7 @@
                             setpagetitle="vm.header.setPageTitle">
             </umb-editor-header>
 
-            <umb-editor-container class="form-horizontal">
+            <umb-editor-container>
                 <umb-editor-sub-views sub-views="vm.page.navigation" model="vm">
                 </umb-editor-sub-views>
             </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/edit.html
@@ -13,7 +13,7 @@
                             setpagetitle="vm.header.setPageTitle">
             </umb-editor-header>
 
-            <umb-editor-container>
+            <umb-editor-container class="form-horizontal">
                 <umb-editor-sub-views sub-views="vm.page.navigation" model="vm">
                 </umb-editor-sub-views>
             </umb-editor-container>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the properties wasn't aligned in "General" box under datatypes. It is a similar issue as this for member groups: https://github.com/umbraco/Umbraco-CMS/issues/9466

**Before**

![image](https://user-images.githubusercontent.com/2919859/104124291-54323e00-5350-11eb-9b63-606e0bb7a180.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/104124326-89d72700-5350-11eb-90dc-40bdfd2f5b76.png)