### PR TITLE
Fixes a memory leak caused by deep cloning

### DIFF
--- a/src/Umbraco.Core/Collections/EventClearingObservableCollection.cs
+++ b/src/Umbraco.Core/Collections/EventClearingObservableCollection.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace Umbraco.Core.Collections
+{
+    /// <summary>
+    /// Allows clearing all event handlers
+    /// </summary>
+    /// <typeparam name="TValue"></typeparam>
+    public class EventClearingObservableCollection<TValue> : ObservableCollection<TValue>
+    {
+        public EventClearingObservableCollection()
+        {
+        }
+
+        public EventClearingObservableCollection(List<TValue> list) : base(list)
+        {
+        }
+
+        public EventClearingObservableCollection(IEnumerable<TValue> collection) : base(collection)
+        {
+        }
+
+        // need to override to clear
+        public override event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        /// <summary>
+        /// Clears all event handlers for the <see cref="CollectionChanged"/> event
+        /// </summary>
+        public void ClearCollectionChangedEvents() => CollectionChanged = null;
+    }
+}

--- a/src/Umbraco.Core/Collections/EventClearingObservableCollection.cs
+++ b/src/Umbraco.Core/Collections/EventClearingObservableCollection.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Core.Collections
     /// Allows clearing all event handlers
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
-    public class EventClearingObservableCollection<TValue> : ObservableCollection<TValue>
+    public class EventClearingObservableCollection<TValue> : ObservableCollection<TValue>, INotifyCollectionChanged
     {
         public EventClearingObservableCollection()
         {
@@ -22,12 +22,20 @@ namespace Umbraco.Core.Collections
         {
         }
 
-        // need to override to clear
-        public override event NotifyCollectionChangedEventHandler CollectionChanged;
+        // need to explicitly implement with event accessor syntax in order to override in order to to clear
+        // c# events are weird, they do not behave the same way as other c# things that are 'virtual',
+        // a good article is here: https://medium.com/@unicorn_dev/virtual-events-in-c-something-went-wrong-c6f6f5fbe252
+        // and https://stackoverflow.com/questions/2268065/c-sharp-language-design-explicit-interface-implementation-of-an-event
+        private NotifyCollectionChangedEventHandler _changed;
+        event NotifyCollectionChangedEventHandler INotifyCollectionChanged.CollectionChanged
+        {
+            add { _changed += value; }
+            remove { _changed -= value; }
+        }
 
         /// <summary>
         /// Clears all event handlers for the <see cref="CollectionChanged"/> event
         /// </summary>
-        public void ClearCollectionChangedEvents() => CollectionChanged = null;
+        public void ClearCollectionChangedEvents() => _changed = null;
     }
 }

--- a/src/Umbraco.Core/Collections/ObservableDictionary.cs
+++ b/src/Umbraco.Core/Collections/ObservableDictionary.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Core.Collections
     /// </remarks>
     /// <typeparam name="TValue">The type of elements contained in the BindableCollection</typeparam>
     /// <typeparam name="TKey">The type of the indexing key</typeparam>
