### PR TITLE
Fixes the Sql server SET LOCK_TIMEOUT call which was missing a space.

### DIFF
--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlServerSyntaxProvider.cs
@@ -281,7 +281,7 @@ where tbl.[name]=@0 and col.[name]=@1;", tableName, columnName)
 
         private static void ObtainWriteLock(IDatabase db, TimeSpan timeout, int lockId)
         {
-            db.Execute("SET LOCK_TIMEOUT" + timeout.TotalMilliseconds + ";");
+            db.Execute("SET LOCK_TIMEOUT " + timeout.TotalMilliseconds + ";");
             var i = db.Execute(
                 @"UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id",
                 new {id = lockId});


### PR DESCRIPTION
No DB writing will work as it is in SQL Server without this fix. 

It was missing a space.