### PR TITLE
Fixes #9824 - Filtering in block picker doesn't work

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.controller.js
@@ -1,11 +1,14 @@
 angular.module("umbraco")
 .controller("Umbraco.Editors.BlockPickerController",
     function ($scope, localizationService) {
-        var vm = this;
 
+        var vm = this;
 
         vm.navigation = [];
 
+        vm.filter = {
+            searchTerm: ''
+        };
 
         localizationService.localizeMany(["blockEditor_tabCreateEmpty", "blockEditor_tabClipboard"]).then(
             function (data) {
@@ -28,33 +31,32 @@ angular.module("umbraco")
                 vm.activeTab = vm.navigation[0];
             }
         );
-
         
-        vm.onNavigationChanged = function(tab) {
+        vm.onNavigationChanged = function (tab) {
             vm.activeTab.active = false;
             vm.activeTab = tab;
             vm.activeTab.active = true;
-        }
+        };
 
-        vm.clickClearClipboard = function() {
+        vm.clickClearClipboard = function () {
             vm.onNavigationChanged(vm.navigation[0]);
             vm.navigation[1].disabled = true;// disabled ws determined when creating the navigation, so we need to update it here.
             vm.model.clipboardItems = [];// This dialog is not connected via the clipboardService events, so we need to update manually.
             vm.model.clickClearClipboard();
-        }
+        };
 
         vm.model = $scope.model;
 
-        vm.selectItem = function(item, $event) {
+        vm.selectItem = function (item, $event) {
             vm.model.selectedItem = item;
             vm.model.submit($scope.model, $event);
-        }
+        };
 
-        vm.close = function() {
+        vm.close = function () {
             if ($scope.model && $scope.model.close) {
                 $scope.model.close($scope.model);
             }
-        }
+        };
 
     }
 );

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -19,7 +19,7 @@
                 <div class="umb-control-group" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
                     <umb-search-filter
                         input-id="icon-search"
-                        model="searchTerm"
+                        model="vm.filter.searchTerm"
                         label-key="placeholders_filter"
                         text="Type to filter..."
                         css-class="w-100"
@@ -27,27 +27,17 @@
                     </umb-search-filter>
                 </div>
 
-                <!--<div class="form-search" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
-                    <i class="icon-search"></i>
-                    <input type="text"
-                            ng-model="searchTerm"
-                            class="umb-search-field search-query input-block-level -full-width-input"
-                            localize="placeholder"
-                            placeholder="@placeholders_filter"
-                            umb-auto-focus
-                            no-dirty-check />
-                </div>-->
-
                 <div class="umb-block-card-grid">
 
                     <umb-block-card
                         class="umb-outline"
                         umb-auto-focus="vm.model.filter === false && $index === 0"
-                        ng-repeat="block in vm.model.availableItems | filter:searchTerm"
+                        ng-repeat="block in vm.model.availableItems | filter: vm.filter.searchTerm"
                         block-config-model="block.blockConfigModel"
                         element-type-model="block.elementTypeModel"
                         ng-click="vm.selectItem(block, $event)">
                     </umb-block-card>
+
                 </div>
             </div>
 
@@ -70,62 +60,11 @@
                         ng-repeat="block in vm.model.clipboardItems"
                         ng-click="vm.model.clickPasteItem(block, $event)">
                     </umb-block-card>
+
                 </div>
             </div>
 
         </umb-editor-container>
-
-        <!--<div class="umb-editor-container umb-panel-body umb-scrollable row-fluid">
-
-            <div class="umb-pane" ng-if="vm.activeTab.alias === 'empty'">
-
-                <div class="form-search" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
-                    <i class="icon-search"></i>
-                    <input type="text"
-                           ng-model="searchTerm"
-                           class="umb-search-field search-query input-block-level -full-width-input"
-                           localize="placeholder"
-                           placeholder="@placeholders_filter"
-                           umb-auto-focus
-                           no-dirty-check />
-                </div>
-
-                <div class="umb-block-card-grid">
-
-                    <umb-block-card
-                        class="umb-outline"
-                        umb-auto-focus="vm.model.filter === false && $index === 0"
-                        ng-repeat="block in vm.model.availableItems | filter:searchTerm"
-                        block-config-model="block.blockConfigModel"
-                        element-type-model="block.elementTypeModel"
-                        ng-click="vm.selectItem(block, $event)">
-                    </umb-block-card>
-                </div>
-            </div>
-
-            <div class="umb-pane" ng-if="vm.activeTab.alias === 'clipboard'">
-                <div style="margin-bottom:20px; text-align: right;">
-                    <umb-button
-                        type="button"
-                        icon="icon-trash"
-                        button-style="link"
-                        label-key="clipboard_labelForClearClipboard"
-                        action="vm.clickClearClipboard()">
-                    </umb-button>
-                </div>
-
-                <div class="umb-block-card-grid">
-
-                    <umb-block-card
-                        block-config-model="block.blockConfigModel"
-                        element-type-model="block.elementTypeModel"
-                        ng-repeat="block in vm.model.clipboardItems"
-                        ng-click="vm.model.clickPasteItem(block, $event)">
-                    </umb-block-card>
-                </div>
-            </div>
-
-        </div>-->
 
         <umb-editor-footer>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -31,7 +31,6 @@
 
                     <umb-block-card
                         class="umb-outline"
