### PR TITLE
Fixes: After deleting a member, a reindex is attempted, which fails

### DIFF
--- a/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Web/Cache/DistributedCacheExtensions.cs
@@ -135,7 +135,10 @@ namespace Umbraco.Web.Cache
         public static void RemoveMemberCache(this DistributedCache dc, params IMember[] members)
         {
             if (members.Length == 0) return;
-            dc.RefreshByPayload(MemberCacheRefresher.UniqueId, members.Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username)));
+            dc.RefreshByPayload(MemberCacheRefresher.UniqueId, members.Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username)
+            {
+                Removed = true
+            }));
         }
 
         #endregion

--- a/src/Umbraco.Web/Cache/MemberCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MemberCacheRefresher.cs
@@ -33,6 +33,10 @@ namespace Umbraco.Web.Cache
             public int Id { get; }
             public string Username { get; }
 
+            // TODO: In netcore change this to be get only and adjust the ctor. We cannot do that now since that
+            // is a breaking change due to only having a single jsonconstructor allowed.
+            public bool Removed { get; set; }
+
         }
 
         #region Define

--- a/src/Umbraco.Web/Search/ExamineComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineComponent.cs
@@ -271,10 +271,20 @@ namespace Umbraco.Web.Search
                     break;
                 case MessageType.RefreshByPayload:
                     var payload = (MemberCacheRefresher.JsonPayload[])args.MessageObject;
-                    var members = payload.Select(x => _services.MemberService.GetById(x.Id));
-                    foreach(var m in members)
+                    foreach(var p in payload)
                     {
-                        ReIndexForMember(m);
+                        if (p.Removed)
+                        {
+                            DeleteIndexForEntity(p.Id, false);
+                        }
+                        else
+                        {
+                            var m = _services.MemberService.GetById(p.Id);
+                            if (m != null)
+                            {
+                                ReIndexForMember(m);
+                            }
+                        }
                     }
                     break;
                 case MessageType.RefreshAll:


### PR DESCRIPTION
Fixes #9684 

The member index was not removing deleted members and was actually throwing exceptions when this occurred.