### PR TITLE
Make properties full width in small infinite editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -35,7 +35,7 @@
         transform: none;
     }
 
-    &--small {
+    &--small .umb-property {
         .control-header {
             float: none;
             width: 100%;

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -34,6 +34,17 @@
     &--level0 {
         transform: none;
     }
+
+    &--small {
+        .control-header {
+            float: none;
+            width: 100%;
+        }
+
+        .controls {
+            margin-left: 0;
+        }
+    }
 }
 
 // use a loop to build the editor levels


### PR DESCRIPTION
When content is displayed inside a "small" editor window (e.g. in the grid or block list) the property labels take up 50% of the available space, making many properties so small they are unusable.

<img width="538" alt="Before" src="https://user-images.githubusercontent.com/16511093/107878856-3b77f380-6ecd-11eb-9d83-567158cdca44.png">

This isn't so much of an issue in other larger sizes, e.g. medium, as the properties have enough space.

<img width="838" alt="Medium" src="https://user-images.githubusercontent.com/16511093/107878922-afb29700-6ecd-11eb-9ef4-1cf5c156e99b.png">

## Solution

Since the introduction of the "labels-on-top" feature in Umbraco 8.10, I propose properties in small editor windows are treated the same by default. This PR changes the labels and properties in these cases to be full width.

After the change here's how it looks:

<img width="538" alt="After" src="https://user-images.githubusercontent.com/16511093/107878948-ed172480-6ecd-11eb-9e52-52f93aac09bc.png">