### PR TITLE
Adjust minimum width of main content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
@@ -278,7 +278,7 @@
     flex: 1 1 auto;
     margin-right: 20px;
     width: calc(~'100%' - ~'@{sidebarwidth}' - ~'20px'); // Make sure that the main content area doesn't gets affected by inline styling
-    min-width: 500px;
+    min-width: 490px;
 }
 
 .umb-package-details__sidebar {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
@@ -278,7 +278,7 @@
     flex: 1 1 auto;
     margin-right: 20px;
     width: calc(~'100%' - ~'@{sidebarwidth}' - ~'20px'); // Make sure that the main content area doesn't gets affected by inline styling
-    min-width: 490px;
+    min-width: 480px;
 }
 
 .umb-package-details__sidebar {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
When using a laptop width a viewport size on 1280 × 720 px the sidebar in e.g. content and media is moved below the main content. This is because the main content is set to a minimum width on 500px where the sidebar flow under the main content.

In packages section this in fine, because the navigation area is not shown here, but in content and media I think it would be great to adjust this a bit, so the sidebar is shown on right with the default width of navigation area on 360 px on since 1280px is a pretty standard screen width.

**Before**

![image](https://user-images.githubusercontent.com/2919859/104630695-5e7b7180-569b-11eb-81b9-23ade7010811.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/104630650-4e639200-569b-11eb-8ce1-5c2f2b4b64dc.png)



