### PR TITLE
Hack: Attempt to add SQLite for CrossPlatform Embedded DB

### DIFF
--- a/src/Umbraco.Core/Configuration/ConfigConnectionString.cs
+++ b/src/Umbraco.Core/Configuration/ConfigConnectionString.cs
@@ -37,6 +37,10 @@ namespace Umbraco.Cms.Core.Configuration
                 {
                     return Umbraco.Cms.Core.Constants.DbProviderNames.SqlCe;
                 }
+                else if (dataSource.EndsWith(".db"))
+                {
+                    return Umbraco.Cms.Core.Constants.DbProviderNames.SQLite;
+                }
             }
 
 

--- a/src/Umbraco.Core/Constants-DatabaseProviders.cs
+++ b/src/Umbraco.Core/Constants-DatabaseProviders.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core
+namespace Umbraco.Cms.Core
 {
     public static partial class Constants
     {
@@ -6,6 +6,7 @@
         {
             public const string SqlCe = "System.Data.SqlServerCe.4.0";
             public const string SqlServer = "System.Data.SqlClient";
+            public const string SQLite = "System.Data.SQLite";
         }
     }
 }

--- a/src/Umbraco.Core/Install/Models/DatabaseType.cs
+++ b/src/Umbraco.Core/Install/Models/DatabaseType.cs
@@ -1,10 +1,11 @@
-﻿namespace Umbraco.Cms.Core.Install.Models
+namespace Umbraco.Cms.Core.Install.Models
 {
     public enum DatabaseType
     {
         SqlCe,
         SqlServer,
         SqlAzure,
+        Sqlite,
         Custom
     }
 }

