### PR TITLE
Remove a bunch of template related, unreferenced methods

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ITemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITemplateRepository.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Umbraco.Cms.Core.Models;
 
@@ -11,17 +11,8 @@ namespace Umbraco.Cms.Core.Persistence.Repositories
         IEnumerable<ITemplate> GetAll(params string[] aliases);
 
         IEnumerable<ITemplate> GetChildren(int masterTemplateId);
-        IEnumerable<ITemplate> GetChildren(string alias);
 
         IEnumerable<ITemplate> GetDescendants(int masterTemplateId);
-        IEnumerable<ITemplate> GetDescendants(string alias);
-
-        /// <summary>
-        /// Validates a <see cref="ITemplate"/>
-        /// </summary>
-        /// <param name="template"><see cref="ITemplate"/> to validate</param>
-        /// <returns>True if Script is valid, otherwise false</returns>
-        bool ValidateTemplate(ITemplate template);
 
         /// <summary>
         /// Gets the content of a template as a stream.
@@ -29,14 +20,5 @@ namespace Umbraco.Cms.Core.Persistence.Repositories
         /// <param name="filepath">The filesystem path to the template.</param>
         /// <returns>The content of the template.</returns>
         Stream GetFileContentStream(string filepath);
-
-        /// <summary>
-        /// Sets the content of a template.
-        /// </summary>
-        /// <param name="filepath">The filesystem path to the template.</param>
-        /// <param name="content">The content of the template.</param>
-        void SetFileContent(string filepath, Stream content);
-
-        long GetFileSize(string filepath);
     }
 }

--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Umbraco.Cms.Core.Models;
@@ -157,30 +157,9 @@ namespace Umbraco.Cms.Core.Services
         /// <summary>
         /// Gets the template descendants
         /// </summary>
-        /// <param name="alias"></param>
-        /// <returns></returns>
-        IEnumerable<ITemplate> GetTemplateDescendants(string alias);
-
-        /// <summary>
-        /// Gets the template descendants
-        /// </summary>
         /// <param name="masterTemplateId"></param>
         /// <returns></returns>
         IEnumerable<ITemplate> GetTemplateDescendants(int masterTemplateId);
-
-        /// <summary>
-        /// Gets the template children
-        /// </summary>
-        /// <param name="alias"></param>
-        /// <returns></returns>
-        IEnumerable<ITemplate> GetTemplateChildren(string alias);
-
-        /// <summary>
-        /// Gets the template children
-        /// </summary>
-        /// <param name="masterTemplateId"></param>
-        /// <returns></returns>
-        IEnumerable<ITemplate> GetTemplateChildren(int masterTemplateId);
 
         /// <summary>
         /// Saves a <see cref="ITemplate"/>
@@ -210,39 +189,11 @@ namespace Umbraco.Cms.Core.Services
         void DeleteTemplate(string alias, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
-        /// Validates a <see cref="ITemplate"/>
-        /// </summary>
-        /// <param name="template"><see cref="ITemplate"/> to validate</param>
-        /// <returns>True if template is valid, otherwise false</returns>
-        bool ValidateTemplate(ITemplate template);
-
-        /// <summary>
         /// Saves a collection of <see cref="Template"/> objects
         /// </summary>
         /// <param name="templates">List of <see cref="Template"/> to save</param>
         /// <param name="userId">Optional id of the user</param>
         void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId);
-
-        /// <summary>
-        /// Gets the content of a template as a stream.
-        /// </summary>
-        /// <param name="filepath">The filesystem path to the template.</param>
-        /// <returns>The content of the template.</returns>
-        Stream GetTemplateFileContentStream(string filepath);
-
-        /// <summary>
-        /// Sets the content of a template.
-        /// </summary>
-        /// <param name="filepath">The filesystem path to the template.</param>
-        /// <param name="content">The content of the template.</param>
-        void SetTemplateFileContent(string filepath, Stream content);
-
-        /// <summary>
-        /// Gets the size of a template.
-        /// </summary>
-        /// <param name="filepath">The filesystem path to the template.</param>
-        /// <returns>The size of the template.</returns>
-        long GetTemplateFileSize(string filepath);
 
         /// <summary>
         /// Gets the content of a stylesheet as a stream.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -450,16 +450,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
         }
 
