### PR TITLE
9808 .umb-editor-placeholder - render overflows the container.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -401,6 +401,7 @@
     text-align: center;
     text-align: -moz-center;
     width: 100%;
+    box-sizing: border-box;
 }
 
 .umb-grid .umb-editor-placeholder i {


### PR DESCRIPTION
PR containing the css fix supplied by @seanhakbb to solve the grid placeholder breaking out of the container.

This resolves #9808
