### PR TITLE
Color picker: Fix label view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -59,7 +59,7 @@
                     font-size: 14px;
                     padding: 1px 5px;
                     min-height: 45px;
-                    max-width: 100%;
+                    max-width: calc(100% - 8px);
                     margin-top: auto;
                     margin-bottom: -3px;
                     margin-left: -1px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While implementing a recent site I noticed that the color swatch label can break a little bit if the text is longer than the swatch width allows. This tiny little PR fixes the issue by substracting the padding + border width from the allowed max-width of 100%.

**Before**
![before](https://user-images.githubusercontent.com/1932158/121688677-03bc3980-cac4-11eb-92f8-9de5d90952e7.png)

**After**
![after](https://user-images.githubusercontent.com/1932158/121688689-09198400-cac4-11eb-97ff-818131dfa39b.png)
