### PR TITLE
Updated serialization defaults for ArtifactBase

### DIFF
--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -1,22 +1,18 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Umbraco.Cms.Core.Deploy
 {
     /// <summary>
     /// Provides a base class to all artifacts.
     /// </summary>
-    [DataContract]
     public abstract class ArtifactBase<TUdi> : IArtifact
         where TUdi : Udi
     {
         protected ArtifactBase(TUdi udi, IEnumerable<ArtifactDependency> dependencies = null)
         {
-            if (udi == null)
-                throw new ArgumentNullException("udi");
-            Udi = udi;
+            Udi = udi ?? throw new ArgumentNullException("udi");
             Name = Udi.ToString();
 
             Dependencies = dependencies ?? Enumerable.Empty<ArtifactDependency>();
@@ -24,38 +20,31 @@ namespace Umbraco.Cms.Core.Deploy
         }
 
         private readonly Lazy<string> _checksum;
+
         private IEnumerable<ArtifactDependency> _dependencies;
 
         protected abstract string GetChecksum();
 
         #region Abstract implementation of IArtifactSignature
 
-        Udi IArtifactSignature.Udi
-        {
-            get { return Udi; }
-        }
+        Udi IArtifactSignature.Udi => Udi;
 
-        [DataMember]
         public TUdi Udi { get; set; }
 
-        [IgnoreDataMember]
-        public string Checksum
-        {
-            get { return _checksum.Value; }
-        }
+        public string Checksum => _checksum.Value;
 
-        [DataMember]
+        public bool ShouldSerializeChecksum() => false;
+
         public IEnumerable<ArtifactDependency> Dependencies
         {
-            get { return _dependencies; }
-            set { _dependencies = value.OrderBy(x => x.Udi); }
+            get => _dependencies;
+            set => _dependencies = value.OrderBy(x => x.Udi);
         }
 
         #endregion
 
-        [DataMember]
         public string Name { get; set; }
-        [DataMember]
+
         public string Alias { get; set; }
     }
 }

--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -33,6 +33,14 @@ namespace Umbraco.Cms.Core.Deploy
 
         public string Checksum => _checksum.Value;
 
+        /// <summary>
+        /// Prevents the <see cref="Checksum" /> property from being serialized.
+        /// </summary>
+        /// <remarks>
+        /// Note that we can't use <see cref="NonSerializedAttribute"/> here as that works only on fields, not properties.  And we want to avoid using [JsonIgnore]
+        /// as that would require an external dependency in Umbraco.Cms.Core.
+        /// So using this method of excluding properties from serialized data, documented here: https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
+        /// </remarks>
         public bool ShouldSerializeChecksum() => false;
 
         public IEnumerable<ArtifactDependency> Dependencies

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Deploy
+{
+    [TestFixture]
+    public class ArtifactBaseTests
+    {
+        [Test]
+        public void CanSerialize()
+        {
+            var udi = new GuidUdi("test", Guid.Parse("3382d5433b5749d08919bc9961422a1f"));
+            var artifact = new TestArtifact(udi, new List<ArtifactDependency>())
+            {
+                Name = "Test Name",
+                Alias = "testAlias",
+            };
+
+            var serialized = JsonConvert.SerializeObject(artifact);
+
+            var expected = "{\"Udi\":\"umb://test/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
+            Assert.AreEqual(expected, serialized);
+        }
+
+        private class TestArtifact : ArtifactBase<GuidUdi>
+        {
+            public TestArtifact(GuidUdi udi, IEnumerable<ArtifactDependency> dependencies = null) : base(udi, dependencies)
+            {
+            }
+
+            protected override string GetChecksum() => "test checksum value";
+        }
+    }
+}


### PR DESCRIPTION
In this PR I've removed the `[DataContract]` attribute added on `ArtifactBase` in the migration from V8 to V9, which has the effect of making all properties on derived artifacts opt-in.

And then handled the omission of the checksum value from the serialized string without taking a Json.Net dependency.

With this included and the Deploy dependency on CMS updated, that should resolve the serialization issues that would otherwise need all properties marked to opt them into serialization, and revert to the V8 behaviour where this isn't necessary.

Have verified with a test that the previous behaviour and the new with regards serialization is the same.