### PR TITLE
V9: Allow custom notification publisher in scope

### DIFF
--- a/src/Umbraco.Infrastructure/Scoping/IScopeProvider.cs
+++ b/src/Umbraco.Infrastructure/Scoping/IScopeProvider.cs
@@ -19,6 +19,7 @@ namespace Umbraco.Cms.Core.Scoping
         /// <param name="isolationLevel">The transaction isolation level.</param>
         /// <param name="repositoryCacheMode">The repositories cache mode.</param>
         /// <param name="eventDispatcher">An optional events dispatcher.</param>
+        /// <param name="scopedNotificationPublisher">An optional notification publisher.</param>
         /// <param name="scopeFileSystems">A value indicating whether to scope the filesystems.</param>
         /// <param name="callContext">A value indicating whether this scope should always be registered in the call context.</param>
         /// <param name="autoComplete">A value indicating whether this scope is auto-completed.</param>
@@ -35,6 +36,7 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher scopedNotificationPublisher = null,
             bool? scopeFileSystems = null,
             bool callContext = false,
             bool autoComplete = false);
@@ -46,6 +48,7 @@ namespace Umbraco.Cms.Core.Scoping
         /// <param name="isolationLevel">The transaction isolation level.</param>
         /// <param name="repositoryCacheMode">The repositories cache mode.</param>
         /// <param name="eventDispatcher">An optional events dispatcher.</param>
+        /// <param name="scopedNotificationPublisher">An option notification publisher.</param>
         /// <param name="scopeFileSystems">A value indicating whether to scope the filesystems.</param>
         /// <remarks>
         /// <para>A detached scope is not ambient and has no parent.</para>
@@ -56,6 +59,7 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher scopedNotificationPublisher = null,
             bool? scopeFileSystems = null);
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -39,7 +39,6 @@ namespace Umbraco.Cms.Core.Scoping
         private EventMessages _messages;
         private ICompletable _fscope;
         private IEventDispatcher _eventDispatcher;
-        // eventually this may need to be injectable - for now we'll create it explicitly and let future needs determine if it should be injectable
         private IScopedNotificationPublisher _notificationPublisher;
 
         private readonly object _dictionaryLocker;
@@ -65,6 +64,7 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher notificationPublisher = null,
             bool? scopeFileSystems = null,
             bool callContext = false,
             bool autoComplete = false)
@@ -80,6 +80,7 @@ namespace Umbraco.Cms.Core.Scoping
             _isolationLevel = isolationLevel;
             _repositoryCacheMode = repositoryCacheMode;
             _eventDispatcher = eventDispatcher;
+            _notificationPublisher = notificationPublisher;
             _scopeFileSystem = scopeFileSystems;
             _callContext = callContext;
             _autoComplete = autoComplete;
@@ -140,6 +141,12 @@ namespace Umbraco.Cms.Core.Scoping
                     throw new ArgumentException("Value cannot be specified on nested scope.", nameof(eventDispatcher));
                 }
 
+                // Only the outermost scope can specify the notification publisher
+                if (_notificationPublisher != null)
+                {
+                    throw new ArgumentException("Value cannot be specified on nested scope.", nameof(notificationPublisher));
+                }
+
                 // cannot specify a different fs scope!
                 // can be 'true' only on outer scope (and false does not make much sense)
                 if (scopeFileSystems != null && parent._scopeFileSystem != scopeFileSystems)
@@ -172,10 +179,11 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher scopedNotificationPublisher = null,
             bool? scopeFileSystems = null,
             bool callContext = false,
             bool autoComplete = false)
-            : this(scopeProvider, coreDebugSettings, mediaFileManager, eventAggregator, logger, fileSystems, null, scopeContext, detachable, isolationLevel, repositoryCacheMode, eventDispatcher, scopeFileSystems, callContext, autoComplete)
+            : this(scopeProvider, coreDebugSettings, mediaFileManager, eventAggregator, logger, fileSystems, null, scopeContext, detachable, isolationLevel, repositoryCacheMode, eventDispatcher, scopedNotificationPublisher, scopeFileSystems, callContext, autoComplete)
         { }
 
         // initializes a new scope in a nested scopes chain, with its parent
