### PR TITLE
Call rebindCallback on errors as well

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -271,7 +271,7 @@
          * @param {any} app the active content app
          */
         function createButtons(content) {
-            
+
             var isBlueprint = content.isBlueprint;
 
             if ($scope.page.isNew && $location.path().search(/contentBlueprints/i) !== -1) {
@@ -474,6 +474,10 @@
                 return $q.when(data);
             },
                 function (err) {
+
+                    //needs to be manually set for infinite editing mode
+                    $scope.page.isNew = false;
+
                     syncTreeNode($scope.content, $scope.content.path);
 
                     resetNestedFieldValiation(fieldsToRollback);
@@ -981,7 +985,7 @@
         $scope.appChanged = function (activeApp) {
 
             $scope.activeApp = activeApp;
-            
+
             _.forEach($scope.content.apps, function (app) {
                 app.active = false;
                 if (app.alias === $scope.activeApp.alias) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -125,7 +125,10 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                             softRedirect: args.softRedirect,
                             err: err,
                             rebindCallback: function () {
-                                rebindCallback.apply(self, [args.content, err.data]);
+                                // if the error contains data, we want to map that back as we want to continue editing this save. Especially important when the content is new as the returned data will contain ID etc.
+                                if(err.data) {
+                                    rebindCallback.apply(self, [args.content, err.data]);
+                                }
                             }
                         });
 
@@ -625,7 +628,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
             if (!args.err) {
                 throw "args.err cannot be null";
             }
-            
+
             //When the status is a 400 status with a custom header: X-Status-Reason: Validation failed, we have validation errors.
             //Otherwise the error is probably due to invalid data (i.e. someone mucking around with the ids or something).
             //Or, some strange server error

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -84,7 +84,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                 //when true, the url will change but it won't actually re-route
                 //this is merely here for compatibility, if only the content/media/members used this service we'd prob be ok but tons of editors
                 //use this service unfortunately and probably packages too.
-                args.softRedirect = false; 
+                args.softRedirect = false;
             }
 
 
@@ -123,7 +123,10 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                         self.handleSaveError({
                             showNotifications: args.showNotifications,
                             softRedirect: args.softRedirect,
-                            err: err
+                            err: err,
+                            rebindCallback: function () {
+                                rebindCallback.apply(self, [args.content, err.data]);
+                            }
                         });
 
                         //update editor state to what is current
@@ -298,7 +301,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                 }
 
                 // if publishing is allowed also allow schedule publish
-                // we add this manually becuase it doesn't have a permission so it wont 
+                // we add this manually becuase it doesn't have a permission so it wont
                 // get picked up by the loop through permissions
                 if (_.contains(args.content.allowedActions, "U")) {
                     buttons.subButtons.push(createButtonDefinition("SCHEDULE"));
@@ -640,7 +643,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
 
                     if (!this.redirectToCreatedContent(args.err.data.id, args.softRedirect) || args.softRedirect) {
                         // If we are not redirecting it's because this is not newly created content, else in some cases we are
-                        // soft-redirecting which means the URL will change but the route wont (i.e. creating content). 
+                        // soft-redirecting which means the URL will change but the route wont (i.e. creating content).
 
                         // In this case we need to detect what properties have changed and re-bind them with the server data.
                         if (args.rebindCallback && angular.isFunction(args.rebindCallback)) {
@@ -687,7 +690,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
             if (!this.redirectToCreatedContent(args.redirectId ? args.redirectId : args.savedContent.id, args.softRedirect) || args.softRedirect) {
 
                 // If we are not redirecting it's because this is not newly created content, else in some cases we are
-                // soft-redirecting which means the URL will change but the route wont (i.e. creating content). 
+                // soft-redirecting which means the URL will change but the route wont (i.e. creating content).
 
                 // In this case we need to detect what properties have changed and re-bind them with the server data.
                 if (args.rebindCallback && angular.isFunction(args.rebindCallback)) {
@@ -723,7 +726,7 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                     navigationService.setSoftRedirect();
                 }
                 //change to new path
-                $location.path("/" + $routeParams.section + "/" + $routeParams.tree + "/" + $routeParams.method + "/" + id);                
+                $location.path("/" + $routeParams.section + "/" + $routeParams.tree + "/" + $routeParams.method + "/" + id);
                 //don't add a browser history for this
                 $location.replace();
                 return true;


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/9341

When new content is created and saved with errors, it's still begin saved and therefore it's not new anymore and future saves should be changes of this. Therefore it's important that ID, Key, and other identifiers of this new content are parsed on. This is done by the rebindCallback and therefor we should call it despite validation issues.

I do have concerns: we have several Property Editors that react when the Content Model is updated, I hope these will still work as intended, our test focus should be around this topic.