### PR TITLE
Netcore: Migrate fileservice events

### DIFF
--- a/src/Umbraco.Core/Events/CreatedNotification.cs
+++ b/src/Umbraco.Core/Events/CreatedNotification.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Events
+{
+    public abstract class CreatedNotification<T> : ObjectNotification<T> where T : class
+    {
+        protected CreatedNotification(T target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public T CreatedEntity => Target;
+    }
+}

--- a/src/Umbraco.Core/Events/CreatingNotification.cs
+++ b/src/Umbraco.Core/Events/CreatingNotification.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Events
+{
+    public abstract class CreatingNotification<T> : CancelableObjectNotification<T> where T : class
+    {
+        protected CreatingNotification(T target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public T CreatedEntity => Target;
+    }
+}

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -33,7 +33,8 @@ namespace Umbraco.Cms.Core.Cache
         INotificationHandler<UserGroupWithUsersSavedNotification>,
         INotificationHandler<UserGroupDeletedNotification>,
         INotificationHandler<MemberGroupDeletedNotification>,
-        INotificationHandler<MemberGroupSavedNotification>
+        INotificationHandler<MemberGroupSavedNotification>,
+        INotificationHandler<TemplateDeletedNotification>
     {
         private List<Action> _unbinders;
 
@@ -70,12 +71,6 @@ namespace Umbraco.Cms.Core.Cache
             Bind(() => DataTypeService.Saved += DataTypeService_Saved,
                 () => DataTypeService.Saved -= DataTypeService_Saved);
 
-            // bind to stylesheet events
-            Bind(() => FileService.SavedStylesheet += FileService_SavedStylesheet,
-                () => FileService.SavedStylesheet -= FileService_SavedStylesheet);
-            Bind(() => FileService.DeletedStylesheet += FileService_DeletedStylesheet,
-                () => FileService.DeletedStylesheet -= FileService_DeletedStylesheet);
-
             // bind to domain events
             Bind(() => DomainService.Saved += DomainService_Saved,
                 () => DomainService.Saved -= DomainService_Saved);
@@ -93,8 +88,6 @@ namespace Umbraco.Cms.Core.Cache
             // bind to template events
             Bind(() => FileService.SavedTemplate += FileService_SavedTemplate,
                 () => FileService.SavedTemplate -= FileService_SavedTemplate);
-            Bind(() => FileService.DeletedTemplate += FileService_DeletedTemplate,
-                () => FileService.DeletedTemplate -= FileService_DeletedTemplate);
 
             // bind to macro events
             Bind(() => MacroService.Saved += MacroService_Saved,
@@ -317,12 +310,13 @@ namespace Umbraco.Cms.Core.Cache
         /// <summary>
         /// Removes cache for template
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void FileService_DeletedTemplate(IFileService sender, DeleteEventArgs<ITemplate> e)
+        /// <param name="notification"></param>
+        public void Handle(TemplateDeletedNotification notification)
         {
-            foreach (var entity in e.DeletedEntities)
+            foreach (ITemplate entity in notification.DeletedEntities)
+            {
                 _distributedCache.RemoveTemplateCache(entity.Id);
+            }
         }
 
         /// <summary>
@@ -335,10 +329,6 @@ namespace Umbraco.Cms.Core.Cache
             foreach (var entity in e.SavedEntities)
                 _distributedCache.RefreshTemplateCache(entity.Id);
         }
-
-        // TODO: our weird events handling wants this for now
-        private void FileService_DeletedStylesheet(IFileService sender, DeleteEventArgs<IStylesheet> e) { }
-        private void FileService_SavedStylesheet(IFileService sender, SaveEventArgs<IStylesheet> e) { }
 
         #endregion
 

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -34,7 +34,8 @@ namespace Umbraco.Cms.Core.Cache
         INotificationHandler<UserGroupDeletedNotification>,
         INotificationHandler<MemberGroupDeletedNotification>,
         INotificationHandler<MemberGroupSavedNotification>,
-        INotificationHandler<TemplateDeletedNotification>
+        INotificationHandler<TemplateDeletedNotification>,
+        INotificationHandler<TemplateSavedNotification>
     {
         private List<Action> _unbinders;
 
@@ -84,10 +85,6 @@ namespace Umbraco.Cms.Core.Cache
                 () => MediaTypeService.Changed -= MediaTypeService_Changed);
             Bind(() => MemberTypeService.Changed += MemberTypeService_Changed,
                 () => MemberTypeService.Changed -= MemberTypeService_Changed);
-
-            // bind to template events
-            Bind(() => FileService.SavedTemplate += FileService_SavedTemplate,
-                () => FileService.SavedTemplate -= FileService_SavedTemplate);
 
             // bind to macro events
             Bind(() => MacroService.Saved += MacroService_Saved,
@@ -322,12 +319,13 @@ namespace Umbraco.Cms.Core.Cache
         /// <summary>
         /// Refresh cache for template
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void FileService_SavedTemplate(IFileService sender, SaveEventArgs<ITemplate> e)
+        /// <param name="notification"></param>
+        public void Handle(TemplateSavedNotification notification)
         {
-            foreach (var entity in e.SavedEntities)
+            foreach (ITemplate entity in notification.SavedEntities)
+            {
                 _distributedCache.RefreshTemplateCache(entity.Id);
+            }
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
+++ b/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
@@ -79,7 +79,8 @@ namespace Umbraco.Cms.Core.Compose
                 .AddNotificationHandler<UserDeletedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<UserGroupWithUsersSavedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<UserGroupDeletedNotification, DistributedCacheBinder>()
-                .AddNotificationHandler<TemplateDeletedNotification, DistributedCacheBinder>();
+                .AddNotificationHandler<TemplateDeletedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<TemplateSavedNotification, DistributedCacheBinder>();
 
             // add notification handlers for auditing
             builder

--- a/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
+++ b/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
@@ -78,7 +78,8 @@ namespace Umbraco.Cms.Core.Compose
                 .AddNotificationHandler<UserSavedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<UserDeletedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<UserGroupWithUsersSavedNotification, DistributedCacheBinder>()
-                .AddNotificationHandler<UserGroupDeletedNotification, DistributedCacheBinder>();
+                .AddNotificationHandler<UserGroupDeletedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<TemplateDeletedNotification, DistributedCacheBinder>();
 
             // add notification handlers for auditing
             builder

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -576,7 +576,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                     _templateRepository.Save(template);
                 }
 
-                scope.Notifications.Publish(new TemplateSavingNotification(templatesA, eventMessages).WithStateFrom(savingNotification));
+                scope.Notifications.Publish(new TemplateSavedNotification(templatesA, eventMessages).WithStateFrom(savingNotification));
 
                 Audit(AuditType.Save, userId, -1, UmbracoObjectTypes.Template.GetName());
                 scope.Complete();

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -322,15 +322,6 @@ namespace Umbraco.Cms.Core.Services.Implement
 
             EventMessages eventMessages = EventMessagesFactory.Get();
 
-            // TODO: This isn't pretty because we're required to maintain backwards compatibility so we could not change
-            // the event args here. The other option is to create a different event with different event
-            // args specifically for this method... which also isn't pretty. So fix this in v8!
-            var additionalData = new Dictionary<string, object>
-            {
-                { "CreateTemplateForContentType", true },
-                { "ContentTypeAlias", contentTypeAlias },
-            };
-
             if (contentTypeAlias != null && contentTypeAlias.Length > 255)
             {
                 throw new InvalidOperationException("Name cannot be more than 255 characters in length.");

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -346,7 +346,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
             using (IScope scope = ScopeProvider.CreateScope())
             {
-                var savingEvent = new TemplateSavingNotification(template, eventMessages, additionalData);
+                var savingEvent = new TemplateSavingNotification(template, eventMessages, true, contentTypeAlias);
                 if (scope.Notifications.PublishCancelable(savingEvent))
                 {
                     scope.Complete();
@@ -354,7 +354,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                 }
 
                 _templateRepository.Save(template);
-                scope.Notifications.Publish(new TemplateSavedNotification(template, eventMessages, savingEvent.AdditionalData).WithStateFrom(savingEvent));
+                scope.Notifications.Publish(new TemplateSavedNotification(template, eventMessages).WithStateFrom(savingEvent));
 
                 Audit(AuditType.Save, userId, template.Id, ObjectTypes.GetName(UmbracoObjectTypes.Template));
                 scope.Complete();

--- a/src/Umbraco.Infrastructure/Services/Notifications/PartialViewCreatedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/PartialViewCreatedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class PartialViewCreatedNotification : CreatedNotification<IPartialView>
+    {
+        public PartialViewCreatedNotification(IPartialView target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/PartialViewCreatingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/PartialViewCreatingNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class PartialViewCreatingNotification : CreatingNotification<IPartialView>
+    {
+        public PartialViewCreatingNotification(IPartialView target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/PartialViewDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/PartialViewDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class PartialViewDeletedNotification : DeletedNotification<IPartialView>
+    {
+        public PartialViewDeletedNotification(IPartialView target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/PartialViewDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/PartialViewDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class PartialViewDeletingNotification : DeletingNotification<IPartialView>
+    {
+        public PartialViewDeletingNotification(IPartialView target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public PartialViewDeletingNotification(IEnumerable<IPartialView> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/PartialViewSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/PartialViewSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class PartialViewSavedNotification : SavedNotification<IPartialView>
+    {
+        public PartialViewSavedNotification(IPartialView target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public PartialViewSavedNotification(IEnumerable<IPartialView> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/PartialViewSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/PartialViewSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class PartialViewSavingNotification : SavingNotification<IPartialView>
+    {
+        public PartialViewSavingNotification(IPartialView target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public PartialViewSavingNotification(IEnumerable<IPartialView> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/ScriptDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/ScriptDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class ScriptDeletedNotification : DeletedNotification<IScript>
+    {
+        public ScriptDeletedNotification(IScript target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/ScriptDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/ScriptDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class ScriptDeletingNotification : DeletingNotification<IScript>
+    {
+        public ScriptDeletingNotification(IScript target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public ScriptDeletingNotification(IEnumerable<IScript> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/ScriptSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/ScriptSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class ScriptSavedNotification : SavedNotification<IScript>
+    {
+        public ScriptSavedNotification(IScript target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public ScriptSavedNotification(IEnumerable<IScript> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/ScriptSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/ScriptSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class ScriptSavingNotification : SavingNotification<IScript>
+    {
+        public ScriptSavingNotification(IScript target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public ScriptSavingNotification(IEnumerable<IScript> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/StylesheetDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/StylesheetDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class StylesheetDeletedNotification : DeletedNotification<IStylesheet>
+    {
+        public StylesheetDeletedNotification(IStylesheet target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/StylesheetDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/StylesheetDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class StylesheetDeletingNotification : DeletingNotification<IStylesheet>
+    {
+        public StylesheetDeletingNotification(IStylesheet target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public StylesheetDeletingNotification(IEnumerable<IStylesheet> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/StylesheetSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/StylesheetSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class StylesheetSavedNotification : SavedNotification<IStylesheet>
+    {
+        public StylesheetSavedNotification(IStylesheet target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public StylesheetSavedNotification(IEnumerable<IStylesheet> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/StylesheetSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/StylesheetSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class StylesheetSavingNotification : SavingNotification<IStylesheet>
+    {
+        public StylesheetSavingNotification(IStylesheet target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public StylesheetSavingNotification(IEnumerable<IStylesheet> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class TemplateDeletedNotification : DeletedNotification<ITemplate>
+    {
+        public TemplateDeletedNotification(ITemplate target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class TemplateDeletingNotification : DeletingNotification<ITemplate>
+    {
+        public TemplateDeletingNotification(ITemplate target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public TemplateDeletingNotification(IEnumerable<ITemplate> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
@@ -17,12 +17,24 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         {
         }
 
-        public TemplateSavedNotification(ITemplate target, EventMessages messages,
-            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+        public bool? CreateTemplateForContentType
+        {
+            get
+            {
+                State.TryGetValue("CreateTemplateForContentType", out var result);
+                return result as bool?;
+            }
+            set => State["CreateTemplateForContentType"] = value;
+        }
 
-        public TemplateSavedNotification(IEnumerable<ITemplate> target, EventMessages messages,
-            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
-
-        public Dictionary<string, object> AdditionalData;
+        public string ContentTypeAlias
+        {
+            get
+            {
+                State.TryGetValue("ContentTypeAlias", out var result);
+                return result as string;
+            }
+            set => State["ContentTypeAlias"] = value;
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class TemplateSavedNotification : SavedNotification<ITemplate>
+    {
+        public TemplateSavedNotification(ITemplate target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public TemplateSavedNotification(IEnumerable<ITemplate> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
@@ -9,6 +9,9 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
 {
     public class TemplateSavedNotification : SavedNotification<ITemplate>
     {
+        private const string s_templateForContentTypeKey = "CreateTemplateForContentType";
+        private const string s_contentTypeAliasKey = "ContentTypeAlias";
+
         public TemplateSavedNotification(ITemplate target, EventMessages messages) : base(target, messages)
         {
         }
@@ -21,20 +24,20 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         {
             get
             {
-                State.TryGetValue("CreateTemplateForContentType", out var result);
+                State.TryGetValue(s_templateForContentTypeKey, out var result);
                 return result as bool?;
             }
-            set => State["CreateTemplateForContentType"] = value;
+            set => State[s_templateForContentTypeKey] = value;
         }
 
         public string ContentTypeAlias
         {
             get
             {
-                State.TryGetValue("ContentTypeAlias", out var result);
+                State.TryGetValue(s_contentTypeAliasKey, out var result);
                 return result as string;
             }
-            set => State["ContentTypeAlias"] = value;
+            set => State[s_contentTypeAliasKey] = value;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
@@ -16,5 +16,13 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         public TemplateSavedNotification(IEnumerable<ITemplate> target, EventMessages messages) : base(target, messages)
         {
         }
+
+        public TemplateSavedNotification(ITemplate target, EventMessages messages,
+            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+
+        public TemplateSavedNotification(IEnumerable<ITemplate> target, EventMessages messages,
+            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+
+        public Dictionary<string, object> AdditionalData;
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavedNotification.cs
@@ -20,12 +20,18 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         {
         }
 
-        public bool? CreateTemplateForContentType
+        public bool CreateTemplateForContentType
         {
             get
             {
                 State.TryGetValue(s_templateForContentTypeKey, out var result);
-                return result as bool?;
+
+                if (result is not bool createTemplate)
+                {
+                    return false;
+                }
+
+                return createTemplate;
             }
             set => State[s_templateForContentTypeKey] = value;
         }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
@@ -16,5 +16,13 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         public TemplateSavingNotification(IEnumerable<ITemplate> target, EventMessages messages) : base(target, messages)
         {
         }
+
+        public TemplateSavingNotification(ITemplate target, EventMessages messages,
+            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+
+        public TemplateSavingNotification(IEnumerable<ITemplate> target, EventMessages messages,
+            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+
+        public Dictionary<string, object> AdditionalData;
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
@@ -9,6 +9,9 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
 {
     public class TemplateSavingNotification : SavingNotification<ITemplate>
     {
+        private const string s_templateForContentTypeKey = "CreateTemplateForContentType";
+        private const string s_contentTypeAliasKey = "ContentTypeAlias";
+
         public TemplateSavingNotification(ITemplate target, EventMessages messages) : base(target, messages)
         {
         }
@@ -36,20 +39,20 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         {
             get
             {
-                State.TryGetValue("CreateTemplateForContentType", out var result);
+                State.TryGetValue(s_templateForContentTypeKey, out var result);
                 return result as bool?;
             }
-            set => State["CreateTemplateForContentType"] = value;
+            set => State[s_templateForContentTypeKey] = value;
         }
 
         public string ContentTypeAlias
         {
             get
             {
-                State.TryGetValue("ContentTypeAlias", out var result);
+                State.TryGetValue(s_contentTypeAliasKey, out var result);
                 return result as string;
             }
-            set => State["ContentTypeAlias"] = value;
+            set => State[s_contentTypeAliasKey] = value;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class TemplateSavingNotification : SavingNotification<ITemplate>
+    {
+        public TemplateSavingNotification(ITemplate target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public TemplateSavingNotification(IEnumerable<ITemplate> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
@@ -17,12 +17,39 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
         {
         }
 
-        public TemplateSavingNotification(ITemplate target, EventMessages messages,
-            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+        public TemplateSavingNotification(ITemplate target, EventMessages messages, bool createTemplateForContentType,
+            string contentTypeAlias) : base(target, messages)
+        {
+            CreateTemplateForContentType = createTemplateForContentType;
+            ContentTypeAlias = contentTypeAlias;
+        }
 
         public TemplateSavingNotification(IEnumerable<ITemplate> target, EventMessages messages,
-            Dictionary<string, object> additionalData) : base(target, messages) => AdditionalData = additionalData;
+            bool createTemplateForContentType,
+            string contentTypeAlias) : base(target, messages)
+        {
+            CreateTemplateForContentType = createTemplateForContentType;
+            ContentTypeAlias = contentTypeAlias;
+        }
 
-        public Dictionary<string, object> AdditionalData;
+        public bool? CreateTemplateForContentType
+        {
+            get
+            {
+                State.TryGetValue("CreateTemplateForContentType", out var result);
+                return result as bool?;
+            }
+            set => State["CreateTemplateForContentType"] = value;
+        }
+
+        public string ContentTypeAlias
+        {
+            get
+            {
+                State.TryGetValue("ContentTypeAlias", out var result);
+                return result as string;
+            }
+            set => State["ContentTypeAlias"] = value;
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/TemplateSavingNotification.cs
@@ -35,12 +35,18 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
             ContentTypeAlias = contentTypeAlias;
         }
 
-        public bool? CreateTemplateForContentType
+        public bool CreateTemplateForContentType
         {
             get
             {
                 State.TryGetValue(s_templateForContentTypeKey, out var result);
-                return result as bool?;
+
+                if (result is not bool createTemplate)
+                {
+                    return false;
+                }
+
+                return createTemplate;
             }
             set => State[s_templateForContentTypeKey] = value;
         }

--- a/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
+++ b/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
@@ -45,9 +45,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
                 new EventDefinition<IDataTypeService, SaveEventArgs<IDataType>>(null, DataTypeService, new SaveEventArgs<IDataType>(Enumerable.Empty<IDataType>())),
                 new EventDefinition<IDataTypeService, DeleteEventArgs<IDataType>>(null, DataTypeService, new DeleteEventArgs<IDataType>(Enumerable.Empty<IDataType>())),
 
-                new EventDefinition<IFileService, SaveEventArgs<IStylesheet>>(null, FileService, new SaveEventArgs<IStylesheet>(Enumerable.Empty<IStylesheet>())),
-                new EventDefinition<IFileService, DeleteEventArgs<IStylesheet>>(null, FileService, new DeleteEventArgs<IStylesheet>(Enumerable.Empty<IStylesheet>())),
-
                 new EventDefinition<IDomainService, SaveEventArgs<IDomain>>(null, DomainService, new SaveEventArgs<IDomain>(Enumerable.Empty<IDomain>())),
                 new EventDefinition<IDomainService, DeleteEventArgs<IDomain>>(null, DomainService, new DeleteEventArgs<IDomain>(Enumerable.Empty<IDomain>())),
 
@@ -60,7 +57,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
                 new EventDefinition<IMemberTypeService, DeleteEventArgs<IMemberType>>(null, MemberTypeService, new DeleteEventArgs<IMemberType>(Enumerable.Empty<IMemberType>())),
 
                 new EventDefinition<IFileService, SaveEventArgs<ITemplate>>(null, FileService, new SaveEventArgs<ITemplate>(Enumerable.Empty<ITemplate>())),
-                new EventDefinition<IFileService, DeleteEventArgs<ITemplate>>(null, FileService, new DeleteEventArgs<ITemplate>(Enumerable.Empty<ITemplate>())),
 
                 new EventDefinition<IMacroService, SaveEventArgs<IMacro>>(null, MacroService, new SaveEventArgs<IMacro>(Enumerable.Empty<IMacro>())),
                 new EventDefinition<IMacroService, DeleteEventArgs<IMacro>>(null, MacroService, new DeleteEventArgs<IMacro>(Enumerable.Empty<IMacro>())),

--- a/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
+++ b/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
@@ -56,8 +56,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
                 new EventDefinition<IMemberTypeService, SaveEventArgs<IMemberType>>(null, MemberTypeService, new SaveEventArgs<IMemberType>(Enumerable.Empty<IMemberType>())),
                 new EventDefinition<IMemberTypeService, DeleteEventArgs<IMemberType>>(null, MemberTypeService, new DeleteEventArgs<IMemberType>(Enumerable.Empty<IMemberType>())),
 
-                new EventDefinition<IFileService, SaveEventArgs<ITemplate>>(null, FileService, new SaveEventArgs<ITemplate>(Enumerable.Empty<ITemplate>())),
-
                 new EventDefinition<IMacroService, SaveEventArgs<IMacro>>(null, MacroService, new SaveEventArgs<IMacro>(Enumerable.Empty<IMacro>())),
                 new EventDefinition<IMacroService, DeleteEventArgs<IMacro>>(null, MacroService, new DeleteEventArgs<IMacro>(Enumerable.Empty<IMacro>())),
 

--- a/src/Umbraco.Web.Common/ModelsBuilder/DependencyInjection/UmbracoBuilderDependencyInjectionExtensions.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/DependencyInjection/UmbracoBuilderDependencyInjectionExtensions.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Infrastructure.ModelsBuilder;
 using Umbraco.Cms.Infrastructure.ModelsBuilder.Building;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
 using Umbraco.Cms.Infrastructure.WebAssets;
 using Umbraco.Cms.Web.Common.ModelBinders;
 using Umbraco.Cms.Web.Common.ModelsBuilder;
@@ -98,7 +99,7 @@ namespace Umbraco.Extensions
 
             // TODO: I feel like we could just do builder.AddNotificationHandler<ModelsBuilderNotificationHandler>() and it
             // would automatically just register for all implemented INotificationHandler{T}?
-            builder.AddNotificationHandler<UmbracoApplicationStarting, ModelsBuilderNotificationHandler>();
+            builder.AddNotificationHandler<TemplateSavingNotification, ModelsBuilderNotificationHandler>();
             builder.AddNotificationHandler<ServerVariablesParsing, ModelsBuilderNotificationHandler>();
             builder.AddNotificationHandler<ModelBindingError, ModelsBuilderNotificationHandler>();
             builder.AddNotificationHandler<UmbracoApplicationStarting, LiveModelsProvider>();

--- a/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
             }
 
             // Don't do anything if we're not requested to create a template for a content type
-            if (notification.CreateTemplateForContentType is null or false)
+            if (notification.CreateTemplateForContentType is false)
             {
                 return;
             }

--- a/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
@@ -97,16 +97,10 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
                 return;
             }
 
-            // don't do anything if this special key is not found
-            if (notification.AdditionalData is null || !notification.AdditionalData.ContainsKey("CreateTemplateForContentType"))
-            {
-                return;
-            }
-
             // ensure we have the content type alias
-            if (!notification.AdditionalData.ContainsKey("ContentTypeAlias"))
+            if (notification.ContentTypeAlias is null)
             {
-                throw new InvalidOperationException("The additionalData key: ContentTypeAlias was not found");
+                throw new InvalidOperationException("ContentTypeAlias was not found on the notification");
             }
 
             foreach (ITemplate template in notification.SavedEntities)
@@ -117,7 +111,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
                 {
                     // ensure is safe and always pascal cased, per razor standard
                     // + this is how we get the default model name in Umbraco.ModelsBuilder.Umbraco.Application
-                    var alias = notification.AdditionalData["ContentTypeAlias"].ToString();
+                    var alias = notification.ContentTypeAlias;
                     var name = template.Name; // will be the name of the content type since we are creating
                     var className = UmbracoServices.GetClrName(_shortStringHelper, name, alias);
 

--- a/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
@@ -97,6 +97,12 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
                 return;
             }
 
+            // Don't do anything if we're not requested to create a template for a content type
+            if (notification.CreateTemplateForContentType is null or false)
+            {
+                return;
+            }
+
             // ensure we have the content type alias
             if (notification.ContentTypeAlias is null)
             {

--- a/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Implement;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.ModelsBuilder;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
 using Umbraco.Cms.Infrastructure.WebAssets;
 using Umbraco.Cms.Web.Common.ModelBinders;
 
@@ -19,7 +20,10 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
     /// <summary>
     /// Handles <see cref="UmbracoApplicationStarting"/> and <see cref="ServerVariablesParsing"/> notifications to initialize MB
     /// </summary>
-    internal class ModelsBuilderNotificationHandler : INotificationHandler<UmbracoApplicationStarting>, INotificationHandler<ServerVariablesParsing>, INotificationHandler<ModelBindingError>
+    internal class ModelsBuilderNotificationHandler :
+        INotificationHandler<ServerVariablesParsing>,
+        INotificationHandler<ModelBindingError>,
+        INotificationHandler<TemplateSavingNotification>
     {
         private readonly ModelsBuilderSettings _config;
         private readonly IShortStringHelper _shortStringHelper;
@@ -33,19 +37,6 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
             _config = config.Value;
             _shortStringHelper = shortStringHelper;
             _modelsBuilderDashboardProvider = modelsBuilderDashboardProvider;
-        }
-
-        /// <summary>
-        /// Handles the <see cref="UmbracoApplicationStarting"/> notification
-        /// </summary>
-        public void Handle(UmbracoApplicationStarting notification)
-        {
-            // always setup the dashboard
-            // note: UmbracoApiController instances are automatically registered
-            if (_config.ModelsMode != ModelsMode.Nothing)
-            {
-                FileService.SavingTemplate += FileService_SavingTemplate;
-            }
         }
 
         /// <summary>
@@ -99,21 +90,26 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
         /// Used to check if a template is being created based on a document type, in this case we need to
         /// ensure the template markup is correct based on the model name of the document type
         /// </summary>
-        private void FileService_SavingTemplate(IFileService sender, SaveEventArgs<ITemplate> e)
+        public void Handle(TemplateSavingNotification notification)
         {
+            if (_config.ModelsMode == ModelsMode.Nothing)
+            {
+                return;
+            }
+
             // don't do anything if this special key is not found
-            if (!e.AdditionalData.ContainsKey("CreateTemplateForContentType"))
+            if (!notification.AdditionalData.ContainsKey("CreateTemplateForContentType"))
             {
                 return;
             }
 
             // ensure we have the content type alias
-            if (!e.AdditionalData.ContainsKey("ContentTypeAlias"))
+            if (!notification.AdditionalData.ContainsKey("ContentTypeAlias"))
             {
                 throw new InvalidOperationException("The additionalData key: ContentTypeAlias was not found");
             }
 
-            foreach (ITemplate template in e.SavedEntities)
+            foreach (ITemplate template in notification.SavedEntities)
             {
                 // if it is in fact a new entity (not been saved yet) and the "CreateTemplateForContentType" key
                 // is found, then it means a new template is being created based on the creation of a document type
@@ -121,7 +117,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
                 {
                     // ensure is safe and always pascal cased, per razor standard
                     // + this is how we get the default model name in Umbraco.ModelsBuilder.Umbraco.Application
-                    var alias = e.AdditionalData["ContentTypeAlias"].ToString();
+                    var alias = notification.AdditionalData["ContentTypeAlias"].ToString();
                     var name = template.Name; // will be the name of the content type since we are creating
                     var className = UmbracoServices.GetClrName(_shortStringHelper, name, alias);
 

--- a/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
             }
 
             // don't do anything if this special key is not found
-            if (!notification.AdditionalData.ContainsKey("CreateTemplateForContentType"))
+            if (notification.AdditionalData is null || !notification.AdditionalData.ContainsKey("CreateTemplateForContentType"))
             {
                 return;
             }


### PR DESCRIPTION
### Description
Migrated the static events in `FileService` over to the new notifications pattern. 

There are a few interesting things this time. 

#### Stylesheet

For some reason `DistributedCacheBinder_Handler` bind to the `DeletedStylesheet` and `SavedStylesheet` event, but do nothing with the events, the methods are just empty. There is a note saying "TODO: our weird events handling wants this for now", but I don't see any reason why this should be necessary for the notifications pattern, so I've just removed the event bindings.

#### Templates

This one used what seems like an old pattern, adding "Additional data"  to the event, I added this to the Notifications classes instead.

This data is then used in the `ModelsBuilderNotificationHandler`, in the same class we also used the `UmbracoApplicationStarting` notification to bind to the `SavingTemplate` event, since we can no longer bind/unbind to events, I moved the check (`_config.ModelsMode != ModelsMode.Nothing`) into the handle method, and then removed the `UmbracoApplicationStarting` handler, since it's no longer used for anything. 


### Testing
The same as the other event PRs, take look at #10075, the approach is the same, just using different events. 