### PR TITLE
Allow KeepAlive controller Ping method to be requested by non local requests

### DIFF
--- a/src/Umbraco.Web/Editors/KeepAliveController.cs
+++ b/src/Umbraco.Web/Editors/KeepAliveController.cs
@@ -1,8 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using System.Web.Http;
-using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
-using Umbraco.Web.WebApi.Filters;
 
 namespace Umbraco.Web.Editors
 {

--- a/src/Umbraco.Web/Editors/KeepAliveController.cs
+++ b/src/Umbraco.Web/Editors/KeepAliveController.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Web.Editors
 {
     public class KeepAliveController : UmbracoApiController
     {
-        [OnlyLocalRequests]
+        [HttpHead]
         [HttpGet]
         public KeepAlivePingResult Ping()
         {


### PR DESCRIPTION
As per #10109 I have swapped the OnlyLocalRequests attribute for HttpHead so that the Ping method can be used by external health probes (Azure Web App Health Check Probe, AZFD Probe etc)