### PR TITLE
NetCore: Types from MB-generated models are not recognized without namespace value

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// Gets or sets a value for models namespace.
         /// </summary>
         /// <remarks>That value could be overriden by other (attribute in user's code...). Return default if no value was supplied.</remarks>
-        public string ModelsNamespace { get; set; }
+        public string ModelsNamespace { get; set; } = Constants.ModelsBuilder.DefaultModelsNamespace;
 
         /// <summary>
         /// Gets or sets a value indicating whether we should flag out-of-date models.

--- a/src/Umbraco.Tests.UnitTests/Umbraco.ModelsBuilder.Embedded/BuilderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.ModelsBuilder.Embedded/BuilderTests.cs
@@ -203,7 +203,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute(""Umbraco.ModelsBuilder.Embedded"", """ + version + @""")]
 		[ImplementPropertyType(""foo"")]
-		public global::System.Collections.Generic.IEnumerable<global::Foo> Foo => this.Value<global::System.Collections.Generic.IEnumerable<global::Foo>>(_publishedValueFallback, ""foo"");
+		public global::System.Collections.Generic.IEnumerable<global::" + modelsBuilderConfig.ModelsNamespace + @".Foo> Foo => this.Value<global::System.Collections.Generic.IEnumerable<global::" + modelsBuilderConfig.ModelsNamespace + @".Foo>>(_publishedValueFallback, ""foo"");
 	}
 }
 ";


### PR DESCRIPTION
## Details
Fixes: #10073

Missing to set the default value for the models' namespace, didn't correctly map the models with their corresponding types, resulting in the issue reported in #10073.

-----------------
In the described scenario, Andy has used the Element type "_Nested Item_" as a property of the **Home** model. Meaning that we had something like:
```c#
namespace Umbraco.Cms.Web.Common.PublishedModels
{
	/// <summary>Nested Item</summary>
	[PublishedModel("nestedItem")]
	public partial class NestedItem : PublishedElementModel
	{ . . . }

        /// <summary>Home</summary>
        [PublishedModel("home")]
        public partial class Home : PublishedContentModel
        {
                . . . 
                
                // properties
                
                ///<summary>
                /// Nested Items
                ///</summary>
                [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.0.0-...")]
                [ImplementPropertyType("nestedItems")]
                public global::System.Collections.Generic.IEnumerable<global::NestedItem> NestedItems => this.Value<global::System.Collections.Generic.IEnumerable<global::NestedItem>>(_publishedValueFallback, "nestedItems");
        }
}
```

The problem was that the type `NestedItem` in `IEnumerable<global::NestedItem>`, which is located under the same namespace, was not recognised. The reason was that we missed to include the namespace as the value of `ClrTypeName` of each of the `TypeModel`s that we generate. Based on the value that we pass as `ns` to `TypeModel.MapModelTypes(IList<TypeModel> typeModels, string ns)`, it will be reflected on the already-mentioned `ClrTypeName` ([code ref.](https://github.com/umbraco/Umbraco-CMS/blob/028396a0f55dfae5ce2d17f30beead2b698ebda2/src/Umbraco.Infrastructure/ModelsBuilder/Building/TypeModel.cs#L195)).

So, basically when we were setting `ModelsNamespace = Config.ModelsNamespace;` in **Builder.cs** ([code ref.](https://github.com/umbraco/Umbraco-CMS/blob/028396a0f55dfae5ce2d17f30beead2b698ebda2/src/Umbraco.Infrastructure/ModelsBuilder/Building/Builder.cs#L77)), no default value was set for `Config.ModelsNamespace`, which in our case should be `"Umbraco.Cms.Web.Common.PublishedModels"`.

The end result is:
```c#
        // properties
        
        ///<summary>
        /// Nested Items
        ///</summary>
        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.0.0-...")]
        [ImplementPropertyType("nestedItems")]
        public global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Web.Common.PublishedModels.NestedItem> NestedItems => this.Value<global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Web.Common.PublishedModels.NestedItem>>(_publishedValueFallback, "nestedItems");
```

-----------
## Test:
Follow the steps to replicate listed in the reported issue and make sure the error doesn't appear and that the `NestedItem` type has its full type reference.

-----------
## Note:
- The prefix `global::` is added when there is no using statement for particular types and therefore we usually prefix the in-line types with it.