-        public void SetFileContent(string filepath, Stream content)
-        {
-            GetFileSystem(filepath).AddFile(filepath, content, true);
-        }
-
-        public long GetFileSize(string filepath)
-        {
-            return GetFileSystem(filepath).GetSize(filepath);
-        }
-
         private IFileSystem GetFileSystem(string filepath)
         {
             var ext = Path.GetExtension(filepath);
@@ -508,14 +498,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             return children;
         }
 
-        public IEnumerable<ITemplate> GetChildren(string alias)
-        {
-            //return from base.GetAll, this is all cached
-            return base.GetMany().Where(x => alias.IsNullOrWhiteSpace()
-                ? x.MasterTemplateAlias.IsNullOrWhiteSpace()
-                : x.MasterTemplateAlias.InvariantEquals(alias));
-        }
-
         public IEnumerable<ITemplate> GetDescendants(int masterTemplateId)
         {
             //return from base.GetAll, this is all cached
@@ -542,30 +524,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             return descendants;
         }
 
-        public IEnumerable<ITemplate> GetDescendants(string alias)
-        {
-            var all = base.GetMany().ToArray();
-            var descendants = new List<ITemplate>();
-            if (alias.IsNullOrWhiteSpace() == false)
-            {
-                var parent = all.FirstOrDefault(x => x.Alias.InvariantEquals(alias));
-                if (parent == null) return Enumerable.Empty<ITemplate>();
-                //recursively add all children
-                AddChildren(all, descendants, parent.Alias);
-            }
-            else
-            {
-                descendants.AddRange(all.Where(x => x.MasterTemplateAlias.IsNullOrWhiteSpace()));
-                foreach (var parent in descendants)
-                {
-                    //recursively add all children with a level
-                    AddChildren(all, descendants, parent.Alias);
-                }
-            }
-            //return the list - it will be naturally ordered by level
-            return descendants;
-        }
-
         private void AddChildren(ITemplate[] all, List<ITemplate> descendants, string masterAlias)
         {
             var c = all.Where(x => x.MasterTemplateAlias.InvariantEquals(masterAlias)).ToArray();
@@ -576,56 +534,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             {
                 AddChildren(all, descendants, child.Alias);
             }
-        }
-
-        /// <summary>
-        /// Validates a <see cref="ITemplate"/>
-        /// </summary>
-        /// <param name="template"><see cref="ITemplate"/> to validate</param>
-        /// <returns>True if Script is valid, otherwise false</returns>
-        public bool ValidateTemplate(ITemplate template)
-        {
-            // get path
-            // TODO: templates should have a real Path somehow - but anyways
-            // are we using Path for something else?!
-            var path = template.VirtualPath;
-
-            // get valid paths
-            var validDirs = new[] { Cms.Core.Constants.SystemDirectories.MvcViews };
-
-            // get valid extensions
-            var validExts = new List<string>();
-            validExts.Add("cshtml");
-            validExts.Add("vbhtml");
-
-            // validate path and extension
-            var validFile = _ioHelper.VerifyEditPath(path, validDirs);
-            var validExtension = _ioHelper.VerifyFileExtension(path, validExts);
-            return validFile && validExtension;
-        }
-
-        private static IEnumerable<TemplateNode> CreateChildren(TemplateNode parent, IEnumerable<ITemplate> childTemplates, ITemplate[] allTemplates)
-        {
-            var children = new List<TemplateNode>();
-            foreach (var childTemplate in childTemplates)
-            {
-                var template = allTemplates.Single(x => x.Id == childTemplate.Id);
-                var child = new TemplateNode(template)
-                    {
-                        Parent = parent
-                    };
-
-                //add to our list
-                children.Add(child);
-
-                //get this node's children
-                var local = childTemplate;
-                var kids = allTemplates.Where(x => x.MasterTemplateAlias.InvariantEquals(local.Alias));
-
-                //recurse
-                child.Children = CreateChildren(child, kids, allTemplates);
-            }
-            return children;
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -473,14 +473,6 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
-        public IEnumerable<ITemplate> GetTemplateDescendants(string alias)
-        {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-            {
-                return _templateRepository.GetDescendants(alias);
-            }
-        }
-
         /// <summary>
         /// Gets the template descendants
         /// </summary>
@@ -491,32 +483,6 @@ namespace Umbraco.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _templateRepository.GetDescendants(masterTemplateId);
-            }
-        }
-
-        /// <summary>
-        /// Gets the template children
-        /// </summary>
-        /// <param name="alias"></param>
-        /// <returns></returns>
-        public IEnumerable<ITemplate> GetTemplateChildren(string alias)
-        {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-            {
-                return _templateRepository.GetChildren(alias);
-            }
-        }
-
-        /// <summary>
-        /// Gets the template children
-        /// </summary>
-        /// <param name="masterTemplateId"></param>
-        /// <returns></returns>
-        public IEnumerable<ITemplate> GetTemplateChildren(int masterTemplateId)
-        {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-            {
-                return _templateRepository.GetChildren(masterTemplateId);
             }
         }
 
