### PR TITLE
Support custom SVG icon in Nested Content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -18,7 +18,13 @@
                              ng-hide="vm.singleMode"
                              umb-auto-focus="{{vm.focusOnNode && vm.currentNode.key === node.key ? 'true' : 'false'}}">
 
-                            <div class="umb-nested-content__heading"><i ng-if="vm.showIcons" class="icon umb-nested-content__item-icon" ng-class="vm.getIcon($index)"></i><span class="umb-nested-content__item-name" ng-class="{'--has-icon': vm.showIcons}" ng-bind="vm.getName($index)"></span></div>
+                            <div class="umb-nested-content__heading">
+                                <umb-icon
+                                    icon="{{vm.getIcon($index)}}"
+                                    class="{{vm.getIcon($index)}} icon umb-nested-content__item-icon">
+                                </umb-icon>
+                                <span class="umb-nested-content__item-name" ng-class="{'--has-icon': vm.showIcons}" ng-bind="vm.getName($index)"></span>
+                            </div>
 
                             <div class="umb-nested-content__icons">
                                 <button type="button" class="umb-nested-content__icon umb-nested-content__icon--copy" title="{{vm.labels.copy_icon_title}}" ng-click="vm.clickCopy($event, node);" ng-if="vm.showCopy">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -6,9 +6,9 @@
 
         <div class="umb-nested-content__items" ng-hide="vm.nodes.length === 0" ui-sortable="vm.sortableOptions" ng-model="vm.nodes">
 
-            <div ng-repeat="node in vm.nodes">
+            <div ng-repeat="node in vm.nodes" ng-init="node.icon == vm.getIcon($index)">
 
-                <ng-form name="ncRowForm" val-server-match="{ 'contains' : node.key  }">
+                <ng-form name="ncRowForm" val-server-match="{ 'contains': node.key }">
 
                     <div class="umb-nested-content__item"
                          ng-class="{ 'umb-nested-content__item--active' : vm.currentNode.key === node.key, 'umb-nested-content__item--single' : vm.singleMode, '--error': ncRowForm.$invalid }">
@@ -20,8 +20,8 @@
 
                             <div class="umb-nested-content__heading">
                                 <umb-icon
-                                    icon="{{vm.getIcon($index)}}"
-                                    class="{{vm.getIcon($index)}} icon umb-nested-content__item-icon">
+                                    icon="{{node.icon}}"
+                                    class="{{node.icon}} icon umb-nested-content__item-icon">
                                 </umb-icon>
                                 <span class="umb-nested-content__item-name" ng-class="{'--has-icon': vm.showIcons}" ng-bind="vm.getName($index)"></span>
                             </div>
@@ -39,7 +39,6 @@
                                 </button>
                             </div>
                         </div>
-
 
                         <div class="umb-nested-content__content" ng-if="vm.currentNode.key === node.key && !vm.sorting">
                             <umb-nested-content-editor ng-model="node" tab-alias="ncTabAlias" />

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -6,7 +6,7 @@
 
         <div class="umb-nested-content__items" ng-hide="vm.nodes.length === 0" ui-sortable="vm.sortableOptions" ng-model="vm.nodes">
 
-            <div ng-repeat="node in vm.nodes" ng-init="node.icon == vm.getIcon($index)">
+            <div ng-repeat="node in vm.nodes" ng-init="node.icon = vm.getIcon($index)">
 
                 <ng-form name="ncRowForm" val-server-match="{ 'contains': node.key }">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
If using a custom SVG icon this wasn't shown in Nested Content. With a few adjustments this can be supported although the newer Block List editor probably is preferred on new projects.

![image](https://user-images.githubusercontent.com/2919859/120225956-85030900-c246-11eb-8193-706cf8ae56dd.png)
