### PR TITLE
Changes the RoslynCompiler to use assemblies resolved from the DependencyContext

### DIFF
--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryModelFactory.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryModelFactory.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -128,7 +129,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
                     return _roslynCompiler;
                 }
 
-                _roslynCompiler = new RoslynCompiler(AssemblyLoadContext.All.SelectMany(x => x.Assemblies));
+                _roslynCompiler = new RoslynCompiler();
                 return _roslynCompiler;
             }
         }


### PR DESCRIPTION
This fixes an issue with invalid framework references when using ModelsBuilder InMemoryAuto mode. We would end up with exceptions like:

```
Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.CompilationFailedException: One or more compilation failures occurred:
D:\Projects\Umbraco-CMS-netcore\src\Umbraco.Web.UI.NetCore\Views\Products.cshtml(28,24): error CS0012: The type 'IEnumerable<>' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
D:\Projects\Umbraco-CMS-netcore\src\Umbraco.Web.UI.NetCore\Views\Products.cshtml(30,51): error CS0012: The type 'IEnumerable<>' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
D:\Projects\Umbraco-CMS-netcore\src\Umbraco.Web.UI.NetCore\Views\Products.cshtml(35,100): error CS0012: The type 'Decimal' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
```

And we'd get this exact error about decimal: https://github.com/dotnet/core/issues/2082 

This changes our internal compiler to use the DependencyContext as referenced in https://github.com/dotnet/core/issues/2082 to add refs to the compiler. Before we were manually adding refs to the runtime libs - which may have almost worked but potentially we weren't adding enough or incorrect ones. Before we were adding refs using `AssemblyLoadContext.All.SelectMany(x => x.Assemblies)` but this is prob incorrect for adding refs to the roslyn compiler - also because this would probably only include assemblies already loaded into the context and some may have been missing.

This change works for me but needs thorough testing.

## Testing

This is with InMemoryAuto mode.

Prior to this, if you created a decimal property editor on a doc type, save the doc type and render that property in a template, then render the page, you'd get an exception like the above.

With this change, you will probably need to go re-save your doc type and then re-render your page so that re-compilation occurs and it should work.