### PR TITLE
Stop allocating arrays for every scope lock

### DIFF
--- a/src/Umbraco.Infrastructure/Extensions/ScopeExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/ScopeExtensions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Extensions
+{
+    public static class ScopeExtensions
+    {
+        public static void ReadLock(this IScope scope, ICollection<int> lockIds)
+        {
+            foreach(var lockId in lockIds)
+            {
+                scope.ReadLock(lockId);
+            } 
+        }
+
+        public static void WriteLock(this IScope scope, ICollection<int> lockIds)
+        {
+            foreach (var lockId in lockIds)
+            {
+                scope.WriteLock(lockId);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Scoping/IScope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/IScope.cs
@@ -56,13 +56,13 @@ namespace Umbraco.Cms.Core.Scoping
         /// Read-locks some lock objects.
         /// </summary>
         /// <param name="lockIds">The lock object identifiers.</param>
-        void ReadLock(params int[] lockIds);
+        void ReadLock(int lockId);
 
         /// <summary>
         /// Write-locks some lock objects.
         /// </summary>
         /// <param name="lockIds">The lock object identifiers.</param>
-        void WriteLock(params int[] lockIds);
+        void WriteLock(int lockId);
 
         /// <summary>
         /// Write-locks some lock objects.

--- a/src/Umbraco.Infrastructure/Services/Implement/ContentTypeService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ContentTypeService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services.Implement
 {
@@ -92,7 +93,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 // that one is special because it works across content, media and member types
-                scope.ReadLock(Cms.Core.Constants.Locks.ContentTypes, Cms.Core.Constants.Locks.MediaTypes, Cms.Core.Constants.Locks.MemberTypes);
+                scope.ReadLock(new[] { Constants.Locks.ContentTypes, Constants.Locks.MediaTypes, Constants.Locks.MemberTypes });
                 return Repository.GetAllPropertyTypeAliases();
             }
         }
@@ -108,7 +109,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 // that one is special because it works across content, media and member types
-                scope.ReadLock(Cms.Core.Constants.Locks.ContentTypes, Cms.Core.Constants.Locks.MediaTypes, Cms.Core.Constants.Locks.MemberTypes);
+                scope.ReadLock(new[] { Constants.Locks.ContentTypes, Constants.Locks.MediaTypes, Constants.Locks.MemberTypes });
                 return Repository.GetAllContentTypeAliases(guids);
             }
         }
@@ -124,7 +125,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 // that one is special because it works across content, media and member types
-                scope.ReadLock(Cms.Core.Constants.Locks.ContentTypes, Cms.Core.Constants.Locks.MediaTypes, Cms.Core.Constants.Locks.MemberTypes);
+                scope.ReadLock(new[] { Constants.Locks.ContentTypes, Constants.Locks.MediaTypes, Constants.Locks.MemberTypes });
                 return Repository.GetAllContentTypeIds(aliases);
             }
         }

--- a/src/Umbraco.Infrastructure/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
This is left over from v8's APIs where we would pass in params int[] but in most cases we are just passing in a single value yet we are then allocating arrays everytime. There's no need to allocate these, it's just extra overhead.