### PR TITLE
V9: Implementing Error Describers for translated error messages

### DIFF
--- a/src/Umbraco.Infrastructure/Security/BackOfficeErrorDescriber.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeErrorDescriber.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Identity;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Security
 {
@@ -7,11 +9,282 @@ namespace Umbraco.Cms.Core.Security
     /// </summary>
     public class BackOfficeErrorDescriber : IdentityErrorDescriber
     {
-        // TODO: Override all the methods in order to provide our own translated error messages
+        private readonly ILocalizedTextService _textService;
+
+        public BackOfficeErrorDescriber(ILocalizedTextService textService) => _textService = textService;
+
+        // Overriding all methods in order to provide our own translated error messages
+
+        public override IdentityError ConcurrencyFailure() => new IdentityError
+        {
+            Code = nameof(ConcurrencyFailure),
+            Description = _textService.Localize("errors/concurrencyError")
+        };
+
+        public override IdentityError DefaultError() => new IdentityError
+        {
+            Code = nameof(DefaultError),
+            Description = _textService.Localize("errors/defaultError")
+        };
+
+        public override IdentityError DuplicateEmail(string email) => new IdentityError
+        {
+            Code = nameof(DuplicateEmail),
+            Description = _textService.Localize("validation/duplicateEmail", new[] { email })
+        };
+
+        public override IdentityError DuplicateRoleName(string role) => new IdentityError
+        {
+            Code = nameof(DuplicateRoleName),
+            Description = _textService.Localize("validation/duplicateUserGroupName", new[] { role })
+        };
+
+        public override IdentityError DuplicateUserName(string userName) => new IdentityError
+        {
+            Code = nameof(DuplicateUserName),
+            Description = _textService.Localize("validation/duplicateUsername", new[] { userName })
+        };
+
+        public override IdentityError InvalidEmail(string email) => new IdentityError
+        {
+            Code = nameof(InvalidEmail),
+            Description = _textService.Localize("validation/invalidEmail")
+        };
+
+        public override IdentityError InvalidRoleName(string role) => new IdentityError
+        {
+            Code = nameof(InvalidRoleName),
+            Description = _textService.Localize("validation/invalidUserGroupName")
+        };
+
+        public override IdentityError InvalidToken() => new IdentityError
+        {
+            Code = nameof(InvalidToken),
+            Description = _textService.Localize("validation/invalidToken")
+        };
+
+        public override IdentityError InvalidUserName(string userName) => new IdentityError
+        {
+            Code = nameof(InvalidUserName),
+            Description = _textService.Localize("validation/invalidUsername")
+        };
+
+        public override IdentityError LoginAlreadyAssociated() => new IdentityError
+        {
+            Code = nameof(LoginAlreadyAssociated),
+            Description = _textService.Localize("user/duplicateLogin")
+        };
+
+        public override IdentityError PasswordMismatch() => new IdentityError
+        {
+            Code = nameof(PasswordMismatch),
+            Description = _textService.Localize("user/passwordMismatch")
+        };
+
+        public override IdentityError PasswordRequiresDigit() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresDigit),
+            Description = _textService.Localize("user/passwordRequiresDigit")
+        };
+
+        public override IdentityError PasswordRequiresLower() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresLower),
+            Description = _textService.Localize("user/passwordRequiresLower")
+        };
+
+        public override IdentityError PasswordRequiresNonAlphanumeric() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresNonAlphanumeric),
+            Description = _textService.Localize("user/passwordRequiresNonAlphanumeric")
+        };
+
+        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) => new IdentityError
+        {
+            Code = nameof(PasswordRequiresUniqueChars),
+            Description = _textService.Localize("user/passwordRequiresUniqueChars", new[] { uniqueChars.ToString() })
+        };
+
+        public override IdentityError PasswordRequiresUpper() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresUpper),
+            Description = _textService.Localize("user/passwordRequiresUpper")
+        };
+
+        public override IdentityError PasswordTooShort(int length) => new IdentityError
+        {
+            Code = nameof(PasswordTooShort),
+            Description = _textService.Localize("user/passwordTooShort", new[] { length.ToString() })
+        };
+
+        public override IdentityError RecoveryCodeRedemptionFailed() => new IdentityError
+        {
+            Code = nameof(RecoveryCodeRedemptionFailed),
+            Description = _textService.Localize("login/resetCodeExpired")
+        };
+
+        public override IdentityError UserAlreadyHasPassword() => new IdentityError
+        {
+            Code = nameof(UserAlreadyHasPassword),
+            Description = _textService.Localize("user/userHasPassword")
+        };
+
+        public override IdentityError UserAlreadyInRole(string role) => new IdentityError
+        {
+            Description = _textService.Localize("user/userHasGroup", new[] { role })
+        };
+
+        public override IdentityError UserLockoutNotEnabled() => new IdentityError
+        {
+            Code = nameof(UserLockoutNotEnabled),
+            Description = _textService.Localize("user/userLockoutNotEnabled")
+        };
+
+        public override IdentityError UserNotInRole(string role) => new IdentityError
+        {
+            Code = nameof(UserNotInRole),
+            Description = _textService.Localize("user/userNotInGroup", new[] { role })
+        };
     }
 
     public class MembersErrorDescriber : IdentityErrorDescriber
     {
-        // TODO: Override all the methods in order to provide our own translated error messages
+        private readonly ILocalizedTextService _textService;
+
+        public MembersErrorDescriber(ILocalizedTextService textService) => _textService = textService;
+
+        // Overriding all methods in order to provide our own translated error messages
+
+        public override IdentityError ConcurrencyFailure() => new IdentityError
+        {
+            Code = nameof(ConcurrencyFailure),
+            Description = _textService.Localize("errors/concurrencyError")
+        };
+
+        public override IdentityError DefaultError() => new IdentityError
+        {
+            Code = nameof(DefaultError),
+            Description = _textService.Localize("errors/defaultError")
+        };
+
+        public override IdentityError DuplicateEmail(string email) => new IdentityError
+        {
+            Code = nameof(DuplicateEmail),
+            Description = _textService.Localize("validation/duplicateEmail", new[] { email })
+        };
+
+        public override IdentityError DuplicateRoleName(string role) => new IdentityError
+        {
+            Code = nameof(DuplicateRoleName),
+            Description = _textService.Localize("validation/duplicateMemberGroupName", new[] { role })
+        };
+
+        public override IdentityError DuplicateUserName(string userName) => new IdentityError
+        {
+            Code = nameof(DuplicateUserName),
+            Description = _textService.Localize("validation/duplicateUsername", new[] { userName })
+        };
+
+        public override IdentityError InvalidEmail(string email) => new IdentityError
+        {
+            Code = nameof(InvalidEmail),
+            Description = _textService.Localize("validation/invalidEmail")
+        };
+
+        public override IdentityError InvalidRoleName(string role) => new IdentityError
+        {
+            Code = nameof(InvalidRoleName),
+            Description = _textService.Localize("validation/invalidMemberGroupName")
+        };
+
+        public override IdentityError InvalidToken() => new IdentityError
+        {
+            Code = nameof(InvalidToken),
+            Description = _textService.Localize("validation/invalidToken")
+        };
+
+        public override IdentityError InvalidUserName(string userName) => new IdentityError
+        {
+            Code = nameof(InvalidUserName),
+            Description = _textService.Localize("validation/invalidUsername")
+        };
+
+        public override IdentityError LoginAlreadyAssociated() => new IdentityError
+        {
+            Code = nameof(LoginAlreadyAssociated),
+            Description = _textService.Localize("member/duplicateMemberLogin")
+        };
+
+        public override IdentityError PasswordMismatch() => new IdentityError
+        {
+            Code = nameof(PasswordMismatch),
+            Description = _textService.Localize("user/passwordMismatch")
+        };
+
+        public override IdentityError PasswordRequiresDigit() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresDigit),
+            Description = _textService.Localize("user/passwordRequiresDigit")
+        };
+
+        public override IdentityError PasswordRequiresLower() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresLower),
+            Description = _textService.Localize("user/passwordRequiresLower")
+        };
+
+        public override IdentityError PasswordRequiresNonAlphanumeric() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresNonAlphanumeric),
+            Description = _textService.Localize("user/passwordRequiresNonAlphanumeric")
+        };
+
+        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) => new IdentityError
+        {
+            Code = nameof(PasswordRequiresUniqueChars),
+            Description = _textService.Localize("user/passwordRequiresUniqueChars", new[] { uniqueChars.ToString() })
+        };
+
+        public override IdentityError PasswordRequiresUpper() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresUpper),
+            Description = _textService.Localize("user/passwordRequiresUpper")
+        };
+
+        public override IdentityError PasswordTooShort(int length) => new IdentityError
+        {
+            Code = nameof(PasswordTooShort),
+            Description = _textService.Localize("user/passwordTooShort", new[] { length.ToString() })
+        };
+
+        public override IdentityError RecoveryCodeRedemptionFailed() => new IdentityError
+        {
+            Code = nameof(RecoveryCodeRedemptionFailed),
+            Description = _textService.Localize("login/resetCodeExpired")
+        };
+
+        public override IdentityError UserAlreadyHasPassword() => new IdentityError
+        {
+            Code = nameof(UserAlreadyHasPassword),
+            Description = _textService.Localize("member/memberHasPassword")
+        };
+
+        public override IdentityError UserAlreadyInRole(string role) => new IdentityError
+        {
+            Code = nameof(UserAlreadyInRole),
+            Description = _textService.Localize("member/memberHasGroup", new[] { role })
+        };
+
+        public override IdentityError UserLockoutNotEnabled() => new IdentityError
+        {
+            Code = nameof(UserLockoutNotEnabled),
+            Description = _textService.Localize("member/memberLockoutNotEnabled")
+        };
+
+        public override IdentityError UserNotInRole(string role) => new IdentityError
+        {
+            Code = nameof(UserNotInRole),
+            Description = _textService.Localize("member/memberNotInGroup", new[] { role })
+        };
     }
 }

