### PR TITLE
Netcore: Add support for sync notification handlers in event aggregator

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
@@ -2,7 +2,6 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Umbraco.Core.Events;
 
 namespace Umbraco.Core.DependencyInjection
@@ -25,6 +24,30 @@ namespace Umbraco.Core.DependencyInjection
         {
             // Register the handler as transient. This ensures that anything can be injected into it.
             var descriptor = new ServiceDescriptor(typeof(INotificationHandler<TNotification>), typeof(TNotificationHandler), ServiceLifetime.Transient);
+
+            // TODO: Waiting on feedback here https://github.com/umbraco/Umbraco-CMS/pull/9556/files#r548365396 about whether
+            // we perform this duplicate check or not.
+            if (!builder.Services.Contains(descriptor))
+            {
+                builder.Services.Add(descriptor);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers a notification async handler against the Umbraco service collection.
+        /// </summary>
+        /// <typeparam name="TNotification">The type of notification.</typeparam>
+        /// <typeparam name="TNotificationAsyncHandler">The type of notification async handler.</typeparam>
+        /// <param name="builder">The Umbraco builder.</param>
+        /// <returns>The <see cref="IUmbracoBuilder"/>.</returns>
+        public static IUmbracoBuilder AddNotificationAsyncHandler<TNotification, TNotificationAsyncHandler>(this IUmbracoBuilder builder)
+            where TNotificationAsyncHandler : INotificationAsyncHandler<TNotification>
+            where TNotification : INotification
+        {
+            // Register the handler as transient. This ensures that anything can be injected into it.
+            var descriptor = new ServiceDescriptor(typeof(INotificationAsyncHandler<TNotification>), typeof(TNotificationAsyncHandler), ServiceLifetime.Transient);
 
             // TODO: Waiting on feedback here https://github.com/umbraco/Umbraco-CMS/pull/9556/files#r548365396 about whether
             // we perform this duplicate check or not.

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
@@ -25,8 +25,6 @@ namespace Umbraco.Core.DependencyInjection
             // Register the handler as transient. This ensures that anything can be injected into it.
             var descriptor = new ServiceDescriptor(typeof(INotificationHandler<TNotification>), typeof(TNotificationHandler), ServiceLifetime.Transient);
 
-            // TODO: Waiting on feedback here https://github.com/umbraco/Umbraco-CMS/pull/9556/files#r548365396 about whether
-            // we perform this duplicate check or not.
             if (!builder.Services.Contains(descriptor))
             {
                 builder.Services.Add(descriptor);
@@ -49,8 +47,6 @@ namespace Umbraco.Core.DependencyInjection
             // Register the handler as transient. This ensures that anything can be injected into it.
             var descriptor = new ServiceDescriptor(typeof(INotificationAsyncHandler<TNotification>), typeof(TNotificationAsyncHandler), ServiceLifetime.Transient);
 
-            // TODO: Waiting on feedback here https://github.com/umbraco/Umbraco-CMS/pull/9556/files#r548365396 about whether
-            // we perform this duplicate check or not.
             if (!builder.Services.Contains(descriptor))
             {
                 builder.Services.Add(descriptor);

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -146,7 +146,7 @@ namespace Umbraco.Core.DependencyInjection
 
             Services.AddSingleton<ManifestWatcher>();
             Services.AddSingleton<UmbracoRequestPaths>();
-            this.AddNotificationHandler<UmbracoApplicationStarting, AppPluginsManifestWatcherNotificationHandler>();
+            this.AddNotificationAsyncHandler<UmbracoApplicationStarting, AppPluginsManifestWatcherNotificationHandler>();
 
             Services.AddUnique<InstallStatusTracker>();
 

--- a/src/Umbraco.Core/Events/EventAggregator.cs
+++ b/src/Umbraco.Core/Events/EventAggregator.cs
@@ -38,6 +38,7 @@ namespace Umbraco.Core.Events
                 throw new ArgumentNullException(nameof(notification));
             }
 
+            PublishNotification(notification);
             return PublishNotificationAsync(notification, cancellationToken);
         }
     }

--- a/src/Umbraco.Core/Events/EventAggregator.cs
+++ b/src/Umbraco.Core/Events/EventAggregator.cs
@@ -41,6 +41,20 @@ namespace Umbraco.Core.Events
             PublishNotification(notification);
             return PublishNotificationAsync(notification, cancellationToken);
         }
+
+        /// <inheritdoc/>
+        public void Publish<TNotification>(TNotification notification)
+            where TNotification : INotification
+        {
+            // TODO: Introduce codegen efficient Guard classes to reduce noise.
+            if (notification == null)
+            {
+                throw new ArgumentNullException(nameof(notification));
+            }
+
+            PublishNotification(notification);
+            Task.WaitAll(PublishNotificationAsync(notification));
+        }
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Events/IEventAggregator.cs
+++ b/src/Umbraco.Core/Events/IEventAggregator.cs
@@ -21,5 +21,13 @@ namespace Umbraco.Core.Events
         /// <returns>A task that represents the publish operation.</returns>
         Task PublishAsync<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
             where TNotification : INotification;
+
+        /// <summary>
+        /// Synchronously send a notification to multiple handlers of both sync and async
+        /// </summary>
+        /// <typeparam name="TNotification">The type of notification being handled.</typeparam>
+        /// <param name="notification">The notification object.</param>
+        void Publish<TNotification>(TNotification notification)
+            where TNotification : INotification;
     }
 }

