### PR TITLE
Add the ability to change the SQL Write Lock TimeOut

### DIFF
--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -391,5 +391,28 @@ namespace Umbraco.Core.Configuration
                 }
             }
         }
+
+
+        /// <summary>
+        /// An int value representing the time in milliseconds to lock the database for a write operation
+        /// </summary>
+        /// <remarks>
+        /// The default value is 1800 milliseconds
+        /// </remarks>
+        /// <value>The timeout in milliseconds.</value>
+        public int SqlWriteLockTimeOut
+        {
+            get
+            {
+                try
+                {
+                    return int.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.SqlWriteLockTimeOut]);
+                }
+                catch
+                {
+                    return 1800;
+                }
+            }
+        }
     }
 }

--- a/src/Umbraco.Core/Configuration/IGlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/IGlobalSettings.cs
@@ -72,5 +72,10 @@
         /// Gets the location of temporary files.
         /// </summary>
         string LocalTempPath { get; }
+
+        /// <summary>
+        /// Gets the write lock timeout.
+        /// </summary>
+        int SqlWriteLockTimeOut { get; }
     }
 }

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -140,6 +140,14 @@ namespace Umbraco.Core
                 /// </summary>
                 public const string DatabaseFactoryServerVersion = "Umbraco.Core.Debug.DatabaseFactoryServerVersion";
             }
+
+            /// <summary>
+            /// An int value representing the time in milliseconds to lock the database for a write operation
+            /// </summary>
+            /// <remarks>
+            /// The default value is 1800 milliseconds
+            /// </remarks>
+            public const string SqlWriteLockTimeOut = "Umbraco.Core.SqlWriteLockTimeOut";
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Data;
 using System.Data.SqlServerCe;
 using System.Linq;
 using NPoco;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Persistence.DatabaseAnnotations;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 
@@ -163,7 +165,8 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
-            db.Execute(@"SET LOCK_TIMEOUT 1800;");
+            var timeOut = Current.Configs.Global().SqlWriteLockTimeOut;
+            db.Execute(@"SET LOCK_TIMEOUT " + timeOut  + ";");
             // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
             foreach (var lockId in lockIds)
             {

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
 using NPoco;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Scoping;
@@ -254,7 +256,8 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
 
         public override void WriteLock(IDatabase db, params int[] lockIds)
         {
-            WriteLock(db, TimeSpan.FromMilliseconds(1800), lockIds);
+            var timeOut = Current.Configs.Global().SqlWriteLockTimeOut;
+            WriteLock(db, TimeSpan.FromMilliseconds(timeOut), lockIds);
         }
 
         public void WriteLock(IDatabase db, TimeSpan timeout, params int[] lockIds)

--- a/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
+++ b/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
@@ -23,7 +23,8 @@ namespace Umbraco.Tests.TestHelpers
                     settings.LocalTempStorageLocation == LocalTempStorage.Default &&
                     settings.LocalTempPath == IOHelper.MapPath("~/App_Data/TEMP") &&
                     settings.ReservedPaths == (GlobalSettings.StaticReservedPaths + "~/umbraco") &&
-                    settings.ReservedUrls == GlobalSettings.StaticReservedUrls);
+                    settings.ReservedUrls == GlobalSettings.StaticReservedUrls &&
+                    settings.SqlWriteLockTimeOut == 1800);
             return config;
         }
 


### PR DESCRIPTION
When acquiring a SQL write lock, we currently have hardcoded this to 1.8 seconds (1800ms). This has been the case since version 8.4.0 - https://github.com/umbraco/Umbraco-CMS/pull/6688

In some cases, people seem to be getting the error `Lock request time out period exceeded.`. From what I gather from Shannon this indicates the followin:

> Has to do with distributed locks when writing/reading from the database at the same time as another thread/process. This means that while something else is holding a write lock, something else is waiting for the readlock and it cannot acquire it because it waited too long. Normally do to too many write locks trying to be used or queries executing slowly.

From what I understand from conversations at HQ, the value of 1800ms is rather arbitrary and there's no objection to increasing it to 5000. This PR is a first step towards that, we have seen various issues with locks being exceeded.

- Issue https://github.com/umbraco/Umbraco-CMS/issues/8433 was resolved by actually improving the performance of operations on members. 
- Issue https://github.com/umbraco/Umbraco-CMS/issues/9386  seems to be related to doing inefficient write operations in custom code
- Issue https://github.com/umbraco/Umbraco-CMS/issues/9514 also shows us the error `Lock request time out period exceeded.`, it might be related but there's not enough info yet.
- Issue https://github.com/umbraco/Umbraco-CMS/issues/9594 also shows this error and might point to a relation to either Forms and/or uSync

With this PR merged, it will be possible to at least experiment with the lock timeout and alleviate some pain for now. It is still a good idea to investigate what's holding locks and why the lock time is not enough for some operations.