### PR TITLE
Add a collection to allow adding CSS and JS to the back office via C#

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Core.Sections;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Tour;
 using Umbraco.Cms.Core.Trees;
+using Umbraco.Cms.Core.WebAssets;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.DependencyInjection
@@ -269,5 +270,11 @@ namespace Umbraco.Cms.Core.DependencyInjection
         /// </summary>
         public static SearchableTreeCollectionBuilder SearchableTrees(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<SearchableTreeCollectionBuilder>();
+
+        /// <summary>
+        /// Gets the back office custom assets collection builder
+        /// </summary>
+        public static CustomBackOfficeAssetsCollectionBuilder BackOfficeAssets(this IUmbracoBuilder builder)
+            => builder.WithCollectionBuilder<CustomBackOfficeAssetsCollectionBuilder>();
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -115,6 +115,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
                 .Append<Hulu>()
                 .Append<Giphy>();
             builder.SearchableTrees().Add(() => builder.TypeLoader.GetTypes<ISearchableTree>());
+            builder.BackOfficeAssets();
         }
 
         /// <summary>

--- a/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollection.cs
+++ b/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollection.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Core.WebAssets
+{
+    public class CustomBackOfficeAssetsCollection : BuilderCollectionBase<IAssetFile>
+    {
+        public CustomBackOfficeAssetsCollection(IEnumerable<IAssetFile> items)
+           : base(items)
+        { }
+    }
+}

--- a/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollectionBuilder.cs
+++ b/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollectionBuilder.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Core.WebAssets
+{
+    public class CustomBackOfficeAssetsCollectionBuilder : OrderedCollectionBuilderBase<CustomBackOfficeAssetsCollectionBuilder, CustomBackOfficeAssetsCollection, IAssetFile>
+    {
+        protected override CustomBackOfficeAssetsCollectionBuilder This => this;
+    }
+}

--- a/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollectionBuilder.cs
+++ b/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.WebAssets
 {

--- a/src/Umbraco.Infrastructure/WebAssets/PropertyEditorAssetAttribute.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/PropertyEditorAssetAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Umbraco.Cms.Core.WebAssets;
 
 namespace Umbraco.Cms.Infrastructure.WebAssets
@@ -10,6 +10,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets
     /// This wraps a CDF asset
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [Obsolete("Use the BackOfficeAssets collection on IUmbracoBuilder instead. Will be removed in the next major version")]
     public class PropertyEditorAssetAttribute : Attribute
     {
         public AssetType AssetType { get; }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10293

### Description

This allows the bundle to be added to using C# from a composer or an extension on IUmbracoBuilder. An example of how this code would be used by a developer.

```
// injected or extended
// IUmbracoBuilder builder;

builder.BackOfficeAssets()
.Append<MyCustomJsFile>()
.Append<MyCustomCssFile>();


public class MyCustomJsFile : JavaScriptFile
{
    public MyCustomJsFile() : base("/abc.js")
    {

    }
}

public class MyCustomCssFile : CssFile
    {
        public MyCustomJsFile() : base("/my-styles.css")
        {
        }
    }
```

The files in the example are within wwwroot

Thanks
Matt


<!-- Thanks for contributing to Umbraco CMS! -->
