### PR TITLE
Added "certified to work on Umbraco Cloud" indicator to packages section in the back-office

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-packages.less
@@ -157,6 +157,16 @@
     color: @red !important;
 }
 
+.umb-package-link .umb-package-cloud {
+    margin-top: 8px;
+    font-size: 11px;
+    height: 11px; // ensures vertical space is taken up even if "works on cloud" isn't visible
+}
+
+.umb-package-link .umb-package-cloud .icon-cloud {
+    color: #2eadaf !important;
+}
+
 // Version
 .umb-package-version {
     display: inline-flex;

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function PackagesRepoController($scope, $route, $location, $timeout, ourPackageRepositoryResource, $q, packageResource, localStorageService, localizationService) {
+    function PackagesRepoController($scope, $timeout, ourPackageRepositoryResource, $q, packageResource, localStorageService, localizationService) {
 
         var vm = this;
 
@@ -75,7 +75,9 @@
             $q.all([
                 ourPackageRepositoryResource.getCategories()
                     .then(function (cats) {
-                        vm.categories = cats;
+                        vm.categories = cats.filter(function (cat) {
+                            return cat.name !== "Umbraco Pro";
+                        });
                     }),
                 ourPackageRepositoryResource.getPopular(8)
                     .then(function (pack) {

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -62,6 +62,12 @@
                                             <strong>{{package.likes}}</strong>
                                         </small>
                                     </div>
+                                    <div class="umb-package-cloud">
+                                        <div ng-if="package.certifiedToWorkOnUmbracoCloud">
+                                            <i class="icon-cloud" aria-hidden="true"></i>
+                                            <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
+                                        </div>
+                                    </div>
 
                                 </div>
                             </div>
@@ -100,6 +106,12 @@
                                             <i class="icon-hearts" aria-hidden="true"></i>
                                             <strong>{{ package.likes }}</strong>
                                         </small>
+                                    </div>
+                                    <div class="umb-package-cloud">
+                                        <div ng-if="package.certifiedToWorkOnUmbracoCloud">
+                                            <i class="icon-cloud" aria-hidden="true"></i>
+                                            <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
+                                        </div>
                                     </div>
 
                                 </div>
@@ -267,6 +279,10 @@
                                 <div class="umb-package-details__information-item" ng-if="vm.package.ownerInfo.karma">
                                     <div class="umb-package-details__information-item-label"><localize key="packager_packageLikes">Likes</localize>:</div>
                                     <div class="umb-package-details__information-item-content">{{vm.package.likes}}</div>
+                                </div>
+
+                                <div class="umb-package-details__information-item" ng-if="vm.package.certifiedToWorkOnUmbracoCloud">
+                                    <div class="umb-package-details__information-item-label"><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco CLoud</localize></div>
                                 </div>
 
                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -54,17 +54,17 @@
 
                                     <div class="umb-package-numbers">
                                         <small class="umb-package-downloads">
-                                            <i class="icon-download-alt" aria-hidden="true"></i>
+                                            <umb-icon icon="icon-download-alt"></umb-icon>
                                             <strong>{{package.downloads}}</strong>
                                         </small>
                                         <small class="umb-package-likes">
-                                            <i class="icon-hearts" aria-hidden="true"></i>
+                                            <umb-icon icon="icon-hearts" class="icon-hearts"></umb-icon>
                                             <strong>{{package.likes}}</strong>
                                         </small>
                                     </div>
                                     <div class="umb-package-cloud">
                                         <div ng-if="package.certifiedToWorkOnUmbracoCloud">
-                                            <i class="icon-cloud" aria-hidden="true"></i>
+                                            <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
                                             <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
                                         </div>
                                     </div>
@@ -99,17 +99,17 @@
 
                                     <div class="umb-package-numbers">
                                         <small class="umb-package-downloads">
-                                            <i class="icon-download-alt" aria-hidden="true"></i>
-                                            <strong>{{ package.downloads }}</strong>
+                                            <umb-icon icon="icon-download-alt"></umb-icon>
+                                            <strong>{{package.downloads}}</strong>
                                         </small>
                                         <small class="umb-package-likes">
-                                            <i class="icon-hearts" aria-hidden="true"></i>
-                                            <strong>{{ package.likes }}</strong>
+                                            <umb-icon icon="icon-hearts" class="icon-hearts"></umb-icon>
+                                            <strong>{{package.likes}}</strong>
                                         </small>
                                     </div>
                                     <div class="umb-package-cloud">
                                         <div ng-if="package.certifiedToWorkOnUmbracoCloud">
-                                            <i class="icon-cloud" aria-hidden="true"></i>
+                                            <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
                                             <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
                                         </div>
                                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -110,7 +110,7 @@
                                     <div class="umb-package-cloud">
                                         <div ng-if="package.certifiedToWorkOnUmbracoCloud">
                                             <i class="icon-cloud" aria-hidden="true"></i>
-                                            <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
+                                            <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
                                         </div>
                                     </div>
 
@@ -282,7 +282,7 @@
                                 </div>
 
                                 <div class="umb-package-details__information-item" ng-if="vm.package.certifiedToWorkOnUmbracoCloud">
-                                    <div class="umb-package-details__information-item-label"><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco CLoud</localize></div>
+                                    <div class="umb-package-details__information-item-label"><localize key="packager_certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco CLoud</localize></div>
                                 </div>
 
                             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -65,7 +65,7 @@
                                     <div class="umb-package-cloud">
                                         <div ng-if="package.certifiedToWorkOnUmbracoCloud">
                                             <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
-                                            <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
+                                            <span><localize key="packager_verifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
                                         </div>
                                     </div>
 
@@ -110,7 +110,7 @@
                                     <div class="umb-package-cloud">
                                         <div ng-if="package.certifiedToWorkOnUmbracoCloud">
                                             <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
-                                            <span><localize key="packager_certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
+                                            <span><localize key="packager_verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
                                         </div>
                                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -65,7 +65,7 @@
                                     <div class="umb-package-cloud">
                                         <div ng-if="package.certifiedToWorkOnUmbracoCloud">
                                             <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
-                                            <span><localize key="packager_verifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</localize></span>
+                                            <span><localize key="packager_verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
                                         </div>
                                     </div>
 
@@ -116,7 +116,7 @@
 
                                 </div>
                             </div>
-                            
+
                         </button>
                     </div> <!-- end package -->
 
@@ -282,7 +282,7 @@
                                 </div>
 
                                 <div class="umb-package-details__information-item" ng-if="vm.package.certifiedToWorkOnUmbracoCloud">
-                                    <div class="umb-package-details__information-item-label"><localize key="packager_certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco CLoud</localize></div>
+                                    <div class="umb-package-details__information-item-label"><localize key="packager_verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco CLoud</localize></div>
                                 </div>
 
                             </div>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1288,7 +1288,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="installStateComplete">All done, your browser will now refresh, please wait...</key>
     <key alias="installStateCompleted">Please click 'Finish' to complete installation and reload the page.</key>
     <key alias="installStateUploading">Uploading package...</key>
-    <key alias="certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</key>
+    <key alias="verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</key>
   </area>
   <area alias="paste">
     <key alias="doNothing">Paste with full formatting (Not recommended)</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1288,6 +1288,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="installStateComplete">All done, your browser will now refresh, please wait...</key>
     <key alias="installStateCompleted">Please click 'Finish' to complete installation and reload the page.</key>
     <key alias="installStateUploading">Uploading package...</key>
+    <key alias="certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</key>
   </area>
   <area alias="paste">
     <key alias="doNothing">Paste with full formatting (Not recommended)</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1288,7 +1288,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="installStateComplete">All done, your browser will now refresh, please wait...</key>
     <key alias="installStateCompleted">Please click 'Finish' to complete installation and reload the page.</key>
     <key alias="installStateUploading">Uploading package...</key>
-    <key alias="certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</key>
+    <key alias="certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</key>
   </area>
   <area alias="paste">
     <key alias="doNothing">Paste with full formatting (Not recommended)</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1294,6 +1294,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="installStateComplete">All done, your browser will now refresh, please wait...</key>
     <key alias="installStateCompleted">Please click 'Finish' to complete installation and reload the page.</key>
     <key alias="installStateUploading">Uploading package...</key>
+    <key alias="certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</key>
   </area>
   <area alias="paste">
     <key alias="doNothing">Paste with full formatting (Not recommended)</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1294,7 +1294,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="installStateComplete">All done, your browser will now refresh, please wait...</key>
     <key alias="installStateCompleted">Please click 'Finish' to complete installation and reload the page.</key>
     <key alias="installStateUploading">Uploading package...</key>
-    <key alias="certifiedToWorkOnUmbracoCloud">Certified to work on Umbraco Cloud</key>
+    <key alias="certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</key>
   </area>
   <area alias="paste">
     <key alias="doNothing">Paste with full formatting (Not recommended)</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1294,7 +1294,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="installStateComplete">All done, your browser will now refresh, please wait...</key>
     <key alias="installStateCompleted">Please click 'Finish' to complete installation and reload the page.</key>
     <key alias="installStateUploading">Uploading package...</key>
-    <key alias="certifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</key>
+    <key alias="verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</key>
   </area>
   <area alias="paste">
     <key alias="doNothing">Paste with full formatting (Not recommended)</key>


### PR DESCRIPTION
This PR updates the display of packages in the back-office to add a "Certified to work on Umbraco Cloud" flag to the packages with this setting in our (now that this info is available in the our API).

The listing has been updated to add this indicator:

![image](https://user-images.githubusercontent.com/1993459/121148109-c0eb2f00-c841-11eb-9246-2ba65779c2e1.png)

And the details screen to show this:

![image](https://user-images.githubusercontent.com/1993459/121148207-dbbda380-c841-11eb-84c0-c5ce08f434df.png)

I've also hidden the "Umbraco Pro", which is empty for V8 and contains little for V7, to remove what for most people in an empty category and a concept/name that no longer exists (to my knowledge).