### PR TITLE
Support custom SVG icon in user group filter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -150,7 +150,7 @@
                                 </umb-checkbox>
                                 <label for="usergroup-{{$index}}">
                                     <span class="flex items-center">
-                                        <i class="{{userGroup.icon}}" aria-hidden="true"></i>
+                                        <umb-icon icon="{{userGroup.icon}}" class="{{userGroup.icon}}"></umb-icon>
                                         <span class="ml1">{{userGroup.name}}</span>
                                     </span>
                                 </label>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
If using a custom SVG icon for a user group this wasn't shown in user group filter.

![image](https://user-images.githubusercontent.com/2919859/120224526-eb3a5c80-c243-11eb-96e4-3a1a3edf5997.png)

