### PR TITLE
Block list editor upload field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -229,7 +229,7 @@
          */
         var notSupportedProperties = [
             "Umbraco.Tags",
-            "Umbraco.UploadField",
+            //"Umbraco.UploadField",
             "Umbraco.ImageCropper",
             "Umbraco.NestedContent"
         ];

--- a/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -203,8 +203,22 @@ namespace Umbraco.Web.PropertyEditors
                         var propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
                         if (propEditor == null) continue;
 
+                        // prepare files, if any matching property and culture
+                        var files = editorValue.Files
+                            .Where(x => x.PropertyAlias == propEditor.Alias)
+                            .ToArray();
+
+                        foreach (var file in files)
+                            file.FileName = file.FileName.ToSafeFileName();
+
                         // Create a fake content property data object
-                        var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration);
+                        //var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration);
+                        var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration)
+                        {
+                            ContentKey = editorValue.ContentKey,
+                            PropertyTypeKey = prop.Value.PropertyType.Key,
+                            Files = files
+                        };
 
                         // Get the property editor to do it's conversion
                         var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, prop.Value.Value);

--- a/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -205,7 +205,7 @@ namespace Umbraco.Web.PropertyEditors
 
                         // prepare files, if any matching property and culture
                         var files = editorValue.Files
-                            .Where(x => x.PropertyAlias == propEditor.Alias)
+                            .Where(x => x.PropertyAlias == prop.Value.PropertyType.Alias)
                             .ToArray();
 
                         foreach (var file in files)

--- a/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -203,7 +203,7 @@ namespace Umbraco.Web.PropertyEditors
                         var propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
                         if (propEditor == null) continue;
 
-                        // prepare files, if any matching property and culture
+                        // prepare files, if any matching property
                         var files = editorValue.Files
                             .Where(x => x.PropertyAlias == prop.Value.PropertyType.Alias)
                             .ToArray();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10103

### Description
Attempt to support Upload property editor in block list. Currently it fails save because content key and property type key are required here:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/PropertyEditors/FileUploadPropertyValueEditor.cs#L57-L60

Looking the the `ControllerBase` these are set here:
https://github.com/umbraco/Umbraco-CMS/blob/d428a4543f33bb7094cf7db5f6b6fdc2d1de3063/src/Umbraco.Web/Editors/ContentControllerBase.cs#L88-L89

With these changes I can save the property with Upload property editor and it also render some values in frontend.

```
<section class="section section">
    @{
        var items = Model.Files.Select(x => x.Content).OfType<BlockFile>();
        foreach (var item in items)
        {
            <h4>@item.Title</h4>
            if (item.File.HasValue())
            {
                <a href="@item.File">@Path.GetFileName(item.File)</a>
            }
        }
    }
</section>
```

However it seems something is not right when opening the editor again. Maybe something in the `FromEditor()` or `ToEditor()` method:

![image](https://user-images.githubusercontent.com/2919859/114079868-f9ef3d80-98aa-11eb-83a5-1ec204d0b95c.png)

According to the docs it should also be possible to use the `HasValue()` extention method, but in this case it throw an ysod.
https://our.umbraco.com/documentation/getting-started/backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/#with-modelsbuilder