### PR TITLE
Copy member type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -432,13 +432,15 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
                 throw "args.id cannot be null";
             }
 
+            var promise = localizationService.localize("contentType_moveFailed");
+
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("contentTypeApiBaseUrl", "PostMove"),
                     {
                         parentId: args.parentId,
                         id: args.id
                     }, { responseType: 'text' }),
-                'Failed to move content');
+                promise);
         },
 
         /**
@@ -475,13 +477,15 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
                 throw "args.id cannot be null";
             }
 
+            var promise = localizationService.localize("contentType_copyFailed");
+
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("contentTypeApiBaseUrl", "PostCopy"),
                     {
                         parentId: args.parentId,
                         id: args.id
                     }, { responseType: 'text' }),
-                'Failed to copy content');
+                promise);
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -208,7 +208,7 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
                 throw "args.id cannot be null";
             }
 
-            var promise = localizationService.localize("media_moveFailed");
+            var promise = localizationService.localize("mediaType_moveFailed");
 
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("mediaTypeApiBaseUrl", "PostMove"),
@@ -230,7 +230,7 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
                 throw "args.id cannot be null";
             }
 
-            var promise = localizationService.localize("media_copyFailed");
+            var promise = localizationService.localize("mediaType_copyFailed");
 
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("mediaTypeApiBaseUrl", "PostCopy"),

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -124,8 +124,7 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
                         id: args.id
                     }, { responseType: 'text' }),
                 promise);
-        },
-
+        }
     };
 }
 angular.module('umbraco.resources').factory('memberTypeResource', memberTypeResource);

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -115,7 +115,7 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
                 throw "args.id cannot be null";
             }
 
-            var promise = localizationService.localize("member_copyFailed");
+            var promise = localizationService.localize("memberType_copyFailed");
 
             return umbRequestHelper.resourcePromise(
                 $http.post(umbRequestHelper.getApiUrl("memberTypeApiBaseUrl", "PostCopy"),

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -3,7 +3,7 @@
     * @name umbraco.resources.memberTypeResource
     * @description Loads in data for member types
     **/
-function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
+function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, localizationService) {
 
     return {
 
@@ -102,7 +102,29 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter) {
             return umbRequestHelper.resourcePromise(
                  $http.post(umbRequestHelper.getApiUrl("memberTypeApiBaseUrl", "PostSave"), saveModel),
                 'Failed to save data for member type id ' + contentType.id);
-        }
+        },
+
+        copy: function (args) {
+            if (!args) {
+                throw "args cannot be null";
+            }
+            if (!args.parentId) {
+                throw "args.parentId cannot be null";
+            }
+            if (!args.id) {
+                throw "args.id cannot be null";
+            }
+
+            var promise = localizationService.localize("member_copyFailed");
+
+            return umbRequestHelper.resourcePromise(
+                $http.post(umbRequestHelper.getApiUrl("memberTypeApiBaseUrl", "PostCopy"),
+                    {
+                        parentId: args.parentId,
+                        id: args.id
+                    }, { responseType: 'text' }),
+                promise);
+        },
 
     };
 }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/copy.html
