### PR TITLE
Fix localization of title attribute in umb-property-info-button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-property-info-button/umb-property-info-button.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-property-info-button/umb-property-info-button.html
@@ -1,5 +1,9 @@
 <button type="button"
     title="{{ vm.show ? '' : vm.buttonTitle}}"
     class="btn-reset umb-outline umb-outline--surrounding __button"
-    ng-click="vm.onMouseClick($event)" ng-bind="vm.symbol"></button>
-<div class="__tooltip" ng-if="vm.show" on-outside-click="vm.onMouseClickOutside($event)"><ng-transclude></ng-transclude></div>
+    ng-click="vm.onMouseClick($event)"
+    ng-bind="vm.symbol">
+</button>
+<div class="__tooltip" ng-if="vm.show" on-outside-click="vm.onMouseClickOutside($event)">
+    <ng-transclude></ng-transclude>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-property-info-button/umbpropertyinfobutton.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-property-info-button/umbpropertyinfobutton.component.js
@@ -10,24 +10,33 @@
             transclude: true,
             bindings: {
                 buttonTitle: "@?",
+                buttonTitleKey: "@?",
                 symbol: "@?"
             }
         });
 
-    function UmbPropertyInfoButtonController() {
+    function UmbPropertyInfoButtonController(localizationService) {
 
         var vm = this;
+
         vm.show = false;
 
         vm.onMouseClick = function ($event) {
             vm.show = !vm.show;
         };
+
         vm.onMouseClickOutside = function ($event) {
             vm.show = false;
         };
 
         vm.$onInit = function() {
             vm.symbol = vm.symbol || "i";
+
+            if (vm.buttonTitleKey) {
+                localizationService.localize(vm.buttonTitleKey).then(value => {
+                    vm.buttonTitle = value;
+                });
+            }
         };
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -37,7 +37,9 @@
                             <div class="control-group umb-control-group -no-border">
                                 <div class="umb-el-wrap">
                                     <label class="control-label" for="iconcolor"><localize key="blockEditor_labelCustomView">Custom view</localize></label>
-                                    <umb-property-info-button button-title="@blockEditor_labelCustomViewInfoTitle" localize="button-title"><localize key="blockEditor_labelCustomViewDescription">Overwrite how this block appears in the BackOffice UI. Pick a .html file containing your presentation.</localize></umb-property-info-button>
+                                    <umb-property-info-button button-title-key="blockEditor_labelCustomViewInfoTitle">
+                                        <localize key="blockEditor_labelCustomViewDescription">Overwrite how this block appears in the BackOffice UI. Pick a .html file containing your presentation.</localize>
+                                    </umb-property-info-button>
                                     <div class="controls">
                                         <div class="__settings-input --hasValue" ng-if="vm.block.view !== null" >
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10593

### Description
This PR fixes localization of title attribute in the `<umb-property-info-button>`.

I don't think the `localize` attribute directive will work in this case (or it actually ever has worked here) as it seems, it will just pass in the `@blockEditor_labelCustomViewInfoTitle` as string to the component before the localize attribute directive has localized the text.

The `buttonTitle` should still work for static text, while `buttonTitleKey` will work for localized title similar to `label` and `labelKey` in many other components.

![xYKUokLTG0](https://user-images.githubusercontent.com/2919859/124521535-235b2f00-ddf0-11eb-9b8a-c8c013cf5200.gif)
