### PR TITLE
Numberrange view: Various minor improvements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/numberrange.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/numberrange.html
@@ -1,25 +1,38 @@
 <div class="umb-property-editor umb-prevalues-numberrange">
-    <ng-form name="prevalueNumberRangeForm">
-        <input name="numberFieldMin" class="__min-input"
-               type="number"
-               ng-model="model.value.min"
-               placeholder="0"
-               min="0"
-               ng-max="model.value.max"
-               fix-number />
+    <ng-form name="prevalueNumberRangeForm" class="flex">
+        <div>
+            <input name="numberFieldMin" class="__min-input"
+            type="number"
+            ng-model="model.value.min"
+            placeholder="0"
+            min="0"
+            ng-max="model.value.max"
+            fix-number
+            id="{{model.alias}}" />
+            <span ng-messages="prevalueNumberRangeForm.numberFieldMin.$error" show-validation-on-submit >
+                <span class="db mt1 red" ng-message="number" aria-describedby="{{model.alias}}">
+                    <localize key="validation_invalidNumber">Not a number</localize>
+                </span>
+            </span>
+        </div>
         <span class="__enDash">–</span>
-        <input name="numberFieldMax" class="__max-input"
-               type="number"
-               ng-model="model.value.max"
-               placeholder="∞"
-               ng-min="model.value.min || 0"
-               fix-number />
+        <div>
+            <label for="validationLimitMax" class="sr-only">
+                <localize key="maxAmount">Maximum amount</localize>
+            </label>
+            <input name="numberFieldMax" class="__max-input"
+                   type="number"
+                   ng-model="model.value.max"
+                   placeholder="∞"
+                   ng-min="model.value.min || 0"
+                   fix-number
+                   id="validationLimitMax" />
 
-        <span ng-messages="prevalueNumberRangeForm.numberFieldMin.$error" show-validation-on-submit >
-            <span class="help-inline" ng-message="number">Not a number</span>
-        </span>
-        <span ng-messages="prevalueNumberRangeForm.numberFieldMax.$error" show-validation-on-submit >
-            <span class="help-inline" ng-message="number">Not a number</span>
-        </span>
+            <span ng-messages="prevalueNumberRangeForm.numberFieldMax.$error" show-validation-on-submit >
+                <span class="db mt1 red" ng-message="number" aria-describedby="amountMax">
+                    <localize key="validation_invalidNumber">Not a number</localize>
+                </span>
+            </span>
+        </div>
     </ng-form>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/numberrange.less
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/numberrange.less
@@ -1,14 +1,7 @@
 .umb-prevalues-numberrange {
-
-    .__min-input {
-    }
-
     .__enDash {
         display: inline-block;
         vertical-align: middle;
-        margin-top: 5px;
-    }
-
-    .__max-input {
+        margin: 5px 2px 0;
     }
 }

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -1932,6 +1932,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="contextMenuDescription">Udfør handling %0% på %1% noden</key>
     <key alias="addImageCaption">Tilføj billede overskrift</key>
     <key alias="searchContentTree">Søg i indholdstræet</key>
+    <key alias="maxAmount">Maximum antal</key>
   </area>
   <area alias="references">
     <key alias="tabName">Referencer</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2329,6 +2329,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contextDialogDescription">Perform action %0% on the %1% node</key>
     <key alias="addImageCaption">Add image caption</key>
     <key alias="searchContentTree">Search content tree</key>
+    <key alias="maxAmount">Maximum amount</key>
   </area>
   <area alias="references">
     <key alias="tabName">References</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2348,6 +2348,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contextDialogDescription">Perform action %0% on the %1% node</key>
     <key alias="addImageCaption">Add image caption</key>
     <key alias="searchContentTree">Search content tree</key>
+    <key alias="maxAmount">Maximum amount</key>
   </area>
   <area alias="references">
     <key alias="tabName">References</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that the "Amount" label did not reference the first input field, so for the sake of consistency I've done some modifications for this to happen, which also improves accessibility.

1. Added an "id" to the first input mapping it to the `model.alias`
2. Added a visually hidden label for the "max input" field

In addition to the above I have also changed the displaying of the validation messages so they appear below the input fields instead of both appearing to the right of the last input field. I think it provides a nicer visual experience even though I know it would probably be rare that people will ever see these messages anyway.

I've added `aria-describedby` to the error messages so they're referencing the id of the input fields their messages belong to as well.

Finally I've mapped an existing dictionary key for the validation messages and added a new one for the "maximum amount" label.

You can see the differences in the GIF's below

**Before**
![numberrange-before](https://user-images.githubusercontent.com/1932158/121775664-501d7d00-cb89-11eb-9b1c-8ea7f1a1c306.gif)

**After**
![numberrange-after](https://user-images.githubusercontent.com/1932158/121775669-56135e00-cb89-11eb-87ef-36c6e268b3e4.gif)
