### PR TITLE
[AMEND] Updated the redirect URL Repository to search for entries wit…

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -214,25 +214,16 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
             if (string.IsNullOrWhiteSpace(culture)) return GetMostRecentUrl(url);
             var urlHash = url.GenerateHash<SHA1>();
             var sql = GetBaseQuery(false)
-                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.Culture == culture.ToLower())
+                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash &&
+                    (x.Culture == culture.ToLower() || x.Culture == string.Empty))
                 .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
             var dtos = Database.Fetch<RedirectUrlDto>(sql);
-            var dto = dtos.FirstOrDefault();
+            var dto = dtos.FirstOrDefault(f => f.Culture == culture.ToLower());
 
             if (dto == null)
-                dto = GetMostRecentUrlWithNoCulture(url);
+                dto = dtos.FirstOrDefault(f => f.Culture == string.Empty);
 
             return dto == null ? null : Map(dto);
-        }
-
-        private RedirectUrlDto GetMostRecentUrlWithNoCulture(string url)
-        {
-            var urlHash = url.GenerateHash<SHA1>();
-            var sql = GetBaseQuery(false)
-                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.Culture == string.Empty)
-                .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
-            var dtos = Database.Fetch<RedirectUrlDto>(sql);
-            return dtos.FirstOrDefault();
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -167,6 +167,23 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
             return dto == null ? null : Map(dto);
         }
 
+        public IRedirectUrl GetMostRecentUrl(string url, string culture)
+        {
+            if (string.IsNullOrWhiteSpace(culture)) return GetMostRecentUrl(url);
+            var urlHash = url.GenerateHash<SHA1>();
+            var sql = GetBaseQuery(false)
+                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash &&
+                    (x.Culture == culture.ToLower() || x.Culture == string.Empty))
+                .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
+            var dtos = Database.Fetch<RedirectUrlDto>(sql);
+            var dto = dtos.FirstOrDefault(f => f.Culture == culture.ToLower());
+
+            if (dto == null)
+                dto = dtos.FirstOrDefault(f => f.Culture == string.Empty);
+
+            return dto == null ? null : Map(dto);
+        }
+
         public IEnumerable<IRedirectUrl> GetContentUrls(Guid contentKey)
         {
             var sql = GetBaseQuery(false)
@@ -207,23 +224,6 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
 
             var rules = result.Items.Select(Map);
             return rules;
-        }
-
-        public IRedirectUrl GetMostRecentUrl(string url, string culture)
-        {
-            if (string.IsNullOrWhiteSpace(culture)) return GetMostRecentUrl(url);
-            var urlHash = url.GenerateHash<SHA1>();
-            var sql = GetBaseQuery(false)
-                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash &&
-                    (x.Culture == culture.ToLower() || x.Culture == string.Empty))
-                .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
-            var dtos = Database.Fetch<RedirectUrlDto>(sql);
-            var dto = dtos.FirstOrDefault(f => f.Culture == culture.ToLower());
-
-            if (dto == null)
-                dto = dtos.FirstOrDefault(f => f.Culture == string.Empty);
-
-            return dto == null ? null : Map(dto);
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -218,7 +218,21 @@ JOIN umbracoNode ON umbracoRedirectUrl.contentKey=umbracoNode.uniqueID");
                 .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
             var dtos = Database.Fetch<RedirectUrlDto>(sql);
             var dto = dtos.FirstOrDefault();
+
+            if (dto == null)
+                dto = GetMostRecentUrlWithNoCulture(url);
+
             return dto == null ? null : Map(dto);
+        }
+
+        private RedirectUrlDto GetMostRecentUrlWithNoCulture(string url)
+        {
+            var urlHash = url.GenerateHash<SHA1>();
+            var sql = GetBaseQuery(false)
+                .Where<RedirectUrlDto>(x => x.Url == url && x.UrlHash == urlHash && x.Culture == string.Empty)
+                .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
+            var dtos = Database.Fetch<RedirectUrlDto>(sql);
+            return dtos.FirstOrDefault();
         }
     }
 }

