### PR TITLE
Add the ability to change the SQL Write Lock TimeOut

### DIFF
--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -6,7 +6,9 @@ using System.Web;
 using System.Web.Configuration;
 using System.Web.Hosting;
 using System.Xml.Linq;
+using Umbraco.Core.Composing;
 using Umbraco.Core.IO;
+using Umbraco.Core.Logging;
 
 namespace Umbraco.Core.Configuration
 {
@@ -23,6 +25,7 @@ namespace Umbraco.Core.Configuration
         // TODO these should not be static
         private static string _reservedPaths;
         private static string _reservedUrls;
+        private static int _sqlWriteLockTimeOut;
 
         //ensure the built on (non-changeable) reserved paths are there at all times
         internal const string StaticReservedPaths = "~/app_plugins/,~/install/,~/mini-profiler-resources/,"; //must end with a comma!
@@ -392,26 +395,38 @@ namespace Umbraco.Core.Configuration
             }
         }
 
-
         /// <summary>
         /// An int value representing the time in milliseconds to lock the database for a write operation
         /// </summary>
         /// <remarks>
-        /// The default value is 1800 milliseconds
+        /// The default value is 5000 milliseconds
         /// </remarks>
         /// <value>The timeout in milliseconds.</value>
         public int SqlWriteLockTimeOut
         {
             get
             {
-                try
+                if (_sqlWriteLockTimeOut != default) return _sqlWriteLockTimeOut;
+
+                var timeOut = 5000; // 5 seconds
+                var appSettingSqlWriteLockTimeOut = ConfigurationManager.AppSettings[Constants.AppSettings.SqlWriteLockTimeOut];
+                if(int.TryParse(appSettingSqlWriteLockTimeOut, out var configuredTimeOut))
                 {
-                    return int.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.SqlWriteLockTimeOut]);
+                    // Only apply this setting if it's not excessively high or low
+                    const int minimumTimeOut = 100;
+                    const int maximumTimeOut = 20000;
+                    if (configuredTimeOut >= minimumTimeOut && configuredTimeOut <= maximumTimeOut) // between 0.1 and 20 seconds
+                    {
+                        timeOut = configuredTimeOut;
+                    }
+                    else
+                    {
+                      Current.Logger.Warn<GlobalSettings>($"The `Umbraco.Core.SqlWriteLockTimeOut` setting in web.config is not between the minimum of {minimumTimeOut} ms and maximum of {maximumTimeOut} ms, defaulting back to {timeOut}");
+                    }
                 }
-                catch
-                {
-                    return 1800;
-                }
+
+                _sqlWriteLockTimeOut = timeOut;
+                return _sqlWriteLockTimeOut;
             }
         }
     }

--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -422,7 +422,7 @@ namespace Umbraco.Core.Configuration
                     }
                     else
                     {
-                      Current.Logger.Warn<GlobalSettings>($"The `Umbraco.Core.SqlWriteLockTimeOut` setting in web.config is not between the minimum of {minimumTimeOut} ms and maximum of {maximumTimeOut} ms, defaulting back to {timeOut}");
+                      Current.Logger.Warn<GlobalSettings>($"The `{Constants.AppSettings.SqlWriteLockTimeOut}` setting in web.config is not between the minimum of {minimumTimeOut} ms and maximum of {maximumTimeOut} ms, defaulting back to {timeOut}");
                     }
                 }
 

--- a/src/Umbraco.Core/Configuration/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/GlobalSettings.cs
@@ -391,5 +391,28 @@ namespace Umbraco.Core.Configuration
                 }
             }
         }
+
+
+        /// <summary>
+        /// An int value representing the time in milliseconds to lock the database for a write operation
+        /// </summary>
+        /// <remarks>
+        /// The default value is 1800 milliseconds
+        /// </remarks>
+        /// <value>The timeout in milliseconds.</value>
+        public int SqlWriteLockTimeOut
+        {
+            get
+            {
+                try
+                {
+                    return int.Parse(ConfigurationManager.AppSettings[Constants.AppSettings.SqlWriteLockTimeOut]);
+                }
+                catch
+                {
+                    return 1800;
+                }
+            }
+        }
     }
 }

