### PR TITLE
Fix: Verify that grid model is JSON object and not IPublishedContent

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3-Fluid.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3-Fluid.cshtml
@@ -6,7 +6,7 @@
     Razor helpers located at the bottom of this file
 *@
 
-@if (Model != null && Model.sections != null)
+@if (Model != null && Model.GetType() == typeof(JObject) && Model.sections != null)
 {
     var oneColumn = ((System.Collections.ICollection)Model.sections).Count == 1;
 

--- a/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/Grid/Bootstrap3.cshtml
@@ -2,7 +2,7 @@
 @using Umbraco.Web.Templates
 @using Newtonsoft.Json.Linq
 
-@if (Model != null && Model.sections != null)
+@if (Model != null && Model.GetType() == typeof(JObject) && Model.sections != null)
 {
     var oneColumn = ((System.Collections.ICollection)Model.sections).Count == 1;
 


### PR DESCRIPTION
The null check for Model.section fails in the event that:

* the grid editor has been added as composition to a page
* the partial `@Html.GetGridHtml(Model, "pageContentGrid")` has been added to the page template
* and the page hasn't been published with the new grid content yet

In this case the `Model` passed into `Html.GetGridHtml` will be `IPublishedContent` and not a `JObject`, and this will cause the grid render to fail.

![Screenshot 2021-02-08 160455](https://user-images.githubusercontent.com/25110864/107238712-72ab5800-6a28-11eb-94c8-de8ddfa60626.png)

### Prerequisites

- [x] I have added steps to test this contribution in the description below