### PR TITLE
Added target="_blank" to "Update available" link

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/main.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/main.controller.js
@@ -118,7 +118,8 @@ function MainController($scope, $location, appState, treeService, notificationsS
                         message: "Click to download",
                         sticky: true,
                         type: "info",
-                        url: update.url
+                        url: update.url,
+                        target: "_blank"
                     };
                     notificationsService.add(notification);
                 }


### PR DESCRIPTION
Feels a bit weird that the **Update available** link opens in the same window, so I've set the `target` option to `_blank`.

![image](https://user-images.githubusercontent.com/3634580/117422807-4ff1e800-af20-11eb-89bd-5d7737c05d86.png)
