### PR TITLE
Support custom SVG icon in content app

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation-item.html
@@ -8,7 +8,7 @@
         class="umb-sub-views-nav-item__action umb-outline umb-outline--thin"
         aria-haspopup="{{ vm.item.anchors && vm.item.anchors.length > 1 }}"
         aria-expanded="{{ vm.expanded }}">
-    <i class="icon {{ vm.item.icon }}" aria-hidden="true"></i>
+    <umb-icon icon="{{vm.item.icon}}" class="icon {{vm.item.icon}}"></umb-icon>
     <span class="umb-sub-views-nav-item-text">{{ vm.item.name }}</span>
     <div ng-show="vm.item.badge" class="badge -type-{{vm.item.badge.type}}">{{vm.item.badge.count}}</div>
     <div ng-show="!vm.item.badge" class="badge -type-alert --error-badge">!</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-navigation.html
@@ -23,8 +23,7 @@
                 text="{{moreButton.name}}"
                 show-text="true"
                 mode="tab"
-                css-class="umb-sub-views-nav-item__action umb-outline umb-outline--thin {{moreButton.active ? 'is-active' : ''}}"
-                >
+                css-class="umb-sub-views-nav-item__action umb-outline umb-outline--thin {{moreButton.active ? 'is-active' : ''}}">
             </umb-button-ellipsis>
 
             <umb-dropdown ng-show="showDropdown" on-close="hideDropdown()" class="umb-sub-views-nav-item-more__dropdown">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently it wasn't possible to use a custom SVG icon uploaded to a folder in App_Plugins and use this in a content app - either registrered via C# code, package.manifest or using changing icon in listview content app icon property.

![image](https://user-images.githubusercontent.com/2919859/120219879-30f32700-c23c-11eb-91f0-462fb7c39f6f.png)

![image](https://user-images.githubusercontent.com/2919859/120219922-410b0680-c23c-11eb-972e-b2743b8ef227.png)
