### PR TITLE
Ensure sub-view components are not self-closed elements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-variant-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-variant-content.html
@@ -36,7 +36,8 @@
 
             <div class="umb-editor-sub-views">
                 <div ng-repeat="app in vm.editor.variantApps track by app.alias">
-                    <umb-editor-sub-view model="app" content="vm.content" variant-content="vm.editor.content"/>
+                    <umb-editor-sub-view model="app" content="vm.content" variant-content="vm.editor.content">
+                    </umb-editor-sub-view>
                 </div>
             </div>
         </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/content/recyclebin.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/recyclebin.html
@@ -11,7 +11,8 @@
         <umb-editor-container>
             <div class="umb-editor-sub-views">
                 <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
-                    <umb-editor-sub-view model="app" content="content" />
+                    <umb-editor-sub-view model="app" content="content">
+                    </umb-editor-sub-view>
                 </div>
             </div>
         </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/media/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/edit.html
@@ -23,7 +23,8 @@
             <umb-editor-container>
                 <div class="umb-editor-sub-views" ng-if="!page.loading">
                     <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
-                        <umb-editor-sub-view model="app" content="content"  />
+                        <umb-editor-sub-view model="app" content="content">
+                        </umb-editor-sub-view>
                     </div>
                 </div>
             </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/media/recyclebin.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/recyclebin.html
@@ -12,7 +12,8 @@
         <umb-editor-container>
             <div class="umb-editor-sub-views">
                 <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
-                    <umb-editor-sub-view model="app" content="content" />
+                    <umb-editor-sub-view model="app" content="content">
+                    </umb-editor-sub-view>
                 </div>
             </div>
         </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/member/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/edit.html
@@ -26,7 +26,8 @@
         <umb-editor-container>
             <div class="umb-editor-sub-views" ng-if="!page.loading">
                 <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
-                    <umb-editor-sub-view model="app" content="content"  />
+                    <umb-editor-sub-view model="app" content="content">
+                    </umb-editor-sub-view>
                 </div>
             </div>
         </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/member/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/list.html
@@ -18,7 +18,8 @@
            <umb-editor-container>
                <div class="umb-editor-sub-views">
                    <div id="sub-view-{{$index}}" ng-repeat="app in content.apps track by app.alias">
-                       <umb-editor-sub-view model="app" content="content" />
+                       <umb-editor-sub-view model="app" content="content">
+                       </umb-editor-sub-view>
                    </div>
                </div>
            </umb-editor-container>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed we have several uses of `<umb-editor-sub-view>` as self-closed (void) elements, but with latest AngularJS v1.x.x version recently upgraded to, we have noticed several issues - mostly that any following sibling elements wouldn't be rendered.

In this case it isn't an issue at the moment, because it is the only child element where used, but if we later add text or elements after the component, it would cause issues rendering these elements. 
