### PR TITLE
Fix startup issues and timing with Examine and Nucache

### DIFF
--- a/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Core/Sync/DatabaseServerMessenger.cs
@@ -111,17 +111,11 @@ namespace Umbraco.Core.Sync
 
         #region Sync
 
-        /// <summary>
-        /// Boots the messenger.
-        /// </summary>
-        /// <remarks>
-        /// Thread safety: this is NOT thread safe. Because it is NOT meant to run multi-threaded.
-        /// Callers MUST ensure thread-safety.
-        /// </remarks>
+        [Obsolete("This is no longer used and will be removed in future versions")]
         protected void Boot()
         {
-            var bootState = GetSyncBootState();
-            Booting?.Invoke(this, bootState);
+            // if called, just forces the boot logic
+            _ = GetSyncBootState();
         }
 
         private SyncBootState BootInternal()
@@ -545,8 +539,6 @@ namespace Umbraco.Core.Sync
             + "/D" + AppDomain.CurrentDomain.Id // eg 22
             + "] " + Guid.NewGuid().ToString("N").ToUpper(); // make it truly unique
 
-        public event EventHandler<SyncBootState> Booting;
-
         private string GetDistCacheFilePath(IGlobalSettings globalSettings)
         {
             var fileName = HttpRuntime.AppDomainAppId.ReplaceNonAlphanumericChars(string.Empty) + "-lastsynced.txt";
@@ -565,7 +557,7 @@ namespace Umbraco.Core.Sync
 
         #endregion
 
-        public SyncBootState GetSyncBootState() => _getSyncBootState.Value;
+        public virtual SyncBootState GetSyncBootState() => _getSyncBootState.Value;
 
         #region Notify refreshers
 

--- a/src/Umbraco.Core/Sync/DatabaseServerMessengerOptions.cs
+++ b/src/Umbraco.Core/Sync/DatabaseServerMessengerOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Umbraco.Core.Sync
 {
@@ -24,13 +25,8 @@ namespace Umbraco.Core.Sync
         /// </summary>
         public int MaxProcessingInstructionCount { get; set; }
 
-        /// <summary>
-        /// A list of callbacks that will be invoked if the lastsynced.txt file does not exist.
-        /// </summary>
-        /// <remarks>
-        /// These callbacks will typically be for eg rebuilding the xml cache file, or examine indexes, based on
-        /// the data in the database to get this particular server node up to date.
-        /// </remarks>
+        [Obsolete("This should not be used. If initialization calls need to be invoked on a cold boot, use the ISyncBootStateAccessor.Booting event.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IEnumerable<Action> InitializingCallbacks { get; set; }
 
         /// <summary>

--- a/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Umbraco.Core.Sync
 {
@@ -16,5 +12,10 @@ namespace Umbraco.Core.Sync
         /// </summary>
         /// <returns></returns>
         SyncBootState GetSyncBootState();
+
+        /// <summary>
+        /// Raised when the boot state is known
+        /// </summary>
+        event EventHandler<SyncBootState> Booting;
     }
 }

--- a/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
@@ -16,6 +16,6 @@ namespace Umbraco.Core.Sync
         /// <summary>
         /// Raised when the boot state is known
         /// </summary>
-        event EventHandler<SyncBootState> Booting;
+        event EventHandler<SyncBootState> Booting; // TODO: This should be removed in netcore
     }
 }

--- a/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Sync
+{
+    /// <summary>
+    /// Retrieve the state of the sync service
+    /// </summary>
+    public interface ISyncBootStateAccessor
+    {
+        /// <summary>
+        /// Get the boot state
+        /// </summary>
+        /// <returns></returns>
+        SyncBootState GetSyncBootState();
+    }
+}

--- a/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/ISyncBootStateAccessor.cs
@@ -12,10 +12,5 @@ namespace Umbraco.Core.Sync
         /// </summary>
         /// <returns></returns>
         SyncBootState GetSyncBootState();
-
-        /// <summary>
-        /// Raised when the boot state is known
-        /// </summary>
-        event EventHandler<SyncBootState> Booting; // TODO: This should be removed in netcore
     }
 }

