### PR TITLE
NETCore: Fix dotnet new template for safe namespaces

### DIFF
--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -29,7 +29,7 @@
             "continueOnError": true
         }
     ],
-    "sourceName": "UmbracoProject",
+    "sourceName": "Umbraco.Cms.Web.UI.NetCore",
     "symbols": {
         "version": {
             "type": "parameter",
@@ -37,16 +37,6 @@
             "defaultValue": "9.0.0-beta003",
             "description": "The version of Umbraco to load using NuGet",
             "replaces": "UMBRACO_VERSION_FROM_TEMPLATE"
-        },
-        "namespaceReplacer": {
-            "type": "generated",
-            "generator": "coalesce",
-            "parameters": {
-                "sourceVariableName": "name",
-                "defaultValue": "UmbracoProject",
-                "fallbackVariableName": "name"
-            },
-            "replaces":"Umbraco.Cms.Web.UI.NetCore"
         },
         "PackageTestSiteName": {
             "type": "parameter",

--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">UmbracoProject</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">UmbracoProject</RootNamespace>
+        <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Umbraco.Cms.Web.UI.NetCore</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fix for invalid chars used in dotnet new templates creations to ensure namespace is valid & compiles

## Testing
* Try the dotnet new template pack before this PR with a name `Umbraco-v9-2021-05-12`
* `dotnet new umbraco --name Umbraco-v9-2021-05-12`
* This will fail to build due to invalid namespace if you do a `dotnet build`
* Install/update new dotnet template pack and retry with the same command & verify it makes the namespace safe & builds
* Retry with various other characters that could make unsafe namespace, perhaps with spaces
* `dotnet new umbraco --name "Umbraco v9 2021 05 12"`