### PR TITLE
#10520 ensure property culture in Nested Content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -190,7 +190,7 @@
         };
 
         vm.openNodeTypePicker = function ($event) {
-            
+
             if (vm.nodes.length >= vm.maxItems) {
                 return;
             }
@@ -537,14 +537,19 @@
                     if (tab) {
                         scaffold.variants[0].tabs.push(tab);
 
-                        tab.properties.forEach(function (property) {
+                        tab.properties.forEach(
+                            function (property) {
                                 if (_.find(notSupported, function (x) { return x === property.editor; })) {
                                     property.notSupported = true;
                                     // TODO: Not supported message to be replaced with 'content_nestedContentEditorNotSupported' dictionary key. Currently not possible due to async/timing quirk.
                                     property.notSupportedMessage = "Property " + property.label + " uses editor " + property.editor + " which is not supported by Nested Content.";
                                 }
-                            });
+                            }
+                        );
                     }
+
+                    // Ensure Culture Data for Complex Validation.
+                    ensureCultureData(scaffold);
 
                     // Store the scaffold object
                     vm.scaffolds.push(scaffold);
@@ -557,6 +562,29 @@
                 initIfAllScaffoldsHaveLoaded();
             });
         });
+
+        /**
+         * Ensure that the containing content variant language and current property culture is transferred along
+         * to the scaffolded content object representing this block.
+         * This is required for validation along with ensuring that the umb-property inheritance is constantly maintained.
+         * @param {any} content
+         */
+         function ensureCultureData(content) {
+
+            if (!content) return;
+
+            if (vm.umbVariantContent.editor.content.language) {
+                // set the scaffolded content's language to the language of the current editor
+                content.language = vm.umbVariantContent.editor.content.language;
+            }
+            // currently we only ever deal with invariant content for blocks so there's only one
+            content.variants[0].tabs.forEach(tab => {
+                tab.properties.forEach(prop => {
+                    // set the scaffolded property to the culture of the containing property
+                    prop.culture = vm.umbProperty.property.culture;
+                });
+            });
+        }
 
         var initIfAllScaffoldsHaveLoaded = function () {
             // Initialize when all scaffolds have loaded

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -571,7 +571,7 @@
          */
          function ensureCultureData(content) {
 
-            if (!content) return;
+            if (!content || !vm.umbVariantContent || !vm.umbProperty) return;
 
             if (vm.umbVariantContent.editor.content.language) {
                 // set the scaffolded content's language to the language of the current editor


### PR DESCRIPTION
This fixes #10520

The description of the above issue doesn't cover exactly whats going on. But from my investigation the problem appears when the Nested Content property is set to vary by culture. If so any server-side validations will not be binded correctly with the form fields, therefor its not possible to revalidate the fields by changing the value of the field. (since the field isn't connected to the server-side validation-message).

In order to fix this we needed the property to have the right culture, this was already solved in Block List Editor, so using the same approach. Parsing the NC property culture to each property of the scaffold model of each Element Type in Nested Content makes this work.

Test notes:
All tests are with a document type with a Nested Content property which has fields for each of these configs: regex, mandatory, non-mandatory.

- Test culture-invarint DocType.
- Test culture-variant DocType, with invariant NC field.
- Test culture-variant DocType with culture-varying NC field.

---
_This item has been added to our backlog [AB#12612](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/12612)_