### PR TITLE
#10193 The listview search within a dialog (eg. minilistview) shows the loading indicator forever for zero results

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
@@ -58,6 +58,9 @@
                 
                 entityResource.getPagedChildren(miniListView.node.id, scope.entityType, miniListView.pagination)
                     .then(function (data) {
+                        if (!data.items) {
+                            data.items = [];
+                        }
                         if (scope.onItemsLoaded) {
                             scope.onItemsLoaded({items: data.items});
                         }

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -80,7 +80,7 @@
                     <span ng-if="search !== ''"><localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize></span>
                 </div>
 
-                <!-- Load indicator when the list doesn't have items -->
+                <!-- Load indicator while items are retrieved -->
                 <div ng-if="miniListView.loading && miniListView.children.length === 0" class="umb-table-row umb-table-row--empty">
                     <umb-load-indicator></umb-load-indicator>
                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -74,7 +74,7 @@
                     <div class="umb-table-cell black" ng-class="{'umb-table-cell--faded':child.published === false}">{{ child.name }}</div>
                 </div>
 
-                <!-- Load indicator when the list doesn't have items -->
+                <!-- Show a message when no items are found, depending on whether you searched or the list was empty anyway -->
                 <div ng-if="!miniListView.loading && miniListView.children.length === 0" class="umb-table-row umb-table-row--empty">
                     <span ng-if="search === ''"><localize key="general_noItemsInList">No items have been added</localize></span>
                     <span ng-if="search !== ''"><localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize></span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -75,13 +75,13 @@
                 </div>
 
                 <!-- Load indicator when the list doesn't have items -->
-                <div ng-if="!miniListView.loading && !miniListView.children" class="umb-table-row umb-table-row--empty">
+                <div ng-if="!miniListView.loading && miniListView.children.length === 0" class="umb-table-row umb-table-row--empty">
                     <span ng-if="search === ''"><localize key="general_noItemsInList">No items have been added</localize></span>
                     <span ng-if="search !== ''"><localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize></span>
                 </div>
 
                 <!-- Load indicator when the list doesn't have items -->
-                <div ng-if="miniListView.loading && !miniListView.children" class="umb-table-row umb-table-row--empty">
+                <div ng-if="miniListView.loading && miniListView.children.length === 0" class="umb-table-row umb-table-row--empty">
                     <umb-load-indicator></umb-load-indicator>
                 </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #10193 

### Testing this fix
1. Start with a fresh install with the starter kit
2. Navigate to Home and edit the page
3. Remove the existing call to action link, and add a new one
4. Navigate into the People list view
5. Type in "Hello", or anything that won't match a person in the list
6. View now correctly shows `Sorry, we can not find what you are looking for.`

![listview-search-fix](https://user-images.githubusercontent.com/675943/116547847-c39b6000-a936-11eb-9f1f-8ca65b2e550d.gif)

