### PR TITLE
Fix grid property editor view urls

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.prevalues.controller.js
@@ -107,7 +107,7 @@ angular.module("umbraco")
                     currentLayout: Utilities.copy(template),
                     rows: $scope.model.value.layouts,
                     columns: $scope.model.value.columns,
-                    view: "views/propertyEditors/grid/dialogs/layoutconfig.html",
+                    view: "views/propertyeditors/grid/dialogs/layoutconfig.html",
                     size: "small",
                     submit: function (model) {
                         if (index === -1) {
@@ -148,7 +148,7 @@ angular.module("umbraco")
                     currentRow: Utilities.copy(layout),
                     editors: $scope.editors,
                     columns: $scope.model.value.columns,
-                    view: "views/propertyEditors/grid/dialogs/rowconfig.html",
+                    view: "views/propertyeditors/grid/dialogs/rowconfig.html",
                     size: "small",
                     submit: function (model) {
                         if (index === -1) {
@@ -169,7 +169,7 @@ angular.module("umbraco")
             function deleteLayout(layout, index, event) {
 
                 const dialog = {
-                    view: "views/propertyEditors/grid/overlays/rowdeleteconfirm.html",
+                    view: "views/propertyeditors/grid/overlays/rowdeleteconfirm.html",
                     layout: layout,
                     submitButtonLabelKey: "contentTypeEditor_yesDelete",
                     submitButtonStyle: "danger",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes some of #10538

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This fixes links that were broken when running Umbraco on Linux due to the case-sensitive file directory.

The links are used in the grid editor (This is a picture of the current behavior):
![image](https://user-images.githubusercontent.com/24605285/123512251-b70d5c80-d686-11eb-9e80-6cb965265326.png)



<!-- Thanks for contributing to Umbraco CMS! -->
