### PR TITLE
Removed unused method from migration expression interface

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Rename/Expressions/RenameColumnExpression.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Rename/Expressions/RenameColumnExpression.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Core.Migrations.Expressions.Rename.Expressions
+namespace Umbraco.Core.Migrations.Expressions.Rename.Expressions
 {
     public class RenameColumnExpression : MigrationExpressionBase
     {
@@ -9,9 +9,6 @@
         public virtual string TableName { get; set; }
         public virtual string OldName { get; set; }
         public virtual string NewName { get; set; }
-
-        public override string Process(IMigrationContext context)
-            => GetSql();
 
         /// <inheritdoc />
         protected override string GetSql()

--- a/src/Umbraco.Infrastructure/Migrations/IMigrationExpression.cs
+++ b/src/Umbraco.Infrastructure/Migrations/IMigrationExpression.cs
@@ -1,11 +1,10 @@
-﻿namespace Umbraco.Core.Migrations
+namespace Umbraco.Core.Migrations
 {
     /// <summary>
     /// Marker interface for migration expressions
     /// </summary>
     public interface IMigrationExpression
     {
-        string Process(IMigrationContext context); // TODO: remove that one?
         void Execute();
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -33,11 +33,6 @@ namespace Umbraco.Core.Migrations
         public DatabaseType DatabaseType => Context.Database.DatabaseType;
 
         public List<IMigrationExpression> Expressions => _expressions ?? (_expressions = new List<IMigrationExpression>());
-
-        public virtual string Process(IMigrationContext context)
-        {
-            return ToString();
-        }
 
         protected virtual string GetSql()
         {


### PR DESCRIPTION
### Description

The `Process()` method of the public interface `IMigrationExpression` is unused and has also been flagged for removal, so I removed it 😄 

Both implementations of `Process()` have also been removed, as all they did was to call `ToString()` eventually.