### PR TITLE
Fixes #9625 - Searching icons for "box" returns all icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
@@ -10,6 +10,10 @@ function IconPickerController($scope, localizationService, iconHelper) {
 
     var vm = this;
 
+    vm.filter = {
+        searchTerm: ''
+    };
+
     vm.selectIcon = selectIcon;
     vm.selectColor = selectColor;
     vm.submit = submit;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -20,7 +20,7 @@
                 <div class="umb-control-group">
                     <umb-search-filter
                         input-id="icon-search"
-                        model="searchTerm"
+                        model="vm.filter.searchTerm"
                         label-key="placeholders_filter"
                         text="Type to filter..."
                         css-class="w-100"
@@ -42,7 +42,7 @@
 
                 <div class="umb-control-group" ng-show="!vm.loading && filtered.length > 0 ">
                     <ul class="umb-iconpicker" ng-class="vm.color.value" ng-show="vm.icons">
-                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: searchTerm | orderBy:'name') track by $id(icon)">
+                        <li class="umb-iconpicker-item" ng-class="{'-selected': icon.name == model.icon}" ng-repeat="icon in filtered = (vm.icons | filter: { 'name': vm.filter.searchTerm } | orderBy:'name') track by $id(icon)">
                             <button type="button" title="{{icon.name}}" ng-click="vm.selectIcon(icon.name, vm.color.value)">
                                 <umb-icon class="umb-iconpicker-svg {{icon.name}} large" icon="{{icon.name}}"></umb-icon>
                                 <span class="sr-only"><localize key="buttons_select">Select</localize> {{icon.name}}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9625

### Description
This PR fixes issues with filtering in icon picker and searching for terms like `box`, `view` and `svg` because these are included in the `svgString` property. We only need to filter on name property. In future releases we might be able to filter on tags or similar - see https://github.com/umbraco/Umbraco-CMS/issues/9122

![KnrdnWkyJc](https://user-images.githubusercontent.com/2919859/108472470-13054600-728d-11eb-9daf-761798e6f27f.gif)

Btw in this GIF I have installed the [Material Design Icon Pack](https://our.umbraco.com/packages/backoffice-extensions/material-design-icon-pack/), which doen't use SVG icons, but demonstrate the filtering also works with custom icons.

This is similar to other filtering where we are working with objects, e.g. in block picker where filter on "image" doesn't really filter anything as mentioned in https://github.com/umbraco/Umbraco-CMS/pull/9831
We can look at this in another PR.