### PR TITLE
fixes: #9564: Infinite Editing, document type template list - fonts are oversized and truncated

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/card.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/card.less
@@ -104,19 +104,18 @@
 	margin: 0 auto;
 	list-style: none;
     width: 100%;
-
 	display: flex;
 	flex-flow: row wrap;
 	justify-content: flex-start;
 }
 
 .umb-card-grid li {
-
 	font-size: 12px;
 	text-align: center;
 	box-sizing: border-box;
 	position: relative;
     width: 100px;
+    margin-bottom: 5px;
 }
 
 .umb-card-grid.-six-in-row li {
@@ -142,18 +141,20 @@
 .umb-card-grid .umb-card-grid-item {
     position: relative;
 	display: block;
-	width: 100%;
-	//height: 100%;
-    padding-top: 100%;
+    width: 100%;
+    height: 100%;
+    padding: 10px 5px;
     border-radius: @baseBorderRadius * 2;
     transition: background-color 120ms;
+    font-size: 13px;
+    line-height: 1.3em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
 
     > span {
-        position: absolute;
-        top: 10px;
-        bottom: 10px;
-        left: 10px;
-        right: 10px;
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
I have updated the CSS for the item picker. It now supports items with long titles. With the updated styles the picker now looks like this:

<img width="409" alt="Screenshot 2021-01-13 at 11 51 49" src="https://user-images.githubusercontent.com/6078361/104443470-c300d880-5596-11eb-975f-e88fec0c9a2d.png">

We use it in a couple of places so we need to make sure that these still work/look as expected.

Where and how to test:
- Add some doc types with long titles
- Add some data types with long titles
- Make sure adding "Allowed child nodes", "properties", and templates to a Doc Type still looks correct
- Make sure adding and copying nested content items still looks correct.
- Make sure adding questions to a form still looks correct.

fixes: #9564 