### PR TITLE
#9886 drag n drop files for upload

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfileupload.directive.js
@@ -20,11 +20,7 @@ function umbFileUpload() {
                 el.val('');
             });
 
-            el.on('drag dragstart dragend dragover dragenter dragleave drop', function (e) {
-                e.preventDefault();
-                e.stopPropagation();
-            })
-            .on('dragover dragenter', function () {
+            el.on('dragover dragenter', function () {
                 scope.$emit("isDragover", { value: true });
             })
             .on('dragleave dragend drop', function () {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/9886

No need to preventDefault or stopPropagation. As this prevents the input from retrieving the dropped-file.

It was introduced in this PR: https://github.com/umbraco/Umbraco-CMS/pull/8390
And those lines didn't serve any purpose towards the goal of that PR. As well it's not used anywhere else, so I conclude it has no purpose and can go away.