--- a/src/Umbraco.Infrastructure/Security/BackOfficeErrorDescriber.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeErrorDescriber.cs
@@ -7,48 +7,17 @@ namespace Umbraco.Cms.Core.Security
     /// <summary>
     /// Umbraco back office specific <see cref="IdentityErrorDescriber"/>
     /// </summary>
-    public class BackOfficeErrorDescriber : IdentityErrorDescriber
+    public class BackOfficeErrorDescriber : UmbracoErrorDescriberBase
     {
         private readonly ILocalizedTextService _textService;
 
-        public BackOfficeErrorDescriber(ILocalizedTextService textService) => _textService = textService;
-
-        // Overriding all methods in order to provide our own translated error messages
-
-        public override IdentityError ConcurrencyFailure() => new IdentityError
-        {
-            Code = nameof(ConcurrencyFailure),
-            Description = _textService.Localize("errors/concurrencyError")
-        };
-
-        public override IdentityError DefaultError() => new IdentityError
-        {
-            Code = nameof(DefaultError),
-            Description = _textService.Localize("errors/defaultError")
-        };
-
-        public override IdentityError DuplicateEmail(string email) => new IdentityError
-        {
-            Code = nameof(DuplicateEmail),
-            Description = _textService.Localize("validation/duplicateEmail", new[] { email })
-        };
+        public BackOfficeErrorDescriber(ILocalizedTextService textService)
+            : base(textService) => _textService = textService;
 
         public override IdentityError DuplicateRoleName(string role) => new IdentityError
         {
             Code = nameof(DuplicateRoleName),
             Description = _textService.Localize("validation/duplicateUserGroupName", new[] { role })
-        };
-
-        public override IdentityError DuplicateUserName(string userName) => new IdentityError
-        {
-            Code = nameof(DuplicateUserName),
-            Description = _textService.Localize("validation/duplicateUsername", new[] { userName })
-        };
-
-        public override IdentityError InvalidEmail(string email) => new IdentityError
-        {
-            Code = nameof(InvalidEmail),
-            Description = _textService.Localize("validation/invalidEmail")
         };
 
         public override IdentityError InvalidRoleName(string role) => new IdentityError
@@ -57,70 +26,10 @@ namespace Umbraco.Cms.Core.Security
             Description = _textService.Localize("validation/invalidUserGroupName")
         };
 