--- a/src/Umbraco.Tests/Integration/ContentEventsTests.cs
+++ b/src/Umbraco.Tests/Integration/ContentEventsTests.cs
@@ -2171,7 +2171,7 @@ namespace Umbraco.Tests.Integration
         [Test]
         public void HasInitialContent()
         {
-            Assert.AreEqual(4, ServiceContext.ContentService.Count());
+            Assert.AreEqual(5, ServiceContext.ContentService.Count());
         }
 
         #endregion

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -1415,7 +1415,7 @@ namespace Umbraco.Tests.Services
         {
             // Arrange
             var contentService = ServiceContext.ContentService;
-            var content = contentService.GetById(NodeDto.NodeIdSeed + 5);
+            var content = contentService.GetById(NodeDto.NodeIdSeed + 6);
 
             // Act
             var published = contentService.SaveAndPublish(content, userId: Constants.Security.SuperUserId);

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -343,7 +343,7 @@ namespace Umbraco.Tests.Services
             }
 
             // Assert
-            Assert.AreEqual(24, contentService.Count());
+            Assert.AreEqual(25, contentService.Count());
         }
 
         [Test]
@@ -1687,7 +1687,7 @@ namespace Umbraco.Tests.Services
 
             Assert.AreNotEqual(-20, content.ParentId);
             Assert.IsFalse(content.Trashed);
-            Assert.AreEqual(3, descendants.Count);
+            Assert.AreEqual(4, descendants.Count);
             Assert.IsFalse(descendants.Any(x => x.Path.StartsWith("-1,-20,")));
             Assert.IsFalse(descendants.Any(x => x.Trashed));
 
@@ -1700,7 +1700,7 @@ namespace Umbraco.Tests.Services
 
             Assert.AreEqual(-20, content.ParentId);
             Assert.IsTrue(content.Trashed);
-            Assert.AreEqual(3, descendants.Count);
+            Assert.AreEqual(4, descendants.Count);
             Assert.IsTrue(descendants.All(x => x.Path.StartsWith("-1,-20,")));
             Assert.True(descendants.All(x => x.Trashed));
 
@@ -1987,7 +1987,7 @@ namespace Umbraco.Tests.Services
             var contentService = ServiceContext.ContentService;
             var temp = contentService.GetById(NodeDto.NodeIdSeed + 2);
             Assert.AreEqual("Home", temp.Name);
-            Assert.AreEqual(2, contentService.CountChildren(temp.Id));
+            Assert.AreEqual(3, contentService.CountChildren(temp.Id));
 
             // Act
             var copy = contentService.Copy(temp, temp.ParentId, false, true, Constants.Security.SuperUserId);
@@ -1997,7 +1997,7 @@ namespace Umbraco.Tests.Services
             Assert.That(copy, Is.Not.Null);
             Assert.That(copy.Id, Is.Not.EqualTo(content.Id));
             Assert.AreNotSame(content, copy);
-            Assert.AreEqual(2, contentService.CountChildren(copy.Id));
+            Assert.AreEqual(3, contentService.CountChildren(copy.Id));
 
             var child = contentService.GetById(NodeDto.NodeIdSeed + 3);
             var childCopy = contentService.GetPagedChildren(copy.Id, 0, 500, out var total).First();
@@ -2013,7 +2013,7 @@ namespace Umbraco.Tests.Services
             var contentService = ServiceContext.ContentService;
             var temp = contentService.GetById(NodeDto.NodeIdSeed + 2);
             Assert.AreEqual("Home", temp.Name);
-            Assert.AreEqual(2, contentService.CountChildren(temp.Id));
+            Assert.AreEqual(3, contentService.CountChildren(temp.Id));
 
             // Act
             var copy = contentService.Copy(temp, temp.ParentId, false, false, Constants.Security.SuperUserId);

