### PR TITLE
Adding extension for MapDefinitions collection builder

### DIFF
--- a/src/Umbraco.Core/CompositionExtensions.cs
+++ b/src/Umbraco.Core/CompositionExtensions.cs
@@ -5,6 +5,7 @@ using Umbraco.Core.Dictionary;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging.Viewer;
 using Umbraco.Core.Manifest;
+using Umbraco.Core.Mapping;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PackageActions;
 using Umbraco.Core.Persistence.Mappers;
@@ -27,6 +28,13 @@ namespace Umbraco.Core
         /// <param name="composition">The composition.</param>
         public static CacheRefresherCollectionBuilder CacheRefreshers(this Composition composition)
             => composition.WithCollectionBuilder<CacheRefresherCollectionBuilder>();
+
+        /// <summary>
+        /// Gets the map definitions collection builder.
+        /// </summary>
+        /// <param name="composition">The composition.</param>
+        public static MapDefinitionCollectionBuilder MapDefinitions(this Composition composition)
+            => composition.WithCollectionBuilder<MapDefinitionCollectionBuilder>();
 
         /// <summary>
         /// Gets the mappers collection builder.


### PR DESCRIPTION
Registering custom mappers with Umbraco's built in object mapper is a little verbose.

In order to register custom mappers you must first get the collection builder like so:

```
composing.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
```

Most of Umbraco's internal collection builders have short-hand extension methods that can be used instead – e.g. `composing.Components()` – but not for MapDefinitions for some reason... This pull request changes that!

Confusingly an extension for `.Mappers()` already exists, but this relates to the mappers used by the persistence layer. I have tried to distinguish the MapDefinitions accordingly by naming the extension method `.MapDefinitions()`