@@ -611,44 +577,6 @@ namespace Umbraco.Core.Services.Implement
 
                 Audit(AuditType.Delete, userId, template.Id, ObjectTypes.GetName(UmbracoObjectTypes.Template));
                 scope.Complete();
-            }
-        }
-
-        /// <summary>
-        /// Validates a <see cref="ITemplate"/>
-        /// </summary>
-        /// <param name="template"><see cref="ITemplate"/> to validate</param>
-        /// <returns>True if Script is valid, otherwise false</returns>
-        public bool ValidateTemplate(ITemplate template)
-        {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-            {
-                return _templateRepository.ValidateTemplate(template);
-            }
-        }
-
-        public Stream GetTemplateFileContentStream(string filepath)
-        {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-            {
-                return _templateRepository.GetFileContentStream(filepath);
-            }
-        }
-
-        public void SetTemplateFileContent(string filepath, Stream content)
-        {
-            using (var scope = ScopeProvider.CreateScope())
-            {
-                _templateRepository.SetFileContent(filepath, content);
-                scope.Complete();
-            }
-        }
-
-        public long GetTemplateFileSize(string filepath)
-        {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-            {
-                return _templateRepository.GetFileSize(filepath);
             }
         }
 

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -372,13 +372,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
 
                 // Act
                 IEnumerable<ITemplate> childrenById = repository.GetChildren(created[1].Id);
-                IEnumerable<ITemplate> childrenByAlias = repository.GetChildren(created[1].Alias);
 
                 // Assert
                 Assert.AreEqual(2, childrenById.Count());
                 Assert.AreEqual(2, childrenById.DistinctBy(x => x.Id).Count());
-                Assert.AreEqual(2, childrenByAlias.Count());
-                Assert.AreEqual(2, childrenByAlias.DistinctBy(x => x.Id).Count());
             }
         }
 
@@ -416,14 +413,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
 
                 // Act
                 IEnumerable<ITemplate> descendantsById = repository.GetDescendants(created[1].Id);
-                IEnumerable<ITemplate> descendantsByAlias = repository.GetDescendants(created[1].Alias);
 
                 // Assert
                 Assert.AreEqual(3, descendantsById.Count());
                 Assert.AreEqual(3, descendantsById.DistinctBy(x => x.Id).Count());
-
-                Assert.AreEqual(3, descendantsByAlias.Count());
-                Assert.AreEqual(3, descendantsByAlias.DistinctBy(x => x.Id).Count());
             }
         }
 


### PR DESCRIPTION
### Description

There is a bunch of unreferenced/unused (and largely untested) code that originates from `IFileSystem` and spills into various file repositories. This is one of four PRs that aim to clean up all this code.

This PR relates to: **Templates**

See also #9875, #9878 and #9879