### PR TITLE
V9 Netcore: Fix missing launch browser param for dotnet run from template

### DIFF
--- a/build/templates/UmbracoProject/Properties/launchSettings.json
+++ b/build/templates/UmbracoProject/Properties/launchSettings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
@@ -17,6 +18,7 @@
     },
     "Umbraco.Web.UI.NetCore": {
       "commandName": "Project",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/Umbraco.Web.UI.NetCore/Properties/launchSettings.json
+++ b/src/Umbraco.Web.UI.NetCore/Properties/launchSettings.json
@@ -1,4 +1,5 @@
-﻿{
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
@@ -17,6 +18,7 @@
     },
     "Umbraco.Web.UI.NetCore": {
       "commandName": "Project",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
Adds in the missing launchBrowser property to the launchSettings.json and also adds inline JSON Schema property so you can get intellisense to add the full blown IIS profile if you want to as well.

This should fix the problem that @crgrieve had at last nights learn-athon