### PR TITLE
Eye Dropper macro parameter editor

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -52,7 +52,7 @@ namespace Umbraco.Core
                 public const string ColorPicker = "Umbraco.ColorPicker";
 
                 /// <summary>
-                /// EyeDropper Color Picker.
+                /// Eye Dropper Color Picker.
                 /// </summary>
                 public const string ColorPickerEyeDropper = "Umbraco.ColorPicker.EyeDropper";
 

--- a/src/Umbraco.Web/PropertyEditors/EyeDropperColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/EyeDropperColorPickerConfigurationEditor.cs
@@ -24,8 +24,6 @@ namespace Umbraco.Web.PropertyEditors
         /// <inheritdoc />
         public override EyeDropperColorPickerConfiguration FromConfigurationEditor(IDictionary<string, object> editorValues, EyeDropperColorPickerConfiguration configuration)
         {
-            var output = new EyeDropperColorPickerConfiguration();
-
             var showAlpha = true;
             var showPalette = true;
 

--- a/src/Umbraco.Web/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Web.PropertyEditors
 {
     [DataEditor(
         Constants.PropertyEditors.Aliases.ColorPickerEyeDropper,
+        EditorType.PropertyValue | EditorType.MacroParameter,
         "Eye Dropper Color Picker",
         "eyedropper",
         Icon = "icon-colorpicker",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR is a follow-up on https://github.com/umbraco/Umbraco-CMS/pull/9646 allowing the Eye Dropper Color Picker to be used as macro parameter editor.

![image](https://user-images.githubusercontent.com/2919859/111384200-83935d00-86a9-11eb-90d2-d03307843e08.png)

![image](https://user-images.githubusercontent.com/2919859/111384117-6d859c80-86a9-11eb-8419-25dc6c171643.png)
