### PR TITLE
Updated signature to Umbraco pipeline filter to avoid multiple calls to UseEndpoints().

### DIFF
--- a/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoApplicationBuilder.cs
@@ -1,6 +1,4 @@
 using System;
-using Microsoft.AspNetCore.Builder;
-using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder
 {

--- a/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoPipelineFilter.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoPipelineFilter.cs
@@ -1,4 +1,6 @@
+using System;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder
 {
@@ -21,19 +23,22 @@ namespace Umbraco.Cms.Web.Common.ApplicationBuilder
         /// <summary>
         /// Executes before Umbraco middlewares are registered
         /// </summary>
-        /// <param name="app"></param>
         void OnPrePipeline(IApplicationBuilder app);
 
         /// <summary>
         /// Executes after core Umbraco middlewares are registered and before any Endpoints are declared
         /// </summary>
-        /// <param name="app"></param>
         void OnPostPipeline(IApplicationBuilder app);
 
         /// <summary>
         /// Executes after <see cref="OnPostPipeline(IApplicationBuilder)"/> just before any Umbraco endpoints are declared.
         /// </summary>
-        /// <param name="app"></param>
-        void OnEndpoints(IApplicationBuilder app);
+        void OnPreEndpoints(IApplicationBuilder app);
+
+        /// <summary>
+        /// Appends registered endpoints to default Umbraco endpoint configuration.
+        /// </summary>
+        /// <returns></returns>
+        Action<IUmbracoEndpointBuilder> AppendEndpoints(Action<IUmbracoEndpointBuilder> configure);
     }
 }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -37,6 +37,12 @@ namespace Umbraco.Cms.Web.Common.ApplicationBuilder
             IOptions<UmbracoPipelineOptions> startupOptions = ApplicationServices.GetRequiredService<IOptions<UmbracoPipelineOptions>>();
             RunPreEndpointsPipeline(startupOptions.Value);
 
+            // Append any application or package registered endpoints to those configured in Startup.
+            foreach (IUmbracoPipelineFilter filter in startupOptions.Value.PipelineFilters)
+            {
+                configureUmbraco = filter.AppendEndpoints(configureUmbraco);
+            }
+
             AppBuilder.UseEndpoints(endpoints =>
             {
                 var umbAppBuilder = (IUmbracoEndpointBuilder)ActivatorUtilities.CreateInstance<UmbracoEndpointBuilder>(
@@ -58,7 +64,7 @@ namespace Umbraco.Cms.Web.Common.ApplicationBuilder
         {
             foreach (IUmbracoPipelineFilter filter in startupOptions.PipelineFilters)
             {
-                filter.OnEndpoints(AppBuilder);
+                filter.OnPreEndpoints(AppBuilder);
             }
         }
     }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoPipelineFilter.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoPipelineFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder
 {
@@ -11,27 +12,46 @@ namespace Umbraco.Cms.Web.Common.ApplicationBuilder
     /// </remarks>
     public class UmbracoPipelineFilter : IUmbracoPipelineFilter
     {
-        public UmbracoPipelineFilter(string name) : this(name, null, null, null) { }
+        public UmbracoPipelineFilter(string name) : this(name, null, null, null, null) { }
 
         public UmbracoPipelineFilter(
             string name,
             Action<IApplicationBuilder> prePipeline,
             Action<IApplicationBuilder> postPipeline,
-            Action<IApplicationBuilder> endpointCallback)
+            Action<IApplicationBuilder> preEndpoints,
+            Action<IUmbracoEndpointBuilder> endpoints)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             PrePipeline = prePipeline;
             PostPipeline = postPipeline;
-            Endpoints = endpointCallback;
+            PreEndpoints = preEndpoints;
+            Endpoints = endpoints;
         }
 
         public Action<IApplicationBuilder> PrePipeline { get; set; }
+
         public Action<IApplicationBuilder> PostPipeline { get; set; }
-        public Action<IApplicationBuilder> Endpoints { get; set; }
+
+        public Action<IApplicationBuilder> PreEndpoints { get; set; }
+
+        public Action<IUmbracoEndpointBuilder> Endpoints { get; set; }
+
         public string Name { get; }
 
         public void OnPrePipeline(IApplicationBuilder app) => PrePipeline?.Invoke(app);
+
         public void OnPostPipeline(IApplicationBuilder app) => PostPipeline?.Invoke(app);
-        public void OnEndpoints(IApplicationBuilder app) => Endpoints?.Invoke(app);
+
+        public void OnPreEndpoints(IApplicationBuilder app) => PreEndpoints?.Invoke(app);
+
+        public Action<IUmbracoEndpointBuilder> AppendEndpoints(Action<IUmbracoEndpointBuilder> configure)
+        {
+            if (Endpoints == null)
+            {
+                return configure;
+            }
+
+            return configure += Endpoints;
+        }
     }
 }


### PR DESCRIPTION
I'm not 100% sure if this is necessary or advisable, but thought would PR for consideration anyway.

In my attempts to get Deploy's SignalR authentication working I read about some issues with calling `UseEndpoints()` multiple times - see [here](https://github.com/dotnet/aspnetcore/issues/17750) and [here](https://stackoverflow.com/questions/59281967/why-is-middleware-not-executed-when-there-are-multiple-calls-to-app-useendpoints) - which effectively we do when endpoints are registered via the `IUmbracoPipelineFilter`.

With this change to the signature instead of adding this code like this:

```
    applicationBuilder =>
    {
        var hubRoutes = applicationBuilder.ApplicationServices.GetRequiredService<DeployUiHubRoutes>();
        applicationBuilder.UseEndpoints(endpoints =>
        {
            hubRoutes.CreateRoutes(endpoints);
        });
    }
```

We'd do this:

```
    endpointBuilder =>
    {
        var hubRoutes = endpointBuilder.AppBuilder.ApplicationServices.GetRequiredService<DeployUiHubRoutes>();
        hubRoutes.CreateRoutes(endpointBuilder.EndpointRouteBuilder);
    }
```

Meaning there'd only be one `UseEndpoints()` call.

To repeat, this didn't solve the problem I was looking into but it may still be incorrect how we are doing things currently and perhaps this is a better approach.

