### PR TITLE
Added null checks for Nested Content where getting content type alias.

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -350,6 +350,16 @@ namespace Umbraco.Web.PropertyEditors
 
             private IContentType GetElementType(NestedContentRowValue item)
             {
+                if (item == null)
+                {
+                    return null;
+                }
+
+                if (string.IsNullOrWhiteSpace(item.ContentTypeAlias))
+                {
+                    return null;
+                }
+
                 _contentTypes.Value.TryGetValue(item.ContentTypeAlias, out var contentType);
                 return contentType;
             }


### PR DESCRIPTION
When migrating from v7 to v8 come datatypes has been created from old non supported datatypes as Archetype, nuPickers etc.. When mirroring datatypes to v8 as content pickers and nested content, some of the values have been stored as nulls.
That means that back office cannot load the content where new datatypes are in use.
This is my own mistake but still it good to have null checks to be done as others can have the same or similar issue. 

Original error:

System.ArgumentNullException: Value cannot be null.
Parameter name: key
   at System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Umbraco.Web.PropertyEditors.NestedContentPropertyEditor.NestedContentValues.GetElementType(NestedContentRowValue item) in D:\a\1\s\src\Umbraco.Web\PropertyEditors\NestedContentPropertyEditor.cs:line 354
   at Umbraco.Web.PropertyEditors.NestedContentPropertyEditor.NestedContentValues.GetPropertyValues(Object propertyValue) in D:\a\1\s\src\Umbraco.Web\PropertyEditors\NestedContentPropertyEditor.cs:line 382