--- a/src/Umbraco.Core/Configuration/IGlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/IGlobalSettings.cs
@@ -72,5 +72,10 @@
         /// Gets the location of temporary files.
         /// </summary>
         string LocalTempPath { get; }
+
+        /// <summary>
+        /// Gets the write lock timeout.
+        /// </summary>
+        int SqlWriteLockTimeOut { get; }
     }
 }

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -144,9 +144,6 @@ namespace Umbraco.Core
             /// <summary>
             /// An int value representing the time in milliseconds to lock the database for a write operation
             /// </summary>
-            /// <remarks>
-            /// The default value is 1800 milliseconds
-            /// </remarks>
             public const string SqlWriteLockTimeOut = "Umbraco.Core.SqlWriteLockTimeOut";
         }
     }

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -140,6 +140,14 @@ namespace Umbraco.Core
                 /// </summary>
                 public const string DatabaseFactoryServerVersion = "Umbraco.Core.Debug.DatabaseFactoryServerVersion";
             }
+
+            /// <summary>
+            /// An int value representing the time in milliseconds to lock the database for a write operation
+            /// </summary>
+            /// <remarks>
+            /// The default value is 1800 milliseconds
+            /// </remarks>
+            public const string SqlWriteLockTimeOut = "Umbraco.Core.SqlWriteLockTimeOut";
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
         string ConvertIntegerToOrderableString { get; }
         string ConvertDateToOrderableString { get; }
         string ConvertDecimalToOrderableString { get; }
-        
+
         /// <summary>
         /// Returns the default isolation level for the database
         /// </summary>
@@ -130,5 +130,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         void ReadLock(IDatabase db, params int[] lockIds);
         void WriteLock(IDatabase db, params int[] lockIds);
+        void ReadLock(IDatabase db, TimeSpan timeout, int lockId);
+        void WriteLock(IDatabase db, TimeSpan timeout, int lockId);
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -9,6 +9,12 @@ using Umbraco.Core.Persistence.Querying;
 
 namespace Umbraco.Core.Persistence.SqlSyntax
 {
+    public interface ISqlSyntaxProvider2 : ISqlSyntaxProvider
+    {
+        void ReadLock(IDatabase db, TimeSpan timeout, int lockId);
+        void WriteLock(IDatabase db, TimeSpan timeout, int lockId);
+    }
+
     /// <summary>
     /// Defines an SqlSyntaxProvider
     /// </summary>
@@ -130,7 +136,5 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         void ReadLock(IDatabase db, params int[] lockIds);
         void WriteLock(IDatabase db, params int[] lockIds);
-        void ReadLock(IDatabase db, TimeSpan timeout, int lockId);
-        void WriteLock(IDatabase db, TimeSpan timeout, int lockId);
     }
 }

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -158,6 +158,16 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             return result > 0;
         }
 
+        public override void WriteLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            // soon as we get Database, a transaction is started
+
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
+
+            ObtainWriteLock(db, timeout, lockId);
+        }
+
         public override void WriteLock(IDatabase db, params int[] lockIds)
         {
             // soon as we get Database, a transaction is started
@@ -165,15 +175,30 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
-            var timeOut = Current.Configs.Global().SqlWriteLockTimeOut;
-            db.Execute(@"SET LOCK_TIMEOUT " + timeOut  + ";");
-            // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
+            var timeout = TimeSpan.FromMilliseconds(Current.Configs.Global().SqlWriteLockTimeOut);
+
             foreach (var lockId in lockIds)
             {
-                var i = db.Execute(@"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id", new { id = lockId });
-                if (i == 0) // ensure we are actually locking!
-                    throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+                ObtainWriteLock(db, timeout, lockId);
             }
+        }
+
+        private static void ObtainWriteLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            db.Execute(@"SET LOCK_TIMEOUT " + timeout.TotalMilliseconds  + ";");
+            var i = db.Execute(@"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id", new { id = lockId });
+            if (i == 0) // ensure we are actually locking!
+                throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+        }
+
+        public override void ReadLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            // soon as we get Database, a transaction is started
+
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
+
+            ObtainReadLock(db, timeout, lockId);
         }
 
         public override void ReadLock(IDatabase db, params int[] lockIds)
