### PR TITLE
Move the SetWeight logic to WeightedCollectionBuilderBase

### DIFF
--- a/src/Umbraco.Core/Composing/WeightedCollectionBuilderBase.cs
+++ b/src/Umbraco.Core/Composing/WeightedCollectionBuilderBase.cs
@@ -16,6 +16,8 @@ namespace Umbraco.Core.Composing
     {
         protected abstract TBuilder This { get; }
 
+        private readonly Dictionary<Type, int> _customWeights = new Dictionary<Type, int>();
+
         /// <summary>
         /// Clears all types in the collection.
         /// </summary>
@@ -107,6 +109,18 @@ namespace Umbraco.Core.Composing
             return This;
         }
 
+        /// <summary>
+        /// Changes the default weight of an item
+        /// </summary>
+        /// <typeparam name="T">The type of item</typeparam>
+        /// <param name="weight">The new weight</param>
+        /// <returns></returns>
+        public TBuilder SetWeight<T>(int weight) where T : TItem
+        {
+            _customWeights[typeof(T)] = weight;
+            return This;
+        }
+
         protected override IEnumerable<Type> GetRegisteringTypes(IEnumerable<Type> types)
         {
             var list = types.ToList();
@@ -118,6 +132,8 @@ namespace Umbraco.Core.Composing
 
         protected virtual int GetWeight(Type type)
         {
+            if (_customWeights.ContainsKey(type))
+                return _customWeights[type];
             var attr = type.GetCustomAttributes(typeof(WeightAttribute), false).OfType<WeightAttribute>().SingleOrDefault();
             return attr?.Weight ?? DefaultWeight;
         }

--- a/src/Umbraco.Tests/Composing/CollectionBuildersTests.cs
+++ b/src/Umbraco.Tests/Composing/CollectionBuildersTests.cs
@@ -442,6 +442,19 @@ namespace Umbraco.Tests.Composing
             AssertCollection(col, typeof(Resolved2), typeof(Resolved1));
         }
 
+        [Test]
+        public void WeightedBuilderSetWeight()
+        {
+            var builder = _composition.WithCollectionBuilder<TestCollectionBuilderWeighted>()
+                .Add<Resolved1>()
+                .Add<Resolved2>();
+            builder.SetWeight<Resolved1>(10);
+
+            var factory = _composition.CreateFactory();
+            var col = builder.CreateCollection(factory);
+            AssertCollection(col, typeof(Resolved1), typeof(Resolved2));
+        }
+
         #region Assertions
 
         private static void AssertCollection(IEnumerable<Resolved> col, params Type[] expected)

--- a/src/Umbraco.Web/Dashboards/DashboardCollectionBuilder.cs
+++ b/src/Umbraco.Web/Dashboards/DashboardCollectionBuilder.cs
@@ -10,21 +10,7 @@ namespace Umbraco.Web.Dashboards
 {
     public class DashboardCollectionBuilder : WeightedCollectionBuilderBase<DashboardCollectionBuilder, DashboardCollection, IDashboard>
     {
-        private Dictionary<Type, int> _customWeights = new Dictionary<Type, int>();
-
         protected override DashboardCollectionBuilder This => this;
-
-        /// <summary>
-        /// Changes the default weight of a dashboard
-        /// </summary>
-        /// <typeparam name="T">The type of dashboard</typeparam>
-        /// <param name="weight">The new dashboard weight</param>
-        /// <returns></returns>
-        public DashboardCollectionBuilder SetWeight<T>(int weight) where T : IDashboard
-        {
-            _customWeights[typeof(T)] = weight;
-            return this;
-        }
 
         protected override IEnumerable<IDashboard> CreateItems(IFactory factory)
         {
@@ -47,20 +33,13 @@ namespace Umbraco.Web.Dashboards
 
         private int GetWeight(IDashboard dashboard)
         {
-            var typeOfDashboard = dashboard.GetType();
-            if(_customWeights.ContainsKey(typeOfDashboard))
-            {
-                return _customWeights[typeOfDashboard];
-            }
-
             switch (dashboard)
             {
                 case ManifestDashboard manifestDashboardDefinition:
                     return manifestDashboardDefinition.Weight;
 
                 default:
-                    var weightAttribute = dashboard.GetType().GetCustomAttribute<WeightAttribute>(false);
-                    return weightAttribute?.Weight ?? DefaultWeight;
+                    return GetWeight(dashboard.GetType());
             }
         }
     }


### PR DESCRIPTION
Inspired by the PR of @kjac (https://github.com/umbraco/Umbraco-CMS/pull/8628), I moved the SetWeigth logic to the WeightedCollectionBuilderBase. I think this is a better place to put this as it's something that should work with all weighted collections, not just the dashboards.
Also added a test for it.

The same code as in the other PR can be used to test this:
```
using Umbraco.Core.Composing;
using Umbraco.Web;
using Umbraco.Web.Dashboards;

namespace Test
{
    public class TestDashboardComposer : IUserComposer
    {
        public void Compose(Composition composition)
        {
            // place the "Redirect URL Management" dashboard before the "Getting Started" dashboard
            composition.Dashboards().SetWeight<Umbraco.Web.Dashboards.RedirectUrlDashboard>(5);
        }
    }
}
```