### PR TITLE
Convert date to datetime in SQL queries for sorting on date

### DIFF
--- a/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Core/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -571,7 +571,7 @@ namespace Umbraco.Core.Persistence.SqlSyntax
         public virtual string CreateDefaultConstraint => "ALTER TABLE {0} ADD CONSTRAINT {1} DEFAULT ({2}) FOR {3}";
 
         public virtual string ConvertIntegerToOrderableString => "REPLACE(STR({0}, 8), SPACE(1), '0')";
-        public virtual string ConvertDateToOrderableString => "CONVERT(nvarchar, {0}, 102)";
+        public virtual string ConvertDateToOrderableString => "CONVERT(nvarchar, {0}, 120)";
         public virtual string ConvertDecimalToOrderableString => "REPLACE(STR({0}, 20, 9), SPACE(1), '0')";
     }
 }


### PR DESCRIPTION
Datetime values where converted to date(102) so sorting by time does not work.
By converting to 120 (yyyy-mm-dd hh:mi:ss (24h)) the time is respected.

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10405

### Description
I've changed the ConvertDateToOrderableString in SqlSyntaxProviderBase from 
`"CONVERT(nvarchar, {0}, 102)";` which converts to yyyy.mm.dd
to
`"CONVERT(nvarchar, {0}, 120)" `which converts to yyyy-mm-dd hh:mi:ss (24h)

so that de time is respected when sorting.

I'm not sure if this will affect other parts of Umbraco. That's why please take a critical look.