@@ -190,10 +198,11 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher notificationPublisher = null,
             bool? scopeFileSystems = null,
             bool callContext = false,
             bool autoComplete = false)
-            : this(scopeProvider, coreDebugSettings, mediaFileManager, eventAggregator, logger, fileSystems, parent, null, false, isolationLevel, repositoryCacheMode, eventDispatcher, scopeFileSystems, callContext, autoComplete)
+            : this(scopeProvider, coreDebugSettings, mediaFileManager, eventAggregator, logger, fileSystems, parent, null, false, isolationLevel, repositoryCacheMode, eventDispatcher, notificationPublisher, scopeFileSystems, callContext, autoComplete)
         { }
 
         public Guid InstanceId { get; } = Guid.NewGuid();
@@ -406,7 +415,11 @@ namespace Umbraco.Cms.Core.Scoping
             get
             {
                 EnsureNotDisposed();
-                if (ParentScope != null) return ParentScope.Notifications;
+                if (ParentScope != null)
+                {
+                    return ParentScope.Notifications;
+                }
+
                 return _notificationPublisher ?? (_notificationPublisher = new ScopedNotificationPublisher(_eventAggregator));
             }
         }

--- a/src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs
+++ b/src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs
@@ -380,8 +380,9 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher scopedNotificationPublisher = null,
             bool? scopeFileSystems = null)
-            => new Scope(this, _coreDebugSettings, _mediaFileManager, _eventAggregator, _loggerFactory.CreateLogger<Scope>(), _fileSystems, true, null, isolationLevel, repositoryCacheMode, eventDispatcher, scopeFileSystems);
+            => new Scope(this, _coreDebugSettings, _mediaFileManager, _eventAggregator, _loggerFactory.CreateLogger<Scope>(), _fileSystems, true, null, isolationLevel, repositoryCacheMode, eventDispatcher, scopedNotificationPublisher, scopeFileSystems);
 
         /// <inheritdoc />
         public void AttachScope(IScope other, bool callContext = false)
@@ -451,6 +452,7 @@ namespace Umbraco.Cms.Core.Scoping
             IsolationLevel isolationLevel = IsolationLevel.Unspecified,
             RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
             IEventDispatcher eventDispatcher = null,
+            IScopedNotificationPublisher notificationPublisher = null,
             bool? scopeFileSystems = null,
             bool callContext = false,
             bool autoComplete = false)
@@ -460,7 +462,7 @@ namespace Umbraco.Cms.Core.Scoping
             {
                 IScopeContext ambientContext = AmbientContext;
                 ScopeContext newContext = ambientContext == null ? new ScopeContext() : null;
-                var scope = new Scope(this, _coreDebugSettings, _mediaFileManager, _eventAggregator, _loggerFactory.CreateLogger<Scope>(), _fileSystems, false, newContext, isolationLevel, repositoryCacheMode, eventDispatcher, scopeFileSystems, callContext, autoComplete);
+                var scope = new Scope(this, _coreDebugSettings, _mediaFileManager, _eventAggregator, _loggerFactory.CreateLogger<Scope>(), _fileSystems, false, newContext, isolationLevel, repositoryCacheMode, eventDispatcher, notificationPublisher, scopeFileSystems, callContext, autoComplete);
                 // assign only if scope creation did not throw!
                 PushAmbientScope(scope);
                 if (newContext != null)
@@ -470,7 +472,7 @@ namespace Umbraco.Cms.Core.Scoping
                 return scope;
             }
 
