### PR TITLE
Make sorting in media consistent with sorting in content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js
@@ -11,6 +11,8 @@
         vm.saveButtonState = "init";
         vm.sortOrder = {};
         vm.sortableOptions = {
+            axis: "y",
+            containment: "parent",
             distance: 10,
             tolerance: "pointer",
             opacity: 0.7,

--- a/src/Umbraco.Web.UI.Client/src/views/media/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/sort.html
@@ -21,8 +21,7 @@
                                 <button type="button" class="btn-reset" ng-click="vm.sort('name')">
                                     <strong><localize key="general_name">Name</localize></strong>
                                     <span ng-if="vm.sortOrder.column === 'name'" aria-hidden="true">
-                                        <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
-                                        <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
+                                        <i ng-class="{ 'icon-navigation-up': vm.sortOrder.reverse, 'icon-navigation-down': !vm.sortOrder.reverse }"></i>
                                     </span>
                                 </button>
                             </th>
@@ -30,8 +29,7 @@
                                 <button type="button" class="btn-reset" ng-click="vm.sort('createDate')">
                                     <strong><localize key="sort_sortCreationDate">Creation date</localize></strong>
                                     <span ng-if="vm.sortOrder.column === 'createDate'" aria-hidden="true">
-                                        <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
-                                        <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
+                                        <i ng-class="{ 'icon-navigation-up': vm.sortOrder.reverse, 'icon-navigation-down': !vm.sortOrder.reverse }"></i>
                                     </span>
                                 </button>
                             </th>

--- a/src/Umbraco.Web.UI.Client/src/views/media/sort.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/sort.html
@@ -19,7 +19,7 @@
                         <tr>
                             <th colspan="2">
                                 <button type="button" class="btn-reset" ng-click="vm.sort('name')">
-                                    <b><localize key="general_name">Name</localize></b>
+                                    <strong><localize key="general_name">Name</localize></strong>
                                     <span ng-if="vm.sortOrder.column === 'name'" aria-hidden="true">
                                         <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                         <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>
@@ -28,7 +28,7 @@
                             </th>
                             <th>
                                 <button type="button" class="btn-reset" ng-click="vm.sort('createDate')">
-                                    <b><localize key="sort_sortCreationDate">Creation date</localize></b>
+                                    <strong><localize key="sort_sortCreationDate">Creation date</localize></strong>
                                     <span ng-if="vm.sortOrder.column === 'createDate'" aria-hidden="true">
                                         <i ng-if="vm.sortOrder.reverse" class="icon-navigation-up"></i>
                                         <i ng-if="!vm.sortOrder.reverse" class="icon-navigation-down"></i>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the sorting in Content and Media currently isn't consistent. In Content section the sorting is restricted to y-axis and within parent container, so this PR updates this as well for media sorting.
I previous worked on that in https://github.com/umbraco/Umbraco-CMS/pull/8419 but somehow I forgot to add this the media as well.

I have also cleaned up the sort view as in the old PR.