### PR TITLE
Netcore: Migrate localization service events

### DIFF
--- a/src/Umbraco.Core/Events/DeletingNotification.cs
+++ b/src/Umbraco.Core/Events/DeletingNotification.cs
@@ -2,9 +2,8 @@
 // See LICENSE for more details.
 
 using System.Collections.Generic;
-using Umbraco.Cms.Core.Events;
 
-namespace Umbraco.Cms.Infrastructure.Services.Notifications
+namespace Umbraco.Cms.Core.Events
 {
     public abstract class DeletingNotification<T> : CancelableEnumerableObjectNotification<T>
     {

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Core.Services.Implement;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Cache
@@ -18,7 +19,11 @@ namespace Umbraco.Cms.Core.Cache
     /// <summary>
     /// Default <see cref="IDistributedCacheBinder"/> implementation.
     /// </summary>
-    public partial class DistributedCacheBinder
+    public partial class DistributedCacheBinder :
+        INotificationHandler<DictionaryItemDeletedNotification>,
+        INotificationHandler<DictionaryItemSavedNotification>,
+        INotificationHandler<LanguageSavedNotification>,
+        INotificationHandler<LanguageDeletedNotification>
     {
         private List<Action> _unbinders;
 
@@ -61,12 +66,6 @@ namespace Umbraco.Cms.Core.Cache
             Bind(() => UserService.UserGroupPermissionsAssigned += UserService_UserGroupPermissionsAssigned,
                 () => UserService.UserGroupPermissionsAssigned -= UserService_UserGroupPermissionsAssigned);
 
-            // bind to dictionary events
-            Bind(() => LocalizationService.DeletedDictionaryItem += LocalizationService_DeletedDictionaryItem,
-                () => LocalizationService.DeletedDictionaryItem -= LocalizationService_DeletedDictionaryItem);
-            Bind(() => LocalizationService.SavedDictionaryItem += LocalizationService_SavedDictionaryItem,
-                () => LocalizationService.SavedDictionaryItem -= LocalizationService_SavedDictionaryItem);
-
             // bind to data type events
             Bind(() => DataTypeService.Deleted += DataTypeService_Deleted,
                 () => DataTypeService.Deleted -= DataTypeService_Deleted);
@@ -84,12 +83,6 @@ namespace Umbraco.Cms.Core.Cache
                 () => DomainService.Saved -= DomainService_Saved);
             Bind(() => DomainService.Deleted += DomainService_Deleted,
                 () => DomainService.Deleted -= DomainService_Deleted);
-
-            // bind to language events
-            Bind(() => LocalizationService.SavedLanguage += LocalizationService_SavedLanguage,
-                () => LocalizationService.SavedLanguage -= LocalizationService_SavedLanguage);
-            Bind(() => LocalizationService.DeletedLanguage += LocalizationService_DeletedLanguage,
-                () => LocalizationService.DeletedLanguage -= LocalizationService_DeletedLanguage);
 
             // bind to content type events
             Bind(() => ContentTypeService.Changed += ContentTypeService_Changed,
@@ -196,17 +189,20 @@ namespace Umbraco.Cms.Core.Cache
         #endregion
 
         #region LocalizationService / Dictionary
-
-        private void LocalizationService_SavedDictionaryItem(ILocalizationService sender, SaveEventArgs<IDictionaryItem> e)
+        public void Handle(DictionaryItemSavedNotification notification)
         {
-            foreach (var entity in e.SavedEntities)
+            foreach (IDictionaryItem entity in notification.SavedEntities)
+            {
                 _distributedCache.RefreshDictionaryCache(entity.Id);
+            }
         }
 
-        private void LocalizationService_DeletedDictionaryItem(ILocalizationService sender, DeleteEventArgs<IDictionaryItem> e)
+        public void Handle(DictionaryItemDeletedNotification notification)
         {
-            foreach (var entity in e.DeletedEntities)
+            foreach (IDictionaryItem entity in notification.DeletedEntities)
+            {
                 _distributedCache.RemoveDictionaryCache(entity.Id);
+            }
         }
 
         #endregion
@@ -248,23 +244,25 @@ namespace Umbraco.Cms.Core.Cache
         /// <summary>
         /// Fires when a language is deleted
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void LocalizationService_DeletedLanguage(ILocalizationService sender, DeleteEventArgs<ILanguage> e)
+        /// <param name="notification"></param>
+        public void Handle(LanguageDeletedNotification notification)
         {
-            foreach (var entity in e.DeletedEntities)
+            foreach (ILanguage entity in notification.DeletedEntities)
+            {
                 _distributedCache.RemoveLanguageCache(entity);
+            }
         }
 
         /// <summary>
         /// Fires when a language is saved
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void LocalizationService_SavedLanguage(ILocalizationService sender, SaveEventArgs<ILanguage> e)
+        /// <param name="notification"></param>
+        public void Handle(LanguageSavedNotification notification)
         {
-            foreach (var entity in e.SavedEntities)
+            foreach (ILanguage entity in notification.SavedEntities)
+            {
                 _distributedCache.RefreshLanguageCache(entity);
+            }
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
+++ b/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
@@ -62,6 +63,13 @@ namespace Umbraco.Cms.Core.Compose
                 .AddNotificationHandler<ContentPublishedNotification, RedirectTrackingHandler>()
                 .AddNotificationHandler<ContentMovingNotification, RedirectTrackingHandler>()
                 .AddNotificationHandler<ContentMovedNotification, RedirectTrackingHandler>();
+
+            // Add notification handlers for DistributedCache
+            builder
+                .AddNotificationHandler<DictionaryItemDeletedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<DictionaryItemSavedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<LanguageSavedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<LanguageDeletedNotification, DistributedCacheBinder>();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Implement/LocalizationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/LocalizationService.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.Services.Implement
     /// <summary>
     /// Represents the Localization Service, which is an easy access to operations involving <see cref="Language"/> and <see cref="DictionaryItem"/>
     /// </summary>
-    public class LocalizationService : RepositoryService, ILocalizationService
+    internal class LocalizationService : RepositoryService, ILocalizationService
     {
         private readonly IDictionaryRepository _dictionaryRepository;
         private readonly ILanguageRepository _languageRepository;

--- a/src/Umbraco.Infrastructure/Services/Implement/LocalizationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/LocalizationService.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services.Implement
@@ -17,15 +18,23 @@ namespace Umbraco.Cms.Core.Services.Implement
     {
         private readonly IDictionaryRepository _dictionaryRepository;
         private readonly ILanguageRepository _languageRepository;
+        private readonly IEventAggregator _eventAggregator;
         private readonly IAuditRepository _auditRepository;
 
-        public LocalizationService(IScopeProvider provider, ILoggerFactory loggerFactory, IEventMessagesFactory eventMessagesFactory,
-            IDictionaryRepository dictionaryRepository, IAuditRepository auditRepository, ILanguageRepository languageRepository)
+        public LocalizationService(
+            IScopeProvider provider,
+            ILoggerFactory loggerFactory,
+            IEventMessagesFactory eventMessagesFactory,
+            IDictionaryRepository dictionaryRepository,
+            IAuditRepository auditRepository,
+            ILanguageRepository languageRepository,
+            IEventAggregator eventAggregator)
             : base(provider, loggerFactory, eventMessagesFactory)
         {
             _dictionaryRepository = dictionaryRepository;
             _auditRepository = auditRepository;
             _languageRepository = languageRepository;
+            _eventAggregator = eventAggregator;
         }
 
         /// <summary>
@@ -88,9 +97,11 @@ namespace Umbraco.Cms.Core.Services.Implement
 
                     item.Translations = translations;
                 }
-                var saveEventArgs = new SaveEventArgs<IDictionaryItem>(item);
 
-                if (scope.Events.DispatchCancelable(SavingDictionaryItem, this, saveEventArgs))
+                EventMessages eventMessages = EventMessagesFactory.Get();
+                var savingNotification = new DictionaryItemSavingNotification(item, eventMessages);
+
+                if (_eventAggregator.PublishCancelable(savingNotification))
                 {
                     scope.Complete();
                     return item;
@@ -100,8 +111,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                 // ensure the lazy Language callback is assigned
                 EnsureDictionaryItemLanguageCallback(item);
 
-                saveEventArgs.CanCancel = false;
-                scope.Events.Dispatch(SavedDictionaryItem, this, saveEventArgs);
+                _eventAggregator.Publish(new DictionaryItemSavedNotification(item, eventMessages).WithStateFrom(savingNotification));
 
                 scope.Complete();
 
@@ -232,7 +242,9 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                if (scope.Events.DispatchCancelable(SavingDictionaryItem, this, new SaveEventArgs<IDictionaryItem>(dictionaryItem)))
+                EventMessages eventMessages = EventMessagesFactory.Get();
+                var savingNotification = new DictionaryItemSavingNotification(dictionaryItem, eventMessages);
+                if (_eventAggregator.PublishCancelable(savingNotification))
                 {
                     scope.Complete();
                     return;
@@ -244,7 +256,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                 // ensure the lazy Language callback is assigned
 
                 EnsureDictionaryItemLanguageCallback(dictionaryItem);
-                scope.Events.Dispatch(SavedDictionaryItem, this, new SaveEventArgs<IDictionaryItem>(dictionaryItem, false));
+                _eventAggregator.Publish(new DictionaryItemSavedNotification(dictionaryItem, eventMessages).WithStateFrom(savingNotification));
 
                 Audit(AuditType.Save, "Save DictionaryItem", userId, dictionaryItem.Id, "DictionaryItem");
                 scope.Complete();
@@ -261,16 +273,16 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var deleteEventArgs = new DeleteEventArgs<IDictionaryItem>(dictionaryItem);
-                if (scope.Events.DispatchCancelable(DeletingDictionaryItem, this, deleteEventArgs))
+                EventMessages eventMessages = EventMessagesFactory.Get();
+                var deletingNotification = new DictionaryItemDeletingNotification(dictionaryItem, eventMessages);
+                if (_eventAggregator.PublishCancelable(deletingNotification))
                 {
                     scope.Complete();
                     return;
                 }
 
                 _dictionaryRepository.Delete(dictionaryItem);
-                deleteEventArgs.CanCancel = false;
-                scope.Events.Dispatch(DeletedDictionaryItem, this, deleteEventArgs);
+                _eventAggregator.Publish(new DictionaryItemDeletedNotification(dictionaryItem, eventMessages).WithStateFrom(deletingNotification));
 
                 Audit(AuditType.Delete, "Delete DictionaryItem", userId, dictionaryItem.Id, "DictionaryItem");
 
@@ -374,16 +386,16 @@ namespace Umbraco.Cms.Core.Services.Implement
                         throw new InvalidOperationException($"Cannot save language {language.IsoCode} with fallback {languages[language.FallbackLanguageId.Value].IsoCode} as it would create a fallback cycle.");
                 }
 
-                var saveEventArgs = new SaveEventArgs<ILanguage>(language);
-                if (scope.Events.DispatchCancelable(SavingLanguage, this, saveEventArgs))
+                EventMessages eventMessages = EventMessagesFactory.Get();
+                var savingNotification = new LanguageSavingNotification(language, eventMessages);
+                if (_eventAggregator.PublishCancelable(savingNotification))
                 {
                     scope.Complete();
                     return;
                 }
 
                 _languageRepository.Save(language);
-                saveEventArgs.CanCancel = false;
-                scope.Events.Dispatch(SavedLanguage, this, saveEventArgs);
+                _eventAggregator.Publish(new LanguageSavedNotification(language, eventMessages).WithStateFrom(savingNotification));
 
                 Audit(AuditType.Save, "Save Language", userId, language.Id, ObjectTypes.GetName(UmbracoObjectTypes.Language));
 
@@ -417,8 +429,9 @@ namespace Umbraco.Cms.Core.Services.Implement
                 // write-lock languages to guard against race conds when dealing with default language
                 scope.WriteLock(Cms.Core.Constants.Locks.Languages);
 
-                var deleteEventArgs = new DeleteEventArgs<ILanguage>(language);
-                if (scope.Events.DispatchCancelable(DeletingLanguage, this, deleteEventArgs))
+                EventMessages eventMessages = EventMessagesFactory.Get();
+                var deletingLanguageNotification = new LanguageDeletingNotification(language, eventMessages);
+                if (_eventAggregator.PublishCancelable(deletingLanguageNotification))
                 {
                     scope.Complete();
                     return;
@@ -426,9 +439,8 @@ namespace Umbraco.Cms.Core.Services.Implement
 
                 // NOTE: Other than the fall-back language, there aren't any other constraints in the db, so possible references aren't deleted
                 _languageRepository.Delete(language);
-                deleteEventArgs.CanCancel = false;
 
-                scope.Events.Dispatch(DeletedLanguage, this, deleteEventArgs);
+                _eventAggregator.Publish(new LanguageDeletedNotification(language, eventMessages).WithStateFrom(deletingLanguageNotification));
 
                 Audit(AuditType.Delete, "Delete Language", userId, language.Id, ObjectTypes.GetName(UmbracoObjectTypes.Language));
                 scope.Complete();

--- a/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DictionaryItemDeletedNotification : DeletedNotification<IDictionaryItem>
+    {
+        public DictionaryItemDeletedNotification(IDictionaryItem target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DictionaryItemDeletingNotification : DeletingNotification<IDictionaryItem>
+    {
+        public DictionaryItemDeletingNotification(IDictionaryItem target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public DictionaryItemDeletingNotification(IEnumerable<IDictionaryItem> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DictionaryItemSavedNotification : SavedNotification<IDictionaryItem>
+    {
+        public DictionaryItemSavedNotification(IDictionaryItem target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public DictionaryItemSavedNotification(IEnumerable<IDictionaryItem> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DictionaryItemSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DictionaryItemSavingNotification : SavingNotification<IDictionaryItem>
+    {
+        public DictionaryItemSavingNotification(IDictionaryItem target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public DictionaryItemSavingNotification(IEnumerable<IDictionaryItem> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/LanguageDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/LanguageDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class LanguageDeletedNotification : DeletedNotification<ILanguage>
+    {
+        public LanguageDeletedNotification(ILanguage target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/LanguageDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/LanguageDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class LanguageDeletingNotification : DeletingNotification<ILanguage>
+    {
+        public LanguageDeletingNotification(ILanguage target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public LanguageDeletingNotification(IEnumerable<ILanguage> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/LanguageSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/LanguageSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class LanguageSavedNotification : SavedNotification<ILanguage>
+    {
+        public LanguageSavedNotification(ILanguage target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public LanguageSavedNotification(IEnumerable<ILanguage> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/LanguageSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/LanguageSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class LanguageSavingNotification : SavingNotification<ILanguage>
+    {
+        public LanguageSavingNotification(ILanguage target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public LanguageSavingNotification(IEnumerable<ILanguage> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.PublishedCache.NuCache/Compose/NotificationsComposer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Compose/NotificationsComposer.cs
@@ -1,0 +1,17 @@
+using Umbraco.Cms.Core.Compose;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
+
+namespace Umbraco.Cms.Infrastructure.PublishedCache.Compose
+{
+    public sealed class NotificationsComposer : ComponentComposer<NotificationsComponent>, ICoreComposer
+    {
+        public override void Compose(IUmbracoBuilder builder)
+        {
+            base.Compose(builder);
+
+            builder.AddNotificationHandler<LanguageSavedNotification, PublishedSnapshotServiceEventHandler>();
+        }
+    }
+}

--- a/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
+++ b/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
@@ -47,9 +47,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
                 new EventDefinition<IUserService, SaveEventArgs<UserGroupWithUsers>>(null, UserService, new SaveEventArgs<UserGroupWithUsers>(Enumerable.Empty<UserGroupWithUsers>())),
                 new EventDefinition<IUserService, DeleteEventArgs<IUserGroup>>(null, UserService, new DeleteEventArgs<IUserGroup>(Enumerable.Empty<IUserGroup>())),
 
-                new EventDefinition<ILocalizationService, SaveEventArgs<IDictionaryItem>>(null, LocalizationService, new SaveEventArgs<IDictionaryItem>(Enumerable.Empty<IDictionaryItem>())),
-                new EventDefinition<ILocalizationService, DeleteEventArgs<IDictionaryItem>>(null, LocalizationService, new DeleteEventArgs<IDictionaryItem>(Enumerable.Empty<IDictionaryItem>())),
-
                 new EventDefinition<IDataTypeService, SaveEventArgs<IDataType>>(null, DataTypeService, new SaveEventArgs<IDataType>(Enumerable.Empty<IDataType>())),
                 new EventDefinition<IDataTypeService, DeleteEventArgs<IDataType>>(null, DataTypeService, new DeleteEventArgs<IDataType>(Enumerable.Empty<IDataType>())),
 
@@ -58,9 +55,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
 
                 new EventDefinition<IDomainService, SaveEventArgs<IDomain>>(null, DomainService, new SaveEventArgs<IDomain>(Enumerable.Empty<IDomain>())),
                 new EventDefinition<IDomainService, DeleteEventArgs<IDomain>>(null, DomainService, new DeleteEventArgs<IDomain>(Enumerable.Empty<IDomain>())),
-
-                new EventDefinition<ILocalizationService, SaveEventArgs<ILanguage>>(null, LocalizationService, new SaveEventArgs<ILanguage>(Enumerable.Empty<ILanguage>())),
-                new EventDefinition<ILocalizationService, DeleteEventArgs<ILanguage>>(null, LocalizationService, new DeleteEventArgs<ILanguage>(Enumerable.Empty<ILanguage>())),
 
                 new EventDefinition<IContentTypeService, SaveEventArgs<IContentType>>(null, ContentTypeService, new SaveEventArgs<IContentType>(Enumerable.Empty<IContentType>())),
                 new EventDefinition<IContentTypeService, DeleteEventArgs<IContentType>>(null, ContentTypeService, new DeleteEventArgs<IContentType>(Enumerable.Empty<IContentType>())),

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopedRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopedRepositoryTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
@@ -14,9 +15,12 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Implement;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.PublishedCache;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
 using Umbraco.Cms.Infrastructure.Sync;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
 {
@@ -42,6 +46,17 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
                 new IsolatedCaches(type => new DeepCloneAppCache(new ObjectCacheAppCache())));
 
             return result;
+        }
+
+        protected override void CustomTestSetup(IUmbracoBuilder builder)
+        {
+            builder.Services.AddUnique<IServerMessenger, LocalServerMessenger>();
+            builder
+                .AddNotificationHandler<DictionaryItemDeletedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<DictionaryItemSavedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<LanguageSavedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<LanguageDeletedNotification, DistributedCacheBinder>();
+            builder.AddNotificationHandler<LanguageSavedNotification, PublishedSnapshotServiceEventHandler>();
         }
 
         [TearDown]
@@ -154,9 +169,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
             Assert.AreEqual(lang.Id, globalCached.Id);
             Assert.AreEqual("fr-FR", globalCached.IsoCode);
 
-            _distributedCacheBinder = new DistributedCacheBinder(new DistributedCache(ServerMessenger, CacheRefresherCollection), GetRequiredService<IUmbracoContextFactory>(), GetRequiredService<ILogger<DistributedCacheBinder>>());
-            _distributedCacheBinder.BindEvents(true);
-
             Assert.IsNull(scopeProvider.AmbientScope);
             using (IScope scope = scopeProvider.CreateScope(repositoryCacheMode: RepositoryCacheMode.Scoped))
             {
@@ -250,8 +262,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
             Assert.AreEqual(item.Id, globalCached.Id);
             Assert.AreEqual("item-key", globalCached.ItemKey);
 
-            _distributedCacheBinder = new DistributedCacheBinder(new DistributedCache(ServerMessenger, CacheRefresherCollection), GetRequiredService<IUmbracoContextFactory>(), GetRequiredService<ILogger<DistributedCacheBinder>>());
-            _distributedCacheBinder.BindEvents(true);
+            // _distributedCacheBinder = new DistributedCacheBinder(new DistributedCache(ServerMessenger, CacheRefresherCollection), GetRequiredService<IUmbracoContextFactory>(), GetRequiredService<ILogger<DistributedCacheBinder>>());
+            // _distributedCacheBinder.BindEvents(true);
 
             Assert.IsNull(scopeProvider.AmbientScope);
             using (IScope scope = scopeProvider.CreateScope(repositoryCacheMode: RepositoryCacheMode.Scoped))

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopedRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopedRepositoryTests.cs
@@ -256,14 +256,15 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
             };
             service.Save(item);
 
+            // Refresh the cache manually because we can't unbind
+            service.GetDictionaryItemById(item.Id);
+            service.GetLanguageById(lang.Id);
+
             // global cache contains the entity
             var globalCached = (IDictionaryItem)globalCache.Get(GetCacheIdKey<IDictionaryItem>(item.Id), () => null);
             Assert.IsNotNull(globalCached);
             Assert.AreEqual(item.Id, globalCached.Id);
             Assert.AreEqual("item-key", globalCached.ItemKey);
-
-            // _distributedCacheBinder = new DistributedCacheBinder(new DistributedCache(ServerMessenger, CacheRefresherCollection), GetRequiredService<IUmbracoContextFactory>(), GetRequiredService<ILogger<DistributedCacheBinder>>());
-            // _distributedCacheBinder.BindEvents(true);
 
             Assert.IsNull(scopeProvider.AmbientScope);
             using (IScope scope = scopeProvider.CreateScope(repositoryCacheMode: RepositoryCacheMode.Scoped))


### PR DESCRIPTION
### Description
Migrate the events in `LocalizationService` to the new `EventAggregator` pattern.

Most of this was fairly straight forward, I did run in to a bit of trouble with the integration tests, there were two issues:
1. Since we now rely on dependency injection to register events, we have to use the registered `IServerMessenger`. The default `IServerMessenger` registered in integration tests is a `NoopServerMessenger` which meant that when the events was raised nothing really happened because the `IServerMessenger` did nothing. This was fixed by registering a `LocalServerMessenger` in the `CustomTestSetup` overridden method.
2. In the `SingleItemsOnlyRepositoryCachePolicy` test, we didn't bind the `DistributedCache` until after we had populated the cache with some test objects, from what I can tell this was done in order to test that the global cache was not changed in a scope. Since we can't unbind/bind the `DistrubutedCache` anymore this caused the test to fail. This was fixed by manually setting the cache to the same state by simply getting the two expected objects from the service, thus populating the cache after it had been cleared.

I noticed that we have an events in the `Umbraco.Infrastructure` project that could be in the `Umbraco.Core`  project, the `DeletingNotification` is in the infrastructure project, but the `DeletedNotification` is in the core project, it seems like `DeletingNotification` should be moved, but I didn't do so, because I don't know if there's a reason for it being in the infrastructure project?


### Testing
This is the testing I've performed.

Existing events: 
1. Set breakpoints in the new `Handle` methods in `DistributedCacheBinder_Handlers`
2. Set a breakpoint in the `Handle` method in `PublishedSnapshotServiceEventHandler`
3. Add/remove a Language and a Dictionary item and ensure that the associated breakpoints are hit


Binding to events:
In the `Umbraco.Web.UI.NetCore` project I created a file `TestHandler` that binds to all the new notifications:

```c#
    public class TestHandler :
        INotificationHandler<DictionaryItemDeletedNotification>,
        INotificationHandler<DictionaryItemDeletingNotification>,
        INotificationHandler<DictionaryItemSavingNotification>,
        INotificationHandler<DictionaryItemSavedNotification>,
        INotificationHandler<LanguageDeletingNotification>,
        INotificationHandler<LanguageDeletedNotification>,
        INotificationHandler<LanguageSavingNotification>,
        INotificationHandler<LanguageSavedNotification>
    {
        public void Handle(DictionaryItemDeletedNotification notification)
        {
            foreach (var entity in notification.DeletedEntities)
            {
                Console.WriteLine($"Dictionary Item deleted {entity.Key}");
            }
        }

        public void Handle(DictionaryItemDeletingNotification notification)
        {
{...}
```

And then registered them with a Composer in the same project: 

```c#
    public class NotificationsComposer : ComponentComposer<NotificationsComponent>
    {
        public override void Compose(IUmbracoBuilder builder)
        {
            base.Compose(builder);

            builder
                .AddNotificationHandler<DictionaryItemDeletedNotification, TestHandler>()
                .AddNotificationHandler<DictionaryItemDeletingNotification, TestHandler>()
                .AddNotificationHandler<DictionaryItemSavingNotification, TestHandler>()
                .AddNotificationHandler<DictionaryItemSavedNotification, TestHandler>()
                .AddNotificationHandler<LanguageDeletingNotification, TestHandler>()
                .AddNotificationHandler<LanguageDeletedNotification, TestHandler>()
                .AddNotificationHandler<LanguageSavingNotification, TestHandler>()
                .AddNotificationHandler<LanguageSavedNotification, TestHandler>();
        }
    }
```

I then set breakpoints in all the `Handle` methods in the `TestHandler` and ensured that they were hit and that I could cancel the "ing" notifications.