### PR TITLE
Changed grid view labels and values to display: inline

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-content-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-content-grid.less
@@ -102,11 +102,11 @@
 
 .umb-content-grid__details-label {
    font-weight: bold;
-   display: inline-block;
+   display: inline;
 }
 
 .umb-content-grid__details-value {
-   display: inline-block;
+   display: inline;
    word-break: break-word;
    margin-left: 3px;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9755

### Description
Changed grid view labels and values to display: inline instead of display: inline-block to fix weird line break.

This is how it looked like with display: inline-block
![before_fix](https://user-images.githubusercontent.com/6603560/107641480-f907aa00-6c73-11eb-93ae-0129ef191e84.PNG)

And this is how it looks like with display: inline
![after_fix](https://user-images.githubusercontent.com/6603560/107641482-fa38d700-6c73-11eb-8598-0af127887f57.PNG)

This can be tested with any grid list view.