### PR TITLE
9940: Make sure that ordering is correct

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
@@ -32,7 +32,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="item in vm.items | orderBy:'displayName' track by item.id" style="cursor: pointer;">
+                    <tr ng-repeat="item in vm.items track by item.id" style="cursor: pointer;">
                         <th>
                             <button type="button" ng-style="item.style" class="btn-reset bold" ng-click="vm.clickItem(item.id)">{{item.name}}</button>
                         </th>

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
@@ -38,13 +38,15 @@
                         </th>
                         <td ng-repeat="column in item.translations | orderBy:'displayName'">
                             <button type="button" class="btn-reset" ng-click="vm.clickItem(item.id)">
-                                <i ng-if="column.hasTranslation" class="icon-check color-green" aria-hidden="true"></i>
-                                <span ng-if="column.hasTranslation" class="sr-only"><localize key="visuallyHiddenTexts_hasTranslation"></localize></span>
-                                <i ng-if="!column.hasTranslation" class="icon-alert color-red" aria-hidden="true"></i>
-                                <span ng-if="!column.hasTranslation" class="sr-only"><localize key="visuallyHiddenTexts_noTranslation"></localize></span>
+                                <umb-icon icon="{{ column.hasTranslation ? 'icon-check' : 'icon-alert' }}" 
+                                    class="{{ column.hasTranslation ? 'color-green' : 'color-red' }}"></umb-icon>
+                                <span class="sr-only">
+                                    <localize ng-if="column.hasTranslation" key="visuallyHiddenTexts_hasTranslation"></localize>
+                                    <localize ng-if="!column.hasTranslation" key="visuallyHiddenTexts_noTranslation"></localize>
+                                </span>
                             </button>
                         </td>
-                    </tr>
+                    </tr> 
                 </tbody>
             </table>
 

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
@@ -36,7 +36,7 @@
                         <th>
                             <button type="button" ng-style="item.style" class="btn-reset bold" ng-click="vm.clickItem(item.id)">{{item.name}}</button>
                         </th>
-                        <td ng-repeat="column in item.translations">
+                        <td ng-repeat="column in item.translations | orderBy:'displayName'">
                             <button type="button" class="btn-reset" ng-click="vm.clickItem(item.id)">
                                 <i ng-if="column.hasTranslation" class="icon-check color-green" aria-hidden="true"></i>
                                 <span ng-if="column.hasTranslation" class="sr-only"><localize key="visuallyHiddenTexts_hasTranslation"></localize></span>


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9940

### Description
The ordering in the translation tab was being used on the wrong ng-repeat element. Moving it to the correct one fixes the issue.

Steps to reproduce can be found in the issue.