### PR TITLE
V9: Fix search ordering of view locations

### DIFF
--- a/src/Umbraco.Web.Website/ViewEngines/RenderRazorViewEngineOptionsSetup.cs
+++ b/src/Umbraco.Web.Website/ViewEngines/RenderRazorViewEngineOptionsSetup.cs
@@ -31,9 +31,10 @@ namespace Umbraco.Cms.Web.Website.ViewEngines
             {
                 string[] umbViewLocations = new string[]
                 {
+                    "/Views/{0}.cshtml",
+                    "/Views/Shared/{0}.cshtml",
                     "/Views/Partials/{0}.cshtml",
                     "/Views/MacroPartials/{0}.cshtml",
-                    "/Views/{0}.cshtml"
                 };
 
                 viewLocations = umbViewLocations.Concat(viewLocations);


### PR DESCRIPTION
### Description
Fixes the ordering in which the views locations are searched and also added the shared folder like in v8: https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Mvc/RenderViewEngine.cs


Also added `/Views/Shared/{0}.cshtml` as a search location