### PR TITLE
Added additional addresses and attachments to core's email sending service.

### DIFF
--- a/src/Umbraco.Core/Models/EmailMessage.cs
+++ b/src/Umbraco.Core/Models/EmailMessage.cs
@@ -1,35 +1,83 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Umbraco.Cms.Core.Models
 {
     public class EmailMessage
     {
         public string From { get; }
-        public string To { get; }
+
+        public string[] To { get; }
+
+        public string[] Cc { get; }
+
+        public string[] Bcc { get; }
+
+        public string[] ReplyTo { get; }
+
         public string Subject { get; }
+
         public string Body { get; }
+
         public bool IsBodyHtml { get; }
 
+        public IList<EmailMessageAttachment> Attachments { get; }
+
+        public bool HasAttachments => Attachments != null && Attachments.Count > 0;
+
         public EmailMessage(string from, string to, string subject, string body, bool isBodyHtml)
+            : this(from, new[] { to }, null, null, null, subject, body, isBodyHtml, null)
         {
-            if (from == null) throw new ArgumentNullException(nameof(from));
-            if (from.Length == 0) throw new ArgumentException("Value cannot be empty.", nameof(from));
+        }
 
-            if (to == null) throw new ArgumentNullException(nameof(to));
-            if (to.Length == 0) throw new ArgumentException("Value cannot be empty.", nameof(to));
-
-            if (subject == null) throw new ArgumentNullException(nameof(subject));
-            if (subject.Length == 0) throw new ArgumentException("Value cannot be empty.", nameof(subject));
-
-            if (body == null) throw new ArgumentNullException(nameof(body));
-            if (body.Length == 0) throw new ArgumentException("Value cannot be empty.", nameof(body));
+        public EmailMessage(string from, string[] to, string[] cc, string[] bcc, string[] replyTo, string subject, string body, bool isBodyHtml, IEnumerable<EmailMessageAttachment> attachments)
+        {
+            ArgumentIsNotNullOrEmpty(from, nameof(from));
+            ArgumentIsNotNullOrEmpty(to, nameof(to));
+            ArgumentIsNotNullOrEmpty(subject, nameof(subject));
+            ArgumentIsNotNullOrEmpty(body, nameof(body));
 
             From = from;
             To = to;
+            Cc = cc;
+            Bcc = bcc;
+            ReplyTo = replyTo;
             Subject = subject;
             Body = body;
-
             IsBodyHtml = isBodyHtml;
+            Attachments = attachments?.ToList();
+        }
+
+        private static void ArgumentIsNotNullOrEmpty(string arg, string argName)
+        {
+            if (arg == null)
+            {
+                throw new ArgumentNullException(argName);
+            }
+
+            if (arg.Length == 0)
+            {
+                throw new ArgumentException("Value cannot be empty.", argName);
+            }
+        }
+
+        private static void ArgumentIsNotNullOrEmpty(string[] arg, string argName)
+        {
+            if (arg == null)
+            {
+                throw new ArgumentNullException(argName);
+            }
+
+            if (arg.Length == 0)
+            {
+                throw new ArgumentException("Value cannot be an empty array.", argName);
+            }
+
+            if (arg.Any(x => x is not null && x.Length > 0) == false)
+            {
+                throw new ArgumentException("Value cannot be an array containing only null or empty elements.", argName);
+            }
         }
     }
 }

