### PR TITLE
Fix check authorization policies on nested tree requests

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ApplicationTreeController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Trees;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Trees;
@@ -18,7 +19,6 @@ using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Cms.Web.Common.ModelBinders;
 using Umbraco.Extensions;
 using static Umbraco.Cms.Core.Constants.Web.Routing;
-using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Web.BackOffice.Trees
 {
@@ -150,11 +150,11 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 foreach (var t in trees)
                 {
                     var nodeResult = await TryGetRootNode(t, queryStrings);
-                    if (!(nodeResult.Result is null))
+                    if (nodeResult != null && nodeResult.Result is not null)
                     {
                         return nodeResult.Result;
                     }
-                    var node = nodeResult.Value;
+                    var node = nodeResult?.Value;
 
                     if (node != null)
                     {

--- a/src/Umbraco.Web.Common/Authorization/FeatureAuthorizeRequirement.cs
+++ b/src/Umbraco.Web.Common/Authorization/FeatureAuthorizeRequirement.cs
@@ -8,5 +8,9 @@ namespace Umbraco.Cms.Web.Common.Authorization
     /// </summary>
     public class FeatureAuthorizeRequirement : IAuthorizationRequirement
     {
+        public FeatureAuthorizeRequirement()
+        {
+        }
+
     }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10179

Not sure this is the best way to resolved it, but it is the only solution I was able to find.

This code is inspired by what the [AuthorizationMiddleware](https://github.com/dotnet/aspnetcore/blob/main/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs) are doing.

It relies on the fact that our `FeatureAuthorizeHandler` are still supporting pre-.NET 5 behaviour, where the resource can be an Endpoint. 🙈 
 