### PR TITLE
Add an option for closed nested content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -591,7 +591,7 @@
                 }
 
                 // If there is only one item, set it as current node
-                if (vm.singleMode || (vm.nodes.length === 1 && vm.maxItems === 1)) {
+                if (vm.singleMode || (!model.config.disableOpenOnLoad && vm.nodes.length === 1 && vm.maxItems === 1)) {
                     setCurrentNode(vm.nodes[0]);
                 }
 

--- a/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentConfiguration.cs
@@ -21,6 +21,9 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("confirmDeletes", "Confirm Deletes", "boolean", Description = "Requires editor confirmation for delete actions.")]
         public bool ConfirmDeletes { get; set; } = true;
 
+        [ConfigurationField("disableOpenOnLoad", "Disable Open on Load", "boolean", Description = "Disables opening when there is one max item available")]
+        public bool DisableOpenOnLoad { get; set; } = false;
+
         [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Show the Element Type icons.")]
         public bool ShowIcons { get; set; } = true;
 


### PR DESCRIPTION
This is a feature that came up in this issue: https://github.com/umbraco/Umbraco-CMS/issues/9841.
I've made an additional PR for this because I think it's something different from the actual fix.

Can be checked with:

- Create a new nested content with min 0, max 1.
- Whenever you open it on a node, it will automatically open if you have an item in it.
- If you check the new option, it'll not automatically open on load.

Personally, I don't see why it should automatically open, but it's probably best to be able to disable it with an option instead of removing the feature.

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/11466511/108887582-beeebe80-760a-11eb-904b-ea407bc6854c.gif)
