### PR TITLE
V9: Reintroduce missing friendly get crop url extensions

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -1,0 +1,319 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Media;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Web.Common.DependencyInjection;
+
+namespace Umbraco.Extensions
+{
+    public static class FriendlyImageCropperTemplateExtensions
+    {
+        private static IImageUrlGenerator ImageUrlGenerator { get; } =
+            StaticServiceProvider.Instance.GetRequiredService<IImageUrlGenerator>();
+
+        private static IPublishedValueFallback PublishedValueFallback { get; } =
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>();
+
+        private static IPublishedUrlProvider PublishedUrlProvider { get; } =
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedUrlProvider>();
+
+
+        /// <summary>
+        /// Gets the ImageProcessor URL by the crop alias (from the "umbracoFile" property alias) on the IPublishedContent item
+        /// </summary>
+        /// <param name="mediaItem">
+        /// The IPublishedContent item.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias e.g. thumbnail
+        /// </param>
+        /// <returns>
+        /// The ImageProcessor.Web URL.
+        /// </returns>
+        public static string GetCropUrl(
+            this IPublishedContent mediaItem,
+            string cropAlias) =>
+            mediaItem.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+
+        /// <summary>
+        /// Gets the ImageProcessor URL by the crop alias using the specified property containing the image cropper Json data on the IPublishedContent item.
+        /// </summary>
+        /// <param name="mediaItem">
+        /// The IPublishedContent item.
+        /// </param>
+        /// <param name="propertyAlias">
+        /// The property alias of the property containing the Json data e.g. umbracoFile
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias e.g. thumbnail
+        /// </param>
+        /// <returns>
+        /// The ImageProcessor.Web URL.
+        /// </returns>
+        public static string GetCropUrl(
+            this IPublishedContent mediaItem,
+            string propertyAlias,
+            string cropAlias) =>
+            mediaItem.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+
+        /// <summary>
+        /// Gets the ImageProcessor URL from the IPublishedContent item.
+        /// </summary>
+        /// <param name="mediaItem">
+        /// The IPublishedContent item.
+        /// </param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="propertyAlias">
+        /// Property alias of the property containing the Json data.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point, to generate an output image using the focal point instead of the predefined crop
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters.
+        /// </param>
+        /// <param name="cacheBuster">
+        /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>
+
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static string GetCropUrl(
+            this IPublishedContent mediaItem,
+            int? width = null,
+            int? height = null,
+            string propertyAlias = Cms.Core.Constants.Conventions.Media.File,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            bool cacheBuster = true,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true)
+            => mediaItem.GetCropUrl(
+                ImageUrlGenerator,
+                PublishedValueFallback,
+                PublishedUrlProvider,
+                width,
+                height,
+                propertyAlias,
+                cropAlias,
+                quality,
+                imageCropMode,
+                imageCropAnchor,
+                preferFocalPoint,
+                useCropDimensions,
+                cacheBuster,
+                furtherOptions,
+                ratioMode,
+                upScale
+            );
+
+        /// <summary>
+        /// Gets the ImageProcessor URL from the image path.
+        /// </summary>
+        /// <param name="imageUrl">
+        /// The image URL.
+        /// </param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="imageCropperValue">
+        /// The Json data from the Umbraco Core Image Cropper property editor
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point to generate an output image using the focal point instead of the predefined crop if there is one
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters
+        /// </param>
+        /// <param name="cacheBusterValue">
+        /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static string GetCropUrl(
+            this string imageUrl,
+            IImageUrlGenerator ImageUrlGenerator,
+            int? width = null,
+            int? height = null,
+            string imageCropperValue = null,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            string cacheBusterValue = null,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true)
+            => imageUrl.GetCropUrl(
+                ImageUrlGenerator,
+                width,
+                height,
+                imageCropperValue,
+                cropAlias,
+                quality,
+                imageCropMode,
+                imageCropAnchor,
+                preferFocalPoint,
+                useCropDimensions,
+                cacheBusterValue,
+                furtherOptions,
+                ratioMode,
+                upScale
+                );
+
+        /// <summary>
+        /// Gets the ImageProcessor URL from the image path.
+        /// </summary>
+        /// <param name="imageUrl">
+        /// The image URL.
+        /// </param>
+        /// <param name="cropDataSet"></param>
+        /// <param name="width">
+        /// The width of the output image.
+        /// </param>
+        /// <param name="height">
+        /// The height of the output image.
+        /// </param>
+        /// <param name="cropAlias">
+        /// The crop alias.
+        /// </param>
+        /// <param name="quality">
+        /// Quality percentage of the output image.
+        /// </param>
+        /// <param name="imageCropMode">
+        /// The image crop mode.
+        /// </param>
+        /// <param name="imageCropAnchor">
+        /// The image crop anchor.
+        /// </param>
+        /// <param name="preferFocalPoint">
+        /// Use focal point to generate an output image using the focal point instead of the predefined crop if there is one
+        /// </param>
+        /// <param name="useCropDimensions">
+        /// Use crop dimensions to have the output image sized according to the predefined crop sizes, this will override the width and height parameters
+        /// </param>
+        /// <param name="cacheBusterValue">
+        /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
+        /// </param>
+        /// <param name="furtherOptions">
+        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// <example>
+        /// <![CDATA[
+        /// furtherOptions: "&bgcolor=fff"
+        /// ]]>
+        /// </example>
+        /// </param>
+        /// <param name="ratioMode">
+        /// Use a dimension as a ratio
+        /// </param>
+        /// <param name="upScale">
+        /// If the image should be upscaled to requested dimensions
+        /// </param>
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static string GetCropUrl(
+            this string imageUrl,
+            ImageCropperValue cropDataSet,
+            int? width = null,
+            int? height = null,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            string cacheBusterValue = null,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true,
+            string animationProcessMode = null)
+            => imageUrl.GetCropUrl(
+                ImageUrlGenerator,
+                cropDataSet,
+                width,
+                height,
+                cropAlias,
+                quality, imageCropMode,
+                imageCropAnchor,
+                preferFocalPoint,
+                useCropDimensions,
+                cacheBusterValue,
+                furtherOptions,
+                ratioMode,
+                upScale,
+                animationProcessMode
+            );
+    }
+}

