### PR TITLE
Adds dotnetRunMessages flag to launch settings for Kestrel

### DIFF
--- a/build/templates/UmbracoProject/Properties/launchSettings.json
+++ b/build/templates/UmbracoProject/Properties/launchSettings.json
@@ -18,11 +18,12 @@
     },
     "Umbraco.Web.UI.NetCore": {
       "commandName": "Project",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
+      "applicationUrl": "https://localhost:HTTPS_PORT_FROM_TEMPLATE;http://localhost:HTTP_PORT_FROM_TEMPLATE",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:HTTPS_PORT_FROM_TEMPLATE;http://localhost:HTTP_PORT_FROM_TEMPLATE"
+      }      
     }
   }
 }


### PR DESCRIPTION
When looking at .NETCore own MVC template I noticed a new property in the Kestrel launchsettings which is undocumented

### Example Launch Settings in MVC template
https://github.com/dotnet/aspnetcore/blob/v6.0.0-preview.5.21301.17/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json#L22

Doing a bit of quick googling I came across the issues that talk about this issue and implement it

### Issue
https://github.com/dotnet/sdk/issues/12227

### PR
https://github.com/dotnet/sdk/pull/12581


## Test Notes
* Create a project with `dotnet new umbraco`
* In same terminal change to directory
* Run `dotnet run` (As noted in the PR it can take a little while before you get output)
* Build template from build.ps1
* Uninstall existing template pack
* Install new template pack from build.out
* Re-test and note you get a message immediately saying the project is building

## Comments
I know this is not a BIG change but the closer we are inline with the official Microsoft MVC templates & similar then people will have a nicer experience when coming from those templates and have same set of expectations. 