### PR TITLE
V9: SqlCeImageMapper only applied for SqlCe

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/IDbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IDbProviderFactoryCreator.cs
@@ -10,5 +10,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         ISqlSyntaxProvider GetSqlSyntaxProvider(string providerName);
         IBulkSqlInsertProvider CreateBulkSqlInsertProvider(string providerName);
         void CreateDatabase(string providerName);
+        NPocoMapperCollection ProviderSpecificMappers(string providerName);
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/IProviderSpecificMapperFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IProviderSpecificMapperFactory.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Infrastructure.Persistence
+{
+    public interface IProviderSpecificMapperFactory
+    {
+        string ProviderName { get; }
+        NPocoMapperCollection Mappers { get; }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/SqlServerDbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlServerDbProviderFactoryCreator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.Common;
 using Microsoft.Extensions.Options;
+using NPoco;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
 
@@ -51,5 +52,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         {
             throw new NotSupportedException("Embedded databases are not supported");
         }
+
+        public NPocoMapperCollection ProviderSpecificMappers(string providerName) => new NPocoMapperCollection(Array.Empty<IMapper>());
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         private readonly DatabaseSchemaCreatorFactory _databaseSchemaCreatorFactory;
         private readonly RetryPolicy _connectionRetryPolicy;
         private readonly RetryPolicy _commandRetryPolicy;
-        //private readonly IEnumerable<IMapper> _mapperCollection;
+        private readonly IEnumerable<IMapper> _mapperCollection;
         private readonly Guid _instanceGuid = Guid.NewGuid();
         private List<CommandInfo> _commands;
 
@@ -50,8 +50,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             IBulkSqlInsertProvider bulkSqlInsertProvider,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
             RetryPolicy connectionRetryPolicy = null,
-            RetryPolicy commandRetryPolicy = null
-            /*IEnumerable<IMapper> mapperCollection = null*/)
+            RetryPolicy commandRetryPolicy = null,
+            IEnumerable<IMapper> mapperCollection = null)
             : base(connectionString, sqlContext.DatabaseType, provider, sqlContext.SqlSyntax.DefaultIsolationLevel)
         {
             SqlContext = sqlContext;
@@ -60,7 +60,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             _databaseSchemaCreatorFactory = databaseSchemaCreatorFactory;
             _connectionRetryPolicy = connectionRetryPolicy;
             _commandRetryPolicy = commandRetryPolicy;
-            //_mapperCollection = mapperCollection;
+            _mapperCollection = mapperCollection;
             Init();
         }
 
@@ -85,10 +85,10 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         {
             EnableSqlTrace = EnableSqlTraceDefault;
             NPocoDatabaseExtensions.ConfigureNPocoBulkExtensions();
-            //if (_mapperCollection != null)
-            //{
-            //    Mappers.AddRange(_mapperCollection);
-            //}
+            if (_mapperCollection != null)
+            {
+                Mappers.AddRange(_mapperCollection);
+            }
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -280,6 +280,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             // add all registered mappers for NPoco
             _pocoMappers.AddRange(_npocoMappers);
 
+            _pocoMappers.AddRange(_npocoMappers);
+
             var factory = new FluentPocoDataFactory(GetPocoDataFactoryResolver);
             _pocoDataFactory = factory;
             var config = new FluentConfig(xmappers => factory);
@@ -323,7 +325,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence
                 _bulkSqlInsertProvider,
                 _databaseSchemaCreatorFactory,
                 _connectionRetryPolicy,
-                _commandRetryPolicy);
+                _commandRetryPolicy,
+                _pocoMappers
+                );
 
         protected override void DisposeResources()
         {

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -280,7 +280,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             // add all registered mappers for NPoco
             _pocoMappers.AddRange(_npocoMappers);
 
-            _pocoMappers.AddRange(_npocoMappers);
+            _pocoMappers.AddRange(_dbProviderFactoryCreator.ProviderSpecificMappers(_providerName));
 
             var factory = new FluentPocoDataFactory(GetPocoDataFactoryResolver);
             _pocoDataFactory = factory;

--- a/src/Umbraco.Persistence.SqlCe/SqlCeSpecificMapperFactory.cs
+++ b/src/Umbraco.Persistence.SqlCe/SqlCeSpecificMapperFactory.cs
@@ -1,0 +1,11 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.Cms.Persistence.SqlCe
+{
+    public class SqlCeSpecificMapperFactory : IProviderSpecificMapperFactory
+    {
+        public string ProviderName => Constants.DatabaseProviders.SqlCe;
+        public NPocoMapperCollection Mappers => new NPocoMapperCollection(new[] {new SqlCeImageMapper()});
+    }
+}

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -145,7 +145,8 @@ namespace Umbraco.Extensions
                 DbProviderFactories.GetFactory,
                 factory.GetServices<ISqlSyntaxProvider>(),
                 factory.GetServices<IBulkSqlInsertProvider>(),
-                factory.GetServices<IEmbeddedDatabaseCreator>()
+                factory.GetServices<IEmbeddedDatabaseCreator>(),
+                factory.GetServices<IProviderSpecificMapperFactory>()
             ));
 
             builder.AddCoreInitialServices();
