### PR TITLE
Keep custom claims that are flowed during security stamp validation

### DIFF
--- a/src/Umbraco.Web/Security/AppBuilderExtensions.cs
+++ b/src/Umbraco.Web/Security/AppBuilderExtensions.cs
@@ -175,7 +175,7 @@ namespace Umbraco.Web.Security
 
                     return SecurityStampValidator
                         .OnValidateIdentity<BackOfficeUserManager, BackOfficeIdentityUser, int>(
-                        TimeSpan.FromMinutes(3),
+                        TimeSpan.FromMinutes(30),
                         async (manager, user) =>
                         {
                             var regenerated = await manager.GenerateUserIdentityAsync(user);

--- a/src/Umbraco.Web/Security/AppBuilderExtensions.cs
+++ b/src/Umbraco.Web/Security/AppBuilderExtensions.cs
@@ -171,10 +171,17 @@ namespace Umbraco.Web.Security
                 // change a password or add an external login to your account.
                 OnValidateIdentity = context =>
                 {
+                    // capture the current ticket for the request
                     var identity = context.Identity;
 
                     return SecurityStampValidator
                         .OnValidateIdentity<BackOfficeUserManager, BackOfficeIdentityUser, int>(
+                        // This will re-verify the security stamp at a throttled 30 mins
+                        // (the standard/default set in aspnet identity).
+                        // This ensures that if the security stamp has changed - i.e. passwords,
+                        // external logins, or other security profile data changed behind the
+                        // scenes while being logged in, that they are logged out and have
+                        // to re-verify their identity.
                         TimeSpan.FromMinutes(30),
                         async (manager, user) =>
                         {

--- a/src/Umbraco.Web/Security/BackOfficeClaimsIdentityFactory.cs
+++ b/src/Umbraco.Web/Security/BackOfficeClaimsIdentityFactory.cs
@@ -27,12 +27,6 @@ namespace Umbraco.Web.Security
         {
             var baseIdentity = await base.CreateAsync(manager, user, authenticationType);
 
-            // now we can flow any custom claims that the actual user has currently assigned which could be done in the OnExternalLogin callback
-            foreach (var claim in user.Claims)
-            {
-                baseIdentity.AddClaim(new Claim(claim.ClaimType, claim.ClaimValue));
-            }
-
             var umbracoIdentity = new UmbracoBackOfficeIdentity(baseIdentity,
                 user.Id,
                 user.UserName,
@@ -40,11 +34,15 @@ namespace Umbraco.Web.Security
                 user.CalculatedContentStartNodeIds,
                 user.CalculatedMediaStartNodeIds,
                 user.Culture,
-                //NOTE - there is no session id assigned here, this is just creating the identity, a session id will be generated when the cookie is written
+                // NOTE - there is no session id assigned here, this is just creating the identity, a session id will be generated when the cookie is written
                 Guid.NewGuid().ToString(),
                 user.SecurityStamp,
                 user.AllowedSections,
                 user.Roles.Select(x => x.RoleId).ToArray());
+
+            // now we can flow any custom claims that the actual user has currently
+            // assigned which could be done in the OnExternalLogin callback
+            umbracoIdentity.MergeClaimsFromBackOfficeIdentity(user);
 
             return umbracoIdentity;
         }

--- a/src/Umbraco.Web/Security/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Web/Security/ClaimsIdentityExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using System.Security.Claims;
+using Umbraco.Core.Models.Identity;
+using Constants = Umbraco.Core.Constants;
+
+namespace Umbraco.Web.Security
+{
+    internal static class ClaimsIdentityExtensions
+    {
+        // Ignore these Claims when merging, these claims are dynamically added whenever the ticket
+        // is re-issued and we don't want to merge old values of these.
+        private static readonly string[] IgnoredClaims = new[] { ClaimTypes.CookiePath, Constants.Security.SessionIdClaimType };
+
+        internal static void MergeClaimsFromBackOfficeIdentity(this ClaimsIdentity destination, ClaimsIdentity source)
+        {
+            foreach (var claim in source.Claims
+                .Where(claim => !IgnoredClaims.Contains(claim.Type))
+                .Where(claim => !destination.HasClaim(claim.Type, claim.Value)))
+            {
+                destination.AddClaim(new Claim(claim.Type, claim.Value));
+            }
+        }
+
+        internal static void MergeClaimsFromBackOfficeIdentity(this ClaimsIdentity destination, BackOfficeIdentityUser source)
+        {
+            foreach (var claim in source.Claims
+                .Where(claim => !IgnoredClaims.Contains(claim.ClaimType))
+                .Where(claim => !destination.HasClaim(claim.ClaimType, claim.ClaimValue)))
+            {
+                destination.AddClaim(new Claim(claim.ClaimType, claim.ClaimValue));
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -288,6 +288,7 @@
     <Compile Include="Security\BackOfficeExternalLoginProviderErrorMiddlware.cs" />
     <Compile Include="Security\BackOfficeExternalLoginProviderErrors.cs" />
     <Compile Include="Security\BackOfficeExternalLoginProviderOptions.cs" />
+    <Compile Include="Security\ClaimsIdentityExtensions.cs" />
     <Compile Include="Security\SignOutAuditEventArgs.cs" />
     <Compile Include="Security\UserInviteEventArgs.cs" />
     <Compile Include="Services\DashboardService.cs" />


### PR DESCRIPTION
When auto linking with callbacks such as OnExternalLogin, custom claims can be added to the user which are flowed to the auth ticket/identity. However, when the security stamp validator executes, the identity is re-created manually without any knowledge of those custom claims so they are lost. 

This ensures that those custom claims flow through to the re-generated identity during the security stamp validation phase.

## Testing

This is annoying to test. The easiest way is to modify source code and breakpoint to verify that it's working.

* Change BackOfficeSignInManager and add a custom claim on sign in. This code will go in the method `PasswordSignInAsyncImpl` above the line: `// We need to verify that the user belongs to one or more groups that define content and media start nodes.` This is basically what would happen if we used auto linking with OnExternalLogin/OnAutoLinking callbacks to assign custom claims to the user.
   ```cs
                user.Claims.Add(new IdentityUserClaim<int>
                {
                    ClaimType = "TEST",
                    ClaimValue = "TESTING"
                });
   ```
* Change the 30 minute default throttling to 3 for testing in `AppBuilderExtensions.UseUmbracoBackOfficeCookieAuthentication`  in the `SecurityStampValidator` call where it is: `TimeSpan.FromMinutes(30)` -> change to `TimeSpan.FromMinutes(3)`
* Change the web.config `Umbraco.Core.TimeOutInMinutes` to 7
* Put a breakpoint in the callback function just below the change to `TimeSpan.FromMinutes(3)` on the line: `var regenerated...`
* Put a breakpoing on the line below that on: `regenerated.MergeClaimsFromBackOfficeIdentity`
* Put a breakpoint just below that on the line: `return regenerated;`

Then F5 and start the app. Login to the back office and wait a few minutes, at least 3 but less than 7. Then click on another section. In theory your break points will be hit. If they are not hit, click on another section (this is all about timing). Once your breakpoint is hit:

* Inspect the value of `identity.Claims` this will show a list of claims assigned to the current ticket and you will see a claim for "TEST"
* F5 to the next breakpoint. Inspect the value of `regenerated.Claims`, this will show a list of claims assigned to the regenerated identity, you will NOT see a "TEST" claim
* F5 to the next breakpoint. Inspect the value of `regenerated.Claims`, this will show a list of claims assigned to the regenerated identity, you WILL see a "TEST" claim because this custom claim has been flowed to the outgoing ticket

Repeat the above again (waiting at least 3 minutes). The "TEST" claim should continue to flow.

Make sure you don't commit your custom code changes :) 