### PR TITLE
First draft of members list on members group page

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Umbraco.Core.Models;
+using Umbraco.Core.Persistence.DatabaseModelDefinitions;
 using Umbraco.Core.Persistence.Querying;
 
 namespace Umbraco.Core.Persistence.Repositories
@@ -24,6 +25,8 @@ namespace Umbraco.Core.Persistence.Repositories
         /// <param name="groupName"></param>
         /// <returns></returns>
         IEnumerable<IMember> GetByMemberGroup(string groupName);
+
+        IEnumerable<IMember> FindMembersByGroup(int memberGroupId, long pageIndex, int pageSize, out long totalRecords);
 
         /// <summary>
         /// Checks if a member with the username exists

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -474,6 +474,39 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         }
 
+
+        public IEnumerable<IMember> FindMembersByGroup(int memberGroupId, long pageNumber, int pageSize, out long totalRecords)
+        {
+            var sql = SqlContext.Sql().Select<MemberDto>(r =>
+                            r.Select(x => x.ContentVersionDto)
+                                .Select(x => x.ContentDto, r1 =>
+                                    r1.Select(x => x.NodeDto)))
+
+                        // ContentRepositoryBase expects a variantName field to order by name
+                        // so get it here, though for members it's just the plain node name
+                        .AndSelect<NodeDto>(x => Alias(x.Text, "variantName"))
+                .From<MemberDto>()
+                .InnerJoin<ContentDto>().On<MemberDto, ContentDto>(left => left.NodeId, right => right.NodeId)
+                .InnerJoin<NodeDto>().On<ContentDto, NodeDto>(left => left.NodeId, right => right.NodeId)
+                .InnerJoin<ContentVersionDto>().On<ContentDto, ContentVersionDto>(left => left.NodeId, right => right.NodeId)
+                .InnerJoin<Member2MemberGroupDto>().On<MemberDto, Member2MemberGroupDto>((left, right) => left.NodeId == right.Member)
+
+                // joining the type so we can do a query against the member type - not sure if this adds much overhead or not?
+                // the execution plan says it doesn't so we'll go with that and in that case, it might be worth joining the content
+                // types by default on the document and media repos so we can query by content type there too.
+                .InnerJoin<ContentTypeDto>().On<ContentDto, ContentTypeDto>(left => left.ContentTypeId, right => right.NodeId);
+
+            sql.Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId);
+            sql.Where("MemberGroup = @memberGroupId", new { memberGroupId });
+            sql.OrderBy("Email");
+                            
+            var result = Database.Page<MemberDto>(pageNumber, pageSize, sql);
+
+            totalRecords = result.TotalItems;
+
+            return MapDtosToContent(result.Items);
+        }
+
         public bool Exists(string username)
         {
             var sql = Sql()

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -161,6 +161,8 @@ namespace Umbraco.Core.Services
         /// <returns><see cref="IEnumerable{IMember}"/></returns>
         IEnumerable<IMember> GetMembersByGroup(string memberGroupName);
 
+        IEnumerable<IMember> GetMembersByGroup(int memberGroupId, long pageIndex, int pageSize, out long totalRecords);
+
         /// <summary>
         /// Gets all Members with the ids specified
         /// </summary>

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -498,6 +498,15 @@ namespace Umbraco.Core.Services.Implement
             }
         }
 
+        public IEnumerable<IMember> GetMembersByGroup(int memberGroupId, long pageNumber, int pageSize, out long totalRecords)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Constants.Locks.MemberTree);
+                return _memberRepository.FindMembersByGroup(memberGroupId, pageNumber, pageSize, out totalRecords);
+            }
+        }
+
         /// <summary>
         /// Gets all Members with the ids specified
         /// </summary>
@@ -1396,7 +1405,6 @@ namespace Umbraco.Core.Services.Implement
         {
             return Current.Services.MemberTypeService.GetDefault();
         }
