### PR TITLE
Fix textboxes inside flatpickr popup to not cause the scheduled publi…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/schedule.controller.js
@@ -121,11 +121,25 @@
          * @param {any} type publish or unpublish
          */
         function datePickerShow(variant, type) {
+            var activeDatePickerInstance;
             if (type === 'publish') {
                 variant.releaseDatePickerOpen = true;
+                activeDatePickerInstance = variant.releaseDatePickerInstance;
             } else if (type === 'unpublish') {
                 variant.expireDatePickerOpen = true;
+                activeDatePickerInstance = variant.expireDatePickerInstance;
             }
+
+            // Prevent enter key in time fields from submitting the overlay before the associated input gets the updated time
+            if (activeDatePickerInstance && !activeDatePickerInstance.hourElement.hasAttribute("overlay-submit-on-enter"))
+            {
+                activeDatePickerInstance.hourElement.setAttribute("overlay-submit-on-enter", "false");
+            }
+            if (activeDatePickerInstance && !activeDatePickerInstance.minuteElement.hasAttribute("overlay-submit-on-enter"))
+            {
+                activeDatePickerInstance.minuteElement.setAttribute("overlay-submit-on-enter", "false");
+            }
+
             checkForBackdropClick();
             $scope.model.disableSubmitButton = !canSchedule();
         }


### PR DESCRIPTION
…shing overlay to submit when enter is pressed.

Overlays listen for enter keypresses and submit themselves automatically. This can be disabled by adding the attribute `overlay-submit-on-enter="false"` on any element that might accept keypresses, such as textfields inside the flatpickr calendar. This change dynamically adds this attribute to the flatpickr popup on this overlay whenever it opens (if not already present from a previous open).


### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/10214

### Testing

1. Go into any content.
2. Click on the Info tab (just so you can see the publish date).
3. Hit Schedule against that content.
4. Take not of your local clock hour and minute.
5. Click on either the Publish at or Unpublish at calendars (both are affected).
6. Change the minute to something that isn't the current minute (eg. 45).
7. Change the hour to something that isn't the current hour (but in the future), eg. 23 via the keyboard.
8. Hit enter while still in the hour field.
9. The calendar will close and your accepted time will be put into the Publish at field correctly.
10. The scheduled publishing overlay *will not submit*.
