### PR TITLE
Replaces System.Drawing with ImageSharp, and thereby fix TODO.

### DIFF
--- a/src/Umbraco.Infrastructure/Media/ImageDimensionExtractor.cs
+++ b/src/Umbraco.Infrastructure/Media/ImageDimensionExtractor.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Drawing;
 using System.IO;
+using SixLabors.ImageSharp;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Media;
-using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Infrastructure.Media
 {
@@ -34,8 +34,12 @@ namespace Umbraco.Cms.Infrastructure.Media
             // we have no choice but to try to read in via GDI
             try
             {
-                // TODO: We should be using ImageSharp for this
-                using (var image = Image.FromStream(stream))
+                if (stream.CanRead && stream.CanSeek)
+                {
+                    stream.Seek(0, SeekOrigin.Begin);
+                }
+
+                using (var image = Image.Load(stream))
                 {
                     var fileWidth = image.Width;
                     var fileHeight = image.Height;

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -45,8 +45,8 @@
       <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
       <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
-      <PackageReference Include="System.Drawing.Common" Version="5.0.1" />
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
       <PackageReference Include="Examine.Core" Version="2.0.0-alpha.20200128.15" />


### PR DESCRIPTION
### Details

- Replaces `System.Drawing` with `ImageSharp`, and thereby fix TODO.

### Test
- Go to the media section and upload files of different types.
- The following formats are supported
  - GIF : GifDecoder
  - PNG : PngDecoder
  - BMP : BmpDecoder
  - JPEG : JpegDecoder
  - TGA : TgaDecoder