### PR TITLE
Netcore: Migrate DatabaseSchemaCreation events to notifications

### DIFF
--- a/src/Umbraco.Core/Events/CancelableNotification.cs
+++ b/src/Umbraco.Core/Events/CancelableNotification.cs
@@ -1,0 +1,11 @@
+namespace Umbraco.Cms.Core.Events
+{
+    public class CancelableNotification : ICancelableNotification
+    {
+        public bool Cancel { get; set; }
+        public void CancelOperation()
+        {
+            Cancel = true;
+        }
+    }
+}

--- a/src/Umbraco.Core/Events/CancelableNotification.cs
+++ b/src/Umbraco.Core/Events/CancelableNotification.cs
@@ -1,6 +1,6 @@
 namespace Umbraco.Cms.Core.Events
 {
-    public class CancelableNotification : ICancelableNotification
+    public class CancelableNotification : StatefulNotification, ICancelableNotification
     {
         public bool Cancel { get; set; }
         public void CancelOperation()

--- a/src/Umbraco.Core/Events/CancelableNotification.cs
+++ b/src/Umbraco.Core/Events/CancelableNotification.cs
@@ -2,10 +2,17 @@ namespace Umbraco.Cms.Core.Events
 {
     public class CancelableNotification : StatefulNotification, ICancelableNotification
     {
+        public CancelableNotification(EventMessages messages) => Messages = messages;
+
+        public EventMessages Messages { get; }
+
         public bool Cancel { get; set; }
-        public void CancelOperation()
+
+        public void CancelOperation(EventMessage cancellationMessage)
         {
             Cancel = true;
+            cancellationMessage.IsDefaultEventMessage = true;
+            Messages.Add(cancellationMessage);
         }
     }
 }

--- a/src/Umbraco.Core/Events/DatabaseCreationEventArgs.cs
+++ b/src/Umbraco.Core/Events/DatabaseCreationEventArgs.cs
@@ -1,4 +1,0 @@
-﻿namespace Umbraco.Cms.Core.Events
-{
-    public class DatabaseCreationEventArgs : System.ComponentModel.CancelEventArgs{}
-}

--- a/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatedNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatedNotification.cs
@@ -4,6 +4,9 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Events
 {
     internal class DatabaseSchemaCreatedNotification : StatefulNotification
     {
+        public DatabaseSchemaCreatedNotification(EventMessages eventMessages) => EventMessages = eventMessages;
+
+        public EventMessages EventMessages { get; }
 
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatedNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatedNotification.cs
@@ -2,7 +2,7 @@ using Umbraco.Cms.Core.Events;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Events
 {
-    internal class DatabaseSchemaCreatedNotification : INotification
+    internal class DatabaseSchemaCreatedNotification : StatefulNotification
     {
 
     }

--- a/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatedNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatedNotification.cs
@@ -1,0 +1,9 @@
+using Umbraco.Cms.Core.Events;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Events
+{
+    internal class DatabaseSchemaCreatedNotification : INotification
+    {
+
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatingNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatingNotification.cs
@@ -4,5 +4,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Events
 {
     internal class DatabaseSchemaCreatingNotification : CancelableNotification
     {
+        public DatabaseSchemaCreatingNotification(EventMessages messages) : base(messages)
+        {
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatingNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Events/DatabaseSchemaCreatingNotification.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Core.Events;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Events
+{
+    internal class DatabaseSchemaCreatingNotification : CancelableNotification
+    {
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -136,7 +136,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             if (!_database.InTransaction)
                 throw new InvalidOperationException("Database is not in a transaction.");
 
-            var creatingNotification = new DatabaseSchemaCreatingNotification();
+            var eventMessages = new EventMessages();
+            var creatingNotification = new DatabaseSchemaCreatingNotification(eventMessages);
             FireBeforeCreation(creatingNotification);
 
             if (creatingNotification.Cancel == false)
@@ -146,7 +147,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
                     CreateTable(false, table, dataCreation);
             }
 
-            DatabaseSchemaCreatedNotification createdNotification = new DatabaseSchemaCreatedNotification().WithStateFrom(creatingNotification);
+            DatabaseSchemaCreatedNotification createdNotification = new DatabaseSchemaCreatedNotification(eventMessages).WithStateFrom(creatingNotification);
             FireAfterCreation(createdNotification);
         }
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -146,7 +146,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
                     CreateTable(false, table, dataCreation);
             }
 
-            FireAfterCreation(new DatabaseSchemaCreatedNotification());
+            DatabaseSchemaCreatedNotification createdNotification = new DatabaseSchemaCreatedNotification().WithStateFrom(creatingNotification);
+            FireAfterCreation(createdNotification);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreatorFactory.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreatorFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Install
@@ -12,20 +13,23 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         private readonly ILogger<DatabaseSchemaCreator> _logger;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IUmbracoVersion _umbracoVersion;
+        private readonly IEventAggregator _eventAggregator;
 
         public DatabaseSchemaCreatorFactory(
             ILogger<DatabaseSchemaCreator> logger,
             ILoggerFactory loggerFactory,
-            IUmbracoVersion umbracoVersion)
+            IUmbracoVersion umbracoVersion,
+            IEventAggregator eventAggregator)
         {
             _logger = logger;
             _loggerFactory = loggerFactory;
             _umbracoVersion = umbracoVersion;
+            _eventAggregator = eventAggregator;
         }
 
         public DatabaseSchemaCreator Create(IUmbracoDatabase database)
         {
-            return new DatabaseSchemaCreator(database, _logger, _loggerFactory, _umbracoVersion);
+            return new DatabaseSchemaCreator(database, _logger, _loggerFactory, _umbracoVersion, _eventAggregator);
         }
     }
 }

--- a/src/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs
+++ b/src/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs
@@ -10,8 +10,10 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence;
 
@@ -135,7 +137,7 @@ namespace Umbraco.Cms.Tests.Integration.Testing
 
                 using (NPoco.ITransaction transaction = database.GetTransaction())
                 {
-                    var schemaCreator = new DatabaseSchemaCreator(database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, new UmbracoVersion());
+                    var schemaCreator = new DatabaseSchemaCreator(database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, new UmbracoVersion(), Mock.Of<IEventAggregator>());
                     schemaCreator.InitializeDatabaseSchema();
 
                     transaction.Complete();

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/AdvancedMigrationTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/AdvancedMigrationTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Migrations;
@@ -27,6 +28,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations
         private readonly ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
 
         private IUmbracoVersion UmbracoVersion => GetRequiredService<IUmbracoVersion>();
+        private IEventAggregator EventAggregator => GetRequiredService<IEventAggregator>();
 
         [Test]
         public void CreateTableOfTDto()
@@ -53,7 +55,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations
 
                 upgrader.Execute(ScopeProvider, builder, Mock.Of<IKeyValueService>(), _loggerFactory.CreateLogger<Upgrader>(), _loggerFactory);
 
-                var helper = new DatabaseSchemaCreator(scope.Database, LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion, EventAggregator);
                 bool exists = helper.TableExists("umbracoUser");
                 Assert.IsTrue(exists);
 

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/DatabaseBuilderTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/DatabaseBuilderTests.cs
@@ -7,6 +7,7 @@ using NPoco;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Tests.Common.TestHelpers;
@@ -65,7 +66,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
             using (var database = UmbracoDatabaseFactory.CreateDatabase())
             using (var transaction = database.GetTransaction())
             {
-                schemaHelper = new DatabaseSchemaCreator(database, Mock.Of<ILogger<DatabaseSchemaCreator>>(), NullLoggerFactory.Instance, new UmbracoVersion());
+                schemaHelper = new DatabaseSchemaCreator(database, Mock.Of<ILogger<DatabaseSchemaCreator>>(), NullLoggerFactory.Instance, new UmbracoVersion(), Mock.Of<IEventAggregator>());
                 schemaHelper.InitializeDatabaseSchema();
                 transaction.Complete();
             }

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/SchemaValidationTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/SchemaValidationTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -12,6 +13,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
     public class SchemaValidationTest : UmbracoIntegrationTest
     {
         private IUmbracoVersion UmbracoVersion => GetRequiredService<IUmbracoVersion>();
+        private IEventAggregator EventAggregator => GetRequiredService<IEventAggregator>();
 
         [Test]
         public void DatabaseSchemaCreation_Produces_DatabaseSchemaResult_With_Zero_Errors()
@@ -20,7 +22,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
 
             using (var scope = ScopeProvider.CreateScope())
             {
-                var schema = new DatabaseSchemaCreator(scope.Database, LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion);
+                var schema = new DatabaseSchemaCreator(scope.Database, LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion, EventAggregator);
                 result = schema.ValidateSchema(DatabaseSchemaCreator.OrderedTables);
             }
 

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/SqlServerTableByTableTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/SqlServerTableByTableTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -15,13 +16,14 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
     {
         private IUmbracoVersion UmbracoVersion => GetRequiredService<IUmbracoVersion>();
         private static ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+        private IEventAggregator EventAggregator => GetRequiredService<IEventAggregator>();
 
         [Test]
         public void Can_Create_umbracoNode_Table()
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
 
@@ -34,7 +36,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<AccessDto>();
@@ -48,7 +50,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<AccessDto>();
@@ -63,7 +65,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentType2ContentTypeDto>();
@@ -77,7 +79,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -92,7 +94,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -106,7 +108,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -122,7 +124,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<DataTypeDto>();
@@ -136,7 +138,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<DictionaryDto>();
 
@@ -149,7 +151,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<DictionaryDto>();
                 helper.CreateTable<LanguageDto>();
@@ -164,7 +166,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<TemplateDto>();
@@ -178,7 +180,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -195,7 +197,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -211,7 +213,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<DomainDto>();
@@ -225,7 +227,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<LogViewerQueryDto>();
 
@@ -238,7 +240,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<LanguageDto>();
 
@@ -251,7 +253,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<LogDto>();
 
@@ -264,7 +266,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<MacroDto>();
 
@@ -277,7 +279,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -293,7 +295,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -310,7 +312,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -325,7 +327,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -343,7 +345,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -360,7 +362,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -375,7 +377,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<RelationTypeDto>();
@@ -390,7 +392,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<RelationTypeDto>();
 
@@ -403,7 +405,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<TagDto>();
 
@@ -416,7 +418,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<ContentTypeDto>();
@@ -437,7 +439,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<UserDto>();
 
@@ -450,7 +452,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<UserGroupDto>();
@@ -464,7 +466,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<UserDto>();
@@ -478,7 +480,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<UserGroupDto>();
@@ -493,7 +495,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion);
+                var helper = new DatabaseSchemaCreator(scope.Database, _loggerFactory.CreateLogger<DatabaseSchemaCreator>(), _loggerFactory, UmbracoVersion, EventAggregator);
 
                 helper.CreateTable<NodeDto>();
                 helper.CreateTable<UserGroupDto>();

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
             var globalSettings = new GlobalSettings();
             var connectionStrings = new ConnectionStrings();
             var f = new UmbracoDatabaseFactory(loggerFactory.CreateLogger<UmbracoDatabaseFactory>(), loggerFactory, Options.Create(globalSettings), Options.Create(connectionStrings), new Lazy<IMapperCollection>(() => new MapperCollection(Enumerable.Empty<BaseMapper>())), TestHelper.DbProviderFactoryCreator,
-                new DatabaseSchemaCreatorFactory(loggerFactory.CreateLogger<DatabaseSchemaCreator>(), loggerFactory, new UmbracoVersion()));
+                new DatabaseSchemaCreatorFactory(loggerFactory.CreateLogger<DatabaseSchemaCreator>(), loggerFactory, new UmbracoVersion(), Mock.Of<IEventAggregator>()));
             var fs = new FileSystems(mock.Object, loggerFactory.CreateLogger<FileSystems>(), loggerFactory, IOHelper, Options.Create(globalSettings), Mock.Of<IHostingEnvironment>());
             var coreDebug = new CoreDebugSettings();
             IMediaFileSystem mediaFileSystem = Mock.Of<IMediaFileSystem>();

--- a/src/Umbraco.Tests/TestHelpers/TestHelper.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestHelper.cs
@@ -20,6 +20,7 @@ using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Diagnostics;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Logging;
@@ -62,7 +63,7 @@ namespace Umbraco.Tests.TestHelpers
             }
 
             public override IDbProviderFactoryCreator DbProviderFactoryCreator { get; } = new UmbracoDbProviderFactoryCreator();
-            public DatabaseSchemaCreatorFactory DatabaseSchemaCreatorFactory { get; } = new DatabaseSchemaCreatorFactory(Mock.Of<ILogger<DatabaseSchemaCreator>>(), NullLoggerFactory.Instance, new UmbracoVersion());
+            public DatabaseSchemaCreatorFactory DatabaseSchemaCreatorFactory { get; } = new DatabaseSchemaCreatorFactory(Mock.Of<ILogger<DatabaseSchemaCreator>>(), NullLoggerFactory.Instance, new UmbracoVersion(), Mock.Of<IEventAggregator>());
 
             public override IBulkSqlInsertProvider BulkSqlInsertProvider { get; } = new SqlCeBulkSqlInsertProvider();
 

--- a/src/Umbraco.Tests/TestHelpers/TestObjects.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestObjects.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Tests.TestHelpers
                     connectionStrings,
                     new Lazy<IMapperCollection>(() => mappers),
                     TestHelper.DbProviderFactoryCreator,
-                    new DatabaseSchemaCreatorFactory(Mock.Of<ILogger<DatabaseSchemaCreator>>(),loggerFactory, new UmbracoVersion()));
+                    new DatabaseSchemaCreatorFactory(Mock.Of<ILogger<DatabaseSchemaCreator>>(),loggerFactory, new UmbracoVersion(), Mock.Of<IEventAggregator>()));
             }
 
             fileSystems ??= new FileSystems(Current.Factory, loggerFactory.CreateLogger<FileSystems>(), loggerFactory, TestHelper.IOHelper, globalSettings, TestHelper.GetHostingEnvironment());

--- a/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
@@ -11,6 +11,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Persistence.Repositories;
@@ -303,7 +304,7 @@ namespace Umbraco.Tests.TestHelpers
             {
                 using (var scope = ScopeProvider.CreateScope())
                 {
-                    var schemaHelper = new DatabaseSchemaCreator(scope.Database, LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion);
+                    var schemaHelper = new DatabaseSchemaCreator(scope.Database, LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion, Mock.Of<IEventAggregator>());
                     //Create the umbraco database and its base data
                     schemaHelper.InitializeDatabaseSchema();
 

--- a/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
+++ b/src/Umbraco.Tests/Testing/UmbracoTestBase.cs
@@ -490,7 +490,7 @@ namespace Umbraco.Tests.Testing
                 connectionStrings,
                 new Lazy<IMapperCollection>(f.GetRequiredService<IMapperCollection>),
                 TestHelper.DbProviderFactoryCreator,
-                new DatabaseSchemaCreatorFactory(LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion)));
+                new DatabaseSchemaCreatorFactory(LoggerFactory.CreateLogger<DatabaseSchemaCreator>(), LoggerFactory, UmbracoVersion, Mock.Of<IEventAggregator>())));
 
             Builder.Services.AddUnique(f => f.GetService<IUmbracoDatabaseFactory>().SqlContext);
 


### PR DESCRIPTION
### Description
Migrates the two events in `DatabaseSchemaCreator`

This was a bit of an odd one, the two events are essentially just empty cancelable events, and seemingly not used, but seeing how the methods that dispatched the events are virtual I assume it's used somewhere else for some integration purposes? 

I also noticed that the events were internal, so I've just made two new, very very basic, empty notifications, with one of them being cancelable.

I opted to inject IEventAggretor and use that to publish the events, partially because from the comments it seems like the notifications are expected to be published instantly, but also because when the method publishing the events are called from unattended install, it's done so out of a scope.

### Testing
I tested that Umbraco still installs without issue. 

I also tried testing unattended install, however unattended install has been broken by another events migration. I didn't spend a long time looking into this, but it seems like the issue occurs with `AuditNotificationsHandler`, during an unattended install we create a new user, causing the `Handle(UserSavedNotification notification)` method to be invoked, there we try to get the performing user, but `BackOfficeSecurity` is null at this point (probably because the site hasn't fully booted yet)
