### PR TITLE
The Value() method for IPublishedContent was not working with the defaultValue parameter

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -173,7 +173,7 @@ namespace Umbraco.Web
                 return value;
 
             // else... if we have a property, at least let the converter return its own
-            // vision of 'no value' (could be an empty enumerable) - otherwise, default
+            // vision of 'no value' (could be an empty enumerable) - otherwise, defaultValue
             return property == null ? defaultValue : property.Value<T>(culture, segment, defaultValue: defaultValue);
         }
 

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -174,7 +174,7 @@ namespace Umbraco.Web
 
             // else... if we have a property, at least let the converter return its own
             // vision of 'no value' (could be an empty enumerable) - otherwise, default
-            return property == null ? default : property.Value<T>(culture, segment);
+            return property == null ? default : property.Value<T>(culture, segment, defaultValue: defaultValue);
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -174,7 +174,7 @@ namespace Umbraco.Web
 
             // else... if we have a property, at least let the converter return its own
             // vision of 'no value' (could be an empty enumerable) - otherwise, default
-            return property == null ? default : property.Value<T>(culture, segment, defaultValue: defaultValue);
+            return property == null ? defaultValue : property.Value<T>(culture, segment, defaultValue: defaultValue);
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Web
             var noValueConverted = noValue.TryConvertTo<T>();
             if (noValueConverted) return noValueConverted.Result;
 
-            // cannot cast noValue nor convert it, nothing we can return but 'default'
+            // cannot cast noValue nor convert it, nothing we can return but 'defaultValue'
             return defaultValue;
         }
 

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -43,22 +43,29 @@ namespace Umbraco.Web
 
                 // cannot cast nor convert the value, nothing we can return but 'default'
                 // note: we don't want to fallback in that case - would make little sense
-                return default;
+                return defaultValue;
             }
 
             // we don't have a value, try fallback
             if (PublishedValueFallback.TryGetValue(property, culture, segment, fallback, defaultValue, out var fallbackValue))
+            {
                 return fallbackValue;
+            }
 
             // we don't have a value - neither direct nor fallback
             // give a chance to the converter to return something (eg empty enumerable)
             var noValue = property.GetValue(culture, segment);
             if (noValue is T noValueAsT) return noValueAsT;
+            if (noValue == null)
+            {
+                return defaultValue;
+            }
+
             var noValueConverted = noValue.TryConvertTo<T>();
             if (noValueConverted) return noValueConverted.Result;
 
             // cannot cast noValue nor convert it, nothing we can return but 'default'
-            return default;
+            return defaultValue;
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -55,11 +55,11 @@ namespace Umbraco.Web
             // we don't have a value - neither direct nor fallback
             // give a chance to the converter to return something (eg empty enumerable)
             var noValue = property.GetValue(culture, segment);
-            if (noValue is T noValueAsT) return noValueAsT;
             if (noValue == null)
             {
                 return defaultValue;
             }
+            if (noValue is T noValueAsT) return noValueAsT;
 
             var noValueConverted = noValue.TryConvertTo<T>();
             if (noValueConverted) return noValueConverted.Result;

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Web
                 var valueConverted = value.TryConvertTo<T>();
                 if (valueConverted) return valueConverted.Result;
 
-                // cannot cast nor convert the value, nothing we can return but 'default'
+                // cannot cast nor convert the value, nothing we can return but 'defaultValue'
                 // note: we don't want to fallback in that case - would make little sense
                 return defaultValue;
             }


### PR DESCRIPTION
The method PublishedPropertyExtension `public static T Value<T>(this IPublishedProperty property, string culture = null, string segment = null, Fallback fallback = default, T defaultValue = default)` does not pass along the `defaultValue` and instead just returns `default` which isn't correct.

The method `public static T Value<T>(this IPublishedContent content, string alias, string culture = null, string segment = null, Fallback fallback = default, T defaultValue = default)` was not passing defaultValue to the inner property.Value call