### PR TITLE
Move relation type id and macro id to sidebar box

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
@@ -1,62 +1,76 @@
 ﻿<div ng-controller="Umbraco.Editors.Macros.SettingsController as vm">
-    <umb-box>
-        <umb-box-header title="Info"></umb-box-header>
-        <umb-box-content>
-            <umb-control-group label="Id">
-                {{model.macro.id}}<br/>
-                {{model.macro.key}}
-            </umb-control-group>
-        </umb-box-content>
-    </umb-box>
-    <umb-box>
-        <umb-box-header title="Macro partial view"></umb-box-header>
-        <umb-box-content>
-            <umb-control-group label="Macro partial view" required="true">
 
-                <umb-node-preview ng-if="model.macro.node"
-                                  icon="model.macro.node.icon"
-                                  name="model.macro.node.name"
-                                  allow-edit="true"
-                                  allow-remove="true"
-                                  on-edit="model.openViewPicker()"
-                                  on-remove="model.removeMacroView()">
-                </umb-node-preview>
+    <div class="umb-package-details">
 
-                <input type="hidden" ng-model="mandatoryViewValidator" ng-required="!model.macro.node" />
+        <div class="umb-package-details__main-content">
 
-                <button type="button"
-                        class="umb-node-preview-add"
-                        ng-show="!model.macro.node"
-                        ng-click="model.openViewPicker()">
-                    <localize key="general_add">Add</localize>
-                </button>
+            <umb-box>
+                <umb-box-header title="Macro partial view"></umb-box-header>
+                <umb-box-content>
+                    <umb-control-group label="Macro partial view" required="true" hide-label="true">
 
-            </umb-control-group>
-        </umb-box-content>
-    </umb-box>
-    <umb-box>
-        <umb-box-header title="Editor settings"></umb-box-header>
-        <umb-box-content>
-            <umb-control-group label="Use in rich text editor and the grid">
-                <umb-toggle checked="model.macro.useInEditor" on-click="model.toggle('useInEditor')"></umb-toggle>
-            </umb-control-group>
-            <umb-control-group label="Render in rich text editor and the grid" ng-if="model.macro.useInEditor">
-                <umb-toggle checked="model.macro.renderInEditor && model.macro.useInEditor" on-click="model.toggle('renderInEditor')"></umb-toggle>
-            </umb-control-group>
-        </umb-box-content>
-    </umb-box>
-    <umb-box>
-        <umb-box-header title="Cache settings"></umb-box-header>
-        <umb-box-content>
-            <umb-control-group label="Cache period">
-               <input type="number" min="0" ng-model="model.macro.cachePeriod"/>
-            </umb-control-group>
-            <umb-control-group label="Cache by page">
-                <umb-toggle checked="model.macro.cacheByPage" on-click="model.toggle('cacheByPage')"></umb-toggle>
-            </umb-control-group>
-            <umb-control-group label="Cache personalized">
-                <umb-toggle checked="model.macro.cacheByUser" on-click="model.toggle('cacheByUser')"></umb-toggle>
-            </umb-control-group>
-        </umb-box-content>
-    </umb-box>
+                        <umb-node-preview
+                            ng-if="model.macro.node"
+                            icon="model.macro.node.icon"
+                            name="model.macro.node.name"
+                            allow-edit="true"
+                            allow-remove="true"
+                            on-edit="model.openViewPicker()"
+                            on-remove="model.removeMacroView()">
+                        </umb-node-preview>
+
+                        <input type="hidden" ng-model="mandatoryViewValidator" ng-required="!model.macro.node" />
+
+                        <button type="button"
+                                class="umb-node-preview-add"
+                                ng-show="!model.macro.node"
+                                ng-click="model.openViewPicker()">
+                            <localize key="general_add">Add</localize>
+                        </button>
+
+                    </umb-control-group>
+                </umb-box-content>
+            </umb-box>
+            <umb-box>
+                <umb-box-header title="Editor settings"></umb-box-header>
+                <umb-box-content>
+                    <umb-control-group label="Use in rich text editor and the grid">
+                        <umb-toggle checked="model.macro.useInEditor" on-click="model.toggle('useInEditor')"></umb-toggle>
+                    </umb-control-group>
+                    <umb-control-group label="Render in rich text editor and the grid" ng-if="model.macro.useInEditor">
+                        <umb-toggle checked="model.macro.renderInEditor && model.macro.useInEditor" on-click="model.toggle('renderInEditor')"></umb-toggle>
+                    </umb-control-group>
+                </umb-box-content>
+            </umb-box>
+            <umb-box>
+                <umb-box-header title="Cache settings"></umb-box-header>
+                <umb-box-content>
+                    <umb-control-group label="Cache period">
+                        <input type="number" min="0" ng-model="model.macro.cachePeriod" />
+                    </umb-control-group>
+                    <umb-control-group label="Cache by page">
+                        <umb-toggle checked="model.macro.cacheByPage" on-click="model.toggle('cacheByPage')"></umb-toggle>
+                    </umb-control-group>
+                    <umb-control-group label="Cache personalized">
+                        <umb-toggle checked="model.macro.cacheByUser" on-click="model.toggle('cacheByUser')"></umb-toggle>
+                    </umb-control-group>
+                </umb-box-content>
+            </umb-box>
+
+        </div>
+
+        <div class="umb-package-details__sidebar">
+            <umb-box data-element="node-info-general">
+                <umb-box-header title-key="general_general"></umb-box-header>
+                <umb-box-content class="block-form">
+                    <umb-control-group label="Id">
+                        <div>{{model.macro.id}}</div>
+                        <small>{{model.macro.key}}</small>
+                    </umb-control-group>
+                </umb-box-content>
+            </umb-box>
+        </div>
+
+    </div>
+
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
@@ -1,46 +1,68 @@
 <div ng-controller="Umbraco.Editors.RelationTypes.SettingsController as vm">
