### PR TITLE
Updates to Examine 1.2.0

### DIFF
--- a/build/NuSpecs/UmbracoCms.Web.nuspec
+++ b/build/NuSpecs/UmbracoCms.Web.nuspec
@@ -28,7 +28,7 @@
                 <dependency id="ClientDependency" version="[1.9.9,1.999999)" />
                 <dependency id="ClientDependency-Mvc5" version="[1.9.3,1.999999)" />
                 <dependency id="CSharpTest.Net.Collections" version="[14.906.1403.1082,14.999999)" />
-                <dependency id="Examine" version="[1.1.0,1.999999)" />
+                <dependency id="Examine" version="[1.2.0,1.999999)" />
                 <dependency id="HtmlAgilityPack" version="[1.8.14,1.999999)" />
                 <dependency id="ImageProcessor" version="[2.7.0.100,2.999999)" />
                 <dependency id="LightInject.Mvc" version="[2.0.0,2.999999)" />

--- a/src/Umbraco.Examine/Umbraco.Examine.csproj
+++ b/src/Umbraco.Examine/Umbraco.Examine.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- note: NuGet deals with transitive references now -->
-    <PackageReference Include="Examine" Version="1.1.0" />
+    <PackageReference Include="Examine" Version="1.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <Version>1.0.0-beta2-19324-01</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine/UmbracoExamineIndex.cs
@@ -25,8 +25,7 @@ namespace Umbraco.Examine
         // wrapping all operations that end up calling base.SafelyProcessQueueItems in a safe call
         // context because they will fork a thread/task/whatever which should *not* capture our
         // call context (and the database it can contain)!
-        // TODO: FIX Examine to not flow the ExecutionContext so callers don't need to worry about this!
-
+        
         /// <summary>
         /// Used to store the path of a content object
         /// </summary>
@@ -99,13 +98,7 @@ namespace Umbraco.Examine
         {
             if (CanInitialize())
             {
-                // Use SafeCallContext to prevent the current CallContext flow to child
-                // tasks executed in the base class so we don't leak Scopes.
-                // TODO: See notes at the top of this class
-                using (new SafeCallContext())
-                {
-                    base.PerformDeleteFromIndex(itemIds, onComplete);
-                }
+                base.PerformDeleteFromIndex(itemIds, onComplete);
             }
         }
 
@@ -113,13 +106,7 @@ namespace Umbraco.Examine
         {
             if (CanInitialize())
             {
-                // Use SafeCallContext to prevent the current CallContext flow to child
-                // tasks executed in the base class so we don't leak Scopes.
-                // TODO: See notes at the top of this class
-                using (new SafeCallContext())
-                {
-                    base.PerformIndexItems(values, onComplete);
-                }
+                base.PerformIndexItems(values, onComplete);
             }
         }
 

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="Examine" Version="1.1.0" />
+    <PackageReference Include="Examine" Version="1.2.0" />
     <PackageReference Include="HtmlAgilityPack">
       <Version>1.8.14</Version>
     </PackageReference>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -88,7 +88,7 @@
     <PackageReference Include="CSharpTest.Net.Collections" Version="14.906.1403.1082" />
     <PackageReference Include="ClientDependency" Version="1.9.9" />
     <PackageReference Include="ClientDependency-Mvc5" Version="1.9.3" />
-    <PackageReference Include="Examine" Version="1.1.0" />
+    <PackageReference Include="Examine" Version="1.2.0" />
     <PackageReference Include="ImageProcessor.Web" Version="4.10.0.100" />
     <PackageReference Include="ImageProcessor.Web.Config" Version="2.5.0.100" />
     <PackageReference Include="Microsoft.AspNet.Identity.Owin" Version="2.2.2" />

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -63,7 +63,7 @@
   <ItemGroup>
     <PackageReference Include="ClientDependency" Version="1.9.9" />
     <PackageReference Include="CSharpTest.Net.Collections" Version="14.906.1403.1082" />
-    <PackageReference Include="Examine" Version="1.1.0" />
+    <PackageReference Include="Examine" Version="1.2.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.8.14" />
     <PackageReference Include="ImageProcessor">
       <Version>2.7.0.100</Version>


### PR DESCRIPTION
And removes ExecutionContext workaround since it's part of Examine now.