@@ -183,13 +208,20 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
-            // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
+            var timeout = TimeSpan.FromMilliseconds(Current.Configs.Global().SqlWriteLockTimeOut);
+
             foreach (var lockId in lockIds)
             {
-                var i = db.ExecuteScalar<int?>("SELECT value FROM umbracoLock WHERE id=@id", new { id = lockId });
-                if (i == null) // ensure we are actually locking!
-                    throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+                ObtainReadLock(db, timeout, lockId);
             }
+        }
+
+        private static void ObtainReadLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            db.Execute(@"SET LOCK_TIMEOUT " + timeout.TotalMilliseconds + ";");
+            var i = db.ExecuteScalar<int?>("SELECT value FROM umbracoLock WHERE id=@id", new {id = lockId});
+            if (i == null) // ensure we are actually locking!
+                throw new ArgumentException($"LockObject with id={lockId} does not exist.");
         }
 
         protected override string FormatIdentity(ColumnDefinition column)

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlCeSyntaxProvider.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Data;
 using System.Data.SqlServerCe;
 using System.Linq;
 using NPoco;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Persistence.DatabaseAnnotations;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 
@@ -163,7 +165,8 @@ where table_name=@0 and column_name=@1", tableName, columnName).FirstOrDefault()
             if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
-            db.Execute(@"SET LOCK_TIMEOUT 1800;");
+            var timeOut = Current.Configs.Global().SqlWriteLockTimeOut;
+            db.Execute(@"SET LOCK_TIMEOUT " + timeOut  + ";");
             // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
             foreach (var lockId in lockIds)
             {

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -258,7 +258,7 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
         {
             // soon as we get Database, a transaction is started
 
-            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+            if (db.Transaction.IsolationLevel < IsolationLevel.ReadCommitted)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
             ObtainWriteLock(db, timeout, lockId);
@@ -268,7 +268,7 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
         {
             // soon as we get Database, a transaction is started
 
-            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+            if (db.Transaction.IsolationLevel < IsolationLevel.ReadCommitted)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
             var timeout = TimeSpan.FromMilliseconds(Current.Configs.Global().SqlWriteLockTimeOut);
@@ -293,7 +293,7 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
         {
             // soon as we get Database, a transaction is started
 
-            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+            if (db.Transaction.IsolationLevel < IsolationLevel.ReadCommitted)
                 throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
             ObtainReadLock(db, timeout, lockId);

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
 using NPoco;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Scoping;
@@ -254,7 +256,8 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
 
         public override void WriteLock(IDatabase db, params int[] lockIds)
         {
-            WriteLock(db, TimeSpan.FromMilliseconds(1800), lockIds);
+            var timeOut = Current.Configs.Global().SqlWriteLockTimeOut;
+            WriteLock(db, TimeSpan.FromMilliseconds(timeOut), lockIds);
         }
 
         public void WriteLock(IDatabase db, TimeSpan timeout, params int[] lockIds)

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -254,30 +254,50 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
             return result > 0;
         }
 
-        public override void WriteLock(IDatabase db, params int[] lockIds)
-        {
-            var timeOut = Current.Configs.Global().SqlWriteLockTimeOut;
-            WriteLock(db, TimeSpan.FromMilliseconds(timeOut), lockIds);
-        }
-
-        public void WriteLock(IDatabase db, TimeSpan timeout, params int[] lockIds)
+        public override void WriteLock(IDatabase db, TimeSpan timeout, int lockId)
         {
             // soon as we get Database, a transaction is started
 
-            if (db.Transaction.IsolationLevel < IsolationLevel.ReadCommitted)
-                throw new InvalidOperationException("A transaction with minimum ReadCommitted isolation level is required.");
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
 
+            ObtainWriteLock(db, timeout, lockId);
+        }
 
-            // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
+        public override void WriteLock(IDatabase db, params int[] lockIds)
+        {
+            // soon as we get Database, a transaction is started
+
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
+
+            var timeout = TimeSpan.FromMilliseconds(Current.Configs.Global().SqlWriteLockTimeOut);
+
             foreach (var lockId in lockIds)
             {
-                db.Execute($"SET LOCK_TIMEOUT {timeout.TotalMilliseconds};");
-                var i = db.Execute(@"UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id", new { id = lockId });
-                if (i == 0) // ensure we are actually locking!
-                    throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+                ObtainWriteLock(db, timeout, lockId);
             }
         }
 
+        private static void ObtainWriteLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            db.Execute("SET LOCK_TIMEOUT" + timeout.TotalMilliseconds + ";");
+            var i = db.Execute(
+                @"UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id",
+                new {id = lockId});
+            if (i == 0) // ensure we are actually locking!
+                throw new ArgumentException($"LockObject with id={lockId} does not exist.");
+        }
+
+        public override void ReadLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            // soon as we get Database, a transaction is started
+
+            if (db.Transaction.IsolationLevel < IsolationLevel.RepeatableRead)
+                throw new InvalidOperationException("A transaction with minimum RepeatableRead isolation level is required.");
+
+            ObtainReadLock(db, timeout, lockId);
+        }
 
         public override void ReadLock(IDatabase db, params int[] lockIds)
         {
@@ -286,13 +306,22 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
             if (db.Transaction.IsolationLevel < IsolationLevel.ReadCommitted)
                 throw new InvalidOperationException("A transaction with minimum ReadCommitted isolation level is required.");
 
-            // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
+            var timeout = TimeSpan.FromMilliseconds(Current.Configs.Global().SqlWriteLockTimeOut);
+
             foreach (var lockId in lockIds)
             {
-                var i = db.ExecuteScalar<int?>("SELECT value FROM umbracoLock WITH (REPEATABLEREAD) WHERE id=@id", new { id = lockId });
-                if (i == null) // ensure we are actually locking!
-                    throw new ArgumentException($"LockObject with id={lockId} does not exist.", nameof(lockIds));
+                ObtainReadLock(db, timeout, lockId);
             }
+        }
+
+        private static void ObtainReadLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            db.Execute(@"SET LOCK_TIMEOUT " + timeout.TotalMilliseconds  + ";");
+            // *not* using a unique 'WHERE IN' query here because the *order* of lockIds is important to avoid deadlocks
+            var i = db.ExecuteScalar<int?>("SELECT value FROM umbracoLock WITH (REPEATABLEREAD) WHERE id=@id",
+                new {id = lockId});
+            if (i == null) // ensure we are actually locking!
+                throw new ArgumentException($"LockObject with id={lockId} does not exist.");
         }
 
         public override string FormatColumnRename(string tableName, string oldName, string newName)

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -235,6 +235,9 @@ namespace Umbraco.Core.Persistence.SqlSyntax
 
         public abstract void ReadLock(IDatabase db, params int[] lockIds);
         public abstract void WriteLock(IDatabase db, params int[] lockIds);
