### PR TITLE
Orders member type grouping of members alphabetically, matching the listing of member types.

### DIFF
--- a/src/Umbraco.Web/Trees/MemberTreeController.cs
+++ b/src/Umbraco.Web/Trees/MemberTreeController.cs
@@ -129,10 +129,12 @@ namespace Umbraco.Web.Trees
 
                 if (_isUmbracoProvider)
                 {
-                    nodes.AddRange(Services.MemberTypeService.GetAll()
-                        .Select(memberType =>
-                            CreateTreeNode(memberType.Alias, id, queryStrings, memberType.Name, memberType.Icon.IfNullOrWhiteSpace(Constants.Icons.Member), true,
-                                queryStrings.GetRequiredValue<string>("application") + TreeAlias.EnsureStartsWith('/') + "/list/" + memberType.Alias)));
+                    nodes.AddRange(
+                        Services.MemberTypeService.GetAll()
+                            .OrderBy(x => x.Name)
+                            .Select(memberType =>
+                                CreateTreeNode(memberType.Alias, id, queryStrings, memberType.Name, memberType.Icon.IfNullOrWhiteSpace(Constants.Icons.Member), true,
+                                    queryStrings.GetRequiredValue<string>("application") + TreeAlias.EnsureStartsWith('/') + "/list/" + memberType.Alias)));
                 }
             }
 


### PR DESCRIPTION
This was reported in the Deploy tracker [here](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/3) but the fix is needed in core.

I've just added an alphabetical ordering to the member type listing used to group members in the members section, which matches what is used when member types are ordered within settings.

To Test:

- Create a member type.
- Create another one with a name that starts with a letter earlier in the alphabet than the first one.
- Check they render under the "Members" section in alphabetical order.

Replaces [this PR](https://github.com/umbraco/Umbraco-CMS/pull/10063) targetting `v8/dev`.