-        public override IdentityError InvalidToken() => new IdentityError
-        {
-            Code = nameof(InvalidToken),
-            Description = _textService.Localize("validation/invalidToken")
-        };
-
-        public override IdentityError InvalidUserName(string userName) => new IdentityError
-        {
-            Code = nameof(InvalidUserName),
-            Description = _textService.Localize("validation/invalidUsername")
-        };
-
         public override IdentityError LoginAlreadyAssociated() => new IdentityError
         {
             Code = nameof(LoginAlreadyAssociated),
             Description = _textService.Localize("user/duplicateLogin")
-        };
-
-        public override IdentityError PasswordMismatch() => new IdentityError
-        {
-            Code = nameof(PasswordMismatch),
-            Description = _textService.Localize("user/passwordMismatch")
-        };
-
-        public override IdentityError PasswordRequiresDigit() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresDigit),
-            Description = _textService.Localize("user/passwordRequiresDigit")
-        };
-
-        public override IdentityError PasswordRequiresLower() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresLower),
-            Description = _textService.Localize("user/passwordRequiresLower")
-        };
-
-        public override IdentityError PasswordRequiresNonAlphanumeric() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresNonAlphanumeric),
-            Description = _textService.Localize("user/passwordRequiresNonAlphanumeric")
-        };
-
-        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) => new IdentityError
-        {
-            Code = nameof(PasswordRequiresUniqueChars),
-            Description = _textService.Localize("user/passwordRequiresUniqueChars", new[] { uniqueChars.ToString() })
-        };
-
-        public override IdentityError PasswordRequiresUpper() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresUpper),
-            Description = _textService.Localize("user/passwordRequiresUpper")
-        };
-
-        public override IdentityError PasswordTooShort(int length) => new IdentityError
-        {
-            Code = nameof(PasswordTooShort),
-            Description = _textService.Localize("user/passwordTooShort", new[] { length.ToString() })
-        };
-
-        public override IdentityError RecoveryCodeRedemptionFailed() => new IdentityError
-        {
-            Code = nameof(RecoveryCodeRedemptionFailed),
-            Description = _textService.Localize("login/resetCodeExpired")
         };
 
         public override IdentityError UserAlreadyHasPassword() => new IdentityError
