### PR TITLE
Improvements to media pickers/crop handling and URL generation

### DIFF
--- a/src/Umbraco.Core/Models/MediaWithCrops.cs
+++ b/src/Umbraco.Core/Models/MediaWithCrops.cs
@@ -8,14 +8,13 @@ namespace Umbraco.Core.Models
     /// </summary>
     public class MediaWithCrops : PublishedContentWrapped
     {
-        public IPublishedContent MediaItem { get; }
+        public IPublishedContent MediaItem => Unwrap();
 
         public ImageCropperValue LocalCrops { get; }
 
         public MediaWithCrops(IPublishedContent content, ImageCropperValue localCrops)
             : base(content)
         {
-            MediaItem = content;
             LocalCrops = localCrops;
         }
     }

--- a/src/Umbraco.Core/Models/MediaWithCrops.cs
+++ b/src/Umbraco.Core/Models/MediaWithCrops.cs
@@ -6,10 +6,17 @@ namespace Umbraco.Core.Models
     /// <summary>
     /// Model used in Razor Views for rendering
     /// </summary>
-    public class MediaWithCrops
+    public class MediaWithCrops : PublishedContentWrapped
     {
-        public IPublishedContent MediaItem { get; set; }
+        public IPublishedContent MediaItem { get; }
 
-        public ImageCropperValue LocalCrops { get; set; }
+        public ImageCropperValue LocalCrops { get; }
+
+        public MediaWithCrops(IPublishedContent content, ImageCropperValue localCrops)
+            : base(content)
+        {
+            MediaItem = content;
+            LocalCrops = localCrops;
+        }
     }
 }

