### PR TITLE
Reduce cold boot times by loading content and media only once on cold boot

### DIFF
--- a/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Core.Sync
     // but only processes instructions coming from remote servers,
     // thus ensuring that instructions run only once
     //
-    public class DatabaseServerMessenger : ServerMessengerBase
+    public class DatabaseServerMessenger : ServerMessengerBase, ISyncBootStateAccessor
     {
         private readonly IRuntimeState _runtime;
         private readonly ManualResetEvent _syncIdle;
@@ -172,35 +172,7 @@ namespace Umbraco.Core.Sync
             lock (_locko)
             {
                 if (_released) return;
-
-                var coldboot = false;
-                if (_lastId < 0) // never synced before
-                {
-                    // we haven't synced - in this case we aren't going to sync the whole thing, we will assume this is a new
-                    // server and it will need to rebuild it's own caches, eg Lucene or the xml cache file.
-                    Logger.Warn<DatabaseServerMessenger>("No last synced Id found, this generally means this is a new server/install."
-                        + " The server will build its caches and indexes, and then adjust its last synced Id to the latest found in"
-                        + " the database and maintain cache updates based on that Id.");
-
-                    coldboot = true;
-                }
-                else
-                {
-                    //check for how many instructions there are to process, each row contains a count of the number of instructions contained in each
-                    //row so we will sum these numbers to get the actual count.
-                    var count = database.ExecuteScalar<int>("SELECT SUM(instructionCount) FROM umbracoCacheInstruction WHERE id > @lastId", new {lastId = _lastId});
-                    if (count > Options.MaxProcessingInstructionCount)
-                    {
-                        //too many instructions, proceed to cold boot
-                        Logger.Warn<DatabaseServerMessenger>(
-                            "The instruction count ({InstructionCount}) exceeds the specified MaxProcessingInstructionCount ({MaxProcessingInstructionCount})."
-                            + " The server will skip existing instructions, rebuild its caches and indexes entirely, adjust its last synced Id"
-                            + " to the latest found in the database and maintain cache updates based on that Id.",
-                            count, Options.MaxProcessingInstructionCount);
-
-                        coldboot = true;
-                    }
-                }
+                var coldboot = IsColdBoot(database);
 
                 if (coldboot)
                 {
@@ -221,6 +193,40 @@ namespace Umbraco.Core.Sync
 
                 _initialized = true;
             }
+        }
+
+        private bool IsColdBoot(IUmbracoDatabase database)
+        {
+            var coldboot = false;
+            if (_lastId < 0) // never synced before
+            {
+                // we haven't synced - in this case we aren't going to sync the whole thing, we will assume this is a new
+                // server and it will need to rebuild it's own caches, eg Lucene or the xml cache file.
+                Logger.Warn<DatabaseServerMessenger>("No last synced Id found, this generally means this is a new server/install."
+                    + " The server will build its caches and indexes, and then adjust its last synced Id to the latest found in"
+                    + " the database and maintain cache updates based on that Id.");
+
+                    coldboot = true;
+                }
+                else
+                {
+                    //check for how many instructions there are to process, each row contains a count of the number of instructions contained in each
+                    //row so we will sum these numbers to get the actual count.
+                    var count = database.ExecuteScalar<int>("SELECT SUM(instructionCount) FROM umbracoCacheInstruction WHERE id > @lastId", new {lastId = _lastId});
+                    if (count > Options.MaxProcessingInstructionCount)
+                    {
+                        //too many instructions, proceed to cold boot
+                        Logger.Warn<DatabaseServerMessenger>(
+                            "The instruction count ({InstructionCount}) exceeds the specified MaxProcessingInstructionCount ({MaxProcessingInstructionCount})."
+                            + " The server will skip existing instructions, rebuild its caches and indexes entirely, adjust its last synced Id"
+                            + " to the latest found in the database and maintain cache updates based on that Id.",
+                            count, Options.MaxProcessingInstructionCount);
+
+                    coldboot = true;
+                }
+            }
+
+            return coldboot;
         }
 
         /// <summary>
@@ -547,6 +553,30 @@ namespace Umbraco.Core.Sync
         }
 
         #endregion
