### PR TITLE
Fixes error trying to load Cosmos.CRTCompat.dll (System.BadImageForma…

### DIFF
--- a/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
+++ b/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 namespace Umbraco.Core.Composing
 {
@@ -14,6 +15,7 @@ namespace Umbraco.Core.Composing
     public class DefaultUmbracoAssemblyProvider : IAssemblyProvider
     {
         private readonly Assembly _entryPointAssembly;
+        private readonly ILoggerFactory _loggerFactory;
         private static readonly string[] UmbracoCoreAssemblyNames = new[]
             {
                 "Umbraco.Core",
@@ -26,9 +28,10 @@ namespace Umbraco.Core.Composing
                 "Umbraco.Web.Website",
             };
 
-        public DefaultUmbracoAssemblyProvider(Assembly entryPointAssembly)
+        public DefaultUmbracoAssemblyProvider(Assembly entryPointAssembly, ILoggerFactory loggerFactory)
         {
             _entryPointAssembly = entryPointAssembly ?? throw new ArgumentNullException(nameof(entryPointAssembly));
+            _loggerFactory = loggerFactory;
         }
 
         // TODO: It would be worth investigating a netcore3 version of this which would use
@@ -41,7 +44,7 @@ namespace Umbraco.Core.Composing
         {
             get
             {
-                var finder = new FindAssembliesWithReferencesTo(new[] { _entryPointAssembly }, UmbracoCoreAssemblyNames, true);
+                var finder = new FindAssembliesWithReferencesTo(new[] { _entryPointAssembly }, UmbracoCoreAssemblyNames, true, _loggerFactory);
                 return finder.Find();
             }
         }

--- a/src/Umbraco.Core/Composing/FindAssembliesWithReferencesTo.cs
+++ b/src/Umbraco.Core/Composing/FindAssembliesWithReferencesTo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 namespace Umbraco.Core.Composing
 {
@@ -17,6 +18,7 @@ namespace Umbraco.Core.Composing
         private readonly Assembly[] _referenceAssemblies;
         private readonly string[] _targetAssemblies;
         private readonly bool _includeTargets;
+        private readonly ILoggerFactory _loggerFactory;
 
         /// <summary>
         /// Constructor
@@ -24,11 +26,13 @@ namespace Umbraco.Core.Composing
         /// <param name="referenceAssemblies">Entry point assemblies</param>
         /// <param name="targetAssemblyNames">Used to check if the entry point or it's transitive assemblies reference these assembly names</param>
         /// <param name="includeTargets">If true will also use the target assembly names as entry point assemblies</param>
-        public FindAssembliesWithReferencesTo(Assembly[] referenceAssemblies, string[] targetAssemblyNames, bool includeTargets)
+        /// <param name="loggerFactory">Logger factory for when scanning goes wrong</param>
+        public FindAssembliesWithReferencesTo(Assembly[] referenceAssemblies, string[] targetAssemblyNames, bool includeTargets, ILoggerFactory loggerFactory)
         {
             _referenceAssemblies = referenceAssemblies;
             _targetAssemblies = targetAssemblyNames;
             _includeTargets = includeTargets;
+            _loggerFactory = loggerFactory;
         }
 
         public IEnumerable<Assembly> Find()
@@ -54,7 +58,7 @@ namespace Umbraco.Core.Composing
                 }
             }
 
-            var provider = new ReferenceResolver(_targetAssemblies, referenceItems);
+            var provider = new ReferenceResolver(_targetAssemblies, referenceItems, _loggerFactory.CreateLogger<ReferenceResolver>());
             var assemblyNames = provider.ResolveAssemblies();
             return assemblyNames.ToList();
         }

--- a/src/Umbraco.Tests.Benchmarks/TypeFinderBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/TypeFinderBenchmarks.cs
@@ -16,14 +16,14 @@ namespace Umbraco.Tests.Benchmarks
         [Benchmark(Baseline = true)]
         public void WithGetReferencingAssembliesCheck()
         {
-            var typeFinder1 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly), new VaryingRuntimeHash());
+            var typeFinder1 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
             var found = typeFinder1.FindClassesOfType<IDiscoverable>().Count();
         }
 
         [Benchmark]
         public void WithoutGetReferencingAssembliesCheck()
         {
-            var typeFinder2 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly), new VaryingRuntimeHash());
+            var typeFinder2 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
             typeFinder2.QueryWithReferencingAssemblies = false;
             var found = typeFinder2.FindClassesOfType<IDiscoverable>().Count();
         }

