### PR TITLE
9841: Don't focus on nested content node at page load

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -105,12 +105,13 @@
         localizationService.localizeMany(["grid_addElement", "content_createEmpty", "actions_copy"]).then(function (data) {
             labels.grid_addElement = data[0];
             labels.content_createEmpty = data[1];
-            labels.copy_icon_title = data[2]
+            labels.copy_icon_title = data[2];
         });
 
-        function setCurrentNode(node) {
+        function setCurrentNode(node, focusNode) {
             updateModel();
             vm.currentNode = node;
+            vm.focusOnNode = focusNode;
         }
 
         var copyAllEntries = function () {
@@ -180,7 +181,7 @@
 
             var newNode = createNode(scaffold, null);
 
-            setCurrentNode(newNode);
+            setCurrentNode(newNode, true);
             setDirty();
             validate();
         };
@@ -202,7 +203,6 @@
             });
 
             const dialog = {
-                view: "itempicker",
                 orderBy: "$index",
                 view: "itempicker",
                 event: $event,
@@ -277,9 +277,9 @@
 
         vm.editNode = function (idx) {
             if (vm.currentNode && vm.currentNode.key === vm.nodes[idx].key) {
-                setCurrentNode(null);
+                setCurrentNode(null, false);
             } else {
-                setCurrentNode(vm.nodes[idx]);
+                setCurrentNode(vm.nodes[idx], true);
             }
         };
 
@@ -500,7 +500,7 @@
             setDirty();
             //updateModel();// done by setting current node...
 
-            setCurrentNode(newNode);
+            setCurrentNode(newNode, true);
         }
 
         function checkAbilityToPasteContent() {
@@ -592,7 +592,7 @@
 
                 // If there is only one item, set it as current node
                 if (vm.singleMode || (vm.nodes.length === 1 && vm.maxItems === 1)) {
-                    setCurrentNode(vm.nodes[0]);
+                    setCurrentNode(vm.nodes[0], false);
                 }
 
                 validate();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -16,7 +16,7 @@
                         <div class="umb-nested-content__header-bar"
                              ng-click="vm.editNode($index)"
                              ng-hide="vm.singleMode"
-                             umb-auto-focus="{{vm.currentNode.key === node.key ? 'true' : 'false'}}">
+                             umb-auto-focus="{{vm.focusOnNode && vm.currentNode.key === node.key ? 'true' : 'false'}}">
 
                             <div class="umb-nested-content__heading"><i ng-if="vm.showIcons" class="icon umb-nested-content__item-icon" ng-class="vm.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-class="{'--has-icon': vm.showIcons}" ng-bind="vm.getName($index)"></span></div>
 


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9841

### Description
How to check (based on starter install):

- Create a new data type (Nested content with Feature as item. Min items: 0, Max items: 1).
- Add this data type to a document type
- Open a node that is of type of that document type
- Create a new nested content node
- Save and publish and reload the page
- The page shouldn't focus on the nested content data type anymore

The nested content item will still focus if you create a new one, so you are able to tab through it.

![focus](https://user-images.githubusercontent.com/11466511/108638310-e15bcd00-748e-11eb-9ee2-c20d952b54d0.gif)
