### PR TITLE
V9: add missing overload is allowed template

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -109,6 +109,9 @@ namespace Umbraco.Extensions
         public static bool IsAllowedTemplate(this IPublishedContent content, int templateId)
             => content.IsAllowedTemplate(ContentTypeService, WebRoutingSettings.Value, templateId);
 
+        public static bool IsAllowedTemplate(this IPublishedContent content, string templateAlias)
+            => content.IsAllowedTemplate(WebRoutingSettings.Value.DisableAlternativeTemplates, WebRoutingSettings.Value.ValidateAlternativeTemplates, templateAlias);
+
         public static bool IsAllowedTemplate(
             this IPublishedContent content,
             bool disableAlternativeTemplates,


### PR DESCRIPTION
Fixes #10391 
This adds in a missing overload for IsAllowedTemplate that allowed you to simply pass the template alias

See the notes in 10391 about testing as out of the box in V8 and V9 it will not work until you turn on `ValidateAlternativeTemplates` to true in `WebRouting` for AppSettings configuration.

## Test Notes
* Ensure you update your appsettings.config as noted above
* Create a home doctype with matching template
* Use this in the Razor view/template

```
@if(Model.IsAllowedTemplate("home"))
{
    <h2>YEP</h2>
}
else {
    <h2>NOPE</h2>
}
```

Then modify it to an invalid string that wont be found as a template
