### PR TITLE
Add Check for ´err´

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -478,7 +478,7 @@
 
                     syncTreeNode($scope.content, $scope.content.path);
 
-                    if (err.status === 400 && err.data) {
+                    if (err && err.status === 400 && err.data) {
                         // content was saved but is invalid.
                         eventsService.emit("content.saved", { content: $scope.content, action: args.action, valid: false });
                     }


### PR DESCRIPTION
After this fix(https://github.com/umbraco/Umbraco-CMS/pull/9690) I sometimes get JS error for `err` being undefined.

This PR add a check for that.

To reproduce: make a DocType with Mandatory Media Picker, try to save without a media picked.