-            var nested = new Scope(this, _coreDebugSettings, _mediaFileManager, _eventAggregator, _loggerFactory.CreateLogger<Scope>(), _fileSystems, ambientScope, isolationLevel, repositoryCacheMode, eventDispatcher, scopeFileSystems, callContext, autoComplete);
+            var nested = new Scope(this, _coreDebugSettings, _mediaFileManager, _eventAggregator, _loggerFactory.CreateLogger<Scope>(), _fileSystems, ambientScope, isolationLevel, repositoryCacheMode, eventDispatcher, notificationPublisher, scopeFileSystems, callContext, autoComplete);
             PushAmbientScope(nested);
             return nested;
         }

--- a/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineBaseTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineBaseTest.cs
@@ -89,6 +89,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
                         It.IsAny<IsolationLevel>(),
                         It.IsAny<RepositoryCacheMode>(),
                         It.IsAny<IEventDispatcher>(),
+                        It.IsAny<IScopedNotificationPublisher>(),
                         It.IsAny<bool?>(),
                         It.IsAny<bool>(),
                         It.IsAny<bool>()))

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
@@ -1,0 +1,96 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
+{
+    [TestFixture]
+    public class ScopedNotificationPublisherTests
+    {
+
+        [Test]
+        public void ScopeUsesInjectedNotificationPublisher()
+        {
+            var notificationPublisherMock = new Mock<IScopedNotificationPublisher>();
+            ScopeProvider scopeProvider = GetScopeProvider(out var eventAggregatorMock);
+
+            using (IScope scope = scopeProvider.CreateScope(notificationPublisher: notificationPublisherMock.Object))
+            {
+                scope.Notifications.Publish(Mock.Of<INotification>());
+                scope.Notifications.PublishCancelable(Mock.Of<ICancelableNotification>());
+
+                notificationPublisherMock.Verify(x => x.Publish(It.IsAny<INotification>()), Times.Once);
+                notificationPublisherMock.Verify(x => x.PublishCancelable(It.IsAny<ICancelableNotification>()), Times.Once);
+
+                // Ensure that the custom scope provider is till used in inner scope.
+                using (IScope innerScope = scopeProvider.CreateScope())
+                {
+                    innerScope.Notifications.Publish(Mock.Of<INotification>());
+                    innerScope.Notifications.PublishCancelable(Mock.Of<ICancelableNotification>());
+
+                    notificationPublisherMock.Verify(x => x.Publish(It.IsAny<INotification>()), Times.Exactly(2));
+                    notificationPublisherMock.Verify(x => x.PublishCancelable(It.IsAny<ICancelableNotification>()), Times.Exactly(2));
+                }
+
+                // Ensure scope exit is not called until outermost scope is being disposed
+                notificationPublisherMock.Verify(x => x.ScopeExit(It.IsAny<bool>()), Times.Never());
+            }
+
+            notificationPublisherMock.Verify(x => x.ScopeExit(It.IsAny<bool>()), Times.Once());
+            // Ensure that the event aggregator isn't used directly.
+            eventAggregatorMock.Verify(x => x.Publish(It.IsAny<INotification>()), Times.Never);
+            eventAggregatorMock.Verify(x => x.PublishCancelable(It.IsAny<ICancelableNotification>()), Times.Never);
+        }
+
+        [Test]
+        public void SpecifyingNotificationPublishInInnerScopeCausesError()
+        {
+            var notificationPublisherMock = new Mock<IScopedNotificationPublisher>();
+            ScopeProvider scopeProvider = GetScopeProvider(out var eventAggregatorMock);
+
+            using (var scope = scopeProvider.CreateScope())
+            {
+                Assert.Throws<ArgumentException>(() => scopeProvider.CreateScope(notificationPublisher: notificationPublisherMock.Object));
+            }
+        }
+
+        private ScopeProvider GetScopeProvider(out Mock<IEventAggregator> eventAggregatorMock)
+        {
+            NullLoggerFactory loggerFactory = NullLoggerFactory.Instance;
+
+            var fileSystems = new FileSystems(
+                loggerFactory,
+                Mock.Of<IIOHelper>(),
+                Options.Create(new GlobalSettings()),
+                Mock.Of<IHostingEnvironment>());
+
+            var mediaFileManager = new MediaFileManager(Mock.Of<IFileSystem>(), Mock.Of<IMediaPathScheme>(),
+                loggerFactory.CreateLogger<MediaFileManager>(), Mock.Of<IShortStringHelper>());
+
+            eventAggregatorMock = new Mock<IEventAggregator>();
+
+            return new ScopeProvider(
+                Mock.Of<IUmbracoDatabaseFactory>(),
+                fileSystems,
+                Options.Create(new CoreDebugSettings()),
+                mediaFileManager,
+                loggerFactory.CreateLogger<ScopeProvider>(),
+                loggerFactory,
+                Mock.Of<IRequestCache>(),
+                eventAggregatorMock.Object
+            );
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockScope = new Mock<IScope>();
             var mockScopeProvider = new Mock<IScopeProvider>();
             mockScopeProvider
-                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(mockScope.Object);
             var mockLogger = new Mock<ILogger<LogScrubber>>();
             var mockProfilingLogger = new Mock<IProfilingLogger>();

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
@@ -30,6 +30,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
                     It.IsAny<IsolationLevel>(),
                     It.IsAny<RepositoryCacheMode>(),
                     It.IsAny<IEventDispatcher>(),
+                    It.IsAny<IScopedNotificationPublisher>(),
                     It.IsAny<bool?>(),
                     It.IsAny<bool>(),
                     It.IsAny<bool>()))

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationTests.cs
@@ -30,6 +30,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations
                 IsolationLevel isolationLevel = IsolationLevel.Unspecified,
                 RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
                 IEventDispatcher eventDispatcher = null,
+                IScopedNotificationPublisher notificationPublisher = null,
                 bool? scopeFileSystems = null,
                 bool callContext = false,
                 bool autoComplete = false) => _scope;
