### PR TITLE
localizes screenreader text in tree context menu button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -3,7 +3,7 @@
 * @name umbraco.directives.directive:umbTree
 * @restrict E
 **/
-function umbTreeDirective($q, $rootScope, treeService, notificationsService, userService, backdropService) {
+function umbTreeDirective($q, treeService, notificationsService, localizationService, backdropService) {
 
     return {
         restrict: 'E',
@@ -263,6 +263,12 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
                     if ($scope.customtreeparams) {
                         args["queryString"] = $scope.customtreeparams;
                     }
+
+                    // localize the text for the ellipsis button
+                    // this isn't tokenised as it's used in two places in the view
+                    // so the string is appended instead
+                    localizationService.localize('visuallyHiddenTexts_openContextMenu')
+                        .then(text => $scope.openContextMenuText = text);
 
                     return treeService.getTree(args)
                         .then(function (data) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -16,7 +16,7 @@
             <umb-button-ellipsis
                 element="tree-item-options"
                 action="options(tree.root, $event)"
-                text="Open context node for {{tree.name}}"
+                text="{{openContextMenuText}} {{tree.name}}"
                 state="hidden"
                 class="umb-options"
                 ng-hide="tree.root.isContainer || !tree.root.menuUrl"
@@ -54,7 +54,7 @@
             <umb-button-ellipsis
                 element="tree-item-options"
                 action="options(group, $event)"
-                text="Open context node for {{group.name}}"
+                text="{{openContextMenuText}} {{group.name}}"
                 state="hidden"
                 class="umb-options"
                 ng-hide="group.isContainer || !group.menuUrl"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

In my travels through some very old pull requests, I came across #6901 from @emma-hq - while the PR is now super ancient, and partially implemented through other changes in the 513 days since it was raised, the actual localization of the screenreader text for the context menu button hadn't been done.

Rather than trying to update the original PR, I figured it was easier to create a new one. This be it.

Change here takes the previously static text and localize it, so that assistive technologies will be culturally accurate. There are more language files without the `openContextMenu` key than with, so could do with some love in that department, but mono-linguistic me is not the man for the job.

![image](https://user-images.githubusercontent.com/3248070/112304405-2d499e00-8ce9-11eb-92f3-b84d36116cf1.png)
