### PR TITLE
Fixes #9993 - Cannot save empty image in Grid

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -202,8 +202,8 @@ namespace Umbraco.Web.PropertyEditors
                     _richTextPropertyValueEditor.GetReferences(x.Value)))
                     yield return umbracoEntityReference;
 
-                foreach (var umbracoEntityReference in mediaValues.SelectMany(x =>
-                    _mediaPickerPropertyValueEditor.GetReferences(x.Value["udi"])))
+                foreach (var umbracoEntityReference in mediaValues.Where(x => x.Value.HasValues)
+                    .SelectMany(x => _mediaPickerPropertyValueEditor.GetReferences(x.Value["udi"])))
                     yield return umbracoEntityReference;
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9993 

### Description

As described in #9993 you can't save a Grid sometimes due to an error.

- Add a new item to the grid of type image
- Do not pick an image, so just the placeholder is there
- Attempt to save the page
- Notice error popping up

In recent changes in the Grid it seems like the model was changed slightly, which now requires us to make sure items have values before we try to parse those values. I believe this might have been due to the change here: https://github.com/umbraco/Umbraco-CMS/pull/9681/files#diff-16bf5e50f31cc4c3ef3f2af6bf0a399b98e5e2e926e793184cffdc9d0f0ecbcdR112-R120

Not entirely sure. 

So far this error is the only side-effect we've seen, but there may be more, we'll need to investigate //cc: @nathanwoulfe 