--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Extensions
 
 
         /// <summary>
-        /// Gets the ImageProcessor URL by the crop alias (from the "umbracoFile" property alias) on the IPublishedContent item
+        /// Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias) on the IPublishedContent item
         /// </summary>
         /// <param name="mediaItem">
         /// The IPublishedContent item.
@@ -30,7 +30,7 @@ namespace Umbraco.Extensions
         /// The crop alias e.g. thumbnail
         /// </param>
         /// <returns>
-        /// The ImageProcessor.Web URL.
+        /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
@@ -38,7 +38,7 @@ namespace Umbraco.Extensions
             mediaItem.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
 
         /// <summary>
-        /// Gets the ImageProcessor URL by the crop alias using the specified property containing the image cropper Json data on the IPublishedContent item.
+        /// Gets the underlying image processing service URL by the crop alias using the specified property containing the image cropper Json data on the IPublishedContent item.
         /// </summary>
         /// <param name="mediaItem">
         /// The IPublishedContent item.
@@ -50,7 +50,7 @@ namespace Umbraco.Extensions
         /// The crop alias e.g. thumbnail
         /// </param>
         /// <returns>
-        /// The ImageProcessor.Web URL.
+        /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
@@ -59,7 +59,7 @@ namespace Umbraco.Extensions
             mediaItem.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
 
         /// <summary>
-        /// Gets the ImageProcessor URL from the IPublishedContent item.
+        /// Gets the underlying image processing service URL from the IPublishedContent item.
         /// </summary>
         /// <param name="mediaItem">
         /// The IPublishedContent item.
@@ -95,7 +95,7 @@ namespace Umbraco.Extensions
         /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
         /// </param>
         /// <param name="furtherOptions">
-        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// These are any query string parameters (formatted as query strings) that the underlying image processing service supports. For example:
         /// <example>
         /// <![CDATA[
         /// furtherOptions: "&bgcolor=fff"
@@ -108,9 +108,8 @@ namespace Umbraco.Extensions
         /// <param name="upScale">
         /// If the image should be upscaled to requested dimensions
         /// </param>
-
         /// <returns>
-        /// The <see cref="string"/>.
+        /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
@@ -147,7 +146,7 @@ namespace Umbraco.Extensions
             );
 
         /// <summary>
-        /// Gets the ImageProcessor URL from the image path.
+        /// Gets the underlying image processing service URL from the image path.
         /// </summary>
         /// <param name="imageUrl">
         /// The image URL.
@@ -183,7 +182,7 @@ namespace Umbraco.Extensions
         /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
         /// </param>
         /// <param name="furtherOptions">
-        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// These are any query string parameters (formatted as query strings) that the underlying image processing service supports. For example:
         /// <example>
         /// <![CDATA[
         /// furtherOptions: "&bgcolor=fff"
@@ -197,11 +196,10 @@ namespace Umbraco.Extensions
         /// If the image should be upscaled to requested dimensions
         /// </param>
         /// <returns>
-        /// The <see cref="string"/>.
+        /// The the URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this string imageUrl,
-            IImageUrlGenerator ImageUrlGenerator,
             int? width = null,
             int? height = null,
             string imageCropperValue = null,