+        public abstract void ReadLock(IDatabase db, TimeSpan timeout, int lockId);
+
+        public abstract void WriteLock(IDatabase db, TimeSpan timeout, int lockId);
 
         public virtual bool DoesTableExist(IDatabase db, string tableName)
         {

--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
     /// All Sql Syntax provider implementations should derive from this abstract class.
     /// </remarks>
     /// <typeparam name="TSyntax"></typeparam>
-    public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
+    public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider2
         where TSyntax : ISqlSyntaxProvider
     {
         protected SqlSyntaxProviderBase()

--- a/src/Umbraco.Core/Scoping/IScope.cs
+++ b/src/Umbraco.Core/Scoping/IScope.cs
@@ -54,9 +54,23 @@ namespace Umbraco.Core.Scoping
         void ReadLock(params int[] lockIds);
 
         /// <summary>
+        /// Read-locks some lock objects.
+        /// </summary>
+        /// <param name="timeout">The database timeout in milliseconds</param>
+        /// <param name="lockId">The lock object identifier.</param>
+        void ReadLock(TimeSpan timeout, int lockId);
+
+        /// <summary>
         /// Write-locks some lock objects.
         /// </summary>
         /// <param name="lockIds">The lock object identifiers.</param>
         void WriteLock(params int[] lockIds);
+
+        /// <summary>
+        /// Write-locks some lock objects.
+        /// </summary>
+        /// <param name="timeout">The database timeout in milliseconds</param>
+        /// <param name="lockId">The lock object identifier.</param>
+        void WriteLock(TimeSpan timeout, int lockId);
     }
 }

