### PR TITLE
Update version and artifact name generated by azure pipeline

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,7 +333,7 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($(Build.ResourceTrigger) -eq "ResourceTrigger"){
+                        if ("$(Build.ResourceTrigger)" -eq "ResourceTrigger"){
                           $continuous = $version.Semver
                               Write-Host "##vso[build.addbuildtag]Release build"
                           }

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -341,7 +341,7 @@ stages:
                         }
                         else
                         {
-                            $continuous = "$($version.Semver).$(Date:yyyyMMdd).$(Rev:rrrr)"
+                            $continuous = "$(version.Semver).$(Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -343,7 +343,6 @@ stages:
                         }
                         else
                         {
-                        {
                             $continuous = "$($version.Semver).$(Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -337,12 +337,12 @@ stages:
                             if ($version.Comment -ne "")
                             {
                               # 8.0.0-beta003.1234
-                              $continuous = "$($version.Semver).$(Build.BuildNumber)"
+                              $continuous = "$($version.Semver)"
                             }
                             else
                             {
                               # 8.0.0-nightly.1234
-                              $continuous = "$($version.Release)-nightly.$(Build.BuildNumber)"
+                              $continuous = "$($version.Release)-nightly"
                             }
                             $ubuild.SetUmbracoVersion($continuous)
 
@@ -375,7 +375,7 @@ stages:
                           }
 
 
-                        Write-Host "##vso[build.updatereleasename]Umbraco.$continuous"
+                        Write-Host "##vso[build.updatebuildnumber]$continuous"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -366,11 +366,14 @@ stages:
                             $a.symbols.version.defaultValue = $continuous
 
                             $a | ConvertTo-Json -depth 32| set-content $templatePath
+                            Write-Host "##vso[build.addbuildtag]Continuous build"
                           }
                           else
                           {
                             $continuous = $version.Semver
+                            Write-Host "##vso[build.addbuildtag]Release build"
                           }
+
 
                         Write-Host "##vso[build.updatebuildnumber]$continuous"
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -375,7 +375,7 @@ stages:
                           }
 
 
-                        Write-Host "##vso[build.updatebuildnumber]Umbraco.$continuous"
+                        Write-Host "##vso[build.updatereleasename]Umbraco.$continuous"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -1,3 +1,4 @@
+name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 variables:
     buildConfiguration: Release
     SA_PASSWORD: UmbracoIntegration123!
@@ -321,8 +322,7 @@ stages:
                       restoreSolution: '*\src\umbraco.sln'
                       feedsToUse: config
                 - task: PowerShell@1
-                  displayName: Update Version
-                  condition: 'eq(variables[''Umbraco.IsReleaseBuild''], ''false'')'
+                  displayName: Update Version and Artifact Name
                   inputs:
                       scriptType: inlineScript
                       inlineScript: >
@@ -333,40 +333,46 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($version.Comment -ne "")
-                        {
-                          # 8.0.0-beta.33.1234
-                          $continuous = "$($version.Semver).$(Build.BuildNumber)"
-                        }
-                        else
-                        {
-                          # 8.0.0-alpha.1234
-                          $continuous = "$($version.Release)-alpha.$(Build.BuildNumber)"
-                        }
-                        $ubuild.SetUmbracoVersion($continuous)
+                        if ($(Umbraco.IsReleaseBuild) -eq "false"){
+                            if ($version.Comment -ne "")
+                            {
+                              # 8.0.0-beta003.1234
+                              $continuous = "$($version.Semver).$(Build.BuildNumber)"
+                            }
+                            else
+                            {
+                              # 8.0.0-nightly.1234
+                              $continuous = "$($version.Release)-nightly.$(Build.BuildNumber)"
+                            }
+                            $ubuild.SetUmbracoVersion($continuous)
+
+                            #Update the version in templates also
+
+                            $templatePath =
+                            'build/templates/UmbracoProject/.template.config/template.json'
+
+                            $a = Get-Content $templatePath -raw | ConvertFrom-Json
+
+                            $a.symbols.version.defaultValue = $continuous
+
+                            $a | ConvertTo-Json -depth 32| set-content $templatePath
 
 
-                        #Update the version in templates also
+                            $templatePath =
+                            'build/templates/UmbracoPackage/.template.config/template.json'
 
-                        $templatePath =
-                        'build/templates/UmbracoProject/.template.config/template.json'
+                            $a = Get-Content $templatePath -raw | ConvertFrom-Json
 
-                        $a = Get-Content $templatePath -raw | ConvertFrom-Json
+                            $a.symbols.version.defaultValue = $continuous
 
-                        $a.symbols.version.defaultValue = $continuous
+                            $a | ConvertTo-Json -depth 32| set-content $templatePath
+                          }
+                          else
+                          {
+                            $continuous = $version
+                          }
 