+
+        public SyncBootState GetSyncBootState()
+        {
+            try
+            {
+                ReadLastSynced(); // get _lastId
+                using (var scope = ScopeProvider.CreateScope())
+                {
+                    EnsureInstructions(scope.Database);
+                    bool isColdBoot = IsColdBoot(scope.Database);
+
+                    if (isColdBoot)
+                    {
+                        return SyncBootState.ColdBoot;
+                    }
+                    return SyncBootState.HasSyncState;
+                }
+            }
+            catch(Exception ex)
+            {
+                Logger.Warn<DatabaseServerMessenger>("Error determining Sync Boot State", ex);
+                return SyncBootState.Unknown;
+            }
+        }
 
         #region Notify refreshers
 

--- a/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Sync
+{
+    /// <summary>
+    /// Retrieve the state of the sync service
+    /// </summary>
+    public interface ISyncBootStateAccessor
+    {
+        /// <summary>
+        /// Get the boot state
+        /// </summary>
+        /// <returns></returns>
+        SyncBootState GetSyncBootState();
+    }
+    public enum SyncBootState
+    {
+        /// <summary>
+        /// Unknown state. Treat as HasSyncState
+        /// </summary>
+        Unknown = 0,
+        /// <summary>
+        /// Cold boot. No Sync state
+        /// </summary>
+        ColdBoot = 1,
+        /// <summary>
+        /// Warm boot. Sync state present
+        /// </summary>
+        HasSyncState = 2
+    }
+}

--- a/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
@@ -17,19 +17,4 @@ namespace Umbraco.Core.Sync
         /// <returns></returns>
         SyncBootState GetSyncBootState();
     }
-    public enum SyncBootState
-    {
-        /// <summary>
-        /// Unknown state. Treat as HasSyncState
-        /// </summary>
-        Unknown = 0,
-        /// <summary>
-        /// Cold boot. No Sync state
-        /// </summary>
-        ColdBoot = 1,
-        /// <summary>
-        /// Warm boot. Sync state present
-        /// </summary>
-        HasSyncState = 2
-    }
 }

--- a/src/Umbraco.Core/Sync/NonRuntimeLevelBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/NonRuntimeLevelBootStateAccessor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Sync
+{
+    /// <summary>
+    /// Boot state implementation for when umbraco is not in the run state
+    /// </summary>
+    public class NonRuntimeLevelBootStateAccessor : ISyncBootStateAccessor
+    {
+        public SyncBootState GetSyncBootState()
+        {
+            return SyncBootState.Unknown;
+        }
+    }
+}

--- a/src/Umbraco.Core/Sync/SyncBootState.cs
+++ b/src/Umbraco.Core/Sync/SyncBootState.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Sync
+{
+    public enum SyncBootState
+    {
+        /// <summary>
+        /// Unknown state. Treat as HasSyncState
+        /// </summary>
+        Unknown = 0,
+        /// <summary>
+        /// Cold boot. No Sync state
+        /// </summary>
+        ColdBoot = 1,
+        /// <summary>
+        /// Warm boot. Sync state present
+        /// </summary>
+        HasSyncState = 2
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -174,6 +174,8 @@
     <Compile Include="Services\IInstallationService.cs" />
     <Compile Include="Services\IUpgradeService.cs" />
     <Compile Include="Sync\ISyncBootStateAccessor.cs" />
+    <Compile Include="Sync\NonRuntimeLevelBootStateAccessor.cs" />
+    <Compile Include="Sync\SyncBootState.cs" />
     <Compile Include="SystemLock.cs" />
     <Compile Include="Attempt.cs" />
     <Compile Include="AttemptOfTResult.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Migrations\Upgrade\V_8_7_0\MissingDictionaryIndex.cs" />
     <Compile Include="Services\IInstallationService.cs" />
     <Compile Include="Services\IUpgradeService.cs" />
+    <Compile Include="Sync\ISyncBootStateAccessor.cs" />
     <Compile Include="SystemLock.cs" />
     <Compile Include="Attempt.cs" />
     <Compile Include="AttemptOfTResult.cs" />

--- a/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Changes;
 using Umbraco.Core.Strings;
+using Umbraco.Core.Sync;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing.Objects;
 using Umbraco.Tests.Testing.Objects.Accessors;
@@ -155,7 +156,8 @@ namespace Umbraco.Tests.PublishedContent
                 globalSettings,
                 Mock.Of<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
 
             // invariant is the current default
             _variationAccesor.VariationContext = new VariationContext();

--- a/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Changes;
 using Umbraco.Core.Strings;
+using Umbraco.Core.Sync;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing.Objects;
 using Umbraco.Tests.Testing.Objects.Accessors;
@@ -201,7 +202,8 @@ namespace Umbraco.Tests.PublishedContent
                 globalSettings,
                 Mock.Of<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
 
             // invariant is the current default
             _variationAccesor.VariationContext = new VariationContext();

--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -99,7 +99,8 @@ namespace Umbraco.Tests.Scoping
                 Factory.GetInstance<IGlobalSettings>(),
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
         }
 
         protected UmbracoContext GetUmbracoContextNu(string url, int templateId = 1234, RouteData routeData = null, bool setSingleton = false, IUmbracoSettingsSection umbracoSettings = null, IEnumerable<IUrlProvider> urlProviders = null)

--- a/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Core.Sync;
+using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;
 using Umbraco.Web.PublishedCache;
@@ -70,7 +71,8 @@ namespace Umbraco.Tests.Services
                 Factory.GetInstance<IGlobalSettings>(),
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
         }
 
         public class LocalServerMessenger : ServerMessengerBase

