### PR TITLE
Don't show configuration header if there is none

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.html
@@ -36,13 +36,15 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <h5><localize key="contentTypeEditor_configuration"></localize></h5>
-                    
-                    <umb-property property="preValue" ng-repeat="preValue in vm.dataType.preValues">
-                        <umb-property-editor model="preValue" is-pre-value="true"></umb-property-editor>
-                    </umb-property>
-                        
+
+                    <div ng-if="vm.dataType.preValues.length > 0">
+                        <h5><localize key="contentTypeEditor_configuration"></localize></h5>
+
+                        <umb-property property="preValue" ng-repeat="preValue in vm.dataType.preValues">
+                            <umb-property-editor model="preValue" is-pre-value="true"></umb-property-editor>
+                        </umb-property>
+                    </div>
+
                 </umb-box-content>
             </umb-box>
         </umb-editor-container>


### PR DESCRIPTION
Currently, there is a small bug that shows the configuration header for a data type even if there is no configuration:
![image](https://user-images.githubusercontent.com/11466511/108887424-864ee500-760a-11eb-9409-6bafe5ca0317.png)

This PR makes it so that the configuration header is only shown if there actually is one:
![image](https://user-images.githubusercontent.com/11466511/108887526-ac748500-760a-11eb-92e1-8719b2ffbc17.png)

The best way to check this is:

- Go to a document type
- Add a new property
- Click on "Select editor"
- Choose the member picker
- Click on the member picker so that the editor settings window opens

Now, you won't see the configuration header if there is none.