### PR TITLE
Fixes #9793 - URL Tracking does not work for descendants that are unpublished in the default culture

### DIFF
--- a/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
@@ -5,6 +5,7 @@ using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
 using Umbraco.Web.PublishedCache;

--- a/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs
@@ -96,7 +96,7 @@ namespace Umbraco.Web.Routing
 
         private OldRoutesDictionary GetOldRoutes(IDictionary<string, object> eventState)
         {
-            if (! eventState.ContainsKey(_eventStateKey))
+            if (!eventState.ContainsKey(_eventStateKey))
             {
                 eventState[_eventStateKey] = new OldRoutesDictionary();
             }
@@ -108,7 +108,7 @@ namespace Umbraco.Web.Routing
         {
             var contentCache = _publishedSnapshotAccessor.PublishedSnapshot.Content;
             var entityContent = contentCache.GetById(entity.Id);
-            if (entityContent == null) return;            
+            if (entityContent == null) return;
 
             var defaultCulture = _variationContextAccessor.VariationContext.Culture;
 
@@ -173,6 +173,7 @@ namespace Umbraco.Web.Routing
         }
 
         private class OldRoutesDictionary : Dictionary<ContentIdAndCulture, ContentKeyAndOldRoute>
-        { }
+        {
+        }
     }
 }


### PR DESCRIPTION
Fixes #9793 

I noticed that `entityContent.DescendantsOrSelf()` is being run in [RedirectTrackingComponent.cs line 111](https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Routing/RedirectTrackingComponent.cs#L111). Since Umbraco introduced variations and VariationContext, this only fetches descendants in the default variation.

The changes proposed makes sure the proper VariationContext is set before the rest of the code exectues - so that all descendants are targeted and not just the ones that are published in the default variation. And in the end make sure the VariationContext is reset to the default variation again. 
