### PR TITLE
Do not change function and class names when minifying JS

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/js.js
@@ -19,12 +19,17 @@ function js() {
     var stream = new MergeStream();
 
     var task = gulp.src(config.sources.globs.js);
+    // NOTE: if you change something here, you probably also need to change it in the processJs util
     if (config.compile.current.minify === true) {
       task = task.pipe(
         minify({
           noSource: true,
           ext: { min: '.min.js' },
-          mangle: false
+          mangle: false,
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true
+          }
         })
       );
     } else {

--- a/src/Umbraco.Web.UI.Client/gulp/util/processJs.js
+++ b/src/Umbraco.Web.UI.Client/gulp/util/processJs.js
@@ -36,12 +36,17 @@ module.exports = function (files, out) {
     
     task = task.pipe(concat(out)).pipe(wrap('(function(){\n%= body %\n})();'))
 
+    // NOTE: if you change something here, you probably also need to change it in the js task
     if (config.compile.current.minify === true) {
       task = task.pipe(
         minify({
           noSource:true,
           ext: {min:'.min.js'},
-          mangle: false
+          mangle: false,
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true
+          }
         })
       );
     } else {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10200

### Description

See the linked issue (https://github.com/umbraco/Umbraco-CMS/issues/10200) for steps to reproduce. Note that this issue only happens for production builds (minified JS).

This PR prevents the JS minification from changing class and function names during compression. At the moment we need those names for locating dependencies up the scope chain (by magic strings).

Unfortunately the current JS build setup is a bit silly, so minification happens in two places. Thus this change has to be applied in both places. This took me a bit to realize, so I have added a comment in both places, referring them to their respective counterparts for future changes.