@@ -131,6 +40,7 @@ namespace Umbraco.Cms.Core.Security
 
         public override IdentityError UserAlreadyInRole(string role) => new IdentityError
         {
+            Code = nameof(UserAlreadyInRole),
             Description = _textService.Localize("user/userHasGroup", new[] { role })
         };
 
@@ -147,48 +57,17 @@ namespace Umbraco.Cms.Core.Security
         };
     }
 
-    public class MembersErrorDescriber : IdentityErrorDescriber
+    public class MembersErrorDescriber : UmbracoErrorDescriberBase
     {
         private readonly ILocalizedTextService _textService;
 
-        public MembersErrorDescriber(ILocalizedTextService textService) => _textService = textService;
-
-        // Overriding all methods in order to provide our own translated error messages
-
-        public override IdentityError ConcurrencyFailure() => new IdentityError
-        {
-            Code = nameof(ConcurrencyFailure),
-            Description = _textService.Localize("errors/concurrencyError")
-        };
-
-        public override IdentityError DefaultError() => new IdentityError
-        {
-            Code = nameof(DefaultError),
-            Description = _textService.Localize("errors/defaultError")
-        };
-
-        public override IdentityError DuplicateEmail(string email) => new IdentityError
-        {
-            Code = nameof(DuplicateEmail),
-            Description = _textService.Localize("validation/duplicateEmail", new[] { email })
-        };
+        public MembersErrorDescriber(ILocalizedTextService textService)
+            : base(textService) => _textService = textService;
 
         public override IdentityError DuplicateRoleName(string role) => new IdentityError
         {
             Code = nameof(DuplicateRoleName),
             Description = _textService.Localize("validation/duplicateMemberGroupName", new[] { role })
-        };
-
-        public override IdentityError DuplicateUserName(string userName) => new IdentityError
-        {
-            Code = nameof(DuplicateUserName),
-            Description = _textService.Localize("validation/duplicateUsername", new[] { userName })
-        };
-
-        public override IdentityError InvalidEmail(string email) => new IdentityError
-        {
-            Code = nameof(InvalidEmail),
-            Description = _textService.Localize("validation/invalidEmail")
         };
 
         public override IdentityError InvalidRoleName(string role) => new IdentityError
@@ -197,70 +76,10 @@ namespace Umbraco.Cms.Core.Security
             Description = _textService.Localize("validation/invalidMemberGroupName")
         };
 
