### PR TITLE
Casing in appsettings:umbraco:cms:contentMacroErrors and using MacroErrorBehaviour Enum

### DIFF
--- a/src/Umbraco.Core/HealthChecks/Checks/Configuration/MacroErrorsCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Configuration/MacroErrorsCheck.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Macros;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
@@ -56,12 +57,12 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Configuration
                     new AcceptableConfiguration
                     {
                         IsRecommended = true,
-                        Value = "inline"
+                        Value = MacroErrorBehaviour.Inline.ToString()
                     },
                     new AcceptableConfiguration
                     {
                         IsRecommended = false,
-                        Value = "silent"
+                        Value = MacroErrorBehaviour.Silent.ToString()
                     }
                 };
 

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Cms.Core.Configuration
 
             var json = GetJson(provider);
 
-            var item = GetDisableRedirectUrlItem(disable.ToString().ToLowerInvariant());
+            var item = GetDisableRedirectUrlItem(disable);
 
             json.Merge(item, new JsonMergeSettings());
 
@@ -115,7 +115,7 @@ namespace Umbraco.Cms.Core.Configuration
             return writer.Token;
         }
 
-        private JToken GetDisableRedirectUrlItem(string value)
+        private JToken GetDisableRedirectUrlItem(bool value)
         {
             JTokenWriter writer = new JTokenWriter();
 

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -18,7 +18,7 @@
         "Notifications": {
           "Email": "your@email.here"
         },
-        "MacroErrors": "throw"
+        "MacroErrors": "Throw"
       },
       "Global": {
         "DefaultUILanguage": "en-us",


### PR DESCRIPTION
### Description
Minor changes to appsettings and MacroErrorsCheck healthcheck

Changed the default appsettings:umbraco:cms:contentMacroErrors from '**t**hrow' => '**T**hrow'.

Changed the strings in `MacroErrorsCheck => Values`, to the `MacroErrorBehaviour `enum counterparts



<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