-    public class ObservableDictionary<TKey, TValue> : ObservableCollection<TValue>, IReadOnlyDictionary<TKey, TValue>, IDictionary<TKey, TValue>
+    public class ObservableDictionary<TKey, TValue> : ObservableCollection<TValue>, IReadOnlyDictionary<TKey, TValue>, IDictionary<TKey, TValue>, INotifyCollectionChanged
     {
         protected Dictionary<TKey, int> Indecies { get; }
         protected Func<TValue, TKey> KeySelector { get; }
@@ -77,13 +77,21 @@ namespace Umbraco.Core.Collections
 
         #endregion
 
-        // need to override to clear
-        public override event NotifyCollectionChangedEventHandler CollectionChanged;
+        // need to explicitly implement with event accessor syntax in order to override in order to to clear
+        // c# events are weird, they do not behave the same way as other c# things that are 'virtual',
+        // a good article is here: https://medium.com/@unicorn_dev/virtual-events-in-c-something-went-wrong-c6f6f5fbe252
+        // and https://stackoverflow.com/questions/2268065/c-sharp-language-design-explicit-interface-implementation-of-an-event
+        private NotifyCollectionChangedEventHandler _changed;
+        event NotifyCollectionChangedEventHandler INotifyCollectionChanged.CollectionChanged
+        {
+            add { _changed += value; }
+            remove { _changed -= value; }
+        }
 
         /// <summary>
         /// Clears all <see cref="CollectionChanged"/> event handlers
         /// </summary>
-        public void ClearCollectionChangedEvents() => CollectionChanged = null;
+        public void ClearCollectionChangedEvents() => _changed = null;
 
         public bool ContainsKey(TKey key)
         {

--- a/src/Umbraco.Core/Collections/ObservableDictionary.cs
+++ b/src/Umbraco.Core/Collections/ObservableDictionary.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Umbraco.Core.Collections
 {
+
     /// <summary>
     /// An ObservableDictionary
     /// </summary>
@@ -73,6 +76,14 @@ namespace Umbraco.Core.Collections
         }
 
         #endregion
+
+        // need to override to clear
+        public override event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        /// <summary>
+        /// Clears all <see cref="CollectionChanged"/> event handlers
+        /// </summary>
+        public void ClearCollectionChangedEvents() => CollectionChanged = null;
 
         public bool ContainsKey(TKey key)
         {

--- a/src/Umbraco.Core/Models/Content.cs
+++ b/src/Umbraco.Core/Models/Content.cs
@@ -98,10 +98,15 @@ namespace Umbraco.Core.Models
             set
             {
                 if (_schedule != null)
-                    _schedule.CollectionChanged -= ScheduleCollectionChanged;
+                {
+                    _schedule.ClearCollectionChangedEvents();
+                }
+                    
                 SetPropertyValueAndDetectChanges(value, ref _schedule, nameof(ContentSchedule));
                 if (_schedule != null)
+                {
                     _schedule.CollectionChanged += ScheduleCollectionChanged;
+                }   
             }
         }
 
@@ -223,10 +228,16 @@ namespace Umbraco.Core.Models
             }
             set
             {
-                if (_publishInfos != null) _publishInfos.CollectionChanged -= PublishNamesCollectionChanged;
+                if (_publishInfos != null)
+                {
+                    _publishInfos.ClearCollectionChangedEvents();
+                }
+
                 _publishInfos = value;
                 if (_publishInfos != null)
+                {
                     _publishInfos.CollectionChanged += PublishNamesCollectionChanged;
+                }   
             }
         }
 
@@ -321,7 +332,7 @@ namespace Umbraco.Core.Models
             else
                 Properties.EnsurePropertyTypes(contentType.CompositionPropertyTypes);
 
-            Properties.CollectionChanged -= PropertiesChanged; // be sure not to double add
+            Properties.ClearCollectionChangedEvents(); // be sure not to double add
             Properties.CollectionChanged += PropertiesChanged;
         }
 
@@ -438,7 +449,7 @@ namespace Umbraco.Core.Models
             //if culture infos exist then deal with event bindings
             if (clonedContent._publishInfos != null)
             {
-                clonedContent._publishInfos.CollectionChanged -= PublishNamesCollectionChanged;          //clear this event handler if any
+                clonedContent._publishInfos.ClearCollectionChangedEvents();          //clear this event handler if any
                 clonedContent._publishInfos = (ContentCultureInfosCollection)_publishInfos.DeepClone(); //manually deep clone
                 clonedContent._publishInfos.CollectionChanged += clonedContent.PublishNamesCollectionChanged;    //re-assign correct event handler
             }
@@ -446,7 +457,7 @@ namespace Umbraco.Core.Models
             //if properties exist then deal with event bindings
             if (clonedContent._schedule != null)
             {
-                clonedContent._schedule.CollectionChanged -= ScheduleCollectionChanged;         //clear this event handler if any
+                clonedContent._schedule.ClearCollectionChangedEvents();         //clear this event handler if any
                 clonedContent._schedule = (ContentScheduleCollection)_schedule.DeepClone();     //manually deep clone
                 clonedContent._schedule.CollectionChanged += clonedContent.ScheduleCollectionChanged;   //re-assign correct event handler
             }

