### PR TITLE
Don't save duplicate templates on save

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -248,7 +248,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             {
                 // else, create or write template.Content to disk
                 content = originalAlias == null
-                    ? _viewHelper.CreateView(template, true)
+                    ? _viewHelper.CreateView(template, false)
                     : _viewHelper.UpdateViewFile(template, originalAlias);
             }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -246,7 +246,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
             else
             {
-                // else, create or write template.Content to disk
+                // else, create or write template.Content to disk,
+                // but don't overwrite existing file.
                 content = originalAlias == null
                     ? _viewHelper.CreateView(template, false)
                     : _viewHelper.UpdateViewFile(template, originalAlias);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -246,10 +246,9 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
             else
             {
-                // else, create or write template.Content to disk,
-                // but don't overwrite existing file.
+                // else, create or write template.Content to disk
                 content = originalAlias == null
-                    ? _viewHelper.CreateView(template, false)
+                    ? _viewHelper.CreateView(template, true)
                     : _viewHelper.UpdateViewFile(template, originalAlias);
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -142,11 +142,10 @@
                     submit();
                 }
 
-
             }, function (err) {
-                if (suppressNotification) {
-                    vm.page.saveButtonState = "error";
+                vm.page.saveButtonState = "error";
 
+                if (suppressNotification) {
                     localizationService.localizeMany(["speechBubbles_validationFailedHeader", "speechBubbles_validationFailedMessage"]).then(function (data) {
                         var header = data[0];
                         var message = data[1];

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -185,20 +185,6 @@
             vm.page.loading = false;
             vm.template = template;
 
-            // if this is a new template, bind to the blur event on the name
-            if (create) {
-                $timeout(function () {
-                    var nameField = $('[data-element="editor-name-field"]');
-                    if (nameField) {
-                        nameField.on('blur', function (event) {
-                            if (event.target.value) {
-                                vm.save(true);
-                            }
-                        });
-                    }
-                });
-            }
-
             // sync state
             if (!infiniteMode) {
                 editorState.set(vm.template);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9817

### Description
This PR removes the logic to save template on blur and since we really don't use the behaviour anywhere else in backoffice, where it require a button click or use the shortcut key. You could easily by mistake remove the focus on the header, which trigger a save.

The `CreateView()` method was set to overwrite which make sense it always overwrite any existing template on disk. Changing this to `false` will instead use the existing view on disk if any exists otherwise create a new view.

Alternatively it could be a configuration option, but not sure we want that 🤷‍♂️

![1b00mGidUf](https://user-images.githubusercontent.com/2919859/113473848-6f52ac80-946c-11eb-8a92-651624463589.gif)
