### PR TITLE
Add config option to select content/media/member type to exclude

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.controller.js
@@ -13,13 +13,21 @@ angular.module('umbraco')
 	            type: "content"
 	        };
         }
-        if (!$scope.model.config) {
-            $scope.model.config = {
-                idType: "udi"
-            };
-        }
 
-        if($scope.model.value.id && $scope.model.value.type !== "member"){
+        // setup the default config
+        var config = {
+            idType: "udi",
+            showXpath: true,
+            allowSelectNode: true
+        };
+
+        // map the user config
+        Utilities.extend(config, $scope.model.config);
+
+        // map back to the model
+        $scope.model.config = config;
+
+        if ($scope.model.value.id && $scope.model.value.type !== "member"){
             entityResource.getById($scope.model.value.id, entityType()).then(function(item){
                 populate(item);
             });
@@ -73,7 +81,7 @@ angular.module('umbraco')
 
 		//we always need to ensure we dont submit anything broken
 	    var unsubscribe = $scope.$on("formSubmitting", function (ev, args) {
-	    	if($scope.model.value.type === "member"){
+	    	if ($scope.model.value.type === "member"){
 	    		$scope.model.value.id = null;
 	    		$scope.model.value.query = "";
 	    	}

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -20,18 +20,20 @@
 	</umb-node-preview>
 
     <div ng-if="!node && model.value.type !== 'member'" class="mt2">
+
         <div ng-hide="showSearch || model.value.query">
             <button type="button" class="umb-node-preview-add"
+                    ng-if="model.config.allowSelectNode"
                     ng-click="openContentPicker()">
                 <localize key="general_choose">Choose a root node</localize>
             </button>
-            <div class="mt2" ng-show="model.value.type == 'content'">
+            <div class="mt2" ng-show="model.config.showXpath && model.value.type == 'content'">
                 <i class="icon icon-search" aria-hidden="true"></i>
                 <button type="button" class="btn-link" ng-click="showSearch = true">Query for root node with xpath</button>
             </div>
         </div>
 
-        <div ng-show="showSearch || model.value.query">
+        <div ng-show="model.config.showXpath && (showSearch || model.value.query)">
 
             <input type="text"
                    ng-model="model.value.query"

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesourcetypepicker.controller.js
@@ -1,5 +1,7 @@
 function TreeSourceTypePickerController($scope, contentTypeResource, mediaTypeResource, memberTypeResource, editorService, eventsService, angularHelper) {
+
     var vm = this;
+
     vm.loading = false;
     vm.itemTypes = [];
     vm.remove = remove;

--- a/src/Umbraco.Web/PropertyEditors/ListViewConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewConfiguration.cs
@@ -60,7 +60,7 @@ namespace Umbraco.Web.PropertyEditors
             Description = "The bulk actions that are allowed from the list view")]
         public BulkActionPermissionSettings BulkActionPermissions { get; set; } = new BulkActionPermissionSettings(); // TODO: managing defaults?
 
-        [ConfigurationField("treesource", "Node Type", "treesource", Description = "Content type to be used in listview")]
+        [ConfigurationField("treesource", "Node Type", "treesource", Description = "Node type to be used in listview")]
         public MultiNodePickerConfigurationTreeSource TreeSource { get; set; }
 
         [ConfigurationField("excludeContentTypes", "Exclude Content Types", "treesourcetypepicker", Description = "Exclude selected content types from the list view")]

--- a/src/Umbraco.Web/PropertyEditors/ListViewConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewConfiguration.cs
@@ -60,6 +60,12 @@ namespace Umbraco.Web.PropertyEditors
             Description = "The bulk actions that are allowed from the list view")]
         public BulkActionPermissionSettings BulkActionPermissions { get; set; } = new BulkActionPermissionSettings(); // TODO: managing defaults?
 
+        [ConfigurationField("treesource", "Node Type", "treesource", Description = "Content type to be used in listview")]
+        public MultiNodePickerConfigurationTreeSource TreeSource { get; set; }
+
+        [ConfigurationField("excludeContentTypes", "Exclude Content Types", "treesourcetypepicker", Description = "Exclude selected content types from the list view")]
+        public string ExcludeContentTypes { get; set; }
+
         [ConfigurationField("icon", "Content app icon", "views/propertyeditors/listview/icon.prevalues.html", Description = "The icon of the listview content app")]
         public string Icon { get; set; }
 

--- a/src/Umbraco.Web/PropertyEditors/ListViewConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ListViewConfigurationEditor.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core.PropertyEditors;
+﻿using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -6,5 +7,15 @@ namespace Umbraco.Web.PropertyEditors
     /// Represents the configuration editor for the listview value editor.
     /// </summary>
     public class ListViewConfigurationEditor : ConfigurationEditor<ListViewConfiguration>
-    { }
+    {
+        public ListViewConfigurationEditor()
+        {
+            Field(nameof(ListViewConfiguration.TreeSource))
+                .Config = new Dictionary<string, object>
+                {
+                    { "showXpath", false },
+                    { "allowSelectNode", false }
+                };
+        }
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9282

### Description
This PR is WIP and add a configuration option in listview to select content/media/member type to be excluded from listview and rendered in tree. We might remove this for members listview as if currently not is possible to create child nodes of members.

I have modified the `treesource` prevalue editor a bit, so it is possible to disable node picker and xpath and just use the node type as this emit the `treeSourceChanged` event used in `treesourcetypepicker` prevalue editor.

![w4FMc70xn2](https://user-images.githubusercontent.com/2919859/112376094-53b90a80-8ce4-11eb-9b86-1d4deccd94c2.gif)

Currently I am not sure how to change this part, so it by default still not render child nodes in tree, but whitelist some content types to be rendered as child nodes.
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Trees/ContentTreeControllerBase.cs#L398-L403

Now it "just" need to render these node types in tree, listview create action and maybe exclude these from listview layout (grid/list/custom).