### PR TITLE
#10431 ensure model value onValueChanged

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -98,6 +98,10 @@
 
             vm.model.value.forEach(mediaEntry => updateMediaEntryData(mediaEntry));
 
+            // set the onValueChanged callback, this will tell us if the media picker model changed on the server
+            // once the data is submitted. If so we need to re-initialize
+            vm.model.onValueChanged = onServerValueChanged;
+
             userService.getCurrentUser().then(function (userData) {
 
                 if (!vm.model.config.startNodeId) {
@@ -119,6 +123,15 @@
             });
 
         };
+
+        function onServerValueChanged(newVal, oldVal) {
+            if(newVal === null || !Array.isArray(newVal)) {
+                newVal = [];
+                vm.model.value = newVal;
+            }
+
+            vm.model.value.forEach(mediaEntry => updateMediaEntryData(mediaEntry));
+        }
 
         function setDirty() {
             if (vm.propertyForm) {
@@ -259,7 +272,7 @@
         function setActiveMedia(mediaEntryOrNull) {
             vm.activeMediaEntry = mediaEntryOrNull;
         }
-        
+
         function editMedia(mediaEntry, options, $event) {
 
             if($event)


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10431

Couldn't reproduce above issue but never the less I can see a potential code problem, as we haven't implemented the onValueChanged callback which is needed to ensure that the data is proper always.

Therefore this fix.

Test-notes: read the issue.