### PR TITLE
Fix mini profiler so that it actually profiles the Content APIs in the back office

### DIFF
--- a/src/Umbraco.Web/Logging/WebProfiler.cs
+++ b/src/Umbraco.Web/Logging/WebProfiler.cs
@@ -26,12 +26,16 @@ namespace Umbraco.Web.Logging
             _provider = new WebProfilerProvider();
 
             //see https://miniprofiler.com/dotnet/AspDotNet
-            MiniProfiler.Configure(new MiniProfilerOptions
+            var options = new MiniProfilerOptions
             {
                 SqlFormatter = new SqlServerFormatter(),
-                StackMaxLength = 5000, 
+                StackMaxLength = 5000,
                 ProfilerProvider = _provider
-            });
+            };
+            // this is a default path and by default it performs a 'contains' check which will match our content controller
+            // (and probably other requests) and ignore them.
+            options.IgnoredPaths.Remove("/content/"); 
+            MiniProfiler.Configure(options);
         }
 
         public void UmbracoApplicationBeginRequest(object sender, EventArgs e)

--- a/src/Umbraco.Web/Logging/WebProfilerProvider.cs
+++ b/src/Umbraco.Web/Logging/WebProfilerProvider.cs
@@ -85,7 +85,11 @@ namespace Umbraco.Web.Logging
         public override MiniProfiler Start(string profilerName, MiniProfilerBaseOptions options)
         {
             var first = Interlocked.Exchange(ref _first, 1) == 0;
-            if (first == false) return base.Start(profilerName, options);
+            if (first == false)
+            {
+                var profiler = base.Start(profilerName, options);
+                return profiler;
+            }
 
             _startupProfiler = new MiniProfiler("StartupProfiler", options);
             CurrentProfiler = _startupProfiler;


### PR DESCRIPTION
Mini profiler was not profiling Umbraco Content API endpoints in the back office because mini profiler has a default ignore path of `/content/` and this path is applied with a 'Contains' check. This means that all requests to get/post content in the back office was not profiled.

This fixes it and you can test by using mini profiler with `/umbraco?umbdebug=true` and seeing that things like /umbraco/backoffice/UmbracoApi/Content/PostSave are profiled. You can also see all latest sessions profiled by going to `/mini-profiler-resources/results-index`