### PR TITLE
Makes #9004 backwards compatible

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbautofocus.directive.js
@@ -10,18 +10,14 @@ angular.module("umbraco.directives")
                 }
             };
 
-            //check if there's a value for the attribute, if there is and it's false then we conditionally don't
-            //use auto focus.
-            if (attrs.umbAutoFocus) {
-                attrs.$observe("umbAutoFocus", function (newVal) {
-                    var enabled = (newVal === "false" || newVal === 0 || newVal === false) ? false : true;
-                    if (enabled) {
-                        $timeout(function() {
-                            update();
-                        });
-                    }
-                });
-            }
+            attrs.$observe("umbAutoFocus", function (newVal) {
+                var enabled = (newVal === "false" || newVal === 0 || newVal === false) ? false : true;
+                if (enabled) {
+                    $timeout(function() {
+                        update();
+                    });
+                }
+            });
 
         };
 });


### PR DESCRIPTION
In order to still accept an empty attribute value for the directive umb-auto-focus, I have removed the if-sentence. Meaning that we will always observe the value. Basicly Enabling the auto-focus when it's not explicitly set to either: "false", false or 0.

Test-notes:

Before this fix, the Document Type Editor didn't focus on the Name input.
Neither for when creating a new property group and again not when creating a new property.
This has been fixed with this issue, but I'm not sure if this ruins other expected behavior, not from my understanding, but please test concerns.