### PR TITLE
Fix issue with active style affected nested block list elements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.less
@@ -45,18 +45,6 @@
         }
     }
 
-    .umb-block-list__block.--active & {
-        border-color: @gray-8;
-        box-shadow: 0 0 2px 0px rgba(0, 0, 0, 0.05);
-
-        > button {
-            > .caret {
-                transform: rotate(0deg);
-            }
-        }
-    }
-
-    
     ng-form.ng-invalid-val-server-match-content > .umb-block-list__block > .umb-block-list__block--content > div > & {
         > button {
             color: @formErrorText;
@@ -104,6 +92,22 @@
     }
 }
 
+.umb-block-list__block.--active {
+    border-color: @gray-8;
+    box-shadow: 0 0 2px 0px rgba(0, 0, 0, 0.05);
+
+    > .umb-block-list__block--content {
+        > .umb-block-list__block--view  {
+            > .blockelement-inlineblock-editor {
+                > button {
+                    > .caret {
+                        transform: rotate(0deg);
+                    }
+                }
+            }
+        }
+    }
+}
 
 .blockelement-inlineblock-editor__inner {
     border-top: 1px solid @gray-8;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -61,5 +61,4 @@
         model="vm.blockTypePicker">
     </umb-overlay>
 
-
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -59,12 +59,12 @@
                     <style>
                     @import "${model.stylesheet}"
                     </style>
-                    <div ng-include="'${model.view}'"></div>
+                    <div class="umb-block-list__block--view" ng-include="'${model.view}'"></div>
                 `;
                 $compile(shadowRoot)($scope);
             }
             else {
-                $element.append($compile('<div ng-include="model.view"></div>')($scope));
+                $element.append($compile('<div class="umb-block-list__block--view" ng-include="model.view"></div>')($scope));
             }
         };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed some styling issues with nested block lists, where the active style also affected all nested block list block elements mainly regarding the caret to visualize the active/open block element.

This happens when using inline mode for both parent and nested block lists.

**Before**

![8pYziVD8QU](https://user-images.githubusercontent.com/2919859/111908172-80f18880-8a58-11eb-8201-3b3e9c7e471c.gif)

**After**

![B9dPnCC3Wl](https://user-images.githubusercontent.com/2919859/111908262-d463d680-8a58-11eb-92cd-7ff95a25c8b2.gif)