### PR TITLE
Replace tree icon in section picker with umb-icon component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/sectionpicker/sectionpicker.html
@@ -19,10 +19,15 @@
             <umb-box ng-if="!vm.loading">
                 <umb-box-content>
                     <ul class="umb-tree">
-                        <li ng-repeat="section in vm.sections" class="umb-tree-item">
+                        <li class="umb-tree-item" ng-repeat="section in vm.sections">
                             <div class="umb-tree-item__inner" style="padding: 5px 10px;">
-                                <button type="button" class="btn-reset text-left flex-auto" ng-click="vm.selectSection(section)" ng-class="{'umb-tree-node-checked': section.selected }">
-                                    <i class="icon umb-tree-icon {{section.icon}}" aria-hidden="true"></i>
+                                <button type="button"
+                                        class="btn-reset text-left flex-auto"
+                                        ng-class="{'umb-tree-node-checked': section.selected }"
+                                        ng-click="vm.selectSection(section)">
+                                    <umb-icon icon="{{section.selected ? 'icon-check' : section.icon}}"
+                                              class="icon umb-tree-icon {{section.selected ? 'icon-check color-green' : section.icon}}">
+                                    </umb-icon>
                                     <span>{{ section.name }}</span>
                                 </button>
                             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replace the icon `icon-check` using `<i>` element with `<umb-icon>` in tree in section picker used in user groups.

![HN1ocaKBBM](https://user-images.githubusercontent.com/2919859/106803208-3e205080-6664-11eb-9c76-e0073089542d.gif)
