### PR TITLE
Netcore: Fix block list bugs

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("validationLimit", "Amount", "numberrange", Description = "Set a required range of blocks")]
         public NumberRange ValidationLimit { get; set; } = new NumberRange();
 
+        [DataContract]
         public class NumberRange
         {
             [DataMember(Name ="min")]

--- a/src/Umbraco.Web.Common/Extensions/BlockListTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/BlockListTemplateExtensions.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Extensions
         public const string DefaultFolder = "blocklist/";
         public const string DefaultTemplate = "default";
 
-        public static IHtmlContent GetBlockListHtml(this HtmlHelper html, BlockListModel model, string template = DefaultTemplate)
+        public static IHtmlContent GetBlockListHtml(this IHtmlHelper html, BlockListModel model, string template = DefaultTemplate)
         {
             if (model?.Count == 0) return new HtmlString(string.Empty);
 
@@ -20,11 +20,11 @@ namespace Umbraco.Extensions
             return html.Partial(view, model);
         }
 
-        public static IHtmlContent GetBlockListHtml(this HtmlHelper html, IPublishedProperty property, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
+        public static IHtmlContent GetBlockListHtml(this IHtmlHelper html, IPublishedProperty property, string template = DefaultTemplate) => GetBlockListHtml(html, property?.GetValue() as BlockListModel, template);
 
-        public static IHtmlContent GetBlockListHtml(this HtmlHelper html, IPublishedContent contentItem, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
+        public static IHtmlContent GetBlockListHtml(this IHtmlHelper html, IPublishedContent contentItem, string propertyAlias) => GetBlockListHtml(html, contentItem, propertyAlias, DefaultTemplate);
 
-        public static IHtmlContent GetBlockListHtml(this HtmlHelper html, IPublishedContent contentItem, string propertyAlias, string template)
+        public static IHtmlContent GetBlockListHtml(this IHtmlHelper html, IPublishedContent contentItem, string propertyAlias, string template)
         {
             if (propertyAlias == null) throw new ArgumentNullException(nameof(propertyAlias));
             if (string.IsNullOrWhiteSpace(propertyAlias)) throw new ArgumentException("Value can't be empty or consist only of white-space characters.", nameof(propertyAlias));


### PR DESCRIPTION
Validation didn't work for the Block List Editor, because the NumberRange missed a DataContract attribute, so I've added that.


Blick List Editor couldn't render either because the GetBlockListHtml extensions were made on HtmlHelper instead of IHtmlHelper, so I added that as well.