### PR TITLE
Fixes #9983 - Getting kicked, if document type has a Umbraco.UserPicker property

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js
@@ -1,8 +1,8 @@
 (function () {
     "use strict";
 
-    function UserPickerController($scope, usersResource, localizationService, eventsService) {
-        
+    function UserPickerController($scope, usersResource, entityResource, localizationService, eventsService) {
+
         var vm = this;
 
         vm.users = [];
@@ -102,17 +102,9 @@
             vm.loading = true;
 
             // Get users
-            usersResource.getPagedResults(vm.usersOptions).then(function (users) {
-
-                vm.users = users.items;
-
-                vm.usersOptions.pageNumber = users.pageNumber;
-                vm.usersOptions.pageSize = users.pageSize;
-                vm.usersOptions.totalItems = users.totalItems;
-                vm.usersOptions.totalPages = users.totalPages;
-
+            entityResource.getAll("User").then(function (data) {
+                vm.users = data;
                 preSelect($scope.model.selection, vm.users);
-
                 vm.loading = false;
             });
         }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function UserPickerController($scope, usersResource, entityResource, localizationService, eventsService) {
+    function UserPickerController($scope, entityResource, localizationService, eventsService) {
 
         var vm = this;
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/userpicker/userpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/userpicker/userpicker.controller.js
@@ -1,4 +1,4 @@
-function userPickerController($scope, usersResource , iconHelper, editorService, overlayService){
+function userPickerController($scope, usersResource , iconHelper, editorService, overlayService, entityResource) {
 
     function trim(str, chr) {
         var rgxtrim = (!chr) ? new RegExp('^\\s+|\\s+$', 'g') : new RegExp('^' + chr + '+|' + chr + '+$', 'g');
@@ -92,17 +92,22 @@ function userPickerController($scope, usersResource , iconHelper, editorService,
         unsubscribe();
     });
 
-    //load user data
-    var modelIds = $scope.model.value ? $scope.model.value.split(',') : [];
-
-    // entityResource.getByIds doesn't support "User" and we would like to show avatars in umb-user-preview as well.
-    usersResource.getUsers(modelIds).then(function (data) {
-        _.each(data, function (item, i) {
-            // set default icon if it's missing
-            item.icon = item.icon ? iconHelper.convertFromLegacyIcon(item.icon) : "icon-user";
-            $scope.renderModel.push({ name: item.name, id: item.id, udi: item.udi, icon: item.icon, avatars: item.avatars });
-        });
-    });
+    //load user data - split to an array of ints (map)
+    const modelIds = $scope.model.value ? $scope.model.value.split(',').map(x => +x) : [];
+    if(modelIds.length !== 0) {
+        entityResource.getAll("User").then(function (users) {
+            const filteredUsers = users.filter(user => modelIds.indexOf(user.id) !== -1);
+            filteredUsers.forEach(item => {
+                    $scope.renderModel.push({
+                        name: item.name,
+                        id: item.id,
+                        udi: item.udi,
+                        icon: item.icon = item.icon ? iconHelper.convertFromLegacyIcon(item.icon) : "icon-user",
+                        avatars: item.avatars
+                    });
+                });
+            });
+    }
 }
 
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/userpicker/userpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/userpicker/userpicker.controller.js
@@ -1,4 +1,4 @@
-function userPickerController($scope, usersResource , iconHelper, editorService, overlayService, entityResource) {
+function userPickerController($scope, iconHelper, editorService, overlayService, entityResource) {
 
     function trim(str, chr) {
         var rgxtrim = (!chr) ? new RegExp('^\\s+|\\s+$', 'g') : new RegExp('^' + chr + '+|' + chr + '+$', 'g');


### PR DESCRIPTION
Temporary fix for this issue. using the entityservice like before.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #9983 

### Description
The new user picker only works properly if you're an admin user because it calls an API that is only available to people who have access to the Users section of the backoffice. If you try to use it without having access you get logged out of the backoffice.

In PR https://github.com/umbraco/Umbraco-CMS/pull/7613/ the endpoint usage changed, before that the user picker would use the entity service to get information about the available users. 

We can't make the new endpoint available to people who don't have access to the users section as it discloses too many details that should not be available to a user of type editor (for example). The new endpoint returns:

```javascript
{
	"userStates": {
		"All": 2,
		"Active": 1,
		"Disabled": 0,
		"LockedOut": 0,
		"Invited": 0,
		"Inactive": 1
	},
	"items": [{
		"username": "test@test.com",
		"emailHash": "b642b4217b34b1e8d3bd915fc65c4452",
		"lastLoginDate": "2021-03-18T08:30:12.15Z",
		"avatars": ["https://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?d=404&s=30", "https://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?d=404&s=60", "https://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?d=404&s=90", "https://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?d=404&s=150", "https://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?d=404&s=300"],
		"userState": 0,
		"culture": "en-US",
		"email": "test@test.com",
		"userGroups": [{
			"notifications": [],
			"sections": [{
				"name": "Content",
				"alias": "content",
				"routePath": null
			}, {
				"name": "Media",
				"alias": "media",
				"routePath": null
			}, {
				"name": "Settings",
				"alias": "settings",
				"routePath": null
			}, {
				"name": "Packages",
				"alias": "packages",
				"routePath": null
			}, {
				"name": "Users",
				"alias": "users",
				"routePath": null
			}, {
				"name": "Members",
				"alias": "member",
				"routePath": null
			}, {
				"name": "Forms",
				"alias": "forms",
				"routePath": null
			}, {
				"name": "Translation",
				"alias": "translation",
				"routePath": null
			}],
			"contentStartNode": {
				"name": "Content root",
				"id": -1,
				"udi": null,
				"icon": "icon-folder",
				"trashed": false,
				"key": "00000000-0000-0000-0000-000000000000",
				"parentId": -1,
				"alias": null,
				"path": "-1",
				"metaData": {}
			},
			"mediaStartNode": {
				"name": "Media root",
				"id": -1,
				"udi": null,
				"icon": "icon-folder",
				"trashed": false,
				"key": "00000000-0000-0000-0000-000000000000",
				"parentId": -1,
				"alias": null,
				"path": "-1",
				"metaData": {}
			},
			"userCount": 0,
			"isSystemUserGroup": true,
			"name": "Administrators",
			"id": 1,
			"udi": null,
			"icon": "icon-medal",
			"trashed": false,
			"key": "00000000-0000-0000-0000-000000000000",
			"parentId": -1,
			"alias": "admin",
			"path": "-1,1",
			"metaData": {}
		}],
		"isCurrentUser": true,
		"notifications": [],
		"name": "Sebastiaan Janssen",
		"id": 1,
		"udi": null,
		"icon": null,
		"trashed": false,
		"key": "00000001-0000-0000-0000-000000000000",
		"parentId": -1,
		"alias": null,
		"path": "-1,1",
		"metaData": {}
	}],
	"pageNumber": 1,
	"pageSize": 25,
	"totalPages": 1,
	"totalItems": 1
}
```

Whereas the entityservice only returns 

```javascript
[{
	"name": "Test",
	"id": -1,
	"udi": null,
	"icon": "icon-user",
	"trashed": false,
	"key": "ffffffff-0000-0000-0000-000000000000",
	"parentId": -1,
	"alias": "test@test.com",
	"path": "",
	"metaData": {}
}]
```

Please also note the overhead in all that extra unused information.

So with this PR, the user display will be a little less rich as the avatar is not available, so we go from:

![image](https://user-images.githubusercontent.com/304656/111598612-b5064880-87cf-11eb-8f40-60f6b230bd96.png)

To: 

![image](https://user-images.githubusercontent.com/304656/111598634-b899cf80-87cf-11eb-84be-6c99f70e21a5.png)

But the functionality is preserved for now and we can still pick users even if we're not an admin. We'll need to figure out what to do about endpoints in the future, this is just fixing the regression for now.

Reproduction:
- Add a user picker on a doctype
- Log in as a user with no access to the Users section
- Note that you get logged out on the pages with the user picker
- Note that after this PR you no longer get kicked out

Additionally, do the same steps as an admin user and note that user picking works in the same way, except it won't show you user's avatars.