### PR TITLE
Netcore: Fix packages with actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/edit.html
@@ -175,7 +175,7 @@
                             <div ng-repeat="template in ::vm.templates | orderBy:'name'">
                                 <umb-checkbox model="template.selected"
                                               on-change="vm.selectTemplate(template)"
-                                                  text="{{template.name}}">umb-expansion-panel__content
+                                                  text="{{template.name}}">
                                     </umb-checkbox>
                             </div>
                         </umb-control-group>


### PR DESCRIPTION
This PR actually fixes two bugs, one in the backend and one in the front end, but the frontend one is so minor I just added it to this. 

### Package installation bug

When trying to install a package with actions you would get an error from trying to parse the stored package XML, this was because "Undo" actions were saved improperly leading to XML with multiple root nodes like this: 

`<actions></actions><Action runat="install" alias="publishRootDocument" documentName="Home" />`

This stemmed from `RunPackageActions` where we just appended to the actions string in the PackageDefinition, this is set to `<action></action>` from initially parsing the XML (since there can be more than one action) so we can't do this. I changed it, so that we now parse the XML in `packageDefiniton.Actions` into an XElement and use that to append the undo actions, and then after the for loop is done we save that back to the `Actions` property. While I was there I also did some rudimentary cleaning, making it a bit easier to read. 

### UI bug

`umb-expansion-panel__content` had accidentally been added the view of available templates, overriding `text="{{template.name}}">` causing all templates to show up as 'umb-expansion-panel__content'