### PR TITLE
Fix getBlueprintScaffold endpoint

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -694,7 +694,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "contentApiBaseUrl",
-                        "GetEmpty",
+                        "GetEmptyBlueprint",
                         { blueprintId: blueprintId, parentId: parentId })),
                 'Failed to retrieve blueprint for id ' + blueprintId)
                 .then(function (result) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10300 

### Description
Method name in ContentController was updated to GetEmptyBlueprint, reference in content.resource.js was updated too, but looks to have reverted at some point since, because managing merges across two diverging branches must be lots of fun.

Change here fixes the reference in the javascript - `GetEmpty` becomes `GetEmptyBlueprint`

To test, create a content blueprint, then create content using that blueprint - should see no errors and new content is created as expected, using the template.