### PR TITLE
Backport cache key fix and optimizations

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ConsentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ConsentRepository.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             Database.Update(dto);
             entity.ResetDirtyProperties();
 
-            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IConsent>(entity.Id));
+            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IConsent, int>(entity.Id));
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             foreach (var translation in dictionaryItem.Translations)
                 translation.Value = translation.Value.ToValidXmlString();
-            
+
             var dto = DictionaryItemFactory.BuildDto(dictionaryItem);
 
             var id = Convert.ToInt32(Database.Insert(dto));
@@ -152,7 +152,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             foreach (var translation in entity.Translations)
                 translation.Value = translation.Value.ToValidXmlString();
-            
+
             var dto = DictionaryItemFactory.BuildDto(entity);
 
             Database.Update(dto);
@@ -174,8 +174,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             entity.ResetDirtyProperties();
 
             //Clear the cache entries that exist by uniqueid/item key
-            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem>(entity.ItemKey));
-            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem>(entity.Key));
+            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem, string>(entity.ItemKey));
+            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem, Guid>(entity.Key));
         }
 
         protected override void PersistDeletedItem(IDictionaryItem entity)
@@ -186,8 +186,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             Database.Delete<DictionaryDto>("WHERE id = @Id", new { Id = entity.Key });
 
             //Clear the cache entries that exist by uniqueid/item key
-            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem>(entity.ItemKey));
-            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem>(entity.Key));
+            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem, string>(entity.ItemKey));
+            IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem, Guid>(entity.Key));
 
             entity.DeleteDate = DateTime.Now;
         }
@@ -203,8 +203,8 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 Database.Delete<DictionaryDto>("WHERE id = @Id", new { Id = dto.UniqueId });
 
                 //Clear the cache entries that exist by uniqueid/item key
