### PR TITLE
Netcore: Added TreeAlias to TreeNodesRenderingNotification

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/TreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeControllerBase.cs
@@ -12,7 +12,6 @@ using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Cms.Web.Common.ModelBinders;
 using Umbraco.Extensions;
-using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Web.BackOffice.Trees
 {
@@ -150,7 +149,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                     node.RoutePath = "#";
 
             //raise the event
-            await _eventAggregator.PublishAsync(new TreeNodesRenderingNotification(nodes, queryStrings));
+            await _eventAggregator.PublishAsync(new TreeNodesRenderingNotification(nodes, queryStrings, TreeAlias));
 
             return nodes;
         }

--- a/src/Umbraco.Web.BackOffice/Trees/TreeNodesRenderingNotification.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeNodesRenderingNotification.cs
@@ -22,10 +22,16 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         /// </summary>
         public FormCollection QueryString { get; }
 
-        public TreeNodesRenderingNotification(TreeNodeCollection nodes, FormCollection queryString)
+        /// <summary>
+        /// The alias of the tree rendered
+        /// </summary>
+        public string TreeAlias { get; }
+
+        public TreeNodesRenderingNotification(TreeNodeCollection nodes, FormCollection queryString, string treeAlias)
         {
             Nodes = nodes;
             QueryString = queryString;
+            TreeAlias = treeAlias;
         }
     }
 }


### PR DESCRIPTION
Added `TreeAlias` to the `TreeNodesRenderingNotification`, so subscribers know what tree has been rendered.