### PR TITLE
Enable email sender to publish an event if smtp is not configured

### DIFF
--- a/src/Umbraco.Core/Mail/IEmailSender.cs
+++ b/src/Umbraco.Core/Mail/IEmailSender.cs
@@ -10,6 +10,8 @@ namespace Umbraco.Cms.Core.Mail
     {
         Task SendAsync(EmailMessage message);
 
+        Task SendAsync(EmailMessage message, bool enableNotification);
+
         bool CanSendRequiredEmail();
     }
 }

--- a/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
+++ b/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
@@ -9,6 +9,10 @@ namespace Umbraco.Cms.Core.Mail
         public Task SendAsync(EmailMessage message)
             => throw new NotImplementedException("To send an Email ensure IEmailSender is implemented with a custom implementation");
 
+        public Task SendAsync(EmailMessage message, bool enableNotification) =>
+            throw new NotImplementedException(
+                "To send an Email ensure IEmailSender is implemented with a custom implementation");
+
         public bool CanSendRequiredEmail()
             => throw new NotImplementedException("To send an Email ensure IEmailSender is implemented with a custom implementation");
     }

--- a/src/Umbraco.Core/Notifications/SendEmailNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendEmailNotification.cs
@@ -1,0 +1,11 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Notifications
+{
+    public class SendEmailNotification : INotification
+    {
+        public SendEmailNotification(EmailMessage message) => Message = message;
+
+        public EmailMessage Message { get; set; }
+    }
+}

--- a/src/Umbraco.Infrastructure/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/EmailSender.cs
@@ -5,8 +5,10 @@ using System.Net.Mail;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Mail;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Infrastructure.Extensions;
 using SmtpClient = MailKit.Net.Smtp.SmtpClient;
 
@@ -18,20 +20,41 @@ namespace Umbraco.Cms.Infrastructure
     public class EmailSender : IEmailSender
     {
         // TODO: This should encapsulate a BackgroundTaskRunner with a queue to send these emails!
-
+        private readonly IEventAggregator _eventAggregator;
         private readonly GlobalSettings _globalSettings;
+        private readonly bool _notificationHandlerRegistered;
 
-        public EmailSender(IOptions<GlobalSettings> globalSettings) => _globalSettings = globalSettings.Value;
+        public EmailSender(IOptions<GlobalSettings> globalSettings, IEventAggregator eventAggregator)
+            : this(globalSettings, eventAggregator, null)
+        {
+
+        }
+
+        public EmailSender(IOptions<GlobalSettings> globalSettings, IEventAggregator eventAggregator, INotificationHandler<SendEmailNotification> handler)
+        {
+            _eventAggregator = eventAggregator;
+            _globalSettings = globalSettings.Value;
+            _notificationHandlerRegistered = handler is not null;
+        }
 
         /// <summary>
         /// Sends the message async
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        public async Task SendAsync(EmailMessage message)
+        public async Task SendAsync(EmailMessage message) => await SendAsyncInternal(message, false);
+
+        public async Task SendAsync(EmailMessage message, bool enableNotification) =>
+            await SendAsyncInternal(message, enableNotification);
+
+        private async Task SendAsyncInternal(EmailMessage message, bool enableNotification)
         {
             if (_globalSettings.IsSmtpServerConfigured == false)
             {
+                if (enableNotification)
+                {
+                    await _eventAggregator.PublishAsync(new SendEmailNotification(message));
+                }
                 return;
             }
 
@@ -66,6 +89,6 @@ namespace Umbraco.Cms.Infrastructure
         /// <remarks>
         /// We assume this is possible if either an event handler is registered or an smtp server is configured
         /// </remarks>
-        public bool CanSendRequiredEmail() => _globalSettings.IsSmtpServerConfigured;
+        public bool CanSendRequiredEmail() => _globalSettings.IsSmtpServerConfigured || _notificationHandlerRegistered;
     }
 }

--- a/src/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
+++ b/src/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
@@ -20,6 +20,7 @@ using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Diagnostics;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Logging;
@@ -136,7 +137,7 @@ namespace Umbraco.Cms.Tests.UnitTests.TestHelpers
 
         public static UriUtility UriUtility => s_testHelperInternal.UriUtility;
 
-        public static IEmailSender EmailSender { get; } = new EmailSender(Options.Create(new GlobalSettings()));
+        public static IEmailSender EmailSender { get; } = new EmailSender(Options.Create(new GlobalSettings()), Mock.Of<IEventAggregator>());
 
         /// <summary>
         /// Some test files are copied to the /bin (/bin/debug) on build, this is a utility to return their physical path based on a virtual path name

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -552,7 +552,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             var mailMessage = new EmailMessage(fromEmail, to.Email, emailSubject, emailBody, true);
 
-            await _emailSender.SendAsync(mailMessage);
+            await _emailSender.SendAsync(mailMessage, true);
         }
 
         /// <summary>


### PR DESCRIPTION
In V8 we had an event you could listen to `EmailSender.SendEmail`, if this event had a handler registered, and `EmailSender` was constructed with enableEvents set to true, we would raise the event if the SMTP was not configured.

This PR reinstates this using notifications instead since it's used in deploy.

 Since EmailSender is now registered in DI, I created an overload for `SendAsync` instead which accepts the bool, looking through V8 I can see that this was only used for `UsersController.SendUserInviteEmailAsync`, so I've set enableNotifications to true there.

`CanSendRequiredEmail()` now also returns true if there is a notification handler for `SendEmailNotification` registered, same as V8.

### Testing 
To test this I first just ran the site normally and made sure that `CanSendRequiredEmail()` returned false, and that InviteUser was hidden.

Then I added this handler: 

```C#
public class EmailHandler : INotificationHandler<SendEmailNotification>
{
    private readonly ILogger<EmailHandler> _logger;

    public EmailHandler(ILogger<EmailHandler> logger)
    {
        _logger = logger;
    }
    
    public void Handle(SendEmailNotification notification)
    {
        _logger.LogInformation("Was requested to send email to {Reciever} body:{Body}", notification.Message.To,
            notification.Message.Body);
    }
}
```

And made sure that when I now run the site `CanSendRequiredEmail()` returns true, and I can invite a user, when I do the Handle method is invoked. 