--- a/src/Umbraco.Core/Scoping/IScope.cs
+++ b/src/Umbraco.Core/Scoping/IScope.cs
@@ -5,6 +5,24 @@ using Umbraco.Core.Persistence;
 
 namespace Umbraco.Core.Scoping
 {
+    // TODO: This is for backward compat - Merge this in netcore
+    public interface IScope2 : IScope
+    {
+        /// <summary>
+        /// Write-locks some lock objects.
+        /// </summary>
+        /// <param name="timeout">The database timeout in milliseconds</param>
+        /// <param name="lockId">The lock object identifier.</param>
+        void WriteLock(TimeSpan timeout, int lockId);
+
+        /// <summary>
+        /// Read-locks some lock objects.
+        /// </summary>
+        /// <param name="timeout">The database timeout in milliseconds</param>
+        /// <param name="lockId">The lock object identifier.</param>
+        void ReadLock(TimeSpan timeout, int lockId);
+    }
+
     /// <summary>
     /// Represents a scope.
     /// </summary>
@@ -54,23 +72,9 @@ namespace Umbraco.Core.Scoping
         void ReadLock(params int[] lockIds);
 
         /// <summary>
-        /// Read-locks some lock objects.
-        /// </summary>
-        /// <param name="timeout">The database timeout in milliseconds</param>
-        /// <param name="lockId">The lock object identifier.</param>
-        void ReadLock(TimeSpan timeout, int lockId);
-
-        /// <summary>
         /// Write-locks some lock objects.
         /// </summary>
         /// <param name="lockIds">The lock object identifiers.</param>
         void WriteLock(params int[] lockIds);
-
-        /// <summary>
-        /// Write-locks some lock objects.
-        /// </summary>
-        /// <param name="timeout">The database timeout in milliseconds</param>
-        /// <param name="lockId">The lock object identifier.</param>
-        void WriteLock(TimeSpan timeout, int lockId);
     }
 }

--- a/src/Umbraco.Core/Scoping/Scope.cs
+++ b/src/Umbraco.Core/Scoping/Scope.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Events;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.SqlSyntax;
 
 namespace Umbraco.Core.Scoping
 {
@@ -13,7 +14,7 @@ namespace Umbraco.Core.Scoping
     /// Implements <see cref="IScope"/>.
     /// </summary>
     /// <remarks>Not thread-safe obviously.</remarks>
-    internal class Scope : IScope
+    internal class Scope : IScope2
     {
         private readonly ScopeProvider _scopeProvider;
         private readonly ILogger _logger;
@@ -489,14 +490,28 @@ namespace Umbraco.Core.Scoping
         public void ReadLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.ReadLock(Database, lockIds);
 
         /// <inheritdoc />
-        public void ReadLock(TimeSpan timeout, int lockId) =>
-            Database.SqlContext.SqlSyntax.ReadLock(Database, timeout, lockId);
+        public void ReadLock(TimeSpan timeout, int lockId)
+        {
+            var syntax2 = Database.SqlContext.SqlSyntax as ISqlSyntaxProvider2;
+            if (syntax2 == null)
+            {
+                throw new InvalidOperationException($"{Database.SqlContext.SqlSyntax.GetType()} is not of type {typeof(ISqlSyntaxProvider2)}");
+            }
+            syntax2.ReadLock(Database, timeout, lockId);
+        }
 
         /// <inheritdoc />
         public void WriteLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.WriteLock(Database, lockIds);
 
         /// <inheritdoc />
-        public void WriteLock(TimeSpan timeout, int lockId) =>
-            Database.SqlContext.SqlSyntax.WriteLock(Database, timeout, lockId);
+        public void WriteLock(TimeSpan timeout, int lockId)
+        {
+            var syntax2 = Database.SqlContext.SqlSyntax as ISqlSyntaxProvider2;
+            if (syntax2 == null)
+            {
+                throw new InvalidOperationException($"{Database.SqlContext.SqlSyntax.GetType()} is not of type {typeof(ISqlSyntaxProvider2)}");
+            }
+            syntax2.WriteLock(Database, timeout, lockId);
+        }
     }
 }