-        public override IdentityError InvalidToken() => new IdentityError
-        {
-            Code = nameof(InvalidToken),
-            Description = _textService.Localize("validation/invalidToken")
-        };
-
-        public override IdentityError InvalidUserName(string userName) => new IdentityError
-        {
-            Code = nameof(InvalidUserName),
-            Description = _textService.Localize("validation/invalidUsername")
-        };
-
         public override IdentityError LoginAlreadyAssociated() => new IdentityError
         {
             Code = nameof(LoginAlreadyAssociated),
             Description = _textService.Localize("member/duplicateMemberLogin")
-        };
-
-        public override IdentityError PasswordMismatch() => new IdentityError
-        {
-            Code = nameof(PasswordMismatch),
-            Description = _textService.Localize("user/passwordMismatch")
-        };
-
-        public override IdentityError PasswordRequiresDigit() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresDigit),
-            Description = _textService.Localize("user/passwordRequiresDigit")
-        };
-
-        public override IdentityError PasswordRequiresLower() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresLower),
-            Description = _textService.Localize("user/passwordRequiresLower")
-        };
-
-        public override IdentityError PasswordRequiresNonAlphanumeric() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresNonAlphanumeric),
-            Description = _textService.Localize("user/passwordRequiresNonAlphanumeric")
-        };
-
-        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) => new IdentityError
-        {
-            Code = nameof(PasswordRequiresUniqueChars),
-            Description = _textService.Localize("user/passwordRequiresUniqueChars", new[] { uniqueChars.ToString() })
-        };
-
-        public override IdentityError PasswordRequiresUpper() => new IdentityError
-        {
-            Code = nameof(PasswordRequiresUpper),
-            Description = _textService.Localize("user/passwordRequiresUpper")
-        };
-
-        public override IdentityError PasswordTooShort(int length) => new IdentityError
-        {
-            Code = nameof(PasswordTooShort),
-            Description = _textService.Localize("user/passwordTooShort", new[] { length.ToString() })
-        };
-
-        public override IdentityError RecoveryCodeRedemptionFailed() => new IdentityError
-        {
-            Code = nameof(RecoveryCodeRedemptionFailed),
-            Description = _textService.Localize("login/resetCodeExpired")
         };
 
         public override IdentityError UserAlreadyHasPassword() => new IdentityError

--- a/src/Umbraco.Infrastructure/Security/UmbracoErrorDescriberBase.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoErrorDescriberBase.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Identity;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;

--- a/src/Umbraco.Infrastructure/Security/UmbracoErrorDescriberBase.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoErrorDescriberBase.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Identity;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Security
+{
+    public abstract class UmbracoErrorDescriberBase : IdentityErrorDescriber
+    {
+        private readonly ILocalizedTextService _textService;
+
+        protected UmbracoErrorDescriberBase(ILocalizedTextService textService) => _textService = textService;
+
+        public override IdentityError ConcurrencyFailure() => new IdentityError
+        {
+            Code = nameof(ConcurrencyFailure),
+            Description = _textService.Localize("errors/concurrencyError")
+        };
+
+        public override IdentityError DefaultError() => new IdentityError
+        {
+            Code = nameof(DefaultError),
+            Description = _textService.Localize("errors/defaultError")
+        };
+
+        public override IdentityError DuplicateEmail(string email) => new IdentityError
+        {
+            Code = nameof(DuplicateEmail),
+            Description = _textService.Localize("validation/duplicateEmail", new[] { email })
+        };
+
+        public override IdentityError DuplicateUserName(string userName) => new IdentityError
+        {
+            Code = nameof(DuplicateUserName),
+            Description = _textService.Localize("validation/duplicateUsername", new[] { userName })
+        };
+
+        public override IdentityError InvalidEmail(string email) => new IdentityError
+        {
+            Code = nameof(InvalidEmail),
+            Description = _textService.Localize("validation/invalidEmail")
+        };
+
+        public override IdentityError InvalidToken() => new IdentityError
+        {
+            Code = nameof(InvalidToken),
+            Description = _textService.Localize("validation/invalidToken")
+        };
+
+        public override IdentityError InvalidUserName(string userName) => new IdentityError
+        {
+            Code = nameof(InvalidUserName),
+            Description = _textService.Localize("validation/invalidUsername")
+        };
+
+        public override IdentityError PasswordMismatch() => new IdentityError
+        {
+            Code = nameof(PasswordMismatch),
+            Description = _textService.Localize("user/passwordMismatch")
+        };
+
+        public override IdentityError PasswordRequiresDigit() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresDigit),
+            Description = _textService.Localize("user/passwordRequiresDigit")
+        };
+
+        public override IdentityError PasswordRequiresLower() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresLower),
+            Description = _textService.Localize("user/passwordRequiresLower")
+        };
+
+        public override IdentityError PasswordRequiresNonAlphanumeric() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresNonAlphanumeric),
+            Description = _textService.Localize("user/passwordRequiresNonAlphanumeric")
+        };
+
+        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) => new IdentityError
+        {
+            Code = nameof(PasswordRequiresUniqueChars),
+            Description = _textService.Localize("user/passwordRequiresUniqueChars", new[] { uniqueChars.ToString() })
+        };
+
+        public override IdentityError PasswordRequiresUpper() => new IdentityError
+        {
+            Code = nameof(PasswordRequiresUpper),
+            Description = _textService.Localize("user/passwordRequiresUpper")
+        };
+
+        public override IdentityError PasswordTooShort(int length) => new IdentityError
+        {
+            Code = nameof(PasswordTooShort),
+            Description = _textService.Localize("user/passwordTooShort", new[] { length.ToString() })
+        };
+
+        public override IdentityError RecoveryCodeRedemptionFailed() => new IdentityError
+        {
+            Code = nameof(RecoveryCodeRedemptionFailed),
+            Description = _textService.Localize("login/resetCodeExpired")
+        };
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -73,7 +73,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
                 _mockPasswordHasher.Object,
                 userValidators,
                 pwdValidators,
