### PR TITLE
Adjust showLabels to be parsed as boolean

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -11,8 +11,8 @@ function booleanEditorController($scope, angularHelper) {
         showLabels: false
     };
 
-    if ($scope.model.config && $scope.model.config.showLabels && Object.toBoolean($scope.model.config.showLabels)) {
-        config.showLabels = true;
+    if ($scope.model.config) {
+        $scope.model.config.showLabels = $scope.model.config.showLabels ? Object.toBoolean($scope.model.config.showLabels) : config.showLabels;
     }
 
     // Map the user config


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9910

### Description
When using boolean property editor in a custom property editor and the "showLabels" configuration option was configurated using the boolean prevalue editor (which store "0" or "1") the labels wasn't shown even though the toggle was enabled.

Add a **Test** folder in `App_Plugins` with the following package.manifest:
```
{
  "propertyEditors": [
    {
      "name": "Custom toggle editor",
      "alias": "CustomToggle",
      "editor": {
        "view": "boolean",
        "valueType": "JSON"
      },
      "prevalues": {
        "fields": [
          {
            "label": "Default value",
            "key": "default",
            "view": "boolean"
          },
          {
            "label": "Show labels",
            "key": "showLabels",
            "view": "boolean"
          },
          {
            "label": "Label on",
            "key": "labelOn",
            "view": "textstring"
          },
          {
            "label": "Label off",
            "key": "labelOff",
            "view": "textstring"
          }
        ]
      }
    }
  ],
  "css": [
  ],
  "javascript": [
  ]
}
```

Create a new property with a datatype using the property editor.
Optionally fill out "Label on" and "Label off".
Test the property editor with "Show labels" toggle enabled and disabled.

![image](https://user-images.githubusercontent.com/2919859/112031531-bd49e500-8b3b-11eb-9df1-ead3e1eb32da.png)

Show labels (enabled):

![image](https://user-images.githubusercontent.com/2919859/112031625-d5b9ff80-8b3b-11eb-8a07-6ae1e7086529.png)

Show labels (disabled):

![image](https://user-images.githubusercontent.com/2919859/112031711-ecf8ed00-8b3b-11eb-8e40-ed3043f15224.png)
