### PR TITLE
V9 - Include models folder in the project

### DIFF
--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -18,16 +18,13 @@
         <Compile Remove="umbraco\Data\**" />
         <Compile Remove="umbraco\logs\**" />
         <Compile Remove="umbraco\MediaCache\**" />
-        <Compile Remove="umbraco\models\**" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Remove="umbraco\Data\**" />
         <EmbeddedResource Remove="umbraco\logs\**" />
         <EmbeddedResource Remove="umbraco\MediaCache\**" />
-        <EmbeddedResource Remove="umbraco\models\**" />
     </ItemGroup>
     <ItemGroup>
-        <None Remove="umbraco\models\**" />
         <None Remove="umbraco\Data\**" />
         <None Remove="umbraco\logs\**" />
         <None Remove="umbraco\MediaCache\**" />
@@ -44,7 +41,6 @@
         <Content Remove="umbraco\Data\**" />
         <Content Remove="umbraco\logs\**" />
         <Content Remove="umbraco\MediaCache\**" />
-        <Content Remove="umbraco\models\**" />
     </ItemGroup>
 
     <!--Set this to true ModelsBuilder mode is not PureLive -->

--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// </summary>
         /// <remarks>
         /// Models become out-of-date when data types or content types are updated. When this
-        /// setting is activated the ~/App_Data/Models/ood.txt file is then created. When models are
+        /// setting is activated the ~/umbraco/models/PureLive/ood.txt file is then created. When models are
         /// generated through the dashboard, the files is cleared. Default value is <c>false</c>.
         /// </remarks>
         public bool FlagOutOfDateModels
@@ -51,8 +51,9 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets or sets a value for the models directory.
         /// </summary>
-        /// <remarks>Default is ~/App_Data/Models but that can be changed.</remarks>
+        /// <remarks>Default is ~/umbraco/models but that can be changed.</remarks>
         public string ModelsDirectory { get; set; } = DefaultModelsDirectory;
+
 
         /// <summary>
         /// Gets or sets a value indicating whether to accept an unsafe value for ModelsDirectory.

--- a/src/Umbraco.Web.Common/ModelsBuilder/PureLiveModelFactory.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/PureLiveModelFactory.cs
@@ -344,7 +344,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
         }
 
 
-        public string PureLiveDirectoryAbsolute() => _hostingEnvironment.MapPathContentRoot("~/App_Data/Temp/PureLive");
+        public string PureLiveDirectoryAbsolute() => _hostingEnvironment.MapPathContentRoot("~/umbraco/Data/TEMP/PureLive");
 
 
         // This is NOT thread safe but it is only called from within a lock

--- a/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
+++ b/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Folder Include="App_Plugins" />
+    <Folder Include="umbraco\models\" />
     <Folder Include="Views" />
     <Folder Include="wwwroot\Media" />
   </ItemGroup>
@@ -28,7 +29,6 @@
     <Compile Remove="umbraco\Data\**" />
     <Compile Remove="umbraco\logs\**" />
     <Compile Remove="umbraco\MediaCache\**" />
-    <Compile Remove="umbraco\models\**" />
     <Compile Remove="wwwroot\Umbraco\**" />
     <Compile Remove="App_Data\**" />
   </ItemGroup>
@@ -56,11 +56,14 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </None>
+    <None Include="umbraco\**\*.*">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </None>
     <None Remove="App_Data\**" />
     <None Remove="umbraco\Data\**" />
     <None Remove="umbraco\logs\**" />
     <None Remove="umbraco\MediaCache\**" />
-    <None Remove="umbraco\models\**" />
     <None Include="umbraco\UmbracoWebsite\NoNodes.cshtml" />
     <None Remove="scripts\aaa\fc75309db05f41609a9e1adb8cf0998c.tmp" />
   </ItemGroup>

--- a/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
+++ b/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
@@ -37,7 +37,6 @@
     <EmbeddedResource Remove="umbraco\Data\**" />
     <EmbeddedResource Remove="umbraco\logs\**" />
     <EmbeddedResource Remove="umbraco\MediaCache\**" />
-    <EmbeddedResource Remove="umbraco\models\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,7 +44,6 @@
     <Content Remove="umbraco\Data\**" />
     <Content Remove="umbraco\logs\**" />
     <Content Remove="umbraco\MediaCache\**" />
-    <Content Remove="umbraco\models\**" />
     <Content Remove="wwwroot\Web.config" />
   </ItemGroup>
 

--- a/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
+++ b/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <Folder Include="App_Plugins" />
-    <Folder Include="umbraco\models\" />
     <Folder Include="Views" />
     <Folder Include="wwwroot\Media" />
   </ItemGroup>
@@ -66,6 +65,7 @@
     <None Remove="umbraco\MediaCache\**" />
     <None Include="umbraco\UmbracoWebsite\NoNodes.cshtml" />
     <None Remove="scripts\aaa\fc75309db05f41609a9e1adb8cf0998c.tmp" />
+    <None Remove="umbraco\models\**" />
   </ItemGroup>
 
   <!-- We don't want to include the generated files, they will throw a lot of errors -->

--- a/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
+++ b/src/Umbraco.Web.UI.NetCore/Umbraco.Web.UI.NetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -53,10 +53,6 @@
 
   <ItemGroup>
     <None Include="config\**\*.*">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-    </None>
-    <None Include="umbraco\**\*.*">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </None>


### PR DESCRIPTION
Fixes #10213 When the models folder is included in the project the cs files have a Build Action of 'C# compiler' so they can be used in code.

As a bonus, I have fixed a couple of comments that indicate the right models' location.