### PR TITLE
Avoid repeated reloads of content and media cache following Deploy operations.

### DIFF
--- a/src/Umbraco.Web/Cache/DistributedCacheBinder.cs
+++ b/src/Umbraco.Web/Cache/DistributedCacheBinder.cs
@@ -61,11 +61,15 @@ namespace Umbraco.Web.Cache
         /// <inheritdoc />
         public void HandleEvents(IEnumerable<IEventDefinition> events)
         {
-            // ensure we run with an UmbracoContext, because this may run in a background task,
-            // yet developers may be using the 'current' UmbracoContext in the event handlers
+            // Ensure we run with an UmbracoContext, because this may run in a background task,
+            // yet developers may be using the 'current' UmbracoContext in the event handlers.
             using (_umbracoContextFactory.EnsureUmbracoContext())
             {
-                foreach (var e in events)
+                // When it comes to content types types, a change to any single one will trigger a reload of the content and media caches.
+                // As far as I (AB) can tell, there's no type specific logic here, they all clear caches for all content types, and trigger a reload of all content and media.
+                // We also have events registered for Changed and Saved, which do the same thing, so really only need one of these.
+                // Hence if we have more than one document or media types, we can and should only handle one of the events for one, to avoid repeated cache reloads.
+                foreach (var e in GetReducedEventList(events))
                 {
                     var handler = FindHandler(e);
                     if (handler == null)
@@ -79,6 +83,50 @@ namespace Umbraco.Web.Cache
                     handler.Invoke(this, new[] { e.Sender, e.Args });
                 }
             }
+        }
+
+        // Internal for tests
+        internal static IEnumerable<IEventDefinition> GetReducedEventList(IEnumerable<IEventDefinition> events)
+        {
+            var reducedEvents = new List<IEventDefinition>();
+
+            var gotDoumentType = false;
+            var gotMediaType = false;
+            var gotMemberType = false;
+
+            foreach (var evt in events)
+            {
+                if (evt.Sender.ToString().Contains(nameof(Core.Services.Implement.ContentTypeService)))
+                {
+                    if (gotDoumentType == false)
+                    {
+                        reducedEvents.Add(evt);
+                        gotDoumentType = true;
+                    }
+                }
+                else if (evt.Sender.ToString().Contains(nameof(Core.Services.Implement.MediaTypeService)))
+                {
+                    if (gotMediaType == false)
+                    {
+                        reducedEvents.Add(evt);
+                        gotMediaType = true;
+                    }
+                }
+                else if (evt.Sender.ToString().Contains(nameof(Core.Services.Implement.MemberTypeService)))
+                {
+                    if (gotMemberType == false)
+                    {
+                        reducedEvents.Add(evt);
+                        gotMemberType = true;
+                    }
+                }
+                else
+                {
+                    reducedEvents.Add(evt);
+                }
+            }
+
+            return reducedEvents;
         }
     }
 }


### PR DESCRIPTION
This PR is an attempt to mitigate some issues reported on Umbraco Cloud with deployment operations containing document type changes and large databases (either numbers of nodes, versions or both).

I've observed from logs that there are repeated calls to reload the content and media cache - twice for every document type in the deployment batch - so with 5 document types, there are 10 full reloads.

This seems unnecessary - as when a document type changes _all_ content is reloaded.  There's no logic to refresh parts of the cache for different document types, hence it seems we don't really care which document type has been updated in this context, just that one has.

So I've amended the logic for refreshing the cache to handle only single content type event, even if there are several.

I [initially tried to adapt this in Deploy](https://github.com/umbraco/Umbraco-Deploy/pull/540) - by only raising one event instead of several - but there are other components, namely Heartcore, that rely on knowing exactly which content type has changed via the distributed cache.

To Test:

- With a Cloud site, push an update containing several document type changes.
- View the logs.  You should see only one entry like the following associated with the deployment.  Before this PR you'd see 2 x number of document types.

```
{"@t":"2021-05-31T13:54:34.1191291Z","@mt":"{StartMessage} [Timing {TimingId}]","StartMessage":"Loading content from database",...
{"@t":"2021-05-31T13:55:08.4989863Z","@mt":"{EndMessage} ({Duration}ms) [Timing {TimingId}]","EndMessage":"Completed.",...
{"@t":"2021-05-31T13:55:08.5249691Z","@mt":"{StartMessage} [Timing {TimingId}]","StartMessage":"Loading media from database",...
{"@t":"2021-05-31T13:55:09.3561273Z","@mt":"{EndMessage} ({Duration}ms) [Timing {TimingId}]","EndMessage":"Completed.",...
```