--- a/src/Umbraco.Core/Models/MediaWithCrops.cs
+++ b/src/Umbraco.Core/Models/MediaWithCrops.cs
@@ -4,18 +4,73 @@ using Umbraco.Core.PropertyEditors.ValueConverters;
 namespace Umbraco.Core.Models
 {
     /// <summary>
-    /// Model used in Razor Views for rendering
+    /// Represents a media item with local crops.
     /// </summary>
+    /// <seealso cref="Umbraco.Core.Models.PublishedContent.PublishedContentWrapped" />
     public class MediaWithCrops : PublishedContentWrapped
     {
+        /// <summary>
+        /// Gets the media item.
+        /// </summary>
+        /// <value>
+        /// The media item.
+        /// </value>
         public IPublishedContent MediaItem => Unwrap();
 
+        /// <summary>
+        /// Gets the local crops.
+        /// </summary>
+        /// <value>
+        /// The local crops.
+        /// </value>
         public ImageCropperValue LocalCrops { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaWithCrops" /> class.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="localCrops">The local crops.</param>
         public MediaWithCrops(IPublishedContent content, ImageCropperValue localCrops)
             : base(content)
         {
             LocalCrops = localCrops;
         }
+    }
+
+    /// <summary>
+    /// Represents a media item with local crops.
+    /// </summary>
+    /// <typeparam name="T">The type of the media item.</typeparam>
+    /// <seealso cref="Umbraco.Core.Models.PublishedContent.PublishedContentWrapped" />
+    public class MediaWithCrops<T> : MediaWithCrops
+        where T : IPublishedContent
+    {
+        /// <summary>
+        /// Gets the media item.
+        /// </summary>
+        /// <value>
+        /// The media item.
+        /// </value>
+        public new T MediaItem { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaWithCrops{T}" /> class.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <param name="localCrops">The local crops.</param>
+        public MediaWithCrops(T content, ImageCropperValue localCrops)
+            : base(content, localCrops)
+        {
+            MediaItem = content;
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="MediaWithCrops{T}" /> to <see cref="T" />.
+        /// </summary>
+        /// <param name="mediaWithCrops">The media with crops.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static implicit operator T(MediaWithCrops<T> mediaWithCrops) => mediaWithCrops.MediaItem;
     }
 }

--- a/src/Umbraco.Core/Models/MediaWithCrops.cs
+++ b/src/Umbraco.Core/Models/MediaWithCrops.cs
@@ -1,3 +1,4 @@
+using System;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors.ValueConverters;
 
@@ -15,7 +16,16 @@ namespace Umbraco.Core.Models
         /// <value>
         /// The media item.
         /// </value>
-        public IPublishedContent MediaItem => Unwrap();
+        [Obsolete("This instance now implements IPublishedContent by wrapping the media item, use the extension methods directly on MediaWithCrops or use the Content property to get the media item instead.")]
+        public IPublishedContent MediaItem => Content;
+
+        /// <summary>
+        /// Gets the content/media item.
+        /// </summary>
+        /// <value>
+        /// The content/media item.
+        /// </value>
+        public IPublishedContent Content => Unwrap();
 
         /// <summary>
         /// Gets the local crops.
@@ -51,7 +61,7 @@ namespace Umbraco.Core.Models
         /// <value>
         /// The media item.
         /// </value>
-        public new T MediaItem { get; }
+        public new T Content { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaWithCrops{T}" /> class.
@@ -61,7 +71,7 @@ namespace Umbraco.Core.Models
         public MediaWithCrops(T content, ImageCropperValue localCrops)
             : base(content, localCrops)
         {
-            MediaItem = content;
+            Content = content;
         }
 
         /// <summary>
@@ -71,6 +81,6 @@ namespace Umbraco.Core.Models
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static implicit operator T(MediaWithCrops<T> mediaWithCrops) => mediaWithCrops.MediaItem;
+        public static implicit operator T(MediaWithCrops<T> mediaWithCrops) => mediaWithCrops.Content;
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ImageCropperConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ImageCropperConfiguration.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Core.PropertyEditors
             {
                 foreach (var configuredCrop in configuredCrops)
                 {
-                    var crop = imageCropperValue.Crops.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
+                    var crop = imageCropperValue.Crops?.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
 
                     crops.Add(new ImageCropperCrop
                     {

--- a/src/Umbraco.Core/PropertyEditors/ImageCropperConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ImageCropperConfiguration.cs
@@ -1,4 +1,8 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.PropertyEditors.ValueConverters;
+using static Umbraco.Core.PropertyEditors.ValueConverters.ImageCropperValue;
 
 namespace Umbraco.Core.PropertyEditors
 {
@@ -20,6 +24,37 @@ namespace Umbraco.Core.PropertyEditors
 
             [JsonProperty("height")]
             public int Height { get; set; }
+        }
+    }
+
+    internal static class ImageCropperConfigurationExtensions
+    {
+        /// <summary>
+        /// Applies the configuration to ensure only valid crops are kept and have the correct width/height.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        public static void ApplyConfiguration(this ImageCropperValue imageCropperValue, ImageCropperConfiguration configuration)
+        {
+            var crops = new List<ImageCropperCrop>();
+
+            var configuredCrops = configuration?.Crops;
+            if (configuredCrops != null)
+            {
+                foreach (var configuredCrop in configuredCrops)
+                {
+                    var crop = imageCropperValue.Crops.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
+
+                    crops.Add(new ImageCropperCrop
+                    {
+                        Alias = configuredCrop.Alias,
+                        Width = configuredCrop.Width,
+                        Height = configuredCrop.Height,
+                        Coordinates = crop?.Coordinates
+                    });
+                }
+            }
+
+            imageCropperValue.Crops = crops;
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -148,48 +148,6 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
         public bool HasImage()
             => !string.IsNullOrWhiteSpace(Src);
 
-        /// <summary>
-        /// Applies a configuration.
-        /// </summary>
-        /// <remarks>Ensures that all crops defined in the configuration exists in the value.</remarks>
-        internal void ApplyConfiguration(ImageCropperConfiguration configuration)
-        {
-            // merge the crop values - the alias + width + height comes from
-            // configuration, but each crop can store its own coordinates
-
-            var configuredCrops = configuration?.Crops;
-            if (configuredCrops == null) return;
-
-            //Use Crops if it's not null, otherwise create a new list
-            var crops = Crops?.ToList() ?? new List<ImageCropperCrop>();
-
-            foreach (var configuredCrop in configuredCrops)
-            {
-                var crop = crops.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
-                if (crop != null)
-                {
-                    // found, apply the height & width
-                    crop.Width = configuredCrop.Width;
-                    crop.Height = configuredCrop.Height;
-                }
-                else
-                {
-                    // not found, add
-                    crops.Add(new ImageCropperCrop
-                    {
-                        Alias = configuredCrop.Alias,
-                        Width = configuredCrop.Width,
-                        Height = configuredCrop.Height
-                    });
-                }
-            }
-
-            // assume we don't have to remove the crops in value, that
-            // are not part of configuration anymore?
-
-            Crops = crops;
-        }
-
         internal ImageCropperValue Merge(ImageCropperValue imageCropperValue)
         {
             var crops = Crops?.ToList() ?? new List<ImageCropperCrop>();

--- a/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+++ b/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
@@ -82,8 +82,20 @@ namespace Umbraco.Tests.PropertyEditors
 
                 var mediaFileSystem = new MediaFileSystem(Mock.Of<IFileSystem>(), config, scheme, logger);
 
+                var imageCropperConfiguration = new ImageCropperConfiguration()
+                {
+                    Crops = new[]
+                    {
+                        new ImageCropperConfiguration.Crop()
+                        {
+                            Alias = "thumb",
+                            Width = 100,
+                            Height = 100
+                        }
+                    }
+                };
                 var dataTypeService = new TestObjects.TestDataTypeService(
-                    new DataType(new ImageCropperPropertyEditor(Mock.Of<ILogger>(), mediaFileSystem, Mock.Of<IContentSection>(), Mock.Of<IDataTypeService>())) { Id = 1 });
+                    new DataType(new ImageCropperPropertyEditor(Mock.Of<ILogger>(), mediaFileSystem, Mock.Of<IContentSection>(), Mock.Of<IDataTypeService>())) { Id = 1, Configuration = imageCropperConfiguration });
 
                 var factory = new PublishedContentTypeFactory(Mock.Of<IPublishedModelFactory>(), new PropertyValueConverterCollection(Array.Empty<IPropertyValueConverter>()), dataTypeService);
 

--- a/src/Umbraco.Web/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateCoreExtensions.cs
@@ -28,6 +28,12 @@ namespace Umbraco.Web
             return mediaItem.GetCropUrl(imageUrlGenerator, cropAlias: cropAlias, useCropDimensions: true);
         }
 
+        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, IImageUrlGenerator imageUrlGenerator)
+        {
+            return mediaWithCrops.GetCropUrl(imageUrlGenerator, cropAlias: cropAlias, useCropDimensions: true);
+        }
+
+        [Obsolete("This method does not get the crops or cache buster value from the media item.")]
         public static string GetCropUrl(this IPublishedContent mediaItem, string cropAlias, IImageUrlGenerator imageUrlGenerator, ImageCropperValue imageCropperValue)
         {
             return mediaItem.Url().GetCropUrl(imageUrlGenerator, imageCropperValue, cropAlias: cropAlias, useCropDimensions: true);
@@ -51,6 +57,11 @@ namespace Umbraco.Web
         public static string GetCropUrl(this IPublishedContent mediaItem, string propertyAlias, string cropAlias, IImageUrlGenerator imageUrlGenerator)
         {
             return mediaItem.GetCropUrl(imageUrlGenerator, propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
+        }
+
+        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias, IImageUrlGenerator imageUrlGenerator)
+        {
+            return mediaWithCrops.GetCropUrl(imageUrlGenerator, propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
         }
 
         /// <summary>
@@ -123,6 +134,47 @@ namespace Umbraco.Web
              ImageCropRatioMode? ratioMode = null,
              bool upScale = true)
         {
+            return mediaItem.GetCropUrl(imageUrlGenerator, null, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
+        }
+
+        public static string GetCropUrl(
+             this MediaWithCrops mediaWithCrops,
+             IImageUrlGenerator imageUrlGenerator,
+             int? width = null,
+             int? height = null,
+             string propertyAlias = Constants.Conventions.Media.File,
+             string cropAlias = null,
+             int? quality = null,
+             ImageCropMode? imageCropMode = null,
+             ImageCropAnchor? imageCropAnchor = null,
+             bool preferFocalPoint = false,
+             bool useCropDimensions = false,
+             bool cacheBuster = true,
+             string furtherOptions = null,
+             ImageCropRatioMode? ratioMode = null,
+             bool upScale = true)
+        {
+            return mediaWithCrops.MediaItem.GetCropUrl(imageUrlGenerator, mediaWithCrops.LocalCrops, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
+        }
+
+        private static string GetCropUrl(
+             this IPublishedContent mediaItem,
+             IImageUrlGenerator imageUrlGenerator,
+             ImageCropperValue localCrops,
+             int? width,
+             int? height,
+             string propertyAlias,
+             string cropAlias,
+             int? quality,
+             ImageCropMode? imageCropMode,
+             ImageCropAnchor? imageCropAnchor,
+             bool preferFocalPoint,
+             bool useCropDimensions,
+             bool cacheBuster,
+             string furtherOptions,
+             ImageCropRatioMode? ratioMode,
+             bool upScale)
+        {
             if (mediaItem == null) throw new ArgumentNullException("mediaItem");
 
             var cacheBusterValue = cacheBuster ? mediaItem.UpdateDate.ToFileTimeUtc().ToString(CultureInfo.InvariantCulture) : null;
@@ -132,31 +184,38 @@ namespace Umbraco.Web
 
             var mediaItemUrl = mediaItem.MediaUrl(propertyAlias: propertyAlias);
 
-            //get the default obj from the value converter
-            var cropperValue = mediaItem.Value(propertyAlias);
-
-            //is it strongly typed?
-            var stronglyTyped = cropperValue as ImageCropperValue;
-            if (stronglyTyped != null)
+            // Only get crops when used
+            if (imageCropMode == ImageCropMode.Crop || imageCropMode == null)
             {
-                return GetCropUrl(
-                    mediaItemUrl, imageUrlGenerator, stronglyTyped, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions,
-                    cacheBusterValue, furtherOptions, ratioMode, upScale);
+                // Get the default cropper value from the value converter
+                var cropperValue = mediaItem.Value(propertyAlias);
+
+                var mediaCrops = cropperValue as ImageCropperValue;
+
+                if (mediaCrops == null && cropperValue is JObject jobj)
+                {
+                    mediaCrops = jobj.ToObject<ImageCropperValue>();
+                }
+
+                if (mediaCrops == null && cropperValue is string imageCropperValue &&
+                    string.IsNullOrEmpty(imageCropperValue) == false && imageCropperValue.DetectIsJson())
+                {
+                    mediaCrops = imageCropperValue.DeserializeImageCropperValue();
+                }
+
+                // Merge crops
+                if (localCrops == null)
+                {
+                    localCrops = mediaCrops;
+                }
+                else if (mediaCrops != null)
+                {
+                    localCrops = localCrops.Merge(mediaCrops);
+                }
             }
 
-            //this shouldn't be the case but we'll check
-            var jobj = cropperValue as JObject;
-            if (jobj != null)
-            {
-                stronglyTyped = jobj.ToObject<ImageCropperValue>();
-                return GetCropUrl(
-                    mediaItemUrl, imageUrlGenerator, stronglyTyped, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions,
-                    cacheBusterValue, furtherOptions, ratioMode, upScale);
-            }
-
-            //it's a single string
             return GetCropUrl(
-                mediaItemUrl, imageUrlGenerator, width, height, mediaItemUrl, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions,
+                mediaItemUrl, imageUrlGenerator, localCrops, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions,
                 cacheBusterValue, furtherOptions, ratioMode, upScale);
         }
 
@@ -237,6 +296,7 @@ namespace Umbraco.Web
             {
                 cropDataSet = imageCropperValue.DeserializeImageCropperValue();
             }
+
             return GetCropUrl(
                 imageUrl, imageUrlGenerator, cropDataSet, width, height, cropAlias, quality, imageCropMode,
                 imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
@@ -381,10 +441,10 @@ namespace Umbraco.Web
             return imageUrlGenerator.GetImageUrl(options);
         }
 
+        [Obsolete("Use GetCrop to merge local and media crops, get automatic cache buster value and have more parameters.")]
         public static string GetLocalCropUrl(this MediaWithCrops mediaWithCrops, string alias, IImageUrlGenerator imageUrlGenerator, string cacheBusterValue)
         {
             return mediaWithCrops.LocalCrops.Src + mediaWithCrops.LocalCrops.GetCropUrl(alias, imageUrlGenerator, cacheBusterValue: cacheBusterValue);
-
         }
     }
 }

--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -30,6 +30,9 @@ namespace Umbraco.Web
         /// </returns>
         public static string GetCropUrl(this IPublishedContent mediaItem, string cropAlias) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, cropAlias, Current.ImageUrlGenerator);
 
+        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, cropAlias, Current.ImageUrlGenerator);
+
+        [Obsolete("This method does not get the crops or cache buster value from the media item.")]
         public static string GetCropUrl(this IPublishedContent mediaItem, string cropAlias, ImageCropperValue imageCropperValue) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, cropAlias, Current.ImageUrlGenerator, imageCropperValue);
 
         /// <summary>
@@ -48,6 +51,8 @@ namespace Umbraco.Web
         /// The ImageProcessor.Web URL.
         /// </returns>
         public static string GetCropUrl(this IPublishedContent mediaItem, string propertyAlias, string cropAlias) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, propertyAlias, cropAlias, Current.ImageUrlGenerator);
+
+        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, propertyAlias, cropAlias, Current.ImageUrlGenerator);
 
         /// <summary>
         /// Gets the ImageProcessor URL from the IPublishedContent item.
@@ -118,12 +123,21 @@ namespace Umbraco.Web
              ImageCropRatioMode? ratioMode = null,
              bool upScale = true) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, Current.ImageUrlGenerator, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
 
-        public static string GetLocalCropUrl(this MediaWithCrops mediaWithCrops,
-            string alias,
-            string cacheBusterValue = null)
-            => ImageCropperTemplateCoreExtensions.GetLocalCropUrl(mediaWithCrops, alias, Current.ImageUrlGenerator,  cacheBusterValue);
-
-
+        public static string GetCropUrl(
+             this MediaWithCrops mediaWithCrops,
+             int? width = null,
+             int? height = null,
+             string propertyAlias = Constants.Conventions.Media.File,
+             string cropAlias = null,
+             int? quality = null,
+             ImageCropMode? imageCropMode = null,
+             ImageCropAnchor? imageCropAnchor = null,
+             bool preferFocalPoint = false,
+             bool useCropDimensions = false,
+             bool cacheBuster = true,
+             string furtherOptions = null,
+             ImageCropRatioMode? ratioMode = null,
+             bool upScale = true) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, Current.ImageUrlGenerator, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
 
         /// <summary>
         /// Gets the ImageProcessor URL from the image path.
@@ -260,6 +274,12 @@ namespace Umbraco.Web
             string furtherOptions = null,
             ImageCropRatioMode? ratioMode = null,
             bool upScale = true) => ImageCropperTemplateCoreExtensions.GetCropUrl(imageUrl, Current.ImageUrlGenerator, cropDataSet, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
+
+        [Obsolete("Use GetCrop to merge local and media crops, get automatic cache buster value and have more parameters.")]
+        public static string GetLocalCropUrl(this MediaWithCrops mediaWithCrops,
+            string alias,
+            string cacheBusterValue = null)
+            => ImageCropperTemplateCoreExtensions.GetLocalCropUrl(mediaWithCrops, alias, Current.ImageUrlGenerator, cacheBusterValue);
 
         private static readonly JsonSerializerSettings ImageCropperValueJsonSerializerSettings = new JsonSerializerSettings
         {

--- a/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web/ImageCropperTemplateExtensions.cs
@@ -32,8 +32,19 @@ namespace Umbraco.Web
 
         public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, cropAlias, Current.ImageUrlGenerator);
 
-        [Obsolete("This method does not get the crops or cache buster value from the media item.")]
-        public static string GetCropUrl(this IPublishedContent mediaItem, string cropAlias, ImageCropperValue imageCropperValue) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, cropAlias, Current.ImageUrlGenerator, imageCropperValue);
+        [Obsolete("Use the GetCropUrl overload with the updated parameter order and note this implementation has changed to get the URL from the media item.")]
+        public static string GetCropUrl(this IPublishedContent mediaItem, string cropAlias, ImageCropperValue imageCropperValue) => mediaItem.GetCropUrl(imageCropperValue, cropAlias);
+
+        /// <summary>
+        /// Gets the crop URL by using only the specified <paramref name="imageCropperValue" />.
+        /// </summary>
+        /// <param name="mediaItem">The media item.</param>
+        /// <param name="imageCropperValue">The image cropper value.</param>
+        /// <param name="cropAlias">The crop alias.</param>
+        /// <returns>
+        /// The image crop URL.
+        /// </returns>
+        public static string GetCropUrl(this IPublishedContent mediaItem, ImageCropperValue imageCropperValue, string cropAlias) => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, imageCropperValue, cropAlias, Current.ImageUrlGenerator);
 
         /// <summary>
         /// Gets the ImageProcessor URL by the crop alias using the specified property containing the image cropper Json data on the IPublishedContent item.

