### PR TITLE
Setting the default culture when no domain rule is defined breaks "ContentFinderByUrl"

### DIFF
--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -319,8 +319,6 @@ namespace Umbraco.Cms.Core.Routing
             {
                 // not matching any existing domain
                 _logger.LogDebug("{TracePrefix}Matches no domain", tracePrefix);
-
-                request.SetCulture(defaultCulture ?? CultureInfo.CurrentUICulture.Name);
             }
 
             _logger.LogDebug("{TracePrefix}Culture={CultureName}", tracePrefix, request.Culture);


### PR DESCRIPTION
fixes #10218