### PR TITLE
UI enhancement: Green checkmark icon for selected item in various views and components

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <umb-icon icon="{{node.selected ? 'icon-check' : node.icon}}" class="icon umb-tree-icon sprTree" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
+        <umb-icon icon="{{node.selected ? 'icon-check' : node.icon}}" class="icon umb-tree-icon sprTree {{node.selected ? 'color-green' : 'color-black'}}" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-item.html
@@ -9,7 +9,7 @@
             <span class="sr-only">Expand child items for {{node.name}}</span>
         </button>
 
-        <umb-icon icon="{{node.selected ? 'icon-check' : node.icon}}" class="icon umb-tree-icon sprTree {{node.selected ? 'color-green' : 'color-black'}}" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
+        <umb-icon icon="{{node.selected ? 'icon-check' : node.icon}}" class="icon umb-tree-icon sprTree {{node.selected ? 'color-green' : ''}}" ng-class="node.cssClass" title="{{::node.title}}" ng-click="select(node, $event)" ng-style="::node.style" tabindex="-1"></umb-icon>
         <span class="umb-tree-item__annotation"></span>
         <a class="umb-tree-item__label" ng-href="#/{{::node.routePath}}" ng-click="select(node, $event)" title="{{::node.title}}">{{node.name}}</a>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -14,7 +14,7 @@
                     ng-click="selectResultCallback($event, result)">
                 <span class="umb-search-group-item-name">
                     <umb-icon icon="{{result.selected ? 'icon-check' : result.icon}}"
-                              class="icon umb-tree-icon sprTree {{result.selected ? 'icon-check' : result.icon}}">
+                              class="icon umb-tree-icon sprTree {{result.selected ? 'icon-check color-green' : result.icon}}">
                     </umb-icon>
                     <span class="umb-search-group-item-name__text">{{ result.name }}</span>
                 </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -5,7 +5,7 @@
             <h5>
                 <a ng-href="#/{{section}}" ng-click="select(tree.root, $event)" class="umb-tree-root-link umb-outline" data-element="tree-root-link">
                     <umb-icon icon="icon-check"
-                              class="umb-tree-icon icon-check"
+                              class="umb-tree-icon icon-check color-green"
                               ng-class="selectEnabledNodeClass(tree.root)"
                               ng-if="enablecheckboxes === 'true'">
                     </umb-icon>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -3,7 +3,7 @@
     <button type="button" class="umb-color-box umb-color-box--{{size}} {{colorClassNamePrefix}}-{{color.value}}" ng-repeat="color in colors" title="{{useLabel || useColorClass ? (color.label || color.value) : ('#' + color.value)}}" hex-bg-inline="{{useColorClass === false}}" hex-bg-color="{{color.value}}" ng-class="{ 'active': isSelectedColor(color) }" ng-click="setColor(color, $index, $event)">
         <div class="umb-color-box-inner">
             <div class="check_circle">
-                <i class="icon icon-check small" ng-show="isSelectedColor(color)"></i>
+                <i class="icon icon-check small color-green" ng-show="isSelectedColor(color)"></i>
             </div>
             <div class="umb-color-box__label" ng-if="useLabel">
                 <div class="umb-color-box__name truncate">{{ color.label || color.value }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -78,7 +78,7 @@
                     <div class="umb-table-row umb-media-grid__list-item -selectable" ng-click="clickItem(item, $event, $index)" ng-repeat="item in items | filter:filterBy | orderBy:sortBy:sortReverse" ng-class="{'-selected': item.selected}">
 
                         <div class="umb-table-cell">
-                            <i ng-show="item.selected" class="umb-table-body__icon umb-table-body__checkicon icon-check" aria-hidden="true"></i>
+                            <i ng-show="item.selected" class="umb-table-body__icon umb-table-body__checkicon icon-check color-green" aria-hidden="true"></i>
                             <i class="{{item.icon}}" class="umb-table-body__icon" aria-hidden="true" ng-if="!item.thumbnail && item.extension != 'svg' && !item.selected"></i><i class="icon-picture"  aria-hidden="true" ng-if="item.thumbnail && !item.selected"></i>
                         </div>
                         <div class="umb-table-cell  umb-table__name">

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -68,7 +68,7 @@
                         <div class="flex items-center">
                             <umb-icon icon="icon-navigation-right" class="icon-navigation-right umb-table__row-expand" ng-click="openNode($event, child)" ng-class="{'umb-table__row-expand--hidden': child.metaData.hasChildren !== true}">&nbsp;</umb-icon>
                             <umb-icon icon="{{child.icon}}" class="umb-table-body__icon umb-table-body__fileicon {{child.icon}}"></umb-icon>
-                            <umb-icon icon="icon-check" class="umb-table-body__icon umb-table-body__checkicon icon-check"></umb-icon>
+                            <umb-icon icon="icon-check" class="umb-table-body__icon umb-table-body__checkicon icon-check color-green"></umb-icon>
                         </div>
                     </div>
                     <div class="umb-table-cell black" ng-class="{'umb-table-cell--faded':child.published === false}">{{ child.name }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -44,7 +44,7 @@
 
                 <div class="umb-table-cell">
                     <i class="umb-table-body__icon umb-table-body__fileicon {{item.icon}}" aria-hidden="true" ng-class="vm.getIcon(item)"></i>
-                    <i class="umb-table-body__icon umb-table-body__checkicon icon-check" aria-hidden="true"></i>
+                    <i class="umb-table-body__icon umb-table-body__checkicon icon-check color-green" aria-hidden="true"></i>
                 </div>
                 <div class="umb-table-cell umb-table__name">
                     <a title="{{ item.name }}" class="umb-table-body__link"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

With the intention to improve the user interface and visibility of interaction in editors, tree pickers, and other components, let's make the checkmark icon green so it appears distinctive from the other unselected items in dark blue/black. Example from the umb-tree-item.html file.

Before:

![Screenshot 2021-03-22 084155](https://user-images.githubusercontent.com/25110864/112023738-cfc02080-8b33-11eb-99a4-d83cd5ee6683.png)

After:

![Screenshot 2021-03-22 084210](https://user-images.githubusercontent.com/25110864/112023747-d189e400-8b33-11eb-94c4-3b4483f0779a.png)

Also, this makes this change consistent with existing use of the checkmark icon:

![image](https://user-images.githubusercontent.com/25110864/112024074-1ca3f700-8b34-11eb-85f1-79da3dfd645d.png)
