### PR TITLE
V8/bug/9432: Backoffice UI - checkboxes on doctype compositions uncheck after selecting an item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button.less
@@ -63,6 +63,11 @@
    border-left-color: @white;
 }
 
+.umb-button__progress.-black {
+   border-color: rgba(255, 255, 255, 0.4);
+   border-left-color: @black;
+}
+
 .umb-button__success,
 .umb-button__error {
    position: absolute;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-checkbox-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-checkbox-list.less
@@ -37,11 +37,23 @@
   align-items: center;
   flex: 0 0 30px;
   margin-right: 5px;
+  position: relative;
 }
 
 .umb-checkbox-list__item-icon {
   margin-right: 5px;
   font-size: 16px;
+}
+
+.umb-checkbox-list__item-icon-wrapper {
+  position: relative;
+
+  .umb-button__progress {
+    width: 10px;
+    height: 10px;
+    margin-left: -10px;
+    margin-top: -8px;
+  }
 }
 
 .umb-checkbox-list__item-text {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.controller.js
@@ -7,7 +7,7 @@
         var oldModel = null;
 
         vm.showConfirmSubmit = false;
-        vm.loading = false;
+        vm.loadingAlias = null;
 
         vm.isSelected = isSelected;
         vm.openContentType = openContentType;
@@ -57,14 +57,13 @@
             $location.path(url);
         }
 
-        function selectCompositeContentType(compositeContentType) {  
-
-            vm.loading = true;
+        function selectCompositeContentType(compositeContentType) {
+            vm.loadingAlias = compositeContentType.contentType.alias
             
             var contentType = compositeContentType.contentType;
 
             $scope.model.selectCompositeContentType(contentType).then(function (response) {
-                vm.loading = false;
+                vm.loadingAlias = null;
             });
 
             // Check if the template is already selected.

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.controller.js
@@ -64,24 +64,7 @@
             var contentType = compositeContentType.contentType;
 
             $scope.model.selectCompositeContentType(contentType).then(function (response) {
-
-                Utilities.forEach(vm.availableGroups, function (group) {
-
-                    Utilities.forEach(group.compositeContentTypes, function (obj) {
-                        if (obj.allowed === false) {
-                            obj.selected = false;
-                        }
-                    });
-                });
-
-                $timeout(function () {
-                    vm.loading = false;
-                }, 500);
-                
-            }, function () {
-                $timeout(function () {
-                    vm.loading = false;
-                }, 500);
+                vm.loading = false;
             });
 
             // Check if the template is already selected.

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -42,10 +42,6 @@
                         <localize key="contentTypeEditor_compositionInUse"></localize>
                     </umb-empty-state>
 
-                    <div ng-show="vm.loading" style="min-height: 20px; position: absolute; left: 0; right: 0; z-index: 1;">
-                        <umb-load-indicator></umb-load-indicator>
-                    </div>
-
                     <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1 && model.whereCompositionUsed.length > 0">
                         <h5><localize key="contentTypeEditor_compositionUsageHeading"></localize></h5>
                         <p><localize key="contentTypeEditor_compositionUsageSpecification"></localize></p>
@@ -74,12 +70,15 @@
                                     <umb-checkbox input-id="umb-overlay-comp-{{compositeContentType.contentType.key}}"
                                                   model="compositeContentType.selected"
                                                   on-change="vm.selectCompositeContentType(compositeContentType)"
-                                                  disabled="(compositeContentType.allowed === false && !compositeContentType.selected) || compositeContentType.inherited || vm.loading">
+                                                  disabled="(compositeContentType.allowed === false && !compositeContentType.selected) || compositeContentType.inherited || vm.loadingAlias">
                                     </umb-checkbox>
                                 </div>
 
                                 <label for="umb-overlay-comp-{{compositeContentType.contentType.key}}" class="umb-checkbox-list__item-text" ng-class="{'-faded': compositeContentType.allowed === false && !compositeContentType.selected}">
-                                    <i class="{{ compositeContentType.contentType.icon }} umb-checkbox-list__item-icon"></i>
+                                    <div class="umb-checkbox-list__item-icon-wrapper">
+                                        <i class="{{ compositeContentType.contentType.icon }} umb-checkbox-list__item-icon" ng-class="{'o-0': compositeContentType.contentType.alias === vm.loadingAlias}"></i>
+                                        <div ng-if="compositeContentType.contentType.alias === vm.loadingAlias" class="umb-button__progress -black umb-checkbox-list__item-checkbox-progress"></div>
+                                    </div>
                                     {{ compositeContentType.contentType.name }}
                                     <span class="umb-checkbox-list__item-caption" ng-if="compositeContentType.inherited">(inherited)</span>
                                 </label>

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -68,17 +68,17 @@
                             </li>
                             <li class="umb-checkbox-list__item"
                                 ng-repeat="compositeContentType in group.compositeContentTypes | orderBy:'contentType.name' | filter:searchTerm"
-                                ng-class="{'-disabled': compositeContentType.allowed === false || compositeContentType.inherited, '-selected': compositeContentType.selected}">
+                                ng-class="{'-disabled': (compositeContentType.allowed === false && !compositeContentType.selected) || compositeContentType.inherited, '-selected': compositeContentType.selected}">
 
                                 <div class="umb-checkbox-list__item-checkbox" ng-class="{'-selected': compositeContentType.selected }">
                                     <umb-checkbox input-id="umb-overlay-comp-{{compositeContentType.contentType.key}}"
                                                   model="compositeContentType.selected"
                                                   on-change="vm.selectCompositeContentType(compositeContentType)"
-                                                  disabled="compositeContentType.allowed === false || compositeContentType.inherited">
+                                                  disabled="(compositeContentType.allowed === false && !compositeContentType.selected) || compositeContentType.inherited || vm.loading">
                                     </umb-checkbox>
                                 </div>
 
-                                <label for="umb-overlay-comp-{{compositeContentType.contentType.key}}" class="umb-checkbox-list__item-text" ng-class="{'-faded': compositeContentType.allowed === false}">
+                                <label for="umb-overlay-comp-{{compositeContentType.contentType.key}}" class="umb-checkbox-list__item-text" ng-class="{'-faded': compositeContentType.allowed === false && !compositeContentType.selected}">
                                     <i class="{{ compositeContentType.contentType.icon }} umb-checkbox-list__item-icon"></i>
                                     {{ compositeContentType.contentType.name }}
                                     <span class="umb-checkbox-list__item-caption" ng-if="compositeContentType.inherited">(inherited)</span>


### PR DESCRIPTION
I have made a couple of updates with the PR to make sure that the following functionality works as expected:

- Disable checkboxes while loading a composition
- Disable and fade the doc types which are not allowed to be added
- Highlight the doc types that is selected

How to test:

1. Open an Umbraco with The Starter Kit installed
2. Create a new doctype
3. Add the Home doc type as a composition
4. Make sure you can't select the Product and Content Base doc types
5. Select any other doc type
6. Make sure the checkmark is still in the checkbox for both Home and the new doc type
7. Make sure you can still deselect both Home and the new doc type
8. Make sure you can't select or deselect any doc types while the overlay is loading

I have also moved the loading indicator. It is now next to the selected doc type. I think this gives a better understanding of what is going on.

https://user-images.githubusercontent.com/6078361/104335118-64cee980-54f3-11eb-8593-db6a6b7f2f1b.mp4

Fixes: #9432 
