### PR TITLE
Re-implemented various file service methods from V8 required in Deploy.

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IFileRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IFileRepository.cs
@@ -1,0 +1,13 @@
+using System.IO;
+
+namespace Umbraco.Cms.Core.Persistence.Repositories
+{
+    public interface IFileRepository
+    {
+        Stream GetFileContentStream(string filepath);
+
+        void SetFileContent(string filepath, Stream content);
+
+        long GetFileSize(string filepath);
+    }
+}

--- a/src/Umbraco.Core/Persistence/Repositories/IFileWithFoldersRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IFileWithFoldersRepository.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.Persistence.Repositories
+{
+    public interface IFileWithFoldersRepository
+    {
+        void AddFolder(string folderPath);
+
+        void DeleteFolder(string folderPath);
+    }
+}

--- a/src/Umbraco.Core/Persistence/Repositories/IPartialViewRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IPartialViewRepository.cs
@@ -2,9 +2,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories
 {
-    public interface IPartialViewRepository : IReadRepository<string, IPartialView>, IWriteRepository<IPartialView>
+    public interface IPartialViewRepository : IReadRepository<string, IPartialView>, IWriteRepository<IPartialView>, IFileRepository, IFileWithFoldersRepository
     {
-        void AddFolder(string folderPath);
-        void DeleteFolder(string folderPath);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IScriptRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IScriptRepository.cs
@@ -1,10 +1,9 @@
+using System.IO;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories
 {
-    public interface IScriptRepository : IReadRepository<string, IScript>, IWriteRepository<IScript>
+    public interface IScriptRepository : IReadRepository<string, IScript>, IWriteRepository<IScript>, IFileRepository, IFileWithFoldersRepository
     {
-        void AddFolder(string folderPath);
-        void DeleteFolder(string folderPath);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IStylesheetRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IStylesheetRepository.cs
@@ -2,9 +2,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories
 {
-    public interface IStylesheetRepository : IReadRepository<string, IStylesheet>, IWriteRepository<IStylesheet>
+    public interface IStylesheetRepository : IReadRepository<string, IStylesheet>, IWriteRepository<IStylesheet>, IFileRepository, IFileWithFoldersRepository
     {
-        void AddFolder(string folderPath);
-        void DeleteFolder(string folderPath);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/ITemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITemplateRepository.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
-using System.IO;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories
 {
-    public interface ITemplateRepository : IReadWriteQueryRepository<int, ITemplate>
+    public interface ITemplateRepository : IReadWriteQueryRepository<int, ITemplate>, IFileRepository
     {
         ITemplate Get(string alias);
 
@@ -13,12 +12,5 @@ namespace Umbraco.Cms.Core.Persistence.Repositories
         IEnumerable<ITemplate> GetChildren(int masterTemplateId);
 
         IEnumerable<ITemplate> GetDescendants(int masterTemplateId);
-
-        /// <summary>
-        /// Gets the content of a template as a stream.
-        /// </summary>
-        /// <param name="filepath">The filesystem path to the template.</param>
-        /// <returns>The content of the template.</returns>
-        Stream GetFileContentStream(string filepath);
     }
 }

--- a/src/Umbraco.Core/Services/IFileService.cs
+++ b/src/Umbraco.Core/Services/IFileService.cs
@@ -25,6 +25,48 @@ namespace Umbraco.Cms.Core.Services
         Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
+        /// Gets the content of a partial view as a stream.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the partial view.</param>
+        /// <returns>The content of the partial view.</returns>
+        Stream GetPartialViewFileContentStream(string filepath);
+
+        /// <summary>
+        /// Sets the content of a partial view.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the partial view.</param>
+        /// <param name="content">The content of the partial view.</param>
+        void SetPartialViewFileContent(string filepath, Stream content);
+
+        /// <summary>
+        /// Gets the size of a partial view.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the partial view.</param>
+        /// <returns>The size of the partial view.</returns>
+        long GetPartialViewFileSize(string filepath);
+
+        /// <summary>
+        /// Gets the content of a macro partial view as a stream.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the macro partial view.</param>
+        /// <returns>The content of the macro partial view.</returns>
+        Stream GetPartialViewMacroFileContentStream(string filepath);
+
+        /// <summary>
+        /// Sets the content of a macro partial view.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the macro partial view.</param>
+        /// <param name="content">The content of the macro partial view.</param>
+        void SetPartialViewMacroFileContent(string filepath, Stream content);
+
+        /// <summary>
+        /// Gets the size of a macro partial view.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the macro partial view.</param>
+        /// <returns>The size of the macro partial view.</returns>
+        long GetPartialViewMacroFileSize(string filepath);
+
+        /// <summary>
         /// Gets a list of all <see cref="IStylesheet"/> objects
         /// </summary>
         /// <returns>An enumerable list of <see cref="IStylesheet"/> objects</returns>
@@ -50,6 +92,40 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="path">Name incl. extension of the Stylesheet to delete</param>
         /// <param name="userId">Optional id of the user deleting the stylesheet</param>
         void DeleteStylesheet(string path, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Creates a folder for style sheets
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <returns></returns>
+        void CreateStyleSheetFolder(string folderPath);
+
+        /// <summary>
+        /// Deletes a folder for style sheets
+        /// </summary>
+        /// <param name="folderPath"></param>
+        void DeleteStyleSheetFolder(string folderPath);
+
+        /// <summary>
+        /// Gets the content of a stylesheet as a stream.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the stylesheet.</param>
+        /// <returns>The content of the stylesheet.</returns>
+        Stream GetStylesheetFileContentStream(string filepath);
+
+        /// <summary>
+        /// Sets the content of a stylesheet.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the stylesheet.</param>
+        /// <param name="content">The content of the stylesheet.</param>
+        void SetStylesheetFileContent(string filepath, Stream content);
+
+        /// <summary>
+        /// Gets the size of a stylesheet.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the stylesheet.</param>
+        /// <returns>The size of the stylesheet.</returns>
+        long GetStylesheetFileSize(string filepath);
 
         /// <summary>
         /// Gets a <see cref="IScript"/> object by its name
@@ -86,17 +162,25 @@ namespace Umbraco.Cms.Core.Services
         void DeleteScriptFolder(string folderPath);
 
         /// <summary>
-        /// Creates a folder for style sheets
+        /// Gets the content of a script file as a stream.
         /// </summary>
-        /// <param name="folderPath"></param>
-        /// <returns></returns>
-        void CreateStyleSheetFolder(string folderPath);
+        /// <param name="filepath">The filesystem path to the script.</param>
+        /// <returns>The content of the script file.</returns>
+        Stream GetScriptFileContentStream(string filepath);
 
         /// <summary>
-        /// Deletes a folder for style sheets
+        /// Sets the content of a script file.
         /// </summary>
-        /// <param name="folderPath"></param>
-        void DeleteStyleSheetFolder(string folderPath);
+        /// <param name="filepath">The filesystem path to the script.</param>
+        /// <param name="content">The content of the script file.</param>
+        void SetScriptFileContent(string filepath, Stream content);
+
+        /// <summary>
+        /// Gets the size of a script file.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the script file.</param>
+        /// <returns>The size of the script file.</returns>
+        long GetScriptFileSize(string filepath);
 
         /// <summary>
         /// Gets a list of all <see cref="ITemplate"/> objects
@@ -171,6 +255,27 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="templates">List of <see cref="Template"/> to save</param>
         /// <param name="userId">Optional id of the user</param>
         void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Gets the content of a template as a stream.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the template.</param>
+        /// <returns>The content of the template.</returns>
+        Stream GetTemplateFileContentStream(string filepath);
+
+        /// <summary>
+        /// Sets the content of a template.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the template.</param>
+        /// <param name="content">The content of the template.</param>
+        void SetTemplateFileContent(string filepath, Stream content);
+
+        /// <summary>
+        /// Gets the size of a template.
+        /// </summary>
+        /// <param name="filepath">The filesystem path to the template.</param>
+        /// <returns>The size of the template.</returns>
+        long GetTemplateFileSize(string filepath);
 
         /// <summary>
         /// Gets the content of a macro partial view snippet as a string

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ScriptRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ScriptRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -442,15 +442,15 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         public Stream GetFileContentStream(string filepath)
         {
-            IFileSystem fs = GetFileSystem(filepath);
-            if (fs.FileExists(filepath) == false)
+            IFileSystem fileSystem = GetFileSystem(filepath);
+            if (fileSystem.FileExists(filepath) == false)
             {
                 return null;
             }
 
             try
             {
-                return GetFileSystem(filepath).OpenFile(filepath);
+                return fileSystem.OpenFile(filepath);
             }
             catch
             {
@@ -462,14 +462,15 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         public long GetFileSize(string filename)
         {
-            if (GetFileSystem(filename).FileExists(filename) == false)
+            IFileSystem fileSystem = GetFileSystem(filename);
+            if (fileSystem.FileExists(filename) == false)
             {
                 return -1;
             }
 
             try
             {
-                return GetFileSystem(filename).GetSize(filename);
+                return fileSystem.GetSize(filename);
             }
             catch
             {

--- a/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/FileService.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Strings;
@@ -57,7 +58,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <inheritdoc />
         public IEnumerable<IStylesheet> GetStylesheets(params string[] names)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _stylesheetRepository.GetMany(names);
             }
@@ -66,14 +67,14 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <inheritdoc />
         public IStylesheet GetStylesheetByName(string name)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _stylesheetRepository.Get(name);
             }
         }
 
         /// <inheritdoc />
-        public void SaveStylesheet(IStylesheet stylesheet, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void SaveStylesheet(IStylesheet stylesheet, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -95,7 +96,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public void DeleteStylesheet(string path, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void DeleteStylesheet(string path, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -123,21 +124,51 @@ namespace Umbraco.Cms.Core.Services.Implement
             }
         }
 
+        /// <inheritdoc />
         public void CreateStyleSheetFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _stylesheetRepository.AddFolder(folderPath);
                 scope.Complete();
             }
         }
 
+        /// <inheritdoc />
         public void DeleteStyleSheetFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _stylesheetRepository.DeleteFolder(folderPath);
                 scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public Stream GetStylesheetFileContentStream(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _stylesheetRepository.GetFileContentStream(filepath);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetStylesheetFileContent(string filepath, Stream content)
+        {
+            using (IScope scope = ScopeProvider.CreateScope())
+            {
+                _stylesheetRepository.SetFileContent(filepath, content);
+                scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public long GetStylesheetFileSize(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _stylesheetRepository.GetFileSize(filepath);
             }
         }
 
@@ -148,14 +179,14 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <inheritdoc />
         public IScript GetScriptByName(string name)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _scriptRepository.Get(name);
             }
         }
 
         /// <inheritdoc />
-        public void SaveScript(IScript script, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void SaveScript(IScript script, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -176,7 +207,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public void DeleteScript(string path, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void DeleteScript(string path, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -203,21 +234,51 @@ namespace Umbraco.Cms.Core.Services.Implement
             }
         }
 
+        /// <inheritdoc />
         public void CreateScriptFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _scriptRepository.AddFolder(folderPath);
                 scope.Complete();
             }
         }
 
+        /// <inheritdoc />
         public void DeleteScriptFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _scriptRepository.DeleteFolder(folderPath);
                 scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public Stream GetScriptFileContentStream(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _scriptRepository.GetFileContentStream(filepath);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetScriptFileContent(string filepath, Stream content)
+        {
+            using (IScope scope = ScopeProvider.CreateScope())
+            {
+                _scriptRepository.SetFileContent(filepath, content);
+                scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public long GetScriptFileSize(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _scriptRepository.GetFileSize(filepath);
             }
         }
 
@@ -234,7 +295,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>
         /// The template created
         /// </returns>
-        public Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public Attempt<OperationResult<OperationResultType, ITemplate>> CreateTemplateForContentType(string contentTypeAlias, string contentTypeName, int userId = Constants.Security.SuperUserId)
         {
             var template = new Template(_shortStringHelper, contentTypeName,
                 //NOTE: We are NOT passing in the content type alias here, we want to use it's name since we don't
@@ -286,7 +347,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <param name="masterTemplate"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
-        public ITemplate CreateTemplateWithIdentity(string name, string alias, string content, ITemplate masterTemplate = null, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public ITemplate CreateTemplateWithIdentity(string name, string alias, string content, ITemplate masterTemplate = null, int userId = Constants.Security.SuperUserId)
         {
             if (name == null)
             {
@@ -325,7 +386,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>An enumerable list of <see cref="ITemplate"/> objects</returns>
         public IEnumerable<ITemplate> GetTemplates(params string[] aliases)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _templateRepository.GetAll(aliases).OrderBy(x => x.Name);
             }
@@ -337,7 +398,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>An enumerable list of <see cref="ITemplate"/> objects</returns>
         public IEnumerable<ITemplate> GetTemplates(int masterTemplateId)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _templateRepository.GetChildren(masterTemplateId).OrderBy(x => x.Name);
             }
@@ -350,7 +411,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>The <see cref="ITemplate"/> object matching the alias, or null.</returns>
         public ITemplate GetTemplate(string alias)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _templateRepository.Get(alias);
             }
@@ -363,7 +424,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>The <see cref="ITemplate"/> object matching the identifier, or null.</returns>
         public ITemplate GetTemplate(int id)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _templateRepository.Get(id);
             }
@@ -376,9 +437,9 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>The <see cref="ITemplate"/> object matching the identifier, or null.</returns>
         public ITemplate GetTemplate(Guid id)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                var query = Query<ITemplate>().Where(x => x.Key == id);
+                IQuery<ITemplate> query = Query<ITemplate>().Where(x => x.Key == id);
                 return _templateRepository.Get(query).SingleOrDefault();
             }
         }
@@ -390,7 +451,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns></returns>
         public IEnumerable<ITemplate> GetTemplateDescendants(int masterTemplateId)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _templateRepository.GetDescendants(masterTemplateId);
             }
@@ -401,7 +462,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// </summary>
         /// <param name="template"><see cref="Template"/> to save</param>
         /// <param name="userId"></param>
-        public void SaveTemplate(ITemplate template, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void SaveTemplate(ITemplate template, int userId = Constants.Security.SuperUserId)
         {
             if (template == null)
             {
@@ -438,7 +499,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// </summary>
         /// <param name="templates">List of <see cref="Template"/> to save</param>
         /// <param name="userId">Optional id of the user</param>
-        public void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId)
         {
             ITemplate[] templatesA = templates.ToArray();
             using (IScope scope = ScopeProvider.CreateScope())
@@ -468,7 +529,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// </summary>
         /// <param name="alias">Alias of the <see cref="ITemplate"/> to delete</param>
         /// <param name="userId"></param>
-        public void DeleteTemplate(string alias, int userId = Cms.Core.Constants.Security.SuperUserId)
+        public void DeleteTemplate(string alias, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -499,22 +560,58 @@ namespace Umbraco.Cms.Core.Services.Implement
         private string GetViewContent(string fileName)
         {
             if (fileName.IsNullOrWhiteSpace())
+            {
                 throw new ArgumentNullException(nameof(fileName));
+            }
 
             if (!fileName.EndsWith(".cshtml"))
+            {
                 fileName = $"{fileName}.cshtml";
+            }
 
-            var fs = _templateRepository.GetFileContentStream(fileName);
-            if (fs == null) return null;
+            Stream fs = _templateRepository.GetFileContentStream(fileName);
+            if (fs == null)
+            {
+                return null;
+            }
+
             using (var view = new StreamReader(fs))
             {
                 return view.ReadToEnd().Trim();
             }
         }
 
-#endregion
+        /// <inheritdoc />
+        public Stream GetTemplateFileContentStream(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _templateRepository.GetFileContentStream(filepath);
+            }
+        }
 
-#region Partial Views
+        /// <inheritdoc />
+        public void SetTemplateFileContent(string filepath, Stream content)
+        {
+            using (IScope scope = ScopeProvider.CreateScope())
+            {
+                _templateRepository.SetFileContent(filepath, content);
+                scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public long GetTemplateFileSize(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _templateRepository.GetFileSize(filepath);
+            }
+        }
+
+        #endregion
+
+        #region Partial Views
 
         public IEnumerable<string> GetPartialViewSnippetNames(params string[] filterNames)
         {
@@ -534,7 +631,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public void DeletePartialViewFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _partialViewRepository.DeleteFolder(folderPath);
                 scope.Complete();
@@ -543,7 +640,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public void DeletePartialViewMacroFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _partialViewMacroRepository.DeleteFolder(folderPath);
                 scope.Complete();
@@ -552,7 +649,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public IPartialView GetPartialView(string path)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _partialViewRepository.Get(path);
             }
@@ -560,23 +657,19 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public IPartialView GetPartialViewMacro(string path)
         {
-            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
             {
                 return _partialViewMacroRepository.Get(path);
             }
         }
 
-        public Attempt<IPartialView> CreatePartialView(IPartialView partialView, string snippetName = null, int userId = Cms.Core.Constants.Security.SuperUserId)
-        {
-            return CreatePartialViewMacro(partialView, PartialViewType.PartialView, snippetName, userId);
-        }
+        public Attempt<IPartialView> CreatePartialView(IPartialView partialView, string snippetName = null, int userId = Constants.Security.SuperUserId) =>
+            CreatePartialViewMacro(partialView, PartialViewType.PartialView, snippetName, userId);
 
-        public Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, string snippetName = null, int userId = Cms.Core.Constants.Security.SuperUserId)
-        {
-            return CreatePartialViewMacro(partialView, PartialViewType.PartialViewMacro, snippetName, userId);
-        }
+        public Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, string snippetName = null, int userId = Constants.Security.SuperUserId) =>
+            CreatePartialViewMacro(partialView, PartialViewType.PartialViewMacro, snippetName, userId);
 
-        private Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, PartialViewType partialViewType, string snippetName = null, int userId = Cms.Core.Constants.Security.SuperUserId)
+        private Attempt<IPartialView> CreatePartialViewMacro(IPartialView partialView, PartialViewType partialViewType, string snippetName = null, int userId = Constants.Security.SuperUserId)
         {
             string partialViewHeader;
             switch (partialViewType)
@@ -646,17 +739,13 @@ namespace Umbraco.Cms.Core.Services.Implement
             return Attempt<IPartialView>.Succeed(partialView);
         }
 
-        public bool DeletePartialView(string path, int userId = Cms.Core.Constants.Security.SuperUserId)
-        {
-            return DeletePartialViewMacro(path, PartialViewType.PartialView, userId);
-        }
+        public bool DeletePartialView(string path, int userId = Constants.Security.SuperUserId) =>
+            DeletePartialViewMacro(path, PartialViewType.PartialView, userId);
 
-        public bool DeletePartialViewMacro(string path, int userId = Cms.Core.Constants.Security.SuperUserId)
-        {
-            return DeletePartialViewMacro(path, PartialViewType.PartialViewMacro, userId);
-        }
+        public bool DeletePartialViewMacro(string path, int userId = Constants.Security.SuperUserId) =>
+            DeletePartialViewMacro(path, PartialViewType.PartialViewMacro, userId);
 
-        private bool DeletePartialViewMacro(string path, PartialViewType partialViewType, int userId = Cms.Core.Constants.Security.SuperUserId)
+        private bool DeletePartialViewMacro(string path, PartialViewType partialViewType, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -686,17 +775,13 @@ namespace Umbraco.Cms.Core.Services.Implement
             return true;
         }
 
-        public Attempt<IPartialView> SavePartialView(IPartialView partialView, int userId = Cms.Core.Constants.Security.SuperUserId)
-        {
-            return SavePartialView(partialView, PartialViewType.PartialView, userId);
-        }
+        public Attempt<IPartialView> SavePartialView(IPartialView partialView, int userId = Constants.Security.SuperUserId) =>
+            SavePartialView(partialView, PartialViewType.PartialView, userId);
 
-        public Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = Cms.Core.Constants.Security.SuperUserId)
-        {
-            return SavePartialView(partialView, PartialViewType.PartialViewMacro, userId);
-        }
+        public Attempt<IPartialView> SavePartialViewMacro(IPartialView partialView, int userId = Constants.Security.SuperUserId) =>
+            SavePartialView(partialView, PartialViewType.PartialViewMacro, userId);
 
-        private Attempt<IPartialView> SavePartialView(IPartialView partialView, PartialViewType partialViewType, int userId = Cms.Core.Constants.Security.SuperUserId)
+        private Attempt<IPartialView> SavePartialView(IPartialView partialView, PartialViewType partialViewType, int userId = Constants.Security.SuperUserId)
         {
             using (IScope scope = ScopeProvider.CreateScope())
             {
@@ -741,7 +826,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public void CreatePartialViewFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _partialViewRepository.AddFolder(folderPath);
                 scope.Complete();
@@ -750,7 +835,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public void CreatePartialViewMacroFolder(string folderPath)
         {
-            using (var scope = ScopeProvider.CreateScope())
+            using (IScope scope = ScopeProvider.CreateScope())
             {
                 _partialViewMacroRepository.AddFolder(folderPath);
                 scope.Complete();
@@ -770,24 +855,76 @@ namespace Umbraco.Cms.Core.Services.Implement
             }
         }
 
+        /// <inheritdoc />
+        public Stream GetPartialViewFileContentStream(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _partialViewRepository.GetFileContentStream(filepath);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetPartialViewFileContent(string filepath, Stream content)
+        {
+            using (IScope scope = ScopeProvider.CreateScope())
+            {
+                _partialViewRepository.SetFileContent(filepath, content);
+                scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public long GetPartialViewFileSize(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _partialViewRepository.GetFileSize(filepath);
+            }
+        }
+
+        /// <inheritdoc />
+        public Stream GetPartialViewMacroFileContentStream(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _partialViewMacroRepository.GetFileContentStream(filepath);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetPartialViewMacroFileContent(string filepath, Stream content)
+        {
+            using (IScope scope = ScopeProvider.CreateScope())
+            {
+                _partialViewMacroRepository.SetFileContent(filepath, content);
+                scope.Complete();
+            }
+        }
+
+        /// <inheritdoc />
+        public long GetPartialViewMacroFileSize(string filepath)
+        {
+            using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                return _partialViewMacroRepository.GetFileSize(filepath);
+            }
+        }
+
         #endregion
 
         #region Snippets
 
-        public string GetPartialViewSnippetContent(string snippetName)
-        {
-            return GetPartialViewMacroSnippetContent(snippetName, PartialViewType.PartialView);
-        }
+        public string GetPartialViewSnippetContent(string snippetName) => GetPartialViewMacroSnippetContent(snippetName, PartialViewType.PartialView);
 
-        public string GetPartialViewMacroSnippetContent(string snippetName)
-        {
-            return GetPartialViewMacroSnippetContent(snippetName, PartialViewType.PartialViewMacro);
-        }
+        public string GetPartialViewMacroSnippetContent(string snippetName) => GetPartialViewMacroSnippetContent(snippetName, PartialViewType.PartialViewMacro);
 
         private string GetPartialViewMacroSnippetContent(string snippetName, PartialViewType partialViewType)
         {
             if (snippetName.IsNullOrWhiteSpace())
+            {
                 throw new ArgumentNullException(nameof(snippetName));
+            }
 
             string partialViewHeader;
             switch (partialViewType)
@@ -803,7 +940,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             }
 
             // Try and get the snippet path
-            var snippetPathAttempt = TryGetSnippetPath(snippetName);
+            Attempt<string> snippetPathAttempt = TryGetSnippetPath(snippetName);
             if (snippetPathAttempt.Success == false)
             {
                 throw new InvalidOperationException("Could not load snippet with name " + snippetName);
@@ -831,10 +968,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         #endregion
 
-        private void Audit(AuditType type, int userId, int objectId, string entityType)
-        {
-            _auditRepository.Save(new AuditItem(objectId, type, userId, entityType));
-        }
+        private void Audit(AuditType type, int userId, int objectId, string entityType) => _auditRepository.Save(new AuditItem(objectId, type, userId, entityType));
 
         // TODO: Method to change name and/or alias of view template
     }


### PR DESCRIPTION
As the title says, this PR is adding in some methods that weren't migrated from V8, and presumably not needed in CMS, so they are available for use in Deploy.

I've done a little tidy-up but mostly the code is just a copy from V8.

They can be tested in views for example with:

```
@inject Umbraco.Cms.Core.Services.IFileService FileService
<p>File size: @FileService.GetPartialViewFileSize(@"C:\Repos\Umbraco\Umbraco-CMS-V9\src\Umbraco.Web.UI.NetCore\Views\Partials\ChildDocType.cshtml")</p>
```