### PR TITLE
Cleanup some of the MB changes for netcore

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Umbraco.Core/DependencyInjection/ServiceProviderExtensions.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Umbraco.Core.DependencyInjection
 {
@@ -8,7 +13,6 @@ namespace Umbraco.Core.DependencyInjection
     /// </summary>
     public static class ServiceProviderExtensions
     {
-
         /// <summary>
         /// Creates an instance with arguments.
         /// </summary>
@@ -27,7 +31,7 @@ namespace Umbraco.Core.DependencyInjection
         /// <summary>
         /// Creates an instance of a service, with arguments.
         /// </summary>
-        /// <param name="serviceProvider"></param>
+        /// <param name="serviceProvider">The <see cref="IServiceProvider"/></param>
         /// <param name="type">The type of the instance.</param>
         /// <param name="args">Named arguments.</param>
         /// <returns>An instance of the specified type.</returns>
@@ -37,46 +41,17 @@ namespace Umbraco.Core.DependencyInjection
         /// are retrieved from the factory.</para>
         /// </remarks>
         public static object CreateInstance(this IServiceProvider serviceProvider, Type type, params object[] args)
+            => ActivatorUtilities.CreateInstance(serviceProvider, type, args);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PublishedModelFactory CreateDefaultPublishedModelFactory(this IServiceProvider factory)
         {
-            // LightInject has this, but then it requires RegisterConstructorDependency etc and has various oddities
-            // including the most annoying one, which is that it does not work on singletons (hard to fix)
-            //return factory.GetInstance(type, args);
-
-            // this method is essentially used to build singleton instances, so it is assumed that it would be
-            // more expensive to build and cache a dynamic method ctor than to simply invoke the ctor, as we do
-            // here - this can be discussed
-
-            // TODO: we currently try the ctor with most parameters, but we could want to fall back to others
-
-            //var ctor = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public).OrderByDescending(x => x.GetParameters().Length).FirstOrDefault();
-            //if (ctor == null) throw new InvalidOperationException($"Could not find a public constructor for type {type.FullName}.");
-
-            //var ctorParameters = ctor.GetParameters();
-            //var ctorArgs = new object[ctorParameters.Length];
-            //var availableArgs = new List<object>(args);
-            //var i = 0;
-            //foreach (var parameter in ctorParameters)
-            //{
-            //    // no! IsInstanceOfType is not ok here
-            //    // ReSharper disable once UseMethodIsInstanceOfType
-            //    var idx = availableArgs.FindIndex(a => parameter.ParameterType.IsAssignableFrom(a.GetType()));
-            //    if (idx >= 0)
-            //    {
-            //        // Found a suitable supplied argument
-            //        ctorArgs[i++] = availableArgs[idx];
-
-            //        // A supplied argument can be used at most once
-            //        availableArgs.RemoveAt(idx);
-            //    }
-            //    else
-            //    {
-            //        // None of the provided arguments is suitable: get an instance from the factory
-            //        ctorArgs[i++] = serviceProvider.GetRequiredService(parameter.ParameterType);
-            //    }
-            //}
-            //return ctor.Invoke(ctorArgs);
-
-            return ActivatorUtilities.CreateInstance(serviceProvider, type, args);
+            TypeLoader typeLoader = factory.GetRequiredService<TypeLoader>();
+            IPublishedValueFallback publishedValueFallback = factory.GetRequiredService<IPublishedValueFallback>();
+            IEnumerable<Type> types = typeLoader
+                .GetTypes<PublishedElementModel>() // element models
+                .Concat(typeLoader.GetTypes<PublishedContentModel>()); // content models
+            return new PublishedModelFactory(types, publishedValueFallback);
         }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Core.Events;
 
 namespace Umbraco.Core.DependencyInjection
 {
+
     /// <summary>
     /// Contains extensions methods for <see cref="IUmbracoBuilder"/> used for registering event handlers.
     /// </summary>
@@ -56,30 +55,5 @@ namespace Umbraco.Core.DependencyInjection
 
             return builder;
         }
-
-        // This is required because the default implementation doesn't implement Equals or GetHashCode.
-        // see: https://github.com/dotnet/runtime/issues/47262
-        private class UniqueServiceDescriptor : ServiceDescriptor, IEquatable<UniqueServiceDescriptor>
-        {
-            public UniqueServiceDescriptor(Type serviceType, Type implementationType, ServiceLifetime lifetime)
-                : base(serviceType, implementationType, lifetime)
-            {
-            }
-
-            public override bool Equals(object obj) => Equals(obj as UniqueServiceDescriptor);
-            public bool Equals(UniqueServiceDescriptor other) => other != null && Lifetime == other.Lifetime && EqualityComparer<Type>.Default.Equals(ServiceType, other.ServiceType) && EqualityComparer<Type>.Default.Equals(ImplementationType, other.ImplementationType) && EqualityComparer<object>.Default.Equals(ImplementationInstance, other.ImplementationInstance) && EqualityComparer<Func<IServiceProvider, object>>.Default.Equals(ImplementationFactory, other.ImplementationFactory);
-
-            public override int GetHashCode()
-            {
-                int hashCode = 493849952;
-                hashCode = hashCode * -1521134295 + Lifetime.GetHashCode();
-                hashCode = hashCode * -1521134295 + EqualityComparer<Type>.Default.GetHashCode(ServiceType);
-                hashCode = hashCode * -1521134295 + EqualityComparer<Type>.Default.GetHashCode(ImplementationType);
-                hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(ImplementationInstance);
-                hashCode = hashCode * -1521134295 + EqualityComparer<Func<IServiceProvider, object>>.Default.GetHashCode(ImplementationFactory);
-                return hashCode;
-            }
-        }
-
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -216,6 +217,11 @@ namespace Umbraco.Core.DependencyInjection
                     ? (IServerRoleAccessor)new SingleServerRoleAccessor()
                     : new ElectedServerRoleAccessor(f.GetRequiredService<IServerRegistrationService>());
             });
+
+            // For Umbraco to work it must have the default IPublishedModelFactory
+            // which may be replaced by models builder but the default is required to make plain old IPublishedContent
+            // instances.
+            Services.AddSingleton<IPublishedModelFactory>(factory => factory.CreateDefaultPublishedModelFactory());
         }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UniqueServiceDescriptor.cs
+++ b/src/Umbraco.Core/DependencyInjection/UniqueServiceDescriptor.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Umbraco.Core.DependencyInjection
+{
+    /// <summary>
+    /// A custom <see cref="ServiceDescriptor"/> that supports unique checking
+    /// </summary>
+    /// <remarks>
+    /// This is required because the default implementation doesn't implement Equals or GetHashCode.
+    /// see: https://github.com/dotnet/runtime/issues/47262
+    /// </remarks>
+    public sealed class UniqueServiceDescriptor : ServiceDescriptor, IEquatable<UniqueServiceDescriptor>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UniqueServiceDescriptor"/> class.
+        /// </summary>
+        public UniqueServiceDescriptor(Type serviceType, Type implementationType, ServiceLifetime lifetime)
+            : base(serviceType, implementationType, lifetime)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as UniqueServiceDescriptor);
+
+        /// <inheritdoc/>
+        public bool Equals(UniqueServiceDescriptor other) => other != null && Lifetime == other.Lifetime && EqualityComparer<Type>.Default.Equals(ServiceType, other.ServiceType) && EqualityComparer<Type>.Default.Equals(ImplementationType, other.ImplementationType) && EqualityComparer<object>.Default.Equals(ImplementationInstance, other.ImplementationInstance) && EqualityComparer<Func<IServiceProvider, object>>.Default.Equals(ImplementationFactory, other.ImplementationFactory);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = 493849952;
+            hashCode = (hashCode * -1521134295) + Lifetime.GetHashCode();
+            hashCode = (hashCode * -1521134295) + EqualityComparer<Type>.Default.GetHashCode(ServiceType);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<Type>.Default.GetHashCode(ImplementationType);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<object>.Default.GetHashCode(ImplementationInstance);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<Func<IServiceProvider, object>>.Default.GetHashCode(ImplementationFactory);
+            return hashCode;
+        }
+    }
+}

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedModelFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedModelFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -17,8 +17,11 @@ namespace Umbraco.Core.Models.PublishedContent
         private class ModelInfo
         {
             public Type ParameterType { get; set; }
+
             public Func<object, IPublishedValueFallback, object> Ctor { get; set; }
+
             public Type ModelType { get; set; }
+
             public Func<IList> ListCtor { get; set; }
         }
 