-                new MembersErrorDescriber(),
+                new MembersErrorDescriber(Mock.Of<ILocalizedTextService>()),
                 _mockServiceProviders.Object,
                 new Mock<ILogger<UserManager<MemberIdentityUser>>>().Object,
                 _mockPasswordConfiguration.Object,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
                     Mock.Of<IPasswordHasher<MemberIdentityUser>>(),
                     Enumerable.Empty<IUserValidator<MemberIdentityUser>>(),
                     Enumerable.Empty<IPasswordValidator<MemberIdentityUser>>(),
-                    new MembersErrorDescriber(),
+                    new MembersErrorDescriber(Mock.Of<ILocalizedTextService>()),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<ILogger<UserManager<MemberIdentityUser>>>(),
                     Options.Create(new MemberPasswordConfigurationSettings()),

--- a/src/Umbraco.Web.UI.NetCore/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI.NetCore/umbraco/config/lang/en_us.xml
@@ -358,9 +358,14 @@
     <key alias="uploadNotAllowed">Upload is not allowed in this location.</key>
   </area>
   <area alias="member">
-    <key alias="createNewMember">Create a new member</key>
     <key alias="allMembers">All Members</key>
+    <key alias="createNewMember">Create a new member</key>
+    <key alias="duplicateMemberLogin">A member with this login already exists</key>
     <key alias="memberGroupNoProperties">Member groups have no additional properties for editing.</key>
+    <key alias="memberHasGroup">The member is already in group '%0%'</key>
+    <key alias="memberHasPassword">The member already has a password set</key>
+    <key alias="memberLockoutNotEnabled">Lockout is not enabled for this member</key>
+    <key alias="memberNotInGroup">The member is not in group '%0%'</key>
   </area>
   <area alias="contentType">
      <key alias="copyFailed">Failed to copy content type</key>
@@ -656,6 +661,8 @@
     <key alias="errorRegExpWithoutTab">%0% is not in a correct format</key>
   </area>
   <area alias="errors">
+    <key alias="defaultError">An unknown failure has occurred</key>
+    <key alias="concurrencyError">Optimistic concurrency failure, object has been modified</key>
     <key alias="receivedErrorFromServer">Received an error from the server</key>
     <key alias="dissallowedMediaType">The specified file type has been disallowed by the administrator</key>
     <key alias="codemirroriewarning">NOTE! Even though CodeMirror is enabled by configuration, it is disabled in Internet Explorer because it's not stable enough.</key>
@@ -1444,7 +1451,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="validationFailedMessage">Validation errors must be fixed before the item can be saved</key>
     <key alias="operationFailedHeader">Failed</key>
     <key alias="operationSavedHeader">Saved</key>
-      <key alias="operationSavedHeaderReloadUser">Saved.  To view the changes please reload your browser</key>
+    <key alias="operationSavedHeaderReloadUser">Saved. To view the changes please reload your browser</key>
     <key alias="invalidUserPermissionsText">Insufficient user permissions, could not complete the operation</key>
     <key alias="operationCancelledHeader">Cancelled</key>
     <key alias="operationCancelledText">Operation was cancelled by a 3rd party add-in</key>
