### PR TITLE
Do not apply runtime optimization to core scripts and script libraries

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -145,7 +145,7 @@ namespace Umbraco.Core.Configuration.Models
                     width:1em;
                 }}
             </style>
-            <script type=""text/javascript"" data-umbraco-path=""{0}"" src=""{0}/js/umbraco.websitepreview.js""></script>";
+            <script type=""text/javascript"" data-umbraco-path=""{0}"" src=""{0}/js/umbraco.websitepreview.min.js""></script>";
 
         /// <summary>
         /// Gets or sets a value for the content notification settings.

--- a/src/Umbraco.Core/WebAssets/IRuntimeMinifier.cs
+++ b/src/Umbraco.Core/WebAssets/IRuntimeMinifier.cs
@@ -40,6 +40,7 @@ namespace Umbraco.Core.WebAssets
         /// Creates a JS bundle
         /// </summary>
         /// <param name="bundleName"></param>
+        /// <param name="optimizeOutput"></param>
         /// <param name="filePaths"></param>
         /// <remarks>
         /// All files must be absolute paths, relative paths will throw <see cref="InvalidOperationException"/>
@@ -47,7 +48,7 @@ namespace Umbraco.Core.WebAssets
         /// <exception cref="InvalidOperationException">
         /// Thrown if any of the paths specified are not absolute
         /// </exception>
-        void CreateJsBundle(string bundleName, params string[] filePaths);
+        void CreateJsBundle(string bundleName, bool optimizeOutput, params string[] filePaths);
 
         /// <summary>
         /// Renders the html script tag for the bundle

--- a/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
@@ -21,7 +21,8 @@ namespace Umbraco.Web.WebAssets
         public const string UmbracoPreviewCssBundleName = "umbraco-preview-css";
         public const string UmbracoCssBundleName = "umbraco-backoffice-css";
         public const string UmbracoInitCssBundleName = "umbraco-backoffice-init-css";
-        public const string UmbracoJsBundleName = "umbraco-backoffice-js";
+        public const string UmbracoCoreJsBundleName = "umbraco-backoffice-js";
+        public const string UmbracoExtensionsJsBundleName = "umbraco-backoffice-extensions-js";
         public const string UmbracoTinyMceJsBundleName = "umbraco-tinymce-js";
         public const string UmbracoUpgradeCssBundleName = "umbraco-authorize-upgrade-css";
 
@@ -62,20 +63,23 @@ namespace Umbraco.Web.WebAssets
             _runtimeMinifier.CreateCssBundle(UmbracoPreviewCssBundleName,
                 FormatPaths("assets/css/canvasdesigner.css"));
 
