### PR TITLE
umbracoUrlAlias bug fix - added support for culture variation

### DIFF
--- a/src/Umbraco.Web/Routing/ContentFinderByUrlAlias.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByUrlAlias.cs
@@ -97,7 +97,6 @@ namespace Umbraco.Web.Routing
                     v = c.Value<string>(propertyAlias);
                 }
                 if (string.IsNullOrWhiteSpace(v)) return false;
-                var replace = "," + v.Replace(" ", "") + ",";
                 v = CleanValue(v);
                 if (v.InvariantContains(a1) || v.InvariantContains(a2)) return true;
 


### PR DESCRIPTION
The problem on #9798 that the "ContentFinderByUrlAlias" doesn't support culture variation and it is failing on the IsMatch() method.

I've added support for culture variation to give it a chance for matching it up again with the current culture.