--- a/src/Umbraco.Core/Scoping/Scope.cs
+++ b/src/Umbraco.Core/Scoping/Scope.cs
@@ -489,6 +489,14 @@ namespace Umbraco.Core.Scoping
         public void ReadLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.ReadLock(Database, lockIds);
 
         /// <inheritdoc />
+        public void ReadLock(TimeSpan timeout, int lockId) =>
+            Database.SqlContext.SqlSyntax.ReadLock(Database, timeout, lockId);
+
+        /// <inheritdoc />
         public void WriteLock(params int[] lockIds) => Database.SqlContext.SqlSyntax.WriteLock(Database, lockIds);
+
+        /// <inheritdoc />
+        public void WriteLock(TimeSpan timeout, int lockId) =>
+            Database.SqlContext.SqlSyntax.WriteLock(Database, timeout, lockId);
     }
 }

--- a/src/Umbraco.Tests/Persistence/LocksTests.cs
+++ b/src/Umbraco.Tests/Persistence/LocksTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlServerCe;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NPoco;
 using NUnit.Framework;
 using Umbraco.Core;
@@ -277,29 +279,149 @@ namespace Umbraco.Tests.Persistence
         }
 
         [Test]
-        public void LockTimeoutTest()
+        public void Throws_When_Lock_Timeout_Is_Exceeded()
+        {   
+            var t1 = Task.Run(() =>
+            {
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    var realScope = (Scope)scope;
+
+                    Console.WriteLine("Write lock A");
+                    // This will acquire right away 
+                    realScope.WriteLock(TimeSpan.FromMilliseconds(2000), Constants.Locks.ContentTree);
+                    Thread.Sleep(6000); // Wait longer than the Read Lock B timeout
+                    scope.Complete();
+                    Console.WriteLine("Finished Write lock A");
+                }
+            });
+
+            Thread.Sleep(500); // 100% sure task 1 starts first
+
+            var t2 = Task.Run(() =>
+            {
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    var realScope = (Scope)scope;
+
+                    Console.WriteLine("Read lock B");
+
+                    // This will wait for the write lock to release but it isn't going to wait long
+                    // enough so an exception will be thrown.
+                    Assert.Throws<SqlCeLockTimeoutException>(() =>
+                        realScope.ReadLock(TimeSpan.FromMilliseconds(3000), Constants.Locks.ContentTree));
+
+                    scope.Complete();
+                    Console.WriteLine("Finished Read lock B");
+                }
+            });
+
+            var t3 = Task.Run(() =>
+            {
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    var realScope = (Scope)scope;
+
+                    Console.WriteLine("Write lock C");
+
+                    // This will wait for the write lock to release but it isn't going to wait long
+                    // enough so an exception will be thrown.
+                    Assert.Throws<SqlCeLockTimeoutException>(() =>
+                        realScope.WriteLock(TimeSpan.FromMilliseconds(3000), Constants.Locks.ContentTree));
+
+                    scope.Complete();
+                    Console.WriteLine("Finished Write lock C");
+                }
+            });
+
+            Task.WaitAll(t1, t2, t3);
+        }
+
+        [Test]
+        public void Read_Lock_Waits_For_Write_Lock()
         {
-            // Can't set test timeouts higher as NUnit stops running a test after 60 seconds
+            var locksCompleted = 0;
 
+            var t1 = Task.Run(() =>
+            {
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    var realScope = (Scope)scope;
+
+                    Console.WriteLine("Write lock A");
+                    // This will acquire right away 
+                    realScope.WriteLock(TimeSpan.FromMilliseconds(2000), Constants.Locks.ContentTree);
+                    Thread.Sleep(4000); // Wait less than the Read Lock B timeout
+                    scope.Complete();
+                    Interlocked.Increment(ref locksCompleted);
+                    Console.WriteLine("Finished Write lock A");
+                }
+            });
+
+            Thread.Sleep(500); // 100% sure task 1 starts first
+
+            var t2 = Task.Run(() =>
+            {
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    var realScope = (Scope)scope;
+
+                    Console.WriteLine("Read lock B");
+
+                    // This will wait for the write lock to release
+                    Assert.DoesNotThrow(() =>
+                        realScope.ReadLock(TimeSpan.FromMilliseconds(6000), Constants.Locks.ContentTree));
+
+                    Assert.GreaterOrEqual(locksCompleted, 1);
+
+                    scope.Complete();
+                    Interlocked.Increment(ref locksCompleted);
+                    Console.WriteLine("Finished Read lock B");
+                }                
+            });
+
+            var t3 = Task.Run(() =>
+            {
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    var realScope = (Scope)scope;
+
+                    Console.WriteLine("Read lock C");
+
+                    // This will wait for the write lock to release
+                    Assert.DoesNotThrow(() =>
+                        realScope.ReadLock(TimeSpan.FromMilliseconds(6000), Constants.Locks.ContentTree));
+
+                    Assert.GreaterOrEqual(locksCompleted, 1);
+
+                    scope.Complete();
+                    Interlocked.Increment(ref locksCompleted);
+                    Console.WriteLine("Finished Read lock C");
+                }
+            });
+
+            Task.WaitAll(t1, t2, t3);
+
+            Assert.AreEqual(3, locksCompleted);
+        }
+
+        [Test]
+        [NUnit.Framework.Ignore("We cannot run this test with SQLCE because it does not support a Command Timeout")]
+        public void Lock_Exceeds_Command_Timeout()
+        {
             using (var scope = ScopeProvider.CreateScope())
             {
                 var realScope = (Scope)scope;
-                // a really long timeout
-                realScope.WriteLock(TimeSpan.FromMilliseconds(25000), Constants.Locks.ContentTree);
-                Thread.Sleep(25100); // Wait longer than the timeout
-                scope.Complete();
-            }
 
-            using (var scope = ScopeProvider.CreateScope())
-            {
-                var realScope = (Scope)scope;
-                // a really long timeout
-                realScope.ReadLock(TimeSpan.FromMilliseconds(20000), Constants.Locks.ContentTree);
-                Thread.Sleep(20100); // Wait longer than the timeout
-                scope.Complete();
-            }
+                var realDb = (Database)realScope.Database;
+                realDb.CommandTimeout = 1000;
 
-            // No exception .. :(
+                Console.WriteLine("Write lock A");
+                // TODO: In theory this would throw
+                realScope.WriteLock(TimeSpan.FromMilliseconds(3000), Constants.Locks.ContentTree);
+                scope.Complete();
+                Console.WriteLine("Finished Write lock A");
+            }
         }
 
         private void NoDeadLockTestThread(int id, EventWaitHandle myEv, WaitHandle otherEv, ref Exception exception)

