### PR TITLE
Add missing UrlHelper GetCropUrl methods

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.WebAssets;
 using Umbraco.Cms.Web.Common.Controllers;
@@ -202,6 +203,56 @@ namespace Umbraco.Extensions
 
             var version = umbracoVersion.SemanticVersion.ToSemanticString();
             return $"{version}.{runtimeMinifier.CacheBuster}".GenerateHash();
+        }
+
+        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent mediaItem, string cropAlias, bool htmlEncode = true)
+        {
+            if (mediaItem == null)
+            {
+                return HtmlString.Empty;
+            }
+
+            var url = mediaItem.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+        }
+
+        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent mediaItem, string propertyAlias, string cropAlias, bool htmlEncode = true)
+        {
+            if (mediaItem == null)
+            {
+                return HtmlString.Empty;
+            }
+
+            var url = mediaItem.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+        }
+
+        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper,
+            IPublishedContent mediaItem,
+            int? width = null,
+            int? height = null,
+            string propertyAlias = Constants.Conventions.Media.File,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            bool cacheBuster = true,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true,
+            bool htmlEncode = true)
+        {
+            if (mediaItem == null)
+            {
+                return HtmlString.Empty;
+            }
+
+            var url = mediaItem.GetCropUrl(width, height, propertyAlias, cropAlias, quality, imageCropMode,
+                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode,
+                upScale);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
         }
 
         public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper,


### PR DESCRIPTION
As discussed at https://github.com/umbraco/Umbraco-CMS/pull/10233 I have added 3 extensions to UrlHelper. The first 2 are friendly extension methods, they could both be dropped as all could be done with the 3rd method accepting the IPublishedContent and all the other parameters

There are a few other methods in v8 such as the string method but I think these should be removed as they were added over time for compatibility https://github.com/umbraco/Umbraco-CMS/blob/809fd819821770472dec3eb2d7241f7d39f3c918/src/Umbraco.Web/UrlHelperRenderExtensions.cs#L217