### PR TITLE
Fix issue with show selected member types on init using treepicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.controller.js
@@ -49,7 +49,7 @@ angular.module('umbraco')
             });
         }
 
-        $scope.openContentPicker = function () {
+        $scope.openTreePicker = function () {
             var treePicker = config;
             treePicker.section = config.type;
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.controller.js
@@ -26,7 +26,7 @@ angular.module('umbraco')
 
         if ($scope.model.value) {
 
-            if (Array.isArray($scope.model.value)) {
+            if (!Array.isArray($scope.model.value)) {
                 $scope.ids = $scope.model.value.split(",");
             } else {
                 $scope.ids.push($scope.model.value);

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.html
@@ -11,7 +11,7 @@
 			allow-remove="allowRemove"
 			allow-edit="allowEdit"
 			on-remove="remove($index)"
-            on-edit="openContentPicker()">
+            on-edit="openTreePicker()">
 		</umb-node-preview>
 	</div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treepicker.html
@@ -18,7 +18,7 @@
 	<button type="button"
 		    class="umb-node-preview-add"
             ng-show="model.config.multiPicker === true || renderModel.length === 0"
-		    ng-click="openContentPicker()">
+		    ng-click="openTreePicker()">
 		<localize key="general_add">Add</localize>
 	</button>
 

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -29,8 +29,8 @@ using Umbraco.Web.Services;
 using Umbraco.Web.Trees;
 using Umbraco.Web.WebApi;
 using Umbraco.Web.WebApi.Filters;
-
 using Constants = Umbraco.Core.Constants;
+
 namespace Umbraco.Web.Editors
 {
     /// <summary>
@@ -456,7 +456,7 @@ namespace Umbraco.Web.Editors
             }
 
             //all udi types will need to be the same in this list so we'll determine by the first
-            //currently we only support GuidIdi for this method
+            //currently we only support GuidUdi for this method
 
             var guidUdi = ids[0] as GuidUdi;
             if (guidUdi != null)
@@ -1132,16 +1132,17 @@ namespace Umbraco.Web.Editors
         }
 
         private static readonly string[] _postFilterSplitStrings = new[]
-            {
-                "=",
-                "==",
-                "!=",
-                "<>",
-                ">",
-                "<",
-                ">=",
-                "<="
-            };
+        {
+            "=",
+            "==",
+            "!=",
+            "<>",
+            ">",
+            "<",
+            ">=",
+            "<="
+        };
+
         private static QueryCondition BuildQueryCondition<T>(string postFilter)
         {
             var postFilterParts = postFilter.Split(_postFilterSplitStrings, 2, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/EntityMapDefinition.cs
@@ -42,7 +42,6 @@ namespace Umbraco.Web.Models.Mapping
             target.Trashed = source.Trashed;
             target.Udi = Udi.Create(ObjectTypes.GetUdiType(source.NodeObjectType), source.Key);
 
-
             if (source is IContentEntitySlim contentSlim)
             {
                 source.AdditionalData["ContentTypeAlias"] = contentSlim.ContentTypeAlias;
@@ -152,6 +151,10 @@ namespace Umbraco.Web.Models.Mapping
 
             if (target.Icon.IsNullOrWhiteSpace())
             {
+                if (source.NodeObjectType == Constants.ObjectTypes.Document)
+                    target.Icon = Constants.Icons.Content;
+                if (source.NodeObjectType == Constants.ObjectTypes.Media)
+                    target.Icon = Constants.Icons.Content;
                 if (source.NodeObjectType == Constants.ObjectTypes.Member)
                     target.Icon = Constants.Icons.Member;
                 else if (source.NodeObjectType == Constants.ObjectTypes.DataType)
@@ -160,6 +163,8 @@ namespace Umbraco.Web.Models.Mapping
                     target.Icon = Constants.Icons.ContentType;
                 else if (source.NodeObjectType == Constants.ObjectTypes.MediaType)
                     target.Icon = Constants.Icons.MediaType;
+                else if (source.NodeObjectType == Constants.ObjectTypes.MemberType)
+                    target.Icon = Constants.Icons.MemberType;
                 else if (source.NodeObjectType == Constants.ObjectTypes.TemplateType)
                     target.Icon = Constants.Icons.Template;
             }
@@ -241,7 +246,7 @@ namespace Umbraco.Web.Models.Mapping
             switch (entity)
             {
                 case IMemberEntitySlim memberEntity:
-                    return memberEntity.ContentTypeIcon.IfNullOrWhiteSpace(Constants.Icons.Member);
+                    return memberEntity.ContentTypeIcon;
                 case IContentEntitySlim contentEntity:
                     // NOTE: this case covers both content and media entities
                     return contentEntity.ContentTypeIcon;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10194

### Description
When using treepicker prevalue editor, it currently fails to show the selected entities, because it for a comma delimited string just push the value to an array and pass this into `entityResource.getByIds()`.

It should instead split by comma if the value is NOT an array.

![pxjJqId4iE](https://user-images.githubusercontent.com/2919859/116580442-abfeb000-a913-11eb-85c7-2d9bb525712b.gif)

I have attached a test property editor here with the prevalues: 
[TestPropertyEditor.zip](https://github.com/umbraco/Umbraco-CMS/files/6400079/TestPropertyEditor.zip)