--- a/src/Umbraco.Tests.Common/TestHelperBase.cs
+++ b/src/Umbraco.Tests.Common/TestHelperBase.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Tests.Common
         protected TestHelperBase(Assembly entryAssembly)
         {
             MainDom = new SimpleMainDom();
-            _typeFinder = new TypeFinder(NullLoggerFactory.Instance.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(entryAssembly), new VaryingRuntimeHash());
+            _typeFinder = new TypeFinder(NullLoggerFactory.Instance.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(entryAssembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
         }
 
         public ITypeFinder GetTypeFinder() => _typeFinder;

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeFinderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeFinderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Core.Composing;
@@ -38,7 +39,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Core.Composing
         [Test]
         public void Find_Class_Of_Type_With_Attribute()
         {
-            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly), new VaryingRuntimeHash());
+            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
             IEnumerable<Type> typesFound = typeFinder.FindClassesOfTypeWithAttribute<TestEditor, MyTestAttribute>(_assemblies);
             Assert.AreEqual(2, typesFound.Count());
         }
@@ -46,7 +47,7 @@ namespace Umbraco.Tests.UnitTests.Umbraco.Core.Composing
         [Test]
         public void Find_Classes_With_Attribute()
         {
-            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly), new VaryingRuntimeHash());
+            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
             IEnumerable<Type> typesFound = typeFinder.FindClassesWithAttribute<TreeAttribute>(_assemblies);
             Assert.AreEqual(0, typesFound.Count()); // 0 classes in _assemblies are marked with [Tree]
 

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -191,7 +191,7 @@ namespace Umbraco.Tests.Testing
             var proflogger = new ProfilingLogger(loggerFactory.CreateLogger<ProfilingLogger>(), profiler);
             IOHelper = TestHelper.IOHelper;
 
-            TypeFinder = new TypeFinder(loggerFactory.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly), new VaryingRuntimeHash());
+            TypeFinder = new TypeFinder(loggerFactory.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
             var appCaches = GetAppCaches();
             var globalSettings = new GlobalSettings();
             var settings = new WebRoutingSettings();

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -191,7 +191,7 @@ namespace Umbraco.Tests.Testing
             var proflogger = new ProfilingLogger(loggerFactory.CreateLogger<ProfilingLogger>(), profiler);
             IOHelper = TestHelper.IOHelper;
 
-            TypeFinder = new TypeFinder(loggerFactory.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
+            TypeFinder = new TypeFinder(loggerFactory.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, loggerFactory), new VaryingRuntimeHash());
             var appCaches = GetAppCaches();
             var globalSettings = new GlobalSettings();
             var settings = new WebRoutingSettings();

--- a/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoCoreServiceCollectionExtensions.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Extensions
 
             var typeFinder =  new TypeFinder(
                 loggerFactory.CreateLogger<TypeFinder>(),
-                new DefaultUmbracoAssemblyProvider(entryAssembly),
+                new DefaultUmbracoAssemblyProvider(entryAssembly, loggerFactory),
                 runtimeHash,
                 new TypeFinderConfig(Options.Create(typeFinderSettings))
             );

--- a/src/Umbraco.Web/UmbracoApplicationBase.cs
+++ b/src/Umbraco.Web/UmbracoApplicationBase.cs
@@ -119,7 +119,7 @@ namespace Umbraco.Web
                 // assembly we can get and we can only get that if we put this code into the WebRuntime since the executing assembly is the 'current' one.
                 // For this purpose, it doesn't matter if it's Umbraco.Web or Umbraco.Infrastructure since all assemblies are in that same path and we are
                 // getting rid of netframework.
-                Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()), runtimeHash);
+                Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly(), _loggerFactory), runtimeHash);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