-                IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem>(dto.Key));
-                IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem>(dto.UniqueId));
+                IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem, string>(dto.Key));
+                IsolatedCache.Clear(RepositoryCacheKeys.GetKey<IDictionaryItem, Guid>(dto.UniqueId));
             }
         }
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1163,7 +1163,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 if (withCache)
                 {
                     // if the cache contains the (proper version of the) item, use it
-                    var cached = IsolatedCache.GetCacheItem<IContent>(RepositoryCacheKeys.GetKey<IContent>(dto.NodeId));
+                    var cached = IsolatedCache.GetCacheItem<IContent>(RepositoryCacheKeys.GetKey<IContent, int>(dto.NodeId));
                     if (cached != null && cached.VersionId == dto.DocumentVersionDto.ContentVersionDto.Id)
                     {
                         content[i] = (Content)cached;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MediaRepository.cs
@@ -508,7 +508,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 if (withCache)
                 {
                     // if the cache contains the (proper version of the) item, use it
-                    var cached = IsolatedCache.GetCacheItem<IMedia>(RepositoryCacheKeys.GetKey<IMedia>(dto.NodeId));
+                    var cached = IsolatedCache.GetCacheItem<IMedia>(RepositoryCacheKeys.GetKey<IMedia, int>(dto.NodeId));
                     if (cached != null && cached.VersionId == dto.ContentVersionDto.Id)
                     {
                         content[i] = (Models.Media)cached;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -331,7 +331,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         }
 
         protected override void PersistUpdatedItem(IMember entity)
-        {   
+        {
             // update
             entity.UpdatingEntity();
 
@@ -534,7 +534,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             var sqlSelectTemplateVersion = SqlContext.Templates.Get("Umbraco.Core.MemberRepository.SetLastLogin2", s => s
                .Select<ContentVersionDto>(x => x.Id)
-               .From<ContentVersionDto>()               
+               .From<ContentVersionDto>()
                .InnerJoin<NodeDto>().On<NodeDto, ContentVersionDto>((l, r) => l.NodeId == r.NodeId)
                .InnerJoin<MemberDto>().On<MemberDto, NodeDto>((l, r) => l.NodeId == r.NodeId)
                .Where<NodeDto>(x => x.NodeObjectType == SqlTemplate.Arg<Guid>("nodeObjectType"))
@@ -606,7 +606,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 if (withCache)
                 {
                     // if the cache contains the (proper version of the) item, use it
-                    var cached = IsolatedCache.GetCacheItem<IMember>(RepositoryCacheKeys.GetKey<IMember>(dto.NodeId));
+                    var cached = IsolatedCache.GetCacheItem<IMember>(RepositoryCacheKeys.GetKey<IMember, int>(dto.NodeId));
                     if (cached != null && cached.VersionId == dto.ContentVersionDto.Id)
                     {
                         content[i] = (Member) cached;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RepositoryCacheKeys.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RepositoryCacheKeys.cs
@@ -16,9 +16,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             return s_keys.TryGetValue(type, out var key) ? key : (s_keys[type] = "uRepo_" + type.Name + "_");
         }
 
-        [Obsolete("Use GetKey<T, TId> instead")]
-        public static string GetKey<T>(object id) => GetKey<T>() + id.ToString().ToUpperInvariant();
-
         public static string GetKey<T, TId>(TId id)
         {
             if (EqualityComparer<TId>.Default.Equals(id, default))

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RepositoryCacheKeys.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RepositoryCacheKeys.cs
@@ -8,14 +8,30 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
     /// </summary>
     internal static class RepositoryCacheKeys
     {
-        private static readonly Dictionary<Type, string> Keys = new Dictionary<Type, string>();
+        private static readonly Dictionary<Type, string> s_keys = new Dictionary<Type, string>();
 
         public static string GetKey<T>()
         {
             var type = typeof(T);
-            return Keys.TryGetValue(type, out var key) ? key : (Keys[type] = "uRepo_" + type.Name + "_");
+            return s_keys.TryGetValue(type, out var key) ? key : (s_keys[type] = "uRepo_" + type.Name + "_");
         }
 
-        public static string GetKey<T>(object id) => GetKey<T>() + id;
+        [Obsolete("Use GetKey<T, TId> instead")]
+        public static string GetKey<T>(object id) => GetKey<T>() + id.ToString().ToUpperInvariant();
+
+        public static string GetKey<T, TId>(TId id)
+        {
+            if (EqualityComparer<TId>.Default.Equals(id, default))
+            {
+                return string.Empty;
+            }
+
+            if (typeof(TId).IsValueType)
+            {
+                return GetKey<T>() + id;
+            }
+
+            return GetKey<T>() + id.ToString().ToUpperInvariant();
+        }
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -83,6 +83,14 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IUser PerformGet(int id)
         {
+            // This will never resolve to a user, yet this is asked
+            // for all of the time (especially in cases of members).
+            // Don't issue a SQL call for this, we know it will not exist.
+            if (id == default || id < -1)
+            {
+                return null;
+            }
+
             var sql = SqlContext.Sql()
                 .Select<UserDto>()
                 .From<UserDto>()
@@ -168,7 +176,7 @@ ORDER BY colName";
         }
 
         public Guid CreateLoginSession(int userId, string requestingIpAddress, bool cleanStaleSessions = true)
-        {            
+        {
             var now = DateTime.UtcNow;
             var dto = new UserLoginDto
             {

--- a/src/Umbraco.Web/Cache/ContentCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/ContentCacheRefresher.cs
@@ -54,9 +54,9 @@ namespace Umbraco.Web.Cache
             foreach (var payload in payloads.Where(x => x.Id != default))
             {
                 //By INT Id
-                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent>(payload.Id));
+                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, int>(payload.Id));
                 //By GUID Key
-                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent>(payload.Key));
+                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, Guid?>(payload.Key));
 
                 _idkMap.ClearCache(payload.Id);
 

--- a/src/Umbraco.Web/Cache/MacroCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MacroCacheRefresher.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Web.Cache
                 var macroRepoCache = AppCaches.IsolatedCaches.Get<IMacro>();
                 if (macroRepoCache)
                 {
-                    macroRepoCache.Result.Clear(RepositoryCacheKeys.GetKey<IMacro>(payload.Id));
+                    macroRepoCache.Result.Clear(RepositoryCacheKeys.GetKey<IMacro, int>(payload.Id));
                 }
             }
 

--- a/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MediaCacheRefresher.cs
@@ -62,8 +62,8 @@ namespace Umbraco.Web.Cache
                     // repository cache
                     // it *was* done for each pathId but really that does not make sense
                     // only need to do it for the current media
-                    mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia>(payload.Id));
-                    mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia>(payload.Key));
+                    mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia, int>(payload.Id));
+                    mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia, Guid?>(payload.Key));
 
                     // remove those that are in the branch
                     if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.RefreshBranch | TreeChangeTypes.Remove))

--- a/src/Umbraco.Web/Cache/MemberCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/MemberCacheRefresher.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Web.Cache
             _legacyMemberRefresher = new LegacyMemberCacheRefresher(this, appCaches);
         }
 
-        public class JsonPayload 
+        public class JsonPayload
         {
             [JsonConstructor]
             public JsonPayload(int id, string username)
@@ -87,11 +87,11 @@ namespace Umbraco.Web.Cache
                 _idkMap.ClearCache(p.Id);
                 if (memberCache)
                 {
-                    memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember>(p.Id));
-                    memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember>(p.Username));
-                }   
+                    memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember, int>(p.Id));
+                    memberCache.Result.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.Username));
+                }
             }
