### PR TITLE
8.15RC Published State as part of IPropertyCacheCompression

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/IPropertyCacheCompression.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyCacheCompression.cs
@@ -9,7 +9,13 @@ namespace Umbraco.Core.PropertyEditors
     /// 
     /// </remarks>
     public interface IPropertyCacheCompression
-    {        
-        bool IsCompressed(IReadOnlyContentBase content, string propertyTypeAlias);
+    {
+        /// <summary>
+        /// Whether a property on the content is/should be compressed
+        /// </summary>
+        /// <param name="content">The content</param>
+        /// <param name="propertyTypeAlias">The property to compress or not</param>
+        /// <param name="published">Whether this content is the published version</param>
+        bool IsCompressed(IReadOnlyContentBase content, string propertyTypeAlias,bool published);
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/IPropertyCacheCompressionOptions.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyCacheCompressionOptions.cs
@@ -4,6 +4,13 @@ namespace Umbraco.Core.PropertyEditors
 {
     public interface IPropertyCacheCompressionOptions
     {
-        bool IsCompressed(IReadOnlyContentBase content, PropertyType propertyType, IDataEditor dataEditor);
+        /// <summary>
+        /// Whether a property on the content is/should be compressed
+        /// </summary>
+        /// <param name="content">The content</param>
+        /// <param name="propertyType">The property to compress or not</param>
+        /// <param name="dataEditor">The datatype of the property to compress or not</param>
+        /// <param name="published">Whether this content is the published version</param>
+        bool IsCompressed(IReadOnlyContentBase content, PropertyType propertyType, IDataEditor dataEditor,bool published);
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/NoopPropertyCacheCompressionOptions.cs
+++ b/src/Umbraco.Core/PropertyEditors/NoopPropertyCacheCompressionOptions.cs
@@ -7,6 +7,6 @@ namespace Umbraco.Core.PropertyEditors
     /// </summary>
     internal class NoopPropertyCacheCompressionOptions : IPropertyCacheCompressionOptions
     {
-        public bool IsCompressed(IReadOnlyContentBase content, PropertyType propertyType, IDataEditor dataEditor) => false;
+        public bool IsCompressed(IReadOnlyContentBase content, PropertyType propertyType, IDataEditor dataEditor,bool published) => false;
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/PropertyCacheCompression.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyCacheCompression.cs
@@ -14,13 +14,13 @@ namespace Umbraco.Core.PropertyEditors
         private readonly IPropertyCacheCompressionOptions _compressionOptions;
         private readonly IReadOnlyDictionary<int, IContentTypeComposition> _contentTypes;
         private readonly PropertyEditorCollection _propertyEditors;
-        private readonly ConcurrentDictionary<(int contentTypeId, string propertyAlias), bool> _isCompressedCache;
+        private readonly ConcurrentDictionary<(int contentTypeId, string propertyAlias,bool published), bool> _isCompressedCache;
 
         public PropertyCacheCompression(
             IPropertyCacheCompressionOptions compressionOptions,
             IReadOnlyDictionary<int, IContentTypeComposition> contentTypes,
             PropertyEditorCollection propertyEditors,
-            ConcurrentDictionary<(int, string), bool> compressedStoragePropertyEditorCache)
+            ConcurrentDictionary<(int, string,bool), bool> compressedStoragePropertyEditorCache)
         {
             _compressionOptions = compressionOptions;
             _contentTypes = contentTypes ?? throw new System.ArgumentNullException(nameof(contentTypes));
@@ -28,9 +28,9 @@ namespace Umbraco.Core.PropertyEditors
             _isCompressedCache = compressedStoragePropertyEditorCache;
         }
 
-        public bool IsCompressed(IReadOnlyContentBase content, string alias)
+        public bool IsCompressed(IReadOnlyContentBase content, string alias, bool published)
         {
-            var compressedStorage = _isCompressedCache.GetOrAdd((content.ContentTypeId, alias), x =>
+            var compressedStorage = _isCompressedCache.GetOrAdd((content.ContentTypeId, alias, published), x =>
             {
                 if (!_contentTypes.TryGetValue(x.contentTypeId, out var ct))
                     return false;
@@ -40,7 +40,7 @@ namespace Umbraco.Core.PropertyEditors
 
                 if (!_propertyEditors.TryGet(propertyType.PropertyEditorAlias, out var propertyEditor)) return false;
 
-                return _compressionOptions.IsCompressed(content, propertyType, propertyEditor);
+                return _compressionOptions.IsCompressed(content, propertyType, propertyEditor, published);
             });
 
             return compressedStorage;

--- a/src/Umbraco.Core/PropertyEditors/UnPublishedContentPropertyCacheCompressionOptions.cs
+++ b/src/Umbraco.Core/PropertyEditors/UnPublishedContentPropertyCacheCompressionOptions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Models;
+
+namespace Umbraco.Core.PropertyEditors
+{
+    /// <summary>
+    /// Compress large, non published text properties
+    /// </summary>
+    internal class UnPublishedContentPropertyCacheCompressionOptions : IPropertyCacheCompressionOptions
+    {
+        public bool IsCompressed(IReadOnlyContentBase content, PropertyType propertyType, IDataEditor dataEditor, bool published)
+        {
+            if (published)
+            {
+                return false;
+            }
+            if (propertyType.SupportsPublishing && propertyType.ValueStorageType == ValueStorageType.Ntext)
+            {
+                //Only compress non published content that supports publishing and the property is text
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/UnPublishedContentPropertyCacheCompressionOptions.cs
+++ b/src/Umbraco.Core/PropertyEditors/UnPublishedContentPropertyCacheCompressionOptions.cs
@@ -14,11 +14,7 @@ namespace Umbraco.Core.PropertyEditors
     {
         public bool IsCompressed(IReadOnlyContentBase content, PropertyType propertyType, IDataEditor dataEditor, bool published)
         {
-            if (published)
-            {
-                return false;
-            }
-            if (propertyType.SupportsPublishing && propertyType.ValueStorageType == ValueStorageType.Ntext)
+            if (!published && propertyType.SupportsPublishing && propertyType.ValueStorageType == ValueStorageType.Ntext)
             {
                 //Only compress non published content that supports publishing and the property is text
                 return true;

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -171,6 +171,7 @@
     <Compile Include="PropertyEditors\NoopPropertyCacheCompressionOptions.cs" />
     <Compile Include="PropertyEditors\PropertyCacheCompression.cs" />
     <Compile Include="PropertyEditors\IPropertyCacheCompression.cs" />
+    <Compile Include="PropertyEditors\UnPublishedContentPropertyCacheCompressionOptions.cs" />
     <Compile Include="Serialization\AutoInterningStringConverter.cs" />
     <Compile Include="Serialization\AutoInterningStringKeyCaseInsensitiveDictionaryConverter.cs" />
     <Compile Include="PropertyEditors\EyeDropperColorPickerConfiguration.cs" />

--- a/src/Umbraco.Tests/PublishedContent/ContentSerializationTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/ContentSerializationTests.cs
@@ -56,14 +56,14 @@ namespace Umbraco.Tests.PublishedContent
 
             var content = Mock.Of<IReadOnlyContentBase>(x => x.ContentTypeId == 1);
 
-            var json = jsonSerializer.Serialize(content, cacheModel).StringData;
-            var msgPack = msgPackSerializer.Serialize(content, cacheModel).ByteData;
+            var json = jsonSerializer.Serialize(content, cacheModel,false).StringData;
+            var msgPack = msgPackSerializer.Serialize(content, cacheModel, false).ByteData;
 
             Console.WriteLine(json);
             Console.WriteLine(msgPackSerializer.ToJson(msgPack));
 
-            var jsonContent = jsonSerializer.Deserialize(content, json, null);
-            var msgPackContent = msgPackSerializer.Deserialize(content, null, msgPack);
+            var jsonContent = jsonSerializer.Deserialize(content, json, null,false);
+            var msgPackContent = msgPackSerializer.Deserialize(content, null, msgPack,false);
 
 
             CollectionAssert.AreEqual(jsonContent.CultureData.Keys, msgPackContent.CultureData.Keys);

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/DatabaseDataSource.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/DatabaseDataSource.cs
@@ -393,12 +393,13 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                 }
                 else
                 {
-                    var deserializedContent = serializer.Deserialize(dto, dto.EditData, dto.EditDataRaw);
+                    bool published = false;
+                    var deserializedContent = serializer.Deserialize(dto, dto.EditData, dto.EditDataRaw, published);
 
                     d = new ContentData
                     {
                         Name = dto.EditName,
-                        Published = false,
+                        Published = published,
                         TemplateId = dto.EditTemplateId,
                         VersionId = dto.VersionId,
                         VersionDate = dto.EditVersionDate,
@@ -420,13 +421,14 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                 }
                 else
                 {
-                    var deserializedContent = serializer.Deserialize(dto, dto.PubData, dto.PubDataRaw);
+                    bool published = true;
+                    var deserializedContent = serializer.Deserialize(dto, dto.PubData, dto.PubDataRaw, published);
 
                     p = new ContentData
                     {
                         Name = dto.PubName,
                         UrlSegment = deserializedContent.UrlSegment,
-                        Published = true,
+                        Published = published,
                         TemplateId = dto.PubTemplateId,
                         VersionId = dto.VersionId,
                         VersionDate = dto.PubVersionDate,
@@ -456,12 +458,13 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             if (dto.EditData == null && dto.EditDataRaw == null)
                 throw new InvalidOperationException("No data for media " + dto.Id);
 
-            var deserializedMedia = serializer.Deserialize(dto, dto.EditData, dto.EditDataRaw);
+            bool published = true;
+            var deserializedMedia = serializer.Deserialize(dto, dto.EditData, dto.EditDataRaw, published);
 
             var p = new ContentData
             {
                 Name = dto.EditName,
-                Published = true,
+                Published = published,
                 TemplateId = -1,
                 VersionId = dto.VersionId,
                 VersionDate = dto.EditVersionDate,

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/IContentCacheDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/IContentCacheDataSerializer.cs
@@ -14,12 +14,12 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         /// <summary>
         /// Deserialize the data into a <see cref="ContentCacheDataModel"/>
         /// </summary>
-        ContentCacheDataModel Deserialize(IReadOnlyContentBase content, string stringData, byte[] byteData);
+        ContentCacheDataModel Deserialize(IReadOnlyContentBase content, string stringData, byte[] byteData, bool published);
 
         /// <summary>
         /// Serializes the <see cref="ContentCacheDataModel"/> 
         /// </summary>
-        ContentCacheDataSerializationResult Serialize(IReadOnlyContentBase content, ContentCacheDataModel model);
+        ContentCacheDataSerializationResult Serialize(IReadOnlyContentBase content, ContentCacheDataModel model,bool published);
     }
 
 }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/JsonContentNestedDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/JsonContentNestedDataSerializer.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             DateFormatString = "o"
         };
         private readonly JsonNameTable _propertyNameTable = new DefaultJsonNameTable();
-        public ContentCacheDataModel Deserialize(IReadOnlyContentBase content, string stringData, byte[] byteData)
+        public ContentCacheDataModel Deserialize(IReadOnlyContentBase content, string stringData, byte[] byteData,bool published)
         {
             if (stringData == null && byteData != null)
                 throw new NotSupportedException($"{typeof(JsonContentNestedDataSerializer)} does not support byte[] serialization");
@@ -39,7 +39,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             }
         }
 
-        public ContentCacheDataSerializationResult Serialize(IReadOnlyContentBase content, ContentCacheDataModel model)
+        public ContentCacheDataSerializationResult Serialize(IReadOnlyContentBase content, ContentCacheDataModel model,bool published)
         {
             // note that numeric values (which are Int32) are serialized without their
             // type (eg "value":1234) and JsonConvert by default deserializes them as Int64

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
@@ -39,7 +39,8 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
 
             _options = defaultOptions
                 .WithResolver(resolver)
-                .WithCompression(MessagePackCompression.Lz4BlockArray);            
+                .WithCompression(MessagePackCompression.Lz4BlockArray)
+                .WithSecurity(MessagePackSecurity.UntrustedData);            
         }
 
         public string ToJson(byte[] bin)
@@ -48,12 +49,12 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             return json;
         }
 
-        public ContentCacheDataModel Deserialize(IReadOnlyContentBase content, string stringData, byte[] byteData)
+        public ContentCacheDataModel Deserialize(IReadOnlyContentBase content, string stringData, byte[] byteData,bool published)
         {
             if (byteData != null)
             {
                 var cacheModel = MessagePackSerializer.Deserialize<ContentCacheDataModel>(byteData, _options);
-                Expand(content, cacheModel);
+                Expand(content, cacheModel, published);
                 return cacheModel;
             }
             else if (stringData != null)
@@ -61,7 +62,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                 // NOTE: We don't really support strings but it's possible if manually used (i.e. tests)
                 var bin = Convert.FromBase64String(stringData);
                 var cacheModel = MessagePackSerializer.Deserialize<ContentCacheDataModel>(bin, _options);
-                Expand(content, cacheModel);
+                Expand(content, cacheModel,published);
                 return cacheModel;
             }
             else
@@ -70,9 +71,9 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
             }
         }
 
-        public ContentCacheDataSerializationResult Serialize(IReadOnlyContentBase content, ContentCacheDataModel model)
+        public ContentCacheDataSerializationResult Serialize(IReadOnlyContentBase content, ContentCacheDataModel model,bool published)
         {
-            Compress(content, model);
+            Compress(content, model, published);
             var bytes = MessagePackSerializer.Serialize(model, _options);
             return new ContentCacheDataSerializationResult(null, bytes);
         }
@@ -88,11 +89,11 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         /// read/decompressed as a string to be displayed on the front-end. This allows for potentially a significant
         /// memory savings but could also affect performance of first rendering pages while decompression occurs.
         /// </remarks>
-        private void Compress(IReadOnlyContentBase content, ContentCacheDataModel model)
+        private void Compress(IReadOnlyContentBase content, ContentCacheDataModel model,bool published)
         {
             foreach(var propertyAliasToData in model.PropertyData)
             {
-                if (_propertyOptions.IsCompressed(content, propertyAliasToData.Key))
+                if (_propertyOptions.IsCompressed(content, propertyAliasToData.Key,published))
                 {
                     foreach(var property in propertyAliasToData.Value.Where(x => x.Value != null && x.Value is string))
                     {
@@ -106,11 +107,11 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         /// Used during deserialization to map the property data as lazy or expand the value
         /// </summary>
         /// <param name="nestedData"></param>
-        private void Expand(IReadOnlyContentBase content, ContentCacheDataModel nestedData)
+        private void Expand(IReadOnlyContentBase content, ContentCacheDataModel nestedData,bool published)
         {
             foreach (var propertyAliasToData in nestedData.PropertyData)
             {
-                if (_propertyOptions.IsCompressed(content, propertyAliasToData.Key))
+                if (_propertyOptions.IsCompressed(content, propertyAliasToData.Key,published))
                 {
                     foreach (var property in propertyAliasToData.Value.Where(x => x.Value != null))
                     {

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializerFactory.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializerFactory.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         private readonly IMemberTypeService _memberTypeService;
         private readonly PropertyEditorCollection _propertyEditors;
         private readonly IPropertyCacheCompressionOptions _compressionOptions;
-        private readonly ConcurrentDictionary<(int, string), bool> _isCompressedCache = new ConcurrentDictionary<(int, string), bool>();
+        private readonly ConcurrentDictionary<(int, string,bool), bool> _isCompressedCache = new ConcurrentDictionary<(int, string,bool), bool>();
 
         public MsgPackContentNestedDataSerializerFactory(
             IContentTypeService contentTypeService,

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheComposer.cs
@@ -26,8 +26,16 @@ namespace Umbraco.Web.PublishedCache.NuCache
             {
                 composition.RegisterUnique<IContentCacheDataSerializerFactory, MsgPackContentNestedDataSerializerFactory>();                
             }
-
-            composition.RegisterUnique<IPropertyCacheCompressionOptions, NoopPropertyCacheCompressionOptions>();
+            var unPublishedContentCompression = ConfigurationManager.AppSettings[NuCacheSerializerComponent.Nucache_UnPublishedContentCompression_Key]; 
+            if ("MsgPack" == serializer && "true" == unPublishedContentCompression)
+            {
+                composition.RegisterUnique<IPropertyCacheCompressionOptions, UnPublishedContentPropertyCacheCompressionOptions>();
+            }
+            else
+            {
+                composition.RegisterUnique<IPropertyCacheCompressionOptions, NoopPropertyCacheCompressionOptions>();
+            }
+           
 
             composition.RegisterUnique(factory => new ContentDataSerializer(new DictionaryOfPropertyDataSerializer()));
 

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheSerializerComponent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheSerializerComponent.cs
@@ -16,6 +16,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
     public class NuCacheSerializerComponent : IComponent
     {
         internal const string Nucache_Serializer_Key = "Umbraco.Web.PublishedCache.NuCache.Serializer";
+        internal const string Nucache_UnPublishedContentCompression_Key = "Umbraco.Web.PublishedCache.NuCache.CompressUnPublishedContent";
         private const string JSON_SERIALIZER_VALUE = "JSON";
         private readonly Lazy<IPublishedSnapshotService> _service;
         private readonly IKeyValueService _keyValueService;

--- a/src/Umbraco.Web/PublishedCache/NuCache/NuCacheSerializerComponent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/NuCacheSerializerComponent.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
             {
                 _profilingLogger.Warn<NuCacheSerializerComponent>($"Database NuCache was serialized using {currentSerializer}. Currently configured NuCache serializer {serializer}. Rebuilding Nucache");
 
-                using (_profilingLogger.TraceDuration<NuCacheSerializerComponent>($"Rebuilding NuCache database with {currentSerializer} serializer"))
+                using (_profilingLogger.TraceDuration<NuCacheSerializerComponent>($"Rebuilding NuCache database with {serializer} serializer"))
                 {
                     _service.Value.Rebuild();
                     _keyValueService.SetValue(Nucache_Serializer_Key, serializer);

--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedSnapshotService.cs
@@ -1491,7 +1491,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 UrlSegment = content.GetUrlSegment(_urlSegmentProviders)
             };
 
-            var serialized = serializer.Serialize(ReadOnlyContentBaseAdapter.Create(content), contentCacheData);
+            var serialized = serializer.Serialize(ReadOnlyContentBaseAdapter.Create(content), contentCacheData,published);
 
             var dto = new ContentNuDto
             {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Include the published state of content for IPropertyCacheCompression. This will allow having a policy of compressing all non published content. Needs to occur before 8.15 to avoid breaking changes to the interface.

Adds an out of the box implementation that compresses ntext properties for only unpublished content (typically rte/blocklist/nestedcontent).

`<add key="Umbraco.Web.PublishedCache.NuCache.CompressUnPublishedContent" value="true"/>`
Requires use of the MessagePack Serializer
`<add key="Umbraco.Web.PublishedCache.NuCache.Serializer" value="MsgPack"/>`
