### PR TITLE
Fix swedish translation for somethingElse.

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
@@ -136,7 +136,7 @@
     <key alias="select">Välj</key>
     <key alias="saveAndPreview">Förhandsgranska</key>
     <key alias="showPageDisabled">Förhandsgranskning är avstängt på grund av att det inte finns någon mall tilldelad</key>
-    <key alias="somethingElse">Ångra</key>
+    <key alias="somethingElse">Gör något annat</key>
     <key alias="styleChoose">Välj stil</key>
     <key alias="styleShow">Visa stil</key>
     <key alias="tableInsert">Infoga tabell</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


If there's an existing issue for this PR then this fixes #9796 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I fixed the translations for the somethingElse key which was translated to the swedish word for "Regret". The new translation is now word for word "Do something else".

Here's where you can find the translated text:
![image](https://user-images.githubusercontent.com/78850524/111773601-aa6eb080-88ae-11eb-87c8-c09590020bf2.png)


<!-- Thanks for contributing to Umbraco CMS! -->
