### PR TITLE
V9: Route plugin controllers by area

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/EndpointRouteBuilderExtensions.cs
@@ -122,5 +122,27 @@ namespace Umbraco.Extensions
                            true,
                            constraints);
         }
+
+        public static void MapUmbracoSurfaceRoute(
+            this IEndpointRouteBuilder endpoints,
+            Type controllerType,
+            string rootSegment,
+            string areaName,
+            string defaultAction = "Index",
+            bool includeControllerNameInRoute = true,
+            object constraints = null)
+        {
+            // If there is an area name it's a plugin controller, and we should use the area name instead of surface
+            string prefixPathSegment = areaName.IsNullOrWhiteSpace() ? "Surface" : areaName;
+
+            endpoints.MapUmbracoRoute(
+                controllerType,
+                rootSegment,
+                areaName,
+                prefixPathSegment,
+                defaultAction,
+                includeControllerNameInRoute,
+                constraints);
+        }
     }
 }

--- a/src/Umbraco.Web.Website/Routing/FrontEndRoutes.cs
+++ b/src/Umbraco.Web.Website/Routing/FrontEndRoutes.cs
@@ -65,11 +65,10 @@ namespace Umbraco.Cms.Web.Website.Routing
                 // exclude front-end api controllers
                 PluginControllerMetadata meta = PluginController.GetMetadata(controller);
 
-                endpoints.MapUmbracoRoute(
+                endpoints.MapUmbracoSurfaceRoute(
                     meta.ControllerType,
                     _umbracoPathSegment,
-                    meta.AreaName,
-                    "Surface");
+                    meta.AreaName);
             }
         }
 


### PR DESCRIPTION
When you created a surface controller in V8 with the `[PluginController("SomeArea")]` attribute, the surface controller would be routed like `/umbraco/{areaname}/{controllername}/{action}/{id}`, however in V9 we don't account for area names when creating the pattern, so even if you have the attribute your plugin surface controller will be routed like a normal surface controller I.E: `/umbraco/surface/{controllername}/{action}/{id}`, which might cause issues since a plugin controller might clash with a locally declared one.

I noticed that we handle this with front end API's, so I've applied the same kind of logic to the normal surface controller routing, so now a surface controller with the plugin controller attribute will be routed the same way as in V8.

I've also added an integration test that shows this, if you revert back to `MapUmbracoRoute` instead of the new `MapUmbracoSurfaceRoute` you can see that the test fails.

It's worth noting that this PR won't affect front end API controllers, only surface controllers