### PR TITLE
RTE render macro as inline element option

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -9,6 +9,7 @@ using Umbraco.Core.Migrations.Upgrade.V_8_1_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_6_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_9_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_10_0;
+using Umbraco.Core.Migrations.Upgrade.V8_11_2;
 
 namespace Umbraco.Core.Migrations.Upgrade
 {
@@ -202,6 +203,7 @@ namespace Umbraco.Core.Migrations.Upgrade
             // to 8.10.0
             To<AddPropertyTypeLabelOnTopColumn>("{D6A8D863-38EC-44FB-91EC-ACD6A668BD18}");
 
+            To<AddPropertyRenderInlineToMacro>("{2ddca6d9-bce4-4510-baef-0eff64968fec}");
             //FINAL
         }
     }

--- a/src/Umbraco.Core/Migrations/Upgrade/V8_11_2/AddPropertyRenderInlineToMacro.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V8_11_2/AddPropertyRenderInlineToMacro.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V8_11_2
+{
+    public class AddPropertyRenderInlineToMacro : MigrationBase
+    {
+        public AddPropertyRenderInlineToMacro(IMigrationContext context)
+            : base(context)
+        { }
+
+        public override void Migrate()
+        {
+            var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToList();
+
+            AddColumnIfNotExists<MacroDto>(columns, "macroRenderInline");
+        }
+    }
+}

--- a/src/Umbraco.Core/Models/IMacro.cs
+++ b/src/Umbraco.Core/Models/IMacro.cs
@@ -29,6 +29,12 @@ namespace Umbraco.Core.Models
         bool UseInEditor { get; set; }
 
         /// <summary>
+        /// Gets or sets a boolean indicating whether the Macro should be rendered with a span instead of a div wrapper in the editor
+        /// </summary>
+        [DataMember]
+        bool RenderInline { get; set; }
+
+        /// <summary>
         /// Gets or sets the Cache Duration for the Macro
         /// </summary>
         [DataMember]

--- a/src/Umbraco.Core/Models/Macro.cs
+++ b/src/Umbraco.Core/Models/Macro.cs
@@ -30,6 +30,7 @@ namespace Umbraco.Core.Models
         /// <param name="id"></param>
         /// <param name="key"></param>
         /// <param name="useInEditor"></param>
+        /// <param name="renderInline"></param>
         /// <param name="cacheDuration"></param>
         /// <param name="alias"></param>
         /// <param name="name"></param>
@@ -37,7 +38,8 @@ namespace Umbraco.Core.Models
         /// <param name="cacheByMember"></param>
         /// <param name="dontRender"></param>
         /// <param name="macroSource"></param>
-        public Macro(int id, Guid key, bool useInEditor, int cacheDuration, string @alias, string name, bool cacheByPage, bool cacheByMember, bool dontRender, string macroSource, MacroTypes macroType)
+        /// <param name="macroType"></param>
+        public Macro(int id, Guid key, bool useInEditor, bool renderInline, int cacheDuration, string @alias, string name, bool cacheByPage, bool cacheByMember, bool dontRender, string macroSource, MacroTypes macroType)
             : this()
         {
             Id = id;
@@ -51,15 +53,18 @@ namespace Umbraco.Core.Models
             DontRender = dontRender;
             MacroSource = macroSource;
             MacroType = macroType;
+            RenderInline = renderInline;
         }
 
         /// <summary>
         /// Creates an instance for persisting a new item
         /// </summary>
         /// <param name="useInEditor"></param>
+        /// <param name="renderInline"></param>
         /// <param name="cacheDuration"></param>
         /// <param name="alias"></param>
         /// <param name="name"></param>
+        /// <param name="macroType"></param>
         /// <param name="cacheByPage"></param>
         /// <param name="cacheByMember"></param>
         /// <param name="dontRender"></param>
@@ -71,10 +76,12 @@ namespace Umbraco.Core.Models
             bool cacheByMember = false,
             bool dontRender = true,
             bool useInEditor = false,
+            bool renderInline = false,
             int cacheDuration = 0)
             : this()
         {
             UseInEditor = useInEditor;
+            RenderInline = renderInline;
             CacheDuration = cacheDuration;
             Alias = alias.ToCleanString(CleanStringType.Alias);
             Name = name;
@@ -88,6 +95,7 @@ namespace Umbraco.Core.Models
         private string _alias;
         private string _name;
         private bool _useInEditor;
+        private bool _renderInline;
         private int _cacheDuration;
         private bool _cacheByPage;
         private bool _cacheByMember;
@@ -192,6 +200,16 @@ namespace Umbraco.Core.Models
         {
             get => _useInEditor;
             set => SetPropertyValueAndDetectChanges(value, ref _useInEditor, nameof(UseInEditor));
+        }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether the Macro should be rendered inline with a span instead of div
+        /// </summary>
+        [DataMember]
+        public bool RenderInline
+        {
+            get => _renderInline;
+            set => SetPropertyValueAndDetectChanges(value, ref _renderInline, nameof(RenderInline));
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Core/Packaging/PackageDataInstallation.cs
@@ -1168,9 +1168,16 @@ namespace Umbraco.Core.Packaging
                 dontRender = bool.Parse(dontRenderElement.Value);
             }
 
+            var renderInlineElement = macroElement.Element("renderInline");
+            var renderInline = false;
+            if (renderInlineElement != null && string.IsNullOrEmpty((string)renderInlineElement) == false)
+            {
+                renderInline = bool.Parse(renderInlineElement.Value);
+            }
+
             var existingMacro = _macroService.GetByAlias(macroAlias) as Macro;
             var macro = existingMacro ?? new Macro(macroAlias, macroName, macroSource, macroType,
-                cacheByPage, cacheByMember, dontRender, useInEditor, cacheDuration);
+                cacheByPage, cacheByMember, dontRender, useInEditor, renderInline, cacheDuration);
 
             var properties = macroElement.Element("properties");
             if (properties != null)

