### PR TITLE
Lookup content root nodes when using MNTP in media and members section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -253,9 +253,9 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
             // find content root nodes
             entityResource.getChildren(-1, "Document").then(function (data) {
 
-                var children = data;
-                if (children.length === 1) {
-                    var nodeId = children[0].id;
+                // if only a single content node at root we can use that in XPath query
+                if (data && data.length === 1) {
+                    var nodeId = data[0].id;
                     entityResource.getByQuery($scope.model.config.startNode.query, nodeId, "Document").then(function (ent) {
                         // ensure an entity is returned
                         if (ent) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -238,11 +238,34 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
         dialogOptions.startNodeId = -1;
     }
     else if ($scope.model.config.startNode.query) {
-        //if we have a query for the startnode, we will use that.
-        var rootId = $routeParams.id;
-        entityResource.getByQuery($scope.model.config.startNode.query, rootId, "Document").then(function (ent) {
-            dialogOptions.startNodeId = ($scope.model.config.idType === "udi" ? ent.udi : ent.id).toString();
-        });
+
+        if ($routeParams.section === "content") {
+            var nodeId = $routeParams.id;
+            //if we have a query for the startnode, we will use that.
+            entityResource.getByQuery($scope.model.config.startNode.query, nodeId, "Document").then(function (ent) {
+                // ensure an entity is returned
+                if (ent) {
+                    dialogOptions.startNodeId = ($scope.model.config.idType === "udi" ? ent.udi : ent.id).toString();
+                }
+            });
+        }
+        else {
+            // find content root nodes
+            entityResource.getChildren(-1, "Document").then(function (data) {
+
+                var children = data;
+                if (children.length === 1) {
+                    var nodeId = children[0].id;
+                    entityResource.getByQuery($scope.model.config.startNode.query, nodeId, "Document").then(function (ent) {
+                        // ensure an entity is returned
+                        if (ent) {
+                            dialogOptions.startNodeId = ($scope.model.config.idType === "udi" ? ent.udi : ent.id).toString();
+                        }
+                    });
+                }
+
+            });
+        }
     }
     else {
         dialogOptions.startNodeId = $scope.model.config.startNode.id;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9917

### Description
When using MNTP in media and member section it was throwing console errors, because `entityResource.getByQuery()` didn't return an enity as `$routeParams.id` is the current node and when `$site` and `$root` in XPath `entityResource.getByQuery()` query for a start node, but it couldn't find one in media and member because no `Document` had those ids - only when accessing MNTP in content section.

Currently I am not sure how much we can do about that since it is possible to have muliple root/site nodes in content and editors/users may have different start nodes.

It seems `GetChildren` in EntityController handle this if start nodes have been configurated:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Editors/EntityController.cs#L483-L490


I tested when user has access to a different start node (site node), where it seems to be same behaviour:

![image](https://user-images.githubusercontent.com/2919859/112211753-78e24600-8c1c-11eb-9a53-9909adcf1fcd.png)

But with "Ignore User Start Nodes" enabled on the datatype, which also seems to be same behaviour:

![image](https://user-images.githubusercontent.com/2919859/112212426-4553eb80-8c1d-11eb-9a45-31320615c388.png)

However if "Content Root" has been selected as start node or no start node is configurated and the entity controller only returns a single root node, it is rendered a bit nicer with the XPath expression.

![p1bw5Yv8wi](https://user-images.githubusercontent.com/2919859/112213464-679a3900-8c1e-11eb-818c-79d97544291e.gif)
