### PR TITLE
Fix some exceptions being logged the wrong way

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/LiveModelsProvider.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/LiveModelsProvider.cs
@@ -91,7 +91,7 @@ namespace Umbraco.ModelsBuilder.Embedded
             catch (Exception e)
             {
                 _mbErrors.Report("Failed to build Live models.", e);
-                _logger.Error<LiveModelsProvider>("Failed to generate models.", e);
+                _logger.Error<LiveModelsProvider>(e, "Failed to generate models.");
             }
             finally
             {

--- a/src/Umbraco.ModelsBuilder.Embedded/PureLiveModelFactory.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/PureLiveModelFactory.cs
@@ -308,7 +308,7 @@ namespace Umbraco.ModelsBuilder.Embedded
                     {
                         try
                         {
-                            _logger.Error<PureLiveModelFactory>("Failed to build models.", e);
+                            _logger.Error<PureLiveModelFactory>(e, "Failed to build models.");
                             _logger.Warn<PureLiveModelFactory>("Running without models."); // be explicit
                             _errors.Report("Failed to build PureLive models.", e);
                         }

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Web.PropertyEditors
             }
             catch (Exception ex)
             {
-                _logger.Error<MultiUrlPickerValueEditor>("Error getting links", ex);
+                _logger.Error<MultiUrlPickerValueEditor>(ex, "Error getting links");
             }
 
             return base.ToEditor(property, dataTypeService, culture, segment);
@@ -150,7 +150,7 @@ namespace Umbraco.Web.PropertyEditors
             }
             catch (Exception ex)
             {
-                _logger.Error<MultiUrlPickerValueEditor>("Error saving links", ex);
+                _logger.Error<MultiUrlPickerValueEditor>(ex, "Error saving links");
             }
 
             return base.FromEditor(editorValue, currentValue);

--- a/src/Umbraco.Web/UmbracoInjectedModule.cs
+++ b/src/Umbraco.Web/UmbracoInjectedModule.cs
@@ -328,7 +328,7 @@ namespace Umbraco.Web
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error<UmbracoModule>("Could not dispose item with key " + k, ex);
+                    _logger.Error<UmbracoModule>(ex, "Could not dispose item with key {Key}", k);
                 }
                 try
                 {
@@ -336,7 +336,7 @@ namespace Umbraco.Web
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error<UmbracoModule>("Could not dispose item key " + k, ex);
+                    _logger.Error<UmbracoModule>(ex, "Could not dispose item key {Key}", k);
                 }
             }
         }


### PR DESCRIPTION
In these statements, the exception was passed as a log message parameter instead of as the exception. This meant the exception and including stack trace was not logged and thus lost.

### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

As above, the log messages were missing important context as the exception was not logged. By switching around the parameters the correct overload is called.

It was calling https://github.com/umbraco/Umbraco-CMS/blob/2bfef741914297c802bc6c77cc48780d7534f920/src/Umbraco.Core/Logging/LoggerExtensions.cs#L65

But it intended to call https://github.com/umbraco/Umbraco-CMS/blob/2bfef741914297c802bc6c77cc48780d7534f920/src/Umbraco.Core/Logging/LoggerExtensions.cs#L37 or https://github.com/umbraco/Umbraco-CMS/blob/2bfef741914297c802bc6c77cc48780d7534f920/src/Umbraco.Core/Logging/LoggerExtensions.cs#L26

#### Testing steps:

- Trigger error
- See log now includes exception and stack traces
- Existing tests pass