@@ -20,7 +20,7 @@
                 <div class="alert alert-success">
                     <strong>{{source.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="close()">Ok</button>
+                <button type="button" class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <div ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/export.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/export.html
@@ -1,8 +1,8 @@
 <div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.DocumentTypes.ExportController">
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
-        <a class="btn btn-link" ng-click="cancel()">
+        <button type="button" class="btn btn-link" ng-click="cancel()">
             <localize key="general_cancel">Cancel</localize>
-        </a>
+        </button>
         <button class="btn btn-primary" ng-click="export()">
             <localize key="actions_export">Export</localize>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
@@ -21,14 +21,12 @@
 
             <localize key="general_or">or</localize>
 
-            <a class="btn-link" ng-click="close()">
+            <button type="button" class="btn-link" ng-click="close()">
                 <localize key="cancel">Cancel</localize>
-            </a>
+            </button>
         </form>        
 
         <div ng-if="importDoctype.file.$error.pattern">Please choose a .udt file to import</div>
-        
-
         
     </div>
     <div ng-if="vm.state === 'confirm'">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/move.html
@@ -20,7 +20,7 @@
                 <div class="alert alert-success">
                     <strong>{{source.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="close()">Ok</button>
+                <button type="button" class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <div ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/copy.html
@@ -20,7 +20,7 @@
                 <div class="alert alert-success">
                     <strong>{{source.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="close()">Ok</button>
+                <button type="button" class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <div ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/move.html
@@ -20,7 +20,7 @@
                 <div class="alert alert-success">
                     <strong>{{source.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="close()">Ok</button>
+                <button type="button" class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <div ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/copy.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/copy.controller.js
@@ -1,0 +1,61 @@
+angular.module("umbraco")
+    .controller("Umbraco.Editors.MemberTypes.CopyController",
+    function ($scope, memberTypeResource, treeService, navigationService, notificationsService, appState, eventsService) {
+
+        $scope.dialogTreeApi = {};
+        $scope.source = _.clone($scope.currentNode);
+
+        function nodeSelectHandler(args) {
+            args.event.preventDefault();
+            args.event.stopPropagation();
+
+            if ($scope.target) {
+                //un-select if there's a current one selected
+                $scope.target.selected = false;
+            }
+
+            $scope.target = args.node;
+            $scope.target.selected = true;
+        }
+
+        $scope.copy = function () {
+
+            $scope.busy = true;
+            $scope.error = false;
+
+            memberTypeResource.copy({ parentId: $scope.target.id, id: $scope.source.id })
+                .then(function (path) {
+                    $scope.error = false;
+                    $scope.success = true;
+                    $scope.busy = false;
+
+                    //get the currently edited node (if any)
+                    var activeNode = appState.getTreeState("selectedNode");
+
+                    //we need to do a double sync here: first sync to the copied content - but don't activate the node,
+                    //then sync to the currenlty edited content (note: this might not be the content that was copied!!)
+
+                    navigationService.syncTree({ tree: "memberTypes", path: path, forceReload: true, activate: false }).then(function (args) {
+                        if (activeNode) {
+                            var activeNodePath = treeService.getPath(activeNode).join();
+                            //sync to this node now - depending on what was copied this might already be synced but might not be
+                            navigationService.syncTree({ tree: "memberTypes", path: activeNodePath, forceReload: false, activate: true });
+                        }
+                    });
+
+                }, function (err) {
+                    $scope.success = false;
+                    $scope.error = err;
+                    $scope.busy = false;
+                });
+        };
+
+        $scope.onTreeInit = function () {
+            $scope.dialogTreeApi.callbacks.treeNodeSelect(nodeSelectHandler);
+        };
+
+        $scope.close = function() {
+            navigationService.hideDialog();
+        };
+        
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/copy.html
@@ -20,7 +20,7 @@
                 <div class="alert alert-success">
                     <strong>{{source.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong>
                 </div>
-                <button class="btn btn-primary" ng-click="close()">Ok</button>
+                <button type="button" class="btn btn-primary" ng-click="close()">Ok</button>
             </div>
 
             <div ng-hide="success">

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/copy.html
@@ -1,0 +1,53 @@
+<div class="umb-dialog" ng-controller="Umbraco.Editors.MemberTypes.CopyController">
+
+    <div class="umb-dialog-body">
+        <div class="umb-pane">
+
+            <p class="abstract" ng-hide="success">
+                <localize key="contentTypeEditor_folderToCopy">Select the folder to copy</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
+            </p>
+
+            <umb-loader ng-show="busy"></umb-loader>
+
+            <div ng-show="error">
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
+            </div>
+
+            <div ng-show="success">
+                <div class="alert alert-success">
+                    <strong>{{source.name}}</strong> <localize key="contentTypeEditor_copiedUnderneath">was copied underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+                </div>
+                <button class="btn btn-primary" ng-click="close()">Ok</button>
+            </div>
+
+            <div ng-hide="success">
+
+                <div>
+                    <umb-tree section="settings"
+                              treealias="memberTypes"
+                              customtreeparams="foldersonly=1"
+                              hideheader="false"
+                              hideoptions="true"
+                              isdialog="true"
+                              api="dialogTreeApi"
+                              on-init="onTreeInit()"
+                              enablecheckboxes="true">
+                    </umb-tree>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
+        <button type="button" class="btn btn-link" ng-click="close()" ng-show="!busy">
+            <localize key="general_cancel">Cancel</localize>
+        </button>
+        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">
+            <localize key="actions_copy">Copy</localize>
+        </button>
+    </div>
+</div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -336,6 +336,17 @@
     <key alias="allMembers">Alle medlemmer</key>
     <key alias="memberGroupNoProperties">Medlemgrupper har ingen yderligere egenskaber til redigering.</key>
   </area>
+  <area alias="contentType">
+     <key alias="copyFailed">Kopiering af indholdstypen fejlede</key>
+     <key alias="moveFailed">Flytning af indholdstypen fejlede</key>
+  </area>
+  <area alias="mediaType">
+     <key alias="copyFailed">Kopiering af medietypen fejlede</key>
+     <key alias="moveFailed">Flytning af medietypen fejlede</key>
+  </area>
+  <area alias="memberType">
+     <key alias="copyFailed">Kopiering af medlemstypen fejlede</key>
+  </area>
   <area alias="create">
     <key alias="chooseNode">Hvor ønsker du at oprette den nye %0%</key>
     <key alias="createUnder">Opret under</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -355,6 +355,17 @@
     <key alias="allMembers">All Members</key>
     <key alias="memberGroupNoProperties">Member groups have no additional properties for editing.</key>
   </area>
+  <area alias="contentType">
+     <key alias="copyFailed">Failed to copy content type</key>
+     <key alias="moveFailed">Failed to move content type</key>
+  </area>
+  <area alias="mediaType">
+     <key alias="copyFailed">Failed to copy media type</key>
+     <key alias="moveFailed">Failed to move media type</key>
+  </area>
+  <area alias="memberType">
+     <key alias="copyFailed">Failed to copy member type</key>
+  </area>
   <area alias="create">
     <key alias="chooseNode">Where do you want to create the new %0%</key>
     <key alias="createUnder">Create an item under</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -362,6 +362,17 @@
     <key alias="allMembers">All Members</key>
     <key alias="memberGroupNoProperties">Member groups have no additional properties for editing.</key>
   </area>
+  <area alias="contentType">
+     <key alias="copyFailed">Failed to copy content type</key>
+     <key alias="moveFailed">Failed to move content type</key>
+  </area>
+  <area alias="mediaType">
+     <key alias="copyFailed">Failed to copy media type</key>
+     <key alias="moveFailed">Failed to move media type</key>
+  </area>
+  <area alias="memberType">
+     <key alias="copyFailed">Failed to copy member type</key>
+  </area>
   <area alias="create">
     <key alias="chooseNode">Where do you want to create the new %0%</key>
     <key alias="createUnder">Create an item under</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -336,6 +336,17 @@
     <key alias="allMembers">Tous les membres</key>
     <key alias="memberGroupNoProperties">Les groupes de membres n'ont pas de propriétés supplémentaires modifiables.</key>
   </area>
+  <area alias="contentType">
+    <key alias="copyFailed">Echec de la copie du type de contenu</key>
+    <key alias="moveFailed">Echec du déplacement du type de contenu</key>
+  </area>
+  <area alias="mediaType">
+    <key alias="copyFailed">Echec de la copie du type de media</key>
+    <key alias="moveFailed">Echec du déplacement du type de media</key>
+  </area>
+  <area alias="memberType">
+    <key alias="copyFailed">Echec de la copie du type de membre</key>
+  </area>
   <area alias="create">
     <key alias="chooseNode">Où voulez-vous créer le nouveau %0%</key>
     <key alias="createUnder">Créer un élément sous</key>

--- a/src/Umbraco.Web/Editors/MemberTypeController.cs
+++ b/src/Umbraco.Web/Editors/MemberTypeController.cs
@@ -237,6 +237,18 @@ namespace Umbraco.Web.Editors
             return display;
         }
 
+        /// <summary>
+        /// Copy the member type
+        /// </summary>
+        /// <param name="copy"></param>
+        /// <returns></returns>
+        public HttpResponseMessage PostCopy(MoveOrCopy copy)
+        {
+            return PerformCopy(
+                copy,
+                getContentType: i => Services.MemberTypeService.Get(i),
+                doCopy: (type, i) => Services.MemberTypeService.Copy(type, i));
+        }
 
     }
 }

--- a/src/Umbraco.Web/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -30,7 +30,13 @@ namespace Umbraco.Web.Trees
             }
             else
             {
-                //delete member type/group
+                var memberType = Services.MemberTypeService.Get(int.Parse(id));
+                if (memberType != null)
+                {
+                    menu.Items.Add<ActionCopy>(Services.TextService, opensDialog: true);
+                }
+
+                // delete member type/group
                 menu.Items.Add<ActionDelete>(Services.TextService, opensDialog: true);
             }
 

--- a/src/Umbraco.Web/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -13,6 +13,10 @@ namespace Umbraco.Web.Trees
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
             var nodes = new TreeNodeCollection();
+
+            // if the request is for folders only then just return
+            if (queryStrings["foldersonly"].IsNullOrWhiteSpace() == false && queryStrings["foldersonly"] == "1") return nodes;
+
             nodes.AddRange(GetTreeNodesFromService(id, queryStrings));
             return nodes;
         }

--- a/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTypeTreeController.cs
@@ -29,6 +29,7 @@ namespace Umbraco.Web.Trees
             root.HasChildren = Services.MemberTypeService.GetAll().Any();
             return root;
         }
+
         protected override IEnumerable<TreeNode> GetTreeNodesFromService(string id, FormDataCollection queryStrings)
         {
             return Services.MemberTypeService.GetAll()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9991

### Description
This PR implement the copy feature for member type similar to how it works for content type and media type. Currently this works (almost) as expected. However unlike content/document types and media types where it use `customtreeparams="foldersonly=1"` I guess it in this context doesn't know what a folder is, so it both shows folders (or only root node) and also all member types. The member type being copied isn't selectable, but the others are, which cause an error if trying to copy a member type under another member type (which is allowed for e.g. media types).

Besides that it is a great feature and could save some time in development if working with several member types in multiple projects.

```
<umb-tree section="settings"
                  treealias="memberTypes"
                  customtreeparams="foldersonly=1"
                  hideheader="false"
                  hideoptions="true"
                  isdialog="true"
                  api="dialogTreeApi"
                  on-init="onTreeInit()"
                  enablecheckboxes="true">
</umb-tree>
```

![OHEzQHul5j](https://user-images.githubusercontent.com/2919859/111826743-5cc36980-88e9-11eb-83ed-c8650c634234.gif)

Furthermore failed move and copy of media types was actually using an incorrect localization since it just use the wording `media` when it is `media type`.
So I have added new areas for specific content type, media type and member type. "Document type" is still used, but now with "Element type" as well, "content type"  area could be used for both.