### PR TITLE
V9: Fixes issue with "Rebuild" nucache not doing anything

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -101,20 +101,9 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache.Persistence
             IReadOnlyCollection<int> mediaTypeIds = null,
             IReadOnlyCollection<int> memberTypeIds = null)
         {
-            if (contentTypeIds != null)
-            {
-                RebuildContentDbCache(groupSize, contentTypeIds);
-            }
-
-            if (mediaTypeIds != null)
-            {
-                RebuildContentDbCache(groupSize, mediaTypeIds);
-            }
-
-            if (memberTypeIds != null)
-            {
-                RebuildContentDbCache(groupSize, memberTypeIds);
-            }
+            RebuildContentDbCache(groupSize, contentTypeIds);
+            RebuildContentDbCache(groupSize, mediaTypeIds);
+            RebuildContentDbCache(groupSize, memberTypeIds);
         }
 
         // assumes content tree lock

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentService.cs
@@ -79,20 +79,10 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache.Persistence
         {
             using (IScope scope = ScopeProvider.CreateScope(repositoryCacheMode: RepositoryCacheMode.Scoped))
             {
-                if (contentTypeIds != null)
-                {
-                    scope.ReadLock(Constants.Locks.ContentTree);
-                }
 
-                if (mediaTypeIds != null)
-                {
-                    scope.ReadLock(Constants.Locks.MediaTree);
-                }
-
-                if (memberTypeIds != null)
-                {
-                    scope.ReadLock(Constants.Locks.MemberTree);
-                }
+                scope.ReadLock(Constants.Locks.ContentTree);
+                scope.ReadLock(Constants.Locks.MediaTree);
+                scope.ReadLock(Constants.Locks.MemberTree);
 
                 _repository.Rebuild(groupSize, contentTypeIds, mediaTypeIds, memberTypeIds);
                 scope.Complete();


### PR DESCRIPTION
Fixes #10394.

The issue was a couple injected `null`s was handled like "no nothing" instead of "clear all" as the XML docs describe.

Steps to test in the issue #10394..