### PR TITLE
Update cypress and fix tests

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/languages.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/languages.ts
@@ -6,7 +6,10 @@ context('Languages', () => {
   });
 
   it('Add language', () => {
-    const name = "Kyrgyz (Kyrgyzstan)"; // Must be an option in the select box
+      // For some reason the languages to chose fom seems to be translated differently than normal, as an example:
+      // My system is set to EN (US), but most languages are translated into Danish for some reason
+      // Aghem seems untranslated though?
+      const name = "Aghem"; // Must be an option in the select box
 
      cy.umbracoEnsureLanguageNameNotExists(name);
 

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/templates.ts
@@ -23,14 +23,18 @@ context('Templates', () => {
         cy.umbracoEnsureTemplateNameNotExists(name);
 
         createTemplate();
+        // We have to wait for the ace editor to load, because when the editor is loading it will "steal" the focus briefly,
+        // which causes the save event to fire if we've added something to the header field, causing errors.
+        cy.wait(500);
+
         //Type name
         cy.umbracoEditorHeaderName(name);
         // Save
         // We must drop focus for the auto save event to occur.
         cy.get('.btn-success').focus();
         // And then wait for the auto save event to finish by finding the page in the tree view.
-        // This is a bit of a roundabout way to find items in a treev view since we dont use umbracoTreeItem
-        // but we must be able to wait for the save evnent to finish, and we can't do that with umbracoTreeItem
+        // This is a bit of a roundabout way to find items in a tree view since we dont use umbracoTreeItem
+        // but we must be able to wait for the save event to finish, and we can't do that with umbracoTreeItem
         cy.get('[data-element="tree-item-templates"] > :nth-child(2) > .umb-animated > .umb-tree-item__inner > .umb-tree-item__label')
             .contains(name).should('be.visible', { timeout: 10000 });
         // Now that the auto save event has finished we can save

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tour/backofficeTour.ts
@@ -49,7 +49,7 @@ function resetTourData() {
     {
         "alias": "umbIntroIntroduction",
         "completed": false,
-        "disabled": false
+        "disabled": true
     };
 
     cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {

--- a/src/Umbraco.Tests.AcceptanceTest/package.json
+++ b/src/Umbraco.Tests.AcceptanceTest/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.2",
-    "cypress": "^6.0.1",
+    "cypress": "^6.8.0",
     "ncp": "^2.0.0",
     "prompt": "^1.0.0",
     "umbraco-cypress-testhelpers": "^1.0.0-beta-52"


### PR DESCRIPTION
### Description

Updates cypress to the latest version (6.8.0) and the failing create template tests, there is also a minor tweak to the backOfficeTour tests, and language tests.

#### Create template test

Unforunately the create template tests is fixed with a 500 ms wait after clicking the create button, the issue is that when the ace editor is loading some javascript runs which briefly takes focus from the header field, normally this is not an issue since the script finishes after ~50 ms, however, this is enough time for cypress to type a single letter in the header field, causing the auto save event to fire, breaking the tests because there is no valid alias yet.  I tried fixing this issue some other way, but as far as I can tell there is nothing in the DOM signalling that the javascript is done.

#### BackOffice tour

I changed "disabled" to true when resetting the tour data, I do this because occasionally the popup would appear during the test, causing it to fail because it blocked other elements, this should no longer happen. 

#### Languages

Changed the language to Aghem, this test was causing some issues on the netcore branch, so changed it here as well so they're consistent.

### Testing

I've already run the test multiple times to make sure the tests are stable again.

1. Set up the site
2. Make sure that it's completely empty
3. Run the tests in the UI (`npm run ui`)
4. Run the tests in the terminal (`npm run test`)



