### PR TITLE
Textstring prevalue editor view: Set id attribute

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/textstring.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/textstring.html
@@ -1,1 +1,1 @@
-<input type="text" ng-model="model.value" ng-trim="false" class="umb-property-editor umb-textstring" />
+<input type="text" id="{{model.alias}}" ng-model="model.value" ng-trim="false" class="umb-property-editor umb-textstring" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this tiny PR I have added the `id` attribute setting the value to the `model.alias` so click the associated label will behave as expected. The effect of the change can be seen in the GIF below.

![textstringprevalue-after](https://user-images.githubusercontent.com/1932158/121775946-b2c34880-cb8a-11eb-857f-30e469571d1a.gif)
