### PR TITLE
Rename UmbracoVersion.Current to UmbracoVersion.Version

### DIFF
--- a/src/Umbraco.Core/Configuration/IUmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/IUmbracoVersion.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.Configuration
         /// <summary>
         /// Gets the non-semantic version of the Umbraco code.
         /// </summary>
-        Version Current { get; }
+        Version Version { get; }
 
         /// <summary>
         /// Gets the semantic version comments of the Umbraco code.

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using Umbraco.Cms.Core.Semver;
 using Umbraco.Extensions;
@@ -25,14 +25,13 @@ namespace Umbraco.Cms.Core.Configuration
             SemanticVersion = SemVersion.Parse(umbracoCoreAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion);
 
             // gets the non-semantic version
-            Current = SemanticVersion.GetVersion(3);
+            Version = SemanticVersion.GetVersion(3);
         }
 
         /// <summary>
         /// Gets the non-semantic version of the Umbraco code.
         /// </summary>
-        // TODO: rename to Version
-        public Version Current { get; }
+        public Version Version { get; }
 
         /// <summary>
         /// Gets the semantic version comments of the Umbraco code.

--- a/src/Umbraco.Core/Models/UpgradeCheckResponse.cs
+++ b/src/Umbraco.Core/Models/UpgradeCheckResponse.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Runtime.Serialization;
 using Umbraco.Cms.Core.Configuration;
 
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.Models
         {
             Type = upgradeType;
             Comment = upgradeComment;
-            Url = upgradeUrl + "?version=" + WebUtility.UrlEncode(umbracoVersion.Current.ToString(3));
+            Url = upgradeUrl + "?version=" + WebUtility.UrlEncode(umbracoVersion.Version.ToString(3));
         }
     }
 }

--- a/src/Umbraco.Core/Packaging/PackageDefinitionXmlParser.cs
+++ b/src/Umbraco.Core/Packaging/PackageDefinitionXmlParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
@@ -81,7 +81,7 @@ namespace Umbraco.Cms.Core.Packaging
                 new XAttribute("name", def.Name ?? string.Empty),
                 new XAttribute("packagePath", def.PackagePath ?? string.Empty),
                 new XAttribute("iconUrl", def.IconUrl ?? string.Empty),
-                new XAttribute("umbVersion", def.UmbracoVersion ?? _umbracoVersion.Current),
+                new XAttribute("umbVersion", def.UmbracoVersion ?? _umbracoVersion.Version),
                 new XAttribute("packageGuid", def.PackageId),
                 new XAttribute("view", def.PackageView ?? string.Empty),
 

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -98,8 +98,8 @@ namespace Umbraco.Web.Install
                 }
 
                 var installLog = new InstallLog(installId: installId, isUpgrade: IsBrandNewInstall == false,
-                    installCompleted: isCompleted, timestamp: DateTime.Now, versionMajor: _umbracoVersion.Current.Major,
-                    versionMinor: _umbracoVersion.Current.Minor, versionPatch: _umbracoVersion.Current.Build,
+                    installCompleted: isCompleted, timestamp: DateTime.Now, versionMajor: _umbracoVersion.Version.Major,
+                    versionMinor: _umbracoVersion.Version.Minor, versionPatch: _umbracoVersion.Version.Build,
                     versionComment: _umbracoVersion.Comment, error: errorMsg, userAgent: userAgent,
                     dbProvider: dbProvider);
 
