### PR TITLE
V9: Do not save runtime level in ctors

### DIFF
--- a/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
+++ b/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
@@ -10,8 +10,9 @@ namespace Umbraco.Cms.Core.PublishedCache
     public class DefaultCultureAccessor : IDefaultCultureAccessor
     {
         private readonly ILocalizationService _localizationService;
+        private readonly IRuntimeState _runtimeState;
         private readonly IOptions<GlobalSettings> _options;
-        private readonly RuntimeLevel _runtimeLevel;
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCultureAccessor"/> class.
@@ -19,12 +20,13 @@ namespace Umbraco.Cms.Core.PublishedCache
         public DefaultCultureAccessor(ILocalizationService localizationService, IRuntimeState runtimeState, IOptions<GlobalSettings> options)
         {
             _localizationService = localizationService;
+            _runtimeState = runtimeState;
             _options = options;
-            _runtimeLevel = runtimeState.Level;
+
         }
 
         /// <inheritdoc />
-        public string DefaultCulture => _runtimeLevel == RuntimeLevel.Run
+        public string DefaultCulture => _runtimeState.Level == RuntimeLevel.Run
             ? _localizationService.GetDefaultLanguageIsoCode() ?? "" // fast
             : _options.Value.DefaultUILanguage; // default for install and upgrade, when the service is n/a
     }


### PR DESCRIPTION
# Details:

Fixed some bugs that were caused by us saving the runtime level in the ctor, before it was determined.

# Test:
1) You can use the debugger and ensure the runtime level is now not `Unknown` anymore.
2) You can change the default language and use a dictionary item in a view. Then you will now see the correct default language from the service is used instead of the one in config.