--- a/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
+++ b/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
@@ -23,7 +23,8 @@ namespace Umbraco.Tests.TestHelpers
                     settings.LocalTempStorageLocation == LocalTempStorage.Default &&
                     settings.LocalTempPath == IOHelper.MapPath("~/App_Data/TEMP") &&
                     settings.ReservedPaths == (GlobalSettings.StaticReservedPaths + "~/umbraco") &&
-                    settings.ReservedUrls == GlobalSettings.StaticReservedUrls);
+                    settings.ReservedUrls == GlobalSettings.StaticReservedUrls &&
+                    settings.SqlWriteLockTimeOut == 1800);
             return config;
         }
 

--- a/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
+++ b/src/Umbraco.Tests/TestHelpers/SettingsForTests.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Tests.TestHelpers
                     settings.LocalTempPath == IOHelper.MapPath("~/App_Data/TEMP") &&
                     settings.ReservedPaths == (GlobalSettings.StaticReservedPaths + "~/umbraco") &&
                     settings.ReservedUrls == GlobalSettings.StaticReservedUrls &&
-                    settings.SqlWriteLockTimeOut == 1800);
+                    settings.SqlWriteLockTimeOut == 5000);
             return config;
         }
 


### PR DESCRIPTION
Updates based on feedback on #9744

- Default value is now 5000
- There's a limit to the range of the timeout values
- Introduced backing field so as not to keep looking up the same value over and over again from the config