-            _runtimeMinifier.CreateJsBundle(UmbracoPreviewJsBundleName,
+            _runtimeMinifier.CreateJsBundle(UmbracoPreviewJsBundleName, false,
                 FormatPaths(GetScriptsForPreview()));
 
-            _runtimeMinifier.CreateJsBundle(UmbracoTinyMceJsBundleName,
+            _runtimeMinifier.CreateJsBundle(UmbracoTinyMceJsBundleName, false,
                 FormatPaths(GetScriptsForTinyMce()));
+
+            _runtimeMinifier.CreateJsBundle(UmbracoCoreJsBundleName, false,
+                FormatPaths(GetScriptsForBackOfficeCore()));
 
             var propertyEditorAssets = ScanPropertyEditors()
                 .GroupBy(x => x.AssetType)
                 .ToDictionary(x => x.Key, x => x.Select(c => c.FilePath));
 
             _runtimeMinifier.CreateJsBundle(
-                UmbracoJsBundleName,
+                UmbracoExtensionsJsBundleName, true,
                 FormatPaths(
-                    GetScriptsForBackOffice(
+                    GetScriptsForBackOfficeExtensions(
                         propertyEditorAssets.TryGetValue(AssetType.Javascript, out var scripts) ? scripts : Enumerable.Empty<string>())));
 
             _runtimeMinifier.CreateCssBundle(
@@ -89,12 +93,9 @@ namespace Umbraco.Web.WebAssets
         /// Returns scripts used to load the back office
         /// </summary>
         /// <returns></returns>
-        private string[] GetScriptsForBackOffice(IEnumerable<string> propertyEditorScripts)
+        private string[] GetScriptsForBackOfficeExtensions(IEnumerable<string> propertyEditorScripts)
         {
-            var umbracoInit = GetInitBackOfficeScripts();
             var scripts = new HashSet<string>();
-            foreach (var script in umbracoInit)
-                scripts.Add(script);
             foreach (var script in _parser.Manifest.Scripts)
                 scripts.Add(script);
             foreach (var script in propertyEditorScripts)
@@ -107,10 +108,10 @@ namespace Umbraco.Web.WebAssets
         /// Returns the list of scripts for back office initialization
         /// </summary>
         /// <returns></returns>
-        private IEnumerable<string> GetInitBackOfficeScripts()
+        private string[] GetScriptsForBackOfficeCore()
         {
             var resources = JsonConvert.DeserializeObject<JArray>(Resources.JsInitialize);
-            return resources.Where(x => x.Type == JTokenType.String).Select(x => x.ToString());
+            return resources.Where(x => x.Type == JTokenType.String).Select(x => x.ToString()).ToArray();
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/WebAssets/JsInitialize.js
+++ b/src/Umbraco.Infrastructure/WebAssets/JsInitialize.js
@@ -1,26 +1,26 @@
-﻿[
+[
     
     'lib/jquery/jquery.min.js',
     'lib/jquery-ui/jquery-ui.min.js',
     'lib/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js',
 
-    'lib/angular/angular.js',
+    'lib/angular/angular.min.js',
     'lib/underscore/underscore-min.js',
 
     'lib/moment/moment.min.js',
-    'lib/flatpickr/flatpickr.js',
+    'lib/flatpickr/flatpickr.min.js',
 
     'lib/animejs/anime.min.js',
 
-    'lib/angular-route/angular-route.js',
-    'lib/angular-cookies/angular-cookies.js',
+    'lib/angular-route/angular-route.min.js',
+    'lib/angular-cookies/angular-cookies.min.js',
     'lib/angular-aria/angular-aria.min.js',
-    'lib/angular-touch/angular-touch.js',
-    'lib/angular-sanitize/angular-sanitize.js',
-    'lib/angular-animate/angular-animate.js',
-    'lib/angular-messages/angular-messages.js',
+    'lib/angular-touch/angular-touch.min.js',
+    'lib/angular-sanitize/angular-sanitize.min.js',
+    'lib/angular-animate/angular-animate.min.js',
+    'lib/angular-messages/angular-messages.min.js',
 
-    'lib/angular-ui-sortable/sortable.js',
+    'lib/angular-ui-sortable/sortable.min.js',
 
     'lib/angular-dynamic-locale/tmhDynamicLocale.min.js',
     'lib/ng-file-upload/ng-file-upload.min.js',
@@ -35,16 +35,16 @@
     'lib/umbraco/NamespaceManager.js',
     'lib/umbraco/LegacySpeechBubble.js',
 
-    'js/utilities.js',
+    'js/utilities.min.js',
 
-    'js/app.js',
+    'js/app.min.js',
 
-    'js/umbraco.resources.js',
-    'js/umbraco.directives.js',
-    'js/umbraco.filters.js',
-    'js/umbraco.services.js',
-    'js/umbraco.interceptors.js',
-    'js/umbraco.controllers.js',
-    'js/routes.js',
-    'js/init.js'    
+    'js/umbraco.resources.min.js',
+    'js/umbraco.directives.min.js',
+    'js/umbraco.filters.min.js',
+    'js/umbraco.services.min.js',
+    'js/umbraco.interceptors.min.js',
+    'js/umbraco.controllers.min.js',
+    'js/routes.min.js',
+    'js/init.min.js'    
 ]

--- a/src/Umbraco.Infrastructure/WebAssets/PreviewInitialize.js
+++ b/src/Umbraco.Infrastructure/WebAssets/PreviewInitialize.js
@@ -1,14 +1,14 @@
-﻿[
+[
     'lib/jquery/jquery.min.js',
-    'lib/angular/angular.js',
+    'lib/angular/angular.min.js',
     'lib/underscore/underscore-min.js',
     'lib/umbraco/Extensions.js',
-    'js/utilities.js',
-    'js/app.js',
-    'js/umbraco.resources.js',
-    'js/umbraco.services.js',
-    'js/umbraco.interceptors.js',
+    'js/utilities.min.js',
+    'js/app.min.js',
+    'js/umbraco.resources.min.js',
+    'js/umbraco.services.min.js',
+    'js/umbraco.interceptors.min.js',
     'ServerVariables',
     'lib/signalr/signalr.min.js',
-    'js/umbraco.preview.js'
+    'js/umbraco.preview.min.js'
 ]

--- a/src/Umbraco.Infrastructure/WebAssets/RuntimeMinifierExtensions.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/RuntimeMinifierExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Umbraco.Core.Configuration.Models;
@@ -15,8 +16,9 @@ namespace Umbraco.Web.WebAssets
         /// <returns></returns>
         public static async Task<string> GetScriptForLoadingBackOfficeAsync(this IRuntimeMinifier minifier, GlobalSettings globalSettings, IHostingEnvironment hostingEnvironment)
         {
-            var files = await minifier.GetAssetPathsAsync(BackOfficeWebAssets.UmbracoJsBundleName);
-            var result = BackOfficeJavaScriptInitializer.GetJavascriptInitialization(files, "umbraco", globalSettings, hostingEnvironment);
+            var coreScripts = await minifier.GetAssetPathsAsync(BackOfficeWebAssets.UmbracoCoreJsBundleName);
+            var extensionsScripts = await minifier.GetAssetPathsAsync(BackOfficeWebAssets.UmbracoExtensionsJsBundleName);
+            var result = BackOfficeJavaScriptInitializer.GetJavascriptInitialization(coreScripts.Union(extensionsScripts), "umbraco", globalSettings, hostingEnvironment);
             result += await GetStylesheetInitializationAsync(minifier);
 
             return result;

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Web.Common.RuntimeMinification
 
         public async Task<string> RenderCssHereAsync(string bundleName) => (await _smidge.SmidgeHelper.CssHereAsync(bundleName, _hostingEnvironment.IsDebugMode)).ToString();
 
-        public void CreateJsBundle(string bundleName, params string[] filePaths)
+        public void CreateJsBundle(string bundleName, bool optimizeOutput, params string[] filePaths)
         {
             if (filePaths.Any(f => !f.StartsWith("/") && !f.StartsWith("~/")))
                 throw new InvalidOperationException("All file paths must be absolute");
@@ -85,7 +85,8 @@ namespace Umbraco.Web.Common.RuntimeMinification
             // Here we could configure bundle options instead of using smidge's global defaults.
             // For example we can use our own custom cache buster for this bundle without having the global one
             // affect this or vice versa.
-            var bundle = _bundles.Create(bundleName, _jsPipeline.Value, WebFileType.Js, filePaths);
+            var pipeline = optimizeOutput ? _jsPipeline.Value : _bundles.PipelineFactory.Create();
+            var bundle = _bundles.Create(bundleName, pipeline, WebFileType.Js, filePaths);
         }
 
         public async Task<string> RenderJsHereAsync(string bundleName) => (await _smidge.SmidgeHelper.JsHereAsync(bundleName, _hostingEnvironment.IsDebugMode)).ToString();

--- a/src/Umbraco.Web.UI.Client/gulp/config.js
+++ b/src/Umbraco.Web.UI.Client/gulp/config.js
@@ -4,15 +4,18 @@ module.exports = {
     compile: {
         build: {
             sourcemaps: false,
-            embedtemplates: true
+            embedtemplates: true,
+            minify: true
         },
         dev: {
             sourcemaps: true,
-            embedtemplates: true
+            embedtemplates: true,
+            minify: false
         },
         test: {
             sourcemaps: false,
-            embedtemplates: true
+            embedtemplates: true,
+            minify: true
         }
     },
     sources: {

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -46,7 +46,7 @@ function dependencies() {
         },
         {
             "name": "angular",
-            "src":  ["./node_modules/angular/angular.js"],
+            "src":  ["./node_modules/angular/angular.min.js"],
             "base": "./node_modules/angular"
         },
         {
@@ -57,7 +57,7 @@ function dependencies() {
         },
         {
             "name": "angular-cookies",
-            "src":  ["./node_modules/angular-cookies/angular-cookies.js"],
+            "src":  ["./node_modules/angular-cookies/angular-cookies.min.js"],
             "base": "./node_modules/angular-cookies"
         },
         {
@@ -70,27 +70,27 @@ function dependencies() {
         },
         {
             "name": "angular-sanitize",
-            "src":  ["./node_modules/angular-sanitize/angular-sanitize.js"],
+            "src":  ["./node_modules/angular-sanitize/angular-sanitize.min.js"],
             "base": "./node_modules/angular-sanitize"
         },
         {
             "name": "angular-touch",
-            "src":  ["./node_modules/angular-touch/angular-touch.js"],
+            "src":  ["./node_modules/angular-touch/angular-touch.min.js"],
             "base": "./node_modules/angular-touch"
         },
         {
             "name": "angular-ui-sortable",
-            "src":  ["./node_modules/angular-ui-sortable/dist/sortable.js"],
+            "src":  ["./node_modules/angular-ui-sortable/dist/sortable.min.js"],
             "base": "./node_modules/angular-ui-sortable/dist"
         },
         {
             "name": "angular-route",
-            "src":  ["./node_modules/angular-route/angular-route.js"],
+            "src":  ["./node_modules/angular-route/angular-route.min.js"],
             "base": "./node_modules/angular-route"
         },
         {
             "name": "angular-animate",
-            "src":  ["./node_modules/angular-animate/angular-animate.js"],
+            "src":  ["./node_modules/angular-animate/angular-animate.min.js"],
             "base": "./node_modules/angular-animate"
         },
         {
@@ -111,7 +111,7 @@ function dependencies() {
         },
         {
             "name": "angular-messages",
-            "src":  ["./node_modules/angular-messages/angular-messages.js"],
+            "src":  ["./node_modules/angular-messages/angular-messages.min.js"],
             "base": "./node_modules/angular-messages"
         },        
         {
@@ -153,7 +153,7 @@ function dependencies() {
         {
             "name": "flatpickr",
             "src":  [
-                "./node_modules/flatpickr/dist/flatpickr.js",
+                "./node_modules/flatpickr/dist/flatpickr.min.js",
                 "./node_modules/flatpickr/dist/flatpickr.css",
                 "./node_modules/flatpickr/dist/l10n/*.js"
             ],

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
@@ -3,6 +3,8 @@
 var config = require('../config');
 var gulp = require('gulp');
 
+var minify = require('gulp-minify');
+var rename = require('gulp-rename');
 var _ = require('lodash');
 var MergeStream = require('merge-stream');
 
@@ -17,6 +19,19 @@ function js() {
     var stream = new MergeStream();
 
     var task = gulp.src(config.sources.globs.js);
+    if (config.compile.current.minify === true) {
+      task = task.pipe(
+        minify({
+          noSource: true,
+          ext: { min: '.min.js' },
+          mangle: false
+        })
+      );
+    } else {
+      task = task.pipe(rename(function(path) {
+        path.basename += '.min';
+      }));
+    }
     _.forEach(config.roots, function(root){
         task = task.pipe( gulp.dest(root + config.targets.js) )
     })

--- a/src/Umbraco.Web.UI.Client/gulp/util/processJs.js
+++ b/src/Umbraco.Web.UI.Client/gulp/util/processJs.js
@@ -8,6 +8,8 @@ var sort = require('gulp-sort');
 var concat = require('gulp-concat');
 var wrap = require("gulp-wrap-js");
 var embedTemplates = require('gulp-angular-embed-templates');
+var minify = require('gulp-minify');
+var rename = require('gulp-rename');
 var _ = require('lodash');
 
 module.exports = function (files, out) {
@@ -33,6 +35,20 @@ module.exports = function (files, out) {
     }
     
     task = task.pipe(concat(out)).pipe(wrap('(function(){\n%= body %\n})();'))
+
+    if (config.compile.current.minify === true) {
+      task = task.pipe(
+        minify({
+          noSource:true,
+          ext: {min:'.min.js'},
+          mangle: false
+        })
+      );
+    } else {
+      task = task.pipe(rename(function(path) {
+        path.basename += '.min';
+      }));
+    }
 
     _.forEach(config.roots, function(root){
         task = task.pipe(gulp.dest(root + config.targets.js));

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -6783,6 +6783,104 @@
         }
       }
     },
+    "gulp-minify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-minify/-/gulp-minify-3.1.0.tgz",
+      "integrity": "sha512-ixF41aYg+NQikI8hpoHdEclYcQkbGdXQu1CBdHaU7Epg8H6e8d2jWXw1+rBPgYwl/XpKgjHj7NI6gkhoSNSSAg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "minimatch": "^3.0.2",
+        "plugin-error": "^0.1.2",
+        "terser": "^3.7.6",
+        "through2": "^2.0.3",
+        "vinyl": "^2.1.0"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
+          }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        },
+        "plugin-error": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+          "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+          "dev": true,
+          "requires": {
+            "ansi-cyan": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "arr-diff": "^1.0.1",
+            "arr-union": "^2.0.1",
+            "extend-shallow": "^1.1.2"
+          }
+        },
+        "replace-ext": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+          "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+          "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+          "dev": true,
+          "requires": {
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
+          }
+        }
+      }
+    },
     "gulp-notify": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.2.0.tgz",
@@ -15021,6 +15119,24 @@
         "urix": "^0.1.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -15546,6 +15662,25 @@
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "terser": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "text-hex": {

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -74,6 +74,7 @@
     "gulp-watch": "5.0.1",
     "gulp-wrap": "0.15.0",
     "gulp-wrap-js": "0.4.1",
+    "gulp-minify": "3.1.0",
     "jasmine-core": "3.5.0",
     "jsdom": "16.4.0",
     "karma": "4.4.1",

--- a/src/Umbraco.Web.UI.Client/src/install.loader.js
+++ b/src/Umbraco.Web.UI.Client/src/install.loader.js
@@ -1,20 +1,20 @@
 LazyLoad.js([
     'lib/jquery/jquery.min.js',
 
-    'lib/angular/angular.js',
-    'lib/angular-cookies/angular-cookies.js',
-    'lib/angular-touch/angular-touch.js',
-    'lib/angular-sanitize/angular-sanitize.js',
-    'lib/angular-messages/angular-messages.js',
+    'lib/angular/angular.min.js',
+    'lib/angular-cookies/angular-cookies.min.js',
+    'lib/angular-touch/angular-touch.min.js',
+    'lib/angular-sanitize/angular-sanitize.min.js',
+    'lib/angular-messages/angular-messages.min.js',
     'lib/angular-aria/angular-aria.min.js',
     'lib/underscore/underscore-min.js',
-    'lib/angular-ui-sortable/sortable.js',
+    'lib/angular-ui-sortable/sortable.min.js',
 
-    'js/utilities.js',
+    'js/utilities.min.js',
 
-    'js/installer.app.js',
-    'js/umbraco.directives.js',
-    'js/umbraco.installer.js'
+    'js/installer.app.min.js',
+    'js/umbraco.directives.min.js',
+    'js/umbraco.installer.min.js'
 
 ], function () {
     jQuery(document).ready(function () {

--- a/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
+++ b/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
@@ -15,15 +15,15 @@ module.exports = function (config) {
             
             //libraries
             'node_modules/jquery/dist/jquery.min.js',
-            'node_modules/angular/angular.js',
-            'node_modules/angular-animate/angular-animate.js',
-            'node_modules/angular-cookies/angular-cookies.js',
+            'node_modules/angular/angular.min.js',
+            'node_modules/angular-animate/angular-animate.min.js',
+            'node_modules/angular-cookies/angular-cookies.min.js',
             'node_modules/angular-aria/angular-aria.min.js',
             'node_modules/angular-local-storage/dist/angular-local-storage.min.js',
-            'node_modules/angular-route/angular-route.js',
-            'node_modules/angular-sanitize/angular-sanitize.js',
+            'node_modules/angular-route/angular-route.min.js',
+            'node_modules/angular-sanitize/angular-sanitize.min.js',
             'node_modules/angular-mocks/angular-mocks.js',
-            'node_modules/angular-ui-sortable/dist/sortable.js',
+            'node_modules/angular-ui-sortable/dist/sortable.min.js',
             'node_modules/underscore/underscore-min.js',
             'node_modules/moment/min/moment-with-locales.js',
             'lib/umbraco/Extensions.js',
@@ -34,12 +34,12 @@ module.exports = function (config) {
             'test/config/app.unit.js',
 
             //application files
-            '../Umbraco.Web.UI/Umbraco/js/*.controllers.js',
-            '../Umbraco.Web.UI/Umbraco/js/*.directives.js',
-            '../Umbraco.Web.UI/Umbraco/js/*.filters.js',
-            '../Umbraco.Web.UI/Umbraco/js/*.services.js',
-            '../Umbraco.Web.UI/Umbraco/js/*.interceptors.js',
-            '../Umbraco.Web.UI/Umbraco/js/*.resources.js',
+            '../Umbraco.Web.UI/Umbraco/js/*.controllers.min.js',
+            '../Umbraco.Web.UI/Umbraco/js/*.directives.min.js',
+            '../Umbraco.Web.UI/Umbraco/js/*.filters.min.js',
+            '../Umbraco.Web.UI/Umbraco/js/*.services.min.js',
+            '../Umbraco.Web.UI/Umbraco/js/*.interceptors.min.js',
+            '../Umbraco.Web.UI/Umbraco/js/*.resources.min.js',
 
             //mocked data and routing
             'src/common/mocks/umbraco.servervariables.js',


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As-is we let Smidge perform runtime optimization and bundling of all client scripts - both the ones shipped with Umbraco and the ones for backoffice extensions. We even optimize some 3rd party libraries runtime, because we ship Umbraco with un-minified versions of these libraries.

This PR aims at minimizing the runtime overhead by never optimizing any of the scripts shipped with Umbraco. This is done by:

1. Ensuring we only ship minified versions of 3rd party libraries.
2. Minifying the core scripts as part of the build process.
3. Splitting the "main script bundle" into two separate bundles - a bundle for the core scripts and a bundle for the backoffice extensions scripts.
4. Only performing optimization/minification on the backoffice extensions bundle. The core bundles now only exist to handle cache busting of the core scripts.

#### Limitations

A few of the core script files aren't part of the gulp setup, namely the files in `\src\Umbraco.Web.UI.Client\lib\umbraco\`. They currently work as both source files and script libraries at the same time. This should really be changed, so they can be rolled into the same setup as the rest of the source files. For now they are excempted from the minification and will remain un-minified in this setup - even in production builds. Fortunately the files are very small, so they represent next to no overhead. 

- `\src\Umbraco.Web.UI.Client\lib\umbraco\Extensions.js`
- `\src\Umbraco.Web.UI.Client\lib\umbraco\LegacySpeechBubble.js`
- `\src\Umbraco.Web.UI.Client\lib\umbraco\NamespaceManager.js`

I'm not really sure that `LegacySpeechBubble.js` and `NamespaceManager.js` are even used by the core anymore, so perhaps they should be cleaned up for the Unicore release.

### Testing this PR

#### Test the default dev setup

First of all, test that the backoffice runs as usual:

1. Stop your dev site if it's running.
2. Delete everything under `\src\Umbraco.Web.UI.NetCore\wwwroot\umbraco` (it's all output from the client build).
3. Build the client by running `gulp dev`.
	- Notice how the generated script files in `\src\Umbraco.Web.UI.NetCore\wwwroot\umbraco\js` are actually un-minified despite their `.min.js` extension, since they have been built in dev mode.
4. Boot up the site and log into the backoffice with Chrome devtools open.
5. Verify that you can click around in the backoffice and that there are no nasty console errors.
6. Use the devtools network tab to verify that the client really did load the generated `.min.js` files.
![debug-mode-js-files](https://user-images.githubusercontent.com/7405322/108335740-919dad00-71d3-11eb-8945-e6356b650a87.png)

#### Test the bundles

Test that the backoffice core and extensions scripts are split into separate bundles, and that the core bundle is not minified runtime:

1. Stop your dev site.
2. Disable debug mode in app settings (`Umbraco.CMS.Hosting.Debug`).
3. Increment the runtime version in app settings (`Umbraco.CMS.RuntimeMinification.version`).
![runtime-version](https://user-images.githubusercontent.com/7405322/108335841-aa0dc780-71d3-11eb-86f2-aefae577d41e.png)
4. Unzip this test dashboard: [MyDashboard.zip](https://github.com/umbraco/Umbraco-CMS/files/6001680/MyDashboard.zip) to `\src\Umbraco.Web.UI.NetCore\App_Plugins` _and_ `\src\Umbraco.Web.UI.NetCore\wwwroot\App_Plugins`.
	- Apparently there is a slight bug in plugin path detection for asset minification (it's not caused by this PR).
	![dashboard-unzip-locations](https://user-images.githubusercontent.com/7405322/108336562-73847c80-71d4-11eb-9408-d33779d108cb.png)
5. Boot up the site and log into the backoffice with Chrome devtools open.
6. Find the script bundle outputs by searching for _"backoffice js"_ in the devtools network tab - you will find two bundles, one for the backoffice core and one for the backoffice extensions (i.e. the installed dashboard).
	- Notice you must look under _All_, because the generated scripts won't list under _JS_ due to the bundle file extension.
	![chrome-devtools](https://user-images.githubusercontent.com/7405322/108335932-ca3d8680-71d3-11eb-8b41-a5ae122d21d8.png)
7. Inspect each bundle output in devtools, and verify that:
	1. The backoffice core bundle is comprised by minified 3rd party libraries (e.g. jQuery, AngularJs) and un-minified Umbraco scripts (controllers, services, ...) - you'll need to scroll quite a bit down to find the Umbraco scripts.
	![inspect-core-js](https://user-images.githubusercontent.com/7405322/108336346-3a4c0c80-71d4-11eb-8cb7-9d5f255d3e89.png)
	2. The backoffice extensions bundle contains minified scripts.
	![inspect-extensions-js](https://user-images.githubusercontent.com/7405322/108336371-40da8400-71d4-11eb-979e-dbdca47d6506.png)

#### Test the minification

To verify that the minification of the backoffice bundle works:

1. Stop your dev site.
2. Set `minify: true` in `\src\Umbraco.Web.UI.Client\gulp\config.js` for the client dev build.
![gulp-config-dev-minify](https://user-images.githubusercontent.com/7405322/108336583-7c754e00-71d4-11eb-987c-79e4eabed9f8.png)
3. Build the client by running `gulp dev`.
	- Notice how the generated script files in `\src\Umbraco.Web.UI.NetCore\wwwroot\umbraco\js` are now minified.
4. Increment the runtime version in app settings (`Umbraco.CMS.RuntimeMinification.version`).
5. Boot up the site and log into the backoffice with Chrome devtools open.
6. Inspect the bundles in Chrome devtools and verify that the Umbraco scripts are now served minified, just like the 3rd party libraries (with the exception of files mentioned under Limitations in the PR description).

### Other optimizations (out of scope for this PR)

I think the CSS shipped with Umbraco could be handled in a similar approach. If this PR is accepted I'll have a look at that later on.

It would be beneficial to generate the core bundles as single file outputs in the client build, instead of having Smidge join them together at runtime. Note however that some of the individual files are referenced by other parts of Umbraco outside of their respective bundles. It would be required to create new bundles for these usages as well. On the upside that would mean we could ensure appropriate cache busting for these usages too.