-                        umb-auto-focus="vm.model.filter === false && $index === 0"
                         ng-repeat="block in vm.model.availableItems | filter: vm.filter.searchTerm"
                         block-config-model="block.blockConfigModel"
                         element-type-model="block.elementTypeModel"

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -12,7 +12,70 @@
             hide-description="true">
         </umb-editor-header>
 
-        <div class="umb-editor-container umb-panel-body umb-scrollable row-fluid">
+        <umb-editor-container class="block-form">
+
+            <div ng-if="vm.activeTab.alias === 'empty'">
+
+                <div class="umb-control-group" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
+                    <umb-search-filter
+                        input-id="icon-search"
+                        model="searchTerm"
+                        label-key="placeholders_filter"
+                        text="Type to filter..."
+                        css-class="w-100"
+                        auto-focus="true">
+                    </umb-search-filter>
+                </div>
+
+                <!--<div class="form-search" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
+                    <i class="icon-search"></i>
+                    <input type="text"
+                            ng-model="searchTerm"
+                            class="umb-search-field search-query input-block-level -full-width-input"
+                            localize="placeholder"
+                            placeholder="@placeholders_filter"
+                            umb-auto-focus
+                            no-dirty-check />
+                </div>-->
+
+                <div class="umb-block-card-grid">
+
+                    <umb-block-card
+                        class="umb-outline"
+                        umb-auto-focus="vm.model.filter === false && $index === 0"
+                        ng-repeat="block in vm.model.availableItems | filter:searchTerm"
+                        block-config-model="block.blockConfigModel"
+                        element-type-model="block.elementTypeModel"
+                        ng-click="vm.selectItem(block, $event)">
+                    </umb-block-card>
+                </div>
+            </div>
+
+            <div ng-if="vm.activeTab.alias === 'clipboard'">
+                <div style="margin-bottom:20px; text-align: right;">
+                    <umb-button
+                        type="button"
+                        icon="icon-trash"
+                        button-style="link"
+                        label-key="clipboard_labelForClearClipboard"
+                        action="vm.clickClearClipboard()">
+                    </umb-button>
+                </div>
+
+                <div class="umb-block-card-grid">
+
+                    <umb-block-card
+                        block-config-model="block.blockConfigModel"
+                        element-type-model="block.elementTypeModel"
+                        ng-repeat="block in vm.model.clipboardItems"
+                        ng-click="vm.model.clickPasteItem(block, $event)">
+                    </umb-block-card>
+                </div>
+            </div>
+
+        </umb-editor-container>
+
+        <!--<div class="umb-editor-container umb-panel-body umb-scrollable row-fluid">
 
             <div class="umb-pane" ng-if="vm.activeTab.alias === 'empty'">
 
@@ -62,7 +125,7 @@
                 </div>
             </div>
 
-        </div>
+        </div>-->
 
         <umb-editor-footer>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9824

### Description
Currently the block picker is showing filter, when enough blocks are available. However the filtering didn't work.
Furthermore when opening the block picker it was scrolling down to last block, because the auto focus set here was stealing focus from the filter. Event worse when start typing in the search input you suddently lost focus, probably because the filtered results now changes the indexes and the `umb-auto-focus` watched these block cards. For now I have removing the, but we can always add it again, when we fix this. For now it works better without the auto focus on the block cards. https://github.com/umbraco/Umbraco-CMS/pull/9831/commits/f6a316802c0b777c99898c63aab7c0bfbeed39a7

I have furthermore cleaner up using `<umb-editor-container>` instead of all the hardcoded classes and also replaced the search filter with `<umb-search-filter>` component.

Finally I have fixed the filtering, so it now works correctly.

![ib4ESEeHm5](https://user-images.githubusercontent.com/2919859/108179130-8da35980-7105-11eb-9cbb-774613a49ce6.gif)

However I noticed it didn't seems to filter the image block correctly. I named the alias of this `blockImage` since a document type with alias `image` was already in use.

![image](https://user-images.githubusercontent.com/2919859/108179429-e70b8880-7105-11eb-9b63-c36f58858ad7.png)

Strange enough it does filter the blocks in searching `block` or a rename the alias `picture` and search on `picture`.