-    <umb-box>
-        <umb-box-content>
-            <!-- ID -->
-            <umb-control-group label="Id">
-                <div>{{model.relationType.id}}</div>
-                <small>{{model.relationType.key}}</small>
-            </umb-control-group>
 
-            <!-- Direction -->
-            <umb-control-group label="@relationType_direction">
-                <ul class="unstyled">
-                    <li>
-                        <umb-radiobutton name="relationTypeDirection"
-                                         value="false"
-                                         model="model.relationType.isBidirectional"
-                                         text="{{vm.labels.parentToChild}}">
-                        </umb-radiobutton>
-                    </li>
-                    <li>
-                        <umb-radiobutton name="relationTypeDirection"
-                                         value="true"
-                                         model="model.relationType.isBidirectional"
-                                         text="{{vm.labels.bidirectional}}">
-                        </umb-radiobutton>
-                    </li>
-                </ul>
-            </umb-control-group>
+    <div class="umb-package-details">
 
-            <!-- Parent-->
-            <umb-control-group label="@relationType_parent">
-                <div>{{model.relationType.parentObjectTypeName}}</div>
-            </umb-control-group>
+        <div class="umb-package-details__main-content">
 
-            <!-- Child -->
-            <umb-control-group label="@relationType_child">
-                <div>{{model.relationType.childObjectTypeName}}</div>
-            </umb-control-group>
+            <umb-box>
+                <umb-box-content>
 
-            <!-- Relation count -->
-            <umb-control-group label="@relationType_count" ng-if="model.relationType.relations.length > 0">
-                <div>{{model.relationType.relations.length}}</div>
-            </umb-control-group>
-        </umb-box-content>
-    </umb-box>
+                    <!-- Direction -->
+                    <umb-control-group label="@relationType_direction">
+                        <ul class="unstyled">
+                            <li>
+                                <umb-radiobutton name="relationTypeDirection"
+                                                 value="false"
+                                                 model="model.relationType.isBidirectional"
+                                                 text="{{vm.labels.parentToChild}}">
+                                </umb-radiobutton>
+                            </li>
+                            <li>
+                                <umb-radiobutton name="relationTypeDirection"
+                                                 value="true"
+                                                 model="model.relationType.isBidirectional"
+                                                 text="{{vm.labels.bidirectional}}">
+                                </umb-radiobutton>
+                            </li>
+                        </ul>
+                    </umb-control-group>
+
+                    <!-- Parent-->
+                    <umb-control-group label="@relationType_parent">
+                        <div>{{model.relationType.parentObjectTypeName}}</div>
+                    </umb-control-group>
+
+                    <!-- Child -->
+                    <umb-control-group label="@relationType_child">
+                        <div>{{model.relationType.childObjectTypeName}}</div>
+                    </umb-control-group>
+
+                    <!-- Relation count -->
+                    <umb-control-group label="@relationType_count" ng-if="model.relationType.relations.length > 0">
+                        <div>{{model.relationType.relations.length}}</div>
+                    </umb-control-group>
+                </umb-box-content>
+            </umb-box>
+
+        </div>
+
+        <div class="umb-package-details__sidebar">
+
+            <umb-box data-element="node-info-general">
+                <umb-box-header title-key="general_general"></umb-box-header>
+                <umb-box-content class="block-form">
+
+                    <umb-control-group label="Id">
+                        <div>{{model.relationType.id}}</div>
+                        <small>{{model.relationType.key}}</small>
+                    </umb-control-group>
+
+                </umb-box-content>
+            </umb-box>
+        </div>
+
+    </div>
+
+
+    
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/views/relationType.html
@@ -47,22 +47,17 @@
         </div>
 
         <div class="umb-package-details__sidebar">
-
             <umb-box data-element="node-info-general">
                 <umb-box-header title-key="general_general"></umb-box-header>
                 <umb-box-content class="block-form">
-
                     <umb-control-group label="Id">
                         <div>{{model.relationType.id}}</div>
                         <small>{{model.relationType.key}}</small>
                     </umb-control-group>
-
                 </umb-box-content>
             </umb-box>
         </div>
 
     </div>
-
-
     
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In backoffice we mostly have id + guid show in an sidebar box, e.g. in content, media, member group, datatype, etc.
So I think it would be a bit more consistent to move this under relation types as well.

Note part of this PR relies on the following PRs as well:
https://github.com/umbraco/Umbraco-CMS/pull/9632
https://github.com/umbraco/Umbraco-CMS/pull/9656

**Before**

![image](https://user-images.githubusercontent.com/2919859/104634998-a30a0b80-56a1-11eb-9709-15b69a611a23.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/104632418-f37f6a00-569d-11eb-9770-312904637b13.png)