--- a/src/Umbraco.Core/Sync/NonRuntimeLevelBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/NonRuntimeLevelBootStateAccessor.cs
@@ -11,6 +11,8 @@ namespace Umbraco.Core.Sync
     /// </summary>
     public class NonRuntimeLevelBootStateAccessor : ISyncBootStateAccessor
     {
+        public event EventHandler<SyncBootState> Booting;
+
         public SyncBootState GetSyncBootState()
         {
             return SyncBootState.Unknown;

--- a/src/Umbraco.Core/Sync/NonRuntimeLevelBootStateAccessor.cs
+++ b/src/Umbraco.Core/Sync/NonRuntimeLevelBootStateAccessor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Sync
+{
+    /// <summary>
+    /// Boot state implementation for when umbraco is not in the run state
+    /// </summary>
+    public class NonRuntimeLevelBootStateAccessor : ISyncBootStateAccessor
+    {
+        public SyncBootState GetSyncBootState()
+        {
+            return SyncBootState.Unknown;
+        }
+    }
+}

--- a/src/Umbraco.Core/Sync/SyncBootState.cs
+++ b/src/Umbraco.Core/Sync/SyncBootState.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Core.Sync
+{
+    public enum SyncBootState
+    {
+        /// <summary>
+        /// Unknown state. Treat as HasSyncState
+        /// </summary>
+        Unknown = 0,
+        /// <summary>
+        /// Cold boot. No Sync state
+        /// </summary>
+        ColdBoot = 1,
+        /// <summary>
+        /// Warm boot. Sync state present
+        /// </summary>
+        HasSyncState = 2
+    }
+}

--- a/src/Umbraco.Core/Sync/SyncBootState.cs
+++ b/src/Umbraco.Core/Sync/SyncBootState.cs
@@ -1,24 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Umbraco.Core.Sync
+﻿namespace Umbraco.Core.Sync
 {
     public enum SyncBootState
     {
         /// <summary>
-        /// Unknown state. Treat as HasSyncState
+        /// Unknown state. Treat as WarmBoot
         /// </summary>
         Unknown = 0,
+
         /// <summary>
         /// Cold boot. No Sync state
         /// </summary>
         ColdBoot = 1,
+
         /// <summary>
         /// Warm boot. Sync state present
         /// </summary>
-        HasSyncState = 2
+        WarmBoot = 2
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -179,6 +179,9 @@
     <Compile Include="Migrations\Upgrade\V_8_7_0\MissingDictionaryIndex.cs" />
     <Compile Include="Services\IInstallationService.cs" />
     <Compile Include="Services\IUpgradeService.cs" />
+    <Compile Include="Sync\ISyncBootStateAccessor.cs" />
+    <Compile Include="Sync\NonRuntimeLevelBootStateAccessor.cs" />
+    <Compile Include="Sync\SyncBootState.cs" />
     <Compile Include="SystemLock.cs" />
     <Compile Include="Attempt.cs" />
     <Compile Include="AttemptOfTResult.cs" />

--- a/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Changes;
 using Umbraco.Core.Strings;
+using Umbraco.Core.Sync;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing.Objects;
 using Umbraco.Tests.Testing.Objects.Accessors;
@@ -155,7 +156,8 @@ namespace Umbraco.Tests.PublishedContent
                 globalSettings,
                 Mock.Of<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
 
             // invariant is the current default
             _variationAccesor.VariationContext = new VariationContext();

--- a/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheChildrenTests.cs
@@ -157,7 +157,7 @@ namespace Umbraco.Tests.PublishedContent
                 Mock.Of<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
-                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
+                new TestSyncBootStateAccessor(SyncBootState.WarmBoot));
 
             // invariant is the current default
             _variationAccesor.VariationContext = new VariationContext();

--- a/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Changes;
 using Umbraco.Core.Strings;
+using Umbraco.Core.Sync;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing.Objects;
 using Umbraco.Tests.Testing.Objects.Accessors;
@@ -201,7 +202,8 @@ namespace Umbraco.Tests.PublishedContent
                 globalSettings,
                 Mock.Of<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
 
             // invariant is the current default
             _variationAccesor.VariationContext = new VariationContext();

--- a/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/NuCacheTests.cs
@@ -203,7 +203,7 @@ namespace Umbraco.Tests.PublishedContent
                 Mock.Of<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
-                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
+                new TestSyncBootStateAccessor(SyncBootState.WarmBoot));
 
             // invariant is the current default
             _variationAccesor.VariationContext = new VariationContext();

--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -100,7 +100,7 @@ namespace Umbraco.Tests.Scoping
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
-                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
+                new TestSyncBootStateAccessor(SyncBootState.WarmBoot));
         }
 
         protected UmbracoContext GetUmbracoContextNu(string url, int templateId = 1234, RouteData routeData = null, bool setSingleton = false, IUmbracoSettingsSection umbracoSettings = null, IEnumerable<IUrlProvider> urlProviders = null)

--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -99,7 +99,8 @@ namespace Umbraco.Tests.Scoping
                 Factory.GetInstance<IGlobalSettings>(),
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
         }
 
         protected UmbracoContext GetUmbracoContextNu(string url, int templateId = 1234, RouteData routeData = null, bool setSingleton = false, IUmbracoSettingsSection umbracoSettings = null, IEnumerable<IUrlProvider> urlProviders = null)

--- a/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Core.Strings;
 using Umbraco.Core.Sync;
+using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.TestHelpers.Entities;
 using Umbraco.Tests.Testing;
 using Umbraco.Web.PublishedCache;
@@ -70,7 +71,8 @@ namespace Umbraco.Tests.Services
                 Factory.GetInstance<IGlobalSettings>(),
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }));
+                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
+                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
         }
 
         public class LocalServerMessenger : ServerMessengerBase

--- a/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
+++ b/src/Umbraco.Tests/Services/ContentTypeServiceVariantsTests.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Tests.Services
                 Factory.GetInstance<IEntityXmlSerializer>(),
                 Mock.Of<IPublishedModelFactory>(),
                 new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider() }),
-                new TestSyncBootStateAccessor(SyncBootState.HasSyncState));
+                new TestSyncBootStateAccessor(SyncBootState.WarmBoot));
         }
 
         public class LocalServerMessenger : ServerMessengerBase

--- a/src/Umbraco.Tests/TestHelpers/TestSyncBootStateAccessor.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestSyncBootStateAccessor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Sync;
+
+namespace Umbraco.Tests.TestHelpers
+{
+    class TestSyncBootStateAccessor : ISyncBootStateAccessor
+    {
+        private readonly SyncBootState _syncBootState;
+
+        public TestSyncBootStateAccessor(SyncBootState syncBootState)
+        {
+            _syncBootState = syncBootState;
+        }
+        public SyncBootState GetSyncBootState()
+        {
+            return _syncBootState;
+        }
+    }
+}