@@ -36,8 +39,7 @@ namespace Umbraco.Core.Models.PublishedContent
         /// PublishedContentModelFactoryResolver.Current.SetFactory(factory);
         /// </code>
         /// </remarks>
-        public PublishedModelFactory(IEnumerable<Type> types,
-            IPublishedValueFallback publishedValueFallback)
+        public PublishedModelFactory(IEnumerable<Type> types, IPublishedValueFallback publishedValueFallback)
         {
             var modelInfos = new Dictionary<string, ModelInfo>(StringComparer.InvariantCultureIgnoreCase);
             var modelTypeMap = new Dictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase);

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="HtmlAgilityPack" Version="1.11.29" />
+      <PackageReference Include="HtmlAgilityPack" Version="1.11.30" />
       <PackageReference Include="MailKit" Version="2.10.1" />
       <PackageReference Include="Markdown" Version="2.2.1" />
       <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -102,8 +102,4 @@
       <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Scheduling" />
-    </ItemGroup>
-
 </Project>

--- a/src/Umbraco.ModelsBuilder.Embedded/Building/ModelsGenerator.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Building/ModelsGenerator.cs
@@ -3,8 +3,8 @@ using System.Text;
 using Microsoft.Extensions.Options;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Configuration.Models;
-using Umbraco.Core.IO;
 using Umbraco.Core.Hosting;
