### PR TITLE
Add more constants for tree icons

### DIFF
--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -25,6 +25,26 @@
             public const string DataType = "icon-autofill";
 
             /// <summary>
+            /// System dictionary icon
+            /// </summary>
+            public const string Dictionary = "icon-book-alt";
+
+            /// <summary>
+            /// System generic folder icon
+            /// </summary>
+            public const string Folder = "icon-folder";
+
+            /// <summary>
+            /// System language icon
+            /// </summary>
+            public const string Language = "icon-globe";
+
+            /// <summary>
+            /// System logviewer icon
+            /// </summary>
+            public const string LogViewer = "icon-box-alt";
+
+            /// <summary>
             /// System list view icon
             /// </summary>
             public const string ListView = "icon-thumbnail-list";
@@ -69,6 +89,11 @@
             /// </summary>
             public const string MemberType = "icon-users";
 
+            /// <summary>
+            /// System packages icon
+            /// </summary>
+            public const string Packages = "icon-box";
+            
             /// <summary>
             /// System property editor icon
             /// </summary>

--- a/src/Umbraco.Web/Trees/DataTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/DataTypeTreeController.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Web.Trees
                    .OrderBy(entity => entity.Name)
                    .Select(dt =>
                    {
-                       var node = CreateTreeNode(dt, Constants.ObjectTypes.DataType, id, queryStrings, "icon-folder", dt.HasChildren);
+                       var node = CreateTreeNode(dt, Constants.ObjectTypes.DataType, id, queryStrings, Constants.Icons.Folder, dt.HasChildren);
                        node.Path = dt.Path;
                        node.NodeType = "container";
                        // TODO: This isn't the best way to ensure a no operation process for clicking a node but it works for now.

--- a/src/Umbraco.Web/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web/Trees/DictionaryTreeController.cs
@@ -67,7 +67,7 @@ namespace Umbraco.Web.Trees
                             id,
                             queryStrings,
                             x.ItemKey,
-                            "icon-book-alt",
+                            Constants.Icons.Dictionary,
                             Services.LocalizationService.GetDictionaryItemChildren(x.Key).Any())));
             }
             else
@@ -83,7 +83,7 @@ namespace Umbraco.Web.Trees
                         id,
                         queryStrings,
                         x.ItemKey,
-                        "icon-book-alt",
+                        Constants.Icons.Dictionary,
                         Services.LocalizationService.GetDictionaryItemChildren(x.Key).Any())));
             }
 

--- a/src/Umbraco.Web/Trees/LanguageTreeController.cs
+++ b/src/Umbraco.Web/Trees/LanguageTreeController.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Web.Trees
 
             //this will load in a custom UI instead of the dashboard for the root node
             root.RoutePath = $"{Constants.Applications.Settings}/{Constants.Trees.Languages}/overview";
-            root.Icon = "icon-globe";
+            root.Icon = Constants.Icons.Language;
             root.HasChildren = false;
             root.MenuUrl = null;
 

--- a/src/Umbraco.Web/Trees/LogViewerTreeController.cs
+++ b/src/Umbraco.Web/Trees/LogViewerTreeController.cs
@@ -33,8 +33,8 @@ namespace Umbraco.Web.Trees
             var root = base.CreateRootNode(queryStrings);
 
             //this will load in a custom UI instead of the dashboard for the root node
-            root.RoutePath = string.Format("{0}/{1}/{2}", Constants.Applications.Settings, Constants.Trees.LogViewer, "overview");
-            root.Icon = "icon-box-alt";
+            root.RoutePath = $"{Constants.Applications.Settings}/{Constants.Trees.LogViewer}/overview";
+            root.Icon = Constants.Icons.LogViewer;
             root.HasChildren = false;
             root.MenuUrl = null;
 

--- a/src/Umbraco.Web/Trees/PackagesTreeController.cs
+++ b/src/Umbraco.Web/Trees/PackagesTreeController.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Trees
 
             //this will load in a custom UI instead of the dashboard for the root node
             root.RoutePath = $"{Constants.Applications.Packages}/{Constants.Trees.Packages}/repo";
-            root.Icon = "icon-box";
+            root.Icon = Constants.Icons.Packages;
 
             root.HasChildren = false;
             return root;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Most trees was using icons from a constants static class, so I have updated this with more icons for tree nodes. Especially a constant for the generic `icon-folder` folder icon would be useful and since more areas in backoffice allow creating folders in tree.