### PR TITLE
Add allowedChildren call to EditorModelEventManager

### DIFF
--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -413,6 +413,7 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <param name="contentId"></param>
         [UmbracoTreeAuthorize(Constants.Trees.DocumentTypes, Constants.Trees.Content)]
+        [OutgoingEditorModelEvent]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
         {
             if (contentId == Constants.System.RecycleBinContent)

--- a/src/Umbraco.Web/Editors/EditorModelEventManager.cs
+++ b/src/Umbraco.Web/Editors/EditorModelEventManager.cs
@@ -23,6 +23,8 @@ namespace Umbraco.Web.Editors
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboard>>>> SendingDashboardModel;
         public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>> SendingDashboardSlimModel;
 
+        public static event TypedEventHandler<HttpActionExecutedContext, EditorModelEventArgs<IEnumerable<ContentTypeBasic>>> SendingAllowedContentChildrenModel;
+
         private static void OnSendingDashboardModel(HttpActionExecutedContext sender, EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>> e)
         {
             var handler = SendingDashboardSlimModel;
@@ -53,6 +55,13 @@ namespace Umbraco.Web.Editors
             handler?.Invoke(sender, e);
         }
 
+        private static void OnSendingAllowedContentChildrenModel(HttpActionExecutedContext sender,
+            EditorModelEventArgs<IEnumerable<ContentTypeBasic>> e)
+        {
+            var handler = SendingAllowedContentChildrenModel;
+            handler?.Invoke(sender, e);
+        }
+
         /// <summary>
         /// Based on the type, emit's a specific event
         /// </summary>
@@ -74,6 +83,9 @@ namespace Umbraco.Web.Editors
 
             if (e.Model is IEnumerable<Tab<IDashboardSlim>>)
                 OnSendingDashboardModel(sender, new EditorModelEventArgs<IEnumerable<Tab<IDashboardSlim>>>(e));
+
+            if (e.Model is IEnumerable<ContentTypeBasic>)
+                OnSendingAllowedContentChildrenModel(sender, new EditorModelEventArgs<IEnumerable<ContentTypeBasic>>(e));
         }
     }
 }

--- a/src/Umbraco.Web/Editors/MediaTypeController.cs
+++ b/src/Umbraco.Web/Editors/MediaTypeController.cs
@@ -263,6 +263,7 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <param name="contentId"></param>
         [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
+        [OutgoingEditorModelEvent]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
         {
             if (contentId == Constants.System.RecycleBinContent)
@@ -309,6 +310,7 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <param name="contentId"></param>
         [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
+        [OutgoingEditorModelEvent]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(Guid contentId)
         {
             var entity = Current.Services.EntityService.Get(contentId);
@@ -325,6 +327,7 @@ namespace Umbraco.Web.Editors
         /// </summary>
         /// <param name="contentId"></param>
         [UmbracoTreeAuthorize(Constants.Trees.MediaTypes, Constants.Trees.Media)]
+        [OutgoingEditorModelEvent]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(Udi contentId)
         {
             var guidUdi = contentId as GuidUdi;


### PR DESCRIPTION
This is something I've been wanting to add to Umbraco for some time now. The need arises because we have some node types that should only be used once in a project however, there is no way to restrict that right now. So I added the GetAllowedChildren response to the EditorModelEventManager so that we are able to have some more control over it. I've added it for Content and for Media items.

Here are two use cases together with the user composer so that you can test this:
![RestrictedSettings](https://user-images.githubusercontent.com/11466511/109339815-77656e00-7868-11eb-8aef-3a93076da116.gif)
```
public class OneSettingsComposer : IUserComposer
    {
        public void Compose(Composition composition)
        {
            EditorModelEventManager.SendingAllowedContentChildrenModel += EditorModelEventManager_SendingAllowedContentChildrenModel;
        }

        private void EditorModelEventManager_SendingAllowedContentChildrenModel(System.Web.Http.Filters.HttpActionExecutedContext sender, EditorModelEventArgs<IEnumerable<Models.ContentEditing.ContentTypeBasic>> e)
        {
            if (e.Model.All(it => it.Alias != "settings"))
                return;

            var currentSettings = e.UmbracoContext.Content.GetSingleByXPath("//settings");
            if (currentSettings is null)
                return;

            e.Model = e.Model.Where(it => it.Alias != "settings");
        }
    }
```

![RestrictedPeople](https://user-images.githubusercontent.com/11466511/109339845-877d4d80-7868-11eb-9ff2-a7eb4fb58b51.gif)
```
public class LimitPeopleComposer : IUserComposer
    {
        public void Compose(Composition composition)
        {
            EditorModelEventManager.SendingAllowedContentChildrenModel += EditorModelEventManager_SendingAllowedContentChildrenModel;
        }

        private void EditorModelEventManager_SendingAllowedContentChildrenModel(System.Web.Http.Filters.HttpActionExecutedContext sender, EditorModelEventArgs<IEnumerable<Models.ContentEditing.ContentTypeBasic>> e)
        {
            var queryDictionary = HttpUtility.ParseQueryString(sender.Request.RequestUri.Query);
            if (!int.TryParse(queryDictionary["contentId"], out var contentId))
            {
                return;
            }

            var content = e.UmbracoContext.Content.GetById(contentId);
            if (content is null)
                return;
            if (content.Children.Count() >= 6)
            {
                e.Model = e.Model.Where(it => it.Alias != "person");
            }
        }
    }
```