### PR TITLE
Proof of concept members password hasher

### DIFF
--- a/src/Umbraco.Infrastructure/Security/MemberPasswordHasher.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberPasswordHasher.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+
+namespace Umbraco.Cms.Infrastructure.Security
+{
+    /// <summary>
+    /// A password hasher for members
+    /// </summary>
+    /// <remarks>
+    /// This will check for the ASP.NET Identity password hash flag before falling back to the legacy password hashing format ("HMACSHA256")
+    /// </remarks>
+    public class MemberPasswordHasher : PasswordHasher<MembersIdentityUser>
+    {
+        private readonly LegacyPasswordSecurity _legacyPasswordHasher;
+
+        public MemberPasswordHasher(LegacyPasswordSecurity legacyPasswordHasher)
+        {
+            _legacyPasswordHasher = legacyPasswordHasher ?? throw new ArgumentNullException(nameof(legacyPasswordHasher));
+        }
+
+        /// <summary>
+        /// Verifies a user's hashed password
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="hashedPassword"></param>
+        /// <param name="providedPassword"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">Thrown when the correct hashing algorith cannot be determined</exception>
+        public override PasswordVerificationResult VerifyHashedPassword(MembersIdentityUser user, string hashedPassword, string providedPassword)
+        {
+            byte[] decodedHashedPassword = null;
+            bool isAspNetIdentityHash = false;
+
+            try
+            {
+                decodedHashedPassword = Convert.FromBase64String(hashedPassword);
+                isAspNetIdentityHash = true;
+            }
+            catch (Exception)
+            {
+                // ignored - decoding throws
+            }
+
+            // check for default ASP.NET Identity password hash flags
+            if (isAspNetIdentityHash)
+            {
+                if (decodedHashedPassword[0] == 0x00 || decodedHashedPassword[0] == 0x01)
+                    return base.VerifyHashedPassword(user, hashedPassword, providedPassword);
+
+                throw new InvalidOperationException("unable to determine member password hashing algorith");
+            }
+
+            var isValid = _legacyPasswordHasher.VerifyPassword(
+                Constants.Security.AspNetUmbraco8PasswordHashAlgorithmName,
+                providedPassword,
+                hashedPassword);
+
+            return isValid ? PasswordVerificationResult.SuccessRehashNeeded : PasswordVerificationResult.Failed;
+        }
+    }
+}

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/MemberPasswordHasherTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/MemberPasswordHasherTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Infrastructure.Security;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Security
+{
+    [TestFixture]
+    public class MemberPasswordHasherTests
+    {
+        private MemberPasswordHasher CreateSut() => new MemberPasswordHasher(new LegacyPasswordSecurity());
+
+        [Test]
+        public void VerifyHashedPassword_GivenAnAspNetIdentity2PasswordHash_ThenExpectSuccessRehashNeeded()
+        {
+            const string password = "Password123!";
+            const string hash = "AJszAsQqxOYbASKfL3JVUu6cjU18ouizXDfX4j7wLlir8SWj2yQaTepE9e5bIohIsQ==";
+
+            var sut = CreateSut();
+            var result = sut.VerifyHashedPassword(null, hash, password);
+
+            Assert.AreEqual(result, PasswordVerificationResult.SuccessRehashNeeded);
+        }
+
+        [Test]
+        public void VerifyHashedPassword_GivenAnAspNetCoreIdentityPasswordHash_ThenExpectSuccess()
+        {
+            const string password = "Password123!";
+            const string hash = "AQAAAAEAACcQAAAAEGF/tTVoL6ef3bQPZFYfbgKFu1CDQIAMgyY1N4EDt9jqdG/hsOX93X1U6LNvlIQ3mw==";
+
+            var sut = CreateSut();
+            var result = sut.VerifyHashedPassword(null, hash, password);
+
+            Assert.AreEqual(result, PasswordVerificationResult.Success);
+        }
+
+        [Test]
+        public void VerifyHashedPassword_GivenALegacyPasswordHash_ThenExpectSuccessRehashNeeded()
+        {
+            const string password = "Password123!";
+            const string hash = "yDiU2YyuYZU4jz6F0fpErQ==BxNRHkXBVyJs9gwWF6ktWdfDwYf5bwm+rvV7tOcNNx8=";
+
+            var sut = CreateSut();
+            var result = sut.VerifyHashedPassword(null, hash, password);
+
+            Assert.AreEqual(result, PasswordVerificationResult.SuccessRehashNeeded);
+        }
+
+        [Test]
+        public void VerifyHashedPassword_GivenAnUnknownBase64Hash_ThenExpectInvalidOperationException()
+        {
+            var hashBytes = new byte[] {3, 2, 1};
+            var hash = Convert.ToBase64String(hashBytes);
+
+            var sut = CreateSut();
+            Assert.Throws<InvalidOperationException>(() => sut.VerifyHashedPassword(null, hash, "password"));
+        }
+
+        [TestCase("AJszAsQqxOYbASKfL3JVUu6cjU18ouizXDfX4j7wLlir8SWj2yQaTepE9e5bIohIsQ==")]
+        [TestCase("AQAAAAEAACcQAAAAEGF/tTVoL6ef3bQPZFYfbgKFu1CDQIAMgyY1N4EDt9jqdG/hsOX93X1U6LNvlIQ3mw==")]
+        [TestCase("yDiU2YyuYZU4jz6F0fpErQ==BxNRHkXBVyJs9gwWF6ktWdfDwYf5bwm+rvV7tOcNNx8=")]
+        public void VerifyHashedPassword_GivenAnInvalidPassword_ThenExpectFailure(string hash)
+        {
+            const string invalidPassword = "nope";
+
+            var sut = CreateSut();
+            var result = sut.VerifyHashedPassword(null, hash, invalidPassword);
+
+            Assert.AreEqual(result, PasswordVerificationResult.Failed);
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Providers;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Infrastructure.Security;
 using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Extensions
@@ -74,7 +75,8 @@ namespace Umbraco.Extensions
             // Services used by Umbraco members identity
             services.TryAddScoped<IUserValidator<MembersIdentityUser>, UserValidator<MembersIdentityUser>>();
             services.TryAddScoped<IPasswordValidator<MembersIdentityUser>, PasswordValidator<MembersIdentityUser>>();
-            services.TryAddScoped<IPasswordHasher<MembersIdentityUser>, PasswordHasher<MembersIdentityUser>>();
+            services.TryAddScoped<IPasswordHasher<MembersIdentityUser>>(_ => new MemberPasswordHasher(new LegacyPasswordSecurity()));
+
             return new MembersIdentityBuilder(services);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Password hasher for members that supports the legacy hashing algorithm and the ASP.NET Identity hashing algorithm. The hashing algorithm is determined by hash format (base64 or not) and the ASP.NET Identity marker byte.

Since `LegacyPasswordSecurity` didn't seem 100% testable I wrote some integration tests using known password hashes.

Let me know if there are any other requirements that I am not aware of.