--- a/src/Umbraco.Web/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPicker3Configuration.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Web.PropertyEditors
             {
                 foreach (var configuredCrop in configuredCrops)
                 {
-                    var crop = imageCropperValue.Crops.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
+                    var crop = imageCropperValue.Crops?.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
 
                     crops.Add(new ImageCropperCrop
                     {
@@ -91,7 +91,7 @@ namespace Umbraco.Web.PropertyEditors
 
             imageCropperValue.Crops = crops;
 
-            if (!configuration.EnableLocalFocalPoint)
+            if (configuration?.EnableLocalFocalPoint == false)
             {
                 imageCropperValue.FocalPoint = null;
             }

--- a/src/Umbraco.Web/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPicker3Configuration.cs
@@ -1,6 +1,10 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors.ValueConverters;
+using static Umbraco.Core.PropertyEditors.ValueConverters.ImageCropperValue;
 
 namespace Umbraco.Web.PropertyEditors
 {
@@ -55,6 +59,37 @@ namespace Umbraco.Web.PropertyEditors
 
             [JsonProperty("height")]
             public int Height { get; set; }
+        }
+    }
+
+    internal static class MediaPicker3ConfigurationExtensions
+    {
+        /// <summary>
+        /// Applies the configuration to ensure only valid crops are kept and have the correct width/height.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        public static void ApplyConfiguration(this ImageCropperValue imageCropperValue, MediaPicker3Configuration configuration)
+        {
+            var crops = new List<ImageCropperCrop>();
+
+            var configuredCrops = configuration?.Crops;
+            if (configuredCrops != null)
+            {
+                foreach (var configuredCrop in configuredCrops)
+                {
+                    var crop = imageCropperValue.Crops.FirstOrDefault(x => x.Alias == configuredCrop.Alias);
+
+                    crops.Add(new ImageCropperCrop
+                    {
+                        Alias = configuredCrop.Alias,
+                        Width = configuredCrop.Width,
+                        Height = configuredCrop.Height,
+                        Coordinates = crop?.Coordinates
+                    });
+                }
+            }
+
+            imageCropperValue.Crops = crops;
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MediaPicker3Configuration.cs
@@ -90,6 +90,11 @@ namespace Umbraco.Web.PropertyEditors
             }
 
             imageCropperValue.Crops = crops;
+
+            if (!configuration.EnableLocalFocalPoint)
+            {
+                imageCropperValue.FocalPoint = null;
+            }
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -120,6 +120,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                             settingsData = null;
                     }
 
+                    // TODO: This should be optimized/cached, as calling Activator.CreateInstance is slow
                     var layoutType = typeof(BlockListItem<,>).MakeGenericType(contentData.GetType(), settingsData?.GetType() ?? typeof(IPublishedElement));
                     var layoutRef = (BlockListItem)Activator.CreateInstance(layoutType, contentGuidUdi, contentData, settingGuidUdi, settingsData);
 

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -51,6 +51,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
             var mediaItems = new List<MediaWithCrops>();
             var dtos = MediaPicker3PropertyEditor.MediaPicker3PropertyValueEditor.Deserialize(inter);
+            var configuration = propertyType.DataType.ConfigurationAs<MediaPicker3Configuration>();
 
             foreach (var dto in dtos)
             {
@@ -63,6 +64,8 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                         FocalPoint = dto.FocalPoint,
                         Src = mediaItem.Url()
                     };
+
+                    localCrops.ApplyConfiguration(configuration);
 
                     mediaItems.Add(new MediaWithCrops(mediaItem, localCrops));
 

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -57,16 +57,14 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 var mediaItem = _publishedSnapshotAccessor.PublishedSnapshot.Media.GetById(preview, dto.MediaKey);
                 if (mediaItem != null)
                 {
-                    mediaItems.Add(new MediaWithCrops
+                    var localCrops = new ImageCropperValue
                     {
-                        MediaItem = mediaItem,
-                        LocalCrops = new ImageCropperValue
-                        {
-                            Crops = dto.Crops,
-                            FocalPoint = dto.FocalPoint,
-                            Src = mediaItem.Url()
-                        }
-                    });
+                        Crops = dto.Crops,
+                        FocalPoint = dto.FocalPoint,
+                        Src = mediaItem.Url()
+                    };
+
+                    mediaItems.Add(new MediaWithCrops(mediaItem, localCrops));
 
                     if (!isMultiple)
                     {

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -67,7 +67,11 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
                     localCrops.ApplyConfiguration(configuration);
 
-                    mediaItems.Add(new MediaWithCrops(mediaItem, localCrops));
+                    // TODO: This should be optimized/cached, as calling Activator.CreateInstance is slow
+                    var mediaWithCropsType = typeof(MediaWithCrops<>).MakeGenericType(mediaItem.GetType());
+                    var mediaWithCrops = (MediaWithCrops)Activator.CreateInstance(mediaWithCropsType, mediaItem, localCrops);
+
+                    mediaItems.Add(mediaWithCrops);
 
                     if (!isMultiple)
                     {

--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -262,32 +262,6 @@ namespace Umbraco.Web
             return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
         }
 
-        public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
-            ImageCropperValue imageCropperValue,
-            string cropAlias,
-            int? width = null,
-            int? height = null,
-            int? quality = null,
-            ImageCropMode? imageCropMode = null,
-            ImageCropAnchor? imageCropAnchor = null,
-            bool preferFocalPoint = false,
-            bool useCropDimensions = true,
-            string cacheBusterValue = null,
-            string furtherOptions = null,
-            ImageCropRatioMode? ratioMode = null,
-            bool upScale = true,
-            bool htmlEncode = true)
-        {
-            if (imageCropperValue == null) return EmptyHtmlString;
-
-            var imageUrl = imageCropperValue.Src;
-            var url = imageUrl.GetCropUrl(imageCropperValue, width, height, cropAlias, quality, imageCropMode,
-                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode,
-                upScale);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
-        }
-
-
         #endregion
 
         /// <summary>

--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -237,6 +237,14 @@ namespace Umbraco.Web
             return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
         }
 
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper, ImageCropperValue imageCropperValue, string cropAlias, bool htmlEncode = true)
+        {
+            if (imageCropperValue == null) return EmptyHtmlString;
+
+            var url = imageCropperValue.Src.GetCropUrl(imageCropperValue, cropAlias: cropAlias, useCropDimensions: true);
+            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+        }
+
         public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
             ImageCropperValue imageCropperValue,
             int? width = null,

--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using System.Web.Mvc;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors.ValueConverters;
 using Umbraco.Web.Composing;
@@ -17,8 +18,9 @@ namespace Umbraco.Web
     /// </summary>
     public static class UrlHelperRenderExtensions
     {
-
         private static readonly IHtmlString EmptyHtmlString = new HtmlString(string.Empty);
+
+        private static IHtmlString CreateHtmlString(string value, bool htmlEncode) => htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(value)) : new HtmlString(value);
 
         #region GetCropUrl
 
@@ -42,7 +44,17 @@ namespace Umbraco.Web
             if (mediaItem == null) return EmptyHtmlString;
 
             var url = mediaItem.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+
+            return CreateHtmlString(url, htmlEncode);
+        }
+
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper, MediaWithCrops mediaWithCrops, string cropAlias, bool htmlEncode = true)
+        {
+            if (mediaWithCrops == null) return EmptyHtmlString;
+
+            var url = mediaWithCrops.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true);
+
+            return CreateHtmlString(url, htmlEncode);
         }
 
         /// <summary>
