### PR TITLE
Netcore: Migrate relationservice events

### DIFF
--- a/src/Umbraco.Core/Events/DeletedNotification.cs
+++ b/src/Umbraco.Core/Events/DeletedNotification.cs
@@ -11,6 +11,10 @@ namespace Umbraco.Cms.Core.Events
         {
         }
 
+        protected DeletedNotification(IEnumerable<T> target, EventMessages messages) : base(target, messages)
+        {
+        }
+
         public IEnumerable<T> DeletedEntities => Target;
     }
 }

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -35,7 +35,9 @@ namespace Umbraco.Cms.Core.Cache
         INotificationHandler<MemberGroupDeletedNotification>,
         INotificationHandler<MemberGroupSavedNotification>,
         INotificationHandler<DataTypeDeletedNotification>,
-        INotificationHandler<DataTypeSavedNotification>
+        INotificationHandler<DataTypeSavedNotification>,
+        INotificationHandler<RelationTypeDeletedNotification>,
+        INotificationHandler<RelationTypeSavedNotification>
     {
         private List<Action> _unbinders;
 
@@ -111,12 +113,6 @@ namespace Umbraco.Cms.Core.Cache
             //    () => ContentService.SavedBlueprint -= ContentService_SavedBlueprint);
             //Bind(() => ContentService.DeletedBlueprint += ContentService_DeletedBlueprint,
             //    () => ContentService.DeletedBlueprint -= ContentService_DeletedBlueprint);
-
-            // bind to relation type events
-            Bind(() => RelationService.SavedRelationType += RelationService_SavedRelationType,
-                () => RelationService.SavedRelationType -= RelationService_SavedRelationType);
-            Bind(() => RelationService.DeletedRelationType += RelationService_DeletedRelationType,
-                () => RelationService.DeletedRelationType -= RelationService_DeletedRelationType);
         }
 
         #region PublicAccessService
@@ -411,18 +407,22 @@ namespace Umbraco.Cms.Core.Cache
 
         #region RelationType
 
-        private void RelationService_SavedRelationType(IRelationService sender, SaveEventArgs<IRelationType> args)
+        public void Handle(RelationTypeSavedNotification notification)
         {
-            var dc = _distributedCache;
-            foreach (var e in args.SavedEntities)
-                dc.RefreshRelationTypeCache(e.Id);
+            DistributedCache dc = _distributedCache;
+            foreach (IRelationType entity in notification.SavedEntities)
+            {
+                dc.RefreshRelationTypeCache(entity.Id);
+            }
         }
 
-        private void RelationService_DeletedRelationType(IRelationService sender, DeleteEventArgs<IRelationType> args)
+        public void Handle(RelationTypeDeletedNotification notification)
         {
-            var dc = _distributedCache;
-            foreach (var e in args.DeletedEntities)
-                dc.RemoveRelationTypeCache(e.Id);
+            DistributedCache dc = _distributedCache;
+            foreach (IRelationType entity in notification.DeletedEntities)
+            {
+                dc.RemoveRelationTypeCache(entity.Id);
+            }
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
+++ b/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
@@ -82,7 +82,9 @@ namespace Umbraco.Cms.Core.Compose
                 .AddNotificationHandler<MemberGroupDeletedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<MemberGroupSavedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<DataTypeDeletedNotification, DistributedCacheBinder>()
-                .AddNotificationHandler<DataTypeSavedNotification, DistributedCacheBinder>();
+                .AddNotificationHandler<DataTypeSavedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<RelationTypeDeletedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<RelationTypeSavedNotification, DistributedCacheBinder>();
 
             // add notification handlers for auditing
             builder

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationDeletedNotification : DeletedNotification<IRelation>
+    {
+        public RelationDeletedNotification(IRelation target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationDeletedNotification.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
@@ -9,6 +10,10 @@ namespace Umbraco.Cms.Infrastructure.Services.Notifications
     public class RelationDeletedNotification : DeletedNotification<IRelation>
     {
         public RelationDeletedNotification(IRelation target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationDeletedNotification(IEnumerable<IRelation> target, EventMessages messages) : base(target, messages)
         {
         }
     }

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationDeletingNotification : DeletingNotification<IRelation>
+    {
+        public RelationDeletingNotification(IRelation target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationDeletingNotification(IEnumerable<IRelation> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationSavedNotification : SavedNotification<IRelation>
+    {
+        public RelationSavedNotification(IRelation target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationSavedNotification(IEnumerable<IRelation> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationSavingNotification : SavingNotification<IRelation>
+    {
+        public RelationSavingNotification(IRelation target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationSavingNotification(IEnumerable<IRelation> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationTypeDeletedNotification : DeletedNotification<IRelationType>
+    {
+        public RelationTypeDeletedNotification(IRelationType target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationTypeDeletingNotification : DeletingNotification<IRelationType>
+    {
+        public RelationTypeDeletingNotification(IRelationType target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationTypeDeletingNotification(IEnumerable<IRelationType> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationTypeSavedNotification : SavedNotification<IRelationType>
+    {
+        public RelationTypeSavedNotification(IRelationType target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationTypeSavedNotification(IEnumerable<IRelationType> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/RelationTypeSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class RelationTypeSavingNotification : SavingNotification<IRelationType>
+    {
+        public RelationTypeSavingNotification(IRelationType target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public RelationTypeSavingNotification(IEnumerable<IRelationType> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
+++ b/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
@@ -65,12 +65,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
                 // not managed
                 //new EventDefinition<IContentService, SaveEventArgs<IContent>>(null, ContentService, new SaveEventArgs<IContent>(Enumerable.Empty<IContent>()), "SavedBlueprint"),
                 //new EventDefinition<IContentService, DeleteEventArgs<IContent>>(null, ContentService, new DeleteEventArgs<IContent>(Enumerable.Empty<IContent>()), "DeletedBlueprint"),
-
-                new EventDefinition<IRelationService, SaveEventArgs<IRelationType>>(null, RelationService, new SaveEventArgs<IRelationType>(Enumerable.Empty<IRelationType>())),
-                new EventDefinition<IRelationService, DeleteEventArgs<IRelationType>>(null, RelationService, new DeleteEventArgs<IRelationType>(Enumerable.Empty<IRelationType>())),
-
-                new EventDefinition<IRelationService, SaveEventArgs<IRelationType>>(null, RelationService, new SaveEventArgs<IRelationType>(Enumerable.Empty<IRelationType>())),
-                new EventDefinition<IRelationService, DeleteEventArgs<IRelationType>>(null, RelationService, new DeleteEventArgs<IRelationType>(Enumerable.Empty<IRelationType>())),
             };
 
             var ok = true;


### PR DESCRIPTION
### Description

Migrated the static events in `RelationService` over to the new notifications pattern.

### Details

#### DeleteRelationsOfType (RelationDeletedNotification)
For some reason we don't raise the `RelationDeletingNotification` here, only the `DeletedRelationNotification`, I'm not sure I understand why we don't, we could just publish one cancelable notification with the list of relations?

#### DeletedNotification

DeletedNotification didn't have a constructor for IEnumerable<T>, even though it inherited EnumerableObjectNotification, I'm assuming it's because this wasn't used until now, however, it's needed for the above, so I added it.


#### RelationSavingNotification
In the `Save(IEnumerable<IRelation> relations)` method I got a multiple enumeration warning, so I turned the `IEnumerable<IRelation>` into an array.

### Testing

The same as the other event PRs, take look at #10075, the approach is the same, just using different events.