### PR TITLE
Adding tests for routing

### DIFF
--- a/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Web.Routing
             }
 
             IPublishedContent node = null;
-            var path = frequest.Uri.GetAbsolutePathDecoded();
+            var path = frequest.AbsolutePathDecoded;
 
             var nodeId = -1;
 

--- a/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
@@ -51,8 +51,8 @@ namespace Umbraco.Web.Routing
             }
 
             var route = frequest.Domain != null
-                ? frequest.Domain.ContentId + DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.Uri.GetAbsolutePathDecoded())
-                : frequest.Uri.GetAbsolutePathDecoded();
+                ? frequest.Domain.ContentId + DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.AbsolutePathDecoded)
+                : frequest.AbsolutePathDecoded;
 
             IRedirectUrl redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(route, frequest.Culture);
 

--- a/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
@@ -44,11 +44,11 @@ namespace Umbraco.Web.Routing
             string route;
             if (frequest.Domain != null)
             {
-                route = frequest.Domain.ContentId + DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.Uri.GetAbsolutePathDecoded());
+                route = frequest.Domain.ContentId + DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.AbsolutePathDecoded);
             }
             else
             {
-                route = frequest.Uri.GetAbsolutePathDecoded();
+                route = frequest.AbsolutePathDecoded;
             }
 
             IPublishedContent node = FindContent(frequest, route);

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAlias.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAlias.cs
@@ -60,7 +60,7 @@ namespace Umbraco.Web.Routing
                     umbCtx.Content,
                     frequest.Domain != null ? frequest.Domain.ContentId : 0,
                     frequest.Culture,
