### PR TITLE
Ensure backward compatibility in listview edit with custom listview layout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/listviewhelper.service.js
@@ -572,13 +572,15 @@
         * Method for opening an item in a list view for editing.
         *
         * @param {Object} item The item to edit
+        * @param {Object} scope The scope with options
         */
         function editItem(item, scope) {
+
             if (!item.editPath) {
                 return;
             }
 
-            if (scope.options.useInfiniteEditor)
+            if (scope && scope.options && scope.options.useInfiniteEditor)
             {
                 var editorModel = {
                     id: item.id,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10016

### Description
This PR fixes the changes introduced in https://github.com/umbraco/Umbraco-CMS/pull/9026 which broke  backward compatibility using custom listview layouts.

Not sure why it need to pass in the entire scope as second parameter and not just the options though, but we probably can't change that now without making another breaking change. It would probably be simpler with something like this:

```
const options = {
      id: 1234,
      useInfiniteEditor: true
}
```

The rest is available from `item`, but maybe it has something to do with it also need `scope.getContent(scope.contentId)`.

To make in easy to test I have create a custom listview for people in default starter kit. Unzip this "ListviewLayouts" folder to `App_Plugins` and configurate a custom listview for the "people" using the following path: **/App_Plugins/ListviewLayouts/grid-people/grid.html**

[ListviewLayouts.zip](https://github.com/umbraco/Umbraco-CMS/files/6172556/ListviewLayouts.zip)

![image](https://user-images.githubusercontent.com/2919859/111809330-267bef00-88d5-11eb-8591-68601d24e139.png)


**Before**

<img width="960" alt="chrome_mLKtQRzRbU" src="https://user-images.githubusercontent.com/2919859/111809519-5cb96e80-88d5-11eb-8485-e1b94d1ece45.png">


**After**


![zvdTwoh0tf](https://user-images.githubusercontent.com/2919859/111809944-c9346d80-88d5-11eb-990e-3f5fb01d4efa.gif)


### Test notes

- Check clicking link works for both standard list and grid + custom layout
- Enabled "Edit in Infinite Editor" in listview configuration and ensure both standard list and grid open infinite editor. The custom listview would do that, but if modifying the listview controller with this following it handle this as well:

```
$scope.gotoItem = function (item) {
    listViewHelper.editItem(item, $scope);
};
```