### PR TITLE
Creates a method allowing validation of a user's credentials without actually logging them in.

### DIFF
--- a/src/Umbraco.Infrastructure/Security/IUmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IUmbracoUserManager.cs
@@ -375,5 +375,13 @@ namespace Umbraco.Cms.Core.Security
         /// A user can only support a phone number if the BackOfficeUserStore is replaced with another that implements IUserPhoneNumberStore
         /// </remarks>
         Task<string> GetPhoneNumberAsync(TUser user);
+
+        /// <summary>
+        /// Validates that a user's credentials are correct without actually logging them in.
+        /// </summary>
+        /// <param name="username">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <returns>True if the credentials are valid.</returns>
+        Task<bool> ValidateCredentialsAsync(string username, string password);
     }
 }

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
@@ -17,13 +15,12 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Security
 {
-
     /// <summary>
     /// A custom user store that uses Umbraco member data
     /// </summary>
     public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdentityRole>, IMemberUserStore
     {
-        private const string genericIdentityErrorCode = "IdentityErrorUserStore";
+        private const string GenericIdentityErrorCode = "IdentityErrorUserStore";
         private readonly IMemberService _memberService;
         private readonly IUmbracoMapper _mapper;
         private readonly IScopeProvider _scopeProvider;
@@ -103,7 +100,7 @@ namespace Umbraco.Cms.Core.Security
             }
             catch (Exception ex)
             {
-                return Task.FromResult(IdentityResult.Failed(new IdentityError { Code = genericIdentityErrorCode, Description = ex.Message }));
+                return Task.FromResult(IdentityResult.Failed(new IdentityError { Code = GenericIdentityErrorCode, Description = ex.Message }));
             }
         }
 
@@ -134,7 +131,7 @@ namespace Umbraco.Cms.Core.Security
                     // we have to remember whether Logins property is dirty, since the UpdateMemberProperties will reset it.
                     var isLoginsPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.Logins));
 
-                    var memberChangeType = UpdateMemberProperties(found, user);
+                    MemberDataChangeType memberChangeType = UpdateMemberProperties(found, user);
                     if (memberChangeType == MemberDataChangeType.FullSave)
                     {
                         _memberService.Save(found);
@@ -163,7 +160,7 @@ namespace Umbraco.Cms.Core.Security
             }
             catch (Exception ex)
             {
-                return Task.FromResult(IdentityResult.Failed(new IdentityError { Code = genericIdentityErrorCode, Description = ex.Message }));
+                return Task.FromResult(IdentityResult.Failed(new IdentityError { Code = GenericIdentityErrorCode, Description = ex.Message }));
             }
         }
 
@@ -192,7 +189,7 @@ namespace Umbraco.Cms.Core.Security
             }
             catch (Exception ex)
             {
-                return Task.FromResult(IdentityResult.Failed(new IdentityError { Code = genericIdentityErrorCode, Description = ex.Message }));
+                return Task.FromResult(IdentityResult.Failed(new IdentityError { Code = GenericIdentityErrorCode, Description = ex.Message }));
             }
         }
 
@@ -505,7 +502,7 @@ namespace Umbraco.Cms.Core.Security
 
         private MemberDataChangeType UpdateMemberProperties(IMember member, MemberIdentityUser identityUser)
         {
-            var changeType = MemberDataChangeType.None;
+            MemberDataChangeType changeType = MemberDataChangeType.None;
 
             // don't assign anything if nothing has changed as this will trigger the track changes of the model
             if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.LastLoginDateUtc))

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
@@ -10,7 +10,8 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Security
 {
-    public abstract class UmbracoUserStore<TUser, TRole> : UserStoreBase<TUser, TRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityUserToken<string>, IdentityRoleClaim<string>>
+    public abstract class UmbracoUserStore<TUser, TRole>
+        : UserStoreBase<TUser, TRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityUserToken<string>, IdentityRoleClaim<string>>
         where TUser : UmbracoIdentityUser
         where TRole : IdentityRole<string>
     {

--- a/src/Umbraco.Web.Common/Security/BackofficeSecurity.cs
+++ b/src/Umbraco.Web.Common/Security/BackofficeSecurity.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Membership;
@@ -23,8 +24,6 @@ namespace Umbraco.Cms.Web.Common.Security
             _httpContextAccessor = httpContextAccessor;
         }
 
-
-
         /// <inheritdoc />
         public IUser CurrentUser
         {
@@ -39,7 +38,7 @@ namespace Umbraco.Cms.Web.Common.Security
                         //Check again
                         if (_currentUser == null)
                         {
-                            var id = GetUserId();
+                            Attempt<int> id = GetUserId();
                             _currentUser = id ? _userService.GetUserById(id.Result) : null;
                         }
                     }
@@ -52,22 +51,18 @@ namespace Umbraco.Cms.Web.Common.Security
         /// <inheritdoc />
         public Attempt<int> GetUserId()
         {
-            var identity = _httpContextAccessor.HttpContext?.GetCurrentIdentity();
+            ClaimsIdentity identity = _httpContextAccessor.HttpContext?.GetCurrentIdentity();
             return identity == null ? Attempt.Fail<int>() : Attempt.Succeed(identity.GetId());
         }
 
         /// <inheritdoc />
         public bool IsAuthenticated()
         {
-            var httpContext = _httpContextAccessor.HttpContext;
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
             return httpContext?.User != null && httpContext.User.Identity.IsAuthenticated && httpContext.GetCurrentIdentity() != null;
         }
 
         /// <inheritdoc />
-        public bool UserHasSectionAccess(string section, IUser user)
-        {
-            return user.HasSectionAccess(section);
-        }
-
+        public bool UserHasSectionAccess(string section, IUser user) => user.HasSectionAccess(section);
     }
 }

--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -1,18 +1,17 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.Extensions;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
-using System.Threading.Tasks;
-using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.Security
 {


### PR DESCRIPTION
This is used in Deploy, and was available in V8, so have made it available in V9.

There's a unit test to verify functionality, but you can also test by dropping in the following controller into the code base:

```
using System.Threading.Tasks;
using Umbraco.Cms.Core.Security;
using Umbraco.Cms.Web.Common.Attributes;
using Constants = Umbraco.Cms.Core.Constants;

namespace Umbraco.Cms.Web.BackOffice.Controllers
{
    [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
    public class TestController : UmbracoAuthorizedApiController
    {
        private readonly IBackOfficeUserManager _backOfficeUserManager;

        public TestController(
            IBackOfficeUserManager backOfficeUserManager) => _backOfficeUserManager = backOfficeUserManager;

        public async Task<ValidateCredentialsResult> ValidateCredentials(string username, string password) =>
            new ValidateCredentialsResult
            {
                UserName = username,
                Password = password,
                Result = await _backOfficeUserManager.ValidateCredentialsAsync(username, password),
            };

        public class ValidateCredentialsResult
        {
            public string UserName { get; set; }

            public string Password { get; set; }

            public bool Result { get; set; }
        }

    }
}
```

And requesting via:

```
https://localhost:44331/umbraco/backoffice/umbracoapi/test/ValidateCredentials?username=<username>&password=<password>
```