### PR TITLE
Block List and Nested Content browser performance problem - don't run heavy count method on `$watch`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js
@@ -25,7 +25,7 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
     function ValFormManagerController($scope) {
         //This exposes an API for direct use with this directive
 
-        // We need this as a way to reference this directive in the scope chain. Since this directive isn't a component and 
+        // We need this as a way to reference this directive in the scope chain. Since this directive isn't a component and
         // because it's an attribute instead of an element, we can't use controllerAs or anything like that. Plus since this is
         // an attribute an isolated scope doesn't work so it's a bit weird. By doing this we are able to lookup the parent valFormManager
         // in the scope hierarchy even if the DOM hierarchy doesn't match (i.e. in infinite editing)
@@ -109,9 +109,9 @@ function valFormManager(serverValidationManager, $rootScope, $timeout, $location
                 labels.stayButton = values[3];
             });
 
-            //watch the list of validation errors to notify the application of any validation changes
-            // TODO: Wouldn't it be easier/faster to watch formCtrl.$invalid ?
-            scope.$watch(() => angularHelper.countAllFormErrors(formCtrl),
+
+            // watch the list of validation errors to notify the application of any validation changes
+            scope.$watch(() => formCtrl.$invalid,
                 function (e) {
 
                     notify(scope);


### PR DESCRIPTION
Block List Editor and Nested Content will most likely freeze when having complex data sets in multiple levels.
The freeze happens cause `collectAllFormErrorsRecursively` runs too often and might get into an infinite loop. Most likely cause it was ran by a AngularJS `$watch`, which means it would be called a lot.

There seem to be no reason to use this recursive count of errors in the `$watch` method as the `$invalid` property also informs whether a form is valid(including child forms validity)

Fixes https://github.com/umbraco/Umbraco-CMS/issues/9667
and https://github.com/umbraco/Umbraco-CMS/issues/9360

The previous attempt on this is still valid, but this fix is needed for more complex situations.
https://github.com/umbraco/Umbraco-CMS/pull/9677

**Test notes:**
- Make a ElementType with a few advanced property editors, TreePicker, ContentPicker, userPicker, MemberPicker, MediaPicker, make sure to make these mandatory.
- Make a docuemntType with a Block List Editor property using the above ElementType.
- Add one textfield and add Mandatory and a Regex exp(like e-mail validation), in order for this to be Server validated.
- Add a property with Block List Editor, using the same ElementType, in order to have multiple levels of complex validation.

- Make a document with three or more levels of Block List entries. (A containing B containing C...)
- I experienced a freeze already in the second level.

---
_This item has been added to our backlog [AB#11447](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/11447)_