### PR TITLE
Remove unnecessary aria-hidden attribute from umb-icon

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -95,7 +95,7 @@
 
         <div ng-if="splitViewOpen">
             <button type="button" class="btn-reset umb-editor-header__close-split-view" ng-click="closeSplitView()">
-                <umb-icon icon="icon-delete" class="icon-delete" aria-hidden="true"></umb-icon>
+                <umb-icon icon="icon-delete" class="icon-delete"></umb-icon>
                 <span class="sr-only"><localize key="general_closepane">Close Pane</localize></span>
             </button>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR just removes an unnecessary `aria-hidden` on `<umb-icon>` introduced in https://github.com/umbraco/Umbraco-CMS/pull/9264 since it is already taken care of in the component itself https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/components/umb-icon.html#L1

In fact it was the only place I could find where this was added to `<umb-icon>`.