@@ -233,7 +231,7 @@ namespace Umbraco.Extensions
                 );
 
         /// <summary>
-        /// Gets the ImageProcessor URL from the image path.
+        /// Gets the underlying image processing service URL from the image path.
         /// </summary>
         /// <param name="imageUrl">
         /// The image URL.
@@ -267,7 +265,7 @@ namespace Umbraco.Extensions
         /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
         /// </param>
         /// <param name="furtherOptions">
-        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// These are any query string parameters (formatted as query strings) that the underlying image processing service supports. For example:
         /// <example>
         /// <![CDATA[
         /// furtherOptions: "&bgcolor=fff"
@@ -281,7 +279,7 @@ namespace Umbraco.Extensions
         /// If the image should be upscaled to requested dimensions
         /// </param>
         /// <returns>
-        /// The <see cref="string"/>.
+        /// The the URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this string imageUrl,

--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Extensions
     public static class ImageCropperTemplateCoreExtensions
     {
         /// <summary>
-        /// Gets the ImageProcessor URL by the crop alias (from the "umbracoFile" property alias) on the IPublishedContent item
+        /// Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias) on the IPublishedContent item
         /// </summary>
         /// <param name="mediaItem">
         /// The IPublishedContent item.
@@ -24,7 +24,7 @@ namespace Umbraco.Extensions
         /// <param name="publishedValueFallback">The published value fallback.</param>
         /// <param name="publishedUrlProvider">The published url provider.</param>
         /// <returns>
-        /// The ImageProcessor.Web URL.
+        /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
@@ -37,7 +37,7 @@ namespace Umbraco.Extensions
         }
 
         /// <summary>
-        /// Gets the ImageProcessor URL by the crop alias using the specified property containing the image cropper Json data on the IPublishedContent item.
+        /// Gets the underlying image processing service URL by the crop alias using the specified property containing the image cropper Json data on the IPublishedContent item.
         /// </summary>
         /// <param name="mediaItem">
         /// The IPublishedContent item.
@@ -52,7 +52,7 @@ namespace Umbraco.Extensions
         /// <param name="publishedValueFallback">The published value fallback.</param>
         /// <param name="publishedUrlProvider">The published url provider.</param>
         /// <returns>
-        /// The ImageProcessor.Web URL.
+        /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
@@ -66,7 +66,7 @@ namespace Umbraco.Extensions
         }
 
         /// <summary>
-        /// Gets the ImageProcessor URL from the IPublishedContent item.
+        /// Gets the underlying image processing service URL from the IPublishedContent item.
         /// </summary>
         /// <param name="mediaItem">
         /// The IPublishedContent item.
@@ -118,9 +118,8 @@ namespace Umbraco.Extensions
         /// <param name="upScale">
         /// If the image should be upscaled to requested dimensions
         /// </param>
-
         /// <returns>
-        /// The <see cref="string"/>.
+        /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
              this IPublishedContent mediaItem,
@@ -179,7 +178,7 @@ namespace Umbraco.Extensions
         }
 
         /// <summary>
-        /// Gets the ImageProcessor URL from the image path.
+        /// Gets the underlying image processing service URL from the image path.
         /// </summary>
         /// <param name="imageUrl">
         /// The image URL.
@@ -215,7 +214,7 @@ namespace Umbraco.Extensions
         /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
         /// </param>
         /// <param name="furtherOptions">
-        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// These are any query string parameters (formatted as query strings) that the underlying image processing service supports. For example:
         /// <example>
         /// <![CDATA[
         /// furtherOptions: "&bgcolor=fff"
@@ -229,7 +228,7 @@ namespace Umbraco.Extensions
         /// If the image should be upscaled to requested dimensions
         /// </param>
         /// <returns>
-        /// The <see cref="string"/>.
+        /// The the URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this string imageUrl,
@@ -261,7 +260,7 @@ namespace Umbraco.Extensions
         }
 
         /// <summary>
-        /// Gets the ImageProcessor URL from the image path.
+        /// Gets the underlying image processing service URL from the image path.
         /// </summary>
         /// <param name="imageUrl">
         /// The image URL.
@@ -298,7 +297,7 @@ namespace Umbraco.Extensions
         /// Add a serialized date of the last edit of the item to ensure client cache refresh when updated
         /// </param>
         /// <param name="furtherOptions">
-        /// These are any query string parameters (formatted as query strings) that ImageProcessor supports. For example:
+        /// These are any query string parameters (formatted as query strings) that the underlying image processing service supports. For example:
         /// <example>
         /// <![CDATA[
         /// furtherOptions: "&bgcolor=fff"


### PR DESCRIPTION
 Reintroduce missing friendly `GetCropUrl` extensions by using the internal service locator to inject the required services.
