### PR TITLE
Netcore: dotnet new template updates and change HideTopLevelNodeFromPath default value to `true`

### DIFF
--- a/build/templates/UmbracoProject/.template.config/dotnetcli.host.json
+++ b/build/templates/UmbracoProject/.template.config/dotnetcli.host.json
@@ -34,6 +34,6 @@
         "dotnet new umbraco -n MyNewProject",
         "dotnet new umbraco -n MyNewProjectWithCE -ce",
         "dotnet new umbraco -n MyNewProject --no-restore",
-        "dotnet new umbraco -n MyNewProject --friendly-name "Friendly User" --email user@email.com --password password1234 --connection-string "Server=ConnectionStringHere""
+        "dotnet new umbraco -n MyNewProject --friendly-name \"Friendly User\" --email user@email.com --password password1234 --connection-string \"Server=ConnectionStringHere\""
     ]
 }

--- a/build/templates/UmbracoProject/appsettings.Development.json
+++ b/build/templates/UmbracoProject/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/appsettings.json",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information"
@@ -23,6 +24,9 @@
   //#endif
   "Umbraco": {
     "CMS": {
+      "Content": {
+        "MacroErrors": "Throw"
+      },
       //#if (UsingUnattenedInstall)
       "Unattended": {
         "InstallUnattended": true,

--- a/build/templates/UmbracoProject/appsettings.json
+++ b/build/templates/UmbracoProject/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/appsettings.json",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -39,7 +39,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets or sets a value indicating whether to hide the top level node from the path.
         /// </summary>
-        public bool HideTopLevelNodeFromPath { get; set; } = false;
+        public bool HideTopLevelNodeFromPath { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether HTTPS should be used.


### PR DESCRIPTION
* Fixes the dotnet new template issue due to non escaped quotes
* Sets the default in code to HideTopLevel to true
* Explicitly add JSON schema URL to appsettings in case IDEs do no auto map it for the user
