### PR TITLE
Render Block List component partial async

### DIFF
--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/blocklist/default.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/blocklist/default.cshtml
@@ -7,6 +7,7 @@
     {
         if (block?.ContentUdi == null) { continue; }
         var data = block.Content;
-        @Html.Partial("BlockList/Components/" + data.ContentType.Alias, block)
+
+        @await Html.PartialAsync("BlockList/Components/" + data.ContentType.Alias, block)
     }
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10508

### Description
Currently Visual Studio shows a warning regarding the use of `@Html.Partial()` as it may result in application deadlocks.

It seems we can render the component async in .NET Core:
https://stackoverflow.com/questions/50774702/should-i-change-html-partial-to-html-partialasync-as-visual-studio-suggest/52723364#52723364