### PR TITLE
Move UrlHelper extensions to Umbraco.Extensions

### DIFF
--- a/src/Umbraco.Web/UrlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/UrlHelperRenderExtensions.cs
@@ -7,7 +7,7 @@ using Umbraco.Core.Models;
 using Umbraco.Extensions;
 using Umbraco.Web.Composing;
 
-namespace Umbraco.Web
+namespace Umbraco.Extensions
 {
     /// <summary>
     /// Extension methods for UrlHelper for use in templates


### PR DESCRIPTION
All other extensions in v9 are in the `Umbraco.Extensions` namespace so these should be moved to the same namespace for consistency.