--- a/src/Umbraco.Tests/Services/EntityServiceTests.cs
+++ b/src/Umbraco.Tests/Services/EntityServiceTests.cs
@@ -490,7 +490,7 @@ namespace Umbraco.Tests.Services
             var entities = service.GetAll(objectTypeId).ToArray();
 
             Assert.That(entities.Any(), Is.True);
-            Assert.That(entities.Length, Is.EqualTo(4));
+            Assert.That(entities.Length, Is.EqualTo(5));
             Assert.That(entities.Any(x => x.Trashed), Is.True);
         }
 

--- a/src/Umbraco.Tests/Services/EntityServiceTests.cs
+++ b/src/Umbraco.Tests/Services/EntityServiceTests.cs
@@ -477,7 +477,7 @@ namespace Umbraco.Tests.Services
             var entities = service.GetAll(UmbracoObjectTypes.Document).ToArray();
 
             Assert.That(entities.Any(), Is.True);
-            Assert.That(entities.Length, Is.EqualTo(4));
+            Assert.That(entities.Length, Is.EqualTo(5));
             Assert.That(entities.Any(x => x.Trashed), Is.True);
         }
 
@@ -502,7 +502,7 @@ namespace Umbraco.Tests.Services
             var entities = service.GetAll<IContent>().ToArray();
 
             Assert.That(entities.Any(), Is.True);
-            Assert.That(entities.Length, Is.EqualTo(4));
+            Assert.That(entities.Length, Is.EqualTo(5));
             Assert.That(entities.Any(x => x.Trashed), Is.True);
         }
 

--- a/src/Umbraco.Tests/Services/RedirectUrlServiceTests.cs
+++ b/src/Umbraco.Tests/Services/RedirectUrlServiceTests.cs
@@ -46,14 +46,14 @@ namespace Umbraco.Tests.Services
                     Url = _url,
                     Culture = _cultureEnglish
                 });
-
+                Thread.Sleep(1000); //Added delay to ensure timestamp difference as sometimes they seem to have the same timestamp
                 repository.Save(new RedirectUrl
                 {
                     ContentKey = _secondSubPage.Key,
                     Url = _url,
                     Culture = _cultureGerman
                 });