--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -138,7 +138,11 @@ namespace Umbraco.Core.Models
             get => _properties;
             set
             {
-                if (_properties != null) _properties.CollectionChanged -= PropertiesChanged;
+                if (_properties != null)
+                {
+                    _properties.ClearCollectionChangedEvents();
+                }
+
                 _properties = value;
                 _properties.CollectionChanged += PropertiesChanged;
             }
@@ -173,10 +177,15 @@ namespace Umbraco.Core.Models
             }
             set
             {
-                if (_cultureInfos != null) _cultureInfos.CollectionChanged -= CultureInfosCollectionChanged;
+                if (_cultureInfos != null)
+                {
+                    _cultureInfos.ClearCollectionChangedEvents();
+                }
                 _cultureInfos = value;
                 if (_cultureInfos != null)
+                {
                     _cultureInfos.CollectionChanged += CultureInfosCollectionChanged;
+                }   
             }
         }
 
@@ -479,7 +488,7 @@ namespace Umbraco.Core.Models
             //if culture infos exist then deal with event bindings
             if (clonedContent._cultureInfos != null)
             {
-                clonedContent._cultureInfos.CollectionChanged -= CultureInfosCollectionChanged;          //clear this event handler if any
+                clonedContent._cultureInfos.ClearCollectionChangedEvents();          //clear this event handler if any
                 clonedContent._cultureInfos = (ContentCultureInfosCollection)_cultureInfos.DeepClone(); //manually deep clone
                 clonedContent._cultureInfos.CollectionChanged += clonedContent.CultureInfosCollectionChanged;    //re-assign correct event handler
             }
@@ -487,7 +496,7 @@ namespace Umbraco.Core.Models
             //if properties exist then deal with event bindings
             if (clonedContent._properties != null)
             {
-                clonedContent._properties.CollectionChanged -= PropertiesChanged;         //clear this event handler if any
+                clonedContent._properties.ClearCollectionChangedEvents();         //clear this event handler if any
                 clonedContent._properties = (PropertyCollection)_properties.DeepClone(); //manually deep clone
                 clonedContent._properties.CollectionChanged += clonedContent.PropertiesChanged;   //re-assign correct event handler
             }

--- a/src/Umbraco.Core/Models/ContentCultureInfosCollection.cs
+++ b/src/Umbraco.Core/Models/ContentCultureInfosCollection.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Core.Models
         public ContentCultureInfosCollection()
             : base(x => x.Culture, StringComparer.InvariantCultureIgnoreCase)
         { }
-        
+
         /// <summary>
         /// Adds or updates a <see cref="ContentCultureInfos"/> instance.
         /// </summary>

--- a/src/Umbraco.Core/Models/ContentScheduleCollection.cs
+++ b/src/Umbraco.Core/Models/ContentScheduleCollection.cs
@@ -14,6 +14,11 @@ namespace Umbraco.Core.Models
 
         public event NotifyCollectionChangedEventHandler CollectionChanged;
 
+        /// <summary>
+        /// Clears all <see cref="CollectionChanged"/> event handlers
+        /// </summary>
+        public void ClearCollectionChangedEvents() => CollectionChanged = null;
+
         private void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
             CollectionChanged?.Invoke(this, args);

