### PR TITLE
Fixes #10402 - GetCropUrl Url extension has duplicate signatures and results in error

### DIFF
--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using System.Web.Mvc;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors.ValueConverters;
 using Umbraco.Web.Composing;
@@ -262,8 +263,8 @@ namespace Umbraco.Web
             return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
         }
 
-        public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
-            ImageCropperValue imageCropperValue,
+        public static IHtmlString GetLocalCropUrl(this UrlHelper urlHelper,
+            MediaWithCrops mediaWithCrops,
             string cropAlias,
             int? width = null,
             int? height = null,
@@ -278,6 +279,7 @@ namespace Umbraco.Web
             bool upScale = true,
             bool htmlEncode = true)
         {
+            var imageCropperValue = mediaWithCrops.LocalCrops;
             if (imageCropperValue == null) return EmptyHtmlString;
 
             var imageUrl = imageCropperValue.Src;


### PR DESCRIPTION
This is a breaking change for people using `GetCropUrl` to get local crops from the media picker v3. In order to disambiguate the extension method an make  it a bit clearer what it does, I propose the method name change, after which there is no need to have the first argument being the local crops, but it can be the whole MediaWithCrops object, since the method name already makes clear you're not trying to get the global crops.

Fixes #10402