+using Umbraco.Core.IO;
 
 namespace Umbraco.ModelsBuilder.Embedded.Building
 {

--- a/src/Umbraco.ModelsBuilder.Embedded/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Umbraco.Core.DependencyInjection;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.ModelsBuilder.Embedded.Building;
+using Umbraco.Web.Common.ModelBinders;
 using Umbraco.Web.WebAssets;
 
 /*
@@ -91,6 +92,7 @@ namespace Umbraco.ModelsBuilder.Embedded.DependencyInjection
             // would automatically just register for all implemented INotificationHandler{T}?
             builder.AddNotificationHandler<UmbracoApplicationStarting, ModelsBuilderNotificationHandler>();
             builder.AddNotificationHandler<ServerVariablesParsing, ModelsBuilderNotificationHandler>();
+            builder.AddNotificationHandler<ModelBindingError, ModelsBuilderNotificationHandler>();
             builder.AddNotificationHandler<UmbracoApplicationStarting, LiveModelsProvider>();
             builder.AddNotificationHandler<UmbracoRequestEnd, LiveModelsProvider>();
             builder.AddNotificationHandler<UmbracoApplicationStarting, OutOfDateModelsStatus>();

--- a/src/Umbraco.ModelsBuilder.Embedded/LiveModelsProvider.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/LiveModelsProvider.cs
@@ -45,10 +45,7 @@ namespace Umbraco.ModelsBuilder.Embedded
         /// <summary>
         /// Handles the <see cref="UmbracoApplicationStarting"/> notification
         /// </summary>
-        public void Handle(UmbracoApplicationStarting notification)
-        {
-            Install();
-        }
+        public void Handle(UmbracoApplicationStarting notification) => Install();
 
         private void Install()
         {

--- a/src/Umbraco.ModelsBuilder.Embedded/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/ModelsBuilderNotificationHandler.cs
@@ -53,7 +53,7 @@ namespace Umbraco.ModelsBuilder.Embedded
         }
 
         /// <summary>
-        /// Handles the <see cref="ServerVariablesParsing"/> notification
+        /// Handles the <see cref="ServerVariablesParsing"/> notification to add custom urls and MB mode
         /// </summary>
         public void Handle(ServerVariablesParsing notification)
         {
@@ -93,7 +93,7 @@ namespace Umbraco.ModelsBuilder.Embedded
         {
             var settings = new Dictionary<string, object>
             {
-                {"mode", _config.ModelsMode.ToString()}
+                {"mode", _config.ModelsMode.ToString() }
             };
 
             return settings;
@@ -188,13 +188,12 @@ namespace Umbraco.ModelsBuilder.Embedded
                 {
                     // both are pure - report, and if different versions, restart
                     // if same version... makes no sense... and better not restart (loops?)
-                    var sourceVersion = notification.SourceType.Assembly.GetName().Version;
-                    var modelVersion = notification.ModelType.Assembly.GetName().Version;
+                    Version sourceVersion = notification.SourceType.Assembly.GetName().Version;
+                    Version modelVersion = notification.ModelType.Assembly.GetName().Version;
                     notification.Message.Append(" Both view and content models are PureLive, with ");
                     notification.Message.Append(sourceVersion == modelVersion
                         ? "same version. The application is in an unstable state and should be restarted."
-                        : "different versions. The application is in an unstable state and is going to be restarted.");
-                    notification.Restart = sourceVersion != modelVersion;
+                        : "different versions. The application is in an unstable state and should be restarted.");
                 }
             }
         }

--- a/src/Umbraco.ModelsBuilder.Embedded/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/ModelsBuilderNotificationHandler.cs
@@ -22,24 +22,21 @@ namespace Umbraco.ModelsBuilder.Embedded
     /// <summary>
     /// Handles <see cref="UmbracoApplicationStarting"/> and <see cref="ServerVariablesParsing"/> notifications to initialize MB
     /// </summary>
-    internal class ModelsBuilderNotificationHandler : INotificationHandler<UmbracoApplicationStarting>, INotificationHandler<ServerVariablesParsing>
+    internal class ModelsBuilderNotificationHandler : INotificationHandler<UmbracoApplicationStarting>, INotificationHandler<ServerVariablesParsing>, INotificationHandler<ModelBindingError>
     {
         private readonly ModelsBuilderSettings _config;
         private readonly IShortStringHelper _shortStringHelper;
         private readonly LinkGenerator _linkGenerator;
-        private readonly ContentModelBinder _modelBinder;
 
         public ModelsBuilderNotificationHandler(
             IOptions<ModelsBuilderSettings> config,
             IShortStringHelper shortStringHelper,
-            LinkGenerator linkGenerator,
-            ContentModelBinder modelBinder)
+            LinkGenerator linkGenerator)
         {
             _config = config.Value;
             _shortStringHelper = shortStringHelper;
             _shortStringHelper = shortStringHelper;
             _linkGenerator = linkGenerator;
-            _modelBinder = modelBinder;
         }
 
         /// <summary>
@@ -49,8 +46,6 @@ namespace Umbraco.ModelsBuilder.Embedded
         {
             // always setup the dashboard
             // note: UmbracoApiController instances are automatically registered
-            _modelBinder.ModelBindingException += ContentModelBinder_ModelBindingException;
-
             if (_config.ModelsMode != ModelsMode.Nothing)
             {
                 FileService.SavingTemplate += FileService_SavingTemplate;
@@ -149,10 +144,13 @@ namespace Umbraco.ModelsBuilder.Embedded
             }
         }
 
-        private void ContentModelBinder_ModelBindingException(object sender, ContentModelBinder.ModelBindingArgs args)
+        /// <summary>
+        /// Handles when a model binding error occurs
+        /// </summary>
+        public void Handle(ModelBindingError notification)
         {
-            ModelsBuilderAssemblyAttribute sourceAttr = args.SourceType.Assembly.GetCustomAttribute<ModelsBuilderAssemblyAttribute>();
-            ModelsBuilderAssemblyAttribute modelAttr = args.ModelType.Assembly.GetCustomAttribute<ModelsBuilderAssemblyAttribute>();
+            ModelsBuilderAssemblyAttribute sourceAttr = notification.SourceType.Assembly.GetCustomAttribute<ModelsBuilderAssemblyAttribute>();
+            ModelsBuilderAssemblyAttribute modelAttr = notification.ModelType.Assembly.GetCustomAttribute<ModelsBuilderAssemblyAttribute>();
 
             // if source or model is not a ModelsBuider type...
             if (sourceAttr == null || modelAttr == null)
@@ -164,11 +162,11 @@ namespace Umbraco.ModelsBuilder.Embedded
                 }
 
                 // else report, but better not restart (loops?)
-                args.Message.Append(" The ");
-                args.Message.Append(sourceAttr == null ? "view model" : "source");
-                args.Message.Append(" is a ModelsBuilder type, but the ");
-                args.Message.Append(sourceAttr != null ? "view model" : "source");
-                args.Message.Append(" is not. The application is in an unstable state and should be restarted.");
+                notification.Message.Append(" The ");
+                notification.Message.Append(sourceAttr == null ? "view model" : "source");
+                notification.Message.Append(" is a ModelsBuilder type, but the ");
+                notification.Message.Append(sourceAttr != null ? "view model" : "source");
+                notification.Message.Append(" is not. The application is in an unstable state and should be restarted.");
                 return;
             }
 
@@ -181,22 +179,22 @@ namespace Umbraco.ModelsBuilder.Embedded
                 if (pureSource == false || pureModel == false)
                 {
                     // only one is pure - report, but better not restart (loops?)
-                    args.Message.Append(pureSource
+                    notification.Message.Append(pureSource
                         ? " The content model is PureLive, but the view model is not."
                         : " The view model is PureLive, but the content model is not.");
-                    args.Message.Append(" The application is in an unstable state and should be restarted.");
+                    notification.Message.Append(" The application is in an unstable state and should be restarted.");
                 }
                 else
                 {
                     // both are pure - report, and if different versions, restart
                     // if same version... makes no sense... and better not restart (loops?)
-                    var sourceVersion = args.SourceType.Assembly.GetName().Version;
-                    var modelVersion = args.ModelType.Assembly.GetName().Version;
-                    args.Message.Append(" Both view and content models are PureLive, with ");
-                    args.Message.Append(sourceVersion == modelVersion
+                    var sourceVersion = notification.SourceType.Assembly.GetName().Version;
+                    var modelVersion = notification.ModelType.Assembly.GetName().Version;
+                    notification.Message.Append(" Both view and content models are PureLive, with ");
+                    notification.Message.Append(sourceVersion == modelVersion
                         ? "same version. The application is in an unstable state and should be restarted."
                         : "different versions. The application is in an unstable state and is going to be restarted.");
-                    args.Restart = sourceVersion != modelVersion;
+                    notification.Restart = sourceVersion != modelVersion;
                 }
             }
         }

--- a/src/Umbraco.ModelsBuilder.Embedded/ModelsGenerationError.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/ModelsGenerationError.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Umbraco.Core.Configuration;
-using Umbraco.Core.Hosting;
 using Umbraco.Core.Configuration.Models;
+using Umbraco.Core.Hosting;
 
 namespace Umbraco.ModelsBuilder.Embedded
 {
@@ -13,6 +13,9 @@ namespace Umbraco.ModelsBuilder.Embedded
         private readonly ModelsBuilderSettings _config;
         private readonly IHostingEnvironment _hostingEnvironment;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelsGenerationError"/> class.
+        /// </summary>
         public ModelsGenerationError(IOptions<ModelsBuilderSettings> config, IHostingEnvironment hostingEnvironment)
         {
             _config = config.Value;
@@ -22,7 +25,10 @@ namespace Umbraco.ModelsBuilder.Embedded
         public void Clear()
         {
             var errFile = GetErrFile();
-            if (errFile == null) return;
+            if (errFile == null)
+            {
+                return;
+            }
 
             // "If the file to be deleted does not exist, no exception is thrown."
             File.Delete(errFile);
@@ -31,7 +37,10 @@ namespace Umbraco.ModelsBuilder.Embedded
         public void Report(string message, Exception e)
         {
             var errFile = GetErrFile();
-            if (errFile == null) return;
+            if (errFile == null)
+            {
+                return;
+            }
 
             var sb = new StringBuilder();
             sb.Append(message);
@@ -47,14 +56,18 @@ namespace Umbraco.ModelsBuilder.Embedded
         public string GetLastError()
         {
             var errFile = GetErrFile();
-            if (errFile == null) return null;
+            if (errFile == null)
+            {
+                return null;
+            }
 
             try
             {
                 return File.ReadAllText(errFile);
             }
-            catch // accepted
+            catch
             {
+                // accepted
                 return null;
             }
         }
@@ -63,7 +76,9 @@ namespace Umbraco.ModelsBuilder.Embedded
         {
             var modelsDirectory = _config.ModelsDirectoryAbsolute(_hostingEnvironment);
             if (!Directory.Exists(modelsDirectory))
+            {
                 return null;
+            }
 
             return Path.Combine(modelsDirectory, "models.err");
         }

--- a/src/Umbraco.ModelsBuilder.Embedded/OutOfDateModelsStatus.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/OutOfDateModelsStatus.cs
@@ -8,19 +8,31 @@ using Umbraco.Web.Cache;
 
 namespace Umbraco.ModelsBuilder.Embedded
 {
+    /// <summary>
+    /// Used to track if ModelsBuilder models are out of date/stale
+    /// </summary>
     public sealed class OutOfDateModelsStatus : INotificationHandler<UmbracoApplicationStarting>
     {
         private readonly ModelsBuilderSettings _config;
         private readonly IHostingEnvironment _hostingEnvironment;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutOfDateModelsStatus"/> class.
+        /// </summary>
         public OutOfDateModelsStatus(IOptions<ModelsBuilderSettings> config, IHostingEnvironment hostingEnvironment)
         {
             _config = config.Value;
             _hostingEnvironment = hostingEnvironment;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether flagging out of date models is enabled
+        /// </summary>
         public bool IsEnabled => _config.FlagOutOfDateModels;
 
+        /// <summary>
+        /// Gets a value indicating whether models are out of date
+        /// </summary>
         public bool IsOutOfDate
         {
             get
@@ -38,10 +50,7 @@ namespace Umbraco.ModelsBuilder.Embedded
         /// <summary>
         /// Handles the <see cref="UmbracoApplicationStarting"/> notification
         /// </summary>
-        public void Handle(UmbracoApplicationStarting notification)
-        {
-            Install();
-        }
+        public void Handle(UmbracoApplicationStarting notification) => Install();
 
         private void Install()
         {

--- a/src/Umbraco.ModelsBuilder.Embedded/UmbracoServices.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/UmbracoServices.cs
@@ -20,6 +20,9 @@ namespace Umbraco.ModelsBuilder.Embedded
         private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
         private readonly IShortStringHelper _shortStringHelper;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoServices"/> class.
+        /// </summary>
         public UmbracoServices(
             IContentTypeService contentTypeService,
             IMediaTypeService mediaTypeService,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/ContentModelBinderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/ContentModelBinderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Routing;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Core;
+using Umbraco.Core.Events;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
 using Umbraco.Web.Common.ModelBinders;
@@ -26,7 +27,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
         private ContentModelBinder _contentModelBinder;
 
         [SetUp]
-        public void SetUp() => _contentModelBinder = new ContentModelBinder();
+        public void SetUp() => _contentModelBinder = new ContentModelBinder(Mock.Of<IEventAggregator>());
 
         [Test]
         [TestCase(typeof(IPublishedContent), false)]

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Views/UmbracoViewPageTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Views/UmbracoViewPageTests.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Core.Events;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web.Common.AspNetCore;
 using Umbraco.Web.Common.ModelBinders;
@@ -311,7 +313,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Web.Common.Views
 
         public class TestPage<TModel> : UmbracoViewPage<TModel>
         {
-            private readonly ContentModelBinder _modelBinder = new ContentModelBinder();
+            private readonly ContentModelBinder _modelBinder = new ContentModelBinder(Mock.Of<IEventAggregator>());
 
             public override Task ExecuteAsync() => throw new NotImplementedException();
 

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -86,7 +86,7 @@
       <Version>2.0.0-alpha.20200128.15</Version>
     </PackageReference>
     <PackageReference Include="HtmlAgilityPack">
-      <Version>1.11.24</Version>
+      <Version>1.11.30</Version>
     </PackageReference>
     <PackageReference Include="Lucene.Net.Contrib" Version="3.0.3" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
@@ -317,7 +317,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Persistence\SyntaxProvider" />
+    <Folder Include="Persistence\SyntaxProvider\" />
   </ItemGroup>
   <!-- get NuGet packages directory -->
   <PropertyGroup>

--- a/src/Umbraco.Web.Common/Events/UmbracoRequestEnd.cs
+++ b/src/Umbraco.Web.Common/Events/UmbracoRequestEnd.cs
@@ -10,11 +10,14 @@ namespace Umbraco.Core.Events
     /// </summary>
     public class UmbracoRequestEnd : INotification
     {
-        public UmbracoRequestEnd(HttpContext httpContext)
-        {
-            HttpContext = httpContext;
-        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoRequestEnd"/> class.
+        /// </summary>
+        public UmbracoRequestEnd(HttpContext httpContext) => HttpContext = httpContext;
 
+        /// <summary>
+        /// Gets the <see cref="HttpContext"/>
+        /// </summary>
         public HttpContext HttpContext { get; }
     }
 }

--- a/src/Umbraco.Web.Common/ModelBinders/ModelBindingError.cs
+++ b/src/Umbraco.Web.Common/ModelBinders/ModelBindingError.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Text;
+using Umbraco.Core.Events;
+
+namespace Umbraco.Web.Common.ModelBinders
+{
+    /// <summary>
+    /// Contains event data for the <see cref="ModelBindingException"/> event.
+    /// </summary>
+    public class ModelBindingError : INotification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelBindingError"/> class.
+        /// </summary>
+        public ModelBindingError(Type sourceType, Type modelType, StringBuilder message)
+        {
+            SourceType = sourceType;
+            ModelType = modelType;
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets the type of the source object.
+        /// </summary>
+        public Type SourceType { get; set; }
+
+        /// <summary>
+        /// Gets the type of the view model.
+        /// </summary>
+        public Type ModelType { get; set; }
+
+        /// <summary>
+        /// Gets the message string builder.
+        /// </summary>
+        /// <remarks>Handlers of the event can append text to the message.</remarks>
+        public StringBuilder Message { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the application should restart.
+        /// </summary>
+        public bool Restart { get; set; }
+    }
+}

--- a/src/Umbraco.Web.Common/ModelBinders/ModelBindingError.cs
+++ b/src/Umbraco.Web.Common/ModelBinders/ModelBindingError.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using Umbraco.Core.Events;
 
@@ -22,22 +22,17 @@ namespace Umbraco.Web.Common.ModelBinders
         /// <summary>
         /// Gets the type of the source object.
         /// </summary>
-        public Type SourceType { get; set; }
+        public Type SourceType { get; }
 
         /// <summary>
         /// Gets the type of the view model.
         /// </summary>
-        public Type ModelType { get; set; }
+        public Type ModelType { get; }
 
         /// <summary>
         /// Gets the message string builder.
         /// </summary>
         /// <remarks>Handlers of the event can append text to the message.</remarks>
         public StringBuilder Message { get; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the application should restart.
-        /// </summary>
-        public bool Restart { get; set; }
     }
 }

--- a/src/Umbraco.Web.UI.NetCore/Startup.cs
+++ b/src/Umbraco.Web.UI.NetCore/Startup.cs
@@ -49,14 +49,6 @@ namespace Umbraco.Web.UI.NetCore
                 .AddBackOffice()
                 .AddWebsite()
                 .AddComposers()
-                // TODO: This call and AddDistributedCache are interesting ones. They are both required for back office and front-end to render
-                // but we don't want to force people to call so many of these ext by default and want to keep all of this relatively simple.
-                // but we still need to allow the flexibility for people to use their own ModelsBuilder. In that case people can call a different
-                // AddModelsBuilderCommunity (or whatever) after our normal calls to replace our services.
-                // So either we call AddModelsBuilder within AddBackOffice AND AddWebsite just like we do with AddDistributedCache or we
-                // have a top level method to add common things required for backoffice/frontend like .AddCommon()
-                // or we allow passing in options to these methods to configure what happens within them.
-                .AddModelsBuilder()
                 .Build();
 #pragma warning restore IDE0022 // Use expression body for methods
 

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.DependencyInjection;
 using Umbraco.Extensions;
 using Umbraco.Infrastructure.DependencyInjection;
 using Umbraco.Infrastructure.PublishedCache.DependencyInjection;
+using Umbraco.ModelsBuilder.Embedded.DependencyInjection;
 using Umbraco.Web.Common.Routing;
 using Umbraco.Web.Website.Collections;
 using Umbraco.Web.Website.Controllers;
@@ -43,7 +44,9 @@ namespace Umbraco.Web.Website.DependencyInjection
             builder.Services.AddSingleton<IUmbracoRenderingDefaults, UmbracoRenderingDefaults>();
             builder.Services.AddSingleton<IRoutableDocumentFilter, RoutableDocumentFilter>();
 
-            builder.AddDistributedCache();
+            builder
+                .AddDistributedCache()
+                .AddModelsBuilder();
 
             return builder;
         }

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -578,108 +578,82 @@ namespace Umbraco.Extensions
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType,
-                                               object additionalRouteVals,
-                                               IDictionary<string, object> htmlAttributes)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, htmlAttributes, FormMethod.Post);
-        }
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            Type surfaceType,
+            object additionalRouteVals,
+            IDictionary<string, object> htmlAttributes)
+            => html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, htmlAttributes, FormMethod.Post);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
         /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action,
-                                                  object additionalRouteVals,
-                                                  IDictionary<string, object> htmlAttributes,
-                                                  FormMethod method)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes, method);
-        }
+        public static MvcForm BeginUmbracoForm<T>(
+            this IHtmlHelper html,
+            string action,
+            object additionalRouteVals,
+            IDictionary<string, object> htmlAttributes,
+            FormMethod method)
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes, method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
         /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action,
-                                               object additionalRouteVals,
-                                               IDictionary<string, object> htmlAttributes)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes);
-        }
+        public static MvcForm BeginUmbracoForm<T>(
+            this IHtmlHelper html,
+            string action,
+            object additionalRouteVals,
+            IDictionary<string, object> htmlAttributes)
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="area"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, string area, FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, controllerName, area, null, new Dictionary<string, object>(), method);
-        }
+            => html.BeginUmbracoForm(action, controllerName, area, null, new Dictionary<string, object>(), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="area"></param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, string area)
-        {
-            return html.BeginUmbracoForm(action, controllerName, area, null, new Dictionary<string, object>());
-        }
+            => html.BeginUmbracoForm(action, controllerName, area, null, new Dictionary<string, object>());
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="area"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, string area,
-                                               object additionalRouteVals,
-                                               IDictionary<string, object> htmlAttributes,
-                                               FormMethod method)
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            string controllerName,
+            string area,
+            object additionalRouteVals,
+            IDictionary<string, object> htmlAttributes,
+            FormMethod method)
         {
             if (action == null)
+            {
                 throw new ArgumentNullException(nameof(action));
-            if (string.IsNullOrEmpty(action))
-                throw new ArgumentException("Value can't be empty.", nameof(action));
-            if (controllerName == null)
-                throw new ArgumentNullException(nameof(controllerName));
-            if (string.IsNullOrWhiteSpace(controllerName))
-                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            }
 
-            var umbracoContextAccessor = GetRequiredService<IUmbracoContextAccessor>(html);
+            if (string.IsNullOrEmpty(action))
+            {
+                throw new ArgumentException("Value can't be empty.", nameof(action));
+            }
+
+            if (controllerName == null)
+            {
+                throw new ArgumentNullException(nameof(controllerName));
+            }
+
+            if (string.IsNullOrWhiteSpace(controllerName))
+            {
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            }
+
+            IUmbracoContextAccessor umbracoContextAccessor = GetRequiredService<IUmbracoContextAccessor>(html);
             var formAction = umbracoContextAccessor.UmbracoContext.OriginalRequestUrl.PathAndQuery;
             return html.RenderForm(formAction, method, htmlAttributes, controllerName, action, area, additionalRouteVals);
         }
@@ -687,45 +661,30 @@ namespace Umbraco.Extensions
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="area"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, string area,
-                                               object additionalRouteVals,
-                                               IDictionary<string, object> htmlAttributes)
-        {
-            return html.BeginUmbracoForm(action, controllerName, area, additionalRouteVals, htmlAttributes, FormMethod.Post);
-        }
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            string controllerName,
+            string area,
+            object additionalRouteVals,
+            IDictionary<string, object> htmlAttributes) => html.BeginUmbracoForm(action, controllerName, area, additionalRouteVals, htmlAttributes, FormMethod.Post);
 
         /// <summary>
         /// This renders out the form for us
         /// </summary>
-        /// <param name="htmlHelper"></param>
-        /// <param name="formAction"></param>
-        /// <param name="method"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="surfaceController"></param>
-        /// <param name="surfaceAction"></param>
-        /// <param name="area"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <returns></returns>
         /// <remarks>
         /// This code is pretty much the same as the underlying MVC code that writes out the form
         /// </remarks>
-        private static MvcForm RenderForm(this IHtmlHelper htmlHelper,
-                                          string formAction,
-                                          FormMethod method,
-                                          IDictionary<string, object> htmlAttributes,
-                                          string surfaceController,
-                                          string surfaceAction,
-                                          string area,
-                                          object additionalRouteVals = null)
+        private static MvcForm RenderForm(
+            this IHtmlHelper htmlHelper,
+            string formAction,
+            FormMethod method,
+            IDictionary<string, object> htmlAttributes,
+            string surfaceController,
+            string surfaceAction,
+            string area,
+            object additionalRouteVals = null)
         {
-
             // ensure that the multipart/form-data is added to the HTML attributes
             if (htmlAttributes.ContainsKey("enctype") == false)
             {
@@ -734,8 +693,10 @@ namespace Umbraco.Extensions
 
             var tagBuilder = new TagBuilder("form");
             tagBuilder.MergeAttributes(htmlAttributes);
+
             // action is implicitly generated, so htmlAttributes take precedence.
             tagBuilder.MergeAttribute("action", formAction);
+
             // method is an explicit parameter, so it takes precedence over the htmlAttributes.
             tagBuilder.MergeAttribute("method", HtmlHelper.GetFormMethodString(method), true);
             var traditionalJavascriptEnabled = htmlHelper.ViewContext.ClientValidationEnabled;
@@ -748,6 +709,7 @@ namespace Umbraco.Extensions
             htmlHelper.ViewContext.Writer.Write(tagBuilder.RenderStartTag());
 
             var htmlEncoder = GetRequiredService<HtmlEncoder>(htmlHelper);
+
             // new UmbracoForm:
             var theForm = new UmbracoForm(htmlHelper.ViewContext, htmlEncoder, surfaceController, surfaceAction, area, additionalRouteVals);
 

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -32,15 +32,15 @@ namespace Umbraco.Extensions
     /// </summary>
     public static class HtmlHelperRenderExtensions
     {
-       private static T GetRequiredService<T>(IHtmlHelper htmlHelper)
-       {
-           return GetRequiredService<T>(htmlHelper.ViewContext);
-       }
+        private static T GetRequiredService<T>(IHtmlHelper htmlHelper)
+        {
+            return GetRequiredService<T>(htmlHelper.ViewContext);
+        }
 
         private static T GetRequiredService<T>(ViewContext viewContext)
-       {
-           return viewContext.HttpContext.RequestServices.GetRequiredService<T>();
-       }
+        {
+            return viewContext.HttpContext.RequestServices.GetRequiredService<T>();
+        }
 
         /// <summary>
         /// Renders the markup for the profiler
@@ -85,13 +85,14 @@ namespace Umbraco.Extensions
             if (umbrcoContext.InPreviewMode)
             {
                 var htmlBadge =
-                    String.Format(contentSettings.PreviewBadge,
-                                ioHelper.ResolveUrl(globalSettings.UmbracoPath),
-                                  WebUtility.UrlEncode(httpContextAccessor.GetRequiredHttpContext().Request.Path),
-                                umbrcoContext.PublishedRequest.PublishedContent.Id);
+                    string.Format(
+                        contentSettings.PreviewBadge,
+                        ioHelper.ResolveUrl(globalSettings.UmbracoPath),
+                        WebUtility.UrlEncode(httpContextAccessor.GetRequiredHttpContext().Request.Path),
+                        umbrcoContext.PublishedRequest.PublishedContent.Id);
                 return new HtmlString(htmlBadge);
             }
-            return new HtmlString("");
+            return new HtmlString(string.Empty);
 
         }
 
@@ -106,7 +107,7 @@ namespace Umbraco.Extensions
             Func<object, ViewDataDictionary, string> contextualKeyBuilder = null)
         {
             var cacheKey = new StringBuilder(partialViewName);
-             //let's always cache by the current culture to allow variants to have different cache results
+            //let's always cache by the current culture to allow variants to have different cache results
             var cultureName = System.Threading.Thread.CurrentThread.CurrentUICulture.Name;
             if (!String.IsNullOrEmpty(cultureName))
             {
@@ -126,7 +127,7 @@ namespace Umbraco.Extensions
             {
                 //TODO reintroduce when members are migrated
                 throw new NotImplementedException("Reintroduce when members are migrated");
-                    // var helper = Current.MembershipHelper;
+                // var helper = Current.MembershipHelper;
                 // var currentMember = helper.GetCurrentMember();
                 // cacheKey.AppendFormat("m{0}-", currentMember?.Id ?? 0);
             }
@@ -163,34 +164,29 @@ namespace Umbraco.Extensions
         /// A validation summary that lets you pass in a prefix so that the summary only displays for elements
         /// containing the prefix. This allows you to have more than on validation summary on a page.
         /// </summary>
-        /// <param name="htmlHelper"></param>
-        /// <param name="prefix"></param>
-        /// <param name="excludePropertyErrors"></param>
-        /// <param name="message"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper,
-                                                     string prefix = "",
-                                                     bool excludePropertyErrors = false,
-                                                     string message = "",
-                                                     object htmlAttributes = null)
+        public static IHtmlContent ValidationSummary(
+            this IHtmlHelper htmlHelper,
+            string prefix = "",
+            bool excludePropertyErrors = false,
+            string message = "",
+            object htmlAttributes = null)
         {
             if (prefix.IsNullOrWhiteSpace())
             {
                 return htmlHelper.ValidationSummary(excludePropertyErrors, message, htmlAttributes);
             }
 
-
-
-
             var htmlGenerator = GetRequiredService<IHtmlGenerator>(htmlHelper);
 
             var viewContext = htmlHelper.ViewContext.Clone();
-            foreach (var key in viewContext.ViewData.Keys.ToArray()){
-                 if(!key.StartsWith(prefix)){
+            foreach (var key in viewContext.ViewData.Keys.ToArray())
+            {
+                if (!key.StartsWith(prefix))
+                {
                     viewContext.ViewData.Remove(key);
-                 }
-             }
+                }
+            }
+
             var tagBuilder = htmlGenerator.GenerateValidationSummary(
                 viewContext,
                 excludePropertyErrors,
@@ -205,7 +201,7 @@ namespace Umbraco.Extensions
             return tagBuilder;
         }
 
-// TODO what to do here? This will be view components right?
+        // TODO what to do here? This will be view components right?
         // /// <summary>
         // /// Returns the result of a child action of a strongly typed SurfaceController
         // /// </summary>
@@ -220,7 +216,7 @@ namespace Umbraco.Extensions
         // }
         //
 
-// TODO what to do here? This will be view components right?
+        // TODO what to do here? This will be view components right?
         // /// <summary>
         // /// Returns the result of a child action of a SurfaceController
         // /// </summary>
@@ -265,15 +261,14 @@ namespace Umbraco.Extensions
         /// </summary>
         internal class UmbracoForm : MvcForm
         {
+            private readonly ViewContext _viewContext;
+            private bool _disposed;
+            private readonly string _encryptedString;
+            private readonly string _controllerName;
+
             /// <summary>
-            /// Creates an UmbracoForm
+            /// Initializes a new instance of the <see cref="UmbracoForm"/> class.
             /// </summary>
-            /// <param name="viewContext"></param>
-            /// <param name="htmlEncoder"></param>
-            /// <param name="controllerName"></param>
-            /// <param name="controllerAction"></param>
-            /// <param name="area"></param>
-            /// <param name="additionalRouteVals"></param>
             public UmbracoForm(
                 ViewContext viewContext,
                 HtmlEncoder htmlEncoder,
@@ -288,28 +283,27 @@ namespace Umbraco.Extensions
                 _encryptedString = EncryptionHelper.CreateEncryptedRouteString(GetRequiredService<IDataProtectionProvider>(viewContext), controllerName, controllerAction, area, additionalRouteVals);
             }
 
-            private readonly ViewContext _viewContext;
-            private bool _disposed;
-            private readonly string _encryptedString;
-            private readonly string _controllerName;
-
             protected new void Dispose()
             {
-                if (this._disposed)
+                if (_disposed)
+                {
                     return;
-                this._disposed = true;
-                //Detect if the call is targeting UmbRegisterController/UmbProfileController/UmbLoginStatusController/UmbLoginController and if it is we automatically output a AntiForgeryToken()
+                }
+
+                _disposed = true;
+
+                // Detect if the call is targeting UmbRegisterController/UmbProfileController/UmbLoginStatusController/UmbLoginController and if it is we automatically output a AntiForgeryToken()
                 // We have a controllerName and area so we can match
                 if (_controllerName == "UmbRegister"
                     || _controllerName == "UmbProfile"
                     || _controllerName == "UmbLoginStatus"
                     || _controllerName == "UmbLogin")
                 {
-                     var antiforgery = _viewContext.HttpContext.RequestServices.GetRequiredService<IAntiforgery>();
+                    IAntiforgery antiforgery = _viewContext.HttpContext.RequestServices.GetRequiredService<IAntiforgery>();
                     _viewContext.Writer.Write(antiforgery.GetHtml(_viewContext.HttpContext).ToString());
                 }
 
-                //write out the hidden surface form routes
+                // write out the hidden surface form routes
                 _viewContext.Writer.Write("<input name=\"ufprt\" type=\"hidden\" value=\"" + _encryptedString + "\" />");
 
                 base.Dispose();
@@ -323,104 +317,79 @@ namespace Umbraco.Extensions
         /// <param name="action">Name of the action.</param>
         /// <param name="controllerName">Name of the controller.</param>
         /// <param name="method">The method.</param>
-        /// <returns></returns>
+        /// <returns>the <see cref="MvcForm"/></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, controllerName, null, new Dictionary<string, object>(), method);
-        }
+            => html.BeginUmbracoForm(action, controllerName, null, new Dictionary<string, object>(), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName)
-        {
-            return html.BeginUmbracoForm(action, controllerName, null, new Dictionary<string, object>());
-        }
+            => html.BeginUmbracoForm(action, controllerName, null, new Dictionary<string, object>());
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, object additionalRouteVals, FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, controllerName, additionalRouteVals, new Dictionary<string, object>(), method);
-        }
+            => html.BeginUmbracoForm(action, controllerName, additionalRouteVals, new Dictionary<string, object>(), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName, object additionalRouteVals)
-        {
-            return html.BeginUmbracoForm(action, controllerName, additionalRouteVals, new Dictionary<string, object>());
-        }
+            => html.BeginUmbracoForm(action, controllerName, additionalRouteVals, new Dictionary<string, object>());
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName,
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            string controllerName,
             object additionalRouteVals,
             object htmlAttributes,
-            FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, controllerName, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes), method);
-        }
+            FormMethod method) => html.BeginUmbracoForm(action, controllerName, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName,
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            string controllerName,
             object additionalRouteVals,
-            object htmlAttributes)
-        {
-            return html.BeginUmbracoForm(action, controllerName, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
-        }
+            object htmlAttributes) => html.BeginUmbracoForm(action, controllerName, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName,
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            string controllerName,
             object additionalRouteVals,
             IDictionary<string, object> htmlAttributes,
             FormMethod method)
         {
-            if (action == null) throw new ArgumentNullException(nameof(action));
-            if (string.IsNullOrWhiteSpace(action)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(action));
-            if (controllerName == null) throw new ArgumentNullException(nameof(controllerName));
-            if (string.IsNullOrWhiteSpace(controllerName)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (string.IsNullOrWhiteSpace(action))
+            {
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(action));
+            }
+
+            if (controllerName == null)
+            {
+                throw new ArgumentNullException(nameof(controllerName));
+            }
+
+            if (string.IsNullOrWhiteSpace(controllerName))
+            {
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            }
 
             return html.BeginUmbracoForm(action, controllerName, "", additionalRouteVals, htmlAttributes, method);
         }
@@ -428,20 +397,32 @@ namespace Umbraco.Extensions
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline against a locally declared controller
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="controllerName"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, string controllerName,
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            string controllerName,
             object additionalRouteVals,
             IDictionary<string, object> htmlAttributes)
         {
-            if (action == null) throw new ArgumentNullException(nameof(action));
-            if (string.IsNullOrWhiteSpace(action)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(action));
-            if (controllerName == null) throw new ArgumentNullException(nameof(controllerName));
-            if (string.IsNullOrWhiteSpace(controllerName)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (string.IsNullOrWhiteSpace(action))
+            {
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(action));
+            }
+
+            if (controllerName == null)
+            {
+                throw new ArgumentNullException(nameof(controllerName));
+            }
+
+            if (string.IsNullOrWhiteSpace(controllerName))
+            {
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            }
 
             return html.BeginUmbracoForm(action, controllerName, "", additionalRouteVals, htmlAttributes);
         }
@@ -449,207 +430,139 @@ namespace Umbraco.Extensions
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="method"></param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType, FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, null, new Dictionary<string, object>(), method);
-        }
+            => html.BeginUmbracoForm(action, surfaceType, null, new Dictionary<string, object>(), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <returns></returns>
         public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, null, new Dictionary<string, object>());
-        }
+            => html.BeginUmbracoForm(action, surfaceType, null, new Dictionary<string, object>());
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
         public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, FormMethod method)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), method);
-        }
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
         public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T));
-        }
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T));
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType,
-                                               object additionalRouteVals, FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, new Dictionary<string, object>(), method);
-        }
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            Type surfaceType,
+            object additionalRouteVals,
+            FormMethod method) => html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, new Dictionary<string, object>(), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="additionalRouteVals"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType,
-                                               object additionalRouteVals)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, new Dictionary<string, object>());
-        }
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            Type surfaceType,
+            object additionalRouteVals) => html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, new Dictionary<string, object>());
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
         public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, object additionalRouteVals, FormMethod method)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, method);
-        }
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
         public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, object additionalRouteVals)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), additionalRouteVals);
-        }
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType,
-                                               object additionalRouteVals,
-                                               object htmlAttributes,
-                                               FormMethod method)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes), method);
-        }
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            Type surfaceType,
+            object additionalRouteVals,
+            object htmlAttributes,
+            FormMethod method) => html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes), method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType,
-                                               object additionalRouteVals,
-                                               object htmlAttributes)
-        {
-            return html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
-        }
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            Type surfaceType,
+            object additionalRouteVals,
+            object htmlAttributes) => html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action,
-                                                  object additionalRouteVals,
-                                                  object htmlAttributes,
-                                                  FormMethod method)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes, method);
-        }
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
+        public static MvcForm BeginUmbracoForm<T>(
+            this IHtmlHelper html,
+            string action,
+            object additionalRouteVals,
+            object htmlAttributes,
+            FormMethod method)
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes, method);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action,
-                                               object additionalRouteVals,
-                                               object htmlAttributes)
-            where T : SurfaceController
-        {
-            return html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes);
-        }
+        public static MvcForm BeginUmbracoForm<T>(
+            this IHtmlHelper html,
+            string action,
+            object additionalRouteVals,
+            object htmlAttributes)
+            where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes);
 
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <param name="html"></param>
-        /// <param name="action"></param>
-        /// <param name="surfaceType">The surface controller to route to</param>
-        /// <param name="additionalRouteVals"></param>
-        /// <param name="htmlAttributes"></param>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        public static MvcForm BeginUmbracoForm(this IHtmlHelper html, string action, Type surfaceType,
-                                               object additionalRouteVals,
-                                               IDictionary<string, object> htmlAttributes,
-                                               FormMethod method)
+        public static MvcForm BeginUmbracoForm(
+            this IHtmlHelper html,
+            string action,
+            Type surfaceType,
+            object additionalRouteVals,
+            IDictionary<string, object> htmlAttributes,
+            FormMethod method)
         {
 
-            if (action == null) throw new ArgumentNullException(nameof(action));
-            if (string.IsNullOrWhiteSpace(action)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(action));
-            if (surfaceType == null) throw new ArgumentNullException(nameof(surfaceType));
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (string.IsNullOrWhiteSpace(action))
+            {
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(action));
+            }
+
+            if (surfaceType == null)
+            {
+                throw new ArgumentNullException(nameof(surfaceType));
+            }
 
             var surfaceControllerTypeCollection = GetRequiredService<SurfaceControllerTypeCollection>(html);
             var surfaceController = surfaceControllerTypeCollection.SingleOrDefault(x => x == surfaceType);
             if (surfaceController == null)
+            {
                 throw new InvalidOperationException("Could not find the surface controller of type " + surfaceType.FullName);
+            }
+
             var metaData = PluginController.GetMetadata(surfaceController);
 
             var area = string.Empty;
@@ -681,7 +594,7 @@ namespace Umbraco.Extensions
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
         /// <param name="html"></param>
         /// <param name="action"></param>
         /// <param name="additionalRouteVals"></param>
@@ -700,7 +613,7 @@ namespace Umbraco.Extensions
         /// <summary>
         /// Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">The <see cref="SurfaceController"/> type</typeparam>
         /// <param name="html"></param>
         /// <param name="action"></param>
         /// <param name="additionalRouteVals"></param>
@@ -757,10 +670,14 @@ namespace Umbraco.Extensions
                                                IDictionary<string, object> htmlAttributes,
                                                FormMethod method)
         {
-            if (action == null) throw new ArgumentNullException(nameof(action));
-            if (string.IsNullOrEmpty(action)) throw new ArgumentException("Value can't be empty.", nameof(action));
-            if (controllerName == null) throw new ArgumentNullException(nameof(controllerName));
-            if (string.IsNullOrWhiteSpace(controllerName)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+            if (string.IsNullOrEmpty(action))
+                throw new ArgumentException("Value can't be empty.", nameof(action));
+            if (controllerName == null)
+                throw new ArgumentNullException(nameof(controllerName));
+            if (string.IsNullOrWhiteSpace(controllerName))
+                throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(controllerName));
 
             var umbracoContextAccessor = GetRequiredService<IUmbracoContextAccessor>(html);
             var formAction = umbracoContextAccessor.UmbracoContext.OriginalRequestUrl.PathAndQuery;
@@ -809,7 +726,7 @@ namespace Umbraco.Extensions
                                           object additionalRouteVals = null)
         {
 
-            //ensure that the multipart/form-data is added to the HTML attributes
+            // ensure that the multipart/form-data is added to the HTML attributes
             if (htmlAttributes.ContainsKey("enctype") == false)
             {
                 htmlAttributes.Add("enctype", "multipart/form-data");
@@ -825,13 +742,13 @@ namespace Umbraco.Extensions
             if (traditionalJavascriptEnabled)
             {
                 // forms must have an ID for client validation
-                tagBuilder.GenerateId("form" + Guid.NewGuid().ToString("N"),  string.Empty);
+                tagBuilder.GenerateId("form" + Guid.NewGuid().ToString("N"), string.Empty);
             }
 
             htmlHelper.ViewContext.Writer.Write(tagBuilder.RenderStartTag());
 
             var htmlEncoder = GetRequiredService<HtmlEncoder>(htmlHelper);
-            //new UmbracoForm:
+            // new UmbracoForm:
             var theForm = new UmbracoForm(htmlHelper.ViewContext, htmlEncoder, surfaceController, surfaceAction, area, additionalRouteVals);
 
             if (traditionalJavascriptEnabled)
@@ -856,9 +773,7 @@ namespace Umbraco.Extensions
         /// The HTML encoded value.
         /// </returns>
         public static IHtmlContent If(this IHtmlHelper html, bool test, string valueIfTrue)
-        {
-            return If(html, test, valueIfTrue, string.Empty);
-        }
+            => If(html, test, valueIfTrue, string.Empty);
 
         /// <summary>
         /// If <paramref name="test" /> is <c>true</c>, the HTML encoded <paramref name="valueIfTrue" /> will be returned; otherwise, <paramref name="valueIfFalse" />.
@@ -871,9 +786,7 @@ namespace Umbraco.Extensions
         /// The HTML encoded value.
         /// </returns>
         public static IHtmlContent If(this IHtmlHelper html, bool test, string valueIfTrue, string valueIfFalse)
-        {
-            return new HtmlString(HttpUtility.HtmlEncode(test ? valueIfTrue : valueIfFalse));
-        }
+            => new HtmlString(HttpUtility.HtmlEncode(test ? valueIfTrue : valueIfFalse));
 
         #endregion
 
@@ -890,113 +803,82 @@ namespace Umbraco.Extensions
         /// The HTML encoded text with text line breaks replaced with HTML line breaks (<c>&lt;br /&gt;</c>).
         /// </returns>
         public static IHtmlContent ReplaceLineBreaks(this IHtmlHelper helper, string text)
-        {
-            return StringUtilities.ReplaceLineBreaks(text);
-        }
+            => StringUtilities.ReplaceLineBreaks(text);
 
         /// <summary>
         /// Generates a hash based on the text string passed in.  This method will detect the
         /// security requirements (is FIPS enabled) and return an appropriate hash.
         /// </summary>
-        /// <param name="helper"></param>
+        /// <param name="helper">The <see cref="IHtmlHelper"/></param>
         /// <param name="text">The text to create a hash from</param>
         /// <returns>Hash of the text string</returns>
-        public static string CreateHash(this IHtmlHelper helper, string text)
-        {
-            return text.GenerateHash();
-        }
+        public static string CreateHash(this IHtmlHelper helper, string text) => text.GenerateHash();
 
         /// <summary>
         /// Strips all HTML tags from a given string, all contents of the tags will remain.
         /// </summary>
         public static IHtmlContent StripHtml(this HtmlHelper helper, IHtmlContent html, params string[] tags)
-        {
-            return helper.StripHtml(html.ToHtmlString(), tags);
-        }
-
-
+            => helper.StripHtml(html.ToHtmlString(), tags);
 
         /// <summary>
         /// Strips all HTML tags from a given string, all contents of the tags will remain.
         /// </summary>
         public static IHtmlContent StripHtml(this HtmlHelper helper, string html, params string[] tags)
-        {
-            return StringUtilities.StripHtmlTags(html, tags);
-        }
+            => StringUtilities.StripHtmlTags(html, tags);
 
         /// <summary>
         /// Will take the first non-null value in the collection and return the value of it.
         /// </summary>
         public static string Coalesce(this HtmlHelper helper, params object[] args)
-        {
-            return StringUtilities.Coalesce(args);
-        }
+            => StringUtilities.Coalesce(args);
 
         /// <summary>
         /// Joins any number of int/string/objects into one string
         /// </summary>
         public static string Concatenate(this HtmlHelper helper, params object[] args)
-        {
-            return StringUtilities.Concatenate(args);
-        }
+            => StringUtilities.Concatenate(args);
 
         /// <summary>
         /// Joins any number of int/string/objects into one string and separates them with the string separator parameter.
         /// </summary>
         public static string Join(this HtmlHelper helper, string separator, params object[] args)
-        {
-            return StringUtilities.Join(separator, args);
-        }
+            => StringUtilities.Join(separator, args);
 
         /// <summary>
         /// Truncates a string to a given length, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
         /// </summary>
         public static IHtmlContent Truncate(this HtmlHelper helper, IHtmlContent html, int length)
-        {
-            return helper.Truncate(html.ToHtmlString(), length, true, false);
-        }
+            => helper.Truncate(html.ToHtmlString(), length, true, false);
 
         /// <summary>
         /// Truncates a string to a given length, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
         /// </summary>
         public static IHtmlContent Truncate(this HtmlHelper helper, IHtmlContent html, int length, bool addElipsis)
-        {
-            return helper.Truncate(html.ToHtmlString(), length, addElipsis, false);
-        }
+            => helper.Truncate(html.ToHtmlString(), length, addElipsis, false);
 
         /// <summary>
         /// Truncates a string to a given length, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
         /// </summary>
         public static IHtmlContent Truncate(this HtmlHelper helper, IHtmlContent html, int length, bool addElipsis, bool treatTagsAsContent)
-        {
-            return helper.Truncate(html.ToHtmlString(), length, addElipsis, treatTagsAsContent);
-        }
+            => helper.Truncate(html.ToHtmlString(), length, addElipsis, treatTagsAsContent);
 
         /// <summary>
         /// Truncates a string to a given length, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
         /// </summary>
         public static IHtmlContent Truncate(this HtmlHelper helper, string html, int length)
-        {
-            return helper.Truncate(html, length, true, false);
-        }
+            => helper.Truncate(html, length, true, false);
 
         /// <summary>
         /// Truncates a string to a given length, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
         /// </summary>
         public static IHtmlContent Truncate(this HtmlHelper helper, string html, int length, bool addElipsis)
-        {
-            return helper.Truncate(html, length, addElipsis, false);
-        }
+            => helper.Truncate(html, length, addElipsis, false);
 
         /// <summary>
         /// Truncates a string to a given length, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
         /// </summary>
         public static IHtmlContent Truncate(this HtmlHelper helper, string html, int length, bool addElipsis, bool treatTagsAsContent)
-        {
-            return StringUtilities.Truncate(html, length, addElipsis, treatTagsAsContent);
-        }
-
-        #region Truncate by Words
+            => StringUtilities.Truncate(html, length, addElipsis, treatTagsAsContent);
 
         /// <summary>
         /// Truncates a string to a given amount of words, can add a ellipsis at the end (...). Method checks for open HTML tags, and makes sure to close them
@@ -1038,7 +920,6 @@ namespace Umbraco.Extensions
             return helper.Truncate(html, length, addElipsis, false);
         }
 
-        #endregion
 
         #endregion
     }

--- a/src/Umbraco.Web.Website/Umbraco.Web.Website.csproj
+++ b/src/Umbraco.Web.Website/Umbraco.Web.Website.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />
         <ProjectReference Include="..\Umbraco.Infrastructure\Umbraco.Infrastructure.csproj" />
+        <ProjectReference Include="..\Umbraco.ModelsBuilder.Embedded\Umbraco.ModelsBuilder.Embedded.csproj" />
         <ProjectReference Include="..\Umbraco.Web.Common\Umbraco.Web.Common.csproj" />
     </ItemGroup>
 

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Examine.Core">
       <Version>2.0.0-alpha.20200128.15</Version>
     </PackageReference>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.30" />
     <PackageReference Include="HtmlSanitizer">
       <Version>5.0.376</Version>
     </PackageReference>


### PR DESCRIPTION
Just a follow up PR to #9672 

* We always must have a default PublishedModelFactory registered since that is required for Umbraco to operate. Previously this was only being registered in the MB extensions which isn't right. Now the default is always registered and the MB ext replaces it if MB is enabled (not required for the back office)
* Ensures the embedded models builder is added when adding the website
* Adds some code to detect if AddModelsBuilder or AddDistributedCache are called more than once and if so it just ignores the additional calls.
* Makes the model binding error an event aggregator notification
* streamlines the htmlagilitypack dependency
* other minor cleanup