### PR TITLE
#9843 - Allow install with DB string pre-configured

### DIFF
--- a/src/Umbraco.Infrastructure/Cache/DatabaseServerMessengerNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/Cache/DatabaseServerMessengerNotificationHandler.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Persistence;
 
@@ -14,7 +15,7 @@ namespace Umbraco.Cms.Core.Cache
     public sealed class DatabaseServerMessengerNotificationHandler : INotificationHandler<UmbracoApplicationStarting>, INotificationHandler<UmbracoRequestEnd>
     {
         private readonly IServerMessenger _messenger;
-        private readonly IUmbracoDatabaseFactory _databaseFactory;
+        private readonly IRuntimeState _runtimeState;
         private readonly IDistributedCacheBinder _distributedCacheBinder;
         private readonly ILogger<DatabaseServerMessengerNotificationHandler> _logger;
 
@@ -23,22 +24,22 @@ namespace Umbraco.Cms.Core.Cache
         /// </summary>
         public DatabaseServerMessengerNotificationHandler(
             IServerMessenger serverMessenger,
-            IUmbracoDatabaseFactory databaseFactory,
+            IRuntimeState runtimeState,
             IDistributedCacheBinder distributedCacheBinder,
             ILogger<DatabaseServerMessengerNotificationHandler> logger)
         {
-            _databaseFactory = databaseFactory;
             _distributedCacheBinder = distributedCacheBinder;
             _logger = logger;
             _messenger = serverMessenger;
+            _runtimeState = runtimeState;
         }
 
         /// <inheritdoc/>
         public void Handle(UmbracoApplicationStarting notification)
         {
-            if (_databaseFactory.CanConnect == false)
+            if (_runtimeState.Level == RuntimeLevel.Install)
             {
-                _logger.LogWarning("Cannot connect to the database, distributed calls will not be enabled for this server.");
+                _logger.LogWarning("Disabling distributed calls during install");
             }
             else
             {


### PR DESCRIPTION
This resolves the error found in #9843 and allows for the install to proceed.  I did take out the check for whether or not the DB can connect, because this check happens in the `RuntimeState.GetUmbracoDatabaseState` method.  If it cannot connect, then either the Level is set to `RuntimeLevel.Install`, in which case we have the same behavior as before, or a boot exception is thrown in the `RuntimeState.DetermineRuntimeLevel` method.  In either case, we are handling the same scenarios without having to make a second connection to the database during server startup.
