### PR TITLE
V9: Fix issue with recurring services that executes too often

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -62,8 +62,9 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             }
             finally
             {
-                // Resume now that the task is complete
-                _timer?.Change((int)_delay.TotalMilliseconds, (int)_period.TotalMilliseconds);
+                // Resume now that the task is complete - Note we use period in both because we don't want to execute again after the delay.
+                // So first execution is after _delay, and the we wait _period between each
+                _timer?.Change((int)_period.TotalMilliseconds, (int)_period.TotalMilliseconds);
             }
         }
 

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -58,12 +58,14 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
                     // Send data to LIVE telemetry
                     s_httpClient.BaseAddress = new Uri("https://telemetry.umbraco.com/");
 
+                    // Set a low timeout - no need to use a larger default timeout for this POST request
+                    s_httpClient.Timeout = new TimeSpan(0, 0, 1);
+
 #if DEBUG
                     // Send data to DEBUG telemetry service
                     s_httpClient.BaseAddress = new Uri("https://telemetry.rainbowsrock.net/");
 
-                    // Set a low timeout - no need to use a larger default timeout for this POST request
-                    s_httpClient.Timeout = new TimeSpan(0, 0, 1);
+
 
 #endif
                 }

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -52,13 +52,22 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
 
             try
             {
-                // Send data to LIVE telemetry
-                s_httpClient.BaseAddress = new Uri("https://telemetry.umbraco.com/");
+
+                if (s_httpClient.BaseAddress is null)
+                {
+                    // Send data to LIVE telemetry
+                    s_httpClient.BaseAddress = new Uri("https://telemetry.umbraco.com/");
 
 #if DEBUG
-                // Send data to DEBUG telemetry service
-                s_httpClient.BaseAddress = new Uri("https://telemetry.rainbowsrock.net/");
+                    // Send data to DEBUG telemetry service
+                    s_httpClient.BaseAddress = new Uri("https://telemetry.rainbowsrock.net/");
+
+                    // Set a low timeout - no need to use a larger default timeout for this POST request
+                    s_httpClient.Timeout = new TimeSpan(0, 0, 1);
+
 #endif
+                }
+
 
                 s_httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
 
@@ -66,9 +75,6 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
                 {
                     var postData = new TelemetryReportData { Id = telemetrySiteIdentifier, Version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild() };
                     request.Content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json"); //CONTENT-TYPE header
-
-                    // Set a low timeout - no need to use a larger default timeout for this POST request
-                    s_httpClient.Timeout = new TimeSpan(0, 0, 1);
 
                     // Make a HTTP Post to telemetry service
                     // https://telemetry.umbraco.com/installs/


### PR DESCRIPTION
This PR fixes two small issues:
- Fix exception in ReportSiteTask.cs, when running multiple times..
  - The `s_httpClient.BaseAddress` and `s_httpClient.Timeout` cannot be changed after it has executed a request (This is the case every day)
- Fix issue with recurring tasks that was executed too often.
  - Due to a recent fix for not executing long running tasks in parallel, another bug was introduced. So basically we executed the recurring jobs after `delay`, and then again after `delay` instead of `period`.

