### PR TITLE
Bugfix Allow you to change your own password if using user section

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -680,15 +680,15 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             IUser currentUser = _backofficeSecurityAccessor.BackOfficeSecurity.CurrentUser;
 
-            // if it's the current user, the current user cannot reset their own password
-            if (currentUser.Username == found.Username)
+            // if it's the current user, the current user cannot reset their own password without providing their old password
+            if (currentUser.Username == found.Username && string.IsNullOrEmpty(changingPasswordModel.OldPassword))
             {
-                return new ValidationErrorResult("Password reset is not allowed");
+                return ValidationErrorResult.CreateNotificationValidationErrorResult("Password reset is not allowed without providing old password");
             }
 
             if (!currentUser.IsAdmin() && found.IsAdmin())
             {
-                return new ValidationErrorResult("The current user cannot change the password for the specified user");
+                return ValidationErrorResult.CreateNotificationValidationErrorResult("The current user cannot change the password for the specified user");
             }
 
             Attempt<PasswordChangedModel> passwordChangeResult = await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _userManager);


### PR DESCRIPTION
This PR fixes #10401 where you was unable to change your own password if using the user section.
If you used the avatar approach this was fine as it uses a different Controller Action to do so.

## Test Notes
* Try before PR to change your own user password in the user section
* Logout and try to login with new password (it will fail)
* Verify password can be changed with the avatar approach top right
* Apply PR and re-test to see if password can be changed in user section