--- a/src/Umbraco.Core/Persistence/Dtos/MacroDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/MacroDto.cs
@@ -22,6 +22,11 @@ namespace Umbraco.Core.Persistence.Dtos
         [Constraint(Default = "0")]
         public bool UseInEditor { get; set; }
 
+        [Column("macroRenderInline")]
+        [Constraint(Default = "0")]
+        public bool RenderInline { get; set; }
+
+
         [Column("macroRefreshRate")]
         [Constraint(Default = "0")]
         public int RefreshRate { get; set; }

--- a/src/Umbraco.Core/Persistence/Factories/MacroFactory.cs
+++ b/src/Umbraco.Core/Persistence/Factories/MacroFactory.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Core.Persistence.Factories
     {
         public static IMacro BuildEntity(MacroDto dto)
         {
-            var model = new Macro(dto.Id, dto.UniqueId, dto.UseInEditor, dto.RefreshRate, dto.Alias, dto.Name, dto.CacheByPage, dto.CachePersonalized, dto.DontRender, dto.MacroSource, (MacroTypes)dto.MacroType);
+            var model = new Macro(dto.Id, dto.UniqueId, dto.UseInEditor, dto.RenderInline, dto.RefreshRate, dto.Alias, dto.Name, dto.CacheByPage, dto.CachePersonalized, dto.DontRender, dto.MacroSource, (MacroTypes)dto.MacroType);
 
             try
             {
@@ -34,18 +34,19 @@ namespace Umbraco.Core.Persistence.Factories
         {
             var dto = new MacroDto
             {
-                    UniqueId = entity.Key,
-                    Alias = entity.Alias,
-                    CacheByPage = entity.CacheByPage,
-                    CachePersonalized = entity.CacheByMember,
-                    DontRender = entity.DontRender,
-                    Name = entity.Name,
-                    MacroSource = entity.MacroSource,
-                    RefreshRate = entity.CacheDuration,
-                    UseInEditor = entity.UseInEditor,
-                    MacroPropertyDtos = BuildPropertyDtos(entity),
-                    MacroType = (int)entity.MacroType
-                };
+                UniqueId = entity.Key,
+                Alias = entity.Alias,
+                CacheByPage = entity.CacheByPage,
+                CachePersonalized = entity.CacheByMember,
+                DontRender = entity.DontRender,
+                Name = entity.Name,
+                MacroSource = entity.MacroSource,
+                RefreshRate = entity.CacheDuration,
+                UseInEditor = entity.UseInEditor,
+                RenderInline = entity.RenderInline,
+                MacroPropertyDtos = BuildPropertyDtos(entity),
+                MacroType = (int)entity.MacroType
+            };
 
             if (entity.HasIdentity)
                 dto.Id = int.Parse(entity.Id.ToString(CultureInfo.InvariantCulture));

--- a/src/Umbraco.Core/Persistence/Mappers/MacroMapper.cs
+++ b/src/Umbraco.Core/Persistence/Mappers/MacroMapper.cs
@@ -25,6 +25,7 @@ namespace Umbraco.Core.Persistence.Mappers
             DefineMap<Macro, MacroDto>(nameof(Macro.CacheDuration), nameof(MacroDto.RefreshRate));
             DefineMap<Macro, MacroDto>(nameof(Macro.MacroSource), nameof(MacroDto.MacroSource));
             DefineMap<Macro, MacroDto>(nameof(Macro.UseInEditor), nameof(MacroDto.UseInEditor));
+            DefineMap<Macro, MacroDto>(nameof(Macro.RenderInline), nameof(MacroDto.RenderInline));
         }
     }
 }

--- a/src/Umbraco.Core/Services/Implement/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/Implement/EntityXmlSerializer.cs
@@ -411,6 +411,7 @@ namespace Umbraco.Core.Services.Implement
             xml.Add(new XElement("macroType", macro.MacroType));
             xml.Add(new XElement("macroSource", macro.MacroSource));
             xml.Add(new XElement("useInEditor", macro.UseInEditor.ToString()));
+            xml.Add(new XElement("renderInline", macro.RenderInline.ToString()));
             xml.Add(new XElement("dontRender", macro.DontRender.ToString()));
             xml.Add(new XElement("refreshRate", macro.CacheDuration.ToString(CultureInfo.InvariantCulture)));
             xml.Add(new XElement("cacheByMember", macro.CacheByMember.ToString()));

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Constants-SqlTemplates.cs" />
     <Compile Include="Exceptions\UnattendedInstallException.cs" />
     <Compile Include="Collections\EventClearingObservableCollection.cs" />
+    <Compile Include="Migrations\Upgrade\V8_11_2\AddPropertyRenderInlineToMacro.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\ContentTypeDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyDataDto80.cs" />
     <Compile Include="Migrations\Upgrade\V_8_0_0\Models\PropertyTypeDto80.cs" />

--- a/src/Umbraco.Tests/Macros/MacroParserTests.cs
+++ b/src/Umbraco.Tests/Macros/MacroParserTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Core.Macros;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
 using Umbraco.Web.Macros;
 
 namespace Umbraco.Tests.Macros
@@ -24,14 +27,14 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""My.Map.isCool eh[boy!]"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
 <div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
@@ -47,14 +50,14 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>(){{"test1", "value1"},{"test2", "value2"}});
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
 
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
@@ -71,14 +74,14 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" ></?UMBRACO_MACRO>
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
 <div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
@@ -94,14 +97,14 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
 <div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
@@ -117,14 +120,14 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
 <div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
@@ -141,7 +144,7 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
             //            Assert.AreEqual(@"<p>asdfasdf</p>
             //<p>asdfsadf</p>
