### PR TITLE
Handling multiple values per field in Examine Management

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementresults.html
@@ -18,9 +18,9 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr ng-repeat="(key, val) in model.searchResultValues track by key">
+                            <tr ng-repeat="(key, values) in model.searchResultValues track by key">
                                 <td>{{key}}</td>
-                                <td style="word-break: break-word;">{{val}}</td>
+                                <td style="word-break: break-word;">{{values | umbCmsJoinArray:', '}}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -25,7 +25,6 @@ namespace Umbraco.Web.Editors
         private readonly IAppPolicyCache _runtimeCache;
         private readonly IndexRebuilder _indexRebuilder;
 
-
         public ExamineManagementController(IExamineManager examineManager, ILogger logger,
             AppCaches appCaches,
             IndexRebuilder indexRebuilder)
@@ -79,13 +78,10 @@ namespace Umbraco.Web.Editors
                 {
                     Id = x.Id,
                     Score = x.Score,
-                    //order the values by key
-                    Values = new Dictionary<string, string>(x.Values.OrderBy(y => y.Key).ToDictionary(y => y.Key, y => y.Value))
+                    Values = x.AllValues.OrderBy(y => y.Key).ToDictionary(y => y.Key, y => y.Value)
                 })
             };
         }
-
-
 
         /// <summary>
         /// Check if the index has been rebuilt
@@ -113,7 +109,6 @@ namespace Umbraco.Web.Editors
             return found != null
                 ? null
                 : CreateModel(index);
-
         }
 
         /// <summary>
@@ -167,8 +162,6 @@ namespace Umbraco.Web.Editors
             }
         }
 
-
-
         private ExamineIndexModel CreateModel(IIndex index)
         {
             var indexName = index.Name;
@@ -182,11 +175,13 @@ namespace Umbraco.Web.Editors
             }
 
             var isHealth = indexDiag.IsHealthy();
+
             var properties = new Dictionary<string, object>
             {
                 [nameof(IIndexDiagnostics.DocumentCount)] = indexDiag.DocumentCount,
                 [nameof(IIndexDiagnostics.FieldCount)] = indexDiag.FieldCount,
             };
+
             foreach (var p in indexDiag.Metadata)
                 properties[p.Key] = p.Value;
 
@@ -197,7 +192,6 @@ namespace Umbraco.Web.Editors
                 ProviderProperties = properties,
                 CanRebuild = _indexRebuilder.CanRebuild(index)
             };
-
 
             return indexerModel;
         }
@@ -210,7 +204,6 @@ namespace Umbraco.Web.Editors
                 searcher = index.GetSearcher();
                 return Request.CreateResponse(HttpStatusCode.OK);
             }
-
 
             //if we didn't find anything try to find it by an explicitly declared searcher
             if (_examineManager.TryGetSearcher(searcherName, out searcher))

--- a/src/Umbraco.Web/Models/ContentEditing/SearchResult.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/SearchResult.cs
@@ -16,6 +16,6 @@ namespace Umbraco.Web.Models.ContentEditing
         public int FieldCount => Values?.Count ?? 0;
 
         [DataMember(Name = "values")]
-        public IReadOnlyDictionary<string, string> Values { get; set; }
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Values { get; set; }
     }
 }


### PR DESCRIPTION
Examine / Lucene supports having multiple values per field, but the backoffice Examine Management dashboard only renders the first.

This PR sets to fix that by rendering all values for each field.

I have modified / cleaned up the API to return the true list of fields + values straight from the Examine results. In the backoffice values are now listed in a comma separated (`, `) list using the existing `umbCmsJoinArray` filter.

Before:

<img width="800" alt="Before" src="https://user-images.githubusercontent.com/16511093/108675958-679fff80-74df-11eb-8b15-bf0812944981.png">

After:

<img width="800" alt="After" src="https://user-images.githubusercontent.com/16511093/108675976-6ec70d80-74df-11eb-9335-c407a3b5b355.png">