### PR TITLE
Render grid editor partial async

### DIFF
--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3-fluid.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3-fluid.cshtml
@@ -14,7 +14,8 @@
     <div class="umb-grid">
         @if (oneColumn)
         {
-            foreach (var section in Model.sections) {
+            foreach (var section in Model.sections)
+            {
                 <div class="grid-section">
                     @foreach (var row in section.rows)
                     {
@@ -22,12 +23,15 @@
                     }
                 </div>
             }
-        }else {
+        }
+        else
+        {
             <div class="row clearfix">
-                @foreach (var s in Model.sections) {
+                @foreach (var sec in Model.sections)
+                {
                     <div class="grid-section">
-                        <div class="col-md-@s.grid column">
-                            @foreach (var row in s.rows)
+                        <div class="col-md-@sec.grid column">
+                            @foreach (var row in sec.rows)
                             {
                                 renderRow(row);
                             }

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3-fluid.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3-fluid.cshtml
@@ -39,38 +39,45 @@
     </div>
 }
 
-@functions {
-    private void renderRow(dynamic row)
+@functions{
+
+    private async Task renderRow(dynamic row)
     {
         <div @RenderElementAttributes(row)>
             <div class="row clearfix">
-                @foreach ( var area in row.areas ) {
+                @foreach (var area in row.areas)
+                {
                     <div class="col-md-@area.grid column">
                         <div @RenderElementAttributes(area)>
-                            @foreach (var control in area.controls) {
-                                if (control !=null && control.editor != null && control.editor.view != null ) {
-                                    <text>@Html.Partial("grid/editors/base", (object)control)</text>
+                            @foreach (var control in area.controls)
+                            {
+                                if (control != null && control.editor != null && control.editor.view != null ) {
+                                    <text>@await Html.PartialAsync("grid/editors/base", (object)control)</text>
                                 }
                             }
                         </div>
-                    </div>}
+                    </div>
+                 }
             </div>
         </div>
     }
 }
 
-@functions {
+@functions{
+
     public static HtmlString RenderElementAttributes(dynamic contentItem)
     {
         var attrs = new List<string>();
         JObject cfg = contentItem.config;
 
-        if(cfg != null)
+        if (cfg != null)
+        {
             foreach (JProperty property in cfg.Properties())
             {
                 var propertyValue = HttpUtility.HtmlAttributeEncode(property.Value.ToString());
                 attrs.Add(property.Name + "=\"" + propertyValue + "\"");
             }
+        }
 
         JObject style = contentItem.styles;
 

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3-fluid.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3-fluid.cshtml
@@ -51,7 +51,8 @@
                         <div @RenderElementAttributes(area)>
                             @foreach (var control in area.controls)
                             {
-                                if (control != null && control.editor != null && control.editor.view != null ) {
+                                if (control != null && control.editor != null && control.editor.view != null)
+                                {
                                     <text>@await Html.PartialAsync("grid/editors/base", (object)control)</text>
                                 }
                             }

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3.cshtml
@@ -21,10 +21,10 @@
         }else {
             <div class="container">
                 <div class="row clearfix">
-                    @foreach (var s in Model.sections) {
+                    @foreach (var sec in Model.sections) {
                         <div class="grid-section">
-                            <div class="col-md-@s.grid column">
-                                @foreach (var row in s.rows)
+                            <div class="col-md-@sec.grid column">
+                                @foreach (var row in sec.rows)
                                 {
                                     renderRow(row, false);
                                 }
@@ -37,25 +37,29 @@
     </div>
 }
 
-@functions {
+@functions{
 
-    private void renderRow(dynamic row, bool singleColumn)
+    private async Task renderRow(dynamic row, bool singleColumn)
     {
         <div @RenderElementAttributes(row)>
             @if (singleColumn) {
                 @:<div class="container">
             }
             <div class="row clearfix">
-                @foreach ( var area in row.areas ) {
+                @foreach (var area in row.areas)
+                {
                     <div class="col-md-@area.grid column">
                         <div @RenderElementAttributes(area)>
-                            @foreach (var control in area.controls) {
-                                if (control !=null && control.editor != null && control.editor.view != null ) {
-                                    <text>@Html.Partial("grid/editors/base", (object)control)</text>
+                            @foreach (var control in area.controls)
+                            {
+                                if (control != null && control.editor != null && control.editor.view != null)
+                                {
+                                    <text>@await Html.PartialAsync("grid/editors/base", (object)control)</text>
                                 }
                             }
                         </div>
-                    </div>}
+                    </div>
+                 }
             </div>
             @if (singleColumn) {
                 @:</div>
@@ -65,23 +69,26 @@
 
 }
 
+@functions{
 
-@functions {
     public static HtmlString RenderElementAttributes(dynamic contentItem)
     {
         var attrs = new List<string>();
         JObject cfg = contentItem.config;
 
-        if(cfg != null)
+        if (cfg != null)
+        {
             foreach (JProperty property in cfg.Properties())
             {
                 var propertyValue = HttpUtility.HtmlAttributeEncode(property.Value.ToString());
                 attrs.Add(property.Name + "=\"" + propertyValue + "\"");
             }
+        }
 
         JObject style = contentItem.styles;
 
-        if (style != null) {
+        if (style != null)
+        {
             var cssVals = new List<string>();
             foreach (JProperty property in style.Properties())
             {

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/bootstrap3.cshtml
@@ -10,7 +10,8 @@
     <div class="umb-grid">
         @if (oneColumn)
         {
-            foreach (var section in Model.sections) {
+            foreach (var section in Model.sections)
+            {
                 <div class="grid-section">
                     @foreach (var row in section.rows)
                     {
@@ -18,10 +19,13 @@
                     }
                 </div>
             }
-        }else {
+        }
+        else
+        {
             <div class="container">
                 <div class="row clearfix">
-                    @foreach (var sec in Model.sections) {
+                    @foreach (var sec in Model.sections)
+                    {
                         <div class="grid-section">
                             <div class="col-md-@sec.grid column">
                                 @foreach (var row in sec.rows)

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/base.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/base.cshtml
@@ -1,23 +1,27 @@
-﻿@model dynamic
+@model dynamic
 
-@functions {
+@try
+{
+    string editor = EditorView(Model);
+    <text>@await Html.PartialAsync(editor, (object)Model)</text>
+}
+catch (Exception ex)
+{
+    <pre>@ex.ToString()</pre>
+}
+
+@functions{
+
     public static string EditorView(dynamic contentItem)
     {
         string view = contentItem.editor.render != null ? contentItem.editor.render.ToString() : contentItem.editor.view.ToString();
         view = view.ToLower().Replace(".html", ".cshtml");
 
-        if (!view.Contains("/")) {
+        if (!view.Contains("/"))
+        {
             view = "grid/editors/" + view;
         }
 
         return view;
     }
-}
-@try
-{
-    string editor = EditorView(Model);
-    <text>@Html.Partial(editor, (object)Model)</text>
-}
-catch (Exception ex) {
-<pre>@ex.ToString()</pre>
 }

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/media.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/media.cshtml
@@ -1,11 +1,13 @@
-﻿@model dynamic
+@model dynamic
 @using Umbraco.Cms.Core.Media
 @using Umbraco.Cms.Core.PropertyEditors.ValueConverters
 @inject IImageUrlGenerator ImageUrlGenerator
 @if (Model.value != null)
 {
     var url = Model.value.image;
-    if(Model.editor.config != null && Model.editor.config.size != null){
+
+    if (Model.editor.config != null && Model.editor.config.size != null)
+    {
         if (Model.value.coordinates != null)
         {
             url = ImageCropperTemplateCoreExtensions.GetCropUrl(

--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/rte.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/rte.cshtml
@@ -1,13 +1,13 @@
-﻿@using Umbraco.Cms.Core.Templates
+@using Umbraco.Cms.Core.Templates
 @model dynamic
 @inject HtmlLocalLinkParser HtmlLocalLinkParser;
 @inject HtmlUrlParser HtmlUrlParser;
 @inject HtmlImageSourceParser HtmlImageSourceParser;
 
 @{
-
     var value = HtmlLocalLinkParser.EnsureInternalLinks(Model.value.ToString());
     value = HtmlUrlParser.EnsureUrls(value);
     value = HtmlImageSourceParser.EnsureImageSources(value);
 }
+
 @Html.Raw(value)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While working on https://github.com/umbraco/Umbraco-CMS/pull/10511 I also noticed some partials in grid wasn't rendered async, but we did it for macro grid editor.

https://github.com/umbraco/Umbraco-CMS/blob/v9/9.0-beta004/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/macro.cshtml#L12-L14


The grid editors seems to render as expected on frontend. I guess it would also improve the performance a bit in backoffice when rendering previews of many grid editors.

![Pf1pVOkhrG](https://user-images.githubusercontent.com/2919859/122981576-34408500-d39a-11eb-8b8e-0efa49390fb5.gif)


![OFXKTPGdvb](https://user-images.githubusercontent.com/2919859/122981713-589c6180-d39a-11eb-9cf6-21eed82f3c11.gif)
