### PR TITLE
V9: Bugfix for modelsbuilder when having inherited doctypes

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentModel.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentModel.cs
@@ -12,8 +12,10 @@
         /// an original <see cref="IPublishedContent"/> instance.
         /// </summary>
         /// <param name="content">The original content.</param>
-        protected PublishedContentModel(IPublishedContent content)
-            : base(content)
+        protected PublishedContentModel(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
+            : base(content, publishedValueFallback)
         { }
+
+
     }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -21,15 +21,18 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
     public abstract class PublishedContentWrapped : IPublishedContent
     {
         private readonly IPublishedContent _content;
+        private readonly IPublishedValueFallback _publishedValueFallback;
 
         /// <summary>
         /// Initialize a new instance of the <see cref="PublishedContentWrapped"/> class
         /// with an <c>IPublishedContent</c> instance to wrap.
         /// </summary>
         /// <param name="content">The content to wrap.</param>
-        protected PublishedContentWrapped(IPublishedContent content)
+        /// <param name="publishedValueFallback">The published value fallback.</param>
+        protected PublishedContentWrapped(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
         {
             _content = content;
+            _publishedValueFallback = publishedValueFallback;
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedElementModel.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedElementModel.cs
@@ -14,8 +14,9 @@
         /// an original <see cref="IPublishedElement"/> instance.
         /// </summary>
         /// <param name="content">The original content.</param>
-        protected PublishedElementModel(IPublishedElement content)
-            : base(content)
+        /// <param name="publishedValueFallback">The published value fallback.</param>
+        protected PublishedElementModel(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
+            : base(content, publishedValueFallback)
         { }
     }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedElementWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedElementWrapped.cs
@@ -10,15 +10,18 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
     public abstract class PublishedElementWrapped : IPublishedElement
     {
         private readonly IPublishedElement _content;
+        private readonly IPublishedValueFallback _publishedValueFallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PublishedElementWrapped"/> class
         /// with an <c>IPublishedElement</c> instance to wrap.
         /// </summary>
         /// <param name="content">The content to wrap.</param>
-        protected PublishedElementWrapped(IPublishedElement content)
+        /// <param name="publishedValueFallback">The published value fallback.</param>
+        protected PublishedElementWrapped(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
         {
             _content = content;
+            _publishedValueFallback = publishedValueFallback;
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -195,7 +195,7 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder.Building
             sb.Append("\t\tprivate IPublishedValueFallback _publishedValueFallback;");
 
             // write the ctor
-            sb.AppendFormat("\n\n\t\t// ctor\n\t\tpublic {0}(IPublished{1} content, IPublishedValueFallback publishedValueFallback)\n\t\t\t: base(content)\n\t\t{{\n\t\t\t_publishedValueFallback = publishedValueFallback;\n\t\t}}\n\n",
+            sb.AppendFormat("\n\n\t\t// ctor\n\t\tpublic {0}(IPublished{1} content, IPublishedValueFallback publishedValueFallback)\n\t\t\t: base(content, publishedValueFallback)\n\t\t{{\n\t\t\t_publishedValueFallback = publishedValueFallback;\n\t\t}}\n\n",
                 type.ClrName, type.IsElement ? "Element" : "Content");
 
             // write the properties

--- a/src/Umbraco.Tests.Common/Published/PublishedSnapshotTestObjects.cs
+++ b/src/Umbraco.Tests.Common/Published/PublishedSnapshotTestObjects.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Tests.Common.Published
         public class TestElementModel1 : PublishedElementModel
         {
             public TestElementModel1(IPublishedElement content, IPublishedValueFallback fallback)
-                : base(content)
+                : base(content, fallback)
             {
             }
 
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Tests.Common.Published
         public class TestElementModel2 : PublishedElementModel
         {
             public TestElementModel2(IPublishedElement content, IPublishedValueFallback fallback)
-                : base(content)
+                : base(content, fallback)
             {
             }
 
@@ -36,7 +36,7 @@ namespace Umbraco.Cms.Tests.Common.Published
         public class TestContentModel1 : PublishedContentModel
         {
             public TestContentModel1(IPublishedContent content, IPublishedValueFallback fallback)
-                : base(content)
+                : base(content, fallback)
             {
             }
 
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Tests.Common.Published
         public class TestContentModel2 : PublishedContentModel
         {
             public TestContentModel2(IPublishedContent content, IPublishedValueFallback fallback)
-                : base(content)
+                : base(content, fallback)
             {
             }
 

--- a/src/Umbraco.Tests.Common/TestHelpers/SolidPublishedSnapshot.cs
+++ b/src/Umbraco.Tests.Common/TestHelpers/SolidPublishedSnapshot.cs
@@ -300,7 +300,7 @@ namespace Umbraco.Cms.Tests.Common.TestHelpers
     public class ContentType2 : PublishedContentModel
     {
         public ContentType2(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content)
+            : base(content, fallback)
         {
         }
 
@@ -319,7 +319,7 @@ namespace Umbraco.Cms.Tests.Common.TestHelpers
     public class PublishedContentStrong1 : PublishedContentModel
     {
         public PublishedContentStrong1(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content)
+            : base(content, fallback)
         {
         }
 
@@ -339,7 +339,7 @@ namespace Umbraco.Cms.Tests.Common.TestHelpers
     public class PublishedContentStrong2 : PublishedContentModel
     {
         public PublishedContentStrong2(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content)
+            : base(content, fallback)
         {
         }
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/NestedContentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/NestedContentTests.cs
@@ -96,7 +96,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
                 {
                     if (element.ContentType.Alias.InvariantEquals("contentN1"))
                     {
-                        return new TestElementModel(element);
+                        return new TestElementModel(element, Mock.Of<IPublishedValueFallback>());
                     }
 
                     return element;
@@ -236,8 +236,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
 
         public class TestElementModel : PublishedElementModel
         {
-            public TestElementModel(IPublishedElement content)
-                : base(content)
+            public TestElementModel(IPublishedElement content, IPublishedValueFallback fallback)
+                : base(content, fallback)
             {
             }
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.ModelsBuilder.Embedded/BuilderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.ModelsBuilder.Embedded/BuilderTests.cs
@@ -88,7 +88,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 
 		// ctor
 		public Type1(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
-			: base(content)
+			: base(content, publishedValueFallback)
 		{
 			_publishedValueFallback = publishedValueFallback;
 		}
@@ -194,7 +194,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 
 		// ctor
 		public Type1(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
-			: base(content)
+			: base(content, publishedValueFallback)
 		{
 			_publishedValueFallback = publishedValueFallback;
 		}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/ContentModelBinderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/ContentModelBinderTests.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
             ModelBindingContext bindingContext = new DefaultModelBindingContext();
 
             // Act
-            _contentModelBinder.BindModel(bindingContext, new ContentModel<ContentType2>(new ContentType2(pc)), typeof(ContentModel<ContentType1>));
+            _contentModelBinder.BindModel(bindingContext, new ContentModel<ContentType2>(new ContentType2(pc, Mock.Of<IPublishedValueFallback>())), typeof(ContentModel<ContentType1>));
 
             // Assert
             Assert.True(bindingContext.Result.IsModelSet);
@@ -132,7 +132,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
         [Test]
         public void BindModel_Returns_If_Same_Type()
         {
-            var content = new ContentType1(Mock.Of<IPublishedContent>());
+            var content = new ContentType1(Mock.Of<IPublishedContent>(), Mock.Of<IPublishedValueFallback>());
             var bindingContext = new DefaultModelBindingContext();
 
             _contentModelBinder.BindModel(bindingContext, content, typeof(ContentType1));
@@ -143,7 +143,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
         [Test]
         public void BindModel_RenderModel_To_IPublishedContent()
         {
-            var content = new ContentType1(Mock.Of<IPublishedContent>());
+            var content = new ContentType1(Mock.Of<IPublishedContent>(), Mock.Of<IPublishedValueFallback>());
             var renderModel = new ContentModel(content);
 
             var bindingContext = new DefaultModelBindingContext();
@@ -155,7 +155,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
         [Test]
         public void BindModel_IPublishedContent_To_RenderModel()
         {
-            var content = new ContentType1(Mock.Of<IPublishedContent>());
+            var content = new ContentType1(Mock.Of<IPublishedContent>(), Mock.Of<IPublishedValueFallback>());
             var bindingContext = new DefaultModelBindingContext();
 
             _contentModelBinder.BindModel(bindingContext, content, typeof(ContentModel));
@@ -167,7 +167,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
         [Test]
         public void BindModel_IPublishedContent_To_Generic_RenderModel()
         {
-            var content = new ContentType1(Mock.Of<IPublishedContent>());
+            var content = new ContentType1(Mock.Of<IPublishedContent>(), Mock.Of<IPublishedValueFallback>());
             var bindingContext = new DefaultModelBindingContext();
 
             _contentModelBinder.BindModel(bindingContext, content, typeof(ContentModel<ContentType1>));
@@ -223,20 +223,20 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ModelBinders
         {
         }
 
-        private IPublishedContent CreatePublishedContent() => new ContentType2(new Mock<IPublishedContent>().Object);
+        private IPublishedContent CreatePublishedContent() => new ContentType2(new Mock<IPublishedContent>().Object, Mock.Of<IPublishedValueFallback>());
 
         public class ContentType1 : PublishedContentWrapped
         {
-            public ContentType1(IPublishedContent content)
-                : base(content)
+            public ContentType1(IPublishedContent content, IPublishedValueFallback fallback)
+                : base(content, fallback)
             {
             }
         }
 
         public class ContentType2 : ContentType1
         {
-            public ContentType2(IPublishedContent content)
-                : base(content)
+            public ContentType2(IPublishedContent content, IPublishedValueFallback fallback)
+                : base(content, fallback)
             {
             }
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Views/UmbracoViewPageTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Views/UmbracoViewPageTests.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_To_RenderModel()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel(content);
             var view = new RenderModelTestPage();
             ViewDataDictionary<ContentModel> viewData = GetViewDataDictionary<ContentModel>(model);
@@ -33,7 +33,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_ContentType1_To_ContentType1()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var view = new ContentType1TestPage();
             ViewDataDictionary<ContentType1> viewData = GetViewDataDictionary<ContentType1>(content);
 
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_ContentType2_To_ContentType1()
         {
-            var content = new ContentType2(null);
+            var content = new ContentType2(null, Mock.Of<IPublishedValueFallback>());
             var view = new ContentType1TestPage();
 
             ViewDataDictionary<ContentType1> viewData = GetViewDataDictionary<ContentType1>(content);
@@ -57,7 +57,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_ContentType1_To_ContentType2()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel(content);
             var view = new ContentType2TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(model);
@@ -68,7 +68,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_ContentType1_To_RenderModelOf_ContentType1()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new RenderModelOfContentType1TestPage();
             ViewDataDictionary<ContentModel<ContentType1>> viewData = GetViewDataDictionary<ContentModel<ContentType1>>(model);
@@ -82,7 +82,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_ContentType2_To_RenderModelOf_ContentType1()
         {
-            var content = new ContentType2(null);
+            var content = new ContentType2(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new RenderModelOfContentType1TestPage();
             ViewDataDictionary<ContentModel<ContentType1>> viewData = GetViewDataDictionary<ContentModel<ContentType1>>(model);
@@ -95,7 +95,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModel_ContentType1_To_RenderModelOf_ContentType2()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel(content);
             var view = new RenderModelOfContentType2TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(model);
@@ -106,7 +106,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType1_To_RenderModel()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new RenderModelTestPage();
             ViewDataDictionary<ContentModel> viewData = GetViewDataDictionary<ContentModel>(model);
@@ -119,7 +119,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType1_To_ContentType1()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new ContentType1TestPage();
             ViewDataDictionary<ContentModel<ContentType1>> viewData = GetViewDataDictionary<ContentModel<ContentType1>>(model);
@@ -132,7 +132,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType2_To_ContentType1()
         {
-            var content = new ContentType2(null);
+            var content = new ContentType2(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType2>(content);
             var view = new ContentType1TestPage();
             var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
@@ -148,7 +148,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType1_To_ContentType2()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new ContentType2TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(model);
@@ -159,7 +159,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType1_To_RenderModelOf_ContentType1()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new RenderModelOfContentType1TestPage();
             ViewDataDictionary<ContentModel<ContentType1>> viewData = GetViewDataDictionary<ContentModel<ContentType1>>(model);
@@ -173,7 +173,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType2_To_RenderModelOf_ContentType1()
         {
-            var content = new ContentType2(null);
+            var content = new ContentType2(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new RenderModelOfContentType1TestPage();
             ViewDataDictionary<ContentModel<ContentType1>> viewData = GetViewDataDictionary<ContentModel<ContentType1>>(model);
@@ -187,7 +187,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void RenderModelOf_ContentType1_To_RenderModelOf_ContentType2()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var model = new ContentModel<ContentType1>(content);
             var view = new RenderModelOfContentType2TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(model);
@@ -198,7 +198,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void ContentType1_To_RenderModel()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var view = new RenderModelTestPage();
 
             ViewDataDictionary<ContentType1> viewData = GetViewDataDictionary<ContentType1>(content);
@@ -211,7 +211,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void ContentType1_To_RenderModelOf_ContentType1()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var view = new RenderModelOfContentType1TestPage();
 
             ViewDataDictionary<ContentType1> viewData = GetViewDataDictionary<ContentType1>(content);
@@ -225,7 +225,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         public void ContentType2_To_RenderModelOf_ContentType1()
         {
             // Same as above but with ContentModel<ContentType2>
-            var content = new ContentType2(null);
+            var content = new ContentType2(null, Mock.Of<IPublishedValueFallback>());
             var view = new RenderModelOfContentType1TestPage();
             ViewDataDictionary<ContentType2> viewData = GetViewDataDictionary<ContentType2>(content);
 
@@ -238,7 +238,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void ContentType1_To_RenderModelOf_ContentType2()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var view = new RenderModelOfContentType2TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(content);
 
@@ -248,7 +248,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void ContentType1_To_ContentType1()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var view = new ContentType1TestPage();
             ViewDataDictionary<ContentType1> viewData = GetViewDataDictionary<ContentType1>(content);
 
@@ -260,7 +260,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void ContentType1_To_ContentType2()
         {
-            var content = new ContentType1(null);
+            var content = new ContentType1(null, Mock.Of<IPublishedValueFallback>());
             var view = new ContentType2TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(content);
 
@@ -270,7 +270,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
         [Test]
         public void ContentType2_To_ContentType1()
         {
-            var content = new ContentType2(null);
+            var content = new ContentType2(null, Mock.Of<IPublishedValueFallback>());
             var view = new ContentType1TestPage();
             ViewDataDictionary viewData = GetViewDataDictionary(content);
 
@@ -296,16 +296,16 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Views
 
         public class ContentType1 : PublishedContentWrapped
         {
-            public ContentType1(IPublishedContent content)
-                : base(content)
+            public ContentType1(IPublishedContent content, IPublishedValueFallback fallback)
+                : base(content, fallback)
             {
             }
         }
 
         public class ContentType2 : ContentType1
         {
-            public ContentType2(IPublishedContent content)
-                : base(content)
+            public ContentType2(IPublishedContent content, IPublishedValueFallback fallback)
+                : base(content, fallback)
             {
             }
         }

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Hosting;
@@ -28,7 +29,6 @@ using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Extensions;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Web.Composing;
-using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Tests.PublishedContent
 {
@@ -248,7 +248,7 @@ namespace Umbraco.Tests.PublishedContent
         internal class Home : PublishedContentModel
         {
             public Home(IPublishedContent content, IPublishedValueFallback fallback)
-                : base(content)
+                : base(content, fallback)
             {}
         }
 
@@ -256,7 +256,7 @@ namespace Umbraco.Tests.PublishedContent
         internal class Anything : PublishedContentModel
         {
             public Anything(IPublishedContent content, IPublishedValueFallback fallback)
-                : base(content)
+                : base(content, fallback)
             { }
         }
 

--- a/src/Umbraco.Tests/PublishedContent/SolidPublishedSnapshot.cs
+++ b/src/Umbraco.Tests/PublishedContent/SolidPublishedSnapshot.cs
@@ -361,7 +361,7 @@ namespace Umbraco.Tests.PublishedContent
         #region Plumbing
 
         public ContentType2(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content)
+            : base(content, fallback)
         { }
 
         #endregion
@@ -384,7 +384,7 @@ namespace Umbraco.Tests.PublishedContent
     public class PublishedContentStrong1 : PublishedContentModel
     {
         public PublishedContentStrong1(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content)
+            : base(content, fallback)
         { }
 
         public int StrongValue => this.Value<int>(Mock.Of<IPublishedValueFallback>(), "strongValue");
@@ -402,7 +402,7 @@ namespace Umbraco.Tests.PublishedContent
     public class PublishedContentStrong2 : PublishedContentModel
     {
         public PublishedContentStrong2(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content)
+            : base(content, fallback)
         { }
 
         public int StrongValue => this.Value<int>(Mock.Of<IPublishedValueFallback>(), "strongValue");


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10232

# Details
- Fixed issue with ModelsBuilder that was failing when you created inherited doc types


# Test
- Create an inherited doc type:
![image](https://user-images.githubusercontent.com/1561480/117271334-5b7adb80-ae5a-11eb-8e7c-0004739e9f78.png)
- Create some content with that nested doc type (HomePage in the image)
- Ensure you can use ModelsBuilder properties from both the child and parent doc type (Layout and Homepage in the image)