-
+                Thread.Sleep(1000);
                 repository.Save(new RedirectUrl
                 {
                     ContentKey = _thirdSubPage.Key,

--- a/src/Umbraco.Tests/Services/RedirectUrlServiceTests.cs
+++ b/src/Umbraco.Tests/Services/RedirectUrlServiceTests.cs
@@ -1,13 +1,10 @@
-﻿using System;
+﻿using Moq;
+using NUnit.Framework;
 using System.Linq;
 using System.Threading;
-using Moq;
-using NUnit.Framework;
 using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
-
-using Umbraco.Core.Persistence.Repositories;
 using Umbraco.Core.Persistence.Repositories.Implement;
 using Umbraco.Core.Scoping;
 using Umbraco.Tests.Testing;
@@ -19,11 +16,14 @@ namespace Umbraco.Tests.Services
     [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
     public class RedirectUrlServiceTests : TestWithSomeContentBase
     {
-        private IContent _testPage;
-        private IContent _altTestPage;
-        private string _url = "blah";
-        private string _cultureA = "en";
-        private string _cultureB = "de";
+        private IContent _firstSubPage;
+        private IContent _secondSubPage;
+        private IContent _thirdSubPage;
+        private readonly string _url = "blah";
+        private readonly string _urlAlt = "alternativeUrl";
+        private readonly string _cultureEnglish = "en";
+        private readonly string _cultureGerman = "de";
+        private readonly string _unusedCulture = "es";
         public override void CreateTestData()
         {
             base.CreateTestData();
@@ -33,22 +33,34 @@ namespace Umbraco.Tests.Services
             {
                 var repository = new RedirectUrlRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger>());
                 var rootContent = ServiceContext.ContentService.GetRootContent().FirstOrDefault();
-                var subPages = ServiceContext.ContentService.GetPagedChildren(rootContent.Id, 0, 2, out _).ToList();
-                _testPage = subPages[0];
-                _altTestPage = subPages[1];
+                var subPages = ServiceContext.ContentService.GetPagedChildren(rootContent.Id, 0, 3, out _).ToList();
+                _firstSubPage = subPages[0];
+                _secondSubPage = subPages[1];
+                _thirdSubPage = subPages[2];
+
+
 
                 repository.Save(new RedirectUrl
                 {
-                    ContentKey = _testPage.Key,
+                    ContentKey = _firstSubPage.Key,
                     Url = _url,
-                    Culture = _cultureA
+                    Culture = _cultureEnglish
                 });
+
                 repository.Save(new RedirectUrl
                 {
-                    ContentKey = _altTestPage.Key,
+                    ContentKey = _secondSubPage.Key,
                     Url = _url,
-                    Culture = _cultureB
+                    Culture = _cultureGerman
                 });
+
+                repository.Save(new RedirectUrl
+                {
+                    ContentKey = _thirdSubPage.Key,
+                    Url = _urlAlt,
+                    Culture = string.Empty
+                });
+
                 scope.Complete();
             }
         }
@@ -64,7 +76,7 @@ namespace Umbraco.Tests.Services
         {
             var redirectUrlService = ServiceContext.RedirectUrlService;
             var redirect = redirectUrlService.GetMostRecentRedirectUrl(_url);
-            Assert.AreEqual(redirect.ContentId, _altTestPage.Id);
+            Assert.AreEqual(redirect.ContentId, _secondSubPage.Id);
 
         }
 
@@ -72,8 +84,17 @@ namespace Umbraco.Tests.Services
         public void Can_Get_Most_Recent_RedirectUrl_With_Culture()
         {
             var redirectUrlService = ServiceContext.RedirectUrlService;
-            var redirect = redirectUrlService.GetMostRecentRedirectUrl(_url, _cultureA);
-            Assert.AreEqual(redirect.ContentId, _testPage.Id);
+            var redirect = redirectUrlService.GetMostRecentRedirectUrl(_url, _cultureEnglish);
+            Assert.AreEqual(redirect.ContentId, _firstSubPage.Id);
+
+        }
+
+        [Test]
+        public void Can_Get_Most_Recent_RedirectUrl_With_Culture_When_No_CultureVariant_Exists()
+        {
+            var redirectUrlService = ServiceContext.RedirectUrlService;
+            var redirect = redirectUrlService.GetMostRecentRedirectUrl(_urlAlt, _unusedCulture);
+            Assert.AreEqual(redirect.ContentId, _thirdSubPage.Id);
 
         }
 

--- a/src/Umbraco.Tests/Services/TestWithSomeContentBase.cs
+++ b/src/Umbraco.Tests/Services/TestWithSomeContentBase.cs
@@ -41,6 +41,9 @@ namespace Umbraco.Tests.Services
             Content subpage2 = MockedContent.CreateSimpleContent(contentType, "Text Page 2", textpage.Id);
             ServiceContext.ContentService.Save(subpage2, 0);
 
+            Content subpage3 = MockedContent.CreateSimpleContent(contentType, "Text Page 3", textpage.Id);
+            ServiceContext.ContentService.Save(subpage3, 0);
+
             //Create and Save Content "Text Page Deleted" based on "umbTextpage" -> 1064
             Content trashed = MockedContent.CreateSimpleContent(contentType, "Text Page Deleted", -20);
             trashed.Trashed = true;


### PR DESCRIPTION
This fix is to address issue #9636 . If a search based on culture fails to return any redirects it will search for any that have no culture defined against them.

I feel that an additional unit test is probably required, but I wasn't sure how to set up the data for the test so have left this off.

I did consider falling back to the original method that doesn't look at culture but I felt that using "no culture" would be a better approach.