### PR TITLE
#10354 - added domain content id as node context for the content find…

### DIFF
--- a/src/Umbraco.Web/Routing/ContentFinderByConfigured404.cs
+++ b/src/Umbraco.Web/Routing/ContentFinderByConfigured404.cs
@@ -33,11 +33,14 @@ namespace Umbraco.Web.Routing
         {
             _logger.Debug<ContentFinderByConfigured404>("Looking for a page to handle 404.");
 
+            int? domainConentId = null;
+
             // try to find a culture as best as we can
             var errorCulture = CultureInfo.CurrentUICulture;
             if (frequest.HasDomain)
             {
                 errorCulture = frequest.Domain.Culture;
+                domainConentId = frequest.Domain.ContentId;
             }
             else
             {
@@ -63,7 +66,9 @@ namespace Umbraco.Web.Routing
                 _contentConfigSection.Error404Collection.ToArray(),
                 _entityService,
                 new PublishedContentQuery(frequest.UmbracoContext.PublishedSnapshot, frequest.UmbracoContext.VariationContextAccessor),
-                errorCulture);
+                errorCulture,
+                domainConentId
+                );
 
             IPublishedContent content = null;
 

--- a/src/Umbraco.Web/Routing/NotFoundHandlerHelper.cs
+++ b/src/Umbraco.Web/Routing/NotFoundHandlerHelper.cs
@@ -41,7 +41,8 @@ namespace Umbraco.Web.Routing
             IContentErrorPage[] error404Collection,
             IEntityService entityService,
             IPublishedContentQuery publishedContentQuery,
-            CultureInfo errorCulture)
+            CultureInfo errorCulture,
+            int? domainContentId)
         {
             if (error404Collection.Length > 1)
             {
@@ -50,11 +51,11 @@ namespace Umbraco.Web.Routing
                     ?? error404Collection.FirstOrDefault(x => x.Culture == "default"); // there should be a default one!
 
                 if (cultureErr != null)
-                    return GetContentIdFromErrorPageConfig(cultureErr, entityService, publishedContentQuery);
+                    return GetContentIdFromErrorPageConfig(cultureErr, entityService, publishedContentQuery, domainContentId);
             }
             else
             {
-                return GetContentIdFromErrorPageConfig(error404Collection.First(), entityService, publishedContentQuery);
+                return GetContentIdFromErrorPageConfig(error404Collection.First(), entityService, publishedContentQuery, domainContentId);
             }
 
             return null;
@@ -67,7 +68,7 @@ namespace Umbraco.Web.Routing
         /// <param name="entityService"></param>
         /// <param name="publishedContentQuery"></param>
         /// <returns></returns>
-        internal static int? GetContentIdFromErrorPageConfig(IContentErrorPage errorPage, IEntityService entityService, IPublishedContentQuery publishedContentQuery)
+        internal static int? GetContentIdFromErrorPageConfig(IContentErrorPage errorPage, IEntityService entityService, IPublishedContentQuery publishedContentQuery, int? domainContentId)
         {
             if (errorPage.HasContentId) return errorPage.ContentId;
 
@@ -92,7 +93,7 @@ namespace Umbraco.Web.Routing
                     //we have an xpath statement to execute
                     var xpathResult = UmbracoXPathPathSyntaxParser.ParseXPathQuery(
                         xpathExpression: errorPage.ContentXPath,
-                        nodeContextId: null,
+                        nodeContextId: domainContentId,
                         getPath: nodeid =>
                         {
                             var ent = entityService.Get(nodeid);


### PR DESCRIPTION
…er for the 404 error page so $site works

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10354

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
I needed to make different 404 pages for different sites and so wanted to use $site in the xPath.  This doesn't currently work since the nodeContextId in the xpath isn't set.  

However, when we get the domain as part of the PublishedRequest, we also get the content id of the site for that domain so we can use this to pass in the site context to the xpath query and make $site work.   I think $current will also look at the site root.  

I opened a issue with more details around this.  https://github.com/umbraco/Umbraco-CMS/issues/10354 

To test this, setup multiple sites with multiple domains that have an error pages setup.  Then configure the error404 using xPath and $site.  See that each domain returns different nodes.

See the ticket for more details around this issue.



<!-- Thanks for contributing to Umbraco CMS! -->
