### PR TITLE
Updates to latest smidge and changes how debug assets work

### DIFF
--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Umbraco.Cms.Infrastructure.Examine</RootNamespace>
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\Umbraco.Infrastructure\Umbraco.Infrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="2.0.0-beta.150" />
+    <PackageReference Include="Examine" Version="2.0.0-beta.154" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -49,7 +49,7 @@
       <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
-      <PackageReference Include="Examine.Core" Version="2.0.0-beta.136" />
+      <PackageReference Include="Examine.Core" Version="2.0.0-beta.154" />
       <PackageReference Include="Umbraco.Code" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -66,7 +66,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.150" />
+        <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.154" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
@@ -98,8 +98,6 @@ namespace Umbraco.Cms.Web.Common.RuntimeMinification
                             .ForDebug(builder => builder
                                 // auto-invalidate bundle if files change in debug
                                 .EnableFileWatcher()
-                                // keep using composite files in debug, not raw static files
-                                .EnableCompositeProcessing()
                                 // use the cache buster defined in config
                                 .SetCacheBusterType(_cacheBusterType))
                             .ForProduction(builder => builder
@@ -144,8 +142,6 @@ namespace Umbraco.Cms.Web.Common.RuntimeMinification
                             .ForDebug(builder => builder
                                 // auto-invalidate bundle if files change in debug
                                 .EnableFileWatcher()
-                                // keep using composite files in debug, not raw static files
-                                .EnableCompositeProcessing()
                                 // use the cache buster defined in config
                                 .SetCacheBusterType(_cacheBusterType))
                             .ForProduction(builder => builder
@@ -182,10 +178,10 @@ namespace Umbraco.Cms.Web.Common.RuntimeMinification
                 case AssetType.Javascript:
                     return await _jsMinPipeline.Value
                         .ProcessAsync(
-                            new FileProcessContext(fileContent, new JavaScriptFile(), BundleContext.CreateEmpty()));
+                            new FileProcessContext(fileContent, new JavaScriptFile(), BundleContext.CreateEmpty(CacheBuster)));
                 case AssetType.Css:
                     return await _cssMinPipeline.Value
-                        .ProcessAsync(new FileProcessContext(fileContent, new CssFile(), BundleContext.CreateEmpty()));
+                        .ProcessAsync(new FileProcessContext(fileContent, new CssFile(), BundleContext.CreateEmpty(CacheBuster)));
                 default:
                     throw new NotSupportedException("Unexpected AssetType");
             }

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -35,9 +35,8 @@
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
       <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.3" />
-      <PackageReference Include="Smidge" Version="4.0.0-beta.274" />
-      <PackageReference Include="Smidge.Nuglify" Version="4.0.0-beta.274" />
-      <PackageReference Include="Smidge.InMemory" Version="4.0.0-beta.274" />
+      <PackageReference Include="Smidge.Nuglify" Version="4.0.0-beta.352" />
+      <PackageReference Include="Smidge.InMemory" Version="4.0.0-beta.352" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
       <PackageReference Include="Umbraco.Code" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This updates to latest Smidge which is now on Nuget and updates how package assets are delivered when in debug mode. This is based off of some discussions like https://github.com/umbraco/Umbraco-CMS/discussions/10469

> Disable composite files for package files when in debug mode. This means that the files will be delivered as-is without being processed but will contain the cache buster value. This is more like how v8 worked. This just makes it simpler for all package source debugging since you'll just be working with the raw files. I realize that the way it is now is not great for various reasons: Even if source maps worked, etc... the minify engine will remove debugging statements like debugger; or possibly even logging statements which is not good for debugging. I'm sure nuglify could be tweaked for debug scenarios but IMO it's not worth the effort. Lets just let devs use their raw files to debug with cache busting enabled and then in non-debug we'll process all package files like we did in v8. This will mean that package devs will still need to test their package in non-debug mode to make sure that the minification/composite processing doesn't have any issues. (this will still be much better than v8 since nuglify is a much smarter js/css processor).