### PR TITLE
added mapdomain fallback with current authority related to current cu…

### DIFF
--- a/src/Umbraco.Web/Routing/SiteDomainHelper.cs
+++ b/src/Umbraco.Web/Routing/SiteDomainHelper.cs
@@ -284,9 +284,10 @@ namespace Umbraco.Web.Routing
             // we do our best, but can't do the impossible
             // get the "default" domain ie the first one for the culture, else the first one (exists, length > 0)
             if (qualifiedSites == null)
-                return domainAndUris.FirstOrDefault(x => x.Culture.Name.InvariantEquals(culture)) ??
-                       domainAndUris.FirstOrDefault(x => x.Culture.Name.InvariantEquals(defaultCulture)) ??
-                       domainAndUris.First();
+            	return (currentAuthority.IsNullOrWhiteSpace() == false ? (currentAuthority.StartsWith("http") ? domainAndUris.FirstOrDefault(x => x.Culture.Name.InvariantEquals(culture) && (x.Uri.Scheme + "://" + x.Uri.Authority).InvariantEquals(currentAuthority)) : domainAndUris.FirstOrDefault(x => x.Culture.Name.InvariantEquals(culture) && x.Uri.Authority.InvariantEquals(currentAuthority))) : null) ??
+					   domainAndUris.FirstOrDefault(x => x.Culture.Name.InvariantEquals(culture)) ??
+					   domainAndUris.FirstOrDefault(x => x.Culture.Name.InvariantEquals(defaultCulture)) ??
+					   domainAndUris.First();
 
             // find a site that contains the current authority
             var currentSite = qualifiedSites.FirstOrDefault(site => site.Value.Contains(currentAuthority));


### PR DESCRIPTION
…lture

Try to map current site to current authority with related current culture if available before taking first available domain with culture. This fixes issue if multiple domains with same culture are connected to page f.e. staging-url.ch/de, live-url.ch/de and local-url.ch/de , where wrong domain urls are rendered with GetUrl() in content loaded via ajax and surfacecontroller (due to umbraco in url for controller which can not be mapped to corresponding url), because it selects first domain by culture and not tries to select domain by authority and culture first.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
