### PR TITLE
Create explicit scope for mappers in UmbracoMapper

### DIFF
--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -305,14 +305,8 @@ namespace Umbraco.Core.Mapping
         {
             var context = new MapperContext(this);
 
-            TTarget targetInstance;
-            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
-            {
-                f(context);
-                targetInstance = Map(source, target, context);
-            }
-
-            return targetInstance;
+            f(context);
+            return Map(source, target, context);;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -304,9 +304,8 @@ namespace Umbraco.Core.Mapping
         public TTarget Map<TSource, TTarget>(TSource source, TTarget target, Action<MapperContext> f)
         {
             var context = new MapperContext(this);
-
             f(context);
-            return Map(source, target, context);;
+            return Map(source, target, context);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Exceptions;
 using Umbraco.Core.Scoping;
 
@@ -57,6 +58,14 @@ namespace Umbraco.Core.Mapping
             foreach (var profile in profiles)
                 profile.DefineMaps(this);
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoMapper"/> class.
+        /// </summary>
+        /// <param name="profiles"></param>
+        [Obsolete("This constructor is no longer used and will be removed in future versions, use the other constructor instead")]
+        public UmbracoMapper(MapDefinitionCollection profiles) : this(profiles, Current.ScopeProvider)
+        {}
 
         #region Define
 

--- a/src/Umbraco.Core/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Core/Mapping/UmbracoMapper.cs
@@ -209,7 +209,7 @@ namespace Umbraco.Core.Mapping
             if (ctor != null && map != null)
             {
                 var target = ctor(source, context);
-                using (var scope = _scopeProvider.CreateScope())
+                using (var scope = _scopeProvider.CreateScope(autoComplete: true))
                 {
                     map(source, target, context);
                 }
@@ -257,7 +257,7 @@ namespace Umbraco.Core.Mapping
         {
             var targetList = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(targetGenericArg));
 
-            using (var scope = _scopeProvider.CreateScope())
+            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
             {
                 foreach (var sourceItem in source)
                 {
@@ -306,7 +306,7 @@ namespace Umbraco.Core.Mapping
             var context = new MapperContext(this);
 
             TTarget targetInstance;
-            using (var scope = _scopeProvider.CreateScope())
+            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
             {
                 f(context);
                 targetInstance = Map(source, target, context);
@@ -334,7 +334,7 @@ namespace Umbraco.Core.Mapping
             // if there is a direct map, map
             if (map != null)
             {
-                using (var scope = _scopeProvider.CreateScope())
+                using (var scope = _scopeProvider.CreateScope(autoComplete: true))
                 {
                     map(source, target, context);
                 }

--- a/src/Umbraco.Tests/Mapping/MappingTests.cs
+++ b/src/Umbraco.Tests/Mapping/MappingTests.cs
@@ -1,17 +1,40 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Core.Events;
 using Umbraco.Core.Mapping;
 using Umbraco.Core.Models;
+using Umbraco.Core.Scoping;
 using Umbraco.Web.Models.ContentEditing;
+using PropertyCollection = Umbraco.Core.Models.PropertyCollection;
 
 namespace Umbraco.Tests.Mapping
 {
     [TestFixture]
     public class MappingTests
     {
+        private IScopeProvider _scopeProvider;
+
+        [SetUp]
+        public void MockScopeProvider()
+        {
+            var scopeMock = new Mock<IScopeProvider>();
+            scopeMock.Setup(x => x.CreateScope(
+                    It.IsAny<IsolationLevel>(),
+                    It.IsAny<RepositoryCacheMode>(),
+                    It.IsAny<IEventDispatcher>(),
+                    It.IsAny<bool?>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>()))
+                .Returns(Mock.Of<IScope>);
+
+            _scopeProvider = scopeMock.Object;
+        }
+
         [Test]
         public void SimpleMap()
         {
@@ -19,7 +42,7 @@ namespace Umbraco.Tests.Mapping
             {
                 new MapperDefinition1(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             var thing1 = new Thing1 { Value = "value" };
             var thing2 = mapper.Map<Thing1, Thing2>(thing1);
@@ -44,7 +67,7 @@ namespace Umbraco.Tests.Mapping
             {
                 new MapperDefinition1(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             var thing1A = new Thing1 { Value = "valueA" };
             var thing1B = new Thing1 { Value = "valueB" };
@@ -78,7 +101,7 @@ namespace Umbraco.Tests.Mapping
             {
                 new MapperDefinition1(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             var thing3 = new Thing3 { Value = "value" };
             var thing2 = mapper.Map<Thing3, Thing2>(thing3);
@@ -103,7 +126,7 @@ namespace Umbraco.Tests.Mapping
             {
                 new MapperDefinition2(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             // can map a PropertyCollection
             var source = new PropertyCollection();
@@ -119,7 +142,7 @@ namespace Umbraco.Tests.Mapping
                 new MapperDefinition1(),
                 new MapperDefinition3(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             // the mapper currently has a map from Thing1 to Thing2
             // because Thing3 inherits from Thing1, it will map a Thing3 instance,
@@ -179,7 +202,7 @@ namespace Umbraco.Tests.Mapping
             {
                 new MapperDefinition4(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             var thing5 = new Thing5()
             {
@@ -203,7 +226,7 @@ namespace Umbraco.Tests.Mapping
             {
                 new MapperDefinition5(),
             });
-            var mapper = new UmbracoMapper(definitions);
+            var mapper = new UmbracoMapper(definitions, _scopeProvider);
 
             var thing7 = new Thing7();
 

--- a/src/Umbraco.Tests/Testing/TestingTests/MockTests.cs
+++ b/src/Umbraco.Tests/Testing/TestingTests/MockTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Web.Security;
@@ -9,11 +10,13 @@ using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Dictionary;
+using Umbraco.Core.Events;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Mapping;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Persistence;
+using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Stubs;
@@ -98,10 +101,21 @@ namespace Umbraco.Tests.Testing.TestingTests
         {
             var umbracoContext = TestObjects.GetUmbracoContextMock();
 
+            var scopeProvider = new Mock<IScopeProvider>();
+            scopeProvider
+                .Setup(x => x.CreateScope(
+                    It.IsAny<IsolationLevel>(),
+                    It.IsAny<RepositoryCacheMode>(),
+                    It.IsAny<IEventDispatcher>(),
+                    It.IsAny<bool?>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>()))
+                .Returns(Mock.Of<IScope>);
+
             var membershipHelper = new MembershipHelper(umbracoContext.HttpContext, Mock.Of<IPublishedMemberCache>(), Mock.Of<MembershipProvider>(), Mock.Of<RoleProvider>(), Mock.Of<IMemberService>(), Mock.Of<IMemberTypeService>(), Mock.Of<IUserService>(), Mock.Of<IPublicAccessService>(), Mock.Of<AppCaches>(), Mock.Of<ILogger>());
             var umbracoHelper = new UmbracoHelper(Mock.Of<IPublishedContent>(), Mock.Of<ITagQuery>(), Mock.Of<ICultureDictionaryFactory>(), Mock.Of<IUmbracoComponentRenderer>(), Mock.Of<IPublishedContentQuery>(), membershipHelper);
-            var umbracoMapper = new UmbracoMapper(new MapDefinitionCollection(new[] { Mock.Of<IMapDefinition>() }));
-            
+            var umbracoMapper = new UmbracoMapper(new MapDefinitionCollection(new[] { Mock.Of<IMapDefinition>() }), scopeProvider.Object);
+
             // ReSharper disable once UnusedVariable
             var umbracoApiController = new FakeUmbracoApiController(Mock.Of<IGlobalSettings>(), Mock.Of<IUmbracoContextAccessor>(), Mock.Of<ISqlContext>(), ServiceContext.CreatePartial(), AppCaches.NoCache, Mock.Of<IProfilingLogger>(), Mock.Of<IRuntimeState>(), umbracoHelper, umbracoMapper);
 


### PR DESCRIPTION
## Description

We have a lot of mappers that makes several calls to multiple services, resulting in multiple transactions. This PR wraps all calls to the mappers' Map methods in an explicit scope, making all Map operation result in a single transaction. 

I've tried to investigate potential issues and pros and cons. I was unable to find any issues, but the benefit of this change is also the downside to it, there will always be created an explicit scope, even for the mapping operations that don't require the scope, however, as far as I can tell, it's only a matter of object allocation, and therefore I think it's a beneficial trade-off.
 
Another minor downside to this is that it can be argued that this introduces more "magic". If you don't take a look at the UmbracoMapper implementation, it's not obvious that a scope is created for mapping operations, however, I don't think that this is a big deal.  

A thing worth noting is that with the current implementation when mapping with IEnumberables, a single scope will be created for all the mapping operations (line 260 in UmbracoMapper).