-                        $a | ConvertTo-Json -depth 32| set-content $templatePath
-
-
-                        $templatePath =
-                        'build/templates/UmbracoPackage/.template.config/template.json'
-
-                        $a = Get-Content $templatePath -raw | ConvertFrom-Json
-
-                        $a.symbols.version.defaultValue = $continuous
-
-                        $a | ConvertTo-Json -depth 32| set-content $templatePath
-
+                        Write-Host "##vso[build.updatebuildnumber]$continuous"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -342,7 +342,8 @@ stages:
                         }
                         else
                         {
-                            $continuous = "$($version.Semver).nightly$(Build.BuildId)"
+                            $date = (Get-Date).ToString("yyyy:MM:dd")
+                            $continuous = "$($version.release).preview$date"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,7 +333,7 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ("$(Build.ResourceTrigger)" -eq "ResourceTrigger"){
+                        if ($Build.ResourceTrigger -eq "ResourceTrigger"){
                           $continuous = $version.Semver
                               Write-Host "##vso[build.addbuildtag]Release build"
                           }

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -341,7 +341,7 @@ stages:
                         }
                         else
                         {
-                            $continuous = "$(version.Semver).$(Build.BuildId)"
+                            $continuous = "$($version.Semver.$Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -343,7 +343,7 @@ stages:
                         else
                         {
                             $date = (Get-Date).ToString("yyyyMMdd")
-                            $continuous = "$($version.release)-preview$date"
+                            $continuous = "$($version.release)-preview$date.$(Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -335,8 +335,7 @@ stages:
 
                         $isRelease = [regex]::matches($env:BUILD_SOURCEBRANCH,"v\d+\/\d+.\d+.*")
 
-                        Write-Host "Is release: $isRelease"
-                        Write-Host "Source Branch: $env:BUILD_SOURCEBRANCH"
+
                         if ($isRelease){
                           $continuous = $version.Semver
                           Write-Host "##vso[build.addbuildtag]Release build"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -336,7 +336,7 @@ stages:
                         $isRelease = [regex]::matches($env:BUILD_SOURCEBRANCH,"v\d+\/\d+.\d+.*")
 
 
-                        if ($isRelease){
+                        if ($isRelease.Count -gt 0){
                           $continuous = $version.Semver
                           Write-Host "##vso[build.addbuildtag]Release build"
                         }

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,11 +333,18 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($(Umbraco.IsReleaseBuild) -ne "true"){
+                        $isTag = [regex]::IsMatch($Env:BUILD_SOURCEBRANCH, "^(refs\/tags\/)");
+
+                        if ($isTag){
+                          $continuous = $version.Semver
+                          Write-Host "##vso[build.addbuildtag]Release build"
+                        }
+                        else
+                        {
                             if ($version.Comment -ne "")
                             {
                               # 8.0.0-beta003.1234
-                              $continuous = "$($version.Semver)"
+                              $continuous = "$($version.Semver).$(Build.BuildNumber)"
                             }
                             else
                             {
@@ -367,11 +374,7 @@ stages:
 
                             $a | ConvertTo-Json -depth 32| set-content $templatePath
                             Write-Host "##vso[build.addbuildtag]Continuous build"
-                          }
-                          else
-                          {
-                            $continuous = $version.Semver
-                            Write-Host "##vso[build.addbuildtag]Release build"
+
                           }
 
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,11 +333,16 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($Build.ResourceTrigger -eq "ResourceTrigger"){
+
+                        $isRelease =  [regex]::matches($Build.SourceBranch,"v\d+\/\d+.\d+.*")
+                        Write-Host "Is release: $isRelease"
+                        Write-Host "Source Branch: $Build.SourceBranch"
+                        if ($isRelease){
                           $continuous = $version.Semver
-                              Write-Host "##vso[build.addbuildtag]Release build"
-                          }
+                          Write-Host "##vso[build.addbuildtag]Release build"
+                        }
                         else
+                        {
                         {
                             $continuous = "$($version.Semver).$(Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -342,8 +342,8 @@ stages:
                         }
                         else
                         {
-                            $date = (Get-Date).ToString("yyyy:MM:dd")
-                            $continuous = "$($version.release).preview$date"
+                            $date = (Get-Date).ToString("yyyyMMdd")
+                            $continuous = "$($version.release)-preview$date"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,7 +333,7 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($(Umbraco.IsReleaseBuild) -eq "true"){
+                        if ($(Umbraco.IsReleaseBuild) -ne "true"){
                             if ($version.Comment -ne "")
                             {
                               # 8.0.0-beta003.1234
@@ -375,7 +375,7 @@ stages:
                           }
 
 
-                        Write-Host "##vso[build.updatebuildnumber]$continuous"
+                        Write-Host "##vso[build.updatebuildnumber]Umbraco.$continuous"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -337,11 +337,11 @@ stages:
 
                         if ($isTag){
                           $continuous = $version.Semver
-                          Write-Host "##vso[build.addbuildtag]Release build"
-                        }
+                              Write-Host "##vso[build.addbuildtag]Release build"
+                          }
                         else
                         {
-                            $continuous = "$($(version.Semver)-($Build.BuildId))"
+                            $continuous = "$($version.Semver).$(Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -370,7 +370,7 @@ stages:
                           }
 
 
-                        Write-Host "##vso[build.updatebuildnumber]$(continuous).$(Build.BuildId)"
+                        Write-Host "##vso[build.updatebuildnumber]$continuous.$Build.BuildId"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -341,16 +341,7 @@ stages:
                         }
                         else
                         {
-                            if ($version.Comment -ne "")
-                            {
-                              # 8.0.0-beta003.1234
-                              $continuous = "$($version.Semver).$(Build.BuildNumber)"
-                            }
-                            else
-                            {
-                              # 8.0.0-nightly.1234
-                              $continuous = "$($version.Release)-nightly"
-                            }
+                            $continuous = "$($version.Semver).$(Date:yyyyMMdd).$(Rev:rrrr)"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,7 +333,7 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($(Umbraco.IsReleaseBuild) -ne "false"){
+                        if ($(Umbraco.IsReleaseBuild) -eq "true"){
                             if ($version.Comment -ne "")
                             {
                               # 8.0.0-beta003.1234

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -370,7 +370,7 @@ stages:
                           }
 
 
-                        Write-Host "##vso[build.updatebuildnumber]$continuous.$Build.BuildId"
+                        Write-Host "##vso[build.updatebuildnumber]$continuous.$(Build.BuildId)"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,9 +333,7 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        $isTag = [regex]::IsMatch($Env:BUILD_SOURCEBRANCH, "^(refs\/tags\/)");
-
-                        if ($isTag){
+                        if ($(Build.ResourceTrigger) -eq "ResourceTrigger"){
                           $continuous = $version.Semver
                               Write-Host "##vso[build.addbuildtag]Release build"
                           }

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -341,7 +341,7 @@ stages:
                         }
                         else
                         {
-                            $continuous = "$($version.Semver.$Build.BuildId)"
+                            $continuous = "$($(version.Semver)-($Build.BuildId))"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,10 +333,10 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
+                        $isRelease = [regex]::matches($env:BUILD_SOURCEBRANCH,"v\d+\/\d+.\d+.*")
 
-                        $isRelease =  [regex]::matches($Build.SourceBranch,"v\d+\/\d+.\d+.*")
                         Write-Host "Is release: $isRelease"
-                        Write-Host "Source Branch: $Build.SourceBranch"
+                        Write-Host "Source Branch: $env:BUILD_SOURCEBRANCH"
                         if ($isRelease){
                           $continuous = $version.Semver
                           Write-Host "##vso[build.addbuildtag]Release build"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -342,7 +342,7 @@ stages:
                         }
                         else
                         {
-                            $continuous = "$($version.Semver).$(Build.BuildId)"
+                            $continuous = "$($version.Semver).nightly$(Build.BuildId)"
                             $ubuild.SetUmbracoVersion($continuous)
 
                             #Update the version in templates also
@@ -370,7 +370,7 @@ stages:
                           }
 
 
-                        Write-Host "##vso[build.updatebuildnumber]$continuous"
+                        Write-Host "##vso[build.updatebuildnumber]$(continuous).$(Build.BuildId)"
 
                         Write-Host "Building: $continuous"
                 - task: PowerShell@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,7 +333,7 @@ stages:
 
                         $version = $ubuild.GetUmbracoVersion()
 
-                        if ($(Umbraco.IsReleaseBuild) -eq "false"){
+                        if ($(Umbraco.IsReleaseBuild) -ne "false"){
                             if ($version.Comment -ne "")
                             {
                               # 8.0.0-beta003.1234
@@ -369,7 +369,7 @@ stages:
                           }
                           else
                           {
-                            $continuous = $version
+                            $continuous = $version.Semver
                           }
 
                         Write-Host "##vso[build.updatebuildnumber]$continuous"

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -1842,8 +1842,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "base64id": {
       "version": "1.0.0",
@@ -2052,8 +2051,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "got": {
           "version": "8.3.2",
@@ -2131,7 +2129,6 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha1-2N0ZeVldLcATnh/ka4tkbLPN8Dg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -2173,7 +2170,6 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
       "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
-      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -2183,15 +2179,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2207,7 +2201,6 @@
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -2348,7 +2341,6 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -2374,8 +2366,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-equal": {
       "version": "1.0.0",
@@ -2572,7 +2563,6 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
       "integrity": "sha1-bDygcfwZRyCIPC3F2psHS/x+npU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -3096,7 +3086,6 @@
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
       "integrity": "sha1-D96NCRIA616AjK8l/mGMAvSOTvo=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -3152,7 +3141,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -3594,7 +3582,6 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -3611,7 +3598,6 @@
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
           "dev": true,
-          "optional": true,
           "requires": {
             "pify": "^3.0.0"
           },
@@ -3620,8 +3606,7 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         }
@@ -3632,7 +3617,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
-      "optional": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -3642,7 +3626,6 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -3653,8 +3636,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3663,7 +3645,6 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -3676,8 +3657,7 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
           "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3686,7 +3666,6 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -3697,8 +3676,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3707,7 +3685,6 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -3719,15 +3696,13 @@
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
-          "optional": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -3737,8 +3712,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4026,8 +4000,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4044,8 +4017,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -4690,7 +4662,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -4832,7 +4803,6 @@
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha1-C5jmTtgvWs8PKTG6v2khLvUt3Tc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "mime-db": "^1.28.0"
       }
@@ -4842,7 +4812,6 @@
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha1-cHgZgdGD7hXROZPIgiBFxQbI8KY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -5080,7 +5049,6 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -5119,15 +5087,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -5476,8 +5442,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
@@ -5524,8 +5489,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5546,14 +5510,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5568,20 +5530,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5698,8 +5657,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5711,7 +5669,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5726,7 +5683,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5734,14 +5690,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5760,7 +5714,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5841,8 +5794,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5854,7 +5806,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5940,8 +5891,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5977,7 +5927,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5997,7 +5946,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6041,14 +5989,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6075,7 +6021,6 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
       "integrity": "sha1-NJ8rTZHUTE1NTpy6KtkBQ/rF75M=",
       "dev": true,
-      "optional": true,
       "requires": {
         "npm-conf": "^1.1.0"
       }
@@ -6084,15 +6029,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "pump": "^3.0.0"
       },
@@ -6102,7 +6045,6 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
-          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -6215,8 +6157,7 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pump": {
           "version": "3.0.0",
@@ -7419,8 +7360,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -7433,7 +7373,6 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -7639,8 +7578,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -7780,8 +7718,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "svgo": {
           "version": "1.3.2",
@@ -7853,7 +7790,6 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -8180,8 +8116,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -8231,8 +8166,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-negated-glob": {
       "version": "1.0.0",
@@ -8270,15 +8204,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
       "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -8348,15 +8280,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -8451,7 +8381,6 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -9347,8 +9276,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -9418,8 +9346,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -9587,8 +9514,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -12935,7 +12861,6 @@
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha1-JWzEe9DiGMJZxOlVC/QTvCGSr/k=",
       "dev": true,
-      "optional": true,
       "requires": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -12945,8 +12870,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12955,7 +12879,6 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -13324,8 +13247,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "p-is-promise": {
       "version": "1.1.0",
@@ -13362,7 +13284,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
-      "optional": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -13553,8 +13474,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -14061,8 +13981,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -14420,7 +14339,6 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -14775,7 +14693,6 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
       "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "commander": "^2.8.1"
       }
@@ -15170,7 +15087,6 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
@@ -15180,7 +15096,6 @@
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "sort-keys": "^1.0.0"
       }
@@ -15528,7 +15443,6 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -15537,8 +15451,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -15568,7 +15481,6 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -15694,7 +15606,6 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -15709,15 +15620,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -15733,7 +15642,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -15744,15 +15652,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
       "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "tempfile": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -15866,8 +15772,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "timers-ext": {
       "version": "0.1.7",
@@ -15924,8 +15829,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -16027,7 +15931,6 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -16163,7 +16066,6 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -16372,8 +16274,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "use": {
       "version": "3.1.1",
@@ -16867,7 +16768,6 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"


### PR DESCRIPTION
###  Goal:
- Have version in the generated artifact name
- Use same pipeline for nightly builds and release builds

###  Details:
 - The new format is:
    - Nightly builds (If source branch is NOT a release format)
        -  e.g Version becomes `9.0.0-preview20210517.63720`  => Artifacts becomes `9.0.0-preview20210517.63720.63720` 
     - Release builds  (If source branch is a release format)
       -  e.g Version becomes `9.0.0-beta003` => Artifacts becomes `9.0.0-beta003.63720` 
- Also adding Azure Pipeline tags to the builds:
-  `Continuous build` vs `Release build`. These can be used to filter releases
![image](https://user-images.githubusercontent.com/1561480/118532115-df7c6f80-b746-11eb-8d26-6598009453f5.png)

### NOTE:
- Please `squash and merge` instead of just `merge`. Azure Pipeline manipulations required a couple of attempts 🙈 