### PR TITLE
Netcore: Only process each cache instruction from DatabaseServerMessenger once.

### DIFF
--- a/src/Umbraco.Core/Services/ICacheInstructionService.cs
+++ b/src/Umbraco.Core/Services/ICacheInstructionService.cs
@@ -39,6 +39,7 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="released">Flag indicating if process is shutting now and operations should exit.</param>
         /// <param name="localIdentity">Local identity of the executing AppDomain.</param>
         /// <param name="lastPruned">Date of last prune operation.</param>
-        CacheInstructionServiceProcessInstructionsResult ProcessInstructions(bool released, string localIdentity, DateTime lastPruned);
+        /// <param name="lastId">Id of the latest processed instruction</param>
+        CacheInstructionServiceProcessInstructionsResult ProcessInstructions(bool released, string localIdentity, DateTime lastPruned, int lastId);
     }
 }

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -286,7 +286,7 @@ namespace Umbraco.Cms.Infrastructure.Sync
 
             try
             {
-                CacheInstructionServiceProcessInstructionsResult result = CacheInstructionService.ProcessInstructions(_released, LocalIdentity, _lastPruned);
+                CacheInstructionServiceProcessInstructionsResult result = CacheInstructionService.ProcessInstructions(_released, LocalIdentity, _lastPruned, _lastId);
                 if (result.InstructionsWerePruned)
                 {
                     _lastPruned = _lastSync;
@@ -307,8 +307,8 @@ namespace Umbraco.Cms.Infrastructure.Sync
 
                 _syncIdle.Set();
             }
-        }        
-        
+        }
+
         /// <summary>
         /// Reads the last-synced id from file into memory.
         /// </summary>


### PR DESCRIPTION
Fixes #10112 

### Description

As described in the issue linked above, the problem was that the `ContentCacheRefresherNotification` was being dispatched over and over again, every 10 seconds.

The problem however was not only with the `ContentCacheRefresherNotification`, but with ***every*** `SomethingCacheRefresherNotification`, the problem lies with how the `ProcessDatabaseInstructions` method from `DatabaseServerMessenger` was migrated, it's now in a different service, the `CacheInstructionService`.

It the `CacheInstructionService` internal process method (`ProcessDatabaseInstructions`), we would always call `GetPendingInstructions` with the last id being 0, this meant that we would always get ***all** the cache instructions, causing us to process the same instructions over and over, to infinity and beyond.

Looking at the V8 code for this (in `DatabaseServerMessenger`, line 307 -> 323) I could see that we used to first get the instructions with the actual id of the last instruction processed, and then set the id to 0 afterwards. The reasoning behind setting the lastID to 0, is to be able to check if we need to save a new ID to the disk, so I've retained this behaviour. 

I've changed it so we now pass the lastId to the `ProcessInstructions` of `CacheInstructionService` and use that when fetching the pending instructions. Doing so required me to change the signature, and make lastId of the `ProcessDatabaseInstructions` method a ref instead of out, to get the new result back out. 

I realize that changing the signature of `ProcessInstructions` on `ICacheInstructionService` is a breaking change, but it won't work properly if we don't do this, and to be entirely frank I'm not entirely certain why this is public instead of internal to begin with. 


### Testing

I've added three new integration tests testing this behaviour, for manually testing you can:

Add a new class to the `Umbraco.Web.Ui.NetCore` project with the following code:

```c#
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core.Cache;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Events;

namespace Umbraco.Cms.Web.UI.NetCore
{
    public class NotificationTester : INotificationHandler<ContentCacheRefresherNotification>,
        INotificationHandler<UserCacheRefresherNotification>,
        INotificationHandler<ContentTypeCacheRefresherNotification>
    {
        private readonly ILogger<NotificationTester> _logger;

        public NotificationTester(ILogger<NotificationTester> logger)
        {
            _logger = logger;
        }
        public void Handle(ContentCacheRefresherNotification notification)
        {
            _logger.LogInformation($"Processing content cache: {notification.MessageType.ToString()}");
        }

        public void Handle(UserCacheRefresherNotification notification)
        {
            _logger.LogInformation($"Processing user cache: {notification.MessageType.ToString()}");
        }

        public void Handle(ContentTypeCacheRefresherNotification notification)
        {
            _logger.LogInformation($"Processing ContentTypeCache {notification.MessageType.ToString()}");
        }
    }

    public class TesterComposer : IUserComposer
    {
        public void Compose(IUmbracoBuilder builder) => builder
            .AddNotificationHandler<ContentCacheRefresherNotification, NotificationTester>()
            .AddNotificationHandler<UserCacheRefresherNotification, NotificationTester>()
            .AddNotificationHandler<ContentTypeCacheRefresherNotification, NotificationTester>();
    }
}
```

Ensure that the handle methods are only called (you can check for the log entries) when:
* A user is created/logs in, etc.
* A document type is saved/deleted
* Content is saved/deleted