### PR TITLE
Added translated descriptions to nested content & block list

### DIFF
--- a/src/Umbraco.Core/Models/ISimpleContentType.cs
+++ b/src/Umbraco.Core/Models/ISimpleContentType.cs
@@ -9,6 +9,7 @@ namespace Umbraco.Core.Models
     {
         new int Id { get; }
         new string Name { get; }
+        string Description { get; set; }
 
         /// <summary>
         /// Gets the alias of the content type.

--- a/src/Umbraco.Core/Models/SimpleContentType.cs
+++ b/src/Umbraco.Core/Models/SimpleContentType.cs
@@ -43,6 +43,7 @@ namespace Umbraco.Core.Models
             Icon = contentType.Icon;
             IsContainer = contentType.IsContainer;
             Name = contentType.Name;
+            Description = contentType.Description;
             AllowedAsRoot = contentType.AllowedAsRoot;
             IsElement = contentType.IsElement;
         }
@@ -67,6 +68,8 @@ namespace Umbraco.Core.Models
         public bool IsContainer { get; }
         
         public string Name { get; }
+
+        public string Description { get; set; }
 
         /// <inheritdoc />
         public bool AllowedAsRoot { get; }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -198,7 +198,7 @@
                     alias: scaffold.contentTypeAlias,
                     name: scaffold.contentTypeName,
                     icon: iconHelper.convertFromLegacyIcon(scaffold.icon),
-                    tooltip: scaffold.documentType.description
+                    tooltip: scaffold.contentTypeDescription
                 });
             });
 

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -382,9 +382,14 @@ namespace Umbraco.Web.Editors
             var mapped = MapToDisplay(emptyContent);
             // translate the content type name if applicable
             mapped.ContentTypeName = Services.TextService.UmbracoDictionaryTranslate(mapped.ContentTypeName);
+            mapped.ContentTypeDescription = Services.TextService.UmbracoDictionaryTranslate(mapped.ContentTypeDescription);
             // if your user type doesn't have access to the Settings section it would not get this property mapped
             if (mapped.DocumentType != null)
+            {
                 mapped.DocumentType.Name = Services.TextService.UmbracoDictionaryTranslate(mapped.DocumentType.Name);
+                mapped.DocumentType.Description = Services.TextService.UmbracoDictionaryTranslate(mapped.DocumentType.Description);
+            }
+                
 
             //remove the listview app if it exists
             mapped.ContentApps = mapped.ContentApps.Where(x => x.Alias != "umbListView").ToList();

--- a/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentItemDisplay.cs
@@ -81,6 +81,12 @@ namespace Umbraco.Web.Models.ContentEditing
         public string ContentTypeName { get; set; }
 
         /// <summary>
+        /// The description of the content type
+        /// </summary>
+        [DataMember(Name = "contentTypeDescription")]
+        public string ContentTypeDescription { get; set; }
+
+        /// <summary>
         /// Indicates if the content is configured as a list view container
         /// </summary>
         [DataMember(Name = "isContainer")]

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -93,6 +93,7 @@ namespace Umbraco.Web.Models.Mapping
             target.ContentTypeKey = source.ContentType.Key;
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = _localizedTextService.UmbracoDictionaryTranslate(source.ContentType.Name);
+            target.ContentTypeDescription = _localizedTextService.UmbracoDictionaryTranslate(source.ContentType.Description);
             target.DocumentType = _commonMapper.GetContentType(source, context);
             target.Icon = source.ContentType.Icon;
             target.Id = source.Id;


### PR DESCRIPTION
### Prerequisites

- I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/9929

### Description
I've included ContentTypeDescription at the SimpleContentType level so that once it's translated and passed back to the nested content and block list editor controller it can use the new property.

In the ContentController (src/Umbraco.Web/Editors/ContentController.cs ~ 388) I've also included the DocumentType.Description translation as it seems that the block list editor uses that.
