### PR TITLE
Fix for #9950 - HttpsCheck/ExcessiveHeaders when UmbracoID is in use

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
         {
             var message = string.Empty;
             var success = false;
-            var url = _runtime.ApplicationUrl;
+            var url = _runtime.ApplicationUrl.GetLeftPart(UriPartial.Authority);
 
             // Access the site home page and check for the headers
             var request = WebRequest.Create(url);
@@ -69,7 +69,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             }
             catch (Exception ex)
             {
-                message = _textService.Localize("healthcheck/httpsCheckInvalidUrl", new[] { url.ToString(), ex.Message });
+                message = _textService.Localize("healthcheck/healthCheckInvalidUrl", new[] { url.ToString(), ex.Message });
             }
 
             var actions = new List<HealthCheckAction>();


### PR DESCRIPTION
Fix for #9950

Updated HttpsCheck to request background login image if ApplicationUrl returns 301/302.

Note: a HEAD request to /umbraco with UmbracoID will return a 404 and throw an exception, this is why I've changed to a GET request but have disabled auto-follow.

Changed ExcessiveHeaders to make the test request to the root instead of the /umbraco path. Also fixed a long gone localisation alias. 

Tested on Umbraco Cloud enabled with UmbracoID. Note that Cloud "Public Access" restrictions will cause 401 on both checks unless all Umbraco Cloud IPs are added to the whitelist.