@@ -168,7 +171,7 @@ namespace Umbraco.Tests.Macros
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
             //            Assert.AreEqual(@"<p>asdfasdf</p>
             //<p>asdfsadf</p>
@@ -202,6 +205,124 @@ namespace Umbraco.Tests.Macros
         }
 
         [Test]
+        public void Format_RTE_Data_For_Editor_Inline_Single_Macro_No_Parameters()
+        {
+            var content = @"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<?UMBRACO_MACRO macroAlias=""Map"" ></?UMBRACO_MACRO>
+<p>asdfasdf</p>";
+            var macroMock = new Mock<IMacro>();
+            macroMock.Setup(x => x.RenderInline).Returns(true);
+            var macroServiceMock = new Mock<IMacroService>();
+            macroServiceMock.Setup(x => x.GetByAlias("Map"))
+                .Returns(macroMock.Object);
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>(), macroServiceMock.Object);
+
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"">
+<!-- <?UMBRACO_MACRO macroAlias=""Map"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></span>
+<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [Test]
+        public void Format_RTE_Data_For_Editor_Inline_Single_Macro_With_Parameters()
+        {
+            var content = @"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
+<p>asdfasdf</p>";
+            var macroMock = new Mock<IMacro>();
+            macroMock.Setup(x => x.RenderInline).Returns(true);
+            var macroServiceMock = new Mock<IMacroService>();
+            macroServiceMock.Setup(x => x.GetByAlias("Map"))
+                .Returns(macroMock.Object);
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() {{ "test1", "value1" }, { "test2", "value2" } }, macroServiceMock.Object);
+
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></span>
+<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [Test]
+        public void Format_RTE_Data_For_Editor_Inline_With_Multiple_Macros()
+        {
+
+            var content = @"<p>asdfasdf</p>
+<?UMBRACO_MACRO macroAlias=""Breadcrumb"" />
+<p>asdfsadf</p>
+<p> </p>
+<?UMBRACO_MACRO macroAlias=""login"" />
+<p> </p>";
+
+            var macroBreadcrumbMock = new Mock<IMacro>();
+            macroBreadcrumbMock.Setup(x => x.RenderInline).Returns(true);
+
+            var macroLoginMock = new Mock<IMacro>();
+            macroLoginMock.Setup(x => x.RenderInline).Returns(true);
+
+
+            var macroServiceMock = new Mock<IMacroService>();
+            macroServiceMock.Setup(x => x.GetByAlias("Breadcrumb"))
+                .Returns(macroBreadcrumbMock.Object);
+
+            macroServiceMock.Setup(x => x.GetByAlias("login"))
+                .Returns(macroLoginMock.Object);
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>(), macroServiceMock.Object);
+
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"">
+<!-- <?UMBRACO_MACRO macroAlias=""Breadcrumb"" /> -->
+<ins>Macro alias: <strong>Breadcrumb</strong></ins></span>
+<p>asdfsadf</p>
+<p> </p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"">
+<!-- <?UMBRACO_MACRO macroAlias=""login"" /> -->
+<ins>Macro alias: <strong>login</strong></ins></span>
+<p> </p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [Test]
+        public void Format_RTE_Data_For_Editor_Inline_With_Params_When_Multiple_Macros()
+        {
+            var content = @"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" />
+<p>asdfsadf</p>
+<?UMBRACO_MACRO test1=""value1"" macroAlias=""Map"" test2=""value2"" />
+<p>asdfsadf</p>
+<?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" />
+<p>asdfasdf</p>";
+
+            var macroMock = new Mock<IMacro>();
+            macroMock.Setup(x => x.RenderInline).Returns(true);
+            var macroServiceMock = new Mock<IMacroService>();
+            macroServiceMock.Setup(x => x.GetByAlias("Map"))
+                .Returns(macroMock.Object);
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, macroServiceMock.Object);
+            
+            Assert.AreEqual(@"<p>asdfasdf</p>
+<p>asdfsadf</p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO test1=""value1"" test2=""value2"" macroAlias=""Map"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></span>
+<p>asdfsadf</p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO test1=""value1"" macroAlias=""Map"" test2=""value2"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></span>
+<p>asdfsadf</p>
+<span class=""umb-macro-holder umb-macro-inline mceNonEditable"" test1=""value1"" test2=""value2"">
+<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+<ins>Macro alias: <strong>Map</strong></ins></span>
+<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+        }
+
+
+        [Test]
         public void Format_RTE_Data_For_Editor_With_Multiple_Macros()
         {
             var content = @"<p>asdfasdf</p>
@@ -210,7 +331,7 @@ namespace Umbraco.Tests.Macros
 <p> </p>
 <?UMBRACO_MACRO macroAlias=""login"" />
 <p> </p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>());
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>(), Mock.Of<IMacroService>());
 
             Assert.AreEqual(@"<p>asdfasdf</p>
 <div class=""umb-macro-holder mceNonEditable"">
@@ -266,14 +387,14 @@ asdfsdf
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" ></?UMBRACO_MACRO>
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
 <div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
@@ -289,14 +410,14 @@ asdfsdf
 <p>asdfsadf</p>
 <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" ><img src='blah.jpg'/></?UMBRACO_MACRO>
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2" } }, Mock.Of<IMacroService>());
 
-//            Assert.AreEqual(@"<p>asdfasdf</p>
-//<p>asdfsadf</p>
-//<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
-//<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
-//<ins>Macro alias: <strong>Map</strong></ins></div>
-//<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
+            //            Assert.AreEqual(@"<p>asdfasdf</p>
+            //<p>asdfsadf</p>
+            //<div class=""umb-macro-holder Map mceNonEditable"" test1=""value1"" test2=""value2"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2"" /> -->
+            //<ins>Macro alias: <strong>Map</strong></ins></div>
+            //<p>asdfasdf</p>".Replace(Environment.NewLine, string.Empty), result.Replace(Environment.NewLine, string.Empty));
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
 <div class=""umb-macro-holder mceNonEditable"" test1=""value1"" test2=""value2"">
@@ -315,7 +436,7 @@ asdfsdf
 <?UMBRACO_MACRO macroAlias=""Map"" test1=""value1"" test2=""value2
 test"" />
 <p>asdfasdf</p>";
-            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2\r\ntest" } });
+            var result = MacroTagParser.FormatRichTextPersistedDataForEditor(content, new Dictionary<string, string>() { { "test1", "value1" }, { "test2", "value2\r\ntest" } }, Mock.Of<IMacroService>());
 
             Assert.AreEqual(@"<p>asdfasdf</p>
 <p>asdfsadf</p>
@@ -330,22 +451,22 @@ test"" /> -->
         [Test]
         public void Format_RTE_Data_For_Persistence()
         {
-//            var content = @"<html>
-//<body>
-//<h1>asdfasdf</h1>
-//<div class='umb-macro-holder Map mceNonEditable' att1='asdf' att2='asdfasdfasdf' att3=""sdfsdfd"">
-//<!-- <?UMBRACO_MACRO macroAlias=""myMacro"" param1=""test1"" param2=""test2"" /> -->
-//asdfasdf
-//asdfas
-//<span>asdfasdfasdf</span>
-//<p>asdfasdf</p>
-//</div>
-//<span>asdfdasf</span>
-//<div>
-//asdfsdf
-//</div>
-//</body>
-//</html>";
+            //            var content = @"<html>
+            //<body>
+            //<h1>asdfasdf</h1>
+            //<div class='umb-macro-holder Map mceNonEditable' att1='asdf' att2='asdfasdfasdf' att3=""sdfsdfd"">
+            //<!-- <?UMBRACO_MACRO macroAlias=""myMacro"" param1=""test1"" param2=""test2"" /> -->
+            //asdfasdf
+            //asdfas
+            //<span>asdfasdfasdf</span>
+            //<p>asdfasdf</p>
+            //</div>
+            //<span>asdfdasf</span>
+            //<div>
+            //asdfsdf
+            //</div>
+            //</body>
+            //</html>";
             var content = @"<html>
 <body>
 <h1>asdfasdf</h1>
@@ -412,14 +533,14 @@ asdfsdf
         [Test]
         public void Format_RTE_Data_For_Persistence_Custom_Single_Entry()
         {
-//            var content = @"<div class=""umb-macro-holder Test mceNonEditable umb-macro-mce_1""><!-- <?UMBRACO_MACRO macroAlias=""Test"" content=""1089"" textArea=""asdfasdf"" title="""" bool=""0"" number="""" contentType="""" multiContentType="""" multiProperties="""" properties="""" tabs="""" multiTabs="""" /> --><ins>
-//<div class=""facts-box"">
-//<div class=""fatcs-box-header"">
-//<h3>null</h3>
-//</div>
-//<div class=""fatcs-box-body"">1089</div>
-//</div>
-//</ins></div>";
+            //            var content = @"<div class=""umb-macro-holder Test mceNonEditable umb-macro-mce_1""><!-- <?UMBRACO_MACRO macroAlias=""Test"" content=""1089"" textArea=""asdfasdf"" title="""" bool=""0"" number="""" contentType="""" multiContentType="""" multiProperties="""" properties="""" tabs="""" multiTabs="""" /> --><ins>
+            //<div class=""facts-box"">
+            //<div class=""fatcs-box-header"">
+            //<h3>null</h3>
+            //</div>
+            //<div class=""fatcs-box-body"">1089</div>
+            //</div>
+            //</ins></div>";
             var content = @"<div class=""umb-macro-holder mceNonEditable umb-macro-mce_1""><!-- <?UMBRACO_MACRO macroAlias=""Test"" content=""1089"" textArea=""asdfasdf"" title="""" bool=""0"" number="""" contentType="""" multiContentType="""" multiProperties="""" properties="""" tabs="""" multiTabs="""" /> --><ins>
 <div class=""facts-box"">
 <div class=""fatcs-box-header"">
@@ -432,6 +553,9 @@ asdfsdf
 
             Assert.AreEqual(@"<?UMBRACO_MACRO macroAlias=""Test"" content=""1089"" textArea=""asdfasdf"" title="""" bool=""0"" number="""" contentType="""" multiContentType="""" multiProperties="""" properties="""" tabs="""" multiTabs="""" />", result);
         }
+
+
+
 
     }
 }

--- a/src/Umbraco.Tests/Models/MacroTests.cs
+++ b/src/Umbraco.Tests/Models/MacroTests.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Tests.Models
         [Test]
         public void Can_Deep_Clone()
         {
-            var macro = new Macro(1, Guid.NewGuid(), true, 3, "test", "Test", false, true, true, "~/script.cshtml", MacroTypes.PartialView);
+            var macro = new Macro(1, Guid.NewGuid(), true, true, 3, "test", "Test", false, true, true, "~/script.cshtml", MacroTypes.PartialView);
             macro.Properties.Add(new MacroProperty(6, Guid.NewGuid(), "rewq", "REWQ", 1, "asdfasdf"));
 
             var clone = (Macro)macro.DeepClone();

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTestBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTestBase.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Tests.PublishedContent
             var pastedImages = new RichTextEditorPastedImages(umbracoContextAccessor, logger, Mock.Of<IMediaService>(), Mock.Of<IContentTypeBaseServiceProvider>());
             var localLinkParser = new HtmlLocalLinkParser(umbracoContextAccessor);
             var dataTypeService = new TestObjects.TestDataTypeService(
-                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, Mock.Of<IImageUrlGenerator>())) { Id = 1 });
+                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, Mock.Of<IImageUrlGenerator>(), Mock.Of<IMacroService>())) { Id = 1 });
 
             var publishedContentTypeFactory = new PublishedContentTypeFactory(Mock.Of<IPublishedModelFactory>(), converters, dataTypeService);
 

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Tests.PublishedContent
             var dataTypeService = new TestObjects.TestDataTypeService(
                 new DataType(new VoidEditor(logger)) { Id = 1 },
                 new DataType(new TrueFalsePropertyEditor(logger)) { Id = 1001 },
-                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, linkParser, pastedImages, Mock.Of<IImageUrlGenerator>())) { Id = 1002 },
+                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, linkParser, pastedImages, Mock.Of<IImageUrlGenerator>(), Mock.Of<IMacroService>())) { Id = 1002 },
                 new DataType(new IntegerPropertyEditor(logger)) { Id = 1003 },
                 new DataType(new TextboxPropertyEditor(logger)) { Id = 1004 },
                 new DataType(new MediaPickerPropertyEditor(logger)) { Id = 1005 });

