### PR TITLE
Scheduled publish does not run after a document is copied

### DIFF
--- a/src/Umbraco.Core/Models/ContentSchedule.cs
+++ b/src/Umbraco.Core/Models/ContentSchedule.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Core.Models
         }
 
         /// <summary>
-        /// Gets the unique identifier of the document targeted by the scheduled action.
+        /// Gets the unique identifier of the scheduled action.
         /// </summary>
         [DataMember]
         public Guid Id { get; internal set; }
@@ -71,7 +71,7 @@ namespace Umbraco.Core.Models
 
         public object DeepClone()
         {
-            return new ContentSchedule(Id, Culture, Date, Action);
+            return new ContentSchedule(default, Culture, Date, Action);
         }
     }
 }

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -2175,6 +2175,9 @@ namespace Umbraco.Core.Services.Implement
                 copy.CreatorId = userId;
                 copy.WriterId = userId;
 
+                // ensure any content schedule is not copied
+                copy.ContentSchedule = new ContentScheduleCollection();
+
                 //get the current permissions, if there are any explicit ones they need to be copied
                 var currentPermissions = GetPermissions(content);
                 currentPermissions.RemoveWhere(p => p.IsDefaultPermissions);


### PR DESCRIPTION
Scheduled publish does not run after a document is copied
https://github.com/umbraco/Umbraco-CMS/issues/9722

### Description

#### What did you do?

I updated the **DeepClone** method on the **ContentSchedule** model to not include the row id in the clone. I also updated the comment on **ContentSchedule.Id** which refers to the property as the unique identifier of the scheduled document when it is actually the unique identifier of the scheduled action.

#### Why did you do it?

To prevent umbracoContentSchedule information being overwritten upon copying, when actually a new row should be inserted into umbracoContentSchedule.

#### How can the changes be tested?

1. Unpublish a live document
2. Add a schedule to publish the document
3. Copy the document

Previously information in umbracoContentSchedule was overwritten with the details of the new document. Now a new record is created in umbracoContentSchedule.

N.B. prior to the fix, when checking the original document schedule through the UI by clicking the **Schedule...** button it can appear that the schedule information is still intact when that is not the case. Check the db to verify the original schedule information is missing. May need to restart the web app before is disappears from the UI.

<!-- Thanks for contributing to Umbraco CMS! -->
