### PR TITLE
Do not apply runtime optimization to core CSS and CSS libraries

### DIFF
--- a/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
@@ -48,19 +48,18 @@ namespace Umbraco.Cms.Infrastructure.WebAssets
         {
             // Create bundles
 
-            // TODO: I think we don't want to optimize these css if/when we get gulp to do that all for us
-            _runtimeMinifier.CreateCssBundle(UmbracoInitCssBundleName, true,
+            _runtimeMinifier.CreateCssBundle(UmbracoInitCssBundleName, false,
                 FormatPaths("lib/bootstrap-social/bootstrap-social.css",
-                "assets/css/umbraco.css",
+                "assets/css/umbraco.min.css",
                 "lib/font-awesome/css/font-awesome.min.css"));
 
-            _runtimeMinifier.CreateCssBundle(UmbracoUpgradeCssBundleName, true,
-                FormatPaths("assets/css/umbraco.css",
+            _runtimeMinifier.CreateCssBundle(UmbracoUpgradeCssBundleName, false,
+                FormatPaths("assets/css/umbraco.min.css",
                 "lib/bootstrap-social/bootstrap-social.css",
                 "lib/font-awesome/css/font-awesome.min.css"));
 
-            _runtimeMinifier.CreateCssBundle(UmbracoPreviewCssBundleName, true,
-                FormatPaths("assets/css/canvasdesigner.css"));
+            _runtimeMinifier.CreateCssBundle(UmbracoPreviewCssBundleName, false,
+                FormatPaths("assets/css/canvasdesigner.min.css"));
 
             _runtimeMinifier.CreateJsBundle(UmbracoPreviewJsBundleName, false,
                 FormatPaths(GetScriptsForPreview()));

--- a/src/Umbraco.Web.UI.Client/gulp/config.js
+++ b/src/Umbraco.Web.UI.Client/gulp/config.js
@@ -23,10 +23,10 @@ module.exports = {
         // less files used by backoffice and preview
         // processed in the less task
         less: {
-            installer: { files: "./src/less/installer.less", watch: "./src/less/**/*.less", out: "installer.css" },
+            installer: { files: "./src/less/installer.less", watch: "./src/less/**/*.less", out: "installer.min.css" },
             nonodes: { files: "./src/less/pages/nonodes.less", watch: "./src/less/**/*.less", out: "nonodes.style.min.css"},
-            preview: { files: "./src/less/canvas-designer.less", watch: "./src/less/**/*.less", out: "canvasdesigner.css" },
-            umbraco: { files: "./src/less/belle.less", watch: "./src/**/*.less", out: "umbraco.css" },
+            preview: { files: "./src/less/canvas-designer.less", watch: "./src/less/**/*.less", out: "canvasdesigner.min.css" },
+            umbraco: { files: "./src/less/belle.less", watch: "./src/**/*.less", out: "umbraco.min.css" },
             rteContent: { files: "./src/less/rte-content.less", watch: "./src/less/**/*.less", out: "rte-content.css" }
         },
 

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -178,7 +178,7 @@ function dependencies() {
             "name": "flatpickr",
             "src":  [
                 "./node_modules/flatpickr/dist/flatpickr.min.js",
-                "./node_modules/flatpickr/dist/flatpickr.css",
+                "./node_modules/flatpickr/dist/flatpickr.min.css",
                 "./node_modules/flatpickr/dist/l10n/*.js"
             ],
             "base": "./node_modules/flatpickr/dist"
@@ -248,7 +248,7 @@ function dependencies() {
             "name": "spectrum",
             "src":  [
                 "./node_modules/spectrum-colorpicker2/dist/spectrum.js",
-                "./node_modules/spectrum-colorpicker2/dist/spectrum.css"
+                "./node_modules/spectrum-colorpicker2/dist/spectrum.min.css"
             ],
             "base": "./node_modules/spectrum-colorpicker2/dist"
         },

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorpicker.directive.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
 @ngdoc directive
 @name umbraco.directives.directive:umbColorPicker
 @restrict E
@@ -84,7 +84,7 @@
         ctrl.$onInit = function () {
 
             // load the separate css for the editor to avoid it blocking our js loading
-            assetsService.loadCss("lib/spectrum/spectrum.css", $scope);
+            assetsService.loadCss("lib/spectrum/spectrum.min.css", $scope);
 
             // load the js file for the color picker
             assetsService.load([

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
@@ -100,7 +100,7 @@ Use this directive to render a date time picker
         ctrl.$onInit = function () {
 
             // load css file for the date picker
-            assetsService.loadCss('lib/flatpickr/flatpickr.css', $scope).then(function () {
+            assetsService.loadCss('lib/flatpickr/flatpickr.min.css', $scope).then(function () {
                 userService.getCurrentUser().then(function (user) {
 
                     // init date picker

--- a/src/Umbraco.Web.UI.Client/src/index.html
+++ b/src/Umbraco.Web.UI.Client/src/index.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
     <base href="/belle/" />
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <title ng-bind="locationTitle">Umbraco</title>
-    <link rel="stylesheet" href="assets/css/umbraco.css" />
+    <link rel="stylesheet" href="assets/css/umbraco.min.css" />
 </head>
 
 <body ng-class="{touch:touchDevice,emptySection:emptySection}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">

--- a/src/Umbraco.Web.UI.Client/src/views/content/umbpreview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/umbpreview.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Loading</title>
-    <link href="/umbraco/assets/css/umbraco.css" type="text/css" rel="stylesheet">
+    <link href="/umbraco/assets/css/umbraco.min.css" type="text/css" rel="stylesheet">
 </head>
 <body class="content-column-body">
 </body>

--- a/src/Umbraco.Web.UI.NetCore/umbraco/UmbracoInstall/Index.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/umbraco/UmbracoInstall/Index.cshtml
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <title>Install Umbraco</title>
-    <link rel="stylesheet" href="assets/css/installer.css" />
+    <link rel="stylesheet" href="assets/css/installer.min.css" />
 </head>
 
 <body ng-class="{loading:installer.loading}" ng-controller="Umbraco.InstallerController" id="umbracoInstallPageBody">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is the CSS equivalent of #9839_

This PR ensures that we ship minified CSS assets and dependencies instead of minifying them at runtime.

As it happens we're already minifying the core CSS when building the backoffice, but we still tell Smidge to minify it (again) at runtime. I have changed the destination files for the backoffice CSS to have a `.min.css` extension to make it clearer that they are actually minified.

Note that the `bootstrap-social` NPM package does not ship with a `.min.css` stylesheet. But `bootstrap-social.css` is still minified, or at least almost minified, so I have chosen to include it as-is:

![image](https://user-images.githubusercontent.com/7405322/111955528-e93c7a80-8ae9-11eb-8644-246cf8d63a20.png)

### Testing this PR

If the backoffice looks alright, the PR works 😄 

Also you might want to test that you can configure a color picker datatype:

![image](https://user-images.githubusercontent.com/7405322/111956210-cced0d80-8aea-11eb-9c5a-b25644fac886.png)

..and use a date/time picker in content:

![image](https://user-images.githubusercontent.com/7405322/111956149-b9da3d80-8aea-11eb-8081-2391053ced17.png)

