### PR TITLE
Removed check for default 

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             // This will never resolve to a user, yet this is asked
             // for all of the time (especially in cases of members).
             // Don't issue a SQL call for this, we know it will not exist.
-            if (id == default || id < -1)
+            if (id < -1)
             {
                 return null;
             }

--- a/src/Umbraco.Tests/Persistence/Repositories/UserRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/UserRepositoryTest.cs
@@ -17,6 +17,7 @@ using Umbraco.Core.Persistence;
 using Umbraco.Core.PropertyEditors;
 using System;
 using Umbraco.Core.Persistence.Dtos;
+using Umbraco.Tests.Components;
 
 namespace Umbraco.Tests.Persistence.Repositories
 {
@@ -67,7 +68,7 @@ namespace Umbraco.Tests.Persistence.Repositories
         private UserRepository CreateRepository(IScopeProvider provider)
         {
             var accessor = (IScopeAccessor) provider;
-            var repository = new UserRepository(accessor, AppCaches.Disabled, Logger, Mappers, TestObjects.GetGlobalSettings());
+            var repository = new UserRepository(accessor, AppCaches.Disabled, Logger, Mappers, TestObjects.GetGlobalSettings(), ComponentTests.MockRuntimeState(RuntimeLevel.Run));
             return repository;
         }
 
@@ -85,8 +86,8 @@ namespace Umbraco.Tests.Persistence.Repositories
             var user = MockedUser.CreateUser();
             using (var scope = provider.CreateScope(autoComplete: true))
             {
-                var repository = CreateRepository(provider);                
-                repository.Save(user);                
+                var repository = CreateRepository(provider);
+                repository.Save(user);
             }
 
             using (var scope = provider.CreateScope(autoComplete: true))
@@ -253,7 +254,7 @@ namespace Umbraco.Tests.Persistence.Repositories
 
                 var id = user.Id;
 
-                var repository2 = new UserRepository((IScopeAccessor) provider, AppCaches.Disabled, Logger, Mock.Of<IMapperCollection>(),TestObjects.GetGlobalSettings());
+                var repository2 = new UserRepository((IScopeAccessor) provider, AppCaches.Disabled, Logger, Mock.Of<IMapperCollection>(), TestObjects.GetGlobalSettings(), ComponentTests.MockRuntimeState(RuntimeLevel.Run));
 
                 repository2.Delete(user);
 


### PR DESCRIPTION
### Prerequisites

If there's an existing issue for this PR then this fixes #10609

### Description
This PR fixes #10609
In v7 the id for the default admin user is 0, while in v8 it's -1.
The bug made it impossible to login from v8 to a v7 DB in order to perform an upgrade.

Haven't verified the fix yet, hence the "Draft pull request"
<!-- Thanks for contributing to Umbraco CMS! -->
