### PR TITLE
Remove obsolete method in UmbracoBuilderExtensions

### DIFF
--- a/src/Umbraco.Tests/TestHelpers/BaseUsingSqlCeSyntax.cs
+++ b/src/Umbraco.Tests/TestHelpers/BaseUsingSqlCeSyntax.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Tests.TestHelpers
 
             services.AddUnique<ISqlContext>(_ => SqlContext);
 
-            var factory = Current.Factory = composition.CreateServiceProvider();
+            var factory = Current.Factory = TestHelper.CreateServiceProvider(composition);
 
             var pocoMappers = new NPoco.MapperCollection { new PocoMapper() };
             var pocoDataFactory = new FluentPocoDataFactory((type, iPocoDataFactory) => new PocoDataBuilder(type, pocoMappers).Init());

--- a/src/Umbraco.Tests/TestHelpers/TestHelper.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,6 +18,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Diagnostics;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -345,5 +346,11 @@ namespace Umbraco.Tests.TestHelpers
         }
 
         public static IPublishedUrlProvider GetPublishedUrlProvider() => _testHelperInternal.GetPublishedUrlProvider();
+
+        public static IServiceProvider CreateServiceProvider(IUmbracoBuilder builder)
+        {
+            builder.Build();
+            return builder.Services.BuildServiceProvider();
+        }
     }
 }

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -242,7 +242,7 @@ namespace Umbraco.Tests.Testing
 
             TestObjects = new TestObjects();
             Compose();
-            Current.Factory = Factory = Builder.CreateServiceProvider();
+            Current.Factory = Factory = TestHelper.CreateServiceProvider(Builder);
             Initialize();
         }
 

--- a/src/Umbraco.Web/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web/UmbracoBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Routing;
@@ -11,13 +11,6 @@ namespace Umbraco.Web
     /// </summary>
     public static class UmbracoBuilderExtensions
     {
-        [Obsolete("This extension method exists only to ease migration, please refactor")]
-        public static IServiceProvider CreateServiceProvider(this IUmbracoBuilder builder)
-        {
-            builder.Build();
-            return builder.Services.BuildServiceProvider();
-        }
-
         #region Uniques
 
         /// <summary>


### PR DESCRIPTION
### Description

The extension method `CreateServiceProvider` on `UmbracoBuilderExtensions` is marked as obsolete. 

As of now the extension method is solely used for wiring up tests, so I have moved the implementation to `TestHelper` instead, so the method doesn't clutter the `UmbracoBuilderExtensions` class.