### PR TITLE
Fix: Searching in mediapicker doesn't filter according to allowedtypes #10429

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -477,9 +477,15 @@ angular.module("umbraco")
                 vm.loading = true;
                 entityResource.getPagedDescendants($scope.filterOptions.excludeSubFolders ? $scope.currentFolder.id : $scope.startNodeId, "Media", vm.searchOptions)
                     .then(function (data) {
+
                         // update image data to work with image grid
                         if (data.items) {
-                            data.items.forEach(mediaItem => setMediaMetaData(mediaItem));
+                            var allowedTypes = dialogOptions.filter ? dialogOptions.filter.split(",") : null;
+
+                            data.items.forEach(function(mediaItem) {
+                                setMediaMetaData(mediaItem);
+                                mediaItem.filtered = allowedTypes && allowedTypes.indexOf(mediaItem.metaData.ContentTypeAlias) < 0;
+                            });
                         }
 
                         // update images


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10429

On normal load, the code will pass through the filtered property set (https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js#L548). However, this doesn't occur when the results come from the search. I added the same logic to the search results.

![fix-10429](https://user-images.githubusercontent.com/11466511/121743715-0dfd2880-cb02-11eb-84fe-6ff3649abc0f.gif)
