### PR TITLE
fix history box label, destructure localization response

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -54,15 +54,15 @@
 
                 localizationService.localizeMany(keys)
                     .then(function (data) {
-                        labels.deleted = data[0];
-                        labels.unpublished = data[1]; //aka draft
-                        labels.published = data[2];
-                        labels.publishedPendingChanges = data[3];
-                        labels.notCreated = data[4];
-                        labels.unsavedChanges = data[5];
-                        labels.doctypeChangeWarning = data[6];
-                        labels.notPublished = data[7];
-                        scope.chooseLabel = data[8];
+                        [labels.deleted, 
+                        labels.unpublished, 
+                        labels.published,
+                        labels.publishedPendingChanges,
+                        labels.notCreated,
+                        labels.unsavedChanges,
+                        labels.doctypeChangeWarning,
+                        labels.notPublished,
+                        scope.chooseLabel] = data;
 
                         setNodePublishStatus();
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -43,7 +43,7 @@
 
         <umb-box data-element="node-info-history">
 
-            <umb-box-header title="{{historyLabel}}">
+            <umb-box-header title-key="{{historyLabelKey}}" ng-if="historyLabelKey">
                 <umb-button
                     ng-hide="node.trashed"
                     type="button"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Noticed the history box on the info app doesn't have a label - looks like there were potentially conflicts in a previous merge and the wrong changes were kept. Changes here restore the label and tidy up a clunky bit of JS to use destructuring assignment rather than accessing each array index.

History label has been missing since at least 8.8, can't see any existing issue reporting it 😃 
