### PR TITLE
Netcore: Fix installing packages

### DIFF
--- a/src/Umbraco.Web.BackOffice/Filters/ValidateAngularAntiForgeryTokenAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ValidateAngularAntiForgeryTokenAttribute.cs
@@ -44,15 +44,6 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
 
             public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
             {
-                if (context.Controller is ControllerBase controller && controller.User.Identity is ClaimsIdentity userIdentity)
-                {
-                    // if there is not CookiePath claim, then exit
-                    if (userIdentity.HasClaim(x => x.Type == ClaimTypes.CookiePath) == false)
-                    {
-                        await next();
-                    }
-                }
-
                 var cookieToken = _cookieManager.GetCookieValue(Constants.Web.CsrfValidationCookieName);
                 var httpContext = context.HttpContext;
 

--- a/src/Umbraco.Web.BackOffice/Filters/ValidateAngularAntiForgeryTokenAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ValidateAngularAntiForgeryTokenAttribute.cs
@@ -44,6 +44,16 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
 
             public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
             {
+                if (context.Controller is ControllerBase controller && controller.User.Identity is ClaimsIdentity userIdentity)
+                {
+                    // if there is not CookiePath claim, then exit
+                    if (userIdentity.HasClaim(x => x.Type == ClaimTypes.CookiePath) == false)
+                    {
+                        await next();
+                        return;
+                    }
+                }
+
                 var cookieToken = _cookieManager.GetCookieValue(Constants.Web.CsrfValidationCookieName);
                 var httpContext = context.HttpContext;
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/install-local.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/install-local.controller.js
@@ -146,13 +146,14 @@
 
                     //check if the app domain is restarted ever 2 seconds
                     var count = 0;
+                    var maxCount = 5;
 
                     function checkRestart() {
                         $timeout(function () {
                             packageResource.checkRestart(pack).then(function (d) {
                                 count++;
                                 //if there is an id it means it's not restarted yet but we'll limit it to only check 10 times
-                                if (d.isRestarting && count < 10) {
+                                if (d.isRestarting && count < maxCount) {
                                     checkRestart();
                                 }
                                 else {
@@ -160,9 +161,16 @@
                                     deferred.resolve(d);
                                 }
                             },
-                                installError);
+                                function(){
+                                  if(count >= maxCount){
+                                    installError();
+                                  }
+                                  else {
+                                    checkRestart();
+                                  }
+                                });
                         },
-                            2000);
+                            2000*(count+1));
                     }
 
                     checkRestart();


### PR DESCRIPTION
Fixed an issue where you could no longer install packages.

The issue was that the ValidateAngularAntiForgeryTokenFilter checked for a cookie path if that path didn't exist it called next but didn't return causing next to be called twice leading to some issues. I ~~removed this since it seems like legacy code, we check for `ClaimTypes.CookiePath` but never use it~~, added a return statement, see the comment below.

The second issue was with the UI, if the server hasn't restarted within 2 seconds we called install error, we now wait longer.

Made these changes with help from @bergmania so this has in effect already been reviewed.