When trying to work with CosmosDB I added `Microsoft.Azure.Cosmos` which includes a dll `Cosmos.CRTCompat.dll`. When trying to read the assembly name from the file I get an error: 

```
Unhandled exception. System.BadImageFormatException: Could not load file or assembly 'D:\Temp\Test\tester\MyTestProject\bin\Debug\net5.0\Cosmos.CRTCompat.dll'. The module was expected to contain an assembly manifest.
File name: 'D:\Temp\Test\tester\MyTestProject\bin\Debug\net5.0\Cosmos.CRTCompat.dll'
   at System.Reflection.AssemblyName.nGetFileInformation(String s)
   at System.Reflection.AssemblyName.GetAssemblyName(String assemblyFile)
   at Umbraco.Core.Composing.ReferenceResolver.ResolveAssemblies()
   at Umbraco.Core.Composing.FindAssembliesWithReferencesTo.Find()
   at Umbraco.Core.Composing.DefaultUmbracoAssemblyProvider.get_Assemblies()
   at Umbraco.Core.Composing.TypeFinder.GetAllAssemblies()
   at Umbraco.Core.Composing.TypeFinder.GetFilteredAssemblies(IEnumerable`1 excludeFromResults, String[] exclusionFilter)
   at Umbraco.Core.Composing.TypeFinder.get_AssembliesToScan()
   at Umbraco.Core.Composing.TypeLoader.get_AssembliesToScan()
   at Umbraco.Core.Composing.TypeLoader.<>c__DisplayClass50_0`1.<GetTypes>b__0()
   at Umbraco.Core.Composing.TypeLoader.GetTypesInternalLocked(Type baseType, Type attributeType, Func`1 finder, String action, Boolean cache)
   at Umbraco.Core.Composing.TypeLoader.GetTypesInternal(Type baseType, Type attributeType, Func`1 finder, String action, Boolean cache)
   at Umbraco.Core.Composing.TypeLoader.GetTypes[T](Boolean cache, IEnumerable`1 specificAssemblies)
   at Umbraco.Core.DependencyInjection.UmbracoBuilderExtensions.AddAllCoreCollectionBuilders(IUmbracoBuilder builder)
   at Umbraco.Core.DependencyInjection.UmbracoBuilder.AddCoreServices()
   at Umbraco.Core.DependencyInjection.UmbracoBuilder..ctor(IServiceCollection services, IConfiguration config, TypeLoader typeLoader, ILoggerFactory loggerFactory)
   at Umbraco.Web.Common.DependencyInjection.UmbracoBuilderExtensions.AddUmbraco(IServiceCollection services, IWebHostEnvironment webHostEnvironment, IConfiguration config)
   at MyTestProject.Startup.ConfigureServices(IServiceCollection services) in D:\Temp\Test\tester\MyTestProject\Startup.cs:line 52
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.InvokeCore(Object instance, IServiceCollection services)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.<>c__DisplayClass9_0.<Invoke>g__Startup|0(IServiceCollection serviceCollection)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.Invoke(Object instance, IServiceCollection services)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.<>c__DisplayClass8_0.<Build>b__0(IServiceCollection services)
   at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.UseStartup(Type startupType, HostBuilderContext context, IServiceCollection services, Object instance)
   at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.<>c__DisplayClass13_0.<UseStartup>b__0(HostBuilderContext context, IServiceCollection services)
   at Microsoft.Extensions.Hosting.HostBuilder.CreateServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at MyTestProject.Program.Main(String[] args) in D:\Temp\Test\tester\MyTestProject\Program.cs:line 11
```

For some reason this dll seems to have a weird format. seems okay to ignore this.

I tried adding logging but I had to update too many class instantiations so I am guessing this resolver might run at a point where the DI is not ready yet and I can't easily instantiate a logger? Happy to fix if someone has a pointer. I would suggest logging with the debug level so it doesn't constantly show up in logs, only if you change the level from Info to Debug.