### PR TITLE
Update icons in umb-tree-search-results component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -155,6 +155,7 @@ body.touch .umb-tree {
 
         &-link {
             display: block;
+            width: 100%;
         }
 
         &-name {

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -132,7 +132,6 @@ body.touch .umb-tree {
 .umb-tree .umb-search-group {
     position: inherit;
     display: inherit;
-
     list-style: none;
 
     h6 {
@@ -156,6 +155,7 @@ body.touch .umb-tree {
         &-link {
             display: block;
             width: 100%;
+            text-align: left;
         }
 
         &-name {

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -14,7 +14,7 @@
                     ng-click="selectResultCallback($event, result)">
                 <span class="umb-search-group-item-name">
                     <umb-icon icon="{{result.selected ? 'icon-check' : result.icon}}"
-                              class="icon umb-tree-icon sprTree {{result.selected ? 'icon-check color-green' : result.icon}}">
+                              class="icon umb-tree-icon sprTree {{result.selected ? 'icon-check' : result.icon}}">
                     </umb-icon>
                     <span class="umb-search-group-item-name__text">{{ result.name }}</span>
                 </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -7,13 +7,14 @@
     <li class="root">
       <ul class="umb-search-group">
         <li class="umb-search-group-item" ng-repeat="result in results">
-          <div ng-class="{'umb-tree-node-checked' : result.selected}">
-            <button type="button" class="btn-reset umb-search-group-item-link" ng-class="{first:$first}"
-                ng-click="selectResultCallback($event, result)">
+          <div ng-class="{ 'umb-tree-node-checked': result.selected }">
+            <button type="button"
+                    class="btn-reset umb-search-group-item-link"
+                    ng-class="{ first: $first }"
+                    ng-click="selectResultCallback($event, result)">
                 <span class="umb-search-group-item-name">
-                    <umb-icon ng-if="result.selected" icon="icon-check" class="icon umb-tree-icon green sprTree icon-check">
-                    </umb-icon>
-                    <umb-icon ng-if="!result.selected" icon="{{result.icon}}" class="icon umb-tree-icon sprTree {{result.icon}}">
+                    <umb-icon icon="{{result.selected ? 'icon-check' : result.icon}}"
+                              class="icon umb-tree-icon sprTree {{result.selected ? 'icon-check color-green' : result.icon}}">
                     </umb-icon>
                     <span class="umb-search-group-item-name__text">{{ result.name }}</span>
                 </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Inside view of `<umb-tree-search-results>` component I noticed some unnecessary use of `ng-if`. Instead the classes can be added using inline conditional statements.

Furthermore after the link in the result item has been changed to a `<button>` element, it no longer used the full width of the container.

This is shown in eg. Move dialog when filtering, where the `<umb-tree-search-results>` component is used the list the result items.

![image](https://user-images.githubusercontent.com/2919859/106795843-e6c9b280-665a-11eb-9294-5d6ebd03f02f.png)
