### PR TITLE
Update casing of listview layout name

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ListViewConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewConfiguration.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Web.PropertyEditors
             Layouts = new[]
             {
                 new Layout { Name = "List", Icon = "icon-list", IsSystem = 1, Selected = true, Path = "views/propertyeditors/listview/layouts/list/list.html" },
-                new Layout { Name = "grid", Icon = "icon-thumbnails-small", IsSystem = 1, Selected = true, Path = "views/propertyeditors/listview/layouts/grid/grid.html" }
+                new Layout { Name = "Grid", Icon = "icon-thumbnails-small", IsSystem = 1, Selected = true, Path = "views/propertyeditors/listview/layouts/grid/grid.html" }
             };
 
             IncludeProperties = new []


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/pull/10036

### Description
This PR update casing of "Grid" listview layout which was changed a long time ago from "Grid" to "grid" in https://github.com/umbraco/Umbraco-CMS/commit/fb246de5fc27a911fe8381026218abc37fbf5a60

It seems to fix the issue with naming of "Grid" layout in "List View - Members".

For the custom listview configuration in still seemed to use the old "grid" name though.

![image](https://user-images.githubusercontent.com/2919859/112048906-3141b880-8b4f-11eb-9c3e-fcb537839231.png)

After deleting the datatype instance an configurate a new custom listview for the document type if does use the correct "Grid" layout name.

![image](https://user-images.githubusercontent.com/2919859/112049625-2b98a280-8b50-11eb-83b7-119008216b68.png)

The reason the listview "Grid" layout name sometimes was correct is because it is added here during install:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs#L267