### PR TITLE
Fix for applying searchResultFormatter on found searchresults

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
@@ -66,11 +66,12 @@ angular.module('umbraco.services')
                     throw "args.term is required";
                 }
 
-                return entityResource.search(args.term, "Document", args.searchFrom, args.canceler, args.dataTypeKey)
-                    _.each(data, function (item) {
-                        data.forEach(item => searchResultFormatter.configureContentResult(item));
-                        return data;
+                return entityResource.search(args.term, 'Document', args.searchFrom, args.canceler, args.dataTypeKey).then(function (data) {
+                    data.forEach(function (item) {
+                        return searchResultFormatter.configureContentResult(item);
                     });
+                    return data;
+                });
             },
 
             /**

--- a/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
@@ -66,7 +66,7 @@ angular.module('umbraco.services')
                     throw "args.term is required";
                 }
 
-                return entityResource.search(args.term, 'Document', args.searchFrom, args.canceler, args.dataTypeKey)
+                return entityResource.search(args.term, "Document", args.searchFrom, args.canceler, args.dataTypeKey)
                     .then(data => {
                         data.forEach(item => searchResultFormatter.configureContentResult(item));
                         return data;

--- a/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/search.service.js
@@ -66,12 +66,12 @@ angular.module('umbraco.services')
                     throw "args.term is required";
                 }
 
-                return entityResource.search(args.term, 'Document', args.searchFrom, args.canceler, args.dataTypeKey).then(function (data) {
-                    data.forEach(function (item) {
-                        return searchResultFormatter.configureContentResult(item);
+                return entityResource.search(args.term, 'Document', args.searchFrom, args.canceler, args.dataTypeKey)
+                    .then(data => {
+                        data.forEach(item => searchResultFormatter.configureContentResult(item));
+                        return data;
                     });
-                    return data;
-                });
+                
             },
 
             /**


### PR DESCRIPTION
We found out that when the searchbox in the linkpicker is used, the URL of a page is not being shown anymore since Umbraco 8.7 and later. This is because of the searchResultFormatter wasn't applied correct.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->


Fixes #9737