### PR TITLE
9769 - shift index increment before tryget to allow loop to continue if current iteration exits early

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -171,9 +171,11 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 while (compositionIx < compositionDtos.Count && compositionDtos[compositionIx].ChildId == contentType.Id)
                 {
                     var parentDto = compositionDtos[compositionIx];
-                    if (!contentTypes.TryGetValue(parentDto.ParentId, out var parentContentType)) continue;
-                    contentType.AddContentType(parentContentType);
                     compositionIx++;
+
+                    if (!contentTypes.TryGetValue(parentDto.ParentId, out var parentContentType))
+                        continue;
+                    contentType.AddContentType(parentContentType);
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9769 

### Description
I ran into this issue in a v8 migration, where the migration completes but the site failed to boot - code was falling into an infinite loop where it kept checking the same composition parentId, and would continue to do so until the inevitable heat-death of the universe. I didn't have that long to wait, hence the PR.

I'm not sure though how to test this - if it was an issue affecting all installs, it would have been noticed before, so I'm thinking it was likely due to something special in my database (db was updated from inheritance to composition a while back, so may have some stale data from that change). Can confirm though with the change my site starts and everything in the backoffice appears correct...

