### PR TITLE
#9964 Removed unneeded check for HttpContext

### DIFF
--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -81,6 +81,7 @@ namespace Umbraco.Core.IO
         public static string MapPath(string path, bool useHttpContext)
         {
             if (path == null) throw new ArgumentNullException("path");
+
             useHttpContext = useHttpContext && IsHosted;
 
             // Check if the path is already mapped
@@ -89,10 +90,8 @@ namespace Umbraco.Core.IO
             {
                 return path;
             }
-            // Check that we even have an HttpContext! otherwise things will fail anyways
-            // http://umbraco.codeplex.com/workitem/30946
 
-            if (useHttpContext && HttpContext.Current != null)
+            if (useHttpContext)
             {
                 //string retval;
                 if (String.IsNullOrEmpty(path) == false && (path.StartsWith("~") || path.StartsWith(SystemDirectories.Root)))


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/9964

### Description
Removes a unneeded check from IOHelper.MapPath that makes virtual directories in IIS not work, see the issue for details.
