### PR TITLE
Reduce sql queries when rendering blocklists in the content panel

### DIFF
--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -323,7 +323,7 @@ namespace Umbraco.Core.Services
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IContent"/> that resides in the bin
         /// </summary>
-        /// <param name="userId">Optional Id of the User emptying the Recycle Bin</param>        
+        /// <param name="userId">Optional Id of the User emptying the Recycle Bin</param>
         OperationResult EmptyRecycleBin(int userId = Constants.Security.SuperUserId);
 
         /// <summary>
@@ -498,6 +498,11 @@ namespace Umbraco.Core.Services
         /// Creates a document.
         /// </summary>
         IContent Create(string name, int parentId, string documentTypeAlias, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Creates a document
+        /// </summary>
+        IContent Create(string name, int parentId, IContentType contentType, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
         /// Creates a document.

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -505,11 +505,6 @@ namespace Umbraco.Core.Services
         IContent Create(string name, int parentId, IContentType contentType, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
-        /// Creates a document
-        /// </summary>
-        IContent Create(string name, IContent parent, IContentType contentType, int userId = Constants.Security.SuperUserId);
-
-        /// <summary>
         /// Creates a document.
         /// </summary>
         IContent Create(string name, IContent parent, string documentTypeAlias, int userId = Constants.Security.SuperUserId);

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -505,6 +505,11 @@ namespace Umbraco.Core.Services
         IContent Create(string name, int parentId, IContentType contentType, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
+        /// Creates a document
+        /// </summary>
+        IContent Create(string name, IContent parent, IContentType contentType, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
         /// Creates a document.
         /// </summary>
         IContent Create(string name, IContent parent, string documentTypeAlias, int userId = Constants.Security.SuperUserId);

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -186,7 +186,6 @@ namespace Umbraco.Core.Services.Implement
         public IContent Create(string name, int parentId, string contentTypeAlias, int userId = Constants.Security.SuperUserId)
         {
             // TODO: what about culture?
-
             var contentType = GetContentType(contentTypeAlias);
             return Create(name, parentId, contentType, userId);
         }
@@ -200,24 +199,40 @@ namespace Umbraco.Core.Services.Implement
         /// </remarks>
         /// <param name="name">The name of the content object.</param>
         /// <param name="parentId">The identifier of the parent, or -1.</param>
-        /// <param name="contentType">The content type of the content</param>
+        /// <param name="contentType">The content type.</param>
         /// <param name="userId">The optional id of the user creating the content.</param>
         /// <returns>The content object.</returns>
-        public IContent Create(string name, int parentId, IContentType contentType,
-            int userId = Constants.Security.SuperUserId)
+        public IContent Create(string name, int parentId, IContentType contentType, int userId = Constants.Security.SuperUserId)
         {
-            if (contentType is null)
-            {
-                throw new ArgumentException("Content type must be specified", nameof(contentType));
-            }
-
             var parent = parentId > 0 ? GetById(parentId) : null;
             if (parentId > 0 && parent is null)
             {
                 throw new ArgumentException("No content with that id.", nameof(parentId));
             }
 
-            var content = new Content(name, parentId, contentType);
+            return Create(name, parent, contentType, userId);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IContent"/> object of a specified content type.
+        /// </summary>
+        /// <remarks>This method simply returns a new, non-persisted, IContent without any identity. It
+        /// is intended as a shortcut to creating new content objects that does not invoke a save
+        /// operation against the database.
+        /// </remarks>
+        /// <param name="name">The name of the content object.</param>
+        /// <param name="parent">The parent of the content</param>
+        /// <param name="contentType">The content type of the content</param>
+        /// <param name="userId">The optional id of the user creating the content.</param>
+        /// <returns>The content object.</returns>
+        public IContent Create(string name, IContent parent, IContentType contentType, int userId = Constants.Security.SuperUserId)
+        {
+            if (contentType is null)
+            {
+                throw new ArgumentException("Content type must be specified", nameof(contentType));
+            }
+
+            var content = new Content(name, parent, contentType);
             using (var scope = ScopeProvider.CreateScope())
             {
                 CreateContent(scope, content, userId, false);

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -188,11 +188,34 @@ namespace Umbraco.Core.Services.Implement
             // TODO: what about culture?
 
             var contentType = GetContentType(contentTypeAlias);
-            if (contentType == null)
-                throw new ArgumentException("No content type with that alias.", nameof(contentTypeAlias));
+            return Create(name, parentId, contentType, userId);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IContent"/> object of a specified content type.
+        /// </summary>
+        /// <remarks>This method simply returns a new, non-persisted, IContent without any identity. It
+        /// is intended as a shortcut to creating new content objects that does not invoke a save
+        /// operation against the database.
+        /// </remarks>
+        /// <param name="name">The name of the content object.</param>
+        /// <param name="parentId">The identifier of the parent, or -1.</param>
+        /// <param name="contentType">The content type of the content</param>
+        /// <param name="userId">The optional id of the user creating the content.</param>
+        /// <returns>The content object.</returns>
+        public IContent Create(string name, int parentId, IContentType contentType,
+            int userId = Constants.Security.SuperUserId)
+        {
+            if (contentType is null)
+            {
+                throw new ArgumentException("Content type must be specified", nameof(contentType));
+            }
+
             var parent = parentId > 0 ? GetById(parentId) : null;
-            if (parentId > 0 && parent == null)
+            if (parentId > 0 && parent is null)
+            {
                 throw new ArgumentException("No content with that id.", nameof(parentId));
+            }
 
             var content = new Content(name, parentId, contentType);
             using (var scope = ScopeProvider.CreateScope())
@@ -1088,7 +1111,7 @@ namespace Umbraco.Core.Services.Implement
         /// <remarks>
         /// <para>
         /// Business logic cases such: as unpublishing a mandatory culture, or unpublishing the last culture, checking for pending scheduled publishing, etc... is dealt with in this method.
-        /// There is quite a lot of cases to take into account along with logic that needs to deal with scheduled saving/publishing, branch saving/publishing, etc...       
+        /// There is quite a lot of cases to take into account along with logic that needs to deal with scheduled saving/publishing, branch saving/publishing, etc...
         /// </para>
         /// </remarks>
         private PublishResult CommitDocumentChangesInternal(IScope scope, IContent content,

--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -186,6 +186,7 @@ namespace Umbraco.Core.Services.Implement
         public IContent Create(string name, int parentId, string contentTypeAlias, int userId = Constants.Security.SuperUserId)
         {
             // TODO: what about culture?
+
             var contentType = GetContentType(contentTypeAlias);
             return Create(name, parentId, contentType, userId);
         }
@@ -199,40 +200,24 @@ namespace Umbraco.Core.Services.Implement
         /// </remarks>
         /// <param name="name">The name of the content object.</param>
         /// <param name="parentId">The identifier of the parent, or -1.</param>
-        /// <param name="contentType">The content type.</param>
-        /// <param name="userId">The optional id of the user creating the content.</param>
-        /// <returns>The content object.</returns>
-        public IContent Create(string name, int parentId, IContentType contentType, int userId = Constants.Security.SuperUserId)
-        {
-            var parent = parentId > 0 ? GetById(parentId) : null;
-            if (parentId > 0 && parent is null)
-            {
-                throw new ArgumentException("No content with that id.", nameof(parentId));
-            }
-
-            return Create(name, parent, contentType, userId);
-        }
-
-        /// <summary>
-        /// Creates an <see cref="IContent"/> object of a specified content type.
-        /// </summary>
-        /// <remarks>This method simply returns a new, non-persisted, IContent without any identity. It
-        /// is intended as a shortcut to creating new content objects that does not invoke a save
-        /// operation against the database.
-        /// </remarks>
-        /// <param name="name">The name of the content object.</param>
-        /// <param name="parent">The parent of the content</param>
         /// <param name="contentType">The content type of the content</param>
         /// <param name="userId">The optional id of the user creating the content.</param>
         /// <returns>The content object.</returns>
-        public IContent Create(string name, IContent parent, IContentType contentType, int userId = Constants.Security.SuperUserId)
+        public IContent Create(string name, int parentId, IContentType contentType,
+            int userId = Constants.Security.SuperUserId)
         {
             if (contentType is null)
             {
                 throw new ArgumentException("Content type must be specified", nameof(contentType));
             }
 
-            var content = new Content(name, parent, contentType);
+            var parent = parentId > 0 ? GetById(parentId) : null;
+            if (parentId > 0 && parent is null)
+            {
+                throw new ArgumentException("No content with that id.", nameof(parentId));
+            }
+
+            var content = new Content(name, parentId, contentType);
             using (var scope = ScopeProvider.CreateScope())
             {
                 CreateContent(scope, content, userId, false);

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -432,7 +432,7 @@ namespace Umbraco.Web.Editors
 
             foreach (var contentType in contentTypes)
             {
-                var emptyContent = Services.ContentService.Create("", parent, contentType, userId);
+                var emptyContent = Services.ContentService.Create("", parentId, contentType, userId);
 
                 var mapped = MapToDisplay(emptyContent, context =>
                 {

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -431,15 +431,7 @@ namespace Umbraco.Web.Editors
 
                 // Get the path for the content, we get this for each just in case some content has Identity and a different path
                 // Since if that's the case we might not be able to re-use the permissions.
-                string path;
-                if (emptyContent.HasIdentity)
-                {
-                    path = emptyContent.Path;
-                }
-                else
-                {
-                    path = parent == null ? "-1" : parent.Path;
-                }
+                string path = parent == null ? "-1" : parent.Path;
 
                 // Only assign permissions once, the idea is that we'll be able to re-use the same permissions most of the time.
                 if (permissions is null)

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -427,7 +427,7 @@ namespace Umbraco.Web.Editors
 
             foreach (var contentType in contentTypes)
             {
-                var emptyContent = Services.ContentService.Create("", parentId, contentType, userId);
+                var emptyContent = Services.ContentService.Create("", parent, contentType, userId);
 
                 // Get the path for the content, we get this for each just in case some content has Identity and a different path
                 // Since if that's the case we might not be able to re-use the permissions.

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -457,7 +457,7 @@ namespace Umbraco.Web.Editors
                     // Since the permissions depend on current user and path, we add both of these to context as well,
                     // that way we can compare the path and current user when mapping, if they're the same just take permissions
                     // and skip getting them again, in theory they should always be the same, but better safe than sorry.
-                    context.Items["CurrentUser"] = Security.CurrentUser;
+                    context.Items["CurrentUser"] = currentUser;
                     context.Items["Path"] = path;
                     context.Items["Permissions"] = permissions;
                 });

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -408,7 +408,14 @@ namespace Umbraco.Web.Editors
             return CleanContentItemDisplay(mapped);
         }
 
-        private IEnumerable<ContentItemDisplay> GetEmpties(IList<IContentType> contentTypes, int parentId)
+        /// <summary>
+        /// Gets an empty <see cref="ContentItemDisplay"/> for each content type in the IEnumerable, all with the same parent ID
+        /// </summary>
+        /// <remarks>Will attempt to re-use the same permissions for every content as long as the path and user are the same</remarks>
+        /// <param name="contentTypes"></param>
+        /// <param name="parentId"></param>
+        /// <returns></returns>
+        private IEnumerable<ContentItemDisplay> GetEmpties(IEnumerable<IContentType> contentTypes, int parentId)
         {
             var result = new List<ContentItemDisplay>();
             var userId = Security.GetUserId().ResultOr(0);
@@ -2325,6 +2332,13 @@ namespace Umbraco.Web.Editors
                 context.Items["CurrentUser"] = Security.CurrentUser;
             });
 
+        /// <summary>
+        /// Used to map an <see cref="IContent"/> instance to a <see cref="ContentItemDisplay"/> and ensuring AllowPreview is set correctly.
+        /// Also allows you to pass in an action for the mapper context where you can pass additional information on to the mapper.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="contextOptions"></param>
+        /// <returns></returns>
         private ContentItemDisplay MapToDisplay(IContent content, Action<MapperContext> contextOptions)
         {
             var display = Mapper.Map<ContentItemDisplay>(content, contextOptions);

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -443,7 +443,8 @@ namespace Umbraco.Web.Editors
                 {
                     // Since the permissions depend on current user and path, we add both of these to context as well,
                     // that way we can compare the path and current user when mapping, if they're the same just take permissions
-                    // and skip getting them again, in theory they should always be the same, but better safe than sorry.
+                    // and skip getting them again, in theory they should always be the same, but better safe than sorry.,
+                    context.Items["Parent"] = parent;
                     context.Items["CurrentUser"] = currentUser;
                     context.Items["Path"] = path;
                     context.Items["Permissions"] = permissions;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -390,7 +390,7 @@ namespace Umbraco.Web.Editors
 
         private ContentItemDisplay GetEmpty(IContentType contentType, int parentId)
         {
-            var emptyContent = Services.ContentService.Create("", parentId, contentType.Alias, Security.GetUserId().ResultOr(0));
+            var emptyContent = Services.ContentService.Create("", parentId, contentType, Security.GetUserId().ResultOr(0));
             var mapped = MapToDisplay(emptyContent);
             // translate the content type name if applicable
             mapped.ContentTypeName = Services.TextService.UmbracoDictionaryTranslate(mapped.ContentTypeName);

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -429,11 +429,6 @@ namespace Umbraco.Web.Editors
             {
                 var emptyContent = Services.ContentService.Create("", parentId, contentType, userId);
 
-                if (emptyContent is null)
-                {
-                    throw new HttpResponseException(HttpStatusCode.NotFound);
-                }
-
                 // Get the path for the content, we get this for each just in case some content has Identity and a different path
                 // Since if that's the case we might not be able to re-use the permissions.
                 string path;

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -477,9 +477,7 @@ namespace Umbraco.Web.Editors
         {
             using var scope = _scopeProvider.CreateScope(autoComplete: true);
             var contentTypes = Services.ContentTypeService.GetAll(contentTypeKeys).ToList();
-
-            var displays = GetEmpties(contentTypes, parentId);
-            return displays.ToDictionary(x => x.ContentTypeKey);
+            return GetEmpties(contentTypes, parentId).ToDictionary(x => x.ContentTypeKey);
         }
 
         [OutgoingEditorModelEvent]

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -86,6 +86,7 @@ namespace Umbraco.Web.Models.Mapping
         // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent
         private void Map(IContent source, ContentItemDisplay target, MapperContext context)
         {
+            // Both GetActions and DetermineIsChildOfListView use parent, so get it once here
             var parent = _contentService.GetParent(source);
 
             target.AllowedActions = GetActions(source, parent, context);

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -258,7 +258,7 @@ namespace Umbraco.Web.Models.Mapping
                     // return false if this is the user's actual start node, the node will be rendered in the tree
                     // regardless of if it's a list view or not
                     if (userStartNodes.Contains(source.Id))
-                        return false;                    
+                        return false;
                 }
             }
 
@@ -297,6 +297,12 @@ namespace Umbraco.Web.Models.Mapping
 
         private IDictionary<string, string> GetAllowedTemplates(IContent source)
         {
+            // Element types can't have templates, so no need to query to get the content type
+            if (source.ContentType.IsElement)
+            {
+                return new Dictionary<string, string>();
+            }
+
             var contentType = _contentTypeService.Get(source.ContentTypeId);
 
             return contentType.AllowedTemplates

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -187,14 +187,14 @@ namespace Umbraco.Web.Models.Mapping
 
             // A bit of a mess, but we need to ensure that all the required values are here AND that they're the right type.
             if (context.Items.TryGetValue("CurrentUser", out var userObject) &&
-                context.Items.TryGetValue("Path", out var pathObject) &&
                 context.Items.TryGetValue("Permissions", out var permissionsObject) &&
                 userObject is IUser currentUser &&
-                pathObject is string contextPath &&
-                permissionsObject is EntityPermissionSet permissions)
+                permissionsObject is Dictionary<string, EntityPermissionSet> permissionsDict)
             {
-                // Both the path and the user is the same, it's safe to assume that the permissions are the same as well.
-                if (contextPath.Equals(path) && umbracoContext.Security.CurrentUser.Id == currentUser.Id)
+                // If we already have permissions for a given path,
+                // and the current user is the same as was used to generate the permissions, return the stored permissions.
+                if (umbracoContext.Security.CurrentUser.Id == currentUser.Id &&
+                    permissionsDict.TryGetValue(path, out var permissions))
                 {
                     return permissions.GetAllPermissions();
                 }

--- a/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentMapDefinition.cs
@@ -87,7 +87,17 @@ namespace Umbraco.Web.Models.Mapping
         private void Map(IContent source, ContentItemDisplay target, MapperContext context)
         {
             // Both GetActions and DetermineIsChildOfListView use parent, so get it once here
-            var parent = _contentService.GetParent(source);
+            // Parent might already be in context, so check there before using content service
+            IContent parent;
+            if (context.Items.TryGetValue("Parent", out var parentObj) &&
+                parentObj is IContent typedParent)
+            {
+                parent = typedParent;
+            }
+            else
+            {
+                parent = _contentService.GetParent(source);
+            }
 
             target.AllowedActions = GetActions(source, parent, context);
             target.AllowedTemplates = GetAllowedTemplates(source);


### PR DESCRIPTION
## Description
This is a continuation of #10235, here I try to reduce the number of SQL queries used when rendering blocklists when adding new content. A lot of the queries and time spent came from mapping the empty `Content` to a `ContentItemDisplay` 

## Details 
There were some low hanging fruit namely I: 

* Added a new `Create` overload to the content service which takes a content type instead of a key. Before we would get all the content types through the content type service, only to pass it to `GetEmpty` where we would then call `ContentService.Create` with the content type alias, only for the content service to then get the content type object one more time. Now we just pass the content type to `Create` which then uses it to create new content.
* Changed it so if we map something that's an element type we don't try to get allowed templates and just return an empty dictionary, we know element types doesn't have any allowed templates
* Both `GetActions` and `DetermineIsChildOfListView` uses the parent object, so instead of getting it twice, we get it once in and then pass it to both those methods.

One of the larger areas of improvement was with the `GetActions` part of mapping to `ContentItemDisplay`. Every time we get actions with ` _userService.GetPermissionsForPath(umbracoContext.Security.CurrentUser, path).GetAllPermissions();` it causes an SQL query, this means that for every possible element type in the blocklist we would execute a get query. But since these are element types on the same doctype the permissions will be the same.

What I tried to do to resolve this is added a new method `GetEmpties` which takes an `IEnumberable` of content types and creates an empty `ContentItemDisplay` for each of these. This method is not super nice, but it seems to work quite well. In the method we first try to get the parent once, this could potentially lead to an extra SQL call, but since we'll save 1 per element type it seems worth it, we'll then generate the path (same as in the mapper), and for the very first item, we'll get the permissions with the path and current user, this permission when then be saved and used for all the entries.

We pass the permissions, path and current user to the mapper in the mapper context, within the mapper we then check if the path in the mapper context matches the one generated by the mapper, and if the user is the same, if they are we can safely assume the permissions are the same and just return the permissions stored in the mapper context.

In reality, I don't know it's truly necessary to pass along the path and user and check them since is currently only used for the blocklist where they should always be the same, however it seemed a bit overly risky to just naively say "if the mapper context contains permissions, then just return those" without doing any checks. 

## Tests

I tried doing some testing before and after with the mini profiler, of course this is just running locally on my machine with a local SQL server, but this is what I found.

I have a document type with two block list editors of the same type, each blocklist editor have 5 element types to chose from.

Before this and Elitsa's PR we'd make a request for each element type available and for each blocklist property, so a total of 10 requests:

Call nr | Time in ms | Queries
-- | -- | --
1 | 30.6 | 7
2 | 30.3 | 7
3 | 26.9 | 7
4 | 34.7 | 7
5 | 26.6 | 7
6 | 25.3 | 7
7 | 25.6 | 7
8 | 33.7 | 7
9 | 35.2 | 7
10 | 33.5 | 7
Total | 302.4 | 70

After Elitsa's and this PR we only do two requests, one for each blocklist property

Block nr | Time in ms | Queries
-- | -- | --
1 | 24.5 | 2
2 | 14.5 | 2
Total | 39 | 4

One of these queries are for the SQL lock, the other is for the permissions, it's of course worth mentioning that getting the parent and so on doesn't result in an SQL query since it's cached.
