### PR TITLE
NetCore: Fix UmbracoProject template to make use of the custom name value

### DIFF
--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -15,7 +15,7 @@
     },
     "primaryOutputs": [
         {
-			"path": "UmbracoProject.csproj"
+            "path": "UmbracoProject.csproj"
         }
     ],
     "postActions": [

--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -15,7 +15,7 @@
     },
     "primaryOutputs": [
         {
-        "path": "UmbracoProject.csproj"
+			"path": "UmbracoProject.csproj"
         }
     ],
     "postActions": [
@@ -29,8 +29,18 @@
             "continueOnError": true
         }
     ],
-    "sourceName": "Umbraco.Cms.Web.UI.NetCore",
+    "sourceName": "UmbracoProject",
     "symbols": {
+        "namespaceReplacer": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+                "sourceVariableName": "name",
+                "defaultValue": "UmbracoProject",
+                "fallbackVariableName": "name"
+            },
+            "replaces":"Umbraco.Cms.Web.UI.NetCore"
+        },
         "version": {
             "type": "parameter",
             "datatype": "string",


### PR DESCRIPTION
## Details

**UmbracoProject** dotnet template will use the value passed as `-n/--name` parameter and create a new Umbraco project with it - *.csproj name will reflect that, as well as the namespace value.

If no name is specified, the name of the current directory is used.

## Test
- Run the **build.ps1** script
- Use `dotnet new -i pathtoyourproject\build.out\Umbraco.Templates.9.0.0-beta003.nupkg` command to install the templates
- Create a project and give it a name like `dotnet new umbraco -n MyCustomUmbracoSolution`
- Project name, folder, namespace, etc. should be with `MyCustomUmbracoSolution` name 
  - You can also try adding a new class, the namespace shouldn't be different
- Confirm that you can install Umbraco using the template 