### PR TITLE
9816: Prefixing ids to not conflict with existing css rules

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -12,7 +12,7 @@
                         <localize key="contentTypeEditor_inheritedFrom"></localize> {{vm.inheritsFrom}}
                     </small>
 
-                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">
+                    <label class="control-label" for="property-{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">
 
                         {{vm.property.label}}
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
@@ -23,7 +23,7 @@
             </div>
         </umb-block-card>
 
-        <button id="{{model.alias}}" type="button" class="btn-reset __add-button" ng-click="vm.openAddDialog($event)">
+        <button id="property-{{model.alias}}" type="button" class="btn-reset __add-button" ng-click="vm.openAddDialog($event)">
             <localize key="general_add">Add</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
@@ -1,6 +1,6 @@
 <div class="umb-property-editor umb-boolean" ng-controller="Umbraco.PropertyEditors.BooleanController">
     <umb-toggle
-        input-id="{{model.alias}}"
+        input-id="property-{{model.alias}}"
         checked="renderModel.value"
         on-click="toggle()"
         show-labels="{{model.config.showLabels}}"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -24,7 +24,7 @@
             type="button"
             class="umb-node-preview-add"
             ng-click="openCurrentPicker()"
-            id="{{model.alias}}"
+            id="property-{{model.alias}}"
             aria-label="{{model.label}}: {{labels.general_add}}"
         >
             <localize key="general_add">Add</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
@@ -13,7 +13,7 @@
                 <div class="input-append">
                     <input type="text"
                            name="datepicker"
-                           id="{{model.alias}}"
+                           id="property-{{model.alias}}"
                            ng-model="model.datetimePickerValue"
                            ng-blur="inputChanged()"
                            ng-required="model.validation.mandatory"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/decimal/decimal.html
@@ -7,7 +7,7 @@
                ng-model="model.value"
                ng-required="model.validation.mandatory"
                aria-required="{{model.validation.mandatory}}"
-               id="{{model.alias}}"
+               id="property-{{model.alias}}"
                val-server="value"
                min="{{model.config.min}}"
                max="{{model.config.max}}"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/email/email.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/email/email.html
@@ -2,7 +2,7 @@
     <ng-form name="emailFieldForm">
         <input type="email" name="textbox"
                ng-model="model.value"
-               id="{{model.alias}}"
+               id="property-{{model.alias}}"
                class="umb-property-editor umb-textstring textstring"
                val-email
                ng-required="model.config.IsRequired || model.validation.mandatory"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
@@ -7,7 +7,7 @@
                ng-model="model.value"
                ng-required="model.validation.mandatory"
                aria-required="{{model.validation.mandatory}}"
-               id="{{model.alias}}"
+               id="property-{{model.alias}}"
                val-server="value"
                fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -1,4 +1,4 @@
-﻿<div id="{{model.alias}}" class="umb-nested-content__doctypepicker" ng-controller="Umbraco.PropertyEditors.NestedContent.DocTypePickerController">
+﻿<div id="property-{{model.alias}}" class="umb-nested-content__doctypepicker" ng-controller="Umbraco.PropertyEditors.NestedContent.DocTypePickerController">
     <div>
         <table class="table table-striped">
             <thead>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
@@ -2,7 +2,7 @@
     <umb-load-indicator ng-if="isLoading"></umb-load-indicator>
 
     <div class="umb-rte-editor-con">
-        <input type="text" id="{{model.alias}}" ng-focus="focus()" style="position:absolute;top:0;width:0;height:0;" />
+        <input type="text" id="property-{{model.alias}}" ng-focus="focus()" style="position:absolute;top:0;width:0;height:0;" />
         <div disable-hotkeys id="{{textAreaHtmlId}}" class="umb-rte-editor" ng-style="{ width: containerWidth, height: containerHeight, overflow: containerOverflow}"></div>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/tags/tags.html
@@ -5,7 +5,7 @@
                      validation="model.validation"
                      on-value-changed="valueChanged(value)"
                      culture="model.culture"
-                     input-id="{{model.alias}}">
+                     input-id="property-{{model.alias}}">
     </umb-tags-editor>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.PropertyEditors.textAreaController">
     <ng-form name="textareaFieldForm">
         <textarea ng-model="model.value"
-            id="{{model.alias}}"
+            id="property-{{model.alias}}"
             name="textarea"
             rows="{{model.config.rows || 10}}"
             class="umb-property-editor umb-textarea textstring"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.PropertyEditors.textboxController">
     <ng-form name="textboxFieldForm">
         <input type="text"
-               id="{{model.alias}}"
+               id="property-{{model.alias}}"
                name="textbox"
                ng-model="model.value"
                class="umb-property-editor umb-textstring textstring"


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9816

### Description
Reproduction of the bug is available in the issue: https://github.com/umbraco/Umbraco-CMS/issues/9816. The issue was that the id="navigation" conflicted with the css that was present.

I am not sure if prefixing has any other problems. I clicked around the back office for a bit and everything seemed to be working, but maybe someone has a better solution for this. I wanted to add them as data attributes (data-property-alias="{{model.alias}}), but then the for attribute doesn't work anymore.