### PR TITLE
log4net upgrade 2.0.8 -> 2.0.12

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -16,7 +16,7 @@
         <tags>umbraco</tags>
         <dependencies>
             <group targetFramework="net452">
-                <dependency id="log4net" version="[2.0.8, 3.0.0)" />
+                <dependency id="log4net" version="[2.0.12, 3.0.0)" />
                 <dependency id="Log4Net.Async" version="[2.0.4, 3.0.0)" />
                 <dependency id="Microsoft.AspNet.Mvc" version="[5.2.7, 6.0.0)" />
                 <dependency id="Microsoft.AspNet.WebApi" version="[5.2.7, 6.0.0)" />

--- a/src/SQLCE4Umbraco/app.config
+++ b/src/SQLCE4Umbraco/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -55,8 +55,8 @@
     <Reference Include="ImageProcessor, Version=2.7.0.100, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ImageProcessor.2.7.0.100\lib\net452\ImageProcessor.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Log4Net.Async, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Log4Net.Async.2.0.4\lib\net40\Log4Net.Async.dll</HintPath>

--- a/src/Umbraco.Core/app.config
+++ b/src/Umbraco.Core/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Umbraco.Core/packages.config
+++ b/src/Umbraco.Core/packages.config
@@ -4,7 +4,7 @@
   <package id="ClientDependency" version="1.9.9" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.8.8" targetFramework="net452" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net452" />
-  <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Log4Net.Async" version="2.0.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.2" targetFramework="net452" />

--- a/src/Umbraco.Tests.Benchmarks/app.config
+++ b/src/Umbraco.Tests.Benchmarks/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/Umbraco.Tests/App.config
+++ b/src/Umbraco.Tests/App.config
@@ -165,7 +165,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -74,8 +74,8 @@
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Log4Net.Async, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Log4Net.Async.2.0.4\lib\net40\Log4Net.Async.dll</HintPath>

--- a/src/Umbraco.Tests/packages.config
+++ b/src/Umbraco.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="Examine" version="0.1.90" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.8.8" targetFramework="net452" />
-  <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Log4Net.Async" version="2.0.4" targetFramework="net45" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.2" targetFramework="net452" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -145,8 +145,8 @@
     <Reference Include="ImageProcessor.Web, Version=4.10.0.100, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ImageProcessor.Web.4.10.0.100\lib\net452\ImageProcessor.Web.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Lucene.Net, Version=2.9.4.1, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>

--- a/src/Umbraco.Web.UI/packages.config
+++ b/src/Umbraco.Web.UI/packages.config
@@ -8,7 +8,7 @@
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net452" />
   <package id="ImageProcessor.Web" version="4.10.0.100" targetFramework="net452" />
   <package id="ImageProcessor.Web.Config" version="2.5.0.100" targetFramework="net452" />
-  <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.2" targetFramework="net452" />

--- a/src/Umbraco.Web/app.config
+++ b/src/Umbraco.Web/app.config
@@ -69,7 +69,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/UmbracoExamine/app.config
+++ b/src/UmbracoExamine/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/umbraco.MacroEngines/app.config
+++ b/src/umbraco.MacroEngines/app.config
@@ -44,7 +44,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/umbraco.businesslogic/app.config
+++ b/src/umbraco.businesslogic/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/umbraco.cms/app.config
+++ b/src/umbraco.cms/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/umbraco.controls/app.config
+++ b/src/umbraco.controls/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/umbraco.datalayer/app.config
+++ b/src/umbraco.datalayer/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/umbraco.editorControls/app.config
+++ b/src/umbraco.editorControls/app.config
@@ -53,7 +53,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
According to WhiteSource Bolt there is a Security Issue in v7 regarding the third party library log4net.

Apache log4net versions before 2.0.10 do not disable XML external entities when parsing log4net configuration files. This allows for XXE-based attacks in applications that accept attacker-controlled log4net configuration files.

Solution: Upgrade to version log4net - 2.0.12

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