@@ -351,14 +352,17 @@ namespace Umbraco.Extensions
                     Type sqlCeSyntaxProviderType = umbSqlCeAssembly.GetType("Umbraco.Cms.Persistence.SqlCe.SqlCeSyntaxProvider");
                     Type sqlCeBulkSqlInsertProviderType = umbSqlCeAssembly.GetType("Umbraco.Cms.Persistence.SqlCe.SqlCeBulkSqlInsertProvider");
                     Type sqlCeEmbeddedDatabaseCreatorType = umbSqlCeAssembly.GetType("Umbraco.Cms.Persistence.SqlCe.SqlCeEmbeddedDatabaseCreator");
-                    Type sqlCeImageMapperType = umbSqlCeAssembly.GetType("Umbraco.Cms.Persistence.SqlCe.SqlCeImageMapper");
+                    Type sqlCeSpecificMapperFactory = umbSqlCeAssembly.GetType("Umbraco.Cms.Persistence.SqlCe.SqlCeSpecificMapperFactory");
 
-                    if (!(sqlCeSyntaxProviderType is null || sqlCeBulkSqlInsertProviderType is null || sqlCeEmbeddedDatabaseCreatorType is null))
+                    if (!(sqlCeSyntaxProviderType is null
+                          || sqlCeBulkSqlInsertProviderType is null
+                          || sqlCeEmbeddedDatabaseCreatorType is null
+                          || sqlCeSpecificMapperFactory is null))
                     {
                         builder.Services.AddSingleton(typeof(ISqlSyntaxProvider), sqlCeSyntaxProviderType);
                         builder.Services.AddSingleton(typeof(IBulkSqlInsertProvider), sqlCeBulkSqlInsertProviderType);
                         builder.Services.AddSingleton(typeof(IEmbeddedDatabaseCreator), sqlCeEmbeddedDatabaseCreatorType);
-                        builder.NPocoMappers().Add(sqlCeImageMapperType);
+                        builder.Services.AddSingleton(typeof(IProviderSpecificMapperFactory), sqlCeSpecificMapperFactory);
                     }
 
                     var sqlCeAssembly = Assembly.LoadFrom(Path.Combine(binFolder, "System.Data.SqlServerCe.dll"));

--- a/src/Umbraco.Web/UmbracoDbProviderFactoryCreator.cs
+++ b/src/Umbraco.Web/UmbracoDbProviderFactoryCreator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data.Common;
 using System.Data.SqlServerCe;
 using Microsoft.Extensions.Options;
+using NPoco;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -57,5 +58,7 @@ namespace Umbraco.Web
             var engine = new SqlCeEngine(DatabaseBuilder.EmbeddedDatabaseConnectionString);
             engine.CreateDatabase();
         }
+
+        public NPocoMapperCollection ProviderSpecificMappers(string providerName) => new NPocoMapperCollection(Array.Empty<IMapper>());
     }
 }


### PR DESCRIPTION
Introduced `IProviderSpecificMapperFactory`, to allow some NPoco mappers to only be applied for specific providers, e.g. `SqlCe` and the `SqlCEImageMapper`.

Before this we saw issues with mapping `byte[]` when using `SqlCE`. Because the `SqlCeImageMapper `was not added to the mappers when using `UmbracoDatabase`.

I had to introduce a `IProviderSpecificMapperFactory `to ensure the `SqlCEImageMapper `was only applied when using `SqlCE`, because it failed otherwise.