-
         #endregion
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/member/umbmembergroupnodeinfo.directive.js
@@ -45,7 +45,8 @@
             replace: true,
             templateUrl: 'views/components/member/umb-membergroup-node-info.html',
             scope: {
-                node: "="
+                node: "=",
+                members: "="
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/member.resource.js
@@ -22,6 +22,30 @@ function memberResource($q, $http, umbDataFormatter, umbRequestHelper) {
     }
 
     return {
+        getMembersByGroup: function(options) {
+            var defaults = {
+                pageSize: 25,
+                pageNumber: 1
+            };
+
+            angular.extend(defaults, options);
+
+            options = defaults;
+
+            var params = [
+                { groupId: options.groupId },
+                { pageNumber: options.pageNumber },
+                { pageSize: options.pageSize }
+            ];
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "memberApiBaseUrl",
+                        "GetMembersByGroup",
+                        params)),
+                'Failed to retrieve members by group');
+        },
         getPagedResults: function(memberTypeAlias, options) {
 
             if (memberTypeAlias === 'all-members') {

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
@@ -10,7 +10,12 @@
 
             </umb-box-content>
         </umb-box>
-
+        <umb-box>
+            <umb-box-header title-key="content_membergroup"></umb-box-header>
+            <umb-box-content class="block-form">
+                <pre>{{ members | json }}</pre>
+            </umb-box-content>
+        </umb-box>
     </div>
 
     <div class="umb-package-details__sidebar">

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the member group editor
  */
-function MemberGroupsEditController($scope, $routeParams, appState, navigationService, memberGroupResource, contentEditingHelper, formHelper, editorState, eventsService) {
+function MemberGroupsEditController($scope, $routeParams, appState, navigationService, memberGroupResource, memberResource, contentEditingHelper, formHelper, editorState, eventsService) {
 
     //setup scope vars
     $scope.page = {};
@@ -38,6 +38,18 @@ function MemberGroupsEditController($scope, $routeParams, appState, navigationSe
     }
     else {
         loadMemberGroup();
+        loadMembers();
+    }
+
+    function loadMembers() {
+        $scope.page.loading = true;
+
+        memberResource.getMembersByGroup({ groupId: $routeParams.id, pageSize: 25, pageNumber: 1 })
+            .then(function (data) {
+                $scope.members = data;
+
+                $scope.page.loading = false;
+            });
     }
 
     function loadMemberGroup() {
@@ -104,6 +116,7 @@ function MemberGroupsEditController($scope, $routeParams, appState, navigationSe
 
     evts.push(eventsService.on("app.refreshEditor", function (name, error) {
         loadMemberGroup();
+        loadMembers();
     }));
 
     //ensure to unregister from all events!

--- a/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membergroups/edit.html
@@ -21,8 +21,9 @@
 
             <umb-editor-container>
 
-                <umb-membergroup-node-info ng-if="content"
-                                           node="content">
+                <umb-membergroup-node-info ng-if="content && members"
+                                           node="content"
+                                           members="members">
                 </umb-membergroup-node-info>
 
             </umb-editor-container>

--- a/src/Umbraco.Web/Editors/MemberController.cs
+++ b/src/Umbraco.Web/Editors/MemberController.cs
@@ -60,6 +60,22 @@ namespace Umbraco.Web.Editors
             get { return Services.MemberService.GetMembershipScenario(); }
         }
 
+        public PagedResult<MemberBasic> GetMembersByGroup(
+            int groupId,
+            int pageNumber = 1,
+            int pageSize = 100)
+        {
+
+            var members = Services.MemberService.GetMembersByGroup(groupId, pageNumber, pageSize, out var totalRecords);
+
+            var pagedResult = new PagedResult<MemberBasic>(totalRecords, pageNumber, pageSize)
+            {
+                Items = members
+                        .Select(x => Mapper.Map<MemberBasic>(x))
+            };
+            return pagedResult;
+        }
+
         public PagedResult<MemberBasic> GetPagedResults(
             int pageNumber = 1,
             int pageSize = 100,


### PR DESCRIPTION
I'm picking up on #7836 from where @cado1982 left off last May in https://github.com/umbraco/Umbraco-CMS/pull/7850. 

In the PR I've cherry-picked his commit into an up-to-date v8/contrib and I'm seeking feedback and advice to get this feature in.

Looking at the comments on the original PR, it appears `GetPagedResultsByQueryWhere` has since been removed in v8/contrib so presumably this allays @nul800sebastiaan concern.

I'm currently looking at how I can reuse the member list from the All Members screen and this is where I could do with the advice and pointers:

1. Do you think this is an good approach?
2. the All Members screen calls the /umbraco/backoffice/UmbracoApi/Member/GetPagedResults endpoint, and that it has a [`memberTypeAlias` argument](https://github.com/umbraco/Umbraco-CMS/blob/5b9cd1bd87ad2c2440c6227e8aea7994e6c9b192/src/Umbraco.Web/Editors/MemberController.cs#L70).  In the issue there's a concern about performance, is this endpoint suitable to use for populating this list or do the underlying APIs have performance issues?
3. Do you have any tips for instantiating the listView in the UI.  Picking through the code I can see the All Members list has an `umb-editor-sub-view` wrapped in an `ng-repeat`.  Is this how it should be done on the Member Type details page or can a list view be used directly?
4. Is there an example of instantiating a list view and what viewModel it expects?  I can't see anything in [the UI documentaion](https://our.umbraco.com/apidocs/v8/ui/#/api).

As you can tell I'm not familiar with the backoffice UI code so if you can give me any pointers, I'm confident I can get the feature implemented. 

Cheers,
Greg