### PR TITLE
Convert Media Picker v2 to v3 progressively

### DIFF
--- a/src/Umbraco.Core/Serialization/MediaWithCropsDtoConverter.cs
+++ b/src/Umbraco.Core/Serialization/MediaWithCropsDtoConverter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core.PropertyEditors.ValueConverters;
+
+namespace Umbraco.Core.Serialization
+{
+    public class MediaWithCropsDtoConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var mediaWithCropsDto = new List<MediaWithCropsDto>();
+
+            var mediaIds = value.ToString().Split(',');
+            if (mediaIds.Any())
+            {
+                foreach (var mediaId in mediaIds)
+                {
+                    Guid mediaItemKey = default;
+                    if (GuidUdi.TryParse(mediaId, out var guidUdi))
+                    {
+                        mediaItemKey = guidUdi.Guid;
+                    }
+
+                    if (mediaItemKey != default)
+                    {
+                        mediaWithCropsDto.Add(new MediaWithCropsDto()
+                        {
+                            Key = Guid.NewGuid(),
+                            MediaKey = mediaItemKey,
+                            Crops = new List<ImageCropperValue.ImageCropperCrop>(),
+                            FocalPoint = new ImageCropperValue.ImageCropperFocalPoint {Left = 0.5m, Top = 0.5m}
+                        });
+                    }
+                }
+            }
+
+            JToken.FromObject(mediaWithCropsDto).WriteTo(writer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(string);
+        }
+    }
+
+    /// <summary>
+    /// Model/DTO that represents the JSON that the MediaPicker3 stores
+    /// </summary>
+    [DataContract]
+    internal class MediaWithCropsDto
+    {
+        [DataMember(Name = "key")]
+        public Guid Key { get; set; }
+
+        [DataMember(Name = "mediaKey")]
+        public Guid MediaKey { get; set; }
+
+        [DataMember(Name = "crops")]
+        public IEnumerable<ImageCropperValue.ImageCropperCrop> Crops { get; set; }
+
+        [DataMember(Name = "focalPoint")]
+        public ImageCropperValue.ImageCropperFocalPoint FocalPoint { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Persistence\Repositories\Implement\InstallationRepository.cs" />
     <Compile Include="PropertyEditors\EyeDropperColorPickerConfiguration.cs" />
     <Compile Include="PropertyEditors\ComplexPropertyEditorContentEventHandler.cs" />
+    <Compile Include="Serialization\MediaWithCropsDtoConverter.cs" />
     <Compile Include="Services\IIconService.cs" />
     <Compile Include="Services\Implement\InstallationService.cs" />
     <Compile Include="Migrations\Upgrade\V_8_6_0\AddMainDomLock.cs" />

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/obsoletemediapickernotice.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/obsoletemediapickernotice.html
@@ -1,1 +1,0 @@
-<p style="background-color: #fee4e1; padding: 8px;"><strong>Important:</strong> switching from the (Obsolete) Media Picker to Media Picker will mean all data (references to previously selected media items) will be deleted and no longer available.</p>

--- a/src/Umbraco.Web/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
 using Umbraco.Core.Models.Editors;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Web.PropertyEditors.ValueConverters;
+using Umbraco.Core.Serialization;
+using Umbraco.Core.Services;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -21,27 +24,55 @@ namespace Umbraco.Web.PropertyEditors
         Icon = Constants.Icons.MediaImage)]
     public class MediaPicker3PropertyEditor : DataEditor
     {
+        private readonly ILogger _logger;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaPicker3PropertyEditor"/> class.
         /// </summary>
         public MediaPicker3PropertyEditor(ILogger logger)
             : base(logger)
         {
+            _logger = logger;
         }
 
         /// <inheritdoc />
         protected override IConfigurationEditor CreateConfigurationEditor() => new MediaPicker3ConfigurationEditor();
 
-        protected override IDataValueEditor CreateValueEditor() => new MediaPicker3PropertyValueEditor(Attribute);
+        protected override IDataValueEditor CreateValueEditor() => new MediaPicker3PropertyValueEditor(Attribute, _logger);
 
         internal class MediaPicker3PropertyValueEditor : DataValueEditor, IDataValueReference
         {
+            private readonly ILogger _logger;
+
             ///<remarks>
-            /// Note: no FromEditor() and ToEditor() methods
-            /// We do not want to transform the way the data is stored in the DB and would like to keep a raw JSON string
+            /// Note: no FromEditor() method
+            /// Only transform the way the data is stored if it's not already JSON
             /// </remarks>
-            public MediaPicker3PropertyValueEditor(DataEditorAttribute attribute) : base(attribute)
+            public MediaPicker3PropertyValueEditor(DataEditorAttribute attribute, ILogger logger) : base(attribute)
             {
+                _logger = logger;
+            }
+
+            public override object ToEditor(Property property, IDataTypeService dataTypeService, string culture = null,
+                string segment = null)
+            {
+                var value = property.GetValue(culture, segment)?.ToString();
+                if (value != null && value.DetectIsJson() == false)
+                {
+                    // If the value is not yet JSON we'll try to convert it
+                    try
+                    {
+                        value = JsonConvert.SerializeObject(value, Formatting.Indented, new MediaWithCropsDtoConverter());
+                        property.SetValue(value);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error<MediaWithCropsDtoConverter>(ex, $"Could not convert data to Media Picker v3 format, the data stored is: {value}");
+                    }
+                }
+
+                // If it is already JSON, just continue as normal
+                return base.ToEditor(property, dataTypeService, culture, segment);
             }
 
             public IEnumerable<UmbracoEntityReference> GetReferences(object value)
@@ -51,14 +82,13 @@ namespace Umbraco.Web.PropertyEditors
                 if (rawJson.IsNullOrWhiteSpace())
                     yield break;
 
-                var mediaWithCropsDtos = JsonConvert.DeserializeObject<MediaPickerWithCropsValueConverter.MediaWithCropsDto[]>(rawJson);
+                var mediaWithCropsDtos = JsonConvert.DeserializeObject<MediaWithCropsDto[]>(rawJson);
 
                 foreach (var mediaWithCropsDto in mediaWithCropsDtos)
                 {
                     yield return new UmbracoEntityReference(GuidUdi.Create(Constants.UdiEntityType.Media, mediaWithCropsDto.MediaKey));
                 }
             }
-
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPickerConfiguration.cs
@@ -8,9 +8,6 @@ namespace Umbraco.Web.PropertyEditors
     /// </summary>
     public class MediaPickerConfiguration : IIgnoreUserStartNodesConfig
     {
-        [ConfigurationField("notice", "You can NOT change the property editor", "obsoletemediapickernotice")]
-        public bool Notice { get; set; }
-
         [ConfigurationField("multiPicker", "Pick multiple items", "boolean")]
         public bool Multiple { get; set; }
 


### PR DESCRIPTION
In order to be easily able to move from Media Picker 2 (MP2) to Media Picker 3 (MP3), this PR helps convert existing values when you switch the datatype. 

In the backoffice, when you switch a datatype from MP2 to MP3 and load any node with this new datatype, we'll detect if the old values were stored (a list of UDIs) and if so, we convert those to the new `MediaWithCrops` type. This allows us to show the previously selected media items in the backoffice. This happens in `MediaPicker3PropertyEditor.ToEditor`. 

Once you save and publish the item with the new MP3 datatype, the converted data will be saved and we won't have to do that conversion again in the future. This way you will be progressively updating your nodes when an editor saves them and it is not needed to do a database migration to convert all the data on all the nodes.

In the frontend, you will need to replace your MP2 querying with MP3 querying. As we can see from the documentation the return type is change, so an example of updating a multiple media picker would be:

- [Media Picker 2](https://our.umbraco.com/documentation/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Media-Picker/): `var typedMultiMediaPicker = Model.Value<IEnumerable<IPublishedContent>>("medias");` / `@entry.Url`
- [Media Picker 3](https://our.umbraco.com/documentation/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Media-Picker-3/): `var typedMultiMediaPicker = Model.Value<IEnumerable<MediaWithCrops>>("medias");` / `@entry.MediaItem.Url()`

We do the exact same detection and conversion that we did in the backoffice on the frontend, see `MediaPickerWithCropsValueConverter`.

Both of the conversions are ultimately being done in the `JsonConverter` named `MediaWithCropsDtoConverter`.  
A note: in Umbraco 7, we stored picked media items by integer identifiers, this was never the case in v8 and the property value converter in v8 never dealt with integer ids. Therefore I did not implement conversions from int in the `MediaWithCropsDtoConverter` either.

If you want to make it an even simpler conversion and you do not plan to use the "local crops" feature on the MP3 datatype (don't configure any crops) then you can write your own property value converter (PVC) to give you the same data as MP2 gave you (`IPublishedContent`/`IEnumerable<IPublishedContent>`). If you want to add local crops in the future you could probably find a solution with an extension method in your PVC.   
We recommend updating your templates with the new `MediaWithCrops` return type.

_Final note: going back from MP3 to MP2 is not possible if MP3 values have been stored already, this is a forward-only fix._