--- a/src/Umbraco.Core/Models/ContentTypeBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeBase.cs
@@ -262,7 +262,10 @@ namespace Umbraco.Core.Models
             set
             {
                 if (_noGroupPropertyTypes != null)
-                    _noGroupPropertyTypes.CollectionChanged -= PropertyTypesChanged;
+                {
+                    _noGroupPropertyTypes.ClearCollectionChangedEvents();
+                }
+
                 _noGroupPropertyTypes = new PropertyTypeCollection(SupportsPublishing, value);
                 _noGroupPropertyTypes.CollectionChanged += PropertyTypesChanged;
                 PropertyTypesChanged(_noGroupPropertyTypes, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
@@ -480,14 +483,14 @@ namespace Umbraco.Core.Models
                 // its ignored from the auto-clone process because its return values are unions, not raw and
                 // we end up with duplicates, see: http://issues.umbraco.org/issue/U4-4842
 
-                clonedEntity._noGroupPropertyTypes.CollectionChanged -= PropertyTypesChanged;                    //clear this event handler if any
+                clonedEntity._noGroupPropertyTypes.ClearCollectionChangedEvents();                    //clear this event handler if any
                 clonedEntity._noGroupPropertyTypes = (PropertyTypeCollection) _noGroupPropertyTypes.DeepClone(); //manually deep clone
                 clonedEntity._noGroupPropertyTypes.CollectionChanged += clonedEntity.PropertyTypesChanged;              //re-assign correct event handler
             }
 
             if (clonedEntity._propertyGroups != null)
             {
-                clonedEntity._propertyGroups.CollectionChanged -= PropertyGroupsChanged;              //clear this event handler if any
+                clonedEntity._propertyGroups.ClearCollectionChangedEvents();              //clear this event handler if any
                 clonedEntity._propertyGroups = (PropertyGroupCollection) _propertyGroups.DeepClone(); //manually deep clone
                 clonedEntity._propertyGroups.CollectionChanged += clonedEntity.PropertyGroupsChanged;        //re-assign correct event handler
             }

--- a/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
+++ b/src/Umbraco.Core/Models/Identity/BackOfficeIdentityUser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
+using Umbraco.Core.Collections;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models.Entities;
 using Umbraco.Core.Models.Membership;
@@ -62,7 +63,7 @@ namespace Umbraco.Core.Models.Identity
             _culture = Current.Configs.Global().DefaultUILanguage; // TODO: inject
 
             // must initialize before setting groups
-            _roles = new ObservableCollection<IdentityUserRole<string>>();
+            _roles = new EventClearingObservableCollection<IdentityUserRole<string>>();
             _roles.CollectionChanged += _roles_CollectionChanged;
 
             // use the property setters - they do more than just setting a field
@@ -223,7 +224,7 @@ namespace Umbraco.Core.Models.Identity
                 _groups = value;
 
                 //now clear all roles and re-add them
-                _roles.CollectionChanged -= _roles_CollectionChanged;
+                _roles.ClearCollectionChangedEvents();
                 _roles.Clear();
                 foreach (var identityUserRole in _groups.Select(x => new IdentityUserRole<string>
                 {
@@ -306,7 +307,7 @@ namespace Umbraco.Core.Models.Identity
             _beingDirty.OnPropertyChanged(nameof(Roles));
         }
 
-        private readonly ObservableCollection<IdentityUserRole<string>> _roles;
+        private readonly EventClearingObservableCollection<IdentityUserRole<string>> _roles;
 
         /// <summary>
         /// helper method to easily add a role without having to deal with IdentityUserRole{T}

--- a/src/Umbraco.Core/Models/Media.cs
+++ b/src/Umbraco.Core/Models/Media.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Core.Models
             else
                 Properties.EnsurePropertyTypes(contentType.CompositionPropertyTypes);
 
-            Properties.CollectionChanged -= PropertiesChanged; // be sure not to double add
+            Properties.ClearCollectionChangedEvents(); // be sure not to double add
             Properties.CollectionChanged += PropertiesChanged;
         }
     }

--- a/src/Umbraco.Core/Models/PropertyCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyCollection.cs
@@ -169,6 +169,8 @@ namespace Umbraco.Core.Models
         /// </summary>
         public event NotifyCollectionChangedEventHandler CollectionChanged;
 
+        public void ClearCollectionChangedEvents() => CollectionChanged = null;
+
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
             CollectionChanged?.Invoke(this, args);

--- a/src/Umbraco.Core/Models/PropertyGroup.cs
+++ b/src/Umbraco.Core/Models/PropertyGroup.cs
@@ -66,7 +66,10 @@ namespace Umbraco.Core.Models
             set
             {
                 if (_propertyTypes != null)
-                    _propertyTypes.CollectionChanged -= PropertyTypesChanged;
+                {
+                    _propertyTypes.ClearCollectionChangedEvents();
+                }
+                    
                 _propertyTypes = value;
 
                 // since we're adding this collection to this group,
@@ -100,7 +103,7 @@ namespace Umbraco.Core.Models
 
             if (clonedEntity._propertyTypes != null)
             {
-                clonedEntity._propertyTypes.CollectionChanged -= PropertyTypesChanged;             //clear this event handler if any
+                clonedEntity._propertyTypes.ClearCollectionChangedEvents();             //clear this event handler if any
                 clonedEntity._propertyTypes = (PropertyTypeCollection) _propertyTypes.DeepClone(); //manually deep clone
                 clonedEntity._propertyTypes.CollectionChanged += clonedEntity.PropertyTypesChanged;       //re-assign correct event handler
             }

--- a/src/Umbraco.Core/Models/PropertyGroupCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyGroupCollection.cs
@@ -160,6 +160,11 @@ namespace Umbraco.Core.Models
 
         public event NotifyCollectionChangedEventHandler CollectionChanged;
 
+        /// <summary>
+        /// Clears all <see cref="CollectionChanged"/> event handlers
+        /// </summary>
+        public void ClearCollectionChangedEvents() => CollectionChanged = null;
+
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
             CollectionChanged?.Invoke(this, args);

--- a/src/Umbraco.Core/Models/PropertyTypeCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyTypeCollection.cs
@@ -161,7 +161,12 @@ namespace Umbraco.Core.Models
             return item.Alias;
         }
 
+        /// <summary>
+        /// Clears all <see cref="CollectionChanged"/> event handlers
+        /// </summary>
         public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        public void ClearCollectionChangedEvents() => CollectionChanged = null;
 
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {

--- a/src/Umbraco.Core/Models/PropertyTypeCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyTypeCollection.cs
@@ -161,13 +161,12 @@ namespace Umbraco.Core.Models
             return item.Alias;
         }
 
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+        
         /// <summary>
         /// Clears all <see cref="CollectionChanged"/> event handlers
         /// </summary>
-        public event NotifyCollectionChangedEventHandler CollectionChanged;
-
         public void ClearCollectionChangedEvents() => CollectionChanged = null;
-
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
             CollectionChanged?.Invoke(this, args);

--- a/src/Umbraco.Core/Models/PublicAccessEntry.cs
+++ b/src/Umbraco.Core/Models/PublicAccessEntry.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.Serialization;
+using Umbraco.Core.Collections;
 using Umbraco.Core.Models.Entities;
 
 namespace Umbraco.Core.Models
@@ -12,7 +13,7 @@ namespace Umbraco.Core.Models
     [DataContract(IsReference = true)]
     public class PublicAccessEntry : EntityBase
     {
-        private readonly ObservableCollection<PublicAccessRule> _ruleCollection;
+        private readonly EventClearingObservableCollection<PublicAccessRule> _ruleCollection;
         private int _protectedNodeId;
         private int _noAccessNodeId;
         private int _loginNodeId;
@@ -28,7 +29,7 @@ namespace Umbraco.Core.Models
             NoAccessNodeId = noAccessNode.Id;
             _protectedNodeId = protectedNode.Id;
 
-            _ruleCollection = new ObservableCollection<PublicAccessRule>(ruleCollection);
+            _ruleCollection = new EventClearingObservableCollection<PublicAccessRule>(ruleCollection);
             _ruleCollection.CollectionChanged += _ruleCollection_CollectionChanged;
 
             foreach (var rule in _ruleCollection)
@@ -44,7 +45,7 @@ namespace Umbraco.Core.Models
             NoAccessNodeId = noAccessNodeId;
             _protectedNodeId = protectedNodeId;
 
-            _ruleCollection = new ObservableCollection<PublicAccessRule>(ruleCollection);
+            _ruleCollection = new EventClearingObservableCollection<PublicAccessRule>(ruleCollection);
             _ruleCollection.CollectionChanged += _ruleCollection_CollectionChanged;
 
             foreach (var rule in _ruleCollection)
@@ -148,7 +149,7 @@ namespace Umbraco.Core.Models
 
             if (cloneEntity._ruleCollection != null)
             {
-                cloneEntity._ruleCollection.CollectionChanged -= _ruleCollection_CollectionChanged;       //clear this event handler if any
+                cloneEntity._ruleCollection.ClearCollectionChangedEvents();       //clear this event handler if any
                 cloneEntity._ruleCollection.CollectionChanged += cloneEntity._ruleCollection_CollectionChanged; //re-assign correct event handler
             }
         }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -128,6 +128,7 @@
     </Compile>
     -->
     <Compile Include="AssemblyExtensions.cs" />
+    <Compile Include="Collections\EventClearingObservableCollection.cs" />
     <Compile Include="Constants-SqlTemplates.cs" />
     <Compile Include="Exceptions\UnattendedInstallException.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\ContentTypeDto80.cs" />


### PR DESCRIPTION
Resolves #9348 

There was a memory leak with PublicAccessEntry during even unassignment which was not clearing the correct handler.
This goes a step further and adds a new ClearCollectionChangedEvents method for all observable collections used in umbraco
which allows fully clearing ALL event handlers instead of having to track specific ones. This will ensure there are no
unintended memory leaks in case end-users have assigned event handlers to the collection changed event which would
not be unassigned during deep cloning. This is much safer.

This memory leak will be present in all Umbraco 8.x versions if there is any public access assigned. The more public access entries configured (i.e. the more nodes that have explicit public access settings applied) the faster the leak.

There is still one issue however which I'll look to resolve in a different PR which is that we cache all public access entries in memory. In some rare cases there could be thousands which is both inefficient to store in memory but also inefficient to query in memory. However the alternative is more SQL queries so I need to determine if there's a happy medium to be had. This cache has existed for most of v7 so it's nothing new. 

## Results

To test this I used an [artillery](https://artillery.io/docs/guides/overview/welcome.html) script. This first calls a custom endpoint `/MemberLogin` that just does a very rudimentary member login with the specified query string parameters. Artillery tracks cookies returned for the virtual user so the resulting cookie will be used for the subsequent requests. It actually isn't necessary that the member is logged in to see this leak! ... it occurs on any check of a page's public access settings but it was worth adding this to this script. 

The test is on the Starter Kit and public access is applied to the about-us page with a few dozen different rules for different user groups. That node and rules are then copied many many times which results in about 1000 entries in the `umbracoAccess` table. This isn't a requirement for testing but it makes the leak much faster.

```yml
config:
  target: 'http://localhost:8910/'
  http:
    pool: 30
  phases:
    - duration: 20
      arrivalRate: 2
scenarios:
  - flow:
    - get:
        url: "/MemberLogin"
        qs:
          username: "testmember"
          passowrd: "123456789"
    - loop:      
      - get:
          url: "/products/"
      - get:
          url: "/about-us/"
      count: 10
```

### Before

These 2 snapshots were taking after testing a few times so it's not an indication of initial memory consumption but it clearly indicates a memory leak. When the artillery script was first run way before the first snapshot was taken the `RPS sent` was 41.38. After each execution and report output this drops significantly as memory grows. This is because the CPU is now working overtime iterating through a lot of objects.

The last report output when snapshot 2 was taken reported `RPS sent`: 7.1 😱 

![image](https://user-images.githubusercontent.com/1742685/104264223-54ad0f00-54df-11eb-9a5b-1d6985424b90.png)

### After

These 2 snapshots were taken right after starting the app which is why the actual memory consumption figures are much lower but that's not what we're comparing here. This clearly shows there is no increase in memory retention as the tests are run.

The first report output was showing `RPS sent`: 42.22 and the last report was `RPS sent`: 42.08 so that shows that the CPU issue and RPS output is directly related to the memory leak.

_NOTE: RPS in these reports is not an indication that umbraco can only serve 42 requests per second! Whatever might be happening on my machine and how these pages are coded, etc... all impact this figure, it's just used as a measurement for comparison with other contextual tests at the same time on the same machine._

![image](https://user-images.githubusercontent.com/1742685/104264537-f2084300-54df-11eb-99c3-dede83bdb051.png)

