### PR TITLE
Change MultiUrlPicker config and property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.html
@@ -17,7 +17,7 @@
             </umb-node-preview>
         </div>
 
-        <button ng-show="!model.config.maxNumber || renderModel.length < model.config.maxNumber"
+        <button ng-show="!model.config.validationLimit.max || renderModel.length < model.config.validationLimit.max"
                 type="button"
                 class="umb-node-preview-add"
                 ng-click="openLinkPicker()">
@@ -25,37 +25,36 @@
             <localize key="general_add">Add</localize>
             <span class="sr-only">url</span>
         </button>
-
         <div class="umb-contentpicker__min-max-help">
 
 
             <!-- Both min and max items -->
-            <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber !== model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber">Add between {{model.config.minNumber}} and {{model.config.maxNumber}} items</span>
-                <span ng-if="renderModel.length > model.config.maxNumber">
-                    <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_itemsSelected"> items selected</localize>
+            <span ng-if="model.config.validationLimit.min && model.config.validationLimit.max && model.config.validationLimit.min !== model.config.validationLimit.max">
+                <span ng-if="renderModel.length < model.config.validationLimit.max">Add between {{model.config.validationLimit.min}} and {{model.config.validationLimit.max}} items</span>
+                <span ng-if="renderModel.length > model.config.validationLimit.max">
+                    <localize key="validation_maxCount">You can only have</localize> {{model.config.validationLimit.max}} <localize key="validation_itemsSelected"> items selected</localize>
                 </span>
             </span>
 
             <!-- Equal min and max -->
-            <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber === model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber">Add {{model.config.minNumber - renderModel.length}} item(s)</span>
-                <span ng-if="renderModel.length > model.config.maxNumber">
-                    <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_urlsSelected"> url(s) selected</localize>
+            <span ng-if="model.config.validationLimit.min && model.config.validationLimit.max && model.config.validationLimit.min === model.config.validationLimit.max">
+                <span ng-if="renderModel.length < model.config.validationLimit.max">Add {{model.config.validationLimit.min - renderModel.length}} item(s)</span>
+                <span ng-if="renderModel.length > model.config.validationLimit.max">
+                    <localize key="validation_maxCount">You can only have</localize> {{model.config.validationLimit.max}} <localize key="validation_urlsSelected"> url(s) selected</localize>
                 </span>
             </span>
 
             <!-- Only max -->
-            <span ng-if="!model.config.minNumber && model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber"><localize key="validation_addUpTo">Add up to</localize> {{model.config.maxNumber}} <localize key="validation_urls">url(s)</localize></span>
-                <span ng-if="renderModel.length > model.config.maxNumber">
-                    <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_urlsSelected">url(s) selected</localize>
+            <span ng-if="!model.config.validationLimit.min && model.config.validationLimit.max">
+                <span ng-if="renderModel.length < model.config.validationLimit.max"><localize key="validation_addUpTo">Add up to</localize> {{model.config.validationLimit.max}} <localize key="validation_urls">url(s)</localize></span>
+                <span ng-if="renderModel.length > model.config.validationLimit.max">
+                    <localize key="validation_maxCount">You can only have</localize> {{model.config.validationLimit.max}} <localize key="validation_urlsSelected">url(s) selected</localize>
                 </span>
             </span>
 
             <!-- Only min -->
-            <span ng-if="model.config.minNumber && !model.config.maxNumber && renderModel.length < model.config.minNumber">
-                <localize key="validation_minCount">You need to add at least</localize> {{model.config.minNumber}} <localize key="validation_urls">url(s)</localize>
+            <span ng-if="model.config.validationLimit.min && !model.config.validationLimit.max && renderModel.length < model.config.validationLimit.min">
+                <localize key="validation_minCount">You need to add at least</localize> {{model.config.validationLimit.min}} <localize key="validation_urls">url(s)</localize>
             </span>
 
         </div>
@@ -68,12 +67,12 @@
 
         <div ng-messages="multiUrlPickerForm.minCount.$error" show-validation-on-submit>
             <div class="help-inline" ng-message="minCount">
-                <localize key="validation_minCount">You need to add at least</localize> {{model.config.minNumber}} <localize key="validation_urls">url(s)</localize>
+                <localize key="validation_minCount">You need to add at least</localize> {{model.config.validationLimit.min}} <localize key="validation_urls">url(s)</localize>
             </div>
         </div>
         <div ng-messages="multiUrlPickerForm.maxCount.$error" show-validation-on-submit>
             <div class="help-inline" ng-message="maxCount">
-                <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_urlsSelected">url(s) selected</localize>
+                <localize key="validation_maxCount">You can only have</localize> {{model.config.validationLimit.max}} <localize key="validation_urlsSelected">url(s) selected</localize>
             </div>
         </div>
     </ng-form>

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerConfiguration.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Web.PropertyEditors
@@ -5,11 +6,17 @@ namespace Umbraco.Web.PropertyEditors
 
     public class MultiUrlPickerConfiguration : IIgnoreUserStartNodesConfig
     {
-        [ConfigurationField("minNumber", "Minimum number of items", "number")]
-        public int MinNumber { get; set; }
+        [ConfigurationField("validationLimit", "Amount", "numberrange", Description = "Set a required range of urls")]
+        public NumberRange ValidationLimit { get; set; } = new NumberRange();
 
-        [ConfigurationField("maxNumber", "Maximum number of items", "number")]
-        public int MaxNumber { get; set; }
+        public class NumberRange
+        {
+            [JsonProperty("min")]
+            public int? Min { get; set; }
+
+            [JsonProperty("max")]
+            public int? Max { get; set; }
+        }
 
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,
             "Ignore User Start Nodes", "boolean",

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public override bool IsConverter(IPublishedPropertyType propertyType) => Constants.PropertyEditors.Aliases.MultiUrlPicker.Equals(propertyType.EditorAlias);
 
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType) =>
-            propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber == 1 ?
+            propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().ValidationLimit.Max== 1 ?
                 typeof(Link) :
                 typeof(IEnumerable<Link>);
 
@@ -40,7 +40,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         {
             using (_proflog.DebugDuration<MultiUrlPickerValueConverter>($"ConvertPropertyToLinks ({propertyType.DataType.Id})"))
             {
-                var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber;
+                var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().ValidationLimit.Max;
 
                 if (inter == null)
                 {
@@ -85,7 +85,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 }
 
                 if (maxNumber == 1) return links.FirstOrDefault();
-                if (maxNumber > 0) return links.Take(maxNumber);
+                if (maxNumber > 0) return links.Take(maxNumber.Value);
                 return links;
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I think the changes I've made in this PR might be breaking or perhaps we need to add a set of migrations to ensure things still work when people upgrade? Either way I trust someone to guide me about this 😅 Please also let me know if there is something I've overlooked and need to change accordingly as well - I've only tested setting up new multi url property editors inside the backoffice and they appear to be working just fine after these changes though.

The reason for the change is because I was thinking it would be nice to align the UI and overall developer experience so min/max is setup in the same fashion whether we use Media Picker v3, Block List editor or other editors where we have min/max configuration.

You can have a look at the before/after images below to see the changed UI these changes result in - I'm going to mark the PR as a draft for now until we're certain this won't mean trouble when/if this change is merged 😄 

**Before**
![multi-url-picker-config-before](https://user-images.githubusercontent.com/1932158/121778230-60882480-cb96-11eb-87b4-205b6e0da9d6.png)

**After**
![multi-url-picker-config-after](https://user-images.githubusercontent.com/1932158/121778093-9b3d8d00-cb95-11eb-9d09-f6708d6657af.png)
