### PR TITLE
Fix validation of step size in integer/numeric field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/email/email.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/email/email.html
@@ -1,6 +1,7 @@
 <div ng-controller="Umbraco.PropertyEditors.EmailController">
     <ng-form name="emailFieldForm">
-        <input type="email" name="textbox"
+        <input type="email"
+               name="textbox"
                ng-model="model.value"
                id="{{model.alias}}"
                class="umb-property-editor umb-textstring textstring"
@@ -8,7 +9,7 @@
                ng-required="model.config.IsRequired || model.validation.mandatory"
                val-server="value" />
 
-        <div ng-messages="emailFieldForm.textbox.$error" show-validation-on-submit >
+        <div ng-messages="emailFieldForm.textbox.$error" show-validation-on-submit>
             <p class="help-inline" ng-message="required">{{mandatoryMessage}}</p>
             <p class="help-inline" ng-message="valEmail"><localize key="validation_invalidEmail">Invalid email</localize></p>
             <p class="help-inline" ng-message="valServer">{{emailFieldForm.textbox.errorMsg}}</p>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/integer/integer.html
@@ -9,10 +9,15 @@
                aria-required="{{model.validation.mandatory}}"
                id="{{model.alias}}"
                val-server="value"
-               fix-number min="{{model.config.min}}" max="{{model.config.max}}" step="{{model.config.step}}" />
+               min="{{model.config.min}}"
+               max="{{model.config.max}}"
+               step="{{model.config.step}}"
+               ng-step="model.config.step"
+               fix-number />
 
-        <span ng-messages="integerFieldForm.integerField.$error" show-validation-on-submit >
+        <span ng-messages="integerFieldForm.integerField.$error" show-validation-on-submit>
             <span class="help-inline" ng-message="number"><localize key="validation_invalidNumber">Not a number</localize></span>
+            <span class="help-inline" ng-message="step"><localize key="validation_invalidNumberStepSize">Not a valid numeric step size</localize></span>
             <span class="help-inline" ng-message="valServer">{{integerFieldForm.integerField.errorMsg}}</span>
         </span>
     </ng-form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When a step size is configurated in integer/numeric datatype the value isn't saved if it doesn't fit with the step size.
Considering the following:

Minimum: 100
Step: 2
Maximum: 200

![image](https://user-images.githubusercontent.com/2919859/112057468-98fd0100-8b59-11eb-871e-5141309dae63.png)

Values below 100 and above 200 are invalid, but also a number like 101 due how the step attribute works with HTML5 input fields.

With this change it add a nicer validation, which has already been fixed for the Decimal datatype in https://github.com/umbraco/Umbraco-CMS/pull/9334

![image](https://user-images.githubusercontent.com/2919859/112057705-eda07c00-8b59-11eb-9894-5ed7067b1c20.png)
