### PR TITLE
Netcore bugfix: DisableRedirectUrlTrackingValue was cached

### DIFF
--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingComponent.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingComponent.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Options;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration.Models;
-using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
@@ -26,14 +25,14 @@ namespace Umbraco.Web.Routing
     {
         private const string _eventStateKey = "Umbraco.Web.Redirects.RedirectTrackingEventHandler";
 
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private readonly IOptionsMonitor<WebRoutingSettings> _webRoutingSettings;
         private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
         private readonly IRedirectUrlService _redirectUrlService;
         private readonly IVariationContextAccessor _variationContextAccessor;
 
-        public RedirectTrackingComponent(IOptions<WebRoutingSettings> webRoutingSettings, IPublishedSnapshotAccessor publishedSnapshotAccessor, IRedirectUrlService redirectUrlService, IVariationContextAccessor variationContextAccessor)
+        public RedirectTrackingComponent(IOptionsMonitor<WebRoutingSettings> webRoutingSettings, IPublishedSnapshotAccessor publishedSnapshotAccessor, IRedirectUrlService redirectUrlService, IVariationContextAccessor variationContextAccessor)
         {
-            _webRoutingSettings = webRoutingSettings.Value;
+            _webRoutingSettings = webRoutingSettings;
             _publishedSnapshotAccessor = publishedSnapshotAccessor;
             _redirectUrlService = redirectUrlService;
             _variationContextAccessor = variationContextAccessor;
@@ -65,7 +64,7 @@ namespace Umbraco.Web.Routing
         private void ContentService_Publishing(IContentService sender, PublishEventArgs<IContent> args)
         {
             // don't let the event handlers kick in if Redirect Tracking is turned off in the config
-            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+            if (_webRoutingSettings.CurrentValue.DisableRedirectUrlTracking) return;
 
             var oldRoutes = GetOldRoutes(args.EventState);
             foreach (var entity in args.PublishedEntities)
@@ -77,7 +76,7 @@ namespace Umbraco.Web.Routing
         private void ContentService_Published(IContentService sender, ContentPublishedEventArgs args)
         {
             // don't let the event handlers kick in if Redirect Tracking is turned off in the config
-            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+            if (_webRoutingSettings.CurrentValue.DisableRedirectUrlTracking) return;
 
             var oldRoutes = GetOldRoutes(args.EventState);
             CreateRedirects(oldRoutes);
@@ -86,7 +85,7 @@ namespace Umbraco.Web.Routing
         private void ContentService_Moving(IContentService sender, MoveEventArgs<IContent> args)
         {
             // don't let the event handlers kick in if Redirect Tracking is turned off in the config
-            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+            if (_webRoutingSettings.CurrentValue.DisableRedirectUrlTracking) return;
 
             var oldRoutes = GetOldRoutes(args.EventState);
             foreach (var info in args.MoveInfoCollection)
@@ -98,7 +97,7 @@ namespace Umbraco.Web.Routing
         private void ContentService_Moved(IContentService sender, MoveEventArgs<IContent> args)
         {
             // don't let the event handlers kick in if Redirect Tracking is turned off in the config
-            if (_webRoutingSettings.DisableRedirectUrlTracking) return;
+            if (_webRoutingSettings.CurrentValue.DisableRedirectUrlTracking) return;
 
             var oldRoutes = GetOldRoutes(args.EventState);
             CreateRedirects(oldRoutes);

--- a/src/Umbraco.Web.BackOffice/Controllers/RedirectUrlManagementController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/RedirectUrlManagementController.cs
@@ -1,21 +1,18 @@
 ﻿using System;
-using System.Xml;
 using System.Security;
+using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Umbraco.Core.Models;
-using Umbraco.Web.Models.ContentEditing;
+using Microsoft.Extensions.Options;
 using Umbraco.Core;
-using Umbraco.Core.Configuration.UmbracoSettings;
-using Umbraco.Core.Hosting;
-using Umbraco.Core.Mapping;
-using Umbraco.Core.Services;
-using Umbraco.Web.Common.Attributes;
-using Umbraco.Web.Security;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Configuration.Models;
-using Microsoft.Extensions.Options;
+using Umbraco.Core.Mapping;
+using Umbraco.Core.Models;
 using Umbraco.Core.Security;
+using Umbraco.Core.Services;
+using Umbraco.Web.Common.Attributes;
+using Umbraco.Web.Models.ContentEditing;
 
 namespace Umbraco.Web.BackOffice.Controllers
 {
@@ -23,28 +20,25 @@ namespace Umbraco.Web.BackOffice.Controllers
     public class RedirectUrlManagementController : UmbracoAuthorizedApiController
     {
         private readonly ILogger<RedirectUrlManagementController> _logger;
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private readonly IOptionsMonitor<WebRoutingSettings> _webRoutingSettings;
         private readonly IBackOfficeSecurityAccessor _backofficeSecurityAccessor;
         private readonly IRedirectUrlService _redirectUrlService;
         private readonly UmbracoMapper _umbracoMapper;
-        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IConfigManipulator _configManipulator;
 
         public RedirectUrlManagementController(
             ILogger<RedirectUrlManagementController> logger,
-            IOptions<WebRoutingSettings> webRoutingSettings,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
             IRedirectUrlService redirectUrlService,
             UmbracoMapper umbracoMapper,
-            IHostingEnvironment hostingEnvironment,
             IConfigManipulator configManipulator)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _webRoutingSettings = webRoutingSettings.Value ?? throw new ArgumentNullException(nameof(webRoutingSettings));
+            _webRoutingSettings = webRoutingSettings ?? throw new ArgumentNullException(nameof(webRoutingSettings));
             _backofficeSecurityAccessor = backofficeSecurityAccessor ?? throw new ArgumentNullException(nameof(backofficeSecurityAccessor));
             _redirectUrlService = redirectUrlService ?? throw new ArgumentNullException(nameof(redirectUrlService));
             _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));
-            _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
             _configManipulator = configManipulator ?? throw new ArgumentNullException(nameof(configManipulator));
         }
 
@@ -55,7 +49,7 @@ namespace Umbraco.Web.BackOffice.Controllers
         [HttpGet]
         public IActionResult GetEnableState()
         {
-            var enabled = _webRoutingSettings.DisableRedirectUrlTracking == false;
+            var enabled = _webRoutingSettings.CurrentValue.DisableRedirectUrlTracking == false;
             var userIsAdmin = _backofficeSecurityAccessor.BackOfficeSecurity.CurrentUser.IsAdmin();
             return Ok(new { enabled, userIsAdmin });
         }
@@ -123,6 +117,11 @@ namespace Umbraco.Web.BackOffice.Controllers
             var action = disable ? "disable" : "enable";
 
             _configManipulator.SaveDisableRedirectUrlTracking(disable);
+
+            // TODO this is ridiculous, but we need to ensure the configuration is reloaded, before this request is ended.
+            // otherwise we can read the old value in GetEnableState.
+            // The value is equal to JsonConfigurationSource.ReloadDelay
+            Thread.Sleep(250);
 
             return Ok($"URL tracker is now {action}d.");
         }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/9813

### Details
- The values of `WebRoutingSettings` was cache due to the injection as `IOptions<WebRoutingSettings>` and not `IOptionsMonitor<WebRoutingSettings>`
- In the method that updates the configuration value, we need to wait the configuration delay time, before we return. Otherwise, the old value will still be read. I couldn't find any way to the set real delay time, so I used the default 250ms and added TODO.