### PR TITLE
Separate remove button and label for settings and styles in Grid Layout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.html
@@ -117,11 +117,10 @@
 
                 <li ng-repeat="configValue in model.value.config">
                     <i class="icon icon-navigation handle" aria-hidden="true"></i>
-
                     <button type="button" class="btn-link" ng-click="vm.removeConfigValue(model.value.config, $index)">
                         <i class="icon icon-delete red" aria-hidden="true"></i>
-                        {{configValue.label}}
                     </button>
+                    <span>{{configValue.label}}</span>
                 </li>
             </ul>
 
@@ -145,12 +144,10 @@
 
                 <li ng-repeat="style in model.value.styles">
                     <i class="icon icon-navigation handle" aria-hidden="true"></i>
-
                     <button type="button" class="btn-link" ng-click="vm.removeConfigValue(model.value.styles, $index)">
                         <i class="icon icon-delete red" aria-hidden="true"></i>
-                        {{style.label}}
                     </button>
-
+                    <span>{{style.label}}</span>
                 </li>
             </ul>
 


### PR DESCRIPTION
It's inconvenient and not intuitive that the click area of the remove button laps over the label of settings and styles in the Grid Layout property editor. Simply as an editor may remove the style/setting by accident by clicking the label – especially since there isn't an undo option.

Known issue: Linebreak of long text labels doesn't appear pretty, but this is cosmetic and can be fixed.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Before:

![Screenshot 2021-02-04 232833](https://user-images.githubusercontent.com/25110864/106966020-d261e480-6744-11eb-8181-6f18d4fcc869.png)

After:

![Screenshot 2021-02-04 235207](https://user-images.githubusercontent.com/25110864/106966043-dc83e300-6744-11eb-8223-0175239d08c8.png)
