### PR TITLE
5596 allow editing alt text in grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -595,6 +595,23 @@ When building a custom infinite editor view you can use the same components as a
 
         /**
          * @ngdoc method
+         * @name umbraco.services.editorService#mediaCropDetails
+         * @methodOf umbraco.services.editorService
+         *
+         * @description
+         * Opens the media crop details editor in infinite editing, the submit callback returns the updated media object.
+         * @param {object} editor rendering options.
+         * @param {function} editor.submit Submits the editor.
+         * @param {function} editor.close Closes the editor.
+         * @returns {object} editor object
+         */
+        function mediaCropDetails(editor) {
+            editor.view = "views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html";
+            open(editor);
+        }
+
+        /**
+         * @ngdoc method
          * @name umbraco.services.editorService#iconPicker
          * @methodOf umbraco.services.editorService
          *
@@ -1055,7 +1072,8 @@ When building a custom infinite editor view you can use the same components as a
             macroPicker: macroPicker,
             memberGroupPicker: memberGroupPicker,
             memberPicker: memberPicker,
-            memberEditor: memberEditor
+            memberEditor: memberEditor,
+            mediaCropDetails
         };
 
         return service;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -479,7 +479,7 @@
 .umb-grid-media--controls {
     display:none;
     position: absolute;
-    bottom:0.5rem;
+    top:0.5rem;
     right:0.5rem;    
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -475,9 +475,19 @@
     }
 }
 
+// Control states 
+.umb-grid-media--controls {
+    display:none;
+    position: absolute;
+    bottom:0.5rem;
+    right:0.5rem;    
+}
 
-
-
+.umb-grid .umb-row .umb-control.-active {
+    .umb-grid-media--controls {
+        display:flex;
+    }
+}
 
 // Title bar and tools
 .umb-grid .umb-row-title-bar {

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -606,6 +606,9 @@ table thead button:focus{
 	display: inline;
 }
 
+.relative {
+  position:relative;
+}
 
 // Input label styles
 // @Simon: not sure where to put this part yet

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -373,12 +373,11 @@ angular.module("umbraco")
             function openDetailsDialog() {
 
                 const dialog = {
-                    view: "views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html",
                     size: "small",
                     cropSize: $scope.cropSize,
                     target: $scope.target,
                     disableFocalPoint: $scope.disableFocalPoint,
-                    submit: function (model) {
+                    submit: function () {
 
                         $scope.model.selection.push($scope.target);
                         $scope.model.submit($scope.model);
@@ -392,7 +391,7 @@ angular.module("umbraco")
 
                 localizationService.localize("defaultdialogs_editSelectedMedia").then(value => {
                     dialog.title = value;
-                    editorService.open(dialog);
+                    editorService.mediaCropDetails(dialog);
                 });
             };
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.controller.js
@@ -7,8 +7,9 @@
             vm.submit = submit;
             vm.close = close;
             vm.hasCrops = cropSet() === true;
-
+            vm.focalPointChanged = focalPointChanged;
             vm.disableFocalPoint = false;
+            
             if(typeof $scope.model.disableFocalPoint === "boolean") {
                 vm.disableFocalPoint = $scope.model.disableFocalPoint
             }
@@ -20,25 +21,17 @@
                 $scope.model.target.focalPoint = { left: .5, top: .5 };
             }
 
-            vm.shouldShowUrl = shouldShowUrl;
-            vm.focalPointChanged = focalPointChanged;
-
             if (!$scope.model.target.image) {
                 $scope.model.target.image = $scope.model.target.url;
             }
 
-            function shouldShowUrl() {
-                if (!$scope.model.target) {
-                    return false;
-                }
-                if ($scope.model.target.id) {
-                    return false;
-                }
-                if ($scope.model.target.url && $scope.model.target.url.toLower().indexOf("blob:") === 0) {
-                    return false;
-                }
-                return true;
-            }
+            if (!$scope.model.target 
+                || $scope.model.target.id 
+                || ($scope.model.target.url && $scope.model.target.url.toLowerCase().startsWith("blob:"))) {
+                vm.shouldShowUrl = false;
+            } else {
+                vm.shouldShowUrl = true;
+            }         
 
             /**
              * Called when the umbImageGravity component updates the focal point value

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html
@@ -10,7 +10,7 @@
 
         <umb-editor-container>
 
-            <div class="umb-control-group" ng-if="vm.shouldShowUrl()">
+            <div class="umb-control-group" ng-if="vm.shouldShowUrl">
                 <h5>
                     <localize key="@general_url"></localize>
                 </h5>
@@ -22,6 +22,13 @@
                     <localize key="@content_altTextOptional"></localize>
                 </h5>
                 <input type="text" class="umb-property-editor umb-textstring" ng-model="model.target.altText" umb-auto-focus />
+            </div>
+
+            <div class="umb-control-group" ng-if="model.target">
+                <h5>
+                    <localize key="@content_captionTextOptional"></localize>
+                </h5>
+                <input type="text" class="umb-property-editor umb-textstring" ng-model="model.target.caption" />
             </div>
 
             <div class="umb-control-group" ng-if="model.target">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -1,10 +1,8 @@
 angular.module("umbraco")
     .controller("Umbraco.PropertyEditors.Grid.MediaController",
-    function ($scope, $timeout, userService, editorService) {
+    function ($scope, userService, editorService, localizationService) {        
         
-        
-        $scope.thumbnailUrl = getThumbnailUrl();
-        
+        $scope.thumbnailUrl = getThumbnailUrl();        
         
         if (!$scope.model.config.startNodeId) {
             if ($scope.model.config.ignoreUserStartNodes === true) {
@@ -12,101 +10,120 @@ angular.module("umbraco")
                 $scope.model.config.startNodeIsVirtual = true;
 
             } else {
-                userService.getCurrentUser().then(function (userData) {
+                userService.getCurrentUser().then(userData => {
                     $scope.model.config.startNodeId = userData.startMediaIds.length !== 1 ? -1 : userData.startMediaIds[0];
                     $scope.model.config.startNodeIsVirtual = userData.startMediaIds.length !== 1;
                 });
             }
         }
-        
-        $scope.setImage = function(){
+
+        $scope.setImage = function() {
             var startNodeId = $scope.model.config && $scope.model.config.startNodeId ? $scope.model.config.startNodeId : undefined;
-            var startNodeIsVirtual = startNodeId ? $scope.model.config.startNodeIsVirtual : undefined;
-            var value = $scope.control.value;
-            var target = value
-                ? {
-                    udi: value.udi,
-                    url: value.image,
-                    image: value.image,
-                    focalPoint: value.focalPoint,
-                    coordinates: value.coordinates
-                }
-                : null;
+
             var mediaPicker = {
                 startNodeId: startNodeId,
-                startNodeIsVirtual: startNodeIsVirtual,
+                startNodeIsVirtual: startNodeId ? $scope.model.config.startNodeIsVirtual : undefined,
                 cropSize: $scope.control.editor.config && $scope.control.editor.config.size ? $scope.control.editor.config.size : undefined,
                 showDetails: true,
                 disableFolderSelect: true,
                 onlyImages: true,
                 dataTypeKey: $scope.model.dataTypeKey,
-                currentTarget: target,
-                submit: function(model) {
-                    var selectedImage = model.selection[0];
-                   
-                    $scope.control.value = {
-                        focalPoint: selectedImage.focalPoint,
-                        coordinates: selectedImage.coordinates,
-                        id: selectedImage.id,
-                        udi: selectedImage.udi,
-                        image: selectedImage.image,
-                        caption: selectedImage.altText
-                    };
-                    
+                submit: model => {
+                    updateControlValue(model.selection[0]);                    
                     editorService.close();
                 },
-                close: function() {
-                    editorService.close();
-                }
-            }
-            
+                close: () => editorService.close()                
+            };
+
             editorService.mediaPicker(mediaPicker);
         };
+
+        $scope.editImage = function() {               
+
+            const mediaCropDetailsConfig = {
+                size: 'small',
+                target: $scope.control.value,
+                submit: model => {
+                    updateControlValue(model.target);
+                    editorService.close();
+                },
+                close: function () {
+                    editorService.close();
+                }
+            };
+
+            localizationService.localize('defaultdialogs_editSelectedMedia').then(value => {
+                mediaCropDetailsConfig.title = value;
+                editorService.mediaCropDetails(mediaCropDetailsConfig);
+            });        
+        }
         
-        $scope.$watch('control.value', function(newValue, oldValue) {
-            if(angular.equals(newValue, oldValue)){
-                return; // simply skip that
-            }
-            
-            $scope.thumbnailUrl = getThumbnailUrl();
-        }, true);
-        
+        /**
+         * 
+         */
         function getThumbnailUrl() {
 
-            if($scope.control.value && $scope.control.value.image) {
+            if ($scope.control.value && $scope.control.value.image) {
                 var url = $scope.control.value.image;
 
-                if($scope.control.editor.config && $scope.control.editor.config.size){
+                if ($scope.control.editor.config && $scope.control.editor.config.size){
                     if ($scope.control.value.coordinates) {
                         // New way, crop by percent must come before width/height.
                         var coords = $scope.control.value.coordinates;
-                        url += "?crop=" + coords.x1 + "," + coords.y1 + "," + coords.x2 + "," + coords.y2 + "&cropmode=percentage";
+                        url += `?crop=${coords.x1},${coords.y1},${coords.x2},${coords.y2}&cropmode=percentage`;
                     } else {
                         // Here in order not to break existing content where focalPoint were used.
                         // For some reason width/height have to come first when mode=crop.
                         if ($scope.control.value.focalPoint) {
-                            url += "?center=" + $scope.control.value.focalPoint.top + "," + $scope.control.value.focalPoint.left;
-                            url += "&mode=crop";
+                            url += `?center=${$scope.control.value.focalPoint.top},${$scope.control.value.focalPoint.left}`;
+                            url += '&mode=crop';
                         } else {
                             // Prevent black padding and no crop when focal point not set / changed from default
-                            url += "?center=0.5,0.5&mode=crop";
+                            url += '?center=0.5,0.5&mode=crop';
                         }
                     }
-                    url += "&width=" + $scope.control.editor.config.size.width;
-                    url += "&height=" + $scope.control.editor.config.size.height;
-                    url += "&animationprocessmode=first";
 
+                    url += '&width=' + $scope.control.editor.config.size.width;
+                    url += '&height=' + $scope.control.editor.config.size.height;
+                    url += '&animationprocessmode=first';
                 }
 
                 // set default size if no crop present (moved from the view)
-                if (url.indexOf('?') == -1)
+                if (url.includes('?') === false)
                 {
-                    url += "?width=800&upscale=false&animationprocessmode=false"
+                    url += '?width=800&upscale=false&animationprocessmode=false'
                 }
+
                 return url;
             }
             
             return null;
-        };
+        }
 
-});
+        /**
+         * 
+         * @param {object} selectedImage 
+         */
+        function updateControlValue(selectedImage) {
+
+            const doGetThumbnail = $scope.control.value.focalPoint !== selectedImage.focalPoint 
+                || $scope.control.value.image !== selectedImage.image;
+
+            // we could apply selectedImage directly to $scope.control.value,
+            // but this allows excluding fields in future if needed
+            $scope.control.value = {
+                focalPoint: selectedImage.focalPoint,
+                coordinates: selectedImage.coordinates,
+                id: selectedImage.id,
+                udi: selectedImage.udi,
+                image: selectedImage.image,
+                caption: selectedImage.caption,
+                altText: selectedImage.altText
+            };
+
+
+            if (doGetThumbnail) {
+                $scope.thumbnailUrl = getThumbnailUrl();
+            }
+        }       
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.controller.js
@@ -18,12 +18,12 @@ angular.module("umbraco")
         }
 
         $scope.setImage = function() {
-            var startNodeId = $scope.model.config && $scope.model.config.startNodeId ? $scope.model.config.startNodeId : undefined;
+            var startNodeId = $scope.model.config && $scope.model.config.startNodeId ? $scope.model.config.startNodeId : null;
 
             var mediaPicker = {
                 startNodeId: startNodeId,
-                startNodeIsVirtual: startNodeId ? $scope.model.config.startNodeIsVirtual : undefined,
-                cropSize: $scope.control.editor.config && $scope.control.editor.config.size ? $scope.control.editor.config.size : undefined,
+                startNodeIsVirtual: startNodeId ? $scope.model.config.startNodeIsVirtual : null,
+                cropSize: $scope.control.editor.config && $scope.control.editor.config.size ? $scope.control.editor.config.size : null,
                 showDetails: true,
                 disableFolderSelect: true,
                 onlyImages: true,
@@ -47,9 +47,7 @@ angular.module("umbraco")
                     updateControlValue(model.target);
                     editorService.close();
                 },
-                close: function () {
-                    editorService.close();
-                }
+                close: () => editorService.close()                
             };
 
             localizationService.localize('defaultdialogs_editSelectedMedia').then(value => {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/media.html
@@ -6,14 +6,23 @@
         </span>
     </button>
 
-    <div ng-if="thumbnailUrl !== null">
-        <button type="button" class="btn-reset" ng-click="setImage()">
-            <img ng-src="{{thumbnailUrl}}" class="fullSizeImage" alt="" />
-        </button>
-        <label class="sr-only" for="grid-media-{{control.value.id}}">
-            <localize key="visuallyHiddenTexts_addImageCaption">Add image caption</localize>
-        </label>
-        <input id="grid-media-{{control.value.id}}" type="text" class="caption" ng-model="control.value.caption" localize="placeholder" placeholder="@grid_placeholderImageCaption" />
-    </div>
+    <div ng-if="thumbnailUrl !== null" class="relative">
+        
+        <img ng-src="{{thumbnailUrl}}" class="fullSizeImage" alt="" />
 
+        <div class="umb-grid-media--controls">
+            <umb-button                
+                action="setImage()"
+                type="button"
+                button-style="info"
+                label-key="defaultdialogs_selectMedia">
+            </umb-button>            
+            <umb-button                
+                action="editImage()"
+                type="button"
+                button-style="info"
+                label-key="general_edit">
+            </umb-button>
+        </div>
+    </div>
 </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -268,6 +268,7 @@
     <key alias="statistics">Statistics</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="altTextOptional">Alternative text (optional)</key>
+    <key alias="captionTextOptional">Caption (optional)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Unpublish</key>
     <key alias="unpublished">Unpublished</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -272,6 +272,7 @@
     <key alias="statistics">Statistics</key>
     <key alias="titleOptional">Title (optional)</key>
     <key alias="altTextOptional">Alternative text (optional)</key>
+    <key alias="captionTextOptional">Caption (optional)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Unpublish</key>
     <key alias="unpublished">Draft</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #5596 

This PR replaces the stale one in #5607 (which I will close)

### Description
Changes here separate the alt text and caption into distinct values - previously the text set as alt text was stored as the caption, which doesn't make sense. To make this work, I've added two buttons to the grid media view, one to change the existing image, one to edit the existing image. 

![Edit-About-Us---Content---localhost](https://user-images.githubusercontent.com/3248070/104979924-297f6e00-5a51-11eb-83fb-0d82f68863aa.gif)

Previously clicking the existing image opened the media picker overlay, which then opened a nested overlay to edit the details. That wasn't the nicest UX as closing the details overlay then returned to the picker, which is unrelated to the action the user had taken. Separating the two actions makes it clear which action will be triggered, and by adding buttons introduces text into the UI, making it more obvious than clicking the unlabeled image.

Adding a new image still triggers the details overlay as before.

No data is automatically migrated (alt text is still stored as the caption), but editing an existing image displays the alt text in the caption field, so should be obvious that it needs to be manually updated. Is it a breaking change? Potentially, since editing and saving an existing image will shift the alt text to the caption, which may cause rendering issues.

Also adds a new function to editorService => mediaCropDetails. I will also update the media picker controller to use this method rather than an inline view reference. Tidied up some existing JS, with whitespace fixes and syntax improvements.

Still needs translations for a new key, will fire up Google Translate and see how I go...


