### PR TITLE
Hide rollback button for content that hasn't been created yet

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -45,7 +45,7 @@
 
             <umb-box-header title="{{historyLabel}}">
                 <umb-button
-                    ng-hide="node.trashed"
+                    ng-hide="node.trashed || node.id === 0"
                     type="button"
                     button-style="outline"
                     action="openRollback()"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When creating a new content new there is no versions yet, so I think we should also hide the rollback button in this case as there is no versions to rollback to anyway.
