### PR TITLE
V9: Add RazorCompileOnPublish property to UmbracoProject for template

### DIFF
--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -47,5 +47,6 @@
     <!-- Set this to true if ModelsBuilder mode is not InMemoryAuto-->
     <PropertyGroup>
         <RazorCompileOnBuild>false</RazorCompileOnBuild>
+        <RazorCompileOnPublish>false</RazorCompileOnPublish>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
This fixes #10585, the template was missing the `RazorCompileOnPublish` property with a value of false, causing sites to be unable to publish when using `InMemoryAuto` for models builder. `Umbraco.Web.UI.NetCore` has this property as well, so it makes sense that templates does too.

I tested by running the build script, installing the template and ensuring that new projects has the property.