@@ -145,7 +145,7 @@ namespace Umbraco.Web.Install
             var packages = new List<Package>();
             try
             {
-                var requestUri = $"https://our.umbraco.com/webapi/StarterKit/Get/?umbracoVersion={_umbracoVersion.Current}";
+                var requestUri = $"https://our.umbraco.com/webapi/StarterKit/Get/?umbracoVersion={_umbracoVersion.Version}";
 
                 using (var request = new HttpRequestMessage(HttpMethod.Get, requestUri))
                 {

--- a/src/Umbraco.Infrastructure/Install/InstallSteps/StarterKitDownloadStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/StarterKitDownloadStep.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -70,7 +70,7 @@ namespace Umbraco.Web.Install.InstallSteps
         private async Task<(string packageFile, int packageId)> DownloadPackageFilesAsync(Guid kitGuid)
         {
             //Go get the package file from the package repo
-            var packageFile = await _packageService.FetchPackageFileAsync(kitGuid, _umbracoVersion.Current, _backofficeSecurityAccessor.BackOfficeSecurity.GetUserId().ResultOr(0));
+            var packageFile = await _packageService.FetchPackageFileAsync(kitGuid, _umbracoVersion.Version, _backofficeSecurityAccessor.BackOfficeSecurity.GetUserId().ResultOr(0));
             if (packageFile == null) throw new InvalidOperationException("Could not fetch package file " + kitGuid);
 
             //add an entry to the installedPackages.config

--- a/src/Umbraco.Infrastructure/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/RuntimeState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -54,7 +54,7 @@ namespace Umbraco.Core
 
 
         /// <inheritdoc />
-        public Version Version => _umbracoVersion.Current;
+        public Version Version => _umbracoVersion.Version;
 
         /// <inheritdoc />
         public string VersionComment => _umbracoVersion.Comment;

--- a/src/Umbraco.Web.BackOffice/Controllers/PackageInstallController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PackageInstallController.cs
@@ -139,7 +139,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             if (ins.UmbracoVersionRequirementsType == RequirementsType.Strict)
             {
                 var packageMinVersion = ins.UmbracoVersion;
-                if (_umbracoVersion.Current < packageMinVersion)
+                if (_umbracoVersion.Version < packageMinVersion)
                 {
                     model.IsCompatible = false;
                 }
@@ -223,7 +223,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             {
                 var packageFile = await _packagingService.FetchPackageFileAsync(
                     Guid.Parse(packageGuid),
-                    _umbracoVersion.Current,
+                    _umbracoVersion.Version,
                     _backofficeSecurityAccessor.BackOfficeSecurity.GetUserId().ResultOr(0));
 
                 fileName = packageFile.Name;
@@ -267,7 +267,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             if (packageInfo.UmbracoVersionRequirementsType == RequirementsType.Strict)
             {
                 var packageMinVersion = packageInfo.UmbracoVersion;
-                if (_umbracoVersion.Current < packageMinVersion)
+                if (_umbracoVersion.Version < packageMinVersion)
                     return ValidationErrorResult.CreateNotificationValidationErrorResult(
                         _localizedTextService.Localize("packager/targetVersionMismatch", new[] {packageMinVersion.ToString()}));
             }

--- a/src/Umbraco.Web.BackOffice/Controllers/UpdateCheckController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UpdateCheckController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -49,8 +49,8 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             {
                 try
                 {
-                    var version = new SemVersion(_umbracoVersion.Current.Major, _umbracoVersion.Current.Minor,
-                        _umbracoVersion.Current.Build, _umbracoVersion.Comment);
+                    var version = new SemVersion(_umbracoVersion.Version.Major, _umbracoVersion.Version.Minor,
+                        _umbracoVersion.Version.Build, _umbracoVersion.Comment);
                     var result = await _upgradeService.CheckUpgrade(version);
 
                     return new UpgradeCheckResponse(result.UpgradeType, result.Comment, result.UpgradeUrl, _umbracoVersion);

--- a/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
+++ b/src/Umbraco.Web/Security/Providers/UmbracoMembershipProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Configuration.Provider;
 using System.Linq;
@@ -319,7 +319,7 @@ namespace Umbraco.Web.Security.Providers
             if (userIsOnline)
             {
                 // when upgrading from 7.2 to 7.3 trying to save will throw
-                if (_umbracoVersion.Current >= new Version(7, 3, 0, 0))
+                if (_umbracoVersion.Version >= new Version(7, 3, 0, 0))
                 {
                     var now = DateTime.Now;
                     // update the database data directly instead of a full member save which requires DB locks
@@ -566,7 +566,7 @@ namespace Umbraco.Web.Security.Providers
             if (requiresFullSave)
             {
                 // when upgrading from 7.2 to 7.3 trying to save will throw
-                if (_umbracoVersion.Current >= new Version(7, 3, 0, 0))
+                if (_umbracoVersion.Version >= new Version(7, 3, 0, 0))
                     MemberService.Save(member, false);
             }
             else


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Renaming `UmbracoVersion.Current` to `UmbracoVersion.Version` is an old TODO from the V8 code. 

I figured it would be nice to get that done, before the Unicore betas start rolling out, as runtime access to the Umbraco version is likely to be used by all sorts of 3rd party packages out there. Best to break it before the betas.

If you feel the urge to test this, create a template with the following content and observe how the current Umbraco version is very neatly printed when it's rendered 😆 

```cshtml
@using Umbraco.Cms.Core.Configuration
@inject IUmbracoVersion umbracoVersion
@inherits Umbraco.Cms.Web.Common.AspNetCore.UmbracoViewPage
@{
  Layout = null;
}
<html>
<body>
  <h1>Version is: @umbracoVersion.Version</h1>
</body>
</html>
```