### PR TITLE
Revert "The Value() method for IPublishedContent was not working with the defaultValue parameter"

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -174,7 +174,7 @@ namespace Umbraco.Web
 
             // else... if we have a property, at least let the converter return its own
             // vision of 'no value' (could be an empty enumerable) - otherwise, default
-            return property == null ? default : property.Value<T>(culture, segment);
+            return property == null ? default : property.Value<T>(culture, segment, fallback, defaultValue);
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -173,8 +173,8 @@ namespace Umbraco.Web
                 return value;
 
             // else... if we have a property, at least let the converter return its own
-            // vision of 'no value' (could be an empty enumerable) - otherwise, defaultValue
-            return property == null ? defaultValue : property.Value<T>(culture, segment, defaultValue: defaultValue);
+            // vision of 'no value' (could be an empty enumerable) - otherwise, default
+            return property == null ? default : property.Value<T>(culture, segment);
         }
 
         #endregion

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models.PublishedContent;
@@ -37,9 +37,16 @@ namespace Umbraco.Web
                 // we have a value
                 // try to cast or convert it
                 var value =  property.GetValue(culture, segment);
-                if (value is T valueAsT) return valueAsT;
+                if (value is T valueAsT)
+                {
+                    return valueAsT;
+                }
+
                 var valueConverted = value.TryConvertTo<T>();
-                if (valueConverted) return valueConverted.Result;
+                if (valueConverted)
+                {
+                    return valueConverted.Result;
+                }
 
                 // cannot cast nor convert the value, nothing we can return but 'default'
                 // note: we don't want to fallback in that case - would make little sense
@@ -48,14 +55,28 @@ namespace Umbraco.Web
 
             // we don't have a value, try fallback
             if (PublishedValueFallback.TryGetValue(property, culture, segment, fallback, defaultValue, out var fallbackValue))
+            {
                 return fallbackValue;
+            }
 
             // we don't have a value - neither direct nor fallback
             // give a chance to the converter to return something (eg empty enumerable)
             var noValue = property.GetValue(culture, segment);
-            if (noValue is T noValueAsT) return noValueAsT;
+            if (noValue == null)
+            {
+                return default;
+            }
+
+            if (noValue is T noValueAsT)
+            {
+                return noValueAsT;
+            }
+
             var noValueConverted = noValue.TryConvertTo<T>();
-            if (noValueConverted) return noValueConverted.Result;
+            if (noValueConverted)
+            {
+                return noValueConverted.Result;
+            }
 
             // cannot cast noValue nor convert it, nothing we can return but 'default'
             return default;

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models.PublishedContent;

--- a/src/Umbraco.Web/PublishedPropertyExtension.cs
+++ b/src/Umbraco.Web/PublishedPropertyExtension.cs
@@ -41,31 +41,24 @@ namespace Umbraco.Web
                 var valueConverted = value.TryConvertTo<T>();
                 if (valueConverted) return valueConverted.Result;
 
-                // cannot cast nor convert the value, nothing we can return but 'defaultValue'
+                // cannot cast nor convert the value, nothing we can return but 'default'
                 // note: we don't want to fallback in that case - would make little sense
-                return defaultValue;
+                return default;
             }
 
             // we don't have a value, try fallback
             if (PublishedValueFallback.TryGetValue(property, culture, segment, fallback, defaultValue, out var fallbackValue))
-            {
                 return fallbackValue;
-            }
 
             // we don't have a value - neither direct nor fallback
             // give a chance to the converter to return something (eg empty enumerable)
             var noValue = property.GetValue(culture, segment);
-            if (noValue == null)
-            {
-                return defaultValue;
-            }
             if (noValue is T noValueAsT) return noValueAsT;
-
             var noValueConverted = noValue.TryConvertTo<T>();
             if (noValueConverted) return noValueConverted.Result;
 
-            // cannot cast noValue nor convert it, nothing we can return but 'defaultValue'
-            return defaultValue;
+            // cannot cast noValue nor convert it, nothing we can return but 'default'
+            return default;
         }
 
         #endregion


### PR DESCRIPTION
Partially reverts umbraco/Umbraco-CMS#9888

PR #9888 introduced an unintended breaking change, so reverting it but with keeping one change: we send the fallback + default value parameter to the inner Value method.