### PR TITLE
Netcore: Make it possible to run some code before umbraco pipeline

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoStartupFilter.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoStartupFilter.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.DependencyInjection
@@ -11,10 +12,15 @@ namespace Umbraco.Cms.Web.Common.DependencyInjection
     /// </summary>
     public sealed class UmbracoStartupFilter : IStartupFilter
     {
+        private readonly IOptions<UmbracoStartupFilterOptions> _options;
+        public UmbracoStartupFilter(IOptions<UmbracoStartupFilterOptions> options) => _options = options;
+
         /// <inheritdoc/>
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) =>
             app =>
             {
+                _options.Value.PreUmbracoPipeline(app);
+
                 app.UseUmbraco();
                 next(app);
             };

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoStartupFilterOptions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoStartupFilterOptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Umbraco.Cms.Web.Common.DependencyInjection
+{
+    public class UmbracoStartupFilterOptions
+    {
+        /// <summary>
+        /// Represents the pipeline that is executed before umbraco. By default this pipeline only adds UseDeveloperExceptionPage when the environments is Development.
+        /// </summary>
+        public Action<IApplicationBuilder> PreUmbracoPipeline { get; set; } = app =>
+        {
+            IWebHostEnvironment env = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+        };
+    }
+}

--- a/src/Umbraco.Web.UI.NetCore/Startup.cs
+++ b/src/Umbraco.Web.UI.NetCore/Startup.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 
@@ -54,11 +53,6 @@ namespace Umbraco.Cms.Web.UI.NetCore
         /// </summary>
         public void Configure(IApplicationBuilder app)
         {
-            if (_env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-
             app.UseUmbracoBackOffice();
             app.UseUmbracoWebsite();
         }


### PR DESCRIPTION
### Details
- This PR simple adds a way to execute some pipeline before umbraco. By default we only want the `DeveloperExceptionPageMiddelware` to execute before, but it has to be configurable.

To archive this, I introduce a new `UmbracoStartupFilterOptions` that contains a delegate that is executed just before we call `IApplicationBuilder.UseUmbraco()`. 

The default implementation of this delegate is 
```cs
app =>
{
    IWebHostEnvironment env = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
    if (env.IsDevelopment())
    {
        app.UseDeveloperExceptionPage();
    }
};
```

But it is easy to override, due to the `IOptions` patterns.

To change the "PreUmbracoPipeline", you can do the following in `Startup.ConfigureServices`:

```cs 
public void ConfigureServices(IServiceCollection services)
{
    ...

    services.Configure<UmbracoStartupFilterOptions>(options =>
    {
        options.PreUmbracoPipeline = app => 
        {
           // Do whatever before Umbraco runs - or just clear what we do my default. 
        };
    });
}

```


