### PR TITLE
Updating typo in audit logging default user

### DIFF
--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Core
             /// <summary>
             /// The name of the 'unknown' user.
             /// </summary>
-            public const string UnknownUserName = "SYTEM";
+            public const string UnknownUserName = "SYSTEM";
 
             public const string AdminGroupAlias = "admin";
             public const string EditorGroupAlias = "editor";


### PR DESCRIPTION
Hello,

Just a wee typo fix, but every little helps, right?
 
I noticed today (using audit log viewer package) when looking in audit logs the unknown user is logged as "SYTEM", I assume this is a typo of "SYSTEM". I have updated :)

Thanks,
Carole