### PR TITLE
Unbind listener in variant content editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -202,6 +202,9 @@
             splitViewChanged();
             unbindSplitViewRequest();
         }
+        
+        // if split view was never closed, the listener is not disposed when changing nodes - this unbinds it
+        $scope.$on('$destroy', () => unbindSplitViewRequest());
 
         /**
          * Changes the currently selected variant


### PR DESCRIPTION
Listening for splitViewRequest was only unbound if the split view editor was opened. Not cleaning up the listener caused a memory leak when changing between nodes as the spit view editor was detached but not garbage-collected.

This contributes to fixing #6053 but I'm not sure if it's solved the issue entirely - GC seems to be running more efficiently, node count doesn't continue to grow when travelling around the backoffice.
