### PR TITLE
Add HTTP response header that requests to opt out of Google FLoC

### DIFF
--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -186,10 +186,13 @@
             <mimeMap fileExtension=".json" mimeType="application/json" />
         </staticContent>
 
-        <!-- Ensure the powered by header is not returned -->
         <httpProtocol>
             <customHeaders>
+                <!-- Ensure the powered by header is not returned -->
                 <remove name="X-Powered-By" />
+                <!-- Opt out of having the site used by Google FLoC for profiling users -->
+                <remove name="Permissions-Policy" />
+                <add name="Permissions-Policy" value="interest-cohort=()"/>
             </customHeaders>
         </httpProtocol>
 


### PR DESCRIPTION
This PR adds a HTTP response header that requests opt-out of Google's FLoC profiling initiative as suggested in issue https://github.com/umbraco/Umbraco-CMS/issues/10147.

I've built Umbraco, installed a site and made sure that it started correctly and that i can see the header in firefox.