### PR TITLE
appsettings "WebRouting:DisableRedirectUrlTracking" should be a bool

### DIFF
--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Cms.Core.Configuration
 
             var json = GetJson(provider);
 
-            var item = GetDisableRedirectUrlItem(disable.ToString().ToLowerInvariant());
+            var item = GetDisableRedirectUrlItem(disable);
 
             json.Merge(item, new JsonMergeSettings());
 
@@ -115,7 +115,7 @@ namespace Umbraco.Cms.Core.Configuration
             return writer.Token;
         }
 
-        private JToken GetDisableRedirectUrlItem(string value)
+        private JToken GetDisableRedirectUrlItem(bool value)
         {
             JTokenWriter writer = new JTokenWriter();
 


### PR DESCRIPTION
### Description
When toggling UrlTracker in the backoffice, WebRouting:DisableRedirectUrlTracking is set as a string 'true'/'false' in appsettings.json.

![image](https://user-images.githubusercontent.com/1222544/116713871-7c17e100-a9d5-11eb-8886-523688f8b3d9.png)

Changed to a bool 

![image](https://user-images.githubusercontent.com/1222544/116713999-9782ec00-a9d5-11eb-8a5f-f5d167000844.png)


<!-- Thanks for contributing to Umbraco CMS! -->
