### PR TITLE
Use color picker plugin when plugins includes table plugin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -352,18 +352,22 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     return plugin.name;
                 });
 
-                //plugins that must always be active
+                // Plugins that must always be active
                 plugins.push("autoresize");
                 plugins.push("noneditable");
+
+                // Table plugin use color picker plugin in table properties
+                if (plugins.includes("table")) {
+                    plugins.push("colorpicker");
+                }
 
                 var modeTheme = '';
                 var modeInline = false;
 
-
-                //Based on mode set
-                //classic = Theme: modern, inline: false
-                //inline = Theme: modern, inline: true,
-                //distraction-free = Theme: inlite, inline: true
+                // Based on mode set
+                // classic = Theme: modern, inline: false
+                // inline = Theme: modern, inline: true,
+                // distraction-free = Theme: inlite, inline: true
                 switch (args.mode) {
                     case "classic":
                         modeTheme  = "modern";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10515

### Description
When table plugin is used in rich text editor, it has some advanced table tools, e.g. set set background and border colors.
It was possible to specify the color code / name, but not editor friendly.

The `table` plugin uses the `colorpicker` plugin, so we can add this, when plugins includes the table plugin.

**Before**

![zZFYXwuD2B](https://user-images.githubusercontent.com/2919859/123155215-21948180-d468-11eb-8140-4cc78c453a95.gif)


**After**

![7cbJChwFQa](https://user-images.githubusercontent.com/2919859/123155516-7f28ce00-d468-11eb-9969-5835d0f8141e.gif)

Not sure why the color picker dialog shows the title "color" and not "Color" like the demo here:
https://www.tiny.cloud/docs-4x/demo/full-featured/

Actually the basic demo here also doesn't show color picker under table advances properties, but I think it makes sense to include this, when table plugin is used.
https://www.tiny.cloud/docs-4x/demo/basic-example/