### PR TITLE
9962: Use $allowedEditors instead of allowed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -143,7 +143,7 @@ angular.module("umbraco")
                     var area = event.target.getScope_HackForSortable().area;
                     var allowedEditors = area.$allowedEditors.map(e => e.alias);
 
-                    if (($.inArray(ui.item[0].getScope_HackForSortable().control.editor.alias, allowedEditors) < 0 && allowedEditors) ||
+                    if (($.inArray(ui.item[0].getScope_HackForSortable().control.editor.alias, allowedEditors) < 0) ||
                         (startingArea != area && area.maxItems != '' && area.maxItems > 0 && area.maxItems < area.controls.length + 1)) {
 
                         $scope.$apply(function () {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -141,7 +141,7 @@ angular.module("umbraco")
                 over: function (event, ui) {
 
                     var area = event.target.getScope_HackForSortable().area;
-                    var allowedEditors = area.allowed;
+                    var allowedEditors = area.$allowedEditors.map(e => e.alias);
 
                     if (($.inArray(ui.item[0].getScope_HackForSortable().control.editor.alias, allowedEditors) < 0 && allowedEditors) ||
                         (startingArea != area && area.maxItems != '' && area.maxItems > 0 && area.maxItems < area.controls.length + 1)) {


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9962

How to check (based on the default install):
Set all grid rows on "Allow all editors". Without this fix, you'll not be able to move between the different rows.

The issue here was that the .allow only has the editors selected by the user. So if you were to only select RTE, it would work because .allow is ["RTE"]. If you use the selectAll editors, it will set allowAll to true, but leave .allow empty.
