### PR TITLE
Block editor cleanup

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
@@ -1,6 +1,7 @@
 angular.module("umbraco")
     .controller("Umbraco.Editors.BlockEditorController",
         function ($scope, localizationService, formHelper, overlayService) {
+
             var vm = this;
 
             vm.model = $scope.model;
@@ -52,7 +53,7 @@ angular.module("umbraco")
                         vm.saveButtonState = "error";
                     }
                 }
-            }
+            };
 
             vm.close = function () {
                 if (vm.model && vm.model.close) {
@@ -93,7 +94,7 @@ angular.module("umbraco")
                     }
 
                 }
-            }
+            };
 
         }
     );

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
@@ -1,4 +1,4 @@
-<div class="umb-block-editor"  ng-controller="Umbraco.Editors.BlockEditorController as vm">
+<div class="umb-block-editor" ng-controller="Umbraco.Editors.BlockEditorController as vm">
 
     <ng-form name="vm.blockForm" val-form-manager>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
@@ -14,20 +14,12 @@
                 hide-description="true">
             </umb-editor-header>
 
-            <div class="umb-editor-container umb-panel-body umb-scrollable row-fluid">
+            <umb-editor-container>
 
-                <!-- Missing Deleted Message Bar (Displayed when viewing node in recycle bin), but Blocks dosnt go into trash-bin jet...
-                    <div ng-show="vm.content.trashed" class="umb-editor--trashed-message">
-                        <i class="icon icon-trash"></i> <localize key="content_nodeIsInTrash">This item is in the Recycle Bin</localize>
-                    </div>
-                -->
+                <umb-editor-sub-views sub-views="vm.tabs" model="vm.model">
+                </umb-editor-sub-views>
 
-                <div class="umb-pane">
-                    <umb-editor-sub-views sub-views="vm.tabs" model="vm.model">
-                    </umb-editor-sub-views>
-                </div>
-
-            </div>
+            </umb-editor-container>
 
             <umb-editor-footer>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -241,30 +241,30 @@
 
             block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true || inlineEditing === true;
             block.showSettings = block.config.settingsElementTypeKey != null;
-            block.showCopy = vm.supportCopy && block.config.contentElementTypeKey != null;// if we have content, otherwise it doesn't make sense to copy.
 
+            // If we have content, otherwise it doesn't make sense to copy.
+            block.showCopy = vm.supportCopy && block.config.contentElementTypeKey != null;
 
             // Index is set by umbblocklistblock component and kept up to date by it.
             block.index = 0;
             block.setParentForm = function (parentForm) {
                 this._parentForm = parentForm;
-            }
+            };
             block.activate = activateBlock.bind(null, block);
             block.edit = function () {
                 var blockIndex = vm.layout.indexOf(this.layout);
                 editBlock(this, false, blockIndex, this._parentForm);
-            }
+            };
             block.editSettings = function () {
                 var blockIndex = vm.layout.indexOf(this.layout);
                 editBlock(this, true, blockIndex, this._parentForm);
-            }
+            };
             block.requestDelete = requestDeleteBlock.bind(null, block);
             block.delete = deleteBlock.bind(null, block);
             block.copy = copyBlock.bind(null, block);
 
             return block;
         }
-
 
         function addNewBlock(index, contentElementTypeKey) {
 
@@ -292,7 +292,6 @@
             vm.setBlockFocus(blockObject);
 
             return true;
-
         }
 
         function deleteBlock(block) {
@@ -316,7 +315,6 @@
             });
 
             modelObject.removeDataAndDestroyModel(block);
-
         }
 
         function deleteAllBlocks() {
@@ -409,6 +407,7 @@
         }
 
         vm.showCreateDialog = showCreateDialog;
+
         function showCreateDialog(createIndex, $event) {
 
             if (vm.blockTypePicker) {
@@ -524,7 +523,7 @@
 
         };
 
-        var requestCopyAllBlocks = function() {
+        var requestCopyAllBlocks = function () {
 
             var aliases = [];
 
@@ -534,7 +533,7 @@
                     aliases.push(entry.$block.content.contentTypeAlias);
 
                     // No need to clone the data as its begin handled by the clipboardService.
-                    return {"layout": entry.$block.layout, "data": entry.$block.data, "settingsData":entry.$block.settingsData}
+                    return { "layout": entry.$block.layout, "data": entry.$block.data, "settingsData": entry.$block.settingsData }
                 }
             );
 
@@ -543,9 +542,9 @@
 
             var contentNodeName = "?";
             var contentNodeIcon = null;
-            if(vm.umbVariantContent) {
+            if (vm.umbVariantContent) {
                 contentNodeName = vm.umbVariantContent.editor.content.name;
-                if(vm.umbVariantContentEditors) {
+                if (vm.umbVariantContentEditors) {
                     contentNodeIcon = vm.umbVariantContentEditors.content.icon.split(" ")[0];
                 } else if (vm.umbElementEditorContent) {
                     contentNodeIcon = vm.umbElementEditorContent.model.documentType.icon.split(" ")[0];
@@ -555,13 +554,15 @@
                 contentNodeIcon = vm.umbElementEditorContent.model.documentType.icon.split(" ")[0];
             }
 
-            localizationService.localize("clipboard_labelForArrayOfItemsFrom", [vm.model.label, contentNodeName]).then(function(localizedLabel) {
+            localizationService.localize("clipboard_labelForArrayOfItemsFrom", [vm.model.label, contentNodeName]).then(function (localizedLabel) {
                 clipboardService.copyArray(clipboardService.TYPES.BLOCK, aliases, elementTypesToCopy, localizedLabel, contentNodeIcon || "icon-thumbnail-list", vm.model.id);
             });
-        }
+        };
+
         function copyBlock(block) {
             clipboardService.copy(clipboardService.TYPES.BLOCK, block.content.contentTypeAlias, {"layout": block.layout, "data": block.data, "settingsData":block.settingsData}, block.label, block.content.icon, block.content.udi);
         }
+
         function requestPasteFromClipboard(index, pasteEntry, pasteType) {
 
             if (pasteEntry === undefined) {
@@ -599,7 +600,6 @@
             vm.currentBlockInFocus = blockObject;
 
             return true;
-
         }
 
         function requestDeleteBlock(block) {
@@ -620,6 +620,7 @@
                 overlayService.confirmDelete(overlay);
             });
         }
+
         function requestDeleteAllBlocks() {
             localizationService.localizeMany(["content_nestedContentDeleteAllItems", "general_delete"]).then(function (data) {
                 overlayService.confirmDelete({
@@ -647,7 +648,7 @@
             requestDeleteBlock: requestDeleteBlock,
             deleteBlock: deleteBlock,
             openSettingsForBlock: openSettingsForBlock
-        }
+        };
 
         vm.sortableOptions = {
             axis: "y",
@@ -663,7 +664,6 @@
                 setDirty();
             }
         };
-
 
         function onAmountOfBlocksChanged() {
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.createButton.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.createButton.controller.js
@@ -9,9 +9,9 @@
         var vm = this;
         vm.plusPosX = 0;
 
-        vm.onMouseMove = function($event) {
+        vm.onMouseMove = function ($event) {
             vm.plusPosX = $event.offsetX;
-        }
+        };
 
     });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -78,7 +78,7 @@
                 model.block.index = index;
                 model.block.updateLabel();
             }
-        }
+        };
     }
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
While looking at https://github.com/umbraco/Umbraco-CMS/issues/9663 I found a few things in block list editor to cleanup.
- Semi colons after named functions
- Use `<umb-editor-container>` component instead of hard coded markup.