### PR TITLE
V9: Fix GetLocalCropUrl

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -337,10 +338,14 @@ namespace Umbraco.Extensions
             );
 
 
+        [Obsolete("Use GetCrop to merge local and media crops, get automatic cache buster value and have more parameters.")]
         public static string GetLocalCropUrl(
             this MediaWithCrops mediaWithCrops,
             string alias,
             string cacheBusterValue = null)
-            => mediaWithCrops.GetLocalCropUrl(alias, cacheBusterValue);
+        {
+            return mediaWithCrops.LocalCrops.Src +
+                   mediaWithCrops.LocalCrops.GetCropUrl(alias, ImageUrlGenerator, cacheBusterValue: cacheBusterValue);
+        }
     }
 }


### PR DESCRIPTION
This fixes a bug which would cause your page to be unable to render if you used `@Model.MyImage.GetLocalCropUrl("someAlias")`. 

This was caused by `GetLocalCropUrl` calling itself recursively and causing a stack overflow. I used the same logic as in V8, and it seems to work fine, I also marked it as obsolete like in V8, letting people know they should use `GetCrop` instead