### PR TITLE
Clean up the IO Helper interface

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -1258,51 +1258,6 @@ namespace Umbraco.Extensions
                    && Path.IsPathRooted(path)
                    && Path.GetPathRoot(path).Equals(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) == false;
         }
-
-        /// <summary>
-        /// Based on the input string, this will detect if the string is a JS path or a JS snippet.
-        /// If a path cannot be determined, then it is assumed to be a snippet the original text is returned
-        /// with an invalid attempt, otherwise a valid attempt is returned with the resolved path
-        /// </summary>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// This is only used for legacy purposes for the Action.JsSource stuff and shouldn't be needed in v8
-        /// </remarks>
-        internal static Attempt<string> DetectIsJavaScriptPath(this string input, IIOHelper ioHelper)
-        {
-            //validate that this is a url, if it is not, we'll assume that it is a text block and render it as a text
-            //block instead.
-            var isValid = true;
-
-            if (Uri.IsWellFormedUriString(input, UriKind.RelativeOrAbsolute))
-            {
-                //ok it validates, but so does alert('hello'); ! so we need to do more checks
-
-                //here are the valid chars in a url without escaping
-                if (Regex.IsMatch(input, @"[^a-zA-Z0-9-._~:/?#\[\]@!$&'\(\)*\+,%;=]"))
-                    isValid = false;
-
-                //we'll have to be smarter and just check for certain js patterns now too!
-                var jsPatterns = new[] { @"\+\s*\=", @"\);", @"function\s*\(", @"!=", @"==" };
-                if (jsPatterns.Any(p => Regex.IsMatch(input, p)))
-                    isValid = false;
-
-                if (isValid)
-                {
-                    var resolvedUrlResult = ioHelper.TryResolveUrl(input);
-                    //if the resolution was success, return it, otherwise just return the path, we've detected
-                    // it's a path but maybe it's relative and resolution has failed, etc... in which case we're just
-                    // returning what was given to us.
-                    return resolvedUrlResult.Success
-                        ? resolvedUrlResult
-                        : Attempt.Succeed(input);
-                }
-            }
-
-            return Attempt.Fail(input);
-        }
-
 
         // FORMAT STRINGS
 

--- a/src/Umbraco.Core/IO/IIOHelper.cs
+++ b/src/Umbraco.Core/IO/IIOHelper.cs
@@ -8,10 +8,8 @@ namespace Umbraco.Cms.Core.IO
     {
         string FindFile(string virtualPath);
 
-        // TODO: This is the same as IHostingEnvironment.ToAbsolute
+        [Obsolete("Use IHostingEnvironment.ToAbsolute instead")]
         string ResolveUrl(string virtualPath);
-
-        Attempt<string> TryResolveUrl(string virtualPath);
 
         /// <summary>
         /// Maps a virtual path to a physical path in the content root folder (i.e. www)
@@ -20,14 +18,6 @@ namespace Umbraco.Cms.Core.IO
         /// <returns></returns>
         [Obsolete("Use IHostingEnvironment.MapPathContentRoot or IHostingEnvironment.MapPathWebRoot instead")]
         string MapPath(string path);
-
-        /// <summary>
-        /// Returns true if the path has a root, and is considered fully qualified for the OS it is on
-        /// See https://github.com/dotnet/runtime/blob/30769e8f31b20be10ca26e27ec279cd4e79412b9/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L281 for the .NET Standard 2.1 version of this
-        /// </summary>
-        /// <param name="path">The path to check</param>
-        /// <returns>True if the path is fully qualified, false otherwise</returns>
-        bool IsPathFullyQualified(string path);
 
         /// <summary>
         /// Verifies that the current filepath matches a directory where the user is allowed to edit a file.

--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -36,29 +36,12 @@ namespace Umbraco.Cms.Core.IO
             return retval;
         }
 
-        // TODO: This is the same as IHostingEnvironment.ToAbsolute
+        // TODO: This is the same as IHostingEnvironment.ToAbsolute - marked as obsolete in IIOHelper for now
         public string ResolveUrl(string virtualPath)
         {
             if (string.IsNullOrWhiteSpace(virtualPath)) return virtualPath;
             return _hostingEnvironment.ToAbsolute(virtualPath);
 
-        }
-
-        public Attempt<string> TryResolveUrl(string virtualPath)
-        {
-            try
-            {
-                if (virtualPath.StartsWith("~"))
-                    return Attempt.Succeed(virtualPath.Replace("~", _hostingEnvironment.ApplicationVirtualPath).Replace("//", "/"));
-                if (Uri.IsWellFormedUriString(virtualPath, UriKind.Absolute))
-                    return Attempt.Succeed(virtualPath);
-
-                return Attempt.Succeed(_hostingEnvironment.ToAbsolute(virtualPath));
-            }
-            catch (Exception ex)
-            {
-                return Attempt.Fail(virtualPath, ex);
-            }
         }
 
         public string MapPath(string path)

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -37,19 +37,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
             Assert.AreEqual(result, first.ToGuid() == second.ToGuid());
         }
 
-        [TestCase("alert('hello');", false)]
-        [TestCase("~/Test.js", true)]
-        [TestCase("../Test.js", true)]
-        [TestCase("/Test.js", true)]
-        [TestCase("Test.js", true)]
-        [TestCase("Test.js==", false)]
-        [TestCase("/Test.js function(){return true;}", false)]
-        public void Detect_Is_JavaScript_Path(string input, bool result)
-        {
-            Attempt<string> output = input.DetectIsJavaScriptPath(Mock.Of<IIOHelper>());
-            Assert.AreEqual(result, output.Success);
-        }
-
         [TestCase("hello.txt", "hello")]
         [TestCase("this.is.a.Txt", "this.is.a")]
         [TestCase("this.is.not.a. Txt", "this.is.not.a. Txt")]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There really is no testing this one 😄 I have performed a little housekeeping on `IIOHelper`:

- `TryResolveUrl` has been removed entirely, since it was only called from the unused method `DetectIsJavaScriptPath` on `StringExtensions` (deprecated/legacy JS handling that is no longer in use).
- `ResolveUrl` has been marked as obsolete, as it only forwards the call to `IHostingEnvironment.ToAbsolute` now.
- `IsPathFullyQualified` has been removed from the interface. Its implementation is retained in (and used by) `IOHelper`, but it's likely to be replaced by the .net standard implementation down the line. The method it is never used outside of `IOHelper`, so there is no acute need for it to be part of the interface.
