### PR TITLE
Netcore: Migrate domainservice events

### DIFF
--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -35,7 +35,9 @@ namespace Umbraco.Cms.Core.Cache
         INotificationHandler<MemberGroupDeletedNotification>,
         INotificationHandler<MemberGroupSavedNotification>,
         INotificationHandler<DataTypeDeletedNotification>,
-        INotificationHandler<DataTypeSavedNotification>
+        INotificationHandler<DataTypeSavedNotification>,
+        INotificationHandler<DomainDeletedNotification>,
+        INotificationHandler<DomainSavedNotification>
     {
         private List<Action> _unbinders;
 
@@ -71,12 +73,6 @@ namespace Umbraco.Cms.Core.Cache
                 () => FileService.SavedStylesheet -= FileService_SavedStylesheet);
             Bind(() => FileService.DeletedStylesheet += FileService_DeletedStylesheet,
                 () => FileService.DeletedStylesheet -= FileService_DeletedStylesheet);
-
-            // bind to domain events
-            Bind(() => DomainService.Saved += DomainService_Saved,
-                () => DomainService.Saved -= DomainService_Saved);
-            Bind(() => DomainService.Deleted += DomainService_Deleted,
-                () => DomainService.Deleted -= DomainService_Deleted);
 
             // bind to content type events
             Bind(() => ContentTypeService.Changed += ContentTypeService_Changed,
@@ -207,16 +203,20 @@ namespace Umbraco.Cms.Core.Cache
 
         #region DomainService
 
-        private void DomainService_Saved(IDomainService sender, SaveEventArgs<IDomain> e)
+        public void Handle(DomainSavedNotification notification)
         {
-            foreach (var entity in e.SavedEntities)
+            foreach (IDomain entity in notification.SavedEntities)
+            {
                 _distributedCache.RefreshDomainCache(entity);
+            }
         }
 
-        private void DomainService_Deleted(IDomainService sender, DeleteEventArgs<IDomain> e)
+        public void Handle(DomainDeletedNotification notification)
         {
-            foreach (var entity in e.DeletedEntities)
+            foreach (IDomain entity in notification.DeletedEntities)
+            {
                 _distributedCache.RemoveDomainCache(entity);
+            }
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
+++ b/src/Umbraco.Infrastructure/Compose/NotificationsComposer.cs
@@ -82,7 +82,9 @@ namespace Umbraco.Cms.Core.Compose
                 .AddNotificationHandler<MemberGroupDeletedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<MemberGroupSavedNotification, DistributedCacheBinder>()
                 .AddNotificationHandler<DataTypeDeletedNotification, DistributedCacheBinder>()
-                .AddNotificationHandler<DataTypeSavedNotification, DistributedCacheBinder>();
+                .AddNotificationHandler<DataTypeSavedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<DomainDeletedNotification, DistributedCacheBinder>()
+                .AddNotificationHandler<DomainSavedNotification, DistributedCacheBinder>();
 
             // add notification handlers for auditing
             builder

--- a/src/Umbraco.Infrastructure/Services/Implement/DomainService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/DomainService.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Services.Notifications;
 
 namespace Umbraco.Cms.Core.Services.Implement
 {
@@ -28,25 +29,24 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public Attempt<OperationResult> Delete(IDomain domain)
         {
-            var evtMsgs = EventMessagesFactory.Get();
+            EventMessages eventMessages = EventMessagesFactory.Get();
 
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
-                var deleteEventArgs = new DeleteEventArgs<IDomain>(domain, evtMsgs);
-                if (scope.Events.DispatchCancelable(Deleting, this, deleteEventArgs))
+                var deletingNotification = new DomainDeletingNotification(domain, eventMessages);
+                if (scope.Notifications.PublishCancelable(deletingNotification))
                 {
                     scope.Complete();
-                    return OperationResult.Attempt.Cancel(evtMsgs);
+                    return OperationResult.Attempt.Cancel(eventMessages);
                 }
 
                 _domainRepository.Delete(domain);
                 scope.Complete();
 
-                deleteEventArgs.CanCancel = false;
-                scope.Events.Dispatch(Deleted, this, deleteEventArgs);
+                scope.Notifications.Publish(new DomainDeletedNotification(domain, eventMessages).WithStateFrom(deletingNotification));
             }
 
-            return OperationResult.Attempt.Succeed(evtMsgs);
+            return OperationResult.Attempt.Succeed(eventMessages);
         }
 
         public IDomain GetByName(string name)
@@ -83,48 +83,23 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public Attempt<OperationResult> Save(IDomain domainEntity)
         {
-            var evtMsgs = EventMessagesFactory.Get();
+            EventMessages eventMessages = EventMessagesFactory.Get();
 
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
-                var saveEventArgs = new SaveEventArgs<IDomain>(domainEntity, evtMsgs);
-                if (scope.Events.DispatchCancelable(Saving, this, saveEventArgs))
+                var savingNotification = new DomainSavingNotification(domainEntity, eventMessages);
+                if (scope.Notifications.PublishCancelable(savingNotification))
                 {
                     scope.Complete();
-                    return OperationResult.Attempt.Cancel(evtMsgs);
+                    return OperationResult.Attempt.Cancel(eventMessages);
                 }
 
                 _domainRepository.Save(domainEntity);
                 scope.Complete();
-                saveEventArgs.CanCancel = false;
-                scope.Events.Dispatch(Saved, this, saveEventArgs);
+                scope.Notifications.Publish(new DomainSavedNotification(domainEntity, eventMessages).WithStateFrom(savingNotification));
             }
 
-            return OperationResult.Attempt.Succeed(evtMsgs);
+            return OperationResult.Attempt.Succeed(eventMessages);
         }
-
-        #region Event Handlers
-        /// <summary>
-        /// Occurs before Delete
-        /// </summary>
-        public static event TypedEventHandler<IDomainService, DeleteEventArgs<IDomain>> Deleting;
-
-        /// <summary>
-        /// Occurs after Delete
-        /// </summary>
-        public static event TypedEventHandler<IDomainService, DeleteEventArgs<IDomain>> Deleted;
-
-        /// <summary>
-        /// Occurs before Save
-        /// </summary>
-        public static event TypedEventHandler<IDomainService, SaveEventArgs<IDomain>> Saving;
-
-        /// <summary>
-        /// Occurs after Save
-        /// </summary>
-        public static event TypedEventHandler<IDomainService, SaveEventArgs<IDomain>> Saved;
-
-
-        #endregion
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Notifications/DomainDeletedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DomainDeletedNotification.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DomainDeletedNotification : DeletedNotification<IDomain>
+    {
+        public DomainDeletedNotification(IDomain target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/DomainDeletingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DomainDeletingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DomainDeletingNotification : DeletingNotification<IDomain>
+    {
+        public DomainDeletingNotification(IDomain target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public DomainDeletingNotification(IEnumerable<IDomain> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/DomainSavedNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DomainSavedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DomainSavedNotification : SavedNotification<IDomain>
+    {
+        public DomainSavedNotification(IDomain target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public DomainSavedNotification(IEnumerable<IDomain> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Services/Notifications/DomainSavingNotification.cs
+++ b/src/Umbraco.Infrastructure/Services/Notifications/DomainSavingNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Services.Notifications
+{
+    public class DomainSavingNotification : SavingNotification<IDomain>
+    {
+        public DomainSavingNotification(IDomain target, EventMessages messages) : base(target, messages)
+        {
+        }
+
+        public DomainSavingNotification(IEnumerable<IDomain> target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
+++ b/src/Umbraco.Tests.Integration/Cache/DistributedCacheBinderTests.cs
@@ -45,9 +45,6 @@ namespace Umbraco.Cms.Tests.Integration.Cache
                 new EventDefinition<IFileService, SaveEventArgs<IStylesheet>>(null, FileService, new SaveEventArgs<IStylesheet>(Enumerable.Empty<IStylesheet>())),
                 new EventDefinition<IFileService, DeleteEventArgs<IStylesheet>>(null, FileService, new DeleteEventArgs<IStylesheet>(Enumerable.Empty<IStylesheet>())),
 
-                new EventDefinition<IDomainService, SaveEventArgs<IDomain>>(null, DomainService, new SaveEventArgs<IDomain>(Enumerable.Empty<IDomain>())),
-                new EventDefinition<IDomainService, DeleteEventArgs<IDomain>>(null, DomainService, new DeleteEventArgs<IDomain>(Enumerable.Empty<IDomain>())),
-
                 new EventDefinition<IContentTypeService, SaveEventArgs<IContentType>>(null, ContentTypeService, new SaveEventArgs<IContentType>(Enumerable.Empty<IContentType>())),
                 new EventDefinition<IContentTypeService, DeleteEventArgs<IContentType>>(null, ContentTypeService, new DeleteEventArgs<IContentType>(Enumerable.Empty<IContentType>())),
                 new EventDefinition<IMediaTypeService, SaveEventArgs<IMediaType>>(null, MediaTypeService, new SaveEventArgs<IMediaType>(Enumerable.Empty<IMediaType>())),


### PR DESCRIPTION
### Description

Migrated the static events in `DomainService` over to the new notifications pattern. Nothing of particular interest to report on this one, everything went smoothly

### Testing

The same as the other event PRs, take look at #10075, the approach is the same, just using different events.
