### PR TITLE
Made recurring hosted service base class PerformExecuteAsync method public.

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -75,7 +75,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _profilingLogger = profilingLogger;
         }
 
-        internal override async Task PerformExecuteAsync(object state)
+        public override async Task PerformExecuteAsync(object state)
         {
             if (_healthChecksSettings.Notification.Enabled == false)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _httpClientFactory = httpClientFactory;
         }
 
-        internal override async Task PerformExecuteAsync(object state)
+        public override async Task PerformExecuteAsync(object state)
         {
             if (_keepAliveSettings.DisableKeepAliveTask)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _profilingLogger = profilingLogger;
         }
 
-        internal override Task PerformExecuteAsync(object state)
+        public override Task PerformExecuteAsync(object state)
         {
             switch (_serverRegistrar.CurrentServerRole)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             // Hat-tip: https://stackoverflow.com/a/14207615/489433
             await PerformExecuteAsync(state);
 
-        internal abstract Task PerformExecuteAsync(object state);
+        public abstract Task PerformExecuteAsync(object state);
 
         /// <inheritdoc/>
         public Task StopAsync(CancellationToken cancellationToken)

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// Runs the background task to send the anonymous ID
         /// to telemetry service
         /// </summary>
-        internal override async Task PerformExecuteAsync(object state)
+        public override async Task PerformExecuteAsync(object state)
         {
             // Try & get a value stored in umbracoSettings.config on the backoffice XML element ID attribute
             var backofficeIdentifierRaw = _globalSettings.Value.Id;

--- a/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
@@ -60,7 +60,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _serverMessenger = serverMessenger;
         }
 
-        internal override Task PerformExecuteAsync(object state)
+        public override Task PerformExecuteAsync(object state)
         {
             if (Suspendable.ScheduledPublishing.CanRun == false)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             _logger = logger;
         }
 
-        internal override Task PerformExecuteAsync(object state)
+        public override Task PerformExecuteAsync(object state)
         {
             if (_runtimeState.Level != RuntimeLevel.Run)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             _globalSettings = globalSettings.Value;
         }
 
-        internal override Task PerformExecuteAsync(object state)
+        public override Task PerformExecuteAsync(object state)
         {
             if (_runtimeState.Level != RuntimeLevel.Run)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/TempFileCleanup.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/TempFileCleanup.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _tempFolders = _ioHelper.GetTempFolders();
         }
 
-        internal override Task PerformExecuteAsync(object state)
+        public override Task PerformExecuteAsync(object state)
         {
             // Ensure we do not run if not main domain
             if (_mainDom.IsMainDom == false)


### PR DESCRIPTION
This was raised in a comment by a community member, and seems correct.  We can make this method public allowing package developers and/or custom solutions creating hosted services to use our base class.