--- a/src/Umbraco.Tests/TestHelpers/TestSyncBootStateAccessor.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestSyncBootStateAccessor.cs
@@ -15,6 +15,9 @@ namespace Umbraco.Tests.TestHelpers
         {
             _syncBootState = syncBootState;
         }
+
+        public event EventHandler<SyncBootState> Booting;
+
         public SyncBootState GetSyncBootState()
         {
             return _syncBootState;

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Services\RedirectUrlServiceTests.cs" />
     <Compile Include="Templates\HtmlLocalLinkParserTests.cs" />
     <Compile Include="TestHelpers\RandomIdRamDirectory.cs" />
+    <Compile Include="TestHelpers\TestSyncBootStateAccessor.cs" />
     <Compile Include="Testing\Objects\TestDataSource.cs" />
     <Compile Include="Published\PublishedSnapshotTestObjects.cs" />
     <Compile Include="Published\ModelTypeTests.cs" />

--- a/src/Umbraco.Web/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Web/BatchedDatabaseServerMessenger.cs
@@ -26,6 +26,7 @@ namespace Umbraco.Web
     public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
     {
         private readonly IUmbracoDatabaseFactory _databaseFactory;
+        private readonly Lazy<SyncBootState> _syncBootState;
 
         [Obsolete("This overload should not be used, enableDistCalls has no effect")]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -39,28 +40,22 @@ namespace Umbraco.Web
             : base(runtime, scopeProvider, sqlContext, proflog, globalSettings, true, options)
         {
             _databaseFactory = databaseFactory;
-        }
-
-        // invoked by DatabaseServerRegistrarAndMessengerComponent
-        internal void Startup()
-        {
-            UmbracoModule.EndRequest += UmbracoModule_EndRequest;
-
-            if (_databaseFactory.CanConnect == false)
+            _syncBootState = new Lazy<SyncBootState>(() =>
             {
-                Logger.Warn<BatchedDatabaseServerMessenger>("Cannot connect to the database, distributed calls will not be enabled for this server.");
-            }
-            else
-            {
-                Boot();
-            }
+                if (_databaseFactory.CanConnect == false)
+                {
+                    Logger.Warn<BatchedDatabaseServerMessenger>("Cannot connect to the database, distributed calls will not be enabled for this server.");
+                    return SyncBootState.Unknown;
+                }
+                else
+                {
+                    return base.GetSyncBootState();
+                }
+            });
         }
 
-        private void UmbracoModule_EndRequest(object sender, UmbracoRequestEventArgs e)
-        {
-            // will clear the batch - will remain in HttpContext though - that's ok
-            FlushBatch();
-        }
+        // override to deal with database connectivity
+        public override SyncBootState GetSyncBootState() => _syncBootState.Value;
 
         protected override void DeliverRemote(ICacheRefresher refresher, MessageType messageType, IEnumerable<object> ids = null, string json = null)
         {

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -4,77 +4,13 @@ using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
-using Umbraco.Core.Services.Changes;
 using Umbraco.Core.Sync;
 using Umbraco.Examine;
-using Umbraco.Web.Cache;
 using Umbraco.Web.Routing;
 using Umbraco.Web.Scheduling;
-using Umbraco.Web.Search;
-using Current = Umbraco.Web.Composing.Current;
 
 namespace Umbraco.Web.Compose
 {
-    /// <summary>
-    /// Ensures that servers are automatically registered in the database, when using the database server registrar.
-    /// </summary>
-    /// <remarks>
-    /// <para>At the moment servers are automatically registered upon first request and then on every
-    /// request but not more than once per (configurable) period. This really is "for information & debug" purposes so
-    /// we can look at the table and see what servers are registered - but the info is not used anywhere.</para>
-    /// <para>Should we actually want to use this, we would need a better and more deterministic way of figuring
-    /// out the "server address" ie the address to which server-to-server requests should be sent - because it
-    /// probably is not the "current request address" - especially in multi-domains configurations.</para>
-    /// </remarks>
-    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
-
-    // during Initialize / Startup, we end up checking Examine, which needs to be initialized beforehand
-    // TODO: should not be a strong dependency on "examine" but on an "indexing component"
-    [ComposeAfter(typeof(ExamineComposer))]
-
-    public sealed class DatabaseServerRegistrarAndMessengerComposer : ComponentComposer<DatabaseServerRegistrarAndMessengerComponent>, ICoreComposer
-    {
-        public static DatabaseServerMessengerOptions GetDefaultOptions(IFactory factory)
-        {
-            var logger = factory.GetInstance<ILogger>();
-            var indexRebuilder = factory.GetInstance<IndexRebuilder>();
-
-            return new DatabaseServerMessengerOptions
-            {
-                //These callbacks will be executed if the server has not been synced
-                // (i.e. it is a new server or the lastsynced.txt file has been removed)
-                InitializingCallbacks = new Action[]
-                {
-                    //rebuild the xml cache file if the server is not synced
-                    () =>
-                    {
-                        // rebuild the published snapshot caches entirely, if the server is not synced
-                        // this is equivalent to DistributedCache RefreshAll... but local only
-                        // (we really should have a way to reuse RefreshAll... locally)
-                        // note: refresh all content & media caches does refresh content types too
-                        var svc = Current.PublishedSnapshotService;
-                        svc.Notify(new[] { new DomainCacheRefresher.JsonPayload(0, DomainChangeTypes.RefreshAll) });
-                        svc.Notify(new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _, out _);
-                        svc.Notify(new[] { new MediaCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) }, out _);
-                    },
-
-                    //rebuild indexes if the server is not synced
-                    // NOTE: This will rebuild ALL indexes including the members, if developers want to target specific
-                    // indexes then they can adjust this logic themselves.
-                    () => { ExamineComponent.RebuildIndexes(indexRebuilder, logger, false, 5000); }
-                }
-            };
-        }
-
-        public override void Compose(Composition composition)
-        {
-            base.Compose(composition);
-
-            composition.SetDatabaseServerMessengerOptions(GetDefaultOptions);
-            composition.SetServerMessenger<BatchedDatabaseServerMessenger>();
-            composition.Register<ISyncBootStateAccessor>(factory=> factory.GetInstance<IServerMessenger>() as BatchedDatabaseServerMessenger, Lifetime.Singleton);
-        }
-    }
 
     public sealed class DatabaseServerRegistrarAndMessengerComponent : IComponent
     {
@@ -88,14 +24,17 @@ namespace Umbraco.Web.Compose
         private readonly BackgroundTaskRunner<IBackgroundTask> _processTaskRunner;
         private bool _started;
         private IBackgroundTask[] _tasks;
-        private IndexRebuilder _indexRebuilder;
 
-        public DatabaseServerRegistrarAndMessengerComponent(IRuntimeState runtime, IServerRegistrar serverRegistrar, IServerMessenger serverMessenger, IServerRegistrationService registrationService, ILogger logger, IndexRebuilder indexRebuilder)
+        public DatabaseServerRegistrarAndMessengerComponent(
+            IRuntimeState runtime,
+            IServerRegistrar serverRegistrar,
+            IServerMessenger serverMessenger,
+            IServerRegistrationService registrationService,
+            ILogger logger)
         {
             _runtime = runtime;
             _logger = logger;
             _registrationService = registrationService;
-            _indexRebuilder = indexRebuilder;
 
             // create task runner for DatabaseServerRegistrar
             _registrar = serverRegistrar as DatabaseServerRegistrar;
@@ -118,7 +57,9 @@ namespace Umbraco.Web.Compose
         {
             //We will start the whole process when a successful request is made
             if (_registrar != null || _messenger != null)
+            {
                 UmbracoModule.RouteAttempt += RegisterBackgroundTasksOnce;
+            }   
 
             // must come last, as it references some _variables
             _messenger?.Startup();

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -72,6 +72,7 @@ namespace Umbraco.Web.Compose
 
             composition.SetDatabaseServerMessengerOptions(GetDefaultOptions);
             composition.SetServerMessenger<BatchedDatabaseServerMessenger>();
+            composition.Register<ISyncBootStateAccessor>(factory=> factory.GetInstance<IServerMessenger>() as BatchedDatabaseServerMessenger, Lifetime.Singleton);
         }
     }
 

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs
@@ -59,14 +59,18 @@ namespace Umbraco.Web.Compose
             if (_registrar != null || _messenger != null)
             {
                 UmbracoModule.RouteAttempt += RegisterBackgroundTasksOnce;
-            }   
-
-            // must come last, as it references some _variables
-            _messenger?.Startup();
+                UmbracoModule.EndRequest += UmbracoModule_EndRequest;
+            }
         }
 
         public void Terminate()
         { }
+
+        private void UmbracoModule_EndRequest(object sender, UmbracoRequestEventArgs e)
+        {
+            // will clear the batch - will remain in HttpContext though - that's ok
+            _messenger?.FlushBatch();
+        }
 
         /// <summary>
         /// Handle when a request is made

--- a/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComposer.cs
+++ b/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComposer.cs
@@ -1,0 +1,38 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Sync;
+using Umbraco.Web.Search;
+
+namespace Umbraco.Web.Compose
+{
+    /// <summary>
+    /// Ensures that servers are automatically registered in the database, when using the database server registrar.
+    /// </summary>
+    /// <remarks>
+    /// <para>At the moment servers are automatically registered upon first request and then on every
+    /// request but not more than once per (configurable) period. This really is "for information & debug" purposes so
+    /// we can look at the table and see what servers are registered - but the info is not used anywhere.</para>
+    /// <para>Should we actually want to use this, we would need a better and more deterministic way of figuring
+    /// out the "server address" ie the address to which server-to-server requests should be sent - because it
+    /// probably is not the "current request address" - especially in multi-domains configurations.</para>
+    /// </remarks>
+    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
+    // TODO: This is legacy, we no longer need to do this but we don't want to change the behavior now
+    [ComposeAfter(typeof(ExamineComposer))]
+    public sealed class DatabaseServerRegistrarAndMessengerComposer : ComponentComposer<DatabaseServerRegistrarAndMessengerComponent>, ICoreComposer
+    {
+        public static DatabaseServerMessengerOptions GetDefaultOptions(IFactory factory)
+        {
+            return new DatabaseServerMessengerOptions();
+        }
+
+        public override void Compose(Composition composition)
+        {
+            base.Compose(composition);
+
+            composition.SetDatabaseServerMessengerOptions(GetDefaultOptions);
+            composition.SetServerMessenger<BatchedDatabaseServerMessenger>();
+            composition.Register<ISyncBootStateAccessor>(factory => factory.GetInstance<IServerMessenger>() as BatchedDatabaseServerMessenger, Lifetime.Singleton);
+        }
+    }
+}

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Core;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Sync;
 using Umbraco.Web.PublishedCache.NuCache.DataSource;
 
 namespace Umbraco.Web.PublishedCache.NuCache
@@ -9,6 +10,9 @@ namespace Umbraco.Web.PublishedCache.NuCache
         public override void Compose(Composition composition)
         {
             base.Compose(composition);
+
+            //Overriden on Run state in DatabaseServerRegistrarAndMessengerComposer
+            composition.Register<ISyncBootStateAccessor, NonRuntimeLevelBootStateAccessor>(Lifetime.Singleton);
 
             // register the NuCache database data source
             composition.Register<IDataSource, DatabaseDataSource>();

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -24,6 +24,7 @@ using Umbraco.Core.Services;
 using Umbraco.Core.Services.Changes;
 using Umbraco.Core.Services.Implement;
 using Umbraco.Core.Strings;
+using Umbraco.Core.Sync;
 using Umbraco.Web.Cache;
 using Umbraco.Web.Install;
 using Umbraco.Web.PublishedCache.NuCache.DataSource;
@@ -63,6 +64,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
         private bool _localContentDbExists;
         private bool _localMediaDbExists;
 
+        private readonly ISyncBootStateAccessor _syncBootStateAccessor;
+
         // define constant - determines whether to use cache when previewing
         // to store eg routes, property converted values, anything - caching
         // means faster execution, but uses memory - not sure if we want it
@@ -81,7 +84,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
             IDataSource dataSource, IGlobalSettings globalSettings,
             IEntityXmlSerializer entitySerializer,
             IPublishedModelFactory publishedModelFactory,
-            UrlSegmentProviderCollection urlSegmentProviders)
+            UrlSegmentProviderCollection urlSegmentProviders,
+            ISyncBootStateAccessor syncBootStateAccessor)
             : base(publishedSnapshotAccessor, variationContextAccessor)
         {
             //if (Interlocked.Increment(ref _singletonCheck) > 1)
@@ -98,6 +102,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
             _defaultCultureAccessor = defaultCultureAccessor;
             _globalSettings = globalSettings;
             _urlSegmentProviders = urlSegmentProviders;
+
+            _syncBootStateAccessor = syncBootStateAccessor;
 
             // we need an Xml serializer here so that the member cache can support XPath,
             // for members this is done by navigating the serialized-to-xml member
@@ -217,7 +223,12 @@ namespace Umbraco.Web.PublishedCache.NuCache
         {
             var okContent = false;
             var okMedia = false;
-
+            if (_syncBootStateAccessor.GetSyncBootState() == SyncBootState.ColdBoot)
+            {
+                _logger.Info<PublishedSnapshotService>("Sync Service is in a Cold Boot state. Skip LoadCachesOnStartup as the Sync Service will trigger a full reload");
+                _isReady = true;
+                return;
+            }
             try
             {
                 if (_localContentDbExists)
@@ -233,7 +244,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     if (!okMedia)
                         _logger.Warn<PublishedSnapshotService>("Loading media from local db raised warnings, will reload from database.");
                 }
-
+                
                 if (!okContent)
                     LockAndLoadContent(scope => LoadContentFromDatabaseLocked(scope, true));
 

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -36,6 +36,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
     internal class PublishedSnapshotService : PublishedSnapshotServiceBase
     {
+        private readonly PublishedSnapshotServiceOptions _options;
+        private readonly IMainDom _mainDom;
         private readonly ServiceContext _serviceContext;
         private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
         private readonly IScopeProvider _scopeProvider;
@@ -50,12 +52,13 @@ namespace Umbraco.Web.PublishedCache.NuCache
         private readonly IDefaultCultureAccessor _defaultCultureAccessor;
         private readonly UrlSegmentProviderCollection _urlSegmentProviders;
 
-        // volatile because we read it with no lock
-        private volatile bool _isReady;
+        private bool _isReady;
+        private bool _isReadSet;
+        private object _isReadyLock;
 
-        private readonly ContentStore _contentStore;
-        private readonly ContentStore _mediaStore;
-        private readonly SnapDictionary<int, Domain> _domainStore;
+        private ContentStore _contentStore;
+        private ContentStore _mediaStore;
+        private SnapDictionary<int, Domain> _domainStore;
         private readonly object _storesLock = new object();
         private readonly object _elementsLock = new object();
 
@@ -88,9 +91,12 @@ namespace Umbraco.Web.PublishedCache.NuCache
             ISyncBootStateAccessor syncBootStateAccessor)
             : base(publishedSnapshotAccessor, variationContextAccessor)
         {
+
             //if (Interlocked.Increment(ref _singletonCheck) > 1)
             //    throw new Exception("Singleton must be instantiated only once!");
 
+            _options = options;
+            _mainDom = mainDom;
             _serviceContext = serviceContext;
             _publishedContentTypeFactory = publishedContentTypeFactory;
             _dataSource = dataSource;
@@ -123,49 +129,23 @@ namespace Umbraco.Web.PublishedCache.NuCache
             if (runtime.Level != RuntimeLevel.Run)
                 return;
 
-            // lock this entire call, we only want a single thread to be accessing the stores at once and within
-            // the call below to mainDom.Register, a callback may occur on a threadpool thread to MainDomRelease
-            // at the same time as we are trying to write to the stores. MainDomRelease also locks on _storesLock so
-            // it will not be able to close the stores until we are done populating (if the store is empty)
-            lock (_storesLock)
-            {
-                if (options.IgnoreLocalDb == false)
-                {
-                    var registered = mainDom.Register(MainDomRegister, MainDomRelease);
-
-                    // stores are created with a db so they can write to it, but they do not read from it,
-                    // stores need to be populated, happens in OnResolutionFrozen which uses _localDbExists to
-                    // figure out whether it can read the databases or it should populate them from sql
-
-                    _logger.Info<PublishedSnapshotService,bool>("Creating the content store, localContentDbExists? {LocalContentDbExists}", _localContentDbExists);
-                    _contentStore = new ContentStore(publishedSnapshotAccessor, variationContextAccessor, logger, _localContentDb);
-                    _logger.Info<PublishedSnapshotService,bool>("Creating the media store, localMediaDbExists? {LocalMediaDbExists}", _localMediaDbExists);
-                    _mediaStore = new ContentStore(publishedSnapshotAccessor, variationContextAccessor, logger, _localMediaDb);
-                }
-                else
-                {
-                    _logger.Info<PublishedSnapshotService>("Creating the content store (local db ignored)");
-                    _contentStore = new ContentStore(publishedSnapshotAccessor, variationContextAccessor, logger);
-                    _logger.Info<PublishedSnapshotService>("Creating the media store (local db ignored)");
-                    _mediaStore = new ContentStore(publishedSnapshotAccessor, variationContextAccessor, logger);
-                }
-
-                _domainStore = new SnapDictionary<int, Domain>();
-
-                _syncBootStateAccessor.Booting += (sender, args) =>
-                {
-                    LoadCachesOnStartup(args);
-                };
-            }
-
-            Guid GetUid(ContentStore store, int id) => store.LiveSnapshot.Get(id)?.Uid ?? default;
-            int GetId(ContentStore store, Guid uid) => store.LiveSnapshot.Get(uid)?.Id ?? default;
-
             if (idkMap != null)
             {
                 idkMap.SetMapper(UmbracoObjectTypes.Document, id => GetUid(_contentStore, id), uid => GetId(_contentStore, uid));
                 idkMap.SetMapper(UmbracoObjectTypes.Media, id => GetUid(_mediaStore, id), uid => GetId(_mediaStore, uid));
             }
+        }
+
+        private int GetId(ContentStore store, Guid uid)
+        {
+            EnsureCaches();
+            return store.LiveSnapshot.Get(uid)?.Id ?? default;
+        }
+
+        private Guid GetUid(ContentStore store, int id)
+        {
+            EnsureCaches();
+            return store.LiveSnapshot.Get(id)?.Uid ?? default;
         }
 
         /// <summary>
@@ -219,51 +199,82 @@ namespace Umbraco.Web.PublishedCache.NuCache
         }
 
         /// <summary>
-        /// Populates the stores
+        /// Lazily populates the stores only when they are first requested
         /// </summary>
-        /// <remarks>This is called inside of a lock for _storesLock</remarks>
-        private void LoadCachesOnStartup(SyncBootState bootState)
-        {
-            // TODO: This is super ugly that this does this as part of the ctor.
-            // In netcore this will be different, the initialization will happen
-            // outside of the ctor.
-
-            var okContent = false;
-            var okMedia = false;
-            
-            try
+        internal void EnsureCaches() => LazyInitializer.EnsureInitialized(
+            ref _isReady,
+            ref _isReadSet,
+            ref _isReadyLock,
+            () =>
             {
-                if (bootState != SyncBootState.ColdBoot && _localContentDbExists)
+                // lock this entire call, we only want a single thread to be accessing the stores at once and within
+                // the call below to mainDom.Register, a callback may occur on a threadpool thread to MainDomRelease
+                // at the same time as we are trying to write to the stores. MainDomRelease also locks on _storesLock so
+                // it will not be able to close the stores until we are done populating (if the store is empty)
+                lock (_storesLock)
                 {
-                    okContent = LockAndLoadContent(scope => LoadContentFromLocalDbLocked(true));
-                    if (!okContent)
-                        _logger.Warn<PublishedSnapshotService>("Loading content from local db raised warnings, will reload from database.");
+                    if (!_options.IgnoreLocalDb)
+                    {
+                        var registered = _mainDom.Register(MainDomRegister, MainDomRelease);
+
+                        // stores are created with a db so they can write to it, but they do not read from it,
+                        // stores need to be populated, happens in OnResolutionFrozen which uses _localDbExists to
+                        // figure out whether it can read the databases or it should populate them from sql
+
+                        _logger.Info<PublishedSnapshotService, bool>("Creating the content store, localContentDbExists? {LocalContentDbExists}", _localContentDbExists);
+                        _contentStore = new ContentStore(PublishedSnapshotAccessor, VariationContextAccessor, _logger, _localContentDb);
+                        _logger.Info<PublishedSnapshotService, bool>("Creating the media store, localMediaDbExists? {LocalMediaDbExists}", _localMediaDbExists);
+                        _mediaStore = new ContentStore(PublishedSnapshotAccessor, VariationContextAccessor, _logger, _localMediaDb);
+                    }
+                    else
+                    {
+                        _logger.Info<PublishedSnapshotService>("Creating the content store (local db ignored)");
+                        _contentStore = new ContentStore(PublishedSnapshotAccessor, VariationContextAccessor, _logger);
+                        _logger.Info<PublishedSnapshotService>("Creating the media store (local db ignored)");
+                        _mediaStore = new ContentStore(PublishedSnapshotAccessor, VariationContextAccessor, _logger);
+                    }
+
+                    _domainStore = new SnapDictionary<int, Domain>();
+
+                    SyncBootState bootState = _syncBootStateAccessor.GetSyncBootState();
+
+                    var okContent = false;
+                    var okMedia = false;
+
+                    try
+                    {
+                        if (bootState != SyncBootState.ColdBoot && _localContentDbExists)
+                        {
+                            okContent = LockAndLoadContent(scope => LoadContentFromLocalDbLocked(true));
+                            if (!okContent)
+                                _logger.Warn<PublishedSnapshotService>("Loading content from local db raised warnings, will reload from database.");
+                        }
+
+                        if (bootState != SyncBootState.ColdBoot && _localMediaDbExists)
+                        {
+                            okMedia = LockAndLoadMedia(scope => LoadMediaFromLocalDbLocked(true));
+                            if (!okMedia)
+                                _logger.Warn<PublishedSnapshotService>("Loading media from local db raised warnings, will reload from database.");
+                        }
+
+                        if (!okContent)
+                            LockAndLoadContent(scope => LoadContentFromDatabaseLocked(scope, true));
+
+                        if (!okMedia)
+                            LockAndLoadMedia(scope => LoadMediaFromDatabaseLocked(scope, true));
+
+                        LockAndLoadDomains();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Fatal<PublishedSnapshotService>(ex, "Panic, exception while loading cache data.");
+                        throw;
+                    }
+
+                    // finally, cache is ready!
+                    return true;
                 }
-
-                if (bootState != SyncBootState.ColdBoot && _localMediaDbExists)
-                {
-                    okMedia = LockAndLoadMedia(scope => LoadMediaFromLocalDbLocked(true));
-                    if (!okMedia)
-                        _logger.Warn<PublishedSnapshotService>("Loading media from local db raised warnings, will reload from database.");
-                }
-
-                if (!okContent)
-                    LockAndLoadContent(scope => LoadContentFromDatabaseLocked(scope, true));
-
-                if (!okMedia)
-                    LockAndLoadMedia(scope => LoadMediaFromDatabaseLocked(scope, true));
-
-                LockAndLoadDomains();
-            }
-            catch (Exception ex)
-            {
-                _logger.Fatal<PublishedSnapshotService>(ex, "Panic, exception while loading cache data.");
-                throw;
-            }
-
-            // finally, cache is ready!
-            _isReady = true;
-        }
+            });
 
         private void InitializeRepositoryEvents()
         {
@@ -1146,9 +1157,13 @@ namespace Umbraco.Web.PublishedCache.NuCache
 
         public override IPublishedSnapshot CreatePublishedSnapshot(string previewToken)
         {
+            EnsureCaches();
+
             // no cache, no joy
-            if (_isReady == false)
+            if (Volatile.Read(ref _isReady) == false)
+            {
                 throw new InvalidOperationException("The published snapshot service has not properly initialized.");
+            }   
 
             var preview = previewToken.IsNullOrWhiteSpace() == false;
             return new PublishedSnapshot(this, preview);
@@ -1159,6 +1174,8 @@ namespace Umbraco.Web.PublishedCache.NuCache
         // even though the underlying elements may not change (store snapshots)
         public PublishedSnapshot.PublishedSnapshotElements GetElements(bool previewDefault)
         {
+            EnsureCaches();
+
             // note: using ObjectCacheAppCache for elements and snapshot caches
             // is not recommended because it creates an inner MemoryCache which is a heavy
             // thing - better use a dictionary-based cache which "just" creates a concurrent
@@ -1805,6 +1822,8 @@ AND cmsContentNu.nodeId IS NULL
 
         public void Collect()
         {
+            EnsureCaches();
+
             var contentCollect = _contentStore.CollectAsync();
             var mediaCollect = _mediaStore.CollectAsync();
             System.Threading.Tasks.Task.WaitAll(contentCollect, mediaCollect);
@@ -1814,8 +1833,17 @@ AND cmsContentNu.nodeId IS NULL
 
         #region Internals/Testing
 
-        internal ContentStore GetContentStore() => _contentStore;
-        internal ContentStore GetMediaStore() => _mediaStore;
+        internal ContentStore GetContentStore()
+        {
+            EnsureCaches();
+            return _contentStore;
+        }
+
+        internal ContentStore GetMediaStore()
+        {
+            EnsureCaches();
+            return _mediaStore;
+        }
 
         #endregion
     }

--- a/src/Umbraco.Web/Search/ExamineFinalComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComponent.cs
@@ -3,6 +3,8 @@ using Umbraco.Core.Logging;
 using Umbraco.Examine;
 using Umbraco.Core.Composing;
 using Umbraco.Core;
+using Umbraco.Core.Sync;
+using Umbraco.Web.Routing;
 
 namespace Umbraco.Web.Search
 {
@@ -16,27 +18,65 @@ namespace Umbraco.Web.Search
         private readonly IExamineManager _examineManager;
         BackgroundIndexRebuilder _indexRebuilder;
         private readonly IMainDom _mainDom;
-        
-        public ExamineFinalComponent(IProfilingLogger logger, IExamineManager examineManager, BackgroundIndexRebuilder indexRebuilder, IMainDom mainDom)
+        private readonly ISyncBootStateAccessor _syncBootStateAccessor;
+        private readonly object _locker = new object();
+        private bool _initialized = false;
+
+        public ExamineFinalComponent(IProfilingLogger logger, IExamineManager examineManager, BackgroundIndexRebuilder indexRebuilder, IMainDom mainDom, ISyncBootStateAccessor syncBootStateAccessor)
         {
             _logger = logger;
             _examineManager = examineManager;
             _indexRebuilder = indexRebuilder;
             _mainDom = mainDom;
+            _syncBootStateAccessor = syncBootStateAccessor;
+
+            // must add the handler in the ctor because it will be too late in Initialize
+            // TODO: All of this boot synchronization for cold boot logic needs should be fixed in netcore
+            _syncBootStateAccessor.Booting += _syncBootStateAccessor_Booting;
+        }
+
+        /// <summary>
+        /// Once the boot state is known we can see if we require rebuilds
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void _syncBootStateAccessor_Booting(object sender, SyncBootState e)
+        {
+            UmbracoModule.RouteAttempt += UmbracoModule_RouteAttempt;
+        }
+
+        private void UmbracoModule_RouteAttempt(object sender, RoutableAttemptEventArgs e)
+        {
+            UmbracoModule.RouteAttempt -= UmbracoModule_RouteAttempt;
+
+            if (!_initialized)
+            {
+                lock (_locker)
+                {
+                    // double check lock, we must only do this once
+                    if (!_initialized)
+                    {
+                        if (!_mainDom.IsMainDom) return;
+
+                        var bootState = _syncBootStateAccessor.GetSyncBootState();
+
+                        _examineManager.ConfigureIndexes(_mainDom, _logger);
+
+                        // if it's a cold boot, rebuild all indexes including non-empty ones
+                        _indexRebuilder.RebuildIndexes(bootState != SyncBootState.ColdBoot, 0);
+                    }
+                }
+            }
+            
         }
 
         public void Initialize()
-        {
-            if (!_mainDom.IsMainDom) return;
-
-            _examineManager.ConfigureIndexes(_mainDom, _logger);
-
-            // TODO: Instead of waiting 5000 ms, we could add an event handler on to fulfilling the first request, then start?
-            _indexRebuilder.RebuildIndexes(true, 5000);
+        {   
         }
 
         public void Terminate()
         {
+            _syncBootStateAccessor.Booting -= _syncBootStateAccessor_Booting;
         }
     }
 }

--- a/src/Umbraco.Web/Search/ExamineFinalComponent.cs
+++ b/src/Umbraco.Web/Search/ExamineFinalComponent.cs
@@ -56,6 +56,8 @@ namespace Umbraco.Web.Search
                     // double check lock, we must only do this once
                     if (!_initialized)
                     {
+                        _initialized = true;
+
                         if (!_mainDom.IsMainDom) return;
 
                         var bootState = _syncBootStateAccessor.GetSyncBootState();
@@ -63,7 +65,8 @@ namespace Umbraco.Web.Search
                         _examineManager.ConfigureIndexes(_mainDom, _logger);
 
                         // if it's a cold boot, rebuild all indexes including non-empty ones
-                        _indexRebuilder.RebuildIndexes(bootState != SyncBootState.ColdBoot, 0);
+                        // delay one minute since a cold boot also triggers nucache rebuilds
+                        _indexRebuilder.RebuildIndexes(bootState != SyncBootState.ColdBoot, 60000);
                     }
                 }
             }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Compose\BackOfficeUserAuditEventsComposer.cs" />
     <Compile Include="Compose\BlockEditorComponent.cs" />
     <Compile Include="Compose\BlockEditorComposer.cs" />
+    <Compile Include="Compose\DatabaseServerRegistrarAndMessengerComposer.cs" />
     <Compile Include="Compose\NestedContentPropertyComponent.cs" />
     <Compile Include="Compose\NotificationsComposer.cs" />
     <Compile Include="Compose\PublicAccessComposer.cs" />


### PR DESCRIPTION
This fixes #8893 and refactors #9859.

* Moves logic for cold boot into the components responsible for what needs to happen in cold boot. This used to be in callbacks in DatabaseServerMessenger.
* Removes the callbacks from DatabaseServerMessenger and obsoletes these callbacks.
* Ensure examine rebuilds don't occur until the first http request is done instead of on a timer which could be problematic with cold boots. A reason for the #8893 can be that during cold boots, the cold boot processing would take more than 5 seconds and then after those 5 seconds indexing occurs and this will happen before custom components execute that customize those indexes.
* PublishedSnapshotService now only initializes lazily when it's needed.
* Removes BatchedDatabaseServerMessenger.Startup, startup logic is just done in the component along with events.

The whole way that startup/init is done in v8 is not ideal but we are stuck with backwards compat.  Once main problems is that nucache (PublishedSnapshotService) does it's init in it's ctor which doesn't leave much flexibility with how the init process works. This will be fixed/changed in netcore (if not already, I know some of it is). 

## Testing

To force a cold boot, just delete the /TEMP/DistCache folder, then restart your app, this will cold boot.

* Ensure all indexes are rebuilt on cold boot
* Ensure indexes are not rebuilt on non-cold boot
* Ensure nucache is rebuilt (once) on a cold boot
* Ensure nucache is not rebuilt on non-cold boot
* Ensure that you can define custom Examine field types (i.e. #8893) on startup with a IUserComposer and those field types work both in a cold boot and non-cold boot
 

