### PR TITLE
Fix issue when deleting an invited user

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -427,6 +427,7 @@ ORDER BY colName";
         {
             var list = new List<string>
             {
+                "DELETE FROM umbracoUserLogin WHERE userId = @id",
                 "DELETE FROM umbracoUser2UserGroup WHERE userId = @id",
                 "DELETE FROM umbracoUser2NodeNotify WHERE userId = @id",
                 "DELETE FROM umbracoUserStartNode WHERE userId = @id",


### PR DESCRIPTION
### Prerequisites

1. Setup the SMTP configurations in the Web.config so Umbraco can send emails (SendGrid account or other as example)
2. Create a user with the "Invite user" in the backoffice
3. Click on the link sent by email but don't fill the password form
4. Delete the user through the backoffice
5. The user should be deleted

Fixes #10269 

### Description
I added a `DELETE` query to make sure there are no entries for the user being deleted in the table `umbracoUserLogin` before deleting the user itself in the `umbracoUser` table. Before, there would be a foreign key conflict on the `userId` column (`FK_umbracoUserLogin_umbracoUser_id`).