--- a/src/Umbraco.Core/Models/EmailMessageAttachment.cs
+++ b/src/Umbraco.Core/Models/EmailMessageAttachment.cs
@@ -1,0 +1,17 @@
+using System.IO;
+
+namespace Umbraco.Cms.Core.Models
+{
+    public class EmailMessageAttachment
+    {
+        public Stream Stream { get; }
+
+        public string FileName { get; }
+
+        public EmailMessageAttachment(Stream stream, string fileName)
+        {
+            Stream = stream;
+            FileName = fileName;
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -1,0 +1,82 @@
+using System;
+using MimeKit;
+using MimeKit.Text;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.Extensions
+{
+    internal static class EmailMessageExtensions
+    {
+        public static MimeMessage ToMimeMessage(this EmailMessage mailMessage, string configuredFromAddress)
+        {
+            var fromEmail = mailMessage.From;
+            if (string.IsNullOrEmpty(fromEmail))
+            {
+                fromEmail = configuredFromAddress;
+            }
+
+            if (!InternetAddress.TryParse(mailMessage.From, out InternetAddress fromAddress))
+            {
+                throw new ArgumentException($"Email could not be sent.  Could not parse from address {fromEmail} as a valid email address.");
+            }
+
+            var messageToSend = new MimeMessage
+            {
+                From = { fromAddress },
+                Subject = mailMessage.Subject,
+            };
+
+            AddAddresses(messageToSend, mailMessage.To, x => x.To, throwIfNoneValid: true);
+            AddAddresses(messageToSend, mailMessage.Cc, x => x.Cc);
+            AddAddresses(messageToSend, mailMessage.Bcc, x => x.Bcc);
+            AddAddresses(messageToSend, mailMessage.ReplyTo, x => x.ReplyTo);
+
+            if (mailMessage.HasAttachments)
+            {
+                var builder = new BodyBuilder();
+                if (mailMessage.IsBodyHtml)
+                {
+                    builder.HtmlBody = mailMessage.Body;
+                }
+                else
+                {
+                    builder.TextBody = mailMessage.Body;
+                }
+
+                foreach (EmailMessageAttachment attachment in mailMessage.Attachments)
+                {
+                    builder.Attachments.Add(attachment.FileName, attachment.Stream);
+                }
+
+                messageToSend.Body = builder.ToMessageBody();
+            }
+            else
+            {
+                messageToSend.Body = new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body };
+            }
+
+            return messageToSend;
+        }
+
+        private static void AddAddresses(MimeMessage message, string[] addresses, Func<MimeMessage, InternetAddressList> addressListGetter, bool throwIfNoneValid = false)
+        {
+            var foundValid = false;
+            if (addresses != null)
+            {
+                foreach (var address in addresses)
+                {
+                    if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+                    {
+                        addressListGetter(message).Add(internetAddress);
+                        foundValid = true;
+                    }
+                }
+            }
+
+            if (throwIfNoneValid && foundValid == false)
+            {
+                throw new InvalidOperationException($"Email could not be sent. Could not parse a valid recipient address.");
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
+{
+    [TestFixture]
+    public class EmailMessageExtensionsTests
+    {
+        private const string ConfiguredSender = "noreply@umbraco.com";
+
+        [Test]
+        public void Can_Construct_MimeMessage_From_Simple_EmailMessage()
+        {
+            const string from = "from@email.com";
+            const string to = "to@email.com";
+            const string subject = "Subject";
+            const string body = "<p>Message</p>";
+            const bool isBodyHtml = true;
+            var emailMesasge = new EmailMessage(from, to, subject, body, isBodyHtml);
+
+            var result = emailMesasge.ToMimeMessage(ConfiguredSender);
+
+            Assert.AreEqual(1, result.From.Count());
+            Assert.AreEqual(from, result.From.First().ToString());
+            Assert.AreEqual(1, result.To.Count());
+            Assert.AreEqual(to, result.To.First().ToString());
+            Assert.AreEqual(subject, result.Subject);
+            Assert.IsNull(result.TextBody);
+            Assert.AreEqual(body, result.HtmlBody.ToString());
+        }
+
+        [Test]
+        public void Can_Construct_MimeMessage_From_Full_EmailMessage()
+        {
+            const string from = "from@email.com";
+            string[] to = new[] { "to@email.com", "to2@email.com" };
+            string[] cc = new[] { "cc@email.com", "cc2@email.com" };
+            string[] bcc = new[] { "bcc@email.com", "bcc2@email.com", "bcc3@email.com", "invalid@email@address" };
+            string[] replyTo = new[] { "replyto@email.com" };
+            const string subject = "Subject";
+            const string body = "Message";
+            const bool isBodyHtml = false;
+
+            using var attachmentStream = new MemoryStream(Encoding.UTF8.GetBytes("test"));
+            var attachments = new List<EmailMessageAttachment>
+                {
+                    new EmailMessageAttachment(attachmentStream, "test.txt"),
+                };
+            var emailMesasge = new EmailMessage(from, to, cc, bcc, replyTo, subject, body, isBodyHtml, attachments);
+
+            var result = emailMesasge.ToMimeMessage(ConfiguredSender);
+
+            Assert.AreEqual(1, result.From.Count());
+            Assert.AreEqual(from, result.From.First().ToString());
+            Assert.AreEqual(2, result.To.Count());
+            Assert.AreEqual(to[0], result.To.First().ToString());
+            Assert.AreEqual(to[1], result.To.Skip(1).First().ToString());
+            Assert.AreEqual(2, result.Cc.Count());
+            Assert.AreEqual(cc[0], result.Cc.First().ToString());
+            Assert.AreEqual(cc[1], result.Cc.Skip(1).First().ToString());
+            Assert.AreEqual(3, result.Bcc.Count());
+            Assert.AreEqual(bcc[0], result.Bcc.First().ToString());
+            Assert.AreEqual(bcc[1], result.Bcc.Skip(1).First().ToString());
+            Assert.AreEqual(bcc[2], result.Bcc.Skip(2).First().ToString());
+            Assert.AreEqual(1, result.ReplyTo.Count());
+            Assert.AreEqual(replyTo[0], result.ReplyTo.First().ToString());
+            Assert.AreEqual(subject, result.Subject);
+            Assert.IsNull(result.HtmlBody);
+            Assert.AreEqual(body, result.TextBody.ToString());
+            Assert.AreEqual(1, result.Attachments.Count());
+        }
+    }
+}


### PR DESCRIPTION
This is needed for the Forms migration - where we have a needs to send emails with multiple recipient, CC, BCC, reply-to addresses, as well as attachments.  So I've extended the core abstraction and implementation using MimeKit to support these features.