-                    frequest.Uri.GetAbsolutePathDecoded());
+                    frequest.AbsolutePathDecoded);
 
                 if (node != null)
                 {

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Web.Routing
         /// <remarks>If successful, also assigns the template.</remarks>
         public override bool TryFindContent(IPublishedRequestBuilder frequest)
         {
-            var path = frequest.Uri.GetAbsolutePathDecoded();
+            var path = frequest.AbsolutePathDecoded;
 
             if (frequest.Domain != null)
             {

--- a/src/Umbraco.Core/Routing/DomainUtilities.cs
+++ b/src/Umbraco.Core/Routing/DomainUtilities.cs
@@ -364,9 +364,7 @@ namespace Umbraco.Web.Routing
         /// <returns>The path part relative to the uri of the domain.</returns>
         /// <remarks>Eg the relative part of <c>/foo/bar/nil</c> to domain <c>example.com/foo</c> is <c>/bar/nil</c>.</remarks>
         public static string PathRelativeToDomain(Uri domainUri, string path)
-        {
-            return path.Substring(domainUri.GetAbsolutePathDecoded().Length).EnsureStartsWith('/');
-        }
+            => path.Substring(domainUri.GetAbsolutePathDecoded().Length).EnsureStartsWith('/');
 
         #endregion
     }

--- a/src/Umbraco.Core/Routing/IPublishedRequest.cs
+++ b/src/Umbraco.Core/Routing/IPublishedRequest.cs
@@ -18,6 +18,11 @@ namespace Umbraco.Web.Routing
         Uri Uri { get; }
 
         /// <summary>
+        /// Gets the URI decoded absolute path of the <see cref="Uri"/>
+        /// </summary>
+        string AbsolutePathDecoded { get; }
+
+        /// <summary>
         /// Gets a value indicating the requested content.
         /// </summary>
         IPublishedContent PublishedContent { get; }

--- a/src/Umbraco.Core/Routing/IPublishedRequestBuilder.cs
+++ b/src/Umbraco.Core/Routing/IPublishedRequestBuilder.cs
@@ -19,6 +19,11 @@ namespace Umbraco.Web.Routing
         Uri Uri { get; }
 
         /// <summary>
+        /// Gets the decoded absolute path of the <see cref="Uri"/>
+        /// </summary>
+        string AbsolutePathDecoded { get; }
+
+        /// <summary>
         /// Gets the <see cref="DomainAndUri"/> assigned (if any)
         /// </summary>
         DomainAndUri Domain { get; }

--- a/src/Umbraco.Core/Routing/IPublishedRequestBuilder.cs
+++ b/src/Umbraco.Core/Routing/IPublishedRequestBuilder.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Web.Routing
         Uri Uri { get; }
 
         /// <summary>
-        /// Gets the decoded absolute path of the <see cref="Uri"/>
+        /// Gets the URI decoded absolute path of the <see cref="Uri"/>
         /// </summary>
         string AbsolutePathDecoded { get; }
 

--- a/src/Umbraco.Core/Routing/PublishedRequest.cs
+++ b/src/Umbraco.Core/Routing/PublishedRequest.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 
@@ -13,10 +11,10 @@ namespace Umbraco.Web.Routing
         /// <summary>
         /// Initializes a new instance of the <see cref="PublishedRequest"/> class.
         /// </summary>
-        public PublishedRequest(Uri uri, string absPathDecoded, IPublishedContent publishedContent, bool isInternalRedirect, ITemplate template, DomainAndUri domain, string culture, string redirectUrl, int? responseStatusCode, IReadOnlyList<string> cacheExtensions, IReadOnlyDictionary<string, string> headers, bool setNoCacheHeader, bool ignorePublishedContentCollisions)
+        public PublishedRequest(Uri uri, string absolutePathDecoded, IPublishedContent publishedContent, bool isInternalRedirect, ITemplate template, DomainAndUri domain, string culture, string redirectUrl, int? responseStatusCode, IReadOnlyList<string> cacheExtensions, IReadOnlyDictionary<string, string> headers, bool setNoCacheHeader, bool ignorePublishedContentCollisions)
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
-            AbsolutePathDecoded = absPathDecoded ?? throw new ArgumentNullException(nameof(absPathDecoded));
+            AbsolutePathDecoded = absolutePathDecoded ?? throw new ArgumentNullException(nameof(absolutePathDecoded));
             PublishedContent = publishedContent;
             IsInternalRedirect = isInternalRedirect;
             Template = template;

--- a/src/Umbraco.Core/Routing/PublishedRequest.cs
+++ b/src/Umbraco.Core/Routing/PublishedRequest.cs
@@ -13,9 +13,10 @@ namespace Umbraco.Web.Routing
         /// <summary>
         /// Initializes a new instance of the <see cref="PublishedRequest"/> class.
         /// </summary>
-        public PublishedRequest(Uri uri, IPublishedContent publishedContent, bool isInternalRedirect, ITemplate template, DomainAndUri domain, string culture, string redirectUrl, int? responseStatusCode, IReadOnlyList<string> cacheExtensions, IReadOnlyDictionary<string, string> headers, bool setNoCacheHeader, bool ignorePublishedContentCollisions)
+        public PublishedRequest(Uri uri, string absPathDecoded, IPublishedContent publishedContent, bool isInternalRedirect, ITemplate template, DomainAndUri domain, string culture, string redirectUrl, int? responseStatusCode, IReadOnlyList<string> cacheExtensions, IReadOnlyDictionary<string, string> headers, bool setNoCacheHeader, bool ignorePublishedContentCollisions)
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            AbsolutePathDecoded = absPathDecoded ?? throw new ArgumentNullException(nameof(absPathDecoded));
             PublishedContent = publishedContent;
             IsInternalRedirect = isInternalRedirect;
             Template = template;
@@ -31,6 +32,9 @@ namespace Umbraco.Web.Routing
 
         /// <inheritdoc/>
         public Uri Uri { get; }
+
+        /// <inheritdoc/>
+        public string AbsolutePathDecoded { get; }
 
         /// <inheritdoc/>
         public bool IgnorePublishedContentCollisions { get; }

--- a/src/Umbraco.Core/Routing/PublishedRequestBuilder.cs
+++ b/src/Umbraco.Core/Routing/PublishedRequestBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
@@ -26,11 +27,15 @@ namespace Umbraco.Web.Routing
         public PublishedRequestBuilder(Uri uri, IFileService fileService)
         {
             Uri = uri;
+            AbsolutePathDecoded = uri.GetAbsolutePathDecoded();
             _fileService = fileService;
         }
 
         /// <inheritdoc/>
         public Uri Uri { get; }
+
+        /// <inheritdoc/>
+        public string AbsolutePathDecoded { get; }
 
         /// <inheritdoc/>
         public DomainAndUri Domain { get; private set; }

--- a/src/Umbraco.Core/Routing/PublishedRequestBuilder.cs
+++ b/src/Umbraco.Core/Routing/PublishedRequestBuilder.cs
@@ -67,6 +67,7 @@ namespace Umbraco.Web.Routing
         /// <inheritdoc/>
         public IPublishedRequest Build() => new PublishedRequest(
                 Uri,
+                AbsolutePathDecoded,
                 PublishedContent,
                 IsInternalRedirect,
                 Template,

--- a/src/Umbraco.Core/Routing/UriUtility.cs
+++ b/src/Umbraco.Core/Routing/UriUtility.cs
@@ -55,9 +55,15 @@ namespace Umbraco.Web
         {
             if (virtualPath.InvariantStartsWith(_appPathPrefix)
                     && (virtualPath.Length == _appPathPrefix.Length || virtualPath[_appPathPrefix.Length] == '/'))
+            {
                 virtualPath = virtualPath.Substring(_appPathPrefix.Length);
+            }
+
             if (virtualPath.Length == 0)
+            {
                 virtualPath = "/";
+            }
+
             return virtualPath;
         }
 
@@ -88,9 +94,8 @@ namespace Umbraco.Web
         // ie no virtual directory, no .aspx, lowercase...
         public Uri UriToUmbraco(Uri uri)
         {
-            // TODO: Ideally we do this witout so many string allocations, we can use
-            // techniques like StringSegment and Span. This is critical code that executes on every request.
-            // not really sure we need ToLower.
+            // TODO: This is critical code that executes on every request, we should
+            // look into if all of this is necessary? not really sure we need ToLower?
 
             // note: no need to decode uri here because we're returning a uri
             // so it will be re-encoded anyway

--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -67,6 +67,8 @@ namespace Umbraco.Core
 
             // cannot get .AbsolutePath on relative uri (InvalidOperation)
             var s = uri.OriginalString;
+
+            // TODO: Shouldn't this just use Uri.GetLeftPart?
             var posq = s.IndexOf("?", StringComparison.Ordinal);
             var posf = s.IndexOf("#", StringComparison.Ordinal);
             var pos = posq > 0 ? posq : (posf > 0 ? posf : 0);

--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -61,7 +61,9 @@ namespace Umbraco.Core
         public static string GetSafeAbsolutePath(this Uri uri)
         {
             if (uri.IsAbsoluteUri)
+            {
                 return uri.AbsolutePath;
+            }
 
             // cannot get .AbsolutePath on relative uri (InvalidOperation)
             var s = uri.OriginalString;

--- a/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
+++ b/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Web.Routing
             }
             else
             {
-                var route = frequest.Uri.GetAbsolutePathDecoded();
+                var route = frequest.AbsolutePathDecoded;
                 var pos = route.LastIndexOf('/');
                 IPublishedContent node = null;
                 while (pos > 1)

--- a/src/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
+++ b/src/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MiniProfiler.AspNetCore" Version="4.2.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.14.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
   </ItemGroup>
 

--- a/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -59,7 +59,7 @@
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="Moq" Version="4.14.6" />
+        <PackageReference Include="Moq" Version="4.15.2" />
         <PackageReference Include="nunit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UriUtilityTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UriUtilityTests.cs
@@ -23,28 +23,12 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Core.Routing
         [TestCase("http://LocalHost/Home/Sub1", "http://localhost/home/sub1")]
         [TestCase("http://LocalHost/Home/Sub1?x=y", "http://localhost/home/sub1?x=y")]
 
-        // same with .aspx
-        [TestCase("http://LocalHost/Home.aspx", "http://localhost/home")]
-        [TestCase("http://LocalHost/Home.aspx?x=y", "http://localhost/home?x=y")]
-        [TestCase("http://LocalHost/Home/Sub1.aspx", "http://localhost/home/sub1")]
-        [TestCase("http://LocalHost/Home/Sub1.aspx?x=y", "http://localhost/home/sub1?x=y")]
-
         // test that the trailing slash goes but not on hostname
         [TestCase("http://LocalHost/", "http://localhost/")]
         [TestCase("http://LocalHost/Home/", "http://localhost/home")]
         [TestCase("http://LocalHost/Home/?x=y", "http://localhost/home?x=y")]
         [TestCase("http://LocalHost/Home/Sub1/", "http://localhost/home/sub1")]
         [TestCase("http://LocalHost/Home/Sub1/?x=y", "http://localhost/home/sub1?x=y")]
-
-        // test that default.aspx goes, even with parameters
-        [TestCase("http://LocalHost/deFault.aspx", "http://localhost/")]
-        [TestCase("http://LocalHost/deFault.aspx?x=y", "http://localhost/?x=y")]
-
-        // test with inner .aspx
-        [TestCase("http://Localhost/Home/Sub1.aspx/Sub2", "http://localhost/home/sub1/sub2")]
-        [TestCase("http://Localhost/Home/Sub1.aspx/Sub2?x=y", "http://localhost/home/sub1/sub2?x=y")]
-        [TestCase("http://Localhost/Home.aspx/Sub1.aspx/Sub2?x=y", "http://localhost/home/sub1/sub2?x=y")]
-        [TestCase("http://Localhost/deFault.aspx/Home.aspx/deFault.aspx/Sub1.aspx", "http://localhost/home/default/sub1")]
         public void Uri_To_Umbraco(string sourceUrl, string expectedUrl)
         {
             // Arrange

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/HijackedRouteEvaluatorTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/HijackedRouteEvaluatorTests.cs
@@ -79,13 +79,13 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
         }
 
         [TestCase("Index", "RenderNotFound", null, false)]
-        [TestCase("index", "Render", "Index", true)]
-        [TestCase("Index", "Render1", "Index", true)]
-        [TestCase("Index", "render2", "Index", true)]
-        [TestCase("NotFound", "Render", "Index", true)]
-        [TestCase("NotFound", "Render1", "Index", true)]
-        [TestCase("NotFound", "Render2", "Index", true)]
-        [TestCase("Custom", "Render1", "Custom", true)]
+        [TestCase("index", "Render", nameof(RenderController.Index), true)]
+        [TestCase("Index", "Render1", nameof(RenderController.Index), true)]
+        [TestCase("Index", "render2", nameof(Render2Controller.Index), true)]
+        [TestCase("NotFound", "Render", nameof(RenderController.Index), true)]
+        [TestCase("NotFound", "Render1", nameof(Render1Controller.Index), true)]
+        [TestCase("NotFound", "Render2", nameof(Render2Controller.Index), true)]
+        [TestCase("Custom", "Render1", nameof(Render1Controller.Custom), true)]
         public void Matches_Controller(string action, string controller, string resultAction, bool matches)
         {
             var evaluator = new HijackedRouteEvaluator(

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/HijackedRouteEvaluatorTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/HijackedRouteEvaluatorTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Extensions;
+using Umbraco.Web;
+using Umbraco.Web.Common.Controllers;
+using Umbraco.Web.Website.Routing;
+
+namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
+{
+    [TestFixture]
+    public class HijackedRouteEvaluatorTests
+    {
+        private class TestActionDescriptorCollectionProvider : ActionDescriptorCollectionProvider
+        {
+            private readonly IEnumerable<ActionDescriptor> _actions;
+
+            public TestActionDescriptorCollectionProvider(IEnumerable<ActionDescriptor> actions) => _actions = actions;
+
+            public override ActionDescriptorCollection ActionDescriptors => new ActionDescriptorCollection(_actions.ToList(), 1);
+
+            public override IChangeToken GetChangeToken() => NullChangeToken.Singleton;
+        }
+
+        private IActionDescriptorCollectionProvider GetActionDescriptors() => new TestActionDescriptorCollectionProvider(
+            new ActionDescriptor[]
+            {
+                new ControllerActionDescriptor
+                {
+                    ActionName = "Index",
+                    ControllerName = ControllerExtensions.GetControllerName<RenderController>(),
+                    ControllerTypeInfo = typeof(RenderController).GetTypeInfo()
+                },
+                new ControllerActionDescriptor
+                {
+                    ActionName = "Index",
+                    ControllerName = ControllerExtensions.GetControllerName<Render1Controller>(),
+                    ControllerTypeInfo = typeof(Render1Controller).GetTypeInfo()
+                },
+                new ControllerActionDescriptor
+                {
+                    ActionName = "Index",
+                    ControllerName = ControllerExtensions.GetControllerName<Render2Controller>(),
+                    ControllerTypeInfo = typeof(Render2Controller).GetTypeInfo()
+                }
+            });
+
+        private class Render1Controller : ControllerBase, IRenderController
+        {
+            public IActionResult Index => Content("hello world");
+        }
+
+        private class Render2Controller : RenderController
+        {
+            public Render2Controller(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor)
+                : base(logger, compositeViewEngine, umbracoContextAccessor)
+            {
+            }
+        }
+
+        [TestCase("index", "Render", "Index", true)]
+        [TestCase("Index", "Render1", "Index", true)]
+        [TestCase("Index", "render2", "Index", true)]
+        [TestCase("NotFound", "Render", "Index", true)]
+        [TestCase("NotFound", "Render1", "Index", true)]
+        [TestCase("NotFound", "Render2", "Index", true)]
+        public void Matches_Controller(string action, string controller, string resultAction, bool matches)
+        {
+            var evaluator = new HijackedRouteEvaluator(
+                new NullLogger<HijackedRouteEvaluator>(),
+                GetActionDescriptors());
+
+            HijackedRouteResult result = evaluator.Evaluate(controller, action);
+            Assert.AreEqual(matches, result.Success);
+            if (matches)
+            {
+                Assert.IsTrue(result.ActionName.InvariantEquals(resultAction), "expected {0} does not match resulting action {1}", resultAction, result.ActionName);
+                Assert.IsTrue(result.ControllerName.InvariantEquals(controller), "expected {0} does not match resulting controller {1}", controller, result.ControllerName);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/HijackedRouteEvaluatorTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/HijackedRouteEvaluatorTests.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -21,6 +19,7 @@ using Umbraco.Web.Website.Routing;
 
 namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
 {
+
     [TestFixture]
     public class HijackedRouteEvaluatorTests
     {
@@ -52,6 +51,12 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
                 },
                 new ControllerActionDescriptor
                 {
+                    ActionName = "Custom",
+                    ControllerName = ControllerExtensions.GetControllerName<Render1Controller>(),
+                    ControllerTypeInfo = typeof(Render1Controller).GetTypeInfo()
+                },
+                new ControllerActionDescriptor
+                {
                     ActionName = "Index",
                     ControllerName = ControllerExtensions.GetControllerName<Render2Controller>(),
                     ControllerTypeInfo = typeof(Render2Controller).GetTypeInfo()
@@ -61,6 +66,8 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
         private class Render1Controller : ControllerBase, IRenderController
         {
             public IActionResult Index => Content("hello world");
+
+            public IActionResult Custom => Content("hello world");
         }
 
         private class Render2Controller : RenderController
@@ -71,12 +78,14 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
             }
         }
 
+        [TestCase("Index", "RenderNotFound", null, false)]
         [TestCase("index", "Render", "Index", true)]
         [TestCase("Index", "Render1", "Index", true)]
         [TestCase("Index", "render2", "Index", true)]
         [TestCase("NotFound", "Render", "Index", true)]
         [TestCase("NotFound", "Render1", "Index", true)]
         [TestCase("NotFound", "Render2", "Index", true)]
+        [TestCase("Custom", "Render1", "Custom", true)]
         public void Matches_Controller(string action, string controller, string resultAction, bool matches)
         {
             var evaluator = new HijackedRouteEvaluator(

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
@@ -10,7 +10,6 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Core;
 using Umbraco.Core.Configuration.Models;
-using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Web;
@@ -84,7 +83,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
         public async Task Noop_When_Runtime_Level_Not_Run()
         {
             UmbracoRouteValueTransformer transformer = GetTransformer(
-                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == null),
+                Mock.Of<IUmbracoContextAccessor>(),
                 Mock.Of<IRuntimeState>());
 
             RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
@@ -95,7 +94,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
         public async Task Noop_When_No_Umbraco_Context()
         {
             UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
-                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == null));
+                Mock.Of<IUmbracoContextAccessor>());
 
             RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
             Assert.AreEqual(0, result.Count);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Core.Configuration.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+using Umbraco.Tests.TestHelpers;
+using Umbraco.Web;
+using Umbraco.Web.Common.Controllers;
+using Umbraco.Web.Common.Routing;
+using Umbraco.Web.PublishedCache;
+using Umbraco.Web.Routing;
+using Umbraco.Web.Website.Controllers;
+using Umbraco.Web.Website.Routing;
+
+namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
+{
+    [TestFixture]
+    public class UmbracoRouteValueTransformerTests
+    {
+        private IOptions<GlobalSettings> GetGlobalSettings() => Options.Create(new GlobalSettings());
+
+        private UmbracoRouteValueTransformer GetTransformerWithRunState(
+            IUmbracoContextAccessor ctx,
+            IRoutableDocumentFilter filter = null,
+            IPublishedRouter router = null,
+            IUmbracoRouteValuesFactory routeValuesFactory = null)
+            => GetTransformer(ctx, Mock.Of<IRuntimeState>(x => x.Level == RuntimeLevel.Run), filter, router, routeValuesFactory);
+
+        private UmbracoRouteValueTransformer GetTransformer(
+            IUmbracoContextAccessor ctx,
+            IRuntimeState state,
+            IRoutableDocumentFilter filter = null,
+            IPublishedRouter router = null,
+            IUmbracoRouteValuesFactory routeValuesFactory = null)
+        {
+            var transformer = new UmbracoRouteValueTransformer(
+                new NullLogger<UmbracoRouteValueTransformer>(),
+                ctx,
+                router ?? Mock.Of<IPublishedRouter>(),
+                GetGlobalSettings(),
+                TestHelper.GetHostingEnvironment(),
+                state,
+                routeValuesFactory ?? Mock.Of<IUmbracoRouteValuesFactory>(),
+                filter ?? Mock.Of<IRoutableDocumentFilter>(x => x.IsDocumentRequest(It.IsAny<string>()) == true));
+
+            return transformer;
+        }
+
+        private IUmbracoContext GetUmbracoContext(bool hasContent)
+        {
+            IPublishedContentCache publishedContent = Mock.Of<IPublishedContentCache>(x => x.HasContent() == hasContent);
+            var uri = new Uri("http://example.com");
+
+            IUmbracoContext umbracoContext = Mock.Of<IUmbracoContext>(x =>
+                x.Content == publishedContent
+                && x.OriginalRequestUrl == uri
+                && x.CleanedUmbracoUrl == uri);
+
+            return umbracoContext;
+        }
+
+        private UmbracoRouteValues GetRouteValues(IPublishedRequest request)
+            => new UmbracoRouteValues(
+                request,
+                ControllerExtensions.GetControllerName<TestController>(),
+                typeof(TestController));
+
+        private IUmbracoRouteValuesFactory GetRouteValuesFactory(IPublishedRequest request)
+            => Mock.Of<IUmbracoRouteValuesFactory>(x => x.Create(It.IsAny<HttpContext>(), It.IsAny<RouteValueDictionary>(), It.IsAny<IPublishedRequest>()) == GetRouteValues(request));
+
+        private IPublishedRouter GetRouter(IPublishedRequest request)
+            => Mock.Of<IPublishedRouter>(x => x.RouteRequestAsync(It.IsAny<IPublishedRequestBuilder>(), It.IsAny<RouteRequestOptions>()) == Task.FromResult(request));
+
+        [Test]
+        public async Task Noop_When_Runtime_Level_Not_Run()
+        {
+            UmbracoRouteValueTransformer transformer = GetTransformer(
+                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == null),
+                Mock.Of<IRuntimeState>());
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task Noop_When_No_Umbraco_Context()
+        {
+            UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
+                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == null));
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task Noop_When_Not_Document_Request()
+        {
+            UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
+                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == Mock.Of<IUmbracoContext>()),
+                Mock.Of<IRoutableDocumentFilter>(x => x.IsDocumentRequest(It.IsAny<string>()) == false));
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task NoContentController_Values_When_No_Content()
+        {
+            IUmbracoContext umbracoContext = GetUmbracoContext(false);
+
+            UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
+                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == umbracoContext));
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(ControllerExtensions.GetControllerName<RenderNoContentController>(), result["controller"]);
+            Assert.AreEqual(nameof(RenderNoContentController.Index), result["action"]);
+        }
+
+        [Test]
+        public async Task Assigns_PublishedRequest_To_UmbracoContext()
+        {
+            IUmbracoContext umbracoContext = GetUmbracoContext(true);
+            IPublishedRequest request = Mock.Of<IPublishedRequest>();
+
+            UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
+                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == umbracoContext),
+                router: GetRouter(request),
+                routeValuesFactory: GetRouteValuesFactory(request));
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+            Assert.AreEqual(request, umbracoContext.PublishedRequest);
+        }
+
+        [Test]
+        public async Task Assigns_Values_To_RouteValueDictionary()
+        {
+            IUmbracoContext umbracoContext = GetUmbracoContext(true);
+            IPublishedRequest request = Mock.Of<IPublishedRequest>();
+            UmbracoRouteValues routeValues = GetRouteValues(request);
+
+            UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
+                Mock.Of<IUmbracoContextAccessor>(x => x.UmbracoContext == umbracoContext),
+                router: GetRouter(request),
+                routeValuesFactory: GetRouteValuesFactory(request));
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+
+            Assert.AreEqual(routeValues.ControllerName, result["controller"]);
+            Assert.AreEqual(routeValues.ActionName, result["action"]);
+        }
+
+        private class TestController : RenderController
+        {
+            public TestController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor)
+                : base(logger, compositeViewEngine, umbracoContextAccessor)
+            {
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactoryTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactoryTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Services;
+using Umbraco.Core.Strings;
+using Umbraco.Web.Common.Routing;
+using Umbraco.Web.Features;
+using Umbraco.Web.Routing;
+using Umbraco.Web.Website.Controllers;
+using Umbraco.Web.Website.Routing;
+
+namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
+{
+    [TestFixture]
+    public class UmbracoRouteValuesFactoryTests
+    {
+        private UmbracoRouteValuesFactory GetFactory(IPublishedRouter router, out UmbracoRenderingDefaults renderingDefaults)
+        {
+            var builder = new PublishedRequestBuilder(new Uri("https://example.com"), Mock.Of<IFileService>());
+            builder.SetPublishedContent(Mock.Of<IPublishedContent>());
+            IPublishedRequest request = builder.Build();
+
+            var publishedRouter = new Mock<IPublishedRouter>();
+            publishedRouter.Setup(x => x.UpdateRequestToNotFound(It.IsAny<IPublishedRequest>()))
+                .Returns((IPublishedRequest r) => builder)
+                .Verifiable();
+
+            renderingDefaults = new UmbracoRenderingDefaults();
+
+            var factory = new UmbracoRouteValuesFactory(
+                renderingDefaults,
+                Mock.Of<IShortStringHelper>(),
+                new UmbracoFeatures(),
+                new HijackedRouteEvaluator(
+                    new NullLogger<HijackedRouteEvaluator>(),
+                    Mock.Of<IActionDescriptorCollectionProvider>()),
+                publishedRouter.Object);
+
+            return factory;
+        }
+
+        [Test]
+        public void Update_Request_To_Not_Found_When_No_Template()
+        {
+            var builder = new PublishedRequestBuilder(new Uri("https://example.com"), Mock.Of<IFileService>());
+            builder.SetPublishedContent(Mock.Of<IPublishedContent>());
+            IPublishedRequest request = builder.Build();
+
+            var publishedRouter = new Mock<IPublishedRouter>();
+            publishedRouter.Setup(x => x.UpdateRequestToNotFound(It.IsAny<IPublishedRequest>()))
+                .Returns((IPublishedRequest r) => builder)
+                .Verifiable();
+
+            UmbracoRouteValuesFactory factory = GetFactory(publishedRouter.Object, out _);
+
+            UmbracoRouteValues result = factory.Create(new DefaultHttpContext(), new RouteValueDictionary(), request);
+
+            // The request has content, no template, no hijacked route and no disabled template features so UpdateRequestToNotFound will be called
+            publishedRouter.Verify(m => m.UpdateRequestToNotFound(It.IsAny<IPublishedRequest>()), Times.Once);
+        }
+
+        [Test]
+        public void Adds_Result_To_Route_Value_Dictionary()
+        {
+            var builder = new PublishedRequestBuilder(new Uri("https://example.com"), Mock.Of<IFileService>());
+            builder.SetPublishedContent(Mock.Of<IPublishedContent>());
+            builder.SetTemplate(Mock.Of<ITemplate>());
+            IPublishedRequest request = builder.Build();
+
+            UmbracoRouteValuesFactory factory = GetFactory(Mock.Of<IPublishedRouter>(), out UmbracoRenderingDefaults renderingDefaults);
+
+            var routeVals = new RouteValueDictionary();
+            UmbracoRouteValues result = factory.Create(new DefaultHttpContext(), routeVals, request);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(routeVals.ContainsKey(Constants.Web.UmbracoRouteDefinitionDataToken));
+            Assert.AreEqual(result, routeVals[Constants.Web.UmbracoRouteDefinitionDataToken]);
+            Assert.AreEqual(renderingDefaults.DefaultControllerType, result.ControllerType);
+            Assert.AreEqual(UmbracoRouteValues.DefaultActionName, result.ActionName);
+            Assert.IsNull(result.TemplateName);
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactoryTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Routing;
@@ -18,16 +18,17 @@ using Umbraco.Web.Website.Routing;
 
 namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
 {
+
     [TestFixture]
     public class UmbracoRouteValuesFactoryTests
     {
-        private UmbracoRouteValuesFactory GetFactory(IPublishedRouter router, out UmbracoRenderingDefaults renderingDefaults)
+        private UmbracoRouteValuesFactory GetFactory(out Mock<IPublishedRouter> publishedRouter, out UmbracoRenderingDefaults renderingDefaults)
         {
             var builder = new PublishedRequestBuilder(new Uri("https://example.com"), Mock.Of<IFileService>());
             builder.SetPublishedContent(Mock.Of<IPublishedContent>());
             IPublishedRequest request = builder.Build();
 
-            var publishedRouter = new Mock<IPublishedRouter>();
+            publishedRouter = new Mock<IPublishedRouter>();
             publishedRouter.Setup(x => x.UpdateRequestToNotFound(It.IsAny<IPublishedRequest>()))
                 .Returns((IPublishedRequest r) => builder)
                 .Verifiable();
@@ -53,12 +54,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
             builder.SetPublishedContent(Mock.Of<IPublishedContent>());
             IPublishedRequest request = builder.Build();
 
-            var publishedRouter = new Mock<IPublishedRouter>();
-            publishedRouter.Setup(x => x.UpdateRequestToNotFound(It.IsAny<IPublishedRequest>()))
-                .Returns((IPublishedRequest r) => builder)
-                .Verifiable();
-
-            UmbracoRouteValuesFactory factory = GetFactory(publishedRouter.Object, out _);
+            UmbracoRouteValuesFactory factory = GetFactory(out Mock<IPublishedRouter> publishedRouter, out _);
 
             UmbracoRouteValues result = factory.Create(new DefaultHttpContext(), new RouteValueDictionary(), request);
 
@@ -74,7 +70,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Website.Routing
             builder.SetTemplate(Mock.Of<ITemplate>());
             IPublishedRequest request = builder.Build();
 
-            UmbracoRouteValuesFactory factory = GetFactory(Mock.Of<IPublishedRouter>(), out UmbracoRenderingDefaults renderingDefaults);
+            UmbracoRouteValuesFactory factory = GetFactory(out _, out UmbracoRenderingDefaults renderingDefaults);
 
             var routeVals = new RouteValueDictionary();
             UmbracoRouteValues result = factory.Create(new DefaultHttpContext(), routeVals, request);

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -112,7 +112,7 @@
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.1.1" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
     <PackageReference Include="MiniProfiler" Version="4.2.1" />
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NPoco" Version="4.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
@@ -307,7 +307,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="IO" />
+    <Folder Include="IO\" />
   </ItemGroup>
   <!-- get NuGet packages directory -->
   <PropertyGroup>

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -61,7 +61,7 @@ namespace Umbraco.Web.Common.AspNetCore
 
         public Uri GetApplicationUrl()
         {
-            //Fixme: This causes problems with site swap on azure because azure pre-warms a site by calling into `localhost` and when it does that
+            // Fixme: This causes problems with site swap on azure because azure pre-warms a site by calling into `localhost` and when it does that
             // it changes the URL to `localhost:80` which actually doesn't work for pinging itself, it only works internally in Azure. The ironic part
             // about this is that this is here specifically for the slot swap scenario https://issues.umbraco.org/issue/U4-10626
 

--- a/src/Umbraco.Web.Common/Localization/UmbracoBackOfficeIdentityCultureProvider.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoBackOfficeIdentityCultureProvider.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Web.Common.Localization
     public class UmbracoBackOfficeIdentityCultureProvider : RequestCultureProvider
     {
         private readonly RequestLocalizationOptions _localizationOptions;
+        private readonly object _locker = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoBackOfficeIdentityCultureProvider"/> class.
@@ -31,18 +32,21 @@ namespace Umbraco.Web.Common.Localization
                 return NullProviderCultureResult;
             }
 
-            // We need to dynamically change the supported cultures since we won't ever know what languages are used since
-            // they are dynamic within Umbraco.
-            var cultureExists = _localizationOptions.SupportedCultures.Contains(culture);
-
-            if (!cultureExists)
+            lock(_locker)
             {
-                // add this as a supporting culture
-                _localizationOptions.SupportedCultures.Add(culture);
-                _localizationOptions.SupportedUICultures.Add(culture);
-            }
+                // We need to dynamically change the supported cultures since we won't ever know what languages are used since
+                // they are dynamic within Umbraco.
+                var cultureExists = _localizationOptions.SupportedCultures.Contains(culture);
 
-            return Task.FromResult(new ProviderCultureResult(culture.Name));
+                if (!cultureExists)
+                {
+                    // add this as a supporting culture
+                    _localizationOptions.SupportedCultures.Add(culture);
+                    _localizationOptions.SupportedUICultures.Add(culture);
+                }
+
+                return Task.FromResult(new ProviderCultureResult(culture.Name));
+            }
         }
     }
 }

--- a/src/Umbraco.Web.Common/Localization/UmbracoPublishedContentCultureProvider.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoPublishedContentCultureProvider.cs
@@ -19,6 +19,7 @@ namespace Umbraco.Web.Common.Localization
     public class UmbracoPublishedContentCultureProvider : RequestCultureProvider
     {
         private readonly RequestLocalizationOptions _localizationOptions;
+        private readonly object _locker = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoPublishedContentCultureProvider"/> class.
@@ -33,19 +34,22 @@ namespace Umbraco.Web.Common.Localization
                 string culture = routeValues.PublishedRequest?.Culture;
                 if (culture != null)
                 {
-                    // We need to dynamically change the supported cultures since we won't ever know what languages are used since
-                    // they are dynamic within Umbraco.
-                    // This code to check existence is borrowed from aspnetcore to avoid creating a CultureInfo
-                    // https://github.com/dotnet/aspnetcore/blob/b795ac3546eb3e2f47a01a64feb3020794ca33bb/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs#L165
-                    CultureInfo existingCulture = _localizationOptions.SupportedCultures.FirstOrDefault(supportedCulture =>
-                        StringSegment.Equals(supportedCulture.Name, culture, StringComparison.OrdinalIgnoreCase));
-
-                    if (existingCulture == null)
+                    lock (_locker)
                     {
-                        // add this as a supporting culture
-                        var ci = CultureInfo.GetCultureInfo(culture);
-                        _localizationOptions.SupportedCultures.Add(ci);
-                        _localizationOptions.SupportedUICultures.Add(ci);
+                        // We need to dynamically change the supported cultures since we won't ever know what languages are used since
+                        // they are dynamic within Umbraco.
+                        // This code to check existence is borrowed from aspnetcore to avoid creating a CultureInfo
+                        // https://github.com/dotnet/aspnetcore/blob/b795ac3546eb3e2f47a01a64feb3020794ca33bb/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs#L165
+                        CultureInfo existingCulture = _localizationOptions.SupportedCultures.FirstOrDefault(supportedCulture =>
+                            StringSegment.Equals(supportedCulture.Name, culture, StringComparison.OrdinalIgnoreCase));
+
+                        if (existingCulture == null)
+                        {
+                            // add this as a supporting culture
+                            var ci = CultureInfo.GetCultureInfo(culture);
+                            _localizationOptions.SupportedCultures.Add(ci);
+                            _localizationOptions.SupportedUICultures.Add(ci);
+                        }
                     }
 
                     return Task.FromResult(new ProviderCultureResult(culture));

--- a/src/Umbraco.Web.Common/Routing/IRoutableDocumentFilter.cs
+++ b/src/Umbraco.Web.Common/Routing/IRoutableDocumentFilter.cs
@@ -1,0 +1,7 @@
+﻿namespace Umbraco.Web.Common.Routing
+{
+    public interface IRoutableDocumentFilter
+    {
+        bool IsDocumentRequest(string absPath);
+    }
+}

--- a/src/Umbraco.Web.Common/Routing/RoutableDocumentFilter.cs
+++ b/src/Umbraco.Web.Common/Routing/RoutableDocumentFilter.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Web.Common.Routing
     /// <remarks>
     /// There are various checks to determine if this is a front-end request such as checking if the request is part of any reserved paths or existing MVC routes.
     /// </remarks>
-    public sealed class RoutableDocumentFilter
+    public sealed class RoutableDocumentFilter : IRoutableDocumentFilter
     {
         private readonly ConcurrentDictionary<string, bool> _routeChecks = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private readonly GlobalSettings _globalSettings;

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Web.Website.DependencyInjection
             builder.Services.AddSingleton<HijackedRouteEvaluator>();
             builder.Services.AddSingleton<IUmbracoRouteValuesFactory, UmbracoRouteValuesFactory>();
             builder.Services.AddSingleton<IUmbracoRenderingDefaults, UmbracoRenderingDefaults>();
-            builder.Services.AddSingleton<RoutableDocumentFilter>();
+            builder.Services.AddSingleton<IRoutableDocumentFilter, RoutableDocumentFilter>();
 
             builder.AddDistributedCache();
 

--- a/src/Umbraco.Web.Website/Routing/HijackedRouteEvaluator.cs
+++ b/src/Umbraco.Web.Website/Routing/HijackedRouteEvaluator.cs
@@ -50,14 +50,22 @@ namespace Umbraco.Web.Website.Routing
                     && TypeHelper.IsTypeAssignableFrom<ControllerBase>(controllerDescriptor.ControllerTypeInfo))
                 {
                     // now check if the custom action matches
-                    var customActionExists = action != null && customControllerCandidates.Any(x => x.ActionName.InvariantEquals(action));
+                    var resultingAction = DefaultActionName;
+                    if (action != null)
+                    {
+                        var found = customControllerCandidates.FirstOrDefault(x => x.ActionName.InvariantEquals(action))?.ActionName;
+                        if (found != null)
+                        {
+                            resultingAction = found;
+                        }
+                    }
 
                     // it's a hijacked route with a custom controller, so return the the values
                     return new HijackedRouteResult(
                         true,
                         controllerDescriptor.ControllerName,
                         controllerDescriptor.ControllerTypeInfo,
-                        customActionExists ? action : DefaultActionName);
+                        resultingAction);
                 }
                 else
                 {

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactory.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactory.cs
@@ -103,7 +103,7 @@ namespace Umbraco.Web.Website.Routing
         {
             IPublishedRequest request = def.PublishedRequest;
 
-            var customControllerName = request.PublishedContent?.ContentType.Alias;
+            var customControllerName = request.PublishedContent?.ContentType?.Alias;
             if (customControllerName != null)
             {
                 HijackedRouteResult hijackedResult = _hijackedRouteEvaluator.Evaluate(customControllerName, def.TemplateName);
@@ -144,6 +144,12 @@ namespace Umbraco.Web.Website.Routing
                 // We then need to re-run this through the pipeline for the last
                 // chance finders to work.
                 IPublishedRequestBuilder builder = _publishedRouter.UpdateRequestToNotFound(request);
+
+                if (builder == null)
+                {
+                    throw new InvalidOperationException($"The call to {nameof(IPublishedRouter.UpdateRequestToNotFound)} cannot return null");
+                }
+
                 request = builder.Build();
 
                 def = new UmbracoRouteValues(

--- a/src/Umbraco.Web/UmbracoContext.cs
+++ b/src/Umbraco.Web/UmbracoContext.cs
@@ -62,7 +62,6 @@ namespace Umbraco.Web
             // 'could' still generate URLs during startup BUT any domain driven URL generation will not work because it is NOT possible to get
             // the current domain during application startup.
             // see: http://issues.umbraco.org/issue/U4-1890
-            //
             OriginalRequestUrl = GetRequestFromContext()?.Url ?? new Uri("http://localhost");
             CleanedUmbracoUrl = uriUtility.UriToUmbraco(OriginalRequestUrl);
         }


### PR DESCRIPTION
* less allocations with AbsolutePathDecoded as part of IPublishedRequestBuilder/IPublishedRequest so that content finders don't have to continuously re-allocate new strings by calling `Uri.GetAbsolutePathDecoded()`
* less allocations in UmbracoContext to lazily allocate the cleaned up URI strings (only when needed)
* removes more aspx checks
* adds interface for IRoutableDocumentFilter
* adds tests for UmbracoRouteValueTransformer
* adds tests for HijackedRouteEvaluator
* adds tests for UmbracoRouteValuesFactoryTests