### PR TITLE
Fixed "user-dialog" dashboard markup

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -130,13 +130,11 @@
 
     </div>
 
-    <div class="umb-control-group" ng-if="tab.length">
+    <div class="umb-control-group" ng-if="dashboard.length > 0">
         <div ng-repeat="tab in dashboard">
+            <h5 ng-if="tab.label">{{tab.label}}</h5>
             <div ng-repeat="property in tab.properties">
-                <div>
-                    <h3 ng-if="property.caption">{{property.caption}}</h3>
-                    <div ng-include="property.path"></div>
-                </div>
+                <div ng-include="property.view"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Following on from issue #6417.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The "user-dialog" dashboard, (that appears in the app header, by clicking on your user's avatar), does not render. I have amended the markup of the `user.html` view to make it work.

To test this, follow the steps to [create a custom dashboard](https://our.umbraco.com/documentation/tutorials/Creating-a-Custom-Dashboard/), make sure to set the `"sections"` to `"user-dialog"`.
