### PR TITLE
Use umb-icon component in listview dropdown

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -31,12 +31,12 @@
                        <umb-dropdown ng-if="page.createDropdownOpen" on-close="page.createDropdownOpen = false">
                            <umb-dropdown-item ng-repeat="contentType in listViewAllowedTypes track by contentType.key | orderBy:'name':false">
                                 <button type="button" ng-click="createBlank(entityType,contentType.alias)">
-                                    <i class="{{::contentType.icon}}" aria-hidden="true"></i>
+                                    <umb-icon icon="{{::contentType.icon}}" class="{{::contentType.icon}}"></umb-icon>
                                     {{::contentType.name}} <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
                                 </button>
 
                                 <button type="button" ng-repeat="blueprint in contentType.blueprints track by blueprint.id | orderBy:'name':false" ng-click="createFromBlueprint(entityType, contentType.alias, blueprint.id)">
-                                    &nbsp;&nbsp;<i class="{{::contentType.icon}}" aria-hidden="true"></i>
+                                    &nbsp;&nbsp;<umb-icon icon="{{::contentType.icon}}" class="{{::contentType.icon}}"></umb-icon>
                                     {{::blueprint.name}}
                                 </button>
                             </umb-dropdown-item>
@@ -53,12 +53,12 @@
                        <umb-dropdown ng-if="page.createDropdownOpen" on-close="page.createDropdownOpen = false">
                            <umb-dropdown-item ng-repeat="contentType in listViewAllowedTypes track by contentType.key | orderBy:'name':false">
                                <button type="button" ng-click="createBlank(entityType,contentType.alias)">
-                                   <i class="{{::contentType.icon}}" aria-hidden="true"></i>
+                                   <umb-icon icon="{{::contentType.icon}}" class="{{::contentType.icon}}"></umb-icon>
                                    {{::contentType.name}} <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
                                </button>
 
                                <button type="button" ng-repeat="blueprint in contentType.blueprints track by blueprint.id | orderBy:'name':false" ng-click="createFromBlueprint(entityType, contentType.alias, blueprint.id)">
-                                   &nbsp;&nbsp;<i class="{{::contentType.icon}}" aria-hidden="true"></i>
+                                   &nbsp;&nbsp;<umb-icon icon="{{::contentType.icon}}" class="{{::contentType.icon}}"></umb-icon>
                                    {{::blueprint.name}}
                                </button>
                            </umb-dropdown-item>
@@ -69,7 +69,7 @@
 
                        <li ng-repeat="blueprint in docType.blueprints track by blueprint.id | orderBy:'name':false">
                            <button type="button" ng-click="createFromBlueprint(blueprint.id)">
-                               <i class="large {{docType.icon}}" aria-hidden="true"></i>
+                               <umb-icon icon="{{docType.icon}}" class="{{docType.icon}} large"></umb-icon>
                                <span class="menu-label">
                                    {{blueprint.name}}&nbsp;
                                </span>
@@ -78,7 +78,7 @@
 
                        <li class="sep" ng-show="allowBlank">
                            <button type="button" ng-click="createBlank(docType)">
-                               <i class="large {{docType.icon}}" aria-hidden="true"></i>
+                               <umb-icon icon="{{docType.icon}}" class="{{docType.icon}} large"></umb-icon>
                                <span class="menu-label">
                                    <localize key="blueprints_blankBlueprint">Blank</localize>
                                </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR update the icons in listview action dropdown to use `<umb-icon>` component, so if using custom SVG icons for content types, these will work here as well, where it currently only works with font icons.