### PR TITLE
Fixes tabbing-mode remains active after closing modal #9790

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -29,10 +29,6 @@
                     var defaultFocusedElement = getAutoFocusElement(focusableElements);
                     var firstFocusableElement = focusableElements[0];
                     var lastFocusableElement = focusableElements[focusableElements.length -1];
-
-                    // We need to add the tabbing-active class in order to highlight the focused button since the default style is
-                    // outline: none; set in the stylesheet specifically
-                    bodyElement.classList.add('tabbing-active');
     
                     // If there is no default focused element put focus on the first focusable element in the nodelist
                     if(defaultFocusedElement === null ){

--- a/src/Umbraco.Web.UI.Client/src/less/application/umb-outline.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/umb-outline.less
@@ -15,6 +15,7 @@
             right: 0;
             border-radius: 3px;
             box-shadow: 0 0 2px 0px @ui-outline, inset 0 0 2px 2px @ui-outline;
+            pointer-events: none;
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -308,7 +308,14 @@ select[size] {
 input[type="file"],
 input[type="radio"],
 input[type="checkbox"] {
-  .umb-outline();
+  &:focus {
+    border-color: @inputBorderFocus;
+    outline: 0;
+
+    .tabbing-active & {
+      outline: 2px solid @ui-outline;
+    }
+  }
 }
 
 


### PR DESCRIPTION
This PR fixes the checkbox focus state and "tabbing"-mode when a dialog has been opened. When a dialog is opened and closed, with mouse clicks only, the UI will stay in "tabbing"-mode. It makes it impossible to use the UI without using the keyboard to get out of "tabbing"-mode. See the demos below:

The PR also fixes the issue described in #9790

Before fix:
https://user-images.githubusercontent.com/6078361/112824317-ac90f600-908a-11eb-8354-a9ffac061075.mp4

After fix:
https://user-images.githubusercontent.com/6078361/112824418-caf6f180-908a-11eb-90e5-baf541235982.mp4

Zip with test dashboard if needed:
[Test.zip](https://github.com/umbraco/Umbraco-CMS/files/6221117/Test.zip)

