### PR TITLE
9826: Make sure to set mculture after switching sections

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/navigation.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/navigation.controller.js
@@ -325,6 +325,9 @@ function NavigationController($scope, $rootScope, $location, $log, $q, $routePar
             var queryParams = {};
             if ($scope.selectedLanguage && $scope.selectedLanguage.culture) {
                 queryParams["culture"] = $scope.selectedLanguage.culture;
+                if (!mainCulture) {
+                    $location.search("mculture", $scope.selectedLanguage.culture);
+                }
             }
             var queryString = $.param(queryParams); //create the query string from the params object
         }


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9826

### Description
Bug could be reproduced like this:

- Update People and Person to be "Allow vary by culture"
- Add a new language
- Go to the log viewer and click on the "Not(@Level='Verbose') and Not(@Level='Debug')". There might be other ways of doing this, but I just managed to find this one. Basically, what you want to do is to get rid of the mculture query string.
- Go back to content and click on the People node
- You'll see an error. 

The whole stacktrace can be found in the issue. The problem here was that mculture wasn't in the url anymore and the getChildren call to Umbraco requires a culture to be given.

![fixMcultureIssue](https://user-images.githubusercontent.com/11466511/108677386-e1d58180-74e9-11eb-8972-9b43f86adfcc.gif)


