### PR TITLE
9842: Fix for defaultConfig not working without prevalues

### DIFF
--- a/src/Umbraco.Core/Manifest/DataEditorConverter.cs
+++ b/src/Umbraco.Core/Manifest/DataEditorConverter.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Core.Manifest
                 PrepareForPropertyEditor(jobject, dataEditor);
             else
                 PrepareForParameterEditor(jobject, dataEditor);
- 
+
             base.Deserialize(jobject, target, serializer);
         }
 
@@ -86,26 +86,33 @@ namespace Umbraco.Core.Manifest
             if (jobject["editor"]["validation"] is JObject validation)
                 jobject["editor"]["validation"] = RewriteValidators(validation);
 
-            if (jobject["prevalues"] is JObject config)
+            var prevalues = jobject["prevalues"] as JObject;
+            var defaultConfig = jobject["defaultConfig"] as JObject;
+            if (prevalues != null || defaultConfig != null)
             {
                 // explicitly assign a configuration editor of type ConfigurationEditor
                 // (else the deserializer will try to read it before setting it)
                 // (and besides it's an interface)
                 target.ExplicitConfigurationEditor = new ConfigurationEditor();
 
-                // see note about validators, above - same applies to field validators
-                if (config["fields"] is JArray jarray)
+                var config = new JObject();
+                if (prevalues != null)
                 {
-                    foreach (var field in jarray)
+                    config = prevalues;
+                    // see note about validators, above - same applies to field validators
+                    if (config["fields"] is JArray jarray)
                     {
-                        if (field["validation"] is JObject fvalidation)
-                            field["validation"] = RewriteValidators(fvalidation);
+                        foreach (var field in jarray)
+                        {
+                            if (field["validation"] is JObject fvalidation)
+                                field["validation"] = RewriteValidators(fvalidation);
+                        }
                     }
                 }
 
                 // in the manifest, default configuration is at editor level
                 // move it down to configuration editor level so it can be deserialized properly
-                if (jobject["defaultConfig"] is JObject defaultConfig)
+                if (defaultConfig != null)
                 {
                     config["defaultConfig"] = defaultConfig;
                     jobject.Remove("defaultConfig");

--- a/src/Umbraco.Tests/Manifest/ManifestParserTests.cs
+++ b/src/Umbraco.Tests/Manifest/ManifestParserTests.cs
@@ -187,6 +187,8 @@ javascript: ['~/test.js',/*** some note about stuff asd09823-4**09234*/ '~/test2
 
             var editor = manifest.PropertyEditors[1];
             Assert.IsTrue((editor.Type & EditorType.MacroParameter) > 0);
+            Assert.IsNotEmpty(editor.DefaultConfiguration);
+            Assert.AreEqual("some default val", editor.DefaultConfiguration["key1"]);
 
             editor = manifest.PropertyEditors[0];
             Assert.AreEqual("Test.Test1", editor.Alias);


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9842

### Description
The manifest was only loading in the defaultConfig if the prevalues were present. This has now been fixed, meaning that the following manifest now works:
```
{
  "propertyEditors": [
    {
      "alias": "UrlPickerMacro",
      "name": "Url Picker (Macro)",
      "group": "Macro Parameter Editors",
      "icon": "icon-link",
      "isParameterEditor": true,
      "editor": {
        "view": "~/umbraco/views/propertyeditors/multiurlpicker/multiurlpicker.html",
        "valueType": "JSON"
      },
      "defaultConfig": {
        "ignoreUserStartNodes": "0",
        "minNumber": "0",
        "maxNumber": "1"
      }
    }
  ]
}
```

Also updated a test to make sure that it checks the defaultconfig. Something it didn't do before this.