### PR TITLE
Stop using .length !== 0 when its not jQuery

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
@@ -85,10 +85,11 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
          */
         focusOnFirstError: function(form) {
             var invalidNgForms = form.$$element.find(`.umb-property ng-form.ng-invalid, .umb-property-editor ng-form.ng-invalid-required`);
-            if(invalidNgForms !== undefined && invalidNgForms.length > 0) {
-                var firstInvalidNgForm = invalidNgForms.first();
-                var focusableFields = firstInvalidNgForm.find("umb-range-slider .noUi-handle,input,textarea,select,button");
-                if(focusableFields !== undefined) {
+            var firstInvalidNgForm = invalidNgForms.first();
+
+            if(firstInvalidNgForm.length !== 0) {
+                var focusableFields = [...firstInvalidNgForm.find("umb-range-slider .noUi-handle,input,textarea,select,button")];
+                if(focusableFields.length !== 0) {
                     var firstErrorEl = focusableFields.find(el => el.type !== "hidden" && el.hasAttribute("readonly") === false);
                     if(firstErrorEl !== undefined) {
                         firstErrorEl.focus();

--- a/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/formhelper.service.js
@@ -46,7 +46,7 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
             args.scope.$broadcast("formSubmitting", { scope: args.scope, action: args.action });
 
             this.focusOnFirstError(currentForm);
-            
+
             // Some property editors need to perform an action after all property editors have reacted to the formSubmitting.
             args.scope.$broadcast("formSubmittingFinalPhase", { scope: args.scope, action: args.action });
 
@@ -80,18 +80,17 @@ function formHelper(angularHelper, serverValidationManager, notificationsService
          *
          * @description
          * Called by submitForm when a form has been submitted, it will fire a focus on the first found invalid umb-property it finds in the form..
-         * 
+         *
          * @param {object} form Pass in a form object.
          */
         focusOnFirstError: function(form) {
             var invalidNgForms = form.$$element.find(`.umb-property ng-form.ng-invalid, .umb-property-editor ng-form.ng-invalid-required`);
-            var firstInvalidNgForm = invalidNgForms.first();
-
-            if(firstInvalidNgForm.length !== 0) {
-                var focusableFields = [...firstInvalidNgForm.find("umb-range-slider .noUi-handle,input,textarea,select,button")];
-                if(focusableFields.length !== 0) { 
+            if(invalidNgForms !== undefined && invalidNgForms.length > 0) {
+                var firstInvalidNgForm = invalidNgForms.first();
+                var focusableFields = firstInvalidNgForm.find("umb-range-slider .noUi-handle,input,textarea,select,button");
+                if(focusableFields !== undefined) {
                     var firstErrorEl = focusableFields.find(el => el.type !== "hidden" && el.hasAttribute("readonly") === false);
-                    if(firstErrorEl.length !== 0) {
+                    if(firstErrorEl !== undefined) {
                         firstErrorEl.focus();
                     }
                 }


### PR DESCRIPTION
As I was getting this error;
![image](https://user-images.githubusercontent.com/6791648/105729870-f3992880-5f2d-11eb-8921-9c94ebb11ea3.png)

I stumbled upon this code which is a bit tricky as it's using some JQuery and some Native code. Most of the code is using the jQuery find(), which always returns a jQuery collection. But the last part is using native find() of an Array, which will return undefined if nothing is found.

Therefor i have changed this.