### PR TITLE
Update ModelsBuilderComposer.cs

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
@@ -47,7 +47,7 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
         {
             var assemblyNames = new[]
             {
-                "Umbraco.ModelsBuider",
+                "Umbraco.ModelsBuilder",
                 "ModelsBuilder.Umbraco"
             };
 


### PR DESCRIPTION
typo in IsExternalModelsBuilderInstalled -> Umbraco.ModelsBuider

If there's an existing issue for this PR then this fixes #10186

### Description
typo in `IsExternalModelsBuilderInstalled -> Umbraco.ModelsBuider`

nuget install Umbraco.ModelsBuilder and set `<add key="Umbraco.ModelsBuilder.ModelsMode" value="Dll" />` results in **Dll mode not allowed** error, as Embedded modelsbuilder is still in use.
