### PR TITLE
V9: Add new email Model for notifications

### DIFF
--- a/src/Umbraco.Core/Events/SendEmailEventArgs.cs
+++ b/src/Umbraco.Core/Events/SendEmailEventArgs.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Core.Events
 {

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Mail;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 

--- a/src/Umbraco.Core/Mail/IEmailSender.cs
+++ b/src/Umbraco.Core/Mail/IEmailSender.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Core.Mail
 {

--- a/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
+++ b/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Core.Mail
 {

--- a/src/Umbraco.Core/Models/Email/EmailMessage.cs
+++ b/src/Umbraco.Core/Models/Email/EmailMessage.cs
@@ -33,7 +33,6 @@ namespace Umbraco.Cms.Core.Models.Email
 
         public EmailMessage(string from, string[] to, string[] cc, string[] bcc, string[] replyTo, string subject, string body, bool isBodyHtml, IEnumerable<EmailMessageAttachment> attachments)
         {
-            ArgumentIsNotNullOrEmpty(from, nameof(from));
             ArgumentIsNotNullOrEmpty(to, nameof(to));
             ArgumentIsNotNullOrEmpty(subject, nameof(subject));
             ArgumentIsNotNullOrEmpty(body, nameof(body));

--- a/src/Umbraco.Core/Models/Email/EmailMessage.cs
+++ b/src/Umbraco.Core/Models/Email/EmailMessage.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Umbraco.Cms.Core.Models
+namespace Umbraco.Cms.Core.Models.Email
 {
     public class EmailMessage
     {

--- a/src/Umbraco.Core/Models/Email/EmailMessageAttachment.cs
+++ b/src/Umbraco.Core/Models/Email/EmailMessageAttachment.cs
@@ -1,6 +1,6 @@
 using System.IO;
 
-namespace Umbraco.Cms.Core.Models
+namespace Umbraco.Cms.Core.Models.Email
 {
     public class EmailMessageAttachment
     {

--- a/src/Umbraco.Core/Models/Email/NotificationEmailAddress.cs
+++ b/src/Umbraco.Core/Models/Email/NotificationEmailAddress.cs
@@ -7,11 +7,11 @@ namespace Umbraco.Cms.Core.Models.Email
     {
         public string DisplayName { get; }
 
-        public string Adress { get; }
+        public string Address { get; }
 
         public NotificationEmailAddress(string address, string displayName)
         {
-            Adress = address;
+            Address = address;
             DisplayName = displayName;
         }
     }

--- a/src/Umbraco.Core/Models/Email/NotificationEmailAddress.cs
+++ b/src/Umbraco.Core/Models/Email/NotificationEmailAddress.cs
@@ -1,0 +1,18 @@
+namespace Umbraco.Cms.Core.Models.Email
+{
+    /// <summary>
+    /// Represents an email address used for notifications. Contains both the address and its display name.
+    /// </summary>
+    public class NotificationEmailAddress
+    {
+        public string DisplayName { get; }
+
+        public string Adress { get; }
+
+        public NotificationEmailAddress(string address, string displayName)
+        {
+            Adress = address;
+            DisplayName = displayName;
+        }
+    }
+}

--- a/src/Umbraco.Core/Models/Email/NotificationEmailModel.cs
+++ b/src/Umbraco.Core/Models/Email/NotificationEmailModel.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Umbraco.Cms.Core.Models.Email
+{
+    /// <summary>
+    /// Represents an email when sent with notifications.
+    /// </summary>
+    public class NotificationEmailModel
+    {
+        public NotificationEmailAddress From { get; }
+
+        public IEnumerable<NotificationEmailAddress> To { get; }
+
+        public IEnumerable<NotificationEmailAddress> Cc { get; }
+
+        public IEnumerable<NotificationEmailAddress> Bcc { get; }
+
+        public IEnumerable<NotificationEmailAddress> ReplyTo { get; }
+
+        public string Subject { get; }
+
+        public string Body { get; }
+
+        public IList<EmailMessageAttachment> Attachments { get; }
+
+        public bool HasAttachments => Attachments != null && Attachments.Count > 0;
+
+        public NotificationEmailModel(
+            NotificationEmailAddress from,
+            IEnumerable<NotificationEmailAddress> to,
+            IEnumerable<NotificationEmailAddress> cc,
+            IEnumerable<NotificationEmailAddress> bcc,
+            IEnumerable<NotificationEmailAddress> replyTo,
+            string subject,
+            string body,
+            IEnumerable<EmailMessageAttachment> attachments)
+        {
+            From = from;
+            To = to;
+            Cc = cc;
+            Bcc = bcc;
+            ReplyTo = replyTo;
+            Subject = subject;
+            Body = body;
+            Attachments = attachments?.ToList();
+        }
+
+    }
+}

--- a/src/Umbraco.Core/Models/Email/NotificationEmailModel.cs
+++ b/src/Umbraco.Core/Models/Email/NotificationEmailModel.cs
@@ -22,6 +22,8 @@ namespace Umbraco.Cms.Core.Models.Email
 
         public string Body { get; }
 
+        public bool IsBodyHtml { get; }
+
         public IList<EmailMessageAttachment> Attachments { get; }
 
         public bool HasAttachments => Attachments != null && Attachments.Count > 0;
@@ -34,7 +36,8 @@ namespace Umbraco.Cms.Core.Models.Email
             IEnumerable<NotificationEmailAddress> replyTo,
             string subject,
             string body,
-            IEnumerable<EmailMessageAttachment> attachments)
+            IEnumerable<EmailMessageAttachment> attachments,
+            bool isBodyHtml)
         {
             From = from;
             To = to;
@@ -43,6 +46,7 @@ namespace Umbraco.Cms.Core.Models.Email
             ReplyTo = replyTo;
             Subject = subject;
             Body = body;
+            IsBodyHtml = isBodyHtml;
             Attachments = attachments?.ToList();
         }
 

--- a/src/Umbraco.Core/Notifications/SendEmailNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendEmailNotification.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Core.Notifications
 {

--- a/src/Umbraco.Core/Notifications/SendEmailNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendEmailNotification.cs
@@ -4,8 +4,8 @@ namespace Umbraco.Cms.Core.Notifications
 {
     public class SendEmailNotification : INotification
     {
-        public SendEmailNotification(EmailMessage message) => Message = message;
+        public SendEmailNotification(NotificationEmailModel message) => Message = message;
 
-        public EmailMessage Message { get; set; }
+        public NotificationEmailModel Message { get; }
     }
 }

--- a/src/Umbraco.Infrastructure/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/EmailSender.cs
@@ -53,7 +53,8 @@ namespace Umbraco.Cms.Infrastructure
             {
                 if (enableNotification)
                 {
-                    await _eventAggregator.PublishAsync(new SendEmailNotification(message.ToNotificationEmail(_globalSettings.Smtp.From)));
+                    await _eventAggregator.PublishAsync(
+                        new SendEmailNotification(message.ToNotificationEmail(_globalSettings.Smtp?.From)));
                 }
                 return;
             }

--- a/src/Umbraco.Infrastructure/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/EmailSender.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Mail;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Infrastructure.Extensions;
 using SmtpClient = MailKit.Net.Smtp.SmtpClient;

--- a/src/Umbraco.Infrastructure/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/EmailSender.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Cms.Infrastructure
             {
                 if (enableNotification)
                 {
-                    await _eventAggregator.PublishAsync(new SendEmailNotification(message));
+                    await _eventAggregator.PublishAsync(new SendEmailNotification(message.ToNotificationEmail(_globalSettings.Smtp.From)));
                 }
                 return;
             }

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using MimeKit;
 using MimeKit.Text;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Infrastructure.Extensions
 {

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using MimeKit;
 using MimeKit.Text;
 using Umbraco.Cms.Core.Models.Email;
@@ -62,27 +62,52 @@ namespace Umbraco.Cms.Infrastructure.Extensions
         public static NotificationEmailModel ToNotificationEmail(this EmailMessage emailMessage,
             string configuredFromAddress)
         {
-            var mimeMessage = emailMessage.ToMimeMessage(configuredFromAddress);
-            if (mimeMessage.From.Any() is false || mimeMessage.To.Any() is false)
-            {
-                throw new InvalidOperationException("There must be a valid from address and recipient address.");
-            }
-            // EmailMessage only supports a single from mail, so take the first.
-            NotificationEmailAddress from = ToNotificationAddress(mimeMessage.From.Mailboxes.First());
+            NotificationEmailAddress from = ToNotificationAddress(emailMessage.From);
 
             return new NotificationEmailModel(from,
-                mimeMessage.To.Mailboxes.Select(ToNotificationAddress),
-                mimeMessage.Cc.Mailboxes.Select(ToNotificationAddress),
-                mimeMessage.Bcc.Mailboxes.Select(ToNotificationAddress),
-                mimeMessage.ReplyTo.Mailboxes.Select(ToNotificationAddress),
-                mimeMessage.Subject,
+                GetNotificationAddresses(emailMessage.To),
+                GetNotificationAddresses(emailMessage.Cc),
+                GetNotificationAddresses(emailMessage.Bcc),
+                GetNotificationAddresses(emailMessage.ReplyTo),
+                emailMessage.Subject,
                 emailMessage.Body,
                 emailMessage.Attachments,
                 emailMessage.IsBodyHtml);
         }
 
-        private static NotificationEmailAddress ToNotificationAddress(MailboxAddress mailboxAddress) =>
-            new NotificationEmailAddress(mailboxAddress.Address, mailboxAddress.Name);
+        private static NotificationEmailAddress ToNotificationAddress(string address)
+        {
+            if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+            {
+                if (internetAddress is MailboxAddress mailboxAddress)
+                {
+                    return new NotificationEmailAddress(mailboxAddress.Address, internetAddress.Name);
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<NotificationEmailAddress> GetNotificationAddresses(IEnumerable<string> addresses)
+        {
+            if (addresses is null)
+            {
+                return null;
+            }
+
+            var notificationAddresses = new List<NotificationEmailAddress>();
+
+            foreach (var address in addresses)
+            {
+                NotificationEmailAddress notificationAddress = ToNotificationAddress(address);
+                if (notificationAddress is not null)
+                {
+                    notificationAddresses.Add(notificationAddress);
+                }
+            }
+
+            return notificationAddresses;
+        }
 
         private static void AddAddresses(MimeMessage message, string[] addresses, Func<MimeMessage, InternetAddressList> addressListGetter, bool throwIfNoneValid = false)
         {

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -77,7 +77,8 @@ namespace Umbraco.Cms.Infrastructure.Extensions
                 mimeMessage.ReplyTo.Mailboxes.Select(ToNotificationAddress),
                 mimeMessage.Subject,
                 emailMessage.Body,
-                emailMessage.Attachments);
+                emailMessage.Attachments,
+                emailMessage.IsBodyHtml);
         }
 
         private static NotificationEmailAddress ToNotificationAddress(MailboxAddress mailboxAddress) =>

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -55,6 +55,27 @@ namespace Umbraco.Cms.Infrastructure.Extensions
             return messageToSend;
         }
 
+        private static void AddAddresses(MimeMessage message, string[] addresses, Func<MimeMessage, InternetAddressList> addressListGetter, bool throwIfNoneValid = false)
+        {
+            var foundValid = false;
+            if (addresses != null)
+            {
+                foreach (var address in addresses)
+                {
+                    if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+                    {
+                        addressListGetter(message).Add(internetAddress);
+                        foundValid = true;
+                    }
+                }
+            }
+
+            if (throwIfNoneValid && foundValid == false)
+            {
+                throw new InvalidOperationException($"Email could not be sent. Could not parse a valid recipient address.");
+            }
+        }
+
         public static NotificationEmailModel ToNotificationEmail(this EmailMessage emailMessage,
             string configuredFromAddress)
         {
@@ -105,27 +126,6 @@ namespace Umbraco.Cms.Infrastructure.Extensions
             }
 
             return notificationAddresses;
-        }
-
-        private static void AddAddresses(MimeMessage message, string[] addresses, Func<MimeMessage, InternetAddressList> addressListGetter, bool throwIfNoneValid = false)
-        {
-            var foundValid = false;
-            if (addresses != null)
-            {
-                foreach (var address in addresses)
-                {
-                    if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
-                    {
-                        addressListGetter(message).Add(internetAddress);
-                        foundValid = true;
-                    }
-                }
-            }
-
-            if (throwIfNoneValid && foundValid == false)
-            {
-                throw new InvalidOperationException($"Email could not be sent. Could not parse a valid recipient address.");
-            }
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -10,11 +10,7 @@ namespace Umbraco.Cms.Infrastructure.Extensions
     {
         public static MimeMessage ToMimeMessage(this EmailMessage mailMessage, string configuredFromAddress)
         {
-            var fromEmail = mailMessage.From;
-            if (string.IsNullOrEmpty(fromEmail))
-            {
-                fromEmail = configuredFromAddress;
-            }
+            var fromEmail = string.IsNullOrEmpty(mailMessage.From) ? configuredFromAddress : mailMessage.From;
 
             if (!InternetAddress.TryParse(fromEmail, out InternetAddress fromAddress))
             {
@@ -62,7 +58,9 @@ namespace Umbraco.Cms.Infrastructure.Extensions
         public static NotificationEmailModel ToNotificationEmail(this EmailMessage emailMessage,
             string configuredFromAddress)
         {
-            NotificationEmailAddress from = ToNotificationAddress(emailMessage.From);
+            var fromEmail = string.IsNullOrEmpty(emailMessage.From) ? configuredFromAddress : emailMessage.From;
+
+            NotificationEmailAddress from = ToNotificationAddress(fromEmail);
 
             return new NotificationEmailModel(from,
                 GetNotificationAddresses(emailMessage.To),

--- a/src/Umbraco.Infrastructure/Services/Implement/NotificationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/NotificationService.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Mail;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Persistence.Repositories;

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Infrastructure.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
@@ -78,5 +78,25 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
             Assert.AreEqual(body, result.TextBody.ToString());
             Assert.AreEqual(1, result.Attachments.Count());
         }
+
+        [Test]
+        public void Can_Construct_MimeMessage_With_ConfiguredSender()
+        {
+            const string to = "to@email.com";
+            const string subject = "Subject";
+            const string body = "<p>Message</p>";
+            const bool isBodyHtml = true;
+            var emailMesasge = new EmailMessage(null, to, subject, body, isBodyHtml);
+
+            var result = emailMesasge.ToMimeMessage(ConfiguredSender);
+
+            Assert.AreEqual(1, result.From.Count());
+            Assert.AreEqual(ConfiguredSender, result.From.First().ToString());
+            Assert.AreEqual(1, result.To.Count());
+            Assert.AreEqual(to, result.To.First().ToString());
+            Assert.AreEqual(subject, result.Subject);
+            Assert.IsNull(result.TextBody);
+            Assert.AreEqual(body, result.HtmlBody.ToString());
+        }
     }
 }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
@@ -123,6 +123,28 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
         }
 
         [Test]
+        public void Can_Construct_NotificationEmailModel_From_Simple_MailMessage_With_Configured_Sender()
+        {
+            const string to = "to@email.com";
+            const string subject = "Subject";
+            const string body = "<p>Message</p>";
+            const bool isBodyHtml = true;
+            var emailMessage = new EmailMessage(null, to, subject, body, isBodyHtml);
+
+            NotificationEmailModel result = emailMessage.ToNotificationEmail(ConfiguredSender);
+
+            Assert.AreEqual(ConfiguredSender, result.From.Adress);
+            Assert.AreEqual("", result.From.DisplayName);
+            Assert.AreEqual(1, result.To.Count());
+            Assert.AreEqual(to, result.To.First().Adress);
+            Assert.AreEqual("", result.To.First().DisplayName);
+            Assert.AreEqual(subject, result.Subject);
+            Assert.AreEqual(body, result.Body);
+            Assert.IsTrue(result.IsBodyHtml);
+            Assert.IsFalse(result.HasAttachments);
+        }
+
+        [Test]
         public void Can_Construct_NotificationEmailModel_From_Simple_MailMessage_With_DisplayName()
         {
             const string from = "\"From Email\" <from@from.com>";

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
@@ -111,10 +111,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
 
             NotificationEmailModel result = emailMessage.ToNotificationEmail(ConfiguredSender);
 
-            Assert.AreEqual(from, result.From.Adress);
+            Assert.AreEqual(from, result.From.Address);
             Assert.AreEqual("", result.From.DisplayName);
             Assert.AreEqual(1, result.To.Count());
-            Assert.AreEqual(to, result.To.First().Adress);
+            Assert.AreEqual(to, result.To.First().Address);
             Assert.AreEqual("", result.To.First().DisplayName);
             Assert.AreEqual(subject, result.Subject);
             Assert.AreEqual(body, result.Body);
@@ -133,10 +133,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
 
             NotificationEmailModel result = emailMessage.ToNotificationEmail(ConfiguredSender);
 
-            Assert.AreEqual(ConfiguredSender, result.From.Adress);
+            Assert.AreEqual(ConfiguredSender, result.From.Address);
             Assert.AreEqual("", result.From.DisplayName);
             Assert.AreEqual(1, result.To.Count());
-            Assert.AreEqual(to, result.To.First().Adress);
+            Assert.AreEqual(to, result.To.First().Address);
             Assert.AreEqual("", result.To.First().DisplayName);
             Assert.AreEqual(subject, result.Subject);
             Assert.AreEqual(body, result.Body);
@@ -156,10 +156,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
 
             NotificationEmailModel result = emailMessage.ToNotificationEmail(ConfiguredSender);
 
-            Assert.AreEqual("from@from.com", result.From.Adress);
+            Assert.AreEqual("from@from.com", result.From.Address);
             Assert.AreEqual("From Email", result.From.DisplayName);
             Assert.AreEqual(1, result.To.Count());
-            Assert.AreEqual("to@to.com", result.To.First().Adress);
+            Assert.AreEqual("to@to.com", result.To.First().Address);
             Assert.AreEqual("To Email", result.To.First().DisplayName);
             Assert.AreEqual(subject, result.Subject);
             Assert.AreEqual(body, result.Body);
@@ -189,31 +189,31 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
 
             var result = emailMessage.ToNotificationEmail(ConfiguredSender);
 
-            Assert.AreEqual("from@from.com", result.From.Adress);
+            Assert.AreEqual("from@from.com", result.From.Address);
             Assert.AreEqual("From Email", result.From.DisplayName);
 
             Assert.AreEqual(2, result.To.Count());
-            Assert.AreEqual("to@email.com", result.To.First().Adress);
+            Assert.AreEqual("to@email.com", result.To.First().Address);
             Assert.AreEqual("", result.To.First().DisplayName);
-            Assert.AreEqual("to2@email.com", result.To.Skip(1).First().Adress);
+            Assert.AreEqual("to2@email.com", result.To.Skip(1).First().Address);
             Assert.AreEqual("Second Email", result.To.Skip(1).First().DisplayName);
 
             Assert.AreEqual(2, result.Cc.Count());
-            Assert.AreEqual("cc@email.com", result.Cc.First().Adress);
+            Assert.AreEqual("cc@email.com", result.Cc.First().Address);
             Assert.AreEqual("First CC", result.Cc.First().DisplayName);
-            Assert.AreEqual("cc2@email.com", result.Cc.Skip(1).First().Adress);
+            Assert.AreEqual("cc2@email.com", result.Cc.Skip(1).First().Address);
             Assert.AreEqual("", result.Cc.Skip(1).First().DisplayName);
 
             Assert.AreEqual(3, result.Bcc.Count());
-            Assert.AreEqual("bcc@email.com", result.Bcc.First().Adress);
+            Assert.AreEqual("bcc@email.com", result.Bcc.First().Address);
             Assert.AreEqual("", result.Bcc.First().DisplayName);
-            Assert.AreEqual("bcc2@email.com", result.Bcc.Skip(1).First().Adress);
+            Assert.AreEqual("bcc2@email.com", result.Bcc.Skip(1).First().Address);
             Assert.AreEqual("", result.Bcc.Skip(1).First().DisplayName);
-            Assert.AreEqual("bcc3@email.com", result.Bcc.Skip(2).First().Adress);
+            Assert.AreEqual("bcc3@email.com", result.Bcc.Skip(2).First().Address);
             Assert.AreEqual("Third BCC", result.Bcc.Skip(2).First().DisplayName);
 
             Assert.AreEqual(1, result.ReplyTo.Count());
-            Assert.AreEqual("replyto@email.com", result.ReplyTo.First().Adress);
+            Assert.AreEqual("replyto@email.com", result.ReplyTo.First().Address);
             Assert.AreEqual("", result.ReplyTo.First().DisplayName);
 
             Assert.AreEqual(subject, result.Subject);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Extensions/EmailMessageExtensionsTests.cs
@@ -150,10 +150,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Extensions
         public void Can_Construct_NotificationEmailModel_From_Full_EmailMessage()
         {
             const string from = "\"From Email\" <from@from.com>";
-            string[] to = new[] { "to@email.com", "\"Second Email\" <to2@email.com>" };
-            string[] cc = new[] { "\"First CC\" <cc@email.com>", "cc2@email.com" };
-            string[] bcc = new[] { "bcc@email.com", "bcc2@email.com", "\"Third BCC\" <bcc3@email.com>", "invalid@email@address" };
-            string[] replyTo = new[] { "replyto@email.com" };
+            string[] to = { "to@email.com", "\"Second Email\" <to2@email.com>", "invalid@invalid@invalid" };
+            string[] cc = { "\"First CC\" <cc@email.com>", "cc2@email.com", "invalid@invalid@invalid" };
+            string[] bcc = { "bcc@email.com", "bcc2@email.com", "\"Third BCC\" <bcc3@email.com>", "invalid@email@address" };
+            string[] replyTo = { "replyto@email.com", "invalid@invalid@invalid" };
             const string subject = "Subject";
             const string body = "Message";
             const bool isBodyHtml = false;

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -17,6 +17,7 @@ using Umbraco.Cms.Core.Mail;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Security;

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -26,6 +26,7 @@ using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;


### PR DESCRIPTION
This PR adds a new email model to be sent with email notifications.

The reason for this is to be able to both send the email address and the email display name, since this is used in Deploy.

I opted to add a new model instead of trying to change the old one, since it doesn't make much sense for that to have the display name, since it gets converted into a MimeMessage down the line.

While I was working on this I also noticed that we added the ability to fall back to a "from email" from the configuration, however the way the code currently was, the configured "from email" was never used, so I've also amended the code so that is no longer the case.

