### PR TITLE
Allow for having appsettings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ src/Umbraco.Tests/TEMP/
 
 /src/Umbraco.Web.UI/config/umbracoSettings.config
 /src/Umbraco.Web.UI.NetCore/Umbraco/models/*
+/src/Umbraco.Web.UI.NetCore/appsettings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -201,4 +201,4 @@ src/Umbraco.Tests/TEMP/
 
 /src/Umbraco.Web.UI/config/umbracoSettings.config
 /src/Umbraco.Web.UI.NetCore/Umbraco/models/*
-/src/Umbraco.Web.UI.NetCore/appsettings.local.json
+/src/Umbraco.Web.UI.NetCore/appsettings.Local.json

--- a/src/Umbraco.Web.UI.NetCore/Program.cs
+++ b/src/Umbraco.Web.UI.NetCore/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -7,18 +8,20 @@ namespace Umbraco.Cms.Web.UI.NetCore
     public class Program
     {
         public static void Main(string[] args)
-        {
-            CreateHostBuilder(args)
+            => CreateHostBuilder(args)
                 .Build()
                 .Run();
-        }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureLogging(x =>
-                {
-                    x.ClearProviders();
-                })
-                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+#if DEBUG
+                .ConfigureAppConfiguration(config
+                    => config.AddJsonFile(
+                            "appsettings.Local.json",
+                            optional: true,
+                            reloadOnChange: true))
+#endif
+                .ConfigureLogging(x => x.ClearProviders())
+                .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
     }
 }

--- a/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
+++ b/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
@@ -81,6 +81,7 @@
 
   <PropertyGroup>
     <RazorCompileOnBuild>false</RazorCompileOnBuild>
+    <RazorCompileOnPublish>false</RazorCompileOnPublish>
   </PropertyGroup>
 
 </Project>

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -38,7 +38,7 @@
         "ConvertUrlsToAscii": "try"
       },
       "RuntimeMinification": {
-        "dataFolder": "Umbraco/Data/TEMP/Smidge",
+        "dataFolder": "umbraco/Data/TEMP/Smidge",
         "version": "1"
       },
       "Security": {

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -38,7 +38,7 @@
         "ConvertUrlsToAscii": "try"
       },
       "RuntimeMinification": {
-        "dataFolder": "Umbraco/TEMP/Smidge",
+        "dataFolder": "Umbraco/Data/TEMP/Smidge",
         "version": "1"
       },
       "Security": {

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -38,8 +38,8 @@
         "ConvertUrlsToAscii": "try"
       },
       "RuntimeMinification": {
-        "dataFolder": "App_Data/TEMP/Smidge",
-        "version": "637432008251409860"
+        "dataFolder": "Umbraco/TEMP/Smidge",
+        "version": "1"
       },
       "Security": {
         "KeepUserLoggedIn": false,


### PR DESCRIPTION
This file is not checked in and can be used to overwrite any custom settings that are in the repo without worrying about accidentally checking in developer settings as you work.

This also fixes up a couple other very minor settings.

How does it work?

Just create a file in the root of the Umbraco.Web.UI.NetCore project called: `appsettings.local.json` and it will automagicaly just be put underneath the appsettings.json.

Then any settings you apply here overwrite the defaults. This means you can have your own persistent connection string in there without having to worry about checking it in or merging when pulling, etc...

For example, mine looks like:

```json
{
  "ConnectionStrings": {
    "umbracoDbDSN": "server=MyServer;database=MyDatabase;user id=MyUser;password='MyPassword'"
  },
  "Serilog": {
    "MinimumLevel": {
      "Default": "Information",
      "Override": {
        "Microsoft": "Warning",
        "Microsoft.Hosting.Lifetime": "Information",
        "System": "Warning",
        "Umbraco.Cms.Core.Scoping.ScopeProvider": "Debug",
        "Umbraco.Cms.Core.Scoping.Scope": "Debug"
      }
    }
  },
  "Umbraco": {
    "CMS": {
      "Core": {
        "Debug": {
          "LogIncompletedScopes":  true
        }
      },
      "RuntimeMinification": {
        "dataFolder": "Umbraco/TEMP/Smidge",
        "version": "637429827442056840"
      }
    }
  }
}
```

This was also checked into the WIP docker branch https://github.com/umbraco/Umbraco-CMS/pull/9743/files ... but I've separated that out now into it's own PR. I've been running locally with this for a long time now.