### PR TITLE
Fix #10188 by addressing a typo preventing Umbraco.ModelsBuilder from being detected

### DIFF
--- a/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
+++ b/src/Umbraco.ModelsBuilder.Embedded/Compose/ModelsBuilderComposer.cs
@@ -47,7 +47,7 @@ namespace Umbraco.ModelsBuilder.Embedded.Compose
         {
             var assemblyNames = new[]
             {
-                "Umbraco.ModelsBuider",
+                "Umbraco.ModelsBuilder",
                 "ModelsBuilder.Umbraco"
             };
 


### PR DESCRIPTION
This PR fixes a small typo resulting in Umbraco.ModelsBuilder not being detected in Umbraco 8.13.0.