--- a/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/macro.service.js
@@ -9,10 +9,10 @@
 function macroService() {
 
     return {
-       
+
         /** parses the special macro syntax like <?UMBRACO_MACRO macroAlias="Map" /> and returns an object with the macro alias and it's parameters */
         parseMacroSyntax: function (syntax) {
-            
+
             //This regex will match an alias of anything except characters that are quotes or new lines (for legacy reasons, when new macros are created
             // their aliases are cleaned an invalid chars are stripped)
             var expression = /(<\?UMBRACO_MACRO (?:.+?)?macroAlias=["']([^\"\'\n\r]+?)["'][\s\S]+?)(\/>|>.*?<\/\?UMBRACO_MACRO>)/i;
@@ -24,9 +24,9 @@ function macroService() {
 
             //this will leave us with just the parameters
             var paramsChunk = match[1].trim().replace(new RegExp("UMBRACO_MACRO macroAlias=[\"']" + alias + "[\"']"), "").trim();
-            
+
             var paramExpression = /(\w+?)=['\"]([\s\S]*?)['\"]/g;
-            
+
             var paramMatch;
             var returnVal = {
                 macroAlias: alias,
@@ -72,7 +72,7 @@ function macroService() {
                         var encoded = encodeURIComponent(json);
                         keyVal = key + "=\"" + encoded + "\" ";
                     }
-                    
+
                     macroString += keyVal;
                 });
 
@@ -82,7 +82,7 @@ function macroService() {
 
             return macroString;
         },
-        
+
         /**
          * @ngdoc function
          * @name umbraco.services.macroService#generateMvcSyntax
@@ -101,18 +101,18 @@ function macroService() {
             var hasParams = false;
             var paramString;
             if (args.macroParamsDictionary) {
-                
+
                 paramString = ", new {";
 
-                _.each(args.macroParamsDictionary, function(val, key) {
+                _.each(args.macroParamsDictionary, function (val, key) {
 
                     hasParams = true;
-                    
+
                     var keyVal = key + "=\"" + (val ? val : "") + "\", ";
 
                     paramString += keyVal;
                 });
-                
+
                 //remove the last , 
                 paramString = paramString.trimEnd(", ");
 
@@ -126,7 +126,7 @@ function macroService() {
             return macroString;
         },
 
-        collectValueData: function(macro, macroParams, renderingEngine) {
+        collectValueData: function (macro, macroParams, renderingEngine) {
 
             var paramDictionary = {};
             var macroAlias = macro.alias;
@@ -165,7 +165,8 @@ function macroService() {
             var macroObject = {
                 "macroParamsDictionary": paramDictionary,
                 "macroAlias": macroAlias,
-                "syntax": syntax
+                "syntax": syntax,
+                "renderInline": macro.metaData["renderInline"]
             };
 
             return macroObject;

--- a/src/Umbraco.Web.UI.Client/src/less/rte-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte-content.less
@@ -8,15 +8,21 @@
     margin: 3px;
 }
 
+.umb-macro-inline {
+    display: inline-block !important
+}
+
 
 .umb-rte .mce-content-body .umb-macro-holder.loading {
     background: url(assets/img/loader.gif) right no-repeat;
-    background-size: 18px; background-position-x: 99%;
+    background-size: 18px;
+    background-position-x: 99%;
 }
 
 
 .umb-rte .embeditem {
-    position:relative;
+    position: relative;
+
     > * {
         user-select: none;
         pointer-events: none;
@@ -28,18 +34,18 @@
 }
 
 .umb-rte .embeditem::before {
-    z-index:1000;
-    width:100%;
-    height:100%;
-    position:absolute;
-    content:' ';
+    z-index: 1000;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    content: ' ';
 }
 
 .umb-rte .embeditem[data-mce-selected]::before {
-    background:rgba(0,0,0,0.025);
+    background: rgba(0,0,0,0.025);
 }
 
 .umb-rte *[data-mce-selected="inline-boundary"] {
-    background:rgba(0,0,0,0.025);
+    background: rgba(0,0,0,0.025);
     outline: 2px solid @pinkLight;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
@@ -43,6 +43,9 @@
             <umb-control-group label="Render in rich text editor and the grid" ng-if="model.macro.useInEditor">
                 <umb-toggle checked="model.macro.renderInEditor && model.macro.useInEditor" on-click="model.toggle('renderInEditor')"></umb-toggle>
             </umb-control-group>
+            <umb-control-group label="Render as inline element in rich text editor preview" ng-if="model.macro.useInEditor">
+                <umb-toggle checked="model.macro.renderInline" on-click="model.toggle('renderInline')"></umb-toggle>
+            </umb-control-group>
         </umb-box-content>
     </umb-box>
     <umb-box>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -82,6 +82,7 @@
   <ItemGroup>
     <Folder Include="App_Data\" />
     <Folder Include="App_Plugins\" />
+    <Folder Include="Views\MacroPartials\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CSharpTest.Net.Collections" Version="14.906.1403.1082" />
@@ -295,7 +296,6 @@
     <Content Include="Umbraco\Views\Preview\Index.cshtml" />
     <Content Include="Umbraco\Views\web.config" />
     <Content Include="Views\Partials\BlockList\Default.cshtml" />
-    <Content Include="Views\MacroPartials\Test.cshtml" />
     <None Include="Web.Debug.config.transformed" />
     <None Include="web.Template.Debug.config">
       <DependentUpon>Web.Template.config</DependentUpon>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -82,7 +82,6 @@
   <ItemGroup>
     <Folder Include="App_Data\" />
     <Folder Include="App_Plugins\" />
-    <Folder Include="Views\MacroPartials\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CSharpTest.Net.Collections" Version="14.906.1403.1082" />
@@ -93,7 +92,13 @@
     <PackageReference Include="ImageProcessor.Web.Config" Version="2.5.0.100" />
     <PackageReference Include="Microsoft.AspNet.Identity.Owin" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.Razor">
+      <Version>3.2.7</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebPages">
+      <Version>3.2.7</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.0.1" />
@@ -103,6 +108,9 @@
       <Version>1.0.0-beta2-19324-01</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Web.Infrastructure">
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="MiniProfiler" Version="4.0.138" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
@@ -287,6 +295,7 @@
     <Content Include="Umbraco\Views\Preview\Index.cshtml" />
     <Content Include="Umbraco\Views\web.config" />
     <Content Include="Views\Partials\BlockList\Default.cshtml" />
+    <Content Include="Views\MacroPartials\Test.cshtml" />
     <None Include="Web.Debug.config.transformed" />
     <None Include="web.Template.Debug.config">
       <DependentUpon>Web.Template.config</DependentUpon>

--- a/src/Umbraco.Web/Editors/MacrosController.cs
+++ b/src/Umbraco.Web/Editors/MacrosController.cs
@@ -202,6 +202,7 @@ namespace Umbraco.Web.Editors
             macro.CacheDuration = macroDisplay.CachePeriod;
             macro.DontRender = !macroDisplay.RenderInEditor;
             macro.UseInEditor = macroDisplay.UseInEditor;
+            macro.RenderInline = macroDisplay.RenderInline;
             macro.MacroSource = macroDisplay.View;
             macro.MacroType = MacroTypes.PartialView;
             macro.Properties.ReplaceAll(macroDisplay.Parameters.Select((x,i) => new MacroProperty(x.Key, x.Label, i, x.Editor)));

--- a/src/Umbraco.Web/Macros/MacroModel.cs
+++ b/src/Umbraco.Web/Macros/MacroModel.cs
@@ -32,6 +32,8 @@ namespace Umbraco.Web.Macros
 
         public bool RenderInEditor { get; set; }
 
+        public bool RenderInline { get; set; }
+
         public string CacheIdentifier { get; set; }
 
         public List<MacroPropertyModel> Properties { get; } = new List<MacroPropertyModel>();
@@ -52,7 +54,7 @@ namespace Umbraco.Web.Macros
             CacheByPage = macro.CacheByPage;
             CacheByMember = macro.CacheByMember;
             RenderInEditor = macro.UseInEditor;
-
+            RenderInline = macro.RenderInline;
             foreach (var prop in macro.Properties)
                 Properties.Add(new MacroPropertyModel(prop.Alias, string.Empty, prop.EditorAlias));
 

--- a/src/Umbraco.Web/Macros/MacroTagParser.cs
+++ b/src/Umbraco.Web/Macros/MacroTagParser.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using Umbraco.Core.Models;
+using Umbraco.Core.Services;
 using Umbraco.Core.Xml;
 using Umbraco.Web.Composing;
 
@@ -27,17 +28,18 @@ namespace Umbraco.Web.Macros
         /// </summary>
         /// <param name="persistedContent"></param>
         /// <param name="htmlAttributes">The HTML attributes to be added to the div</param>
+        /// <param name="macroService"></param>
         /// <returns></returns>
         /// <remarks>
         /// This converts the persisted macro format to this:
-        ///
+        /// 
         ///     {div class='umb-macro-holder'}
         ///         <!-- <?UMBRACO_MACRO macroAlias=\"myMacro\" /> -->
         ///         {ins}Macro alias: {strong}My Macro{/strong}{/ins}
         ///     {/div}
-        ///
+        /// 
         /// </remarks>
-        internal static string FormatRichTextPersistedDataForEditor(string persistedContent, IDictionary<string, string> htmlAttributes)
+        internal static string FormatRichTextPersistedDataForEditor(string persistedContent, IDictionary<string, string> htmlAttributes, IMacroService macroService)
         {
             return MacroPersistedFormat.Replace(persistedContent, match =>
             {
@@ -46,8 +48,8 @@ namespace Umbraco.Web.Macros
                     string wrapperElement = "div";
                     //<div || span class="umb-macro-holder (umb-macro-inline) myMacro mceNonEditable">
                     var alias = match.Groups[2].Value;
-
-                    IMacro macro = Current.Services.MacroService.GetByAlias(alias);
+                    
+                    IMacro macro = macroService.GetByAlias(alias);
                     bool renderInline = false;
                     if (macro != null && macro.RenderInline)
                     {

--- a/src/Umbraco.Web/Models/ContentEditing/MacroDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MacroDisplay.cs
@@ -35,6 +35,12 @@ namespace Umbraco.Web.Models.ContentEditing
         public bool RenderInEditor { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the macro should be rendered inline with a span in the rich text editor.
+        /// </summary>
+        [DataMember(Name = "renderInline")]
+        public bool RenderInline { get; set; }
+
+        /// <summary>
         /// Gets or sets the cache period.
         /// </summary>
         [DataMember(Name = "cachePeriod")]

--- a/src/Umbraco.Web/Models/Mapping/MacroMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MacroMapDefinition.cs
@@ -40,6 +40,7 @@ namespace Umbraco.Web.Models.Mapping
             target.ParentId = -1;
             target.Path = "-1," + source.Id;
             target.Udi = Udi.Create(Constants.UdiEntityType.Macro, source.Key);
+            target.AdditionalData.Add("renderInline", source.RenderInline);
         }
 
         private void Map(IMacro source, MacroDisplay target, MapperContext context)
@@ -57,6 +58,7 @@ namespace Umbraco.Web.Models.Mapping
             target.CachePeriod = source.CacheDuration;
             target.UseInEditor = source.UseInEditor;
             target.RenderInEditor = !source.DontRender;
+            target.RenderInline = source.RenderInline;
             target.View = source.MacroSource;
         }
         // Umbraco.Code.MapAll -Value

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -32,6 +32,7 @@ namespace Umbraco.Web.PropertyEditors
         private readonly RichTextEditorPastedImages _pastedImages;
         private readonly HtmlLocalLinkParser _localLinkParser;
         private readonly IImageUrlGenerator _imageUrlGenerator;
+        private readonly IMacroService _macroService;
 
         [Obsolete("Use the constructor which takes an IImageUrlGenerator")]
         public GridPropertyEditor(ILogger logger,
@@ -39,7 +40,7 @@ namespace Umbraco.Web.PropertyEditors
             HtmlImageSourceParser imageSourceParser,
             RichTextEditorPastedImages pastedImages,
             HtmlLocalLinkParser localLinkParser)
-            : this(logger, umbracoContextAccessor, imageSourceParser, pastedImages, localLinkParser, Current.ImageUrlGenerator)
+            : this(logger, umbracoContextAccessor, imageSourceParser, pastedImages, localLinkParser, Current.ImageUrlGenerator, Current.Services.MacroService)
         {
         }
 
@@ -48,7 +49,8 @@ namespace Umbraco.Web.PropertyEditors
             HtmlImageSourceParser imageSourceParser,
             RichTextEditorPastedImages pastedImages,
             HtmlLocalLinkParser localLinkParser,
-            IImageUrlGenerator imageUrlGenerator)
+            IImageUrlGenerator imageUrlGenerator,
+            IMacroService macroService)
             : base(logger)
         {
             _umbracoContextAccessor = umbracoContextAccessor;
@@ -56,6 +58,7 @@ namespace Umbraco.Web.PropertyEditors
             _pastedImages = pastedImages;
             _localLinkParser = localLinkParser;
             _imageUrlGenerator = imageUrlGenerator;
+            _macroService = macroService;
         }
 
         public override IPropertyIndexValueFactory PropertyIndexValueFactory => new GridPropertyIndexValueFactory();
@@ -64,7 +67,7 @@ namespace Umbraco.Web.PropertyEditors
         /// Overridden to ensure that the value is validated
         /// </summary>
         /// <returns></returns>
-        protected override IDataValueEditor CreateValueEditor() => new GridPropertyValueEditor(Attribute, _umbracoContextAccessor, _imageSourceParser, _pastedImages, _localLinkParser, _imageUrlGenerator);
+        protected override IDataValueEditor CreateValueEditor() => new GridPropertyValueEditor(Attribute, _umbracoContextAccessor, _imageSourceParser, _pastedImages, _localLinkParser, _imageUrlGenerator, _macroService);
 
         protected override IConfigurationEditor CreateConfigurationEditor() => new GridConfigurationEditor();
 
@@ -76,6 +79,7 @@ namespace Umbraco.Web.PropertyEditors
             private readonly RichTextPropertyEditor.RichTextPropertyValueEditor _richTextPropertyValueEditor;
             private readonly MediaPickerPropertyEditor.MediaPickerPropertyValueEditor _mediaPickerPropertyValueEditor;
             private readonly IImageUrlGenerator _imageUrlGenerator;
+            private readonly IMacroService _macroService;
 
             [Obsolete("Use the constructor which takes an IImageUrlGenerator")]
             public GridPropertyValueEditor(DataEditorAttribute attribute,
@@ -83,7 +87,7 @@ namespace Umbraco.Web.PropertyEditors
                 HtmlImageSourceParser imageSourceParser,
                 RichTextEditorPastedImages pastedImages,
                 HtmlLocalLinkParser localLinkParser)
-                : this(attribute, umbracoContextAccessor, imageSourceParser, pastedImages, localLinkParser, Current.ImageUrlGenerator)
+                : this(attribute, umbracoContextAccessor, imageSourceParser, pastedImages, localLinkParser, Current.ImageUrlGenerator, Current.Services.MacroService)
             {
             }
 
@@ -92,15 +96,17 @@ namespace Umbraco.Web.PropertyEditors
                 HtmlImageSourceParser imageSourceParser,
                 RichTextEditorPastedImages pastedImages,
                 HtmlLocalLinkParser localLinkParser,
-                IImageUrlGenerator imageUrlGenerator)
+                IImageUrlGenerator imageUrlGenerator,
+                IMacroService macroService)
                 : base(attribute)
             {
                 _umbracoContextAccessor = umbracoContextAccessor;
                 _imageSourceParser = imageSourceParser;
                 _pastedImages = pastedImages;
-                _richTextPropertyValueEditor = new RichTextPropertyEditor.RichTextPropertyValueEditor(attribute, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, _imageUrlGenerator);
+                _richTextPropertyValueEditor = new RichTextPropertyEditor.RichTextPropertyValueEditor(attribute, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, _imageUrlGenerator, macroService);
                 _mediaPickerPropertyValueEditor = new MediaPickerPropertyEditor.MediaPickerPropertyValueEditor(attribute);
                 _imageUrlGenerator = imageUrlGenerator;
+                _macroService = macroService;
             }
 
             /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -32,21 +32,21 @@ namespace Umbraco.Web.PropertyEditors
         private readonly HtmlLocalLinkParser _localLinkParser;
         private readonly RichTextEditorPastedImages _pastedImages;
         private readonly IImageUrlGenerator _imageUrlGenerator;
-
+        private readonly IMacroService _macroService;
 
         /// <summary>
         /// The constructor will setup the property editor based on the attribute if one is found
         /// </summary>
         [Obsolete("Use the constructor which takes an IImageUrlGenerator")]
         public RichTextPropertyEditor(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, HtmlImageSourceParser imageSourceParser, HtmlLocalLinkParser localLinkParser, RichTextEditorPastedImages pastedImages)
-            : this(logger, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, Current.ImageUrlGenerator)
+            : this(logger, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, Current.ImageUrlGenerator, Current.Services.MacroService)
         {
         }
 
         /// <summary>
         /// The constructor will setup the property editor based on the attribute if one is found
         /// </summary>
-        public RichTextPropertyEditor(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, HtmlImageSourceParser imageSourceParser, HtmlLocalLinkParser localLinkParser, RichTextEditorPastedImages pastedImages, IImageUrlGenerator imageUrlGenerator)
+        public RichTextPropertyEditor(ILogger logger, IUmbracoContextAccessor umbracoContextAccessor, HtmlImageSourceParser imageSourceParser, HtmlLocalLinkParser localLinkParser, RichTextEditorPastedImages pastedImages, IImageUrlGenerator imageUrlGenerator, IMacroService macroService)
             : base(logger)
         {
             _umbracoContextAccessor = umbracoContextAccessor;
@@ -54,13 +54,14 @@ namespace Umbraco.Web.PropertyEditors
             _localLinkParser = localLinkParser;
             _pastedImages = pastedImages;
             _imageUrlGenerator = imageUrlGenerator;
+            _macroService = macroService;
         }
 
         /// <summary>
         /// Create a custom value editor
         /// </summary>
         /// <returns></returns>
-        protected override IDataValueEditor CreateValueEditor() => new RichTextPropertyValueEditor(Attribute, _umbracoContextAccessor, _imageSourceParser, _localLinkParser, _pastedImages, _imageUrlGenerator);
+        protected override IDataValueEditor CreateValueEditor() => new RichTextPropertyValueEditor(Attribute, _umbracoContextAccessor, _imageSourceParser, _localLinkParser, _pastedImages, _imageUrlGenerator, _macroService);
 
         protected override IConfigurationEditor CreateConfigurationEditor() => new RichTextConfigurationEditor();
 
@@ -76,8 +77,9 @@ namespace Umbraco.Web.PropertyEditors
             private readonly HtmlLocalLinkParser _localLinkParser;
             private readonly RichTextEditorPastedImages _pastedImages;
             private readonly IImageUrlGenerator _imageUrlGenerator;
+            private readonly IMacroService _macroService;
 
-            public RichTextPropertyValueEditor(DataEditorAttribute attribute, IUmbracoContextAccessor umbracoContextAccessor, HtmlImageSourceParser imageSourceParser, HtmlLocalLinkParser localLinkParser, RichTextEditorPastedImages pastedImages, IImageUrlGenerator imageUrlGenerator)
+            public RichTextPropertyValueEditor(DataEditorAttribute attribute, IUmbracoContextAccessor umbracoContextAccessor, HtmlImageSourceParser imageSourceParser, HtmlLocalLinkParser localLinkParser, RichTextEditorPastedImages pastedImages, IImageUrlGenerator imageUrlGenerator, IMacroService macroService)
                 : base(attribute)
             {
                 _umbracoContextAccessor = umbracoContextAccessor;
@@ -85,6 +87,7 @@ namespace Umbraco.Web.PropertyEditors
                 _localLinkParser = localLinkParser;
                 _pastedImages = pastedImages;
                 _imageUrlGenerator = imageUrlGenerator;
+                _macroService = macroService;
             }
 
             /// <inheritdoc />
@@ -117,7 +120,7 @@ namespace Umbraco.Web.PropertyEditors
                     return null;
 
                 var propertyValueWithMediaResolved = _imageSourceParser.EnsureImageSources(val.ToString());
-                var parsed = MacroTagParser.FormatRichTextPersistedDataForEditor(propertyValueWithMediaResolved, new Dictionary<string, string>());
+                var parsed = MacroTagParser.FormatRichTextPersistedDataForEditor(propertyValueWithMediaResolved, new Dictionary<string, string>(), _macroService);
                 return parsed;
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
I have noticed that a macro is "rendered" in a wrapper div when used in RTE, regardless of whether the actual macro outputs inline elements only. This means that if an editor would like to use an macro in the RTE as an inline macro, a div is always added to the RTE (even though this is temporary) but the RTE fixes the invalid markup by splitting the paragraph into three. The start P, the macro div, and the remaining P.

My PR gives the editor / developer the option of specifying per macro basis, if it should be rendered in RTE as an inline element, using a SPAN instead of a DIV

Test steps:
- on the Macro in the backoffice set "Render as inline element in rich text editor preview"
- Go to an RTE and add the macro
- Verify that it renders as span instead of DIV

unit tests has been added to MacroParserTests.cs

![image](https://user-images.githubusercontent.com/58024838/107225806-91562280-6a19-11eb-8df8-2402dc2b0b69.png)

![image](https://user-images.githubusercontent.com/58024838/107226160-0f1a2e00-6a1a-11eb-8501-5fa70a2a9fbe.png)

![image](https://user-images.githubusercontent.com/58024838/107226199-1a6d5980-6a1a-11eb-9e28-e9cc697ae59d.png)