--- a/src/Umbraco.Core/Events/IEventAggregator.cs
+++ b/src/Umbraco.Core/Events/IEventAggregator.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Core.Events
     public interface IEventAggregator
     {
         /// <summary>
-        /// Asynchronously send a notification to multiple handlers
+        /// Asynchronously send a notification to multiple handlers of both sync and async
         /// </summary>
         /// <typeparam name="TNotification">The type of notification being handled.</typeparam>
         /// <param name="notification">The notification object.</param>

--- a/src/Umbraco.Core/Events/INotificationHandler.cs
+++ b/src/Umbraco.Core/Events/INotificationHandler.cs
@@ -17,6 +17,20 @@ namespace Umbraco.Core.Events
         /// Handles a notification
         /// </summary>
         /// <param name="notification">The notification</param>
+        void Handle(TNotification notification);
+    }
+
+    /// <summary>
+    /// Defines a handler for a async notification.
+    /// </summary>
+    /// <typeparam name="TNotification">The type of notification being handled.</typeparam>
+    public interface INotificationAsyncHandler<in TNotification>
+        where TNotification : INotification
+    {
+        /// <summary>
+        /// Handles a notification
+        /// </summary>
+        /// <param name="notification">The notification</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task HandleAsync(TNotification notification, CancellationToken cancellationToken);

--- a/src/Umbraco.Core/Runtime/AppPluginsManifestWatcherNotificationHandler.cs
+++ b/src/Umbraco.Core/Runtime/AppPluginsManifestWatcherNotificationHandler.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.Runtime
     /// <summary>
     /// Starts monitoring AppPlugins directory during debug runs, to restart site when a plugin manifest changes.
     /// </summary>
-    public sealed class AppPluginsManifestWatcherNotificationHandler : INotificationHandler<UmbracoApplicationStarting>
+    public sealed class AppPluginsManifestWatcherNotificationHandler : INotificationAsyncHandler<UmbracoApplicationStarting>
     {
         private readonly ManifestWatcher _manifestWatcher;
         private readonly IHostingEnvironment _hostingEnvironment;

--- a/src/Umbraco.Core/Runtime/EssentialDirectoryCreator.cs
+++ b/src/Umbraco.Core/Runtime/EssentialDirectoryCreator.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Umbraco.Core.Configuration.Models;
 using Umbraco.Core.Events;
@@ -21,7 +19,7 @@ namespace Umbraco.Core.Runtime
             _globalSettings = globalSettings.Value;
         }
 
-        public Task HandleAsync(UmbracoApplicationStarting notification, CancellationToken cancellationToken)
+        public void Handle(UmbracoApplicationStarting notification)
         {
             // ensure we have some essential directories
             // every other component can then initialize safely
@@ -31,7 +29,6 @@ namespace Umbraco.Core.Runtime
             _ioHelper.EnsurePathExists(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.PartialViews));
             _ioHelper.EnsurePathExists(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.MacroPartials));
 
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Cache/DatabaseServerMessengerNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/Cache/DatabaseServerMessengerNotificationHandler.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Core.Events;
 using Umbraco.Core.Persistence;
@@ -39,7 +37,7 @@ namespace Umbraco.Infrastructure.Cache
         }
 
         /// <inheritdoc/>
-        public Task HandleAsync(UmbracoApplicationStarting notification, CancellationToken cancellationToken)
+        public void Handle(UmbracoApplicationStarting notification)
         {
             // The scheduled tasks - TouchServerTask and InstructionProcessTask - run as .NET Core hosted services.
             // The former (as well as other hosted services that run outside of an HTTP request context) depends on the application URL
@@ -50,8 +48,6 @@ namespace Umbraco.Infrastructure.Cache
             _requestAccessor.EndRequest += EndRequest;
 
             Startup();
-
-            return Task.CompletedTask;
         }
 
         private void Startup()

--- a/src/Umbraco.Web.Common/Profiler/InitializeWebProfiling.cs
+++ b/src/Umbraco.Web.Common/Profiler/InitializeWebProfiling.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Core.Events;
 using Umbraco.Core.Logging;
@@ -46,7 +44,7 @@ namespace Umbraco.Web.Common.Profiler
         }
 
         /// <inheritdoc/>
-        public Task HandleAsync(UmbracoApplicationStarting notification, CancellationToken cancellationToken)
+        public void Handle(UmbracoApplicationStarting notification)
         {
             if (_profile)
             {
@@ -57,8 +55,6 @@ namespace Umbraco.Web.Common.Profiler
                 // Stop the profiling of the booting process
                 _profiler.StopBoot();
             }
-
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
### Details
- Added support for sync notification handlers in the `EventAggregator`
- Updated async handlers that was not using the async parts to be sync.


### Test
- Everything should work as before. E.g Set a breakpoint in one of the sync handlers and see it breaks as expected