### PR TITLE
Fix interface inheritance

### DIFF
--- a/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoApplicationBuilder.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder
 {
-    public interface IUmbracoApplicationBuilder : IUmbracoMiddlewareBuilder
+    public interface IUmbracoApplicationBuilder
     {
         /// <summary>
         /// Called to include umbraco middleware

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Web.Common.ApplicationBuilder
     /// <summary>
     /// A builder to allow encapsulating the enabled endpoints in Umbraco
     /// </summary>
-    internal class UmbracoApplicationBuilder : IUmbracoApplicationBuilder
+    internal class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoMiddlewareBuilder
     {
         public UmbracoApplicationBuilder(IServiceProvider services, IRuntimeState runtimeState, IApplicationBuilder appBuilder)
         {


### PR DESCRIPTION
We need to split some interfaces here since this is possible but it shouldn't be:

```cs
app.UseUmbraco()
                .WithWebsite()
```

The WithWebsite and WithBackOffice should only be allowed within the WithMiddleware like 

```cs
 app.UseUmbraco()
                .WithMiddleware(u =>
                {
                    u.WithBackOffice();
                    u.WithWebsite();
                })
                .WithEndpoints(u =>
                {
                    u.UseInstallerEndpoints();
                    u.UseBackOfficeEndpoints();
                    u.UseWebsiteEndpoints();
                });
```

but due to how the inheritance works the previous is still possible.