### PR TITLE
Add back icon name in class attribute to work again with font icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-node-preview.html
@@ -1,6 +1,6 @@
 <div class="umb-node-preview" ng-class="{'umb-node-preview--sortable': sortable, 'umb-node-preview--unpublished': published === false }">
     <div class="flex"> <!-- div keeps icon and nodename from wrapping -->
-        <umb-icon ng-if="icon" icon="{{icon}}" class="umb-node-preview__icon"></umb-icon>
+        <umb-icon ng-if="icon" icon="{{icon}}" class="umb-node-preview__icon {{icon}}"></umb-icon>
         
         <div class="umb-node-preview__content">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9665

### Description
I noticed in users section some icons were missing 🙈 

![image](https://user-images.githubusercontent.com/2919859/104768412-e3cf5680-576d-11eb-907c-f0902c3dc224.png)

I figured out that I removed the icon name from the class here, because I thought it wasn't necessary:
https://github.com/umbraco/Umbraco-CMS/commit/a9a4b0894a626adaea407f3a2bab4a6bca77e5f6#diff-6a8c6488e5f6832a8854541a572ad9893f004e32733a52fe2591fec34a0344deL3

Now it works again!

![image](https://user-images.githubusercontent.com/2919859/104769674-f3e83580-576f-11eb-9e6b-d40c048bcaf6.png)

Mostly you won't notice in core, because we have SVG icons for most of the old font icon classes. But currently it IS necessary currently, when the icon isn't available as SVG icon: https://github.com/umbraco/Umbraco-CMS/pull/9255

At least until we find a better way to handle this and since many packages are using `<umb-node-preview>` component and probably with font icons since that was the original approach.