### PR TITLE
Fixed copy preserving sort order

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -1415,7 +1415,7 @@ namespace Umbraco.Core.Services.Implement
 
                         var result = CommitDocumentChangesInternal(scope, d, saveEventArgs, allLangs.Value, d.WriterId);
                         if (result.Success == false)
-                            Logger.Error<ContentService,int,PublishResultType>(null, "Failed to publish document id={DocumentId}, reason={Reason}.", d.Id, result.Result);
+                            Logger.Error<ContentService, int, PublishResultType>(null, "Failed to publish document id={DocumentId}, reason={Reason}.", d.Id, result.Result);
                         results.Add(result);
 
                     }
@@ -2201,7 +2201,7 @@ namespace Umbraco.Core.Services.Implement
                     while (page * pageSize < total)
                     {
                         var descendants = GetPagedDescendants(content.Id, page++, pageSize, out total);
-                        foreach (var descendant in descendants)
+                        foreach (var descendant in descendants.OrderBy(x => x.Level).ThenBy(y => y.SortOrder))
                         {
                             // if parent has not been copied, skip, else gets its copy id
                             if (idmap.TryGetValue(descendant.ParentId, out parentId) == false) continue;
@@ -2420,7 +2420,7 @@ namespace Umbraco.Core.Services.Implement
                 if (report.FixedIssues.Count > 0)
                 {
                     //The event args needs a content item so we'll make a fake one with enough properties to not cause a null ref
-                    var root = new Content("root", -1, new ContentType(-1)) {Id = -1, Key = Guid.Empty};
+                    var root = new Content("root", -1, new ContentType(-1)) { Id = -1, Key = Guid.Empty };
                     scope.Events.Dispatch(TreeChanged, this, new TreeChange<IContent>.EventArgs(new TreeChange<IContent>(root, TreeChangeTypes.RefreshAll)));
                 }
 
@@ -3169,7 +3169,7 @@ namespace Umbraco.Core.Services.Implement
                 if (rollbackSaveResult.Success == false)
                 {
                     //Log the error/warning
-                    Logger.Error<ContentService,int,int,int>("User '{UserId}' was unable to rollback content '{ContentId}' to version '{VersionId}'", userId, id, versionId);
+                    Logger.Error<ContentService, int, int, int>("User '{UserId}' was unable to rollback content '{ContentId}' to version '{VersionId}'", userId, id, versionId);
                 }
                 else
                 {
@@ -3178,7 +3178,7 @@ namespace Umbraco.Core.Services.Implement
                     scope.Events.Dispatch(RolledBack, this, rollbackEventArgs);
 
                     //Logging & Audit message
-                    Logger.Info<ContentService,int,int,int>("User '{UserId}' rolled back content '{ContentId}' to version '{VersionId}'", userId, id, versionId);
+                    Logger.Info<ContentService, int, int, int>("User '{UserId}' rolled back content '{ContentId}' to version '{VersionId}'", userId, id, versionId);
                     Audit(AuditType.RollBack, userId, id, $"Content '{content.Name}' was rolled back to version '{versionId}'");
                 }
 

--- a/src/Umbraco.Tests/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests/Services/ContentServiceTests.cs
@@ -2083,6 +2083,32 @@ namespace Umbraco.Tests.Services
         }
 
         [Test]
+        public void Copy_Recursive_Preserves_Sort_Order()
+        {
+            // Arrange
+            var contentService = ServiceContext.ContentService;
+            var temp = contentService.GetById(NodeDto.NodeIdSeed + 2);
+            Assert.AreEqual("Home", temp.Name);
+            Assert.AreEqual(3, contentService.CountChildren(temp.Id));
+            var reversedChildren = contentService.GetPagedChildren(temp.Id, 0, 10, out var total1).Reverse().ToArray();
+            contentService.Sort(reversedChildren);
+
+            // Act
+            var copy = contentService.Copy(temp, temp.ParentId, false, true, Constants.Security.SuperUserId);
+            var content = contentService.GetById(NodeDto.NodeIdSeed + 2);
+
+            // Assert
+            Assert.That(copy, Is.Not.Null);
+            Assert.That(copy.Id, Is.Not.EqualTo(content.Id));
+            Assert.AreNotSame(content, copy);
+            Assert.AreEqual(3, contentService.CountChildren(copy.Id));
+
+            var copiedChildren = contentService.GetPagedChildren(copy.Id, 0, 10, out var total2).OrderBy(c => c.SortOrder).ToArray();
+            Assert.AreEqual(reversedChildren.First().Name, copiedChildren.First().Name);
+            Assert.AreEqual(reversedChildren.Last().Name, copiedChildren.Last().Name);
+        }
+
+        [Test]
         public void Can_Rollback_Version_On_Content()
         {
             // Arrange


### PR DESCRIPTION
Fixed the order of the Descendants nodes during the copy
I've also created a Unit Test to test it

Fixes #8033 