### PR TITLE
Close Modal window on error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -598,6 +598,7 @@
                                 formHelper.resetForm({ scope: $scope, hasErrors: true });
                                 $scope.page.buttonGroupState = 'error';
                                 handleHttpException(err);
+                                overlayService.close();
                             });
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Issue:
When unPublish event is cancelled modal window doesn't close and remains stuck even when API has returned HTTP 40x. 
    
Reproduce steps:
Intercept unpublish event and cancel it. Expected result - modal window closes. Actual result - modal remains open.

Resolution:
Added overlayService.close(); to error function. Without it modal window remains stuck even though unPublish event is cancelled.

Image to bug attached:
    
![image](https://user-images.githubusercontent.com/9220983/120140164-0bf7b780-c22e-11eb-90c5-28a1f008ec7c.png)