@@ -1908,6 +1915,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="descriptionField">Description field</key>
     <key alias="disabled">Disable User</key>
     <key alias="documentType">Document Type</key>
+    <key alias="duplicateLogin">A user with this login already exists</key>
     <key alias="editors">Editor</key>
     <key alias="excerptField">Excerpt field</key>
     <key alias="failedPasswordAttempts">Failed login attempts</key>
@@ -1940,6 +1948,12 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="passwordInvalid">Invalid current password</key>
     <key alias="passwordIsDifferent">There was a difference between the new password and the confirmed password. Please try again!</key>
     <key alias="passwordMismatch">The confirmed password doesn't match the new password!</key>
+    <key alias="passwordRequiresDigit">The password must have at least one digit ('0'-'9')</key>
+    <key alias="passwordRequiresLower">The password must have at least one lowercase ('a'-'z')</key>
+    <key alias="passwordRequiresNonAlphanumeric">The password must have at least one non alphanumeric character</key>
+    <key alias="passwordRequiresUniqueChars">The password must use at least %0% different characters</key>
+    <key alias="passwordRequiresUpper">The password must have at least one uppercase ('A'-'Z')</key>
+    <key alias="passwordTooShort">The password must be at least %0% characters long</key>
     <key alias="permissionReplaceChildren">Replace child node permissions</key>
     <key alias="permissionSelectedPages">You are currently modifying permissions for the pages:</key>
     <key alias="permissionSelectPages">Select pages to modify their permissions</key>
@@ -1960,8 +1974,12 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="updateDate">User last updated</key>
     <key alias="userCreated">has been created</key>
     <key alias="userCreatedSuccessHelp">The new user has successfully been created. To log in to Umbraco use the password below.</key>
+    <key alias="userHasPassword">The user already has a password set</key>
+    <key alias="userHasGroup">The user is already in group '%0%'</key>
+    <key alias="userLockoutNotEnabled">Lockout is not enabled for this user</key>
     <key alias="userManagement">User management</key>
     <key alias="username">Name</key>
+    <key alias="userNotInGroup">The user is not in group '%0%'</key>
     <key alias="userPermissions">User permissions</key>
     <key alias="usergroup">User group</key>
     <key alias="userInvited">has been invited</key>
@@ -2111,6 +2129,14 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="invalidNull">Value cannot be null</key>
     <key alias="invalidEmpty">Value cannot be empty</key>
     <key alias="invalidPattern">Value is invalid, it does not match the correct pattern</key>
+    <key alias="invalidMemberGroupName">Invalid member group name</key>
+    <key alias="invalidUserGroupName">Invalid user group name</key>
+    <key alias="invalidToken">Invalid token</key>
+    <key alias="invalidUsername">Invalid username</key>
+    <key alias="duplicateEmail">Email '%0%' is already taken</key>
+    <key alias="duplicateUserGroupName">User group name '%0%' is already taken</key>
+    <key alias="duplicateMemberGroupName">Member group name '%0%' is already taken</key>
+    <key alias="duplicateUsername">Username '%0%' is already taken</key>
     <key alias="customValidation">Custom validation</key>
     <key alias="entriesShort"><![CDATA[Minimum %0% entries, requires <strong>%1%</strong> more.]]></key>
     <key alias="entriesExceed"><![CDATA[Maximum %0% entries, <strong>%1%</strong> too many.]]></key>


### PR DESCRIPTION
## Details

Implementing the following error describers:
- BackOfficeErrorDescriber
- MembersErrorDescriber

By using our own translation engine, `ILocalizedTextService`,  to return localized error message from identity correctly.
Translation keys that were missing for the specific methods of error describers are added to the default language file **en_us.xml**.

---

## Notes
- Every time the IdentityErrorDescriber methods mention "role" we refer to it as _group_;
- For **RecoveryCodeRedemptionFailed** I used `login/resetCodeExpired` key which I found similar to the original description `Recovery code redemption failed`. Let me know if you think that we should add a new key for that!;
- I saw that we use both  member role and member group when referring to members but I kept it as _group_ as I wasn't sure;
- `DuplicateUsername` and `InvalidUsername` are reused for members.
