### PR TITLE
#10520 Correct mandatory markers in nested content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-nested-content.less
@@ -15,17 +15,6 @@
     pointer-events: none;
 }
 
-.umb-nested-content--mandatory {
-    /*
-        yeah so this is a pain, but we must be super specific in targeting the mandatory property labels,
-        otherwise all properties within a reqired, nested, nested content property will all appear mandatory
-    */
-    .umb-property > ng-form > .control-group > .umb-el-wrap > .control-header label:after {
-        content: '*';
-        color: @red;
-    }
-}
-
 .umb-nested-content-overlay {
     position: absolute;
     top: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -16,7 +16,7 @@
 
                         {{vm.property.label}}
 
-                        <span ng-if="vm.property.validation.mandatory">
+                        <span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory">
                             <strong class="umb-control-required">*</strong>
                         </span>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.editor.html
@@ -4,7 +4,7 @@
         <umb-property property="property"
                       property-alias="{{property.propertyAlias}}"
                       element-key="{{model.key}}"
-                      ng-class="{'umb-nested-content--not-supported': property.notSupported, 'umb-nested-content--mandatory': property.ncMandatory}"
+                      ng-class="{'umb-nested-content--not-supported': property.notSupported }"
                       data-element="property-{{property.alias}}">
 
             <umb-property-editor model="property"></umb-property-editor>


### PR DESCRIPTION
Scenario: 
When two nested content property editors are nested inside each other, and the inner nested content is set to mandatory. All properties inside the inner nested content will be marked with an asterisk (*). Validation doesn't kick in though.

_Before: Text 4 is not set to mandatory_
<img width="1057" alt="Screenshot 2021-06-30 at 15 25 37" src="https://user-images.githubusercontent.com/6078361/123968499-90696180-d9b7-11eb-9744-fed81e620342.png">

_After:_
The PR fixes so only mandatory properties are marked with an asterisk (*).
<img width="1059" alt="Screenshot 2021-06-30 at 15 24 19" src="https://user-images.githubusercontent.com/6078361/123968565-9f501400-d9b7-11eb-8b10-ea5f03e22dc7.png">

#10520
