### PR TITLE
Fix for #10627 - UmbracoDictionaryTranslate checks.

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -76,7 +76,7 @@ namespace Umbraco.Extensions
              if (text == null)
                  return null;
 
-             if (text.StartsWith("#") == false)
+             if (text.StartsWith("#") == false || text.IndexOf('_') == -1)
                  return text;
 
              text = text.Substring(1);
@@ -87,6 +87,9 @@ namespace Umbraco.Extensions
              }
 
              var areaAndKey = text.Split('_');
+
+             if (areaAndKey.Length < 2) 
+                return text;
 
              value = manager.Localize(areaAndKey[0], areaAndKey[1]);
              return value.StartsWith("[") ? text : value;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10627 

### Description
Adds some range checking for splitting the string for localization 

if a string doesn't contain a _ then the source text is returned (localization requires an area and key separated by _)
