### PR TITLE
Update contributing.md Visual Studio min version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -136,7 +136,7 @@ You can get in touch with [the core contributors team](#the-core-contributors-te
 
 In order to build the Umbraco source code locally, first make sure you have the following installed.
 
-  * [Visual Studio 2019 v16.3+ (with .NET Core 3.0)](https://visualstudio.microsoft.com/vs/)
+  * [Visual Studio 2019 v16.8+ (with .NET Core 3.0)](https://visualstudio.microsoft.com/vs/)
   * [Node.js v10+](https://nodejs.org/en/download/)
   * npm v6.4.1+ (installed with Node.js)
   * [Git command line](https://git-scm.com/download/)


### PR DESCRIPTION
Having had an older version of visual studio running I've been unable to build the source without making changes to the solution. However, upgrading to at least VS 16.8 has meant those changes haven't been required. This is to do with how the language target "latest" was working.  
Propose upping the min version listed here to avoid build issues being raised.

