### PR TITLE
Use umb-icon component in tree item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -348,7 +348,7 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
             };
 
             $scope.selectEnabledNodeClass = node =>
-                node && node.selected ? 'icon umb-tree-icon sprTree icon-check green temporary' : '';            
+                node && node.selected ? 'icon sprTree icon-check green temporary' : '-hidden';
 
             /* helper to force reloading children of a tree node */
             $scope.loadChildren = (node, forceReload) => loadChildren(node, forceReload);

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -338,7 +338,12 @@ body.touch .umb-tree {
     margin: 0 13px 0 0;
     //color: @gray-1;
     color: @ui-option-type;
-    font-size: 20px;   
+    font-size: 20px;
+
+    &.-hidden {
+        display: none;
+        visibility: hidden;
+    }
     
     &.blue {
         color: @blue;

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -4,7 +4,11 @@
         <div class="umb-tree-root" data-element="tree-root" ng-class="getNodeCssClass(tree.root)" ng-hide="hideheader === 'true'" on-right-click="altSelect(tree.root, $event)">
             <h5>
                 <a ng-href="#/{{section}}" ng-click="select(tree.root, $event)" class="umb-tree-root-link umb-outline" data-element="tree-root-link">
-                    <i ng-if="enablecheckboxes === 'true'" ng-class="selectEnabledNodeClass(tree.root)" aria-hidden="true"></i>
+                    <umb-icon icon="icon-check"
+                              class="umb-tree-icon icon-check"
+                              ng-class="selectEnabledNodeClass(tree.root)"
+                              ng-if="enablecheckboxes === 'true'">
+                    </umb-icon>
                     {{tree.name}}
                 </a>
             </h5>
@@ -38,7 +42,11 @@
         <div class="umb-tree-root" data-element="tree-root" ng-class="getNodeCssClass(group)" ng-hide="hideheader === 'true'" on-right-click="altSelect(group, $event)">
             <h5>
                 <a ng-href="#/{{section}}" ng-click="select(group, $event)" class="umb-tree-root-link umb-outline" data-element="tree-root-link">
-                    <i ng-if="enablecheckboxes === 'true'" ng-class="selectEnabledNodeClass(group)" aria-hidden="true"></i>
+                    <umb-icon icon="icon-check"
+                              class="umb-tree-icon icon-check"
+                              ng-class="selectEnabledNodeClass(group)"
+                              ng-if="enablecheckboxes === 'true'">
+                    </umb-icon>
                     {{group.name}}
                 </a>
             </h5>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replace the icon `icon-check` using `<i>` element with `<umb-icon>` in tree, where `enablecheckboxes` is used, e.g. in Move dialog.


![GhM6FNaZ5c](https://user-images.githubusercontent.com/2919859/106800257-850c4700-6660-11eb-9ae6-cf711af2604e.gif)
