### PR TITLE
Fix issue with hardcoded '\' as directory separator char.

### DIFF
--- a/src/Umbraco.Core/Packaging/CompiledPackageXmlParser.cs
+++ b/src/Umbraco.Core/Packaging/CompiledPackageXmlParser.cs
@@ -133,7 +133,7 @@ namespace Umbraco.Cms.Core.Packaging
 
         private static string PrepareAsFilePathElement(string pathElement)
         {
-            return pathElement.TrimStart(new[] { '\\', '/', '~' }).Replace("/", "\\");
+            return pathElement.TrimStart(new[] { '\\', '/', '~' }).Replace('/', Path.DirectorySeparatorChar);
         }
 
         private string UpdatePathPlaceholders(string path)


### PR DESCRIPTION
Fixes issue with hardcoded '\\' as directory separator char. This caused all files in packages to be restored in the root folder with '\\' in the filename on Linux.

I tested the new beta version of Umbraco 9 on Linux. When I install any package, for example by clicking on install in the forms tab, then I get an install which results in the attached screenshot of the folder listing:
![directory listing with backslash in filename](https://user-images.githubusercontent.com/1468798/116759102-d8005b00-aa11-11eb-808e-2b814eb562bb.png)

Of course I also tested this patch. With this patch any package will install into the right folders. The forms plugin ends up in the App_Plugins folder. Please see:
![directory listing with correct installation of package into the App_plugins folder](https://user-images.githubusercontent.com/1468798/116759444-a340d380-aa12-11eb-9188-3acb721d65fc.png)

