### PR TITLE
NetCore: Fix authorization policies bound to Translation section

### DIFF
--- a/src/Umbraco.Web.BackOffice/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/ServiceCollectionExtensions.cs
@@ -365,16 +365,10 @@ namespace Umbraco.Extensions
                 policy.Requirements.Add(new TreeRequirement(Constants.Trees.Languages));
             });
 
-            options.AddPolicy(AuthorizationPolicies.TreeAccessDocumentTypes, policy =>
-            {
-                policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);
-                policy.Requirements.Add(new TreeRequirement(Constants.Trees.Dictionary));
-            });
-
             options.AddPolicy(AuthorizationPolicies.TreeAccessDictionary, policy =>
             {
                 policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);
-                policy.Requirements.Add(new TreeRequirement(Constants.Trees.Dictionary, Constants.Trees.Dictionary));
+                policy.Requirements.Add(new TreeRequirement(Constants.Trees.Dictionary));
             });
 
             options.AddPolicy(AuthorizationPolicies.TreeAccessDictionaryOrTemplates, policy =>

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "umbracoDbDSN": "Server=(LocalDB)\\Umbraco;Database=Netcore;Integrated Security=true"
+    "umbracoDbDSN": ""
   },
   "Serilog": {
     "MinimumLevel": {
@@ -25,8 +25,7 @@
         "HideTopLevelNodeFromPath": true,
         "UmbracoPath": "~/umbraco",
         "TimeOutInMinutes": 20,
-        "UseHttps": false,
-        "Id": "ddc95ed0-565b-4a63-bcdc-841f312f3e12"
+        "UseHttps": false
       },
       "Hosting": {
         "Debug": false
@@ -43,7 +42,7 @@
         "version": "637432008251409860"
       },
       "Security": {
-        "KeepUserLoggedIn": true,
+        "KeepUserLoggedIn": false,
         "UsernameIsEmail": true,
         "HideDisabledUsersInBackoffice": false,
         "UserPassword": {


### PR DESCRIPTION
Fixes #9938 

### Details
* A duplicated `TreeAccessDocumentTypes` policy had a requirement for user access to the Dictionary tree, which a user failed to achieve by removing the Translation section from their user group;
* By removing this policy as well as fixing the one for `TreeAccessDictionary` the issue is resolved

### Test  
Follow the steps to reproduce listed on the original issue and verify that we meet the **Expected result**.

----
Bonus: 
* This PR also contains a change for reverting to the default state of appsettings.json.