### PR TITLE
adjusted the maxQueryString and maxQueryStringLength

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -1261,20 +1261,26 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 errorPageId: errorPageId
             };
             if (Utilities.isArray(groups) && groups.length) {
-                publicAccess.groups = groups;
+                return umbRequestHelper.resourcePromise(
+                    $http.post(
+                        umbRequestHelper.getApiUrl("contentApiBaseUrl", "PostPublicAccess", publicAccess),
+                        groups
+                    ),
+                    "Failed to update public access for content item with id " + contentId
+                );
             }
             else if (Utilities.isArray(usernames) && usernames.length) {
                 publicAccess.usernames = usernames;
+                return umbRequestHelper.resourcePromise(
+                    $http.post(
+                        umbRequestHelper.getApiUrl("contentApiBaseUrl", "PostPublicAccess", publicAccess)
+                    ),
+                    "Failed to update public access for content item with id " + contentId
+                );
             }
             else {
                 throw "must supply either userName/password or roles";
             }
-            return umbRequestHelper.resourcePromise(
-                $http.post(
-                    umbRequestHelper.getApiUrl("contentApiBaseUrl", "PostPublicAccess", publicAccess)
-                ),
-                "Failed to update public access for content item with id " + contentId
-            );
         },
 
         /**

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -85,7 +85,7 @@
 
         <trace enabled="true" requestLimit="10" pageOutput="false" traceMode="SortByTime" localOnly="true" />
 
-        <httpRuntime requestValidationMode="2.0" enableVersionHeader="false" targetFramework="4.7.2" maxRequestLength="51200" fcnMode="Single" maxQueryStringLength="2097151"/>
+        <httpRuntime requestValidationMode="2.0" enableVersionHeader="false" targetFramework="4.7.2" maxRequestLength="51200" fcnMode="Single"/>
 
         <httpModules>
             <add name="ScriptModule" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
@@ -196,7 +196,7 @@
         <!-- Increase the default upload file size limit -->
         <security>
             <requestFiltering>
-                <requestLimits maxAllowedContentLength="52428800" maxQueryString="9999"/>
+                <requestLimits maxAllowedContentLength="52428800"/>
             </requestFiltering>
         </security>
 

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -85,7 +85,7 @@
 
         <trace enabled="true" requestLimit="10" pageOutput="false" traceMode="SortByTime" localOnly="true" />
 
-        <httpRuntime requestValidationMode="2.0" enableVersionHeader="false" targetFramework="4.7.2" maxRequestLength="51200" fcnMode="Single" />
+        <httpRuntime requestValidationMode="2.0" enableVersionHeader="false" targetFramework="4.7.2" maxRequestLength="51200" fcnMode="Single" maxQueryStringLength="2097151"/>
 
         <httpModules>
             <add name="ScriptModule" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
@@ -196,7 +196,7 @@
         <!-- Increase the default upload file size limit -->
         <security>
             <requestFiltering>
-                <requestLimits maxAllowedContentLength="52428800" />
+                <requestLimits maxAllowedContentLength="52428800" maxQueryString="9999"/>
             </requestFiltering>
         </security>
 

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -2436,7 +2436,7 @@ namespace Umbraco.Web.Editors
         // set up public access using role based access
         [EnsureUserPermissionForContent("contentId", ActionProtect.ActionLetter)]
         [HttpPost]
-        public HttpResponseMessage PostPublicAccess(int contentId, [FromUri]string[] groups, [FromUri]string[] usernames, int loginPageId, int errorPageId)
+        public HttpResponseMessage PostPublicAccess(int contentId, [FromBody]string[] groups, [FromUri]string[] usernames, int loginPageId, int errorPageId)
         {
             if ((groups == null || groups.Any() == false) && (usernames == null || usernames.Any() == false))
             {


### PR DESCRIPTION
Adjust the value for the bug with the limitation of total of concatenated rolenames (Member groups)

This fixes #9695