### PR TITLE
Adds an extension method allowing checks for whether a notification handler is registered for a given notification.

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
@@ -72,5 +73,10 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             return services;
         }
+
+        public static bool IsNotificationHandlerRegistered<TNotification>(this IUmbracoBuilder builder)
+            where TNotification : INotification => builder.Services
+            .Any(x => x.ServiceType == typeof(INotificationHandler<TNotification>) ||
+                      x.ServiceType == typeof(INotificationAsyncHandler<TNotification>));
     }
 }

--- a/src/Umbraco.Tests.UnitTests/TestHelpers/BaseUsingSqlSyntax.cs
+++ b/src/Umbraco.Tests.UnitTests/TestHelpers/BaseUsingSqlSyntax.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Cms.Tests.UnitTests.TestHelpers
             IServiceCollection container = TestHelper.GetServiceCollection();
             TypeLoader typeLoader = TestHelper.GetMockedTypeLoader();
 
-            var composition = new UmbracoBuilder(container, Mock.Of<IConfiguration>(), TestHelper.GetMockedTypeLoader());
+            var composition = new UmbracoBuilder(container, Mock.Of<IConfiguration>(), typeLoader);
 
             composition.WithCollectionBuilder<MapperCollectionBuilder>()
                 .AddCoreMappers();

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/DependencyInjection/UmbracoBuilderExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/DependencyInjection/UmbracoBuilderExtensionsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Tests.UnitTests.TestHelpers;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DependencyInjection
+{
+    [TestFixture]
+    public class UmbracoBuilderExtensionsTests
+    {
+        [Test]
+        public void CanRegisterAndRetrieveNotificationHandlers()
+        {
+            IServiceCollection container = TestHelper.GetServiceCollection();
+            TypeLoader typeLoader = TestHelper.GetMockedTypeLoader();
+
+            var composition = new UmbracoBuilder(container, Mock.Of<IConfiguration>(), typeLoader);
+            composition.AddNotificationHandler<TestNotification, TestNotificationHandler>();
+
+            var result = composition.IsNotificationHandlerRegistered<TestNotification>();
+            var result2 = composition.IsNotificationHandlerRegistered<TestNotification2>();
+
+            Assert.IsTrue(result);
+            Assert.IsFalse(result2);
+        }
+
+        private class TestNotification : INotification
+        {
+        }
+
+        private class TestNotification2 : INotification
+        {
+        }
+
+        private class TestNotificationHandler : INotificationHandler<TestNotification>, INotificationHandler<TestNotification2>
+        {
+            public void Handle(TestNotification notification) => throw new NotImplementedException();
+
+            public void Handle(TestNotification2 notification) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
We appear to have a use case for this in Forms, where we have different code paths for pre-populating a form for whether or not custom code is registered with the "pre-populate form" event.

Hence considering this as a method of checking if a particular notification has one or more handlers.