--- a/src/Umbraco.Tests/TestHelpers/TestSyncBootStateAccessor.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestSyncBootStateAccessor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Sync;
+
+namespace Umbraco.Tests.TestHelpers
+{
+    class TestSyncBootStateAccessor : ISyncBootStateAccessor
+    {
+        private readonly SyncBootState _syncBootState;
+
+        public TestSyncBootStateAccessor(SyncBootState syncBootState)
+        {
+            _syncBootState = syncBootState;
+        }
+        public SyncBootState GetSyncBootState()
+        {
+            return _syncBootState;
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Services\RedirectUrlServiceTests.cs" />
     <Compile Include="Templates\HtmlLocalLinkParserTests.cs" />
     <Compile Include="TestHelpers\RandomIdRamDirectory.cs" />
+    <Compile Include="TestHelpers\TestSyncBootStateAccessor.cs" />
     <Compile Include="Testing\Objects\TestDataSource.cs" />
     <Compile Include="Published\PublishedSnapshotTestObjects.cs" />
     <Compile Include="Published\ModelTypeTests.cs" />

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -72,6 +72,7 @@ namespace Umbraco.Web.Compose
 
             composition.SetDatabaseServerMessengerOptions(GetDefaultOptions);
             composition.SetServerMessenger<BatchedDatabaseServerMessenger>();
+            composition.Register<ISyncBootStateAccessor, BatchedDatabaseServerMessenger>(Lifetime.Singleton);
         }
     }
 

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Web.Compose
 
             composition.SetDatabaseServerMessengerOptions(GetDefaultOptions);
             composition.SetServerMessenger<BatchedDatabaseServerMessenger>();
-            composition.Register<ISyncBootStateAccessor, BatchedDatabaseServerMessenger>(Lifetime.Singleton);
+            composition.Register<ISyncBootStateAccessor>(factory=> factory.GetInstance<IServerMessenger>() as BatchedDatabaseServerMessenger, Lifetime.Singleton);
         }
     }
 

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Core;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Sync;
 using Umbraco.Web.PublishedCache.NuCache.DataSource;
 
 namespace Umbraco.Web.PublishedCache.NuCache
@@ -9,6 +10,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
         public override void Compose(Composition composition)
         {
             base.Compose(composition);
+
+            //Overriden on Run state in DatabaseServerRegistrarAndMessengerComposer
+            composition.Register<ISyncBootStateAccessor, NonRuntimeLevelBootStateAccessor>(Lifetime.Singleton);
 
             // register the NuCache database data source
             composition.Register<IDataSource, DatabaseDataSource>();

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -225,7 +225,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             var okMedia = false;
             if (_syncBootStateAccessor.GetSyncBootState() == SyncBootState.ColdBoot)
             {
-                _logger.Warn<PublishedSnapshotService>("Sync Service is in a Cold Boot state. Skip LoadCachesOnStartup as the Sync Service will trigger a full reload");
+                _logger.Info<PublishedSnapshotService>("Sync Service is in a Cold Boot state. Skip LoadCachesOnStartup as the Sync Service will trigger a full reload");
                 _isReady = true;
                 return;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9779

### Description
What?

Lets the PublishedSnapshotService know if the servermessenger is going to cold boot so PublishedSnapshotService does not attempt to load all content and media twice.

Why?
Load content and media only once on cold boot saving significant boot time on sites with large amounts of content/media . Saves on memory as otherwise there is 2 generations of every content and media in memory at boot.

How to test?
Delete the NuCache.db and server sync state text file. The log message about loading content from the database should appear only once.