### PR TITLE
Fixes logging issue with Published Router and adds logging for Collision Detection

### DIFF
--- a/src/Umbraco.Web/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Web/Routing/PublishedRouter.cs
@@ -417,8 +417,8 @@ namespace Umbraco.Web.Routing
             // some finders may implement caching
 
             using (_profilingLogger.DebugDuration<PublishedRouter>(
-                $"{tracePrefix}Begin finders",
-                $"{tracePrefix}End finders, {(request.HasPublishedContent ? "a document was found" : "no document was found")}"))
+                $"{tracePrefix}Executing finders...",
+                $"{tracePrefix}Completed executing finders"))
             {
                 //iterate but return on first one that finds it
                 var found = _contentFinders.Any(finder =>
@@ -426,6 +426,16 @@ namespace Umbraco.Web.Routing
                     _logger.Debug<PublishedRouter>("Finder {ContentFinderType}", finder.GetType().FullName);
                     return finder.TryFindContent(request);
                 });
+
+                _profilingLogger.Debug<PublishedRouter>(
+                    "Found? {Found} Content: {PublishedContentId}, Template: {TemplateAlias}, Domain: {Domain}, Culture: {Culture}, Is404: {Is404}, StatusCode: {StatusCode}",
+                    found,
+                    request.HasPublishedContent ? request.PublishedContent.Id : "NULL",
+                    request.HasTemplate ? request.TemplateAlias : "NULL",
+                    request.HasDomain ? request.Domain.ToString() : "NULL",
+                    request.Culture?.Name ?? "NULL",
+                    request.Is404,
+                    request.ResponseStatusCode);
             }
 
             // indicate that the published content (if any) we have at the moment is the

--- a/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Web/Routing/UrlProviderExtensions.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Web.Routing
                 if (urls.Add(otherUrl)) //avoid duplicates
                     yield return otherUrl;
         }
-        
+
         /// <summary>
         /// Tries to return a <see cref="UrlInfo"/> for each culture for the content while detecting collisions/errors
         /// </summary>
@@ -131,10 +131,14 @@ namespace Umbraco.Web.Routing
 
                     // got a url, deal with collisions, add url
                     default:
-                        if (DetectCollision(content, url, culture, umbracoContext, publishedRouter, textService, out var urlInfo)) // detect collisions, etc
+                        if (DetectCollision(logger, content, url, culture, umbracoContext, publishedRouter, textService, out var urlInfo)) // detect collisions, etc
+                        {
                             yield return urlInfo;
+                        }
                         else
+                        {
                             yield return UrlInfo.Url(url, culture);
+                        }
                         break;
                 }
             }
@@ -152,16 +156,23 @@ namespace Umbraco.Web.Routing
             while (parent != null && parent.Published && (!parent.ContentType.VariesByCulture() || parent.IsCulturePublished(culture)));
 
             if (parent == null) // oops, internal error
+            {
                 return UrlInfo.Message(textService.Localize("content/parentNotPublishedAnomaly"), culture);
+            }
 
             else if (!parent.Published) // totally not published
-                return UrlInfo.Message(textService.Localize("content/parentNotPublished", new[] {parent.Name}), culture);
+            {
+                return UrlInfo.Message(textService.Localize("content/parentNotPublished", new[] { parent.Name }), culture);
+            }
 
-            else // culture not published
-                return UrlInfo.Message(textService.Localize("content/parentCultureNotPublished", new[] {parent.Name}), culture);
+            else
+            {
+                // culture not published
+                return UrlInfo.Message(textService.Localize("content/parentCultureNotPublished", new[] { parent.Name }), culture);
+            }
         }
 
-        private static bool DetectCollision(IContent content, string url, string culture, UmbracoContext umbracoContext, IPublishedRouter publishedRouter, ILocalizedTextService textService, out UrlInfo urlInfo)
+        private static bool DetectCollision(ILogger logger, IContent content, string url, string culture, UmbracoContext umbracoContext, IPublishedRouter publishedRouter, ILocalizedTextService textService, out UrlInfo urlInfo)
         {
             // test for collisions on the 'main' url
             var uri = new Uri(url.TrimEnd('/'), UriKind.RelativeOrAbsolute);
@@ -174,6 +185,16 @@ namespace Umbraco.Web.Routing
 
             if (pcr.HasPublishedContent == false)
             {
+                var logMsg = nameof(DetectCollision) + " did not resolve a content item for original url: {Url}, translated to {TranslatedUrl} and culture: {Culture}";
+                if (pcr.IgnorePublishedContentCollisions)
+                {
+                    logger.Debug(typeof(UrlProviderExtensions), logMsg, url, uri, culture);
+                }
+                else
+                {
+                    logger.Warn(typeof(UrlProviderExtensions), logMsg, url, uri, culture);
+                }
+
                 urlInfo = UrlInfo.Message(textService.Localize("content/routeErrorCannotRoute"), culture);
                 return true;
             }
@@ -193,7 +214,7 @@ namespace Umbraco.Web.Routing
                 l.Reverse();
                 var s = "/" + string.Join("/", l) + " (id=" + pcr.PublishedContent.Id + ")";
 
-                 urlInfo = UrlInfo.Message(textService.Localize("content/routeError", new[] { s }), culture);
+                urlInfo = UrlInfo.Message(textService.Localize("content/routeError", new[] { s }), culture);
                 return true;
             }
 


### PR DESCRIPTION
This fixes the logging done with PublishedRouter where it was always reporting "no document was found" for every request. This was because it was resolving the HasPublishedContent flag before the finders were even executed. Now it logs correctly and also adds a much nicer verbose debug log to help with debugging.

Have also added a log output for when `DetectCollision` fails - which is used in a couple places but namely this is used when showing the URL in the back office for a content item. It will run the inbound routing for that item to see if it can be routed to. If this fails we will get the "This document is published but its url cannot be routed" error. This now adds a warning to the log for when that occurs when "IgnorePublishedContentCollisions" is false (this is always false unless a developer has chosen to set this to true in their own finder = rare and in that case it's just a Debug log).

Hopefully this will allow us to shed some more light on this ongoing issue: https://github.com/umbraco/Umbraco-CMS/issues/9514