### PR TITLE
MNTP xpath help button doesn't do anything

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -41,9 +41,9 @@
             <ul class="unstyled list-icons mt3">
                 <li style="max-width: 600px">
                     <i class="icon icon-help-alt" aria-hidden="true"></i>
-                    <button type="button" class="btn-link" ng-click="showHelp = 1">Show xpath query help</button>
+                    <button type="button" class="btn-link" ng-click="showHelp = !showHelp">{{showHelp ? 'Hide' : 'Show'}} xpath query help</button>
 
-                    <div class="small" ng-if="showHelp">
+                    <div class="small" ng-show="showHelp">
                         <p>
                             Use Xpath query to set a root node on the tree, either based on a search from the root of the content tree, or by using a context-aware placeholder.
                         </p>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR fixes a minor issue with xpath help button, which didn't do anything. Now it act as a simple toggle button instead 🔛 

![dc31TRSURL](https://user-images.githubusercontent.com/2919859/104224162-e1ef5580-5444-11eb-81f2-a7e034be6daf.gif)