--- a/src/Umbraco.Core/Persistence/Constants-DbProviderNames.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DbProviderNames.cs
@@ -1,4 +1,4 @@
-﻿ // ReSharper disable once CheckNamespace
+ // ReSharper disable once CheckNamespace
 namespace Umbraco.Cms.Core
 {
     static partial class Constants
@@ -7,6 +7,7 @@ namespace Umbraco.Cms.Core
         {
             public const string SqlServer = "System.Data.SqlClient";
             public const string SqlCe = "System.Data.SqlServerCe.4.0";
+            public const string SQLite = "System.Data.SQLite";
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseConfigureStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseConfigureStep.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -53,6 +53,11 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
             {
                 _databaseBuilder.ConfigureEmbeddedDatabaseConnection();
             }
+            else if(database.DatabaseType == DatabaseType.Sqlite)
+            {
+                _databaseBuilder.ConfigureEmbeddedSQLiteDatabaseConnection();
+
+            }
             else if (database.IntegratedAuth)
             {
                 _databaseBuilder.ConfigureIntegratedSecurityDatabaseConnection(database.Server, database.DatabaseName);
@@ -76,6 +81,7 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
                 {
                     new { name = "Microsoft SQL Server", id = DatabaseType.SqlServer.ToString() },
                     new { name = "Microsoft SQL Azure", id = DatabaseType.SqlAzure.ToString() },
+                    new { name = "SQLite Cross Platform Embedded", id = DatabaseType.Sqlite.ToString() },
                     new { name = "Custom connection string", id = DatabaseType.Custom.ToString() },
                 };
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -181,9 +181,6 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             var path = _hostingEnvironment.MapPathContentRoot("Umbraco.db");
             if (File.Exists(path) == false)
             {
-                // this should probably be in a "using (new SqlCeEngine)" clause but not sure
-                // of the side effects and it's been like this for quite some time now
-
                 _dbProviderFactoryCreator.CreateDatabase(Constants.DbProviderNames.SQLite);
             }
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -143,6 +143,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         #region Configure Connection String
 
         public const string EmbeddedDatabaseConnectionString = @"Data Source=|DataDirectory|\Umbraco.sdf;Flush Interval=1;";
+        public const string EmbeddedSQLiteDatabaseConnectionString = @"Data Source=./Umbraco.db;";
 
         /// <summary>
         /// Configures a connection string for the embedded database.
@@ -150,6 +151,11 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         public void ConfigureEmbeddedDatabaseConnection()
         {
             ConfigureEmbeddedDatabaseConnection(_databaseFactory);
+        }
+
+        public void ConfigureEmbeddedSQLiteDatabaseConnection()
+        {
+            ConfigureEmbeddedSQLiteDatabaseConnection(_databaseFactory);
         }
 
         private void ConfigureEmbeddedDatabaseConnection(IUmbracoDatabaseFactory factory)
@@ -166,6 +172,22 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             }
 
             factory.Configure(EmbeddedDatabaseConnectionString, Constants.DbProviderNames.SqlCe);
+        }
+
+        private void ConfigureEmbeddedSQLiteDatabaseConnection(IUmbracoDatabaseFactory factory)
+        {
+            _configManipulator.SaveConnectionString(EmbeddedSQLiteDatabaseConnectionString, Constants.DbProviderNames.SQLite);
+
+            var path = _hostingEnvironment.MapPathContentRoot("Umbraco.db");
+            if (File.Exists(path) == false)
+            {
+                // this should probably be in a "using (new SqlCeEngine)" clause but not sure
+                // of the side effects and it's been like this for quite some time now
+
+                _dbProviderFactoryCreator.CreateDatabase(Constants.DbProviderNames.SQLite);
+            }
+
+            factory.Configure(EmbeddedSQLiteDatabaseConnectionString, Constants.DbProviderNames.SQLite);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -80,8 +80,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         /// </summary>
         public bool CanConnect(string databaseType, string connectionString, string server, string database, string login, string password, bool integratedAuth)
         {
-            // we do not test SqlCE connection
-            if (databaseType.InvariantContains("sqlce"))
+            // we do not test SqlCE or SQLite connection
+            if (databaseType.InvariantContains("sqlce") || databaseType.InvariantContains("sqlite"))
                 return true;
 
             string providerName;

--- a/src/Umbraco.Infrastructure/Persistence/DbConnectionExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DbConnectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Extensions
             return Cms.Core.Constants.DbProviderNames.SqlServer;
         }
 
-    public static bool IsConnectionAvailable(string connectionString, DbProviderFactory factory)
+        public static bool IsConnectionAvailable(string connectionString, DbProviderFactory factory)
         {
 
             var connection = factory.CreateConnection();
@@ -46,6 +46,7 @@ namespace Umbraco.Extensions
             connection.ConnectionString = connectionString;
             using (connection)
             {
+                // TODO: File needs to exist for this to be happy for SQLite
                 return connection.IsAvailable();
             }
         }

--- a/src/Umbraco.Infrastructure/Persistence/DbConnectionExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DbConnectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -22,6 +22,14 @@ namespace Umbraco.Extensions
                 && builder["Data source"].ToString().InvariantContains(".sdf"))
             {
                 return Cms.Core.Constants.DbProviderNames.SqlCe;
+            }
+
+            // SQLite DB connection strings use .db file extensions
+            else if (allKeys.InvariantContains("Data Source")
+                //this dictionary is case insensitive
+                && builder["Data source"].ToString().InvariantContains(".db"))
+            {
+                return Cms.Core.Constants.DbProviderNames.SQLite;
             }
 
             return Cms.Core.Constants.DbProviderNames.SqlServer;

--- a/src/Umbraco.Infrastructure/Persistence/NPocoDatabaseTypeExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoDatabaseTypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using NPoco;
+using NPoco;
 
 namespace Umbraco.Cms.Infrastructure.Persistence
 {
@@ -30,6 +30,11 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         public static bool IsSqlServerOrCe(this DatabaseType databaseType)
         {
             return databaseType.IsSqlServer() || databaseType.IsSqlCe();
+        }
+
+        public static bool IsSQLite(this DatabaseType databaseType)
+        {
+            return databaseType is NPoco.DatabaseTypes.SQLiteDatabaseType;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/SQLiteEmbeddedDatabaseCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SQLiteEmbeddedDatabaseCreator.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Umbraco.Cms.Infrastructure.Persistence
+{
+    public class SQLiteEmbeddedDatabaseCreator : IEmbeddedDatabaseCreator
+    {
+        public string ProviderName => Cms.Core.Constants.DatabaseProviders.SQLite;
+
+        public string ConnectionString { get; set; } = "Data Source=C:/Application.db;";
+
+        public void Create()
+        {
+            // Do we need to do anything as SQLite will create file if not exist it seems
+
+            // Parse Connection String
+            var connection = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder(ConnectionString);
+            var dataSource = connection.DataSource; // Could be c:/something.db OR ./Something.db
+
+
+
+            // Do we just create a file on disk in the connection string location?
+
+            // Use DB in project directory.  If it does not exist, create it:
+            //var connectionStringBuilder = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder
+            //{
+            //    DataSource = "./SqliteDB.db"
+            //};
+
+
+
+            // SQL CE example...
+            //var engine = new System.Data.SqlServerCe.SqlCeEngine(ConnectionString);
+            //engine.CreateDatabase();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/SQLiteEmbeddedDatabaseCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SQLiteEmbeddedDatabaseCreator.cs
@@ -1,38 +1,32 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.IO;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Hosting;
 
 namespace Umbraco.Cms.Infrastructure.Persistence
 {
     public class SQLiteEmbeddedDatabaseCreator : IEmbeddedDatabaseCreator
     {
+        private readonly IHostingEnvironment _hostingEnvironment;
+
+        public SQLiteEmbeddedDatabaseCreator(IHostingEnvironment hostingEnvironment)
+        {
+            _hostingEnvironment = hostingEnvironment;
+        }
+
         public string ProviderName => Cms.Core.Constants.DatabaseProviders.SQLite;
 
-        public string ConnectionString { get; set; } = "Data Source=C:/Application.db;";
+        public string ConnectionString { get; set; }
 
         public void Create()
         {
-            // Do we need to do anything as SQLite will create file if not exist it seems
+            // NOTE: Not sure we need to do anything as SQLite will create file if it does not exist when opening connection
 
-            // Parse Connection String
-            var connection = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder(ConnectionString);
-            var dataSource = connection.DataSource; // Could be c:/something.db OR ./Something.db
-
-
-
-            // Do we just create a file on disk in the connection string location?
-
-            // Use DB in project directory.  If it does not exist, create it:
-            //var connectionStringBuilder = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder
+            // Create file on disk from standard path....
+            //var path = _hostingEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.Data, "Umbraco.db"));
+            //if (File.Exists(path) == false)
             //{
-            //    DataSource = "./SqliteDB.db"
-            //};
-
-
-
-            // SQL CE example...
-            //var engine = new System.Data.SqlServerCe.SqlCeEngine(ConnectionString);
-            //engine.CreateDatabase();
+            //    File.Create(path);
+            //}
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqliteSyntaxProvider.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.SqlSyntax
+{
+    public class SqliteSyntaxProvider : MicrosoftSqlSyntaxProviderBase<SqliteSyntaxProvider>
+    {
+        public override string ProviderName => Cms.Core.Constants.DatabaseProviders.SQLite;
+
+        public override IsolationLevel DefaultIsolationLevel => IsolationLevel.ReadCommitted; // No idea if this is the right one ?
+
+        public override string DbProvider => Cms.Core.Constants.DatabaseProviders.SQLite;
+
+
+        public override IEnumerable<Tuple<string, string, string, bool>> GetDefinedIndexes(IDatabase db)
+        {
+            // PRAGMA index_info('foo');
+            // SELECT name as INDEX_NAME, tbl_name as TABLE_NAME, sql, type FROM sqlite_master where type == 'index'
+
+
+            var items = db.Fetch<dynamic>(
+        @"SELECT
+	m.tbl_name AS TABLE_NAME,
+	ilist.name AS INDEX_NAME,
+	iinfo.name AS COLUMN_NAME,
+	ilist.[unique] AS UNIQUE_INDEX
+FROM 
+	sqlite_master AS m, 
+	pragma_index_list(m.name) AS ilist, 
+	pragma_index_info(ilist.name) AS iinfo");
+
+            return items.Select(item => new Tuple<string, string, string, bool>(item.TABLE_NAME, item.INDEX_NAME, item.COLUMN_NAME, item.UNIQUE_INDEX == 1)).ToList();
+        }
+
+        public override void ReadLock(IDatabase db, params int[] lockIds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void ReadLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Sql<ISqlContext> SelectTop(Sql<ISqlContext> sql, int top)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool TryGetDefaultConstraint(IDatabase db, string tableName, string columnName, out string constraintName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteLock(IDatabase db, params int[] lockIds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteLock(IDatabase db, TimeSpan timeout, int lockId)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string FormatIdentity(ColumnDefinition column)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string FormatSystemMethods(SystemMethods systemMethod)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/SqliteBulkSqlInsertProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqliteBulkSqlInsertProvider.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Persistence
+{
+    /// <summary>
+    /// A bulk sql insert provider for Sqlite
+    /// </summary>
+    public class SqliteBulkSqlInsertProvider : IBulkSqlInsertProvider
+    {
+        public string ProviderName => Cms.Core.Constants.DatabaseProviders.SQLite;
+
+        public int BulkInsertRecords<T>(IUmbracoDatabase database, IEnumerable<T> records)
+        {
+            var recordsA = records.ToArray();
+            if (recordsA.Length == 0) return 0;
+
+            var pocoData = database.PocoDataFactory.ForType(typeof(T));
+            if (pocoData == null) throw new InvalidOperationException("Could not find PocoData for " + typeof(T));
+
+            return BulkInsertRecordsSqlite(database, pocoData, recordsA);
+        }
+
+        /// <summary>
+        /// Bulk-insert records using SqlServer BulkCopy method.
+        /// </summary>
+        /// <typeparam name="T">The type of the records.</typeparam>
+        /// <param name="database">The database.</param>
+        /// <param name="pocoData">The PocoData object corresponding to the record's type.</param>
+        /// <param name="records">The records.</param>
+        /// <returns>The number of records that were inserted.</returns>
+        private int BulkInsertRecordsSqlite<T>(IUmbracoDatabase database, PocoData pocoData, IEnumerable<T> records)
+        {
+            // create command against the original database.Connection
+            using (var command = database.CreateCommand(database.Connection, CommandType.Text, string.Empty))
+            {
+                // use typed connection and transaction or SqlBulkCopy
+                var tConnection = NPocoDatabaseExtensions.GetTypedConnection<SqlConnection>(database.Connection);
+                var tTransaction = NPocoDatabaseExtensions.GetTypedTransaction<SqlTransaction>(command.Transaction);
+                var tableName = pocoData.TableInfo.TableName;
+
+                var syntax = database.SqlContext.SqlSyntax as SqliteSyntaxProvider;
+                if (syntax == null) throw new NotSupportedException("SqlSyntax must be SqliteSyntaxProvider.");
+
+                using (var copy = new SqlBulkCopy(tConnection, SqlBulkCopyOptions.Default, tTransaction) { BulkCopyTimeout = 10000, DestinationTableName = tableName })
+                using (var bulkReader = new PocoDataDataReader<T, SqliteSyntaxProvider>(records, pocoData, syntax))
+                {
+                    //we need to add column mappings here because otherwise columns will be matched by their order and if the order of them are different in the DB compared
+                    //to the order in which they are declared in the model then this will not work, so instead we will add column mappings by name so that this explicitly uses
+                    //the names instead of their ordering.
+                    foreach (var col in bulkReader.ColumnMappings)
+                    {
+                        copy.ColumnMappings.Add(col.DestinationColumn, col.DestinationColumn);
+                    }
+
+                    copy.WriteToServer(bulkReader);
+                    return bulkReader.RecordsAffected;
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -23,6 +23,7 @@
       <PackageReference Include="Markdown" Version="2.2.1" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
       <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+      <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -138,6 +138,7 @@ namespace Umbraco.Extensions
 
             // Add supported databases
             builder.AddUmbracoSqlServerSupport();
+            builder.AddUmbracoSqliteSupport();
             builder.AddUmbracoSqlCeSupport();
             builder.Services.AddUnique<DatabaseSchemaCreatorFactory>();
 
@@ -399,12 +400,16 @@ namespace Umbraco.Extensions
             builder.Services.AddSingleton<IBulkSqlInsertProvider, SqlServerBulkSqlInsertProvider>();
             builder.Services.AddSingleton<IEmbeddedDatabaseCreator, NoopEmbeddedDatabaseCreator>();
 
-            //SQLite (Test)
-            DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SQLite, Microsoft.Data.Sqlite.SqliteFactory.Instance);
-            // builder.Services.AddSingleton<ISqlSyntaxProvider, SqlServerSyntaxProvider>();
-            // builder.Services.AddSingleton<IBulkSqlInsertProvider, SqlServerBulkSqlInsertProvider>();
-            builder.Services.AddSingleton<IEmbeddedDatabaseCreator, SQLiteEmbeddedDatabaseCreator>();
+            return builder;
+        }
 
+        private static IUmbracoBuilder AddUmbracoSqliteSupport(this IUmbracoBuilder builder)
+        {
+            DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SQLite, Microsoft.Data.Sqlite.SqliteFactory.Instance);
+
+            builder.Services.AddSingleton<ISqlSyntaxProvider, SqliteSyntaxProvider>();
+            builder.Services.AddSingleton<IBulkSqlInsertProvider, SqliteBulkSqlInsertProvider>();
+            builder.Services.AddSingleton<IEmbeddedDatabaseCreator, SQLiteEmbeddedDatabaseCreator>();
 
             return builder;
         }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -394,13 +394,17 @@ namespace Umbraco.Extensions
         private static IUmbracoBuilder AddUmbracoSqlServerSupport(this IUmbracoBuilder builder)
         {
             DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SqlServer, SqlClientFactory.Instance);
-
-            //SQLite (Test)
-            DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SQLite, Microsoft.Data.Sqlite.SqliteFactory.Instance);
-
+            
             builder.Services.AddSingleton<ISqlSyntaxProvider, SqlServerSyntaxProvider>();
             builder.Services.AddSingleton<IBulkSqlInsertProvider, SqlServerBulkSqlInsertProvider>();
             builder.Services.AddSingleton<IEmbeddedDatabaseCreator, NoopEmbeddedDatabaseCreator>();
+
+            //SQLite (Test)
+            DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SQLite, Microsoft.Data.Sqlite.SqliteFactory.Instance);
+            // builder.Services.AddSingleton<ISqlSyntaxProvider, SqlServerSyntaxProvider>();
+            // builder.Services.AddSingleton<IBulkSqlInsertProvider, SqlServerBulkSqlInsertProvider>();
+            builder.Services.AddSingleton<IEmbeddedDatabaseCreator, SQLiteEmbeddedDatabaseCreator>();
+
 
             return builder;
         }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -395,6 +395,9 @@ namespace Umbraco.Extensions
         {
             DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SqlServer, SqlClientFactory.Instance);
 
+            //SQLite (Test)
+            DbProviderFactories.RegisterFactory(Cms.Core.Constants.DbProviderNames.SQLite, Microsoft.Data.Sqlite.SqliteFactory.Instance);
+
             builder.Services.AddSingleton<ISqlSyntaxProvider, SqlServerSyntaxProvider>();
             builder.Services.AddSingleton<IBulkSqlInsertProvider, SqlServerBulkSqlInsertProvider>();
             builder.Services.AddSingleton<IEmbeddedDatabaseCreator, NoopEmbeddedDatabaseCreator>();

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
@@ -17,7 +17,7 @@
             </div>
         </div>
 
-        <div class="controls" ng-if="installer.current.model.dbType == 'SqlCe' ">
+        <div class="controls" ng-if="installer.current.model.dbType == 'SqlCe' || installer.current.model.dbType == 'Sqlite'">
             <p>Great! No need to configure anything, you can simply click the <strong>continue</strong> button below to continue to the next step</p>
         </div>
 


### PR DESCRIPTION
# Experiment
This is very rough and a WIP PR to try and see if we can use the cross platform SQLite embedded database that the .NETCore default templates uses.

It currently is just a very trial and error and debug approach in attempt to get this to work.

## Why?
SQLCE is deprecated 
NPoco supports SQLite ✔️
A need for a X-Platform Embedded DB engine for quick spin up of sites

## TODO
- [ ] Need help on the SQLite Syntax Provider and figuring out what SQL syntax is different/specific for SQLite
- [ ] Lots of testing
- [ ] Add unit tests