### PR TITLE
Added two further notifications to the boot process.

### DIFF
--- a/src/Umbraco.Core/Notifications/UmbracoApplicationComponentsInstallingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationComponentsInstallingNotification.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications
+{
+    /// <summary>
+    /// Notification that occurs during the Umbraco boot process, before instances of <see cref="IComponent"/> initialize.
+    /// </summary>
+    public class UmbracoApplicationComponentsInstallingNotification : INotification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification"/> class.
+        /// </summary>
+        /// <param name="runtimeLevel">The runtime level</param>
+        public UmbracoApplicationComponentsInstallingNotification(RuntimeLevel runtimeLevel) => RuntimeLevel = runtimeLevel;
+
+        /// <summary>
+        /// Gets the runtime level of execution.
+        /// </summary>
+        public RuntimeLevel RuntimeLevel { get; }
+    }
+}

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationMainDomAcquiredNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationMainDomAcquiredNotification.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications
+{
+    /// <summary>
+    /// Notification that occurs during Umbraco boot after the MainDom has been acquired.
+    /// </summary>
+    public class UmbracoApplicationMainDomAcquiredNotification : INotification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationMainDomAcquiredNotification"/> class.
+        /// </summary>
+        /// <param name="runtimeLevel">The runtime level</param>
+        public UmbracoApplicationMainDomAcquiredNotification()
+        {
+        }
+    }
+}


### PR DESCRIPTION
These two notifications have been added to provide hooks for functionality that may need to run earlier in the boot process.

Specifically I'm looking to lay the ground for the migration of [this class](https://github.com/umbraco/Umbraco-Deploy/blob/v4/dev/Umbraco.Deploy.Cloud/Initializing/CloudInitializer.cs) (and the ones it depends on) in Deploy.

For more details see the [related Deploy PR](https://github.com/umbraco/Umbraco-Deploy/pull/558).