@@ -70,7 +82,17 @@ namespace Umbraco.Web
             if (mediaItem == null) return EmptyHtmlString;
 
             var url = mediaItem.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+
+            return CreateHtmlString(url, htmlEncode);
+        }
+
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper, MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias, bool htmlEncode = true)
+        {
+            if (mediaWithCrops == null) return EmptyHtmlString;
+
+            var url = mediaWithCrops.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
+
+            return CreateHtmlString(url, htmlEncode);
         }
 
         /// <summary>
@@ -150,10 +172,33 @@ namespace Umbraco.Web
         {
             if (mediaItem == null) return EmptyHtmlString;
 
-            var url = mediaItem.GetCropUrl(width, height, propertyAlias, cropAlias, quality, imageCropMode,
-                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode,
-                upScale);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+            var url = mediaItem.GetCropUrl(width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
+
+            return CreateHtmlString(url, htmlEncode);
+        }
+
+        public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
+            MediaWithCrops mediaWithCrops,
+            int? width = null,
+            int? height = null,
+            string propertyAlias = Umbraco.Core.Constants.Conventions.Media.File,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            bool cacheBuster = true,
+            string furtherOptions = null,
+            ImageCropRatioMode? ratioMode = null,
+            bool upScale = true,
+            bool htmlEncode = true)
+        {
+            if (mediaWithCrops == null) return EmptyHtmlString;
+
+            var url = mediaWithCrops.GetCropUrl(width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
+
+            return CreateHtmlString(url, htmlEncode);
         }
 
         /// <summary>
@@ -231,10 +276,9 @@ namespace Umbraco.Web
             bool upScale = true,
             bool htmlEncode = true)
         {
-            var url = imageUrl.GetCropUrl(width, height, imageCropperValue, cropAlias, quality, imageCropMode,
-                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode,
-                upScale);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+            var url = imageUrl.GetCropUrl(width, height, imageCropperValue, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
+
+            return CreateHtmlString(url, htmlEncode);
         }
 
         public static IHtmlString GetCropUrl(this UrlHelper urlHelper, ImageCropperValue imageCropperValue, string cropAlias, bool htmlEncode = true)
@@ -242,7 +286,8 @@ namespace Umbraco.Web
             if (imageCropperValue == null) return EmptyHtmlString;
 
             var url = imageCropperValue.Src.GetCropUrl(imageCropperValue, cropAlias: cropAlias, useCropDimensions: true);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+
+            return CreateHtmlString(url, htmlEncode);
         }
 
         public static IHtmlString GetCropUrl(this UrlHelper urlHelper,
@@ -263,11 +308,9 @@ namespace Umbraco.Web
         {
             if (imageCropperValue == null) return EmptyHtmlString;
 
-            var imageUrl = imageCropperValue.Src;
-            var url = imageUrl.GetCropUrl(imageCropperValue, width, height, cropAlias, quality, imageCropMode,
-                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode,
-                upScale);
-            return htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
+            var url = imageCropperValue.Src.GetCropUrl(imageCropperValue, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
+
+            return CreateHtmlString(url, htmlEncode);
         }
 
         #endregion

--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -283,7 +283,7 @@ namespace Umbraco.Web
 
         public static IHtmlString GetCropUrl(this UrlHelper urlHelper, ImageCropperValue imageCropperValue, string cropAlias, bool htmlEncode = true)
         {
-            if (imageCropperValue == null) return EmptyHtmlString;
+            if (imageCropperValue == null || string.IsNullOrEmpty(imageCropperValue.Src)) return EmptyHtmlString;
 
             var url = imageCropperValue.Src.GetCropUrl(imageCropperValue, cropAlias: cropAlias, useCropDimensions: true);
 
@@ -306,7 +306,7 @@ namespace Umbraco.Web
             bool upScale = true,
             bool htmlEncode = true)
         {
-            if (imageCropperValue == null) return EmptyHtmlString;
+            if (imageCropperValue == null || string.IsNullOrEmpty(imageCropperValue.Src)) return EmptyHtmlString;
 
             var url = imageCropperValue.Src.GetCropUrl(imageCropperValue, width, height, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBusterValue, furtherOptions, ratioMode, upScale);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10308, https://github.com/umbraco/Umbraco-CMS/issues/10402 and https://github.com/umbraco/Umbraco-CMS/issues/10397.

### Description
Building upon PR https://github.com/umbraco/Umbraco-CMS/pull/10517 that introduces backwards compatibility for the stored data format between `Media Picker (legacy)` (v2) and the new `Media Picker` (v3), this PR adds compatibility to the returned models on the front-end (and includes some additional improvements).

#### Model compatibility with `IPublishedContent`
This compatibility is added by making `MediaWithCrops` inherit from `PublishedContentWrapped`, making it an `IPublishedContent` instance again, so the following Razor/view code won't break by switching to the new picker:

```cshtml
@if (Model.Image is IPublishedContent image)
{
   <img src="@image.Url()" alt="@image.Name" />
}
```

One thing to note though: the concrete implementation of the `IPublishedContent` will change to `MediaWithCrops<T>`, so you can't cast directly to the Models Builder generated model (e.g. `var image = (Image)Model.Image` will still break). If you want the concrete media item model, you can either cast the 'wrapped' content to `Image` or better yet, cast to `MediaWithCrops<Image>` and access it using the new `Content` property:

```cshtml
@if (Model.Image?.Content is Image image)
{
    <img src="@image.Url()" width="@image.UmbracoWidth" height="@image.UmbracoHeight" alt="@image.Name" />
}

@if (Model.Image is MediaWithCrops<Image> image)
{
    // Now you still have access to the local crops (image.LocalCrops)
    <img src="@image.Url()" width="@image.Content.UmbracoWidth" height="@image.Content.UmbracoHeight" alt="@image.Name" />
}
```

#### New `GetCropUrl()` extension methods
Using local crops (defined on the Media Picker data type) together with media crops (defined on the Image Cropper data type) wasn't yet possible, so you'd have to ensure you're using the correct crops and aliases. This PR now merges local crops with the media ones, so the calling code can be the same for local and media crops:

```cshtml
@if (Model.Image is MediaWithCrops<Image> image)
{
    // Use the Hero crop either from the local or media crops
    <img src="@image.GetCropUrl("Hero")" width="@image.Content.UmbracoWidth" height="@image.Content.UmbracoHeight" alt="@image.Name" />

    // Use the Hero crop only from the local crops
    <img src="@image.GetCropUrl(image.LocalCrops, "Hero")" width="@image.Content.UmbracoWidth" height="@image.Content.UmbracoHeight" alt="@image.Name" />

    // Use the Hero crop only from the media crops
    <img src="@image.Content.GetCropUrl("Hero")" width="@image.Content.UmbracoWidth" height="@image.Content.UmbracoHeight" alt="@image.Name" />
}
```

In short: if the local crops doesn't contain the crop alias, it will look in the media crops. Also, if you have the focal point disabled on the Media Picker, it will fall-back to the global focal point (on the media item/Image Cropper).

#### Only return configured crops in the model
Because the stored data contains all crop information (as JSON), removing a crop from the configuration didn't remove existing crops from the returned model. A previous PR (https://github.com/umbraco/Umbraco-CMS/pull/6950) already added missing crops (not in the stored data, but later added to the configuration), but because removing a local crop should now fall-back to the media crops, this caused a problem. This PR ensures crops removed from the configuration (either local crops on the Media Picker or media crops on the Image Cropper) are not returned in the model anymore, making sure you can't use outdated crops on the front-end.

I'll make sure to add some comments to the code, as it might be quite a lot to go though 😇 