### PR TITLE
Adding content property to IBlockReference

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
@@ -7,9 +7,8 @@ namespace Umbraco.Core.Models.Blocks
     /// <summary>
     /// Represents a layout item for the Block List editor.
     /// </summary>
-    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
     [DataContract(Name = "block", Namespace = "")]
-    public class BlockListItem : IBlockReference<IPublishedElement>
+    public class BlockListItem : IBlockReference<IPublishedElement, IPublishedElement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockListItem" /> class.
@@ -70,7 +69,6 @@ namespace Umbraco.Core.Models.Blocks
     /// Represents a layout item with a generic content type for the Block List editor.
     /// </summary>
     /// <typeparam name="T">The type of the content.</typeparam>
-    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
     public class BlockListItem<T> : BlockListItem
         where T : IPublishedElement
     {
@@ -101,7 +99,6 @@ namespace Umbraco.Core.Models.Blocks
     /// </summary>
     /// <typeparam name="TContent">The type of the content.</typeparam>
     /// <typeparam name="TSettings">The type of the settings.</typeparam>
-    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
     public class BlockListItem<TContent, TSettings> : BlockListItem<TContent>
         where TContent : IPublishedElement
         where TSettings : IPublishedElement

--- a/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
@@ -24,15 +24,9 @@
     /// <remarks>
     /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
     /// </remarks>
-    public interface IBlockReference<TSettings> : IBlockReference
+    public interface IBlockReference<TSettings> : IBlockSettings<TSettings>
     {
-        /// <summary>
-        /// Gets the settings.
-        /// </summary>
-        /// <value>
-        /// The settings.
-        /// </value>
-        TSettings Settings { get; }
+
     }
 
     /// <summary>
@@ -52,5 +46,23 @@
         /// The content.
         /// </value>
         TContent Content { get; }
+    }
+
+    /// <summary>
+    /// Represents the settings for a Block editor implementation.
+    /// </summary>
+    /// <typeparam name="TSettings">The type of the settings.</typeparam>
+    /// <remarks>
+    /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
+    /// </remarks>
+    public interface IBlockSettings<TSettings>
+    {
+        /// <summary>
+        /// Gets the settings.
+        /// </summary>
+        /// <value>
+        /// The settings.
+        /// </value>
+        TSettings Settings { get; }
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
@@ -37,13 +37,25 @@
     /// <remarks>
     /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
     /// </remarks>
-    public interface IBlockReference<TContent, TSettings> : IBlockReference<TSettings>
+    public interface IBlockReference<TContent, TSettings> : IBlockContent<TContent>, IBlockSettings<TSettings>, IBlockReference
+    {
+
+    }
+
+    /// <summary>
+    /// Represents the content for a Block editor implementation.
+    /// </summary>
+    /// <typeparam name="TContent">The type of the content.</typeparam>
+    /// <remarks>
+    /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
+    /// </remarks>
+    public interface IBlockContent<TContent>
     {
         /// <summary>
-        /// Gets the content.
+        /// Gets the settings.
         /// </summary>
         /// <value>
-        /// The content.
+        /// The settings.
         /// </value>
         TContent Content { get; }
     }

--- a/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Core.Models.Blocks
+﻿using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Core.Models.Blocks
 {
     /// <summary>
     /// Represents a data item reference for a Block Editor implementation.
@@ -38,6 +40,7 @@
     /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
     /// </remarks>
     public interface IBlockReference<TContent, TSettings> : IBlockContent<TContent>, IBlockSettings<TSettings>, IBlockReference
+        where TContent : IPublishedElement
     {
 
     }
@@ -50,6 +53,7 @@
     /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
     /// </remarks>
     public interface IBlockContent<TContent>
+        where TContent : IPublishedElement
     {
         /// <summary>
         /// Gets the settings.

--- a/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
+++ b/src/Umbraco.Core/Models/Blocks/IBlockReference.cs
@@ -34,4 +34,23 @@
         /// </value>
         TSettings Settings { get; }
     }
+
+    /// <summary>
+    /// Represents a data item reference with content and settings for a Block editor implementation.
+    /// </summary>
+    /// <typeparam name="TContent">The type of the content.</typeparam>
+    /// <typeparam name="TSettings">The type of the settings.</typeparam>
+    /// <remarks>
+    /// See: https://github.com/umbraco/rfcs/blob/907f3758cf59a7b6781296a60d57d537b3b60b8c/cms/0011-block-data-structure.md#strongly-typed
+    /// </remarks>
+    public interface IBlockReference<TContent, TSettings> : IBlockReference<TSettings>
+    {
+        /// <summary>
+        /// Gets the content.
+        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
+        TContent Content { get; }
+    }
 }


### PR DESCRIPTION
I found it frustrating that `IBlockReference` doesn't have a property for `Content` despite having a property called `ContentUdi`.

I think this comes from the eventual plan to store element content in the DB ([as per this RFC](https://github.com/umbraco/rfcs)) - meaning the data stored by Block Editors will only be the content UDI + settings object.

However, `IBlockReference` has nothing to do with data storage - it's purely the contract that represents block items within the object returned by the value converter - so I see no reason why being able to access the content wouldn't be needed.

This PR attempts to expose a content property on `IBlockReference` and block editor models, but without breaking the existing interface. While Umbraco is only using it in one place internally, I know other projects like Vendr also implement it, so would likely be an unacceptable change...

I've introduced a new `IBlockReference<TContent, TSettings>` to cover the use cases where a `Content` property might be wanted to avoid breaking the interface. Further, I have introduced 2 new `IBlockContent<T>` and `IBlockSettings<T>` interfaces to represent the desired properties. `IBlockContent<T>` has a constraint for only `IPublishedElement` - I think this makes sense as that's what looking up the `ContentUdi` would resolve to, and this was [already the case elsewhere in Core](https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Core/Models/Blocks/BlockListItem.cs#L105).

The existing `IBlockReference<T>` now implements `IBlockSettings<T>`, the previous `Settings` property has been moved to that interface and so should be no breaking changes there. While the existing `IBlockReference` interface remains unchanged - though it is now rather pointless... I considered obsoleting it and adding a `ContentUdi` property to `IBlockContent<T>` also, but not sure on opinions there?