-            
+
         }
 
         #endregion

--- a/src/Umbraco.Web/Cache/RelationTypeCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/RelationTypeCacheRefresher.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Web.Cache
         public override void Refresh(int id)
         {
             var cache = AppCaches.IsolatedCaches.Get<IRelationType>();
-            if (cache) cache.Result.Clear(RepositoryCacheKeys.GetKey<IRelationType>(id));
+            if (cache) cache.Result.Clear(RepositoryCacheKeys.GetKey<IRelationType, int>(id));
             base.Refresh(id);
         }
 
@@ -48,7 +48,7 @@ namespace Umbraco.Web.Cache
         public override void Remove(int id)
         {
             var cache = AppCaches.IsolatedCaches.Get<IRelationType>();
-            if (cache) cache.Result.Clear(RepositoryCacheKeys.GetKey<IRelationType>(id));
+            if (cache) cache.Result.Clear(RepositoryCacheKeys.GetKey<IRelationType, int>(id));
             base.Remove(id);
         }
 

--- a/src/Umbraco.Web/Cache/UserCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/UserCacheRefresher.cs
@@ -43,13 +43,13 @@ namespace Umbraco.Web.Cache
             var userCache = AppCaches.IsolatedCaches.Get<IUser>();
             if (userCache)
             {
-                userCache.Result.Clear(RepositoryCacheKeys.GetKey<IUser>(id));
+                userCache.Result.Clear(RepositoryCacheKeys.GetKey<IUser, int>(id));
                 userCache.Result.ClearByKey(CacheKeys.UserContentStartNodePathsPrefix + id);
                 userCache.Result.ClearByKey(CacheKeys.UserMediaStartNodePathsPrefix + id);
                 userCache.Result.ClearByKey(CacheKeys.UserAllContentStartNodesPrefix + id);
                 userCache.Result.ClearByKey(CacheKeys.UserAllMediaStartNodesPrefix + id);
             }
-                
+
 
             base.Remove(id);
         }

--- a/src/Umbraco.Web/Cache/UserGroupCacheRefresher.cs
+++ b/src/Umbraco.Web/Cache/UserGroupCacheRefresher.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Web.Cache
             var userGroupCache = AppCaches.IsolatedCaches.Get<IUserGroup>();
             if (userGroupCache)
             {
-                userGroupCache.Result.Clear(RepositoryCacheKeys.GetKey<IUserGroup>(id));
+                userGroupCache.Result.Clear(RepositoryCacheKeys.GetKey<IUserGroup, int>(id));
                 userGroupCache.Result.ClearByKey(UserGroupRepository.GetByAliasCacheKeyPrefix);
             }
 


### PR DESCRIPTION
This PR backports the fixes made by Shannon in netcore. The commit containing the netcore fixes can be seen here: https://github.com/umbraco/Umbraco-CMS/commit/8326b0428c4698552d3730ddc1167014ce7d5513

Shannon mentioned that there might be some breaking changes, however I was unable to find any since we're changing internal classes, so custom code shouldn't be affected by this.

## Testing

### Setup

Before you start testing you need to set up your site to allow members to login, you can follow [this video](https://umbraco.tv/videos/umbraco-v8/content-editor/administrative-content/members/role-based-protection/) if you're unsure how to do it.

### Test steps

1. Create a user that is not approved
2. Login using casing that is not equal to the Login on the member.
    * You should not be able to log in because the member is not approved
3. Go the the backoffice and approve and save the member
4. Login with the same casing as the first attempt
5. You should now be logged in

Before this would fail and only allow you to login when using the same casing as on the member Login field