### PR TITLE
Fix routing when custom segment provider returns uppercase

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             IPublishedModelFactory publishedModelFactory,
             UrlSegmentProviderCollection urlSegmentProviders,
             ISyncBootStateAccessor syncBootStateAccessor,
-            IContentCacheDataSerializerFactory contentCacheDataSerializerFactory, 
+            IContentCacheDataSerializerFactory contentCacheDataSerializerFactory,
             ContentDataSerializer contentDataSerializer = null)
             : base(publishedSnapshotAccessor, variationContextAccessor)
         {
@@ -262,7 +262,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                             if (!okMedia)
                                 _logger.Warn<PublishedSnapshotService>("Loading media from local db raised warnings, will reload from database.");
                         }
-                
+
                         if (!okContent)
                             LockAndLoadContent(scope => LoadContentFromDatabaseLocked(scope, true));
 
@@ -1168,7 +1168,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             if (Volatile.Read(ref _isReady) == false)
             {
                 throw new InvalidOperationException("The published snapshot service has not properly initialized.");
-            }   
+            }
 
             var preview = previewToken.IsNullOrWhiteSpace() == false;
             return new PublishedSnapshot(this, preview);
@@ -1488,7 +1488,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             {
                 PropertyData = propertyData,
                 CultureData = cultureData,
-                UrlSegment = content.GetUrlSegment(_urlSegmentProviders)
+                UrlSegment = content.GetUrlSegment(_urlSegmentProviders).ToLower()
             };
 
             var serialized = serializer.Serialize(ReadOnlyContentBaseAdapter.Create(content), contentCacheData);


### PR DESCRIPTION
If you create a custom url segment provider, which does not return the segment as all lowercase, the routing will break, this PR addresses that. 

This is caused because when a piece of content is created with the `PublishedSnapShotService`  it will use the `GetUrlSegment` extension on the `IContentBase`, which uses the segment providers if a user has replaced the default provider with one that doesn't return all lowercase, that segment will be saved as non lowercase, I.E "MyContent"

Later when a request comes in the URL will be made all lower case with the `UriUtility.UriToUmbraco`  when the `ContentFinderByUrl` then tries to find the content using the `ContentCache` the path is now all lowercase I.E "mycontent".

This then breaks in the `GetByRouteInteral` of `ContentCache` when we try to find the content like so: 

```C#
content = hideTopLevelNode.Value
                    ? GetAtRoot(preview).SelectMany(x => x.Children(culture)).FirstOrDefault(x => x.UrlSegment(culture) == parts[0])
                    : GetAtRoot(preview).FirstOrDefault(x => x.UrlSegment(culture) == parts[0]);
```

The `parts` array is based off the path, so this will be "mycontent", but the `x.UrlSegment` will be the one saved by the `PublishedSnapShotService` when the content was created so "MyContent", and therefore nothing will be found, and the content will be marked as "published but cannot be routed" 

I found three possible ways to fix this, but I'm not entirely sure which is best 

1. Make the URL section lowercase, before saving it in the `PublishedSnapshotService`, this works, and the benefit is that we only have to call `ToLower` once, when creating content. The downside is that `IContent.GetUrlSegment` will still return the UrlSegment, as upper case, for instance in `ContentValueSetBuilder`, this doesn't seem to be a huge issue though, since any request made with the segment will be made lowercase by the `UriUtility´
2. Invoke `ToLower` on the URL in the `GetUrlSegment` on the `ContentBaseExtensions`, this will make sure that no matter what provider is used, the URL will always be lowercase, however, it does require us to invoke `ToLower` every time a URL segment is requested
3. Change the comparison when finding content in the `ContentCache`, this is essentially just doing `x.UrlSegment(culture).Equals(parts[0], StringComparison.InvariantCultureIgnoreCase)` in the code posted above, this will also fix the issue, but it feels a bit more like a band-aid than an actual fix, and I'm not entirely sure how it would behave with different cultures.


### Test / steps to reproduce

First create and register a custom URL segment provider, that does not necessarily return all lowercase, I used the one from the documentation:

```c#
public class ProductPageUrlSegmentProvider : IUrlSegmentProvider
    {
        private readonly IUrlSegmentProvider _provider = new DefaultUrlSegmentProvider();
        public string GetUrlSegment(IContentBase content, string culture = null)
        {
            if (content.ContentType.Alias != "productPage") return null;

            var segment = _provider.GetUrlSegment(content, culture);

            var productSku = content.GetValue<string>("productSKU");
            return $"{segment}--{productSku}";
        }
    }
```

Next create some content that uses the custom segment provider, and returns something with uppercase characters, if using the above snippet:

1. Create a document type with the alias `productPage` and a string property with the alias `productSKU`
2. Create some content with the Product SKU property containing uppercase, for instance "MYPRODUCT"
3. Save an publish the content, you will see that before this PR the URL won't be shown in the properties tab, instead you will see something like "This has been published, but cannot be routed", after the PR everything should work normally again.