### PR TITLE
Add "Insert Macro" as language key

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.controller.js
@@ -1,57 +1,59 @@
 angular.module("umbraco")
     .controller("Umbraco.PropertyEditors.Grid.MacroController",
-    function ($scope, $timeout, editorService, macroResource, macroService,  $routeParams) {
+        function ($scope, $timeout, editorService, macroResource, macroService, localizationService, $routeParams) {
 
-        $scope.title = "Click to insert macro";
-
-        $scope.setMacro = function(){
-
-            var dialogData = {
-                richTextEditor: true,
-                macroData: $scope.control.value || {
-                    macroAlias: $scope.control.editor.config && $scope.control.editor.config.macroAlias
-                      ? $scope.control.editor.config.macroAlias : ""
-                }
-            };
-
-            var macroPicker = {
-                dialogData: dialogData,
-                submit: function(model) {
-                    var macroObject = macroService.collectValueData(model.selectedMacro, model.macroParams, dialogData.renderingEngine);
-
-                    $scope.control.value = {
-                        macroAlias: macroObject.macroAlias,
-                        macroParamsDictionary: macroObject.macroParamsDictionary
-                    };
-    
-                    $scope.setPreview($scope.control.value );
-                    editorService.close();
-                },
-                close: function() {
-                    editorService.close();
-                }
-            }
-            editorService.macroPicker(macroPicker);
-    	};
-
-        $scope.setPreview = function(macro){
-            var contentId = $routeParams.id;
-
-            macroResource.getMacroResultAsHtmlForEditor(macro.macroAlias, contentId, macro.macroParamsDictionary)
-            .then(function (htmlResult) {
-                $scope.title = macro.macroAlias;
-                if(htmlResult.trim().length > 0 && htmlResult.indexOf("Macro:") < 0){
-                    $scope.preview = htmlResult;
-                }
+            localizationService.localize("grid_clickToInsertMacro").then(function(label) {
+                $scope.title = label;
             });
 
-        };
+            $scope.setMacro = function () {
 
-    	$timeout(function(){
-    		if($scope.control.$initializing){
-    			$scope.setMacro();
-    		}else if($scope.control.value){
-                $scope.setPreview($scope.control.value);
-            }
-    	}, 200);
-});
+                var dialogData = {
+                    richTextEditor: true,
+                    macroData: $scope.control.value || {
+                        macroAlias: $scope.control.editor.config && $scope.control.editor.config.macroAlias
+                            ? $scope.control.editor.config.macroAlias : ""
+                    }
+                };
+
+                var macroPicker = {
+                    dialogData: dialogData,
+                    submit: function (model) {
+                        var macroObject = macroService.collectValueData(model.selectedMacro, model.macroParams, dialogData.renderingEngine);
+
+                        $scope.control.value = {
+                            macroAlias: macroObject.macroAlias,
+                            macroParamsDictionary: macroObject.macroParamsDictionary
+                        };
+
+                        $scope.setPreview($scope.control.value);
+                        editorService.close();
+                    },
+                    close: function () {
+                        editorService.close();
+                    }
+                }
+                editorService.macroPicker(macroPicker);
+            };
+
+            $scope.setPreview = function (macro) {
+                var contentId = $routeParams.id;
+
+                macroResource.getMacroResultAsHtmlForEditor(macro.macroAlias, contentId, macro.macroParamsDictionary)
+                    .then(function (htmlResult) {
+                        $scope.title = macro.macroAlias;
+                        if (htmlResult.trim().length > 0 && htmlResult.indexOf("Macro:") < 0) {
+                            $scope.preview = htmlResult;
+                        }
+                    });
+
+            };
+
+            $timeout(function () {
+                if ($scope.control.$initializing) {
+                    $scope.setMacro();
+                } else if ($scope.control.value) {
+                    $scope.setPreview($scope.control.value);
+                }
+            }, 200);
+        });

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1619,6 +1619,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentAllowed">This content is allowed here</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
+      <key alias="clickToInsertMacro">Click to insert a macro</key>
     <key alias="placeholderImageCaption">Image caption...</key>
     <key alias="placeholderWriteHere">Write here...</key>
     <key alias="gridLayouts">Grid Layouts</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1619,7 +1619,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentAllowed">This content is allowed here</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
-      <key alias="clickToInsertMacro">Click to insert a macro</key>
+      <key alias="clickToInsertMacro">Click to insert macro</key>
     <key alias="placeholderImageCaption">Image caption...</key>
     <key alias="placeholderWriteHere">Write here...</key>
     <key alias="gridLayouts">Grid Layouts</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1619,7 +1619,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentAllowed">This content is allowed here</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
-      <key alias="clickToInsertMacro">Click to insert macro</key>
+    <key alias="clickToInsertMacro">Click to insert macro</key>
     <key alias="placeholderImageCaption">Image caption...</key>
     <key alias="placeholderWriteHere">Write here...</key>
     <key alias="gridLayouts">Grid Layouts</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1637,6 +1637,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentAllowed">This content is allowed here</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
+      <key alias="clickToInsertMacro">Click to insert a macro</key>
     <key alias="placeholderImageCaption">Image caption...</key>
     <key alias="placeholderWriteHere">Write here...</key>
     <key alias="gridLayouts">Grid Layouts</key>
@@ -1663,7 +1664,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="setAsDefault">Set as default</key>
     <key alias="chooseExtra">Choose extra</key>
     <key alias="chooseDefault">Choose default</key>
-    <key alias="areAdded">are added</key>
+      <key alias="areAdded">are added</key>
         <key alias="warning">Warning</key>
         <key alias="youAreDeleting">You are deleting the row configuration</key>
         <key alias="deletingARow">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1637,7 +1637,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentAllowed">This content is allowed here</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
-      <key alias="clickToInsertMacro">Click to insert a macro</key>
+      <key alias="clickToInsertMacro">Click to insert macro</key>
     <key alias="placeholderImageCaption">Image caption...</key>
     <key alias="placeholderWriteHere">Write here...</key>
     <key alias="gridLayouts">Grid Layouts</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1637,7 +1637,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentAllowed">This content is allowed here</key>
     <key alias="clickToEmbed">Click to embed</key>
     <key alias="clickToInsertImage">Click to insert image</key>
-      <key alias="clickToInsertMacro">Click to insert macro</key>
+    <key alias="clickToInsertMacro">Click to insert macro</key>
     <key alias="placeholderImageCaption">Image caption...</key>
     <key alias="placeholderWriteHere">Write here...</key>
     <key alias="gridLayouts">Grid Layouts</key>


### PR DESCRIPTION
This was something that Alexander on the slack channel figured out. The "Click to insert macro" is not a translatable key in the CMS. I've changed the code so that it is part of the translatable keys.

Can be tested by changing the key "clickToInsertMacro" and then see it change in the grid editor.

(I am not quite sure what happened to the formatting)