@@ -38,6 +39,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations
                 IsolationLevel isolationLevel = IsolationLevel.Unspecified,
                 RepositoryCacheMode repositoryCacheMode = RepositoryCacheMode.Unspecified,
                 IEventDispatcher eventDispatcher = null,
+                IScopedNotificationPublisher notificationPublisher = null,
                 bool? scopeFileSystems = null) => throw new NotImplementedException();
 
             public void AttachScope(IScope scope, bool callContext = false) => throw new NotImplementedException();

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
             var mockScope = new Mock<IScope>();
             var mockScopeProvider = new Mock<IScopeProvider>();
             mockScopeProvider
-                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(mockScope.Object);
 
             return new MemberUserStore(

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
@@ -508,6 +508,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
                 It.IsAny<IsolationLevel>(),
                 It.IsAny<RepositoryCacheMode>(),
                 It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
                 It.IsAny<bool?>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>()) == Mock.Of<IScope>());


### PR DESCRIPTION
Allows a custom `IScopedNotificationPublisher` to be injected into a scope using the `IScopeProvider.CreateScope` method.

The logic is very much the same as for the `IEventDispatcher`, not allowing you to set it anywhere but the outermost scope, I know we talked about allowing a custom publisher in inner scopes as well for a NoOpPublisher, to suppress events, but this requires some more changes on how we handle the notifications, and I think that should be a separate task. This change shouldn't compromise our ability to do that later though.

We also talked about removing the `IEventDispatcher`, but thinking more about it, I'm not sure that's the best idea, wouldn't it make it quite a bit harder to port over custom code where you might still use (and want to use) the old event pattern for your own events?

I added a couple of unit tests as well to test that it is in fact the injected `IScopedNotificationPublisher` that is used for notifications.

I think this is a breaking change though if you happen to have used `CreateScope` with all the arguments as positional arguments