### PR TITLE
Fixes runtime hash calculation

### DIFF
--- a/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
+++ b/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
@@ -17,12 +17,17 @@ namespace Umbraco.Cms.Core.Composing
     {
         private readonly Assembly _entryPointAssembly;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly IEnumerable<string> _additionalTargetAssemblies;
         private List<Assembly> _discovered;
 
-        public DefaultUmbracoAssemblyProvider(Assembly entryPointAssembly, ILoggerFactory loggerFactory)
+        public DefaultUmbracoAssemblyProvider(
+            Assembly entryPointAssembly,
+            ILoggerFactory loggerFactory,
+            IEnumerable<string> additionalTargetAssemblies = null)
         {
             _entryPointAssembly = entryPointAssembly ?? throw new ArgumentNullException(nameof(entryPointAssembly));
             _loggerFactory = loggerFactory;
+            _additionalTargetAssemblies = additionalTargetAssemblies;
         }
 
         // TODO: It would be worth investigating a netcore3 version of this which would use
@@ -40,7 +45,9 @@ namespace Umbraco.Cms.Core.Composing
                     return _discovered;
                 }
 
-                var finder = new FindAssembliesWithReferencesTo(new[] { _entryPointAssembly }, Constants.Composing.UmbracoCoreAssemblyNames, true, _loggerFactory);
+                IEnumerable<string> additionalTargetAssemblies = _additionalTargetAssemblies.Concat(Constants.Composing.UmbracoCoreAssemblyNames);
+
+                var finder = new FindAssembliesWithReferencesTo(new[] { _entryPointAssembly }, additionalTargetAssemblies.ToArray(), true, _loggerFactory);
                 _discovered = finder.Find().ToList();
 
                 return _discovered;

--- a/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
+++ b/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
@@ -16,6 +17,7 @@ namespace Umbraco.Cms.Core.Composing
     {
         private readonly Assembly _entryPointAssembly;
         private readonly ILoggerFactory _loggerFactory;
+        private List<Assembly> _discovered;
 
         public DefaultUmbracoAssemblyProvider(Assembly entryPointAssembly, ILoggerFactory loggerFactory)
         {
@@ -33,8 +35,15 @@ namespace Umbraco.Cms.Core.Composing
         {
             get
             {
+                if (_discovered != null)
+                {
+                    return _discovered;
+                }
+
                 var finder = new FindAssembliesWithReferencesTo(new[] { _entryPointAssembly }, Constants.Composing.UmbracoCoreAssemblyNames, true, _loggerFactory);
-                return finder.Find();
+                _discovered = finder.Find().ToList();
+
+                return _discovered;
             }
         }
     }

--- a/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
+++ b/src/Umbraco.Core/Composing/DefaultUmbracoAssemblyProvider.cs
@@ -45,7 +45,11 @@ namespace Umbraco.Cms.Core.Composing
                     return _discovered;
                 }
 
-                IEnumerable<string> additionalTargetAssemblies = _additionalTargetAssemblies.Concat(Constants.Composing.UmbracoCoreAssemblyNames);
+                IEnumerable<string> additionalTargetAssemblies = Constants.Composing.UmbracoCoreAssemblyNames;
+                if (_additionalTargetAssemblies != null)
+                {
+                    additionalTargetAssemblies = additionalTargetAssemblies.Concat(_additionalTargetAssemblies);
+                }
 
                 var finder = new FindAssembliesWithReferencesTo(new[] { _entryPointAssembly }, additionalTargetAssemblies.ToArray(), true, _loggerFactory);
                 _discovered = finder.Find().ToList();

--- a/src/Umbraco.Core/Composing/FindAssembliesWithReferencesTo.cs
+++ b/src/Umbraco.Core/Composing/FindAssembliesWithReferencesTo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -18,6 +18,7 @@ namespace Umbraco.Cms.Core.Composing
         private readonly string[] _targetAssemblies;
         private readonly bool _includeTargets;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger<FindAssembliesWithReferencesTo> _logger;
 
         /// <summary>
         /// Constructor
@@ -32,6 +33,7 @@ namespace Umbraco.Cms.Core.Composing
             _targetAssemblies = targetAssemblyNames;
             _includeTargets = includeTargets;
             _loggerFactory = loggerFactory;
+            _logger = _loggerFactory.CreateLogger<FindAssembliesWithReferencesTo>();
         }
 
         public IEnumerable<Assembly> Find()
@@ -50,9 +52,10 @@ namespace Umbraco.Cms.Core.Composing
                     {
                         referenceItems.Add(Assembly.Load(target));
                     }
-                    catch (FileNotFoundException)
+                    catch (FileNotFoundException ex)
                     {
                         // occurs if we cannot load this ... for example in a test project where we aren't currently referencing Umbraco.Web, etc...
+                        _logger.LogDebug(ex, "Could not load assembly " + target);
                     }
                 }
             }

--- a/src/Umbraco.Core/Composing/ITypeFinder.cs
+++ b/src/Umbraco.Core/Composing/ITypeFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -51,14 +51,5 @@ namespace Umbraco.Cms.Core.Composing
             Type attributeType,
             IEnumerable<Assembly> assemblies,
             bool onlyConcreteClasses);
-
-        /// <summary>
-        /// Gets a hash value of the current runtime
-        /// </summary>
-        /// <remarks>
-        /// This is used to detect if the runtime itself has changed, like a DLL has changed or another dynamically compiled
-        /// part of the application has changed. This is used to detect if we need to re-type scan.
-        /// </remarks>
-        string GetRuntimeHash();
     }
 }

--- a/src/Umbraco.Core/Composing/RuntimeHashPaths.cs
+++ b/src/Umbraco.Core/Composing/RuntimeHashPaths.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 
 namespace Umbraco.Cms.Core.Composing
 {
@@ -14,6 +15,24 @@ namespace Umbraco.Cms.Core.Composing
         public RuntimeHashPaths AddFolder(DirectoryInfo pathInfo)
         {
             _paths.Add(pathInfo);
+            return this;
+        }
+
+        /// <summary>
+        /// Creates a runtime hash based on the assembly provider
+        /// </summary>
+        /// <param name="assemblyProvider"></param>
+        /// <returns></returns>
+        public RuntimeHashPaths AddAssemblies(IAssemblyProvider assemblyProvider)
+        {
+            foreach (Assembly assembly in assemblyProvider.Assemblies)
+            {
+                // TODO: We need to test this on a published website
+                if (!assembly.IsDynamic && assembly.Location != null)
+                {
+                    AddFile(new FileInfo(assembly.Location));
+                }
+            }
             return this;
         }
 

--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -17,7 +17,6 @@ namespace Umbraco.Cms.Core.Composing
     {
         private readonly ILogger<TypeFinder> _logger;
         private readonly IAssemblyProvider _assemblyProvider;
-        private readonly IRuntimeHash _runtimeHash;
         private volatile HashSet<Assembly> _localFilteredAssemblyCache;
         private readonly object _localFilteredAssemblyCacheLocker = new object();
         private readonly List<string> _notifiedLoadExceptionAssemblies = new List<string>();
@@ -27,13 +26,12 @@ namespace Umbraco.Cms.Core.Composing
         // used for benchmark tests
         internal bool QueryWithReferencingAssemblies { get; set; } = true;
 
-        public TypeFinder(ILogger<TypeFinder> logger, IAssemblyProvider assemblyProvider, IRuntimeHash runtimeHash, ITypeFinderConfig typeFinderConfig = null)
+        public TypeFinder(ILogger<TypeFinder> logger, IAssemblyProvider assemblyProvider, ITypeFinderConfig typeFinderConfig = null)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _assemblyProvider = assemblyProvider;
-            _runtimeHash = runtimeHash;
             _typeFinderConfig = typeFinderConfig;
-     }
+        }
 
         private string[] _assembliesAcceptingLoadExceptions = null;
 
@@ -64,9 +62,12 @@ namespace Umbraco.Cms.Core.Composing
             var name = a.GetName().Name; // simple name of the assembly
             return AssembliesAcceptingLoadExceptions.Any(pattern =>
             {
-                if (pattern.Length > name.Length) return false; // pattern longer than name
-                if (pattern.Length == name.Length) return pattern.InvariantEquals(name); // same length, must be identical
-                if (pattern[pattern.Length] != '.') return false; // pattern is shorter than name, must end with dot
+                if (pattern.Length > name.Length)
+                    return false; // pattern longer than name
+                if (pattern.Length == name.Length)
+                    return pattern.InvariantEquals(name); // same length, must be identical
+                if (pattern[pattern.Length] != '.')
+                    return false; // pattern is shorter than name, must end with dot
                 return name.StartsWith(pattern); // and name must start with pattern
             });
         }
@@ -111,6 +112,8 @@ namespace Umbraco.Cms.Core.Composing
                             && x.GlobalAssemblyCache == false
                             && exclusionFilter.Any(f => x.FullName.StartsWith(f)) == false);
         }
+
+        // TODO: Kill this
 
         /// <summary>
         /// this is our assembly filter to filter out known types that def don't contain types we'd like to find or plugins
@@ -231,9 +234,6 @@ namespace Umbraco.Cms.Core.Composing
 
             return GetClassesWithAttribute(attributeType, assemblyList, onlyConcreteClasses);
         }
-
-        /// <inheritdoc />
-        public string GetRuntimeHash() => _runtimeHash.GetHashValue();
 
         /// <summary>
         /// Returns a Type for the string type name
@@ -455,7 +455,8 @@ namespace Umbraco.Cms.Core.Composing
                 var ex = new ReflectionTypeLoadException(rex.Types, rex.LoaderExceptions, sb.ToString());
 
                 // rethrow with new message, unless accepted
-                if (AcceptsLoadExceptions(a) == false) throw ex;
+                if (AcceptsLoadExceptions(a) == false)
+                    throw ex;
 
                 // log a warning, and return what we can
                 lock (_notifiedLoadExceptionAssemblies)

--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.Composing
         private volatile HashSet<Assembly> _localFilteredAssemblyCache;
         private readonly object _localFilteredAssemblyCacheLocker = new object();
         private readonly List<string> _notifiedLoadExceptionAssemblies = new List<string>();
-        private static readonly ConcurrentDictionary<string, Type> TypeNamesCache = new ConcurrentDictionary<string, Type>();
+        private static readonly ConcurrentDictionary<string, Type> s_typeNamesCache = new ConcurrentDictionary<string, Type>();
 
         private readonly ITypeFinderConfig _typeFinderConfig;
         // used for benchmark tests
@@ -255,7 +255,7 @@ namespace Umbraco.Cms.Core.Composing
             }
 
             // It didn't parse, so try loading from each already loaded assembly and cache it
-            return TypeNamesCache.GetOrAdd(name, s =>
+            return s_typeNamesCache.GetOrAdd(name, s =>
                 AppDomain.CurrentDomain.GetAssemblies()
                     .Select(x => x.GetType(s))
                     .FirstOrDefault(x => x != null));

--- a/src/Umbraco.Core/Composing/TypeFinderConfig.cs
+++ b/src/Umbraco.Core/Composing/TypeFinderConfig.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Configuration.UmbracoSettings;
@@ -15,17 +16,16 @@ namespace Umbraco.Cms.Core.Composing
         private readonly TypeFinderSettings _settings;
         private IEnumerable<string> _assembliesAcceptingLoadExceptions;
 
-        public TypeFinderConfig(IOptions<TypeFinderSettings> settings)
-        {
-            _settings = settings.Value;
-        }
+        public TypeFinderConfig(IOptions<TypeFinderSettings> settings) => _settings = settings.Value;
 
         public IEnumerable<string> AssembliesAcceptingLoadExceptions
         {
             get
             {
                 if (_assembliesAcceptingLoadExceptions != null)
+                {
                     return _assembliesAcceptingLoadExceptions;
+                }
 
                 var s = _settings.AssembliesAcceptingLoadExceptions;
                 return _assembliesAcceptingLoadExceptions = string.IsNullOrWhiteSpace(s)

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -96,6 +96,8 @@ namespace Umbraco.Cms.Core.Composing
                 //if they have changed, we need to write the new file
                 if (RequiresRescanning)
                 {
+                    _logger.LogDebug("Plugin types are being re-scanned. Cached hash value: {CachedHash}, Current hash value: {CurrentHash}", CachedAssembliesHash, CurrentAssembliesHash);
+
                     // if the hash has changed, clear out the persisted list no matter what, this will force
                     // rescanning of all types including lazy ones.
                     // http://issues.umbraco.org/issue/U4-4789

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
@@ -55,8 +54,8 @@ namespace Umbraco.Cms.Core.Composing
         /// <param name="localTempPath">Files storage location.</param>
         /// <param name="logger">A profiling logger.</param>
         /// <param name="assembliesToScan"></param>
-        public TypeLoader(ITypeFinder typeFinder, IAppPolicyCache runtimeCache, DirectoryInfo localTempPath, ILogger<TypeLoader> logger, IProfilingLogger profilingLogger, IEnumerable<Assembly> assembliesToScan = null)
-            : this(typeFinder, runtimeCache, localTempPath, logger, profilingLogger, true, assembliesToScan)
+        public TypeLoader(ITypeFinder typeFinder, IAppPolicyCache runtimeCache, DirectoryInfo localTempPath, ILogger<TypeLoader> logger, IProfiler profiler, IEnumerable<Assembly> assembliesToScan = null)
+            : this(typeFinder, runtimeCache, localTempPath, logger, profiler, true, assembliesToScan)
         { }
 
         /// <summary>
@@ -68,13 +67,18 @@ namespace Umbraco.Cms.Core.Composing
         /// <param name="logger">A profiling logger.</param>
         /// <param name="detectChanges">Whether to detect changes using hashes.</param>
         /// <param name="assembliesToScan"></param>
-        public TypeLoader(ITypeFinder typeFinder, IAppPolicyCache runtimeCache, DirectoryInfo localTempPath, ILogger<TypeLoader> logger, IProfilingLogger profilingLogger, bool detectChanges, IEnumerable<Assembly> assembliesToScan = null)
+        public TypeLoader(ITypeFinder typeFinder, IAppPolicyCache runtimeCache, DirectoryInfo localTempPath, ILogger<TypeLoader> logger, IProfiler profiler, bool detectChanges, IEnumerable<Assembly> assembliesToScan = null)
         {
+            if (profiler is null)
+            {
+                throw new ArgumentNullException(nameof(profiler));
+            }
+
             TypeFinder = typeFinder ?? throw new ArgumentNullException(nameof(typeFinder));
             _runtimeCache = runtimeCache ?? throw new ArgumentNullException(nameof(runtimeCache));
             _localTempPath = localTempPath;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _profilingLogger = profilingLogger ?? throw new ArgumentNullException(nameof(profilingLogger));
+            _profilingLogger = new ProfilingLogger(logger, profiler);
             _assemblies = assembliesToScan;
 
             _fileBasePath = new Lazy<string>(GetFileBasePath);

--- a/src/Umbraco.Core/Configuration/Models/TypeFinderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/TypeFinderSettings.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Collections;
+using System.Collections.Generic;
+
 namespace Umbraco.Cms.Core.Configuration.Models
 {
     /// <summary>
@@ -13,5 +16,11 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// Gets or sets a value for the assemblies that accept load exceptions during type finder operations.
         /// </summary>
         public string AssembliesAcceptingLoadExceptions { get; set; }
+
+        /// <summary>
+        /// By default the entry assemblies for scanning plugin types is the Umbraco DLLs. If you require
+        /// scanning for plugins based on different root referenced assemblies you can add the assembly name to this list.
+        /// </summary>
+        public IEnumerable<string> AdditionalEntryAssemblies { get; set; }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/IUmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/IUmbracoBuilder.cs
@@ -1,7 +1,10 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Logging;
 
 namespace Umbraco.Cms.Core.DependencyInjection
 {
@@ -10,7 +13,24 @@ namespace Umbraco.Cms.Core.DependencyInjection
         IServiceCollection Services { get; }
         IConfiguration Config { get; }
         TypeLoader TypeLoader { get; }
+
+        /// <summary>
+        /// A Logger factory created specifically for the <see cref="IUmbracoBuilder"/>. This is NOT the same
+        /// instance that will be resolved from DI. Use only if required during configuration.
+        /// </summary>
         ILoggerFactory BuilderLoggerFactory { get; }
+
+        /// <summary>
+        /// A hosting environment created specifically for the <see cref="IUmbracoBuilder"/>. This is NOT the same
+        /// instance that will be resolved from DI. Use only if required during configuration.
+        /// </summary>
+        /// <remarks>
+        /// This may be null.
+        /// </remarks>
+        IHostingEnvironment BuilderHostingEnvironment { get; }
+
+        IProfiler Profiler { get; }
+        AppCaches AppCaches { get; }
         TBuilder WithCollectionBuilder<TBuilder>() where TBuilder : ICollectionBuilder, new();
         void Build();
     }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -52,23 +52,41 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
         public TypeLoader TypeLoader { get; }
 
+        /// <inheritdoc />
         public ILoggerFactory BuilderLoggerFactory { get; }
 
+        /// <inheritdoc />
+        public IHostingEnvironment BuilderHostingEnvironment { get; }
+
+        public IProfiler Profiler { get; }
+
+        public AppCaches AppCaches { get; }
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoBuilder"/> class.
+        /// Initializes a new instance of the <see cref="UmbracoBuilder"/> class primarily for testing.
         /// </summary>
         public UmbracoBuilder(IServiceCollection services, IConfiguration config, TypeLoader typeLoader)
-            : this(services, config, typeLoader, NullLoggerFactory.Instance)
+            : this(services, config, typeLoader, NullLoggerFactory.Instance, new NoopProfiler(), AppCaches.Disabled, null)
         { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoBuilder"/> class.
         /// </summary>
-        public UmbracoBuilder(IServiceCollection services, IConfiguration config, TypeLoader typeLoader, ILoggerFactory loggerFactory)
+        public UmbracoBuilder(
+            IServiceCollection services,
+            IConfiguration config,
+            TypeLoader typeLoader,
+            ILoggerFactory loggerFactory,
+            IProfiler profiler,
+            AppCaches appCaches,
+            IHostingEnvironment hostingEnvironment)
         {
             Services = services;
             Config = config;
             BuilderLoggerFactory = loggerFactory;
+            BuilderHostingEnvironment = hostingEnvironment;
+            Profiler = profiler;
+            AppCaches = appCaches;
             TypeLoader = typeLoader;
 
             AddCoreServices();
@@ -106,6 +124,9 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
         private void AddCoreServices()
         {
+            Services.AddSingleton(AppCaches);
+            Services.AddSingleton(Profiler);
+
             // Register as singleton to allow injection everywhere.
             Services.AddSingleton<ServiceFactory>(p => p.GetService);
             Services.AddSingleton<IEventAggregator, EventAggregator>();

--- a/src/Umbraco.Core/HashGenerator.cs
+++ b/src/Umbraco.Core/HashGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -73,14 +73,12 @@ namespace Umbraco.Cms.Core
             AddDateTime(f.LastWriteTimeUtc);
 
             //check if it is a file or folder
-            var fileInfo = f as FileInfo;
-            if (fileInfo != null)
+            if (f is FileInfo fileInfo)
             {
                 AddLong(fileInfo.Length);
             }
 
-            var dirInfo = f as DirectoryInfo;
-            if (dirInfo != null)
+            if (f is DirectoryInfo dirInfo)
             {
                 foreach (var d in dirInfo.GetFiles())
                 {

--- a/src/Umbraco.Core/IO/FileSystemExtensions.cs
+++ b/src/Umbraco.Core/IO/FileSystemExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using Umbraco.Cms.Core.IO;
 
@@ -7,6 +9,25 @@ namespace Umbraco.Extensions
 {
     public static class FileSystemExtensions
     {
+        public static string GetStreamHash(this Stream fileStream)
+        {
+            if (fileStream.CanSeek)
+            {
+                fileStream.Seek(0, SeekOrigin.Begin);
+            }
+
+            using HashAlgorithm alg = SHA1.Create();
+
+            // create a string output for the hash
+            var stringBuilder = new StringBuilder();
+            var hashedByteArray = alg.ComputeHash(fileStream);
+            foreach (var b in hashedByteArray)
+            {
+                stringBuilder.Append(b.ToString("x2"));
+            }
+            return stringBuilder.ToString();
+        }
+
         /// <summary>
         /// Attempts to open the file at <code>filePath</code> up to <code>maxRetries</code> times,
         /// with a thread sleep time of <code>sleepPerRetryInMilliseconds</code> between retries.

--- a/src/Umbraco.Core/Logging/ProfilingLogger.cs
+++ b/src/Umbraco.Core/Logging/ProfilingLogger.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.Logging
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilingLogger"/> class.
         /// </summary>
-        public ProfilingLogger(ILogger<ProfilingLogger> logger, IProfiler profiler)
+        public ProfilingLogger(ILogger logger, IProfiler profiler)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Profiler = profiler ?? throw new ArgumentNullException(nameof(profiler));

--- a/src/Umbraco.Core/Logging/ProfilingLogger.cs
+++ b/src/Umbraco.Core/Logging/ProfilingLogger.cs
@@ -21,6 +21,15 @@ namespace Umbraco.Cms.Core.Logging
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilingLogger"/> class.
         /// </summary>
+        public ProfilingLogger(ILogger<ProfilingLogger> logger, IProfiler profiler)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            Profiler = profiler ?? throw new ArgumentNullException(nameof(profiler));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfilingLogger"/> class.
+        /// </summary>
         public ProfilingLogger(ILogger logger, IProfiler profiler)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/Umbraco.Core/Templates/HtmlUrlParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlUrlParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Core.Templates
         private static readonly Regex ResolveUrlPattern = new Regex("(=[\"\']?)(\\W?\\~(?:.(?![\"\']?\\s+(?:\\S+)=|[>\"\']))+.)[\"\']?",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        public HtmlUrlParser(IOptions<ContentSettings> contentSettings, ILogger<HtmlUrlParser> logger ,IProfilingLogger profilingLogger, IIOHelper ioHelper)
+        public HtmlUrlParser(IOptions<ContentSettings> contentSettings, ILogger<HtmlUrlParser> logger, IProfilingLogger profilingLogger, IIOHelper ioHelper)
         {
             _contentSettings = contentSettings.Value;
             _logger = logger;
@@ -36,7 +36,8 @@ namespace Umbraco.Cms.Core.Templates
         /// </remarks>
         public string EnsureUrls(string text)
         {
-            if (_contentSettings.ResolveUrlsFromTextString == false) return text;
+            if (_contentSettings.ResolveUrlsFromTextString == false)
+                return text;
 
             using (var timer = _profilingLogger.DebugDuration(typeof(IOHelper), "ResolveUrlsFromTextString starting", "ResolveUrlsFromTextString complete"))
             {

--- a/src/Umbraco.Tests.Benchmarks/TypeFinderBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/TypeFinderBenchmarks.cs
@@ -16,8 +16,8 @@ namespace Umbraco.Tests.Benchmarks
 
         public TypeFinderBenchmarks()
         {
-            _typeFinder1 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
-            _typeFinder2 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash())
+            _typeFinder1 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance));
+            _typeFinder2 = new TypeFinder(new NullLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance))
             {
                 QueryWithReferencingAssemblies = false
             };

--- a/src/Umbraco.Tests.Benchmarks/TypeLoaderBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/TypeLoaderBenchmarks.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Tests.Benchmarks
 
             // populate the cache
             cache.Insert(
-                TypeLoader.CacheKey,
+                _typeLoader1.CacheKey,
                 GetCache,
                 TimeSpan.FromDays(1));
 

--- a/src/Umbraco.Tests.Benchmarks/TypeLoaderBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/TypeLoaderBenchmarks.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Tests.Benchmarks
                 cache,
                 null,
                 new NullLogger<TypeLoader>(),
-                new ProfilingLogger(new NullLogger<ProfilingLogger>(), new NoopProfiler()));
+                new NoopProfiler());
 
             // populate the cache
             cache.Insert(
@@ -43,7 +43,7 @@ namespace Umbraco.Tests.Benchmarks
                 NoAppCache.Instance,
                 null,
                 new NullLogger<TypeLoader>(),
-                new ProfilingLogger(new NullLogger<ProfilingLogger>(), new NoopProfiler()));
+                new NoopProfiler());
         }
 
         /// <summary>

--- a/src/Umbraco.Tests.Benchmarks/TypeLoaderBenchmarks.cs
+++ b/src/Umbraco.Tests.Benchmarks/TypeLoaderBenchmarks.cs
@@ -21,12 +21,12 @@ namespace Umbraco.Tests.Benchmarks
         {
             var typeFinder1 = new TypeFinder(
                 new NullLogger<TypeFinder>(),
-                new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance),
-                new VaryingRuntimeHash());
+                new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance));
 
             var cache = new ObjectCacheAppCache();
             _typeLoader1 = new TypeLoader(
                 typeFinder1,
+                new VaryingRuntimeHash(),
                 cache,
                 null,
                 new NullLogger<TypeLoader>(),
@@ -40,6 +40,7 @@ namespace Umbraco.Tests.Benchmarks
 
             _typeLoader2 = new TypeLoader(
                 typeFinder1,
+                new VaryingRuntimeHash(),
                 NoAppCache.Instance,
                 null,
                 new NullLogger<TypeLoader>(),

--- a/src/Umbraco.Tests.Common/TestHelperBase.cs
+++ b/src/Umbraco.Tests.Common/TestHelperBase.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Tests.Common
         public ITypeFinder GetTypeFinder() => _typeFinder;
 
         public TypeLoader GetMockedTypeLoader() =>
-            new TypeLoader(Mock.Of<ITypeFinder>(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfilingLogger>());
+            new TypeLoader(Mock.Of<ITypeFinder>(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
 
         //// public Configs GetConfigs() => GetConfigsFactory().Create();
 

--- a/src/Umbraco.Tests.Common/TestHelperBase.cs
+++ b/src/Umbraco.Tests.Common/TestHelperBase.cs
@@ -44,13 +44,13 @@ namespace Umbraco.Cms.Tests.Common
         protected TestHelperBase(Assembly entryAssembly)
         {
             MainDom = new SimpleMainDom();
-            _typeFinder = new TypeFinder(NullLoggerFactory.Instance.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(entryAssembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
+            _typeFinder = new TypeFinder(NullLoggerFactory.Instance.CreateLogger<TypeFinder>(), new DefaultUmbracoAssemblyProvider(entryAssembly, NullLoggerFactory.Instance));
         }
 
         public ITypeFinder GetTypeFinder() => _typeFinder;
 
         public TypeLoader GetMockedTypeLoader() =>
-            new TypeLoader(Mock.Of<ITypeFinder>(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
+            new TypeLoader(Mock.Of<ITypeFinder>(), new VaryingRuntimeHash(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
 
         //// public Configs GetConfigs() => GetConfigsFactory().Create();
 

--- a/src/Umbraco.Tests.Integration/TestServerTest/UmbracoTestServerTestBase.cs
+++ b/src/Umbraco.Tests.Integration/TestServerTest/UmbracoTestServerTestBase.cs
@@ -134,10 +134,8 @@ namespace Umbraco.Cms.Tests.Integration.TestServerTest
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddTransient<TestUmbracoDatabaseFactoryProvider>();
-            IWebHostEnvironment webHostEnvironment = TestHelper.GetWebHostEnvironment();
             TypeLoader typeLoader = services.AddTypeLoader(
                 GetType().Assembly,
-                webHostEnvironment,
                 TestHelper.GetHostingEnvironment(),
                 TestHelper.ConsoleLoggerFactory,
                 AppCaches.NoCache,

--- a/src/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/src/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -202,14 +202,15 @@ namespace Umbraco.Cms.Tests.Integration.Testing
             services.AddRequiredNetCoreServices(TestHelper, webHostEnvironment);
 
             // Add it!
+            Core.Hosting.IHostingEnvironment hostingEnvironment = TestHelper.GetHostingEnvironment();
             TypeLoader typeLoader = services.AddTypeLoader(
                 GetType().Assembly,
-                TestHelper.GetHostingEnvironment(),
+                hostingEnvironment,
                 TestHelper.ConsoleLoggerFactory,
                 AppCaches.NoCache,
                 Configuration,
                 TestHelper.Profiler);
-            var builder = new UmbracoBuilder(services, Configuration, typeLoader, TestHelper.ConsoleLoggerFactory);
+            var builder = new UmbracoBuilder(services, Configuration, typeLoader, TestHelper.ConsoleLoggerFactory, TestHelper.Profiler, AppCaches.NoCache, hostingEnvironment);
 
             builder.Services.AddLogger(TestHelper.GetHostingEnvironment(), TestHelper.GetLoggingConfiguration(), Configuration);
 

--- a/src/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/src/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -204,7 +204,6 @@ namespace Umbraco.Cms.Tests.Integration.Testing
             // Add it!
             TypeLoader typeLoader = services.AddTypeLoader(
                 GetType().Assembly,
-                webHostEnvironment,
                 TestHelper.GetHostingEnvironment(),
                 TestHelper.ConsoleLoggerFactory,
                 AppCaches.NoCache,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
 
         private static IServiceCollection MockRegister() => new ServiceCollection();
 
-        private static TypeLoader MockTypeLoader() => new TypeLoader(Mock.Of<ITypeFinder>(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfilingLogger>());
+        private static TypeLoader MockTypeLoader() => new TypeLoader(Mock.Of<ITypeFinder>(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
 
         [Test]
         public void Boot1A()
@@ -438,7 +438,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
         public void AllComposers()
         {
             ITypeFinder typeFinder = TestHelper.GetTypeFinder();
-            var typeLoader = new TypeLoader(typeFinder, AppCaches.Disabled.RuntimeCache, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfilingLogger>());
+            var typeLoader = new TypeLoader(typeFinder, AppCaches.Disabled.RuntimeCache, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
 
             IServiceCollection register = MockRegister();
             var builder = new UmbracoBuilder(register, Mock.Of<IConfiguration>(), TestHelper.GetMockedTypeLoader());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
 
         private static IServiceCollection MockRegister() => new ServiceCollection();
 
-        private static TypeLoader MockTypeLoader() => new TypeLoader(Mock.Of<ITypeFinder>(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
+        private static TypeLoader MockTypeLoader() => new TypeLoader(Mock.Of<ITypeFinder>(), new VaryingRuntimeHash(), Mock.Of<IAppPolicyCache>(), new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
 
         [Test]
         public void Boot1A()
@@ -438,7 +438,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
         public void AllComposers()
         {
             ITypeFinder typeFinder = TestHelper.GetTypeFinder();
-            var typeLoader = new TypeLoader(typeFinder, AppCaches.Disabled.RuntimeCache, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
+            var typeLoader = new TypeLoader(typeFinder, new VaryingRuntimeHash(), AppCaches.Disabled.RuntimeCache, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>());
 
             IServiceCollection register = MockRegister();
             var builder = new UmbracoBuilder(register, Mock.Of<IConfiguration>(), TestHelper.GetMockedTypeLoader());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/ComposingTestBase.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/ComposingTestBase.cs
@@ -19,15 +19,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
     {
         protected TypeLoader TypeLoader { get; private set; }
 
-        protected IProfilingLogger ProfilingLogger { get; private set; }
-
         [SetUp]
         public void Initialize()
         {
-            ProfilingLogger = new ProfilingLogger(Mock.Of<ILogger<ProfilingLogger>>(), Mock.Of<IProfiler>());
-
             var typeFinder = TestHelper.GetTypeFinder();
-            TypeLoader = new TypeLoader(typeFinder, NoAppCache.Instance, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), ProfilingLogger, false, AssembliesToScan);
+            TypeLoader = new TypeLoader(typeFinder, NoAppCache.Instance, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>(), false, AssembliesToScan);
         }
 
         protected virtual IEnumerable<Assembly> AssembliesToScan

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/ComposingTestBase.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/ComposingTestBase.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
         public void Initialize()
         {
             var typeFinder = TestHelper.GetTypeFinder();
-            TypeLoader = new TypeLoader(typeFinder, NoAppCache.Instance, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>(), false, AssembliesToScan);
+            TypeLoader = new TypeLoader(typeFinder, new VaryingRuntimeHash(), NoAppCache.Instance, new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)), Mock.Of<ILogger<TypeLoader>>(), Mock.Of<IProfiler>(), false, AssembliesToScan);
         }
 
         protected virtual IEnumerable<Assembly> AssembliesToScan

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeFinderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeFinderTests.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
         [Test]
         public void Find_Class_Of_Type_With_Attribute()
         {
-            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
+            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance));
             IEnumerable<Type> typesFound = typeFinder.FindClassesOfTypeWithAttribute<TestEditor, MyTestAttribute>(_assemblies);
             Assert.AreEqual(2, typesFound.Count());
         }
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
         [Test]
         public void Find_Classes_With_Attribute()
         {
-            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance), new VaryingRuntimeHash());
+            var typeFinder = new TypeFinder(Mock.Of<ILogger<TypeFinder>>(), new DefaultUmbracoAssemblyProvider(GetType().Assembly, NullLoggerFactory.Instance));
             IEnumerable<Type> typesFound = typeFinder.FindClassesWithAttribute<TreeAttribute>(_assemblies);
             Assert.AreEqual(0, typesFound.Count()); // 0 classes in _assemblies are marked with [Tree]
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
                 NoAppCache.Instance,
                 new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)),
                 Mock.Of<ILogger<TypeLoader>>(),
-                new ProfilingLogger(Mock.Of<ILogger<ProfilingLogger>>(), Mock.Of<IProfiler>()),
+                Mock.Of<IProfiler>(),
                 false,
                 assemblies);
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
@@ -48,6 +48,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
                 };
             _typeLoader = new TypeLoader(
                 typeFinder,
+                new VaryingRuntimeHash(),
                 NoAppCache.Instance,
                 new DirectoryInfo(TestHelper.GetHostingEnvironment().MapPathContentRoot(Constants.SystemDirectories.TempData)),
                 Mock.Of<ILogger<TypeLoader>>(),

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -106,7 +106,14 @@ namespace Umbraco.Extensions
             IProfiler profiler = GetWebProfiler(config);
             
             ILoggerFactory loggerFactory = LoggerFactory.Create(cfg => cfg.AddSerilog(Log.Logger, false));
-            TypeLoader typeLoader = services.AddTypeLoader(Assembly.GetEntryAssembly(), tempHostingEnvironment, loggerFactory, appCaches, config, profiler);
+
+            TypeLoader typeLoader = services.AddTypeLoader(
+                Assembly.GetEntryAssembly(),
+                tempHostingEnvironment,
+                loggerFactory,
+                appCaches,
+                config,
+                profiler);
 
             // adds the umbraco startup filter which will call UseUmbraco early on before
             // other start filters are applied (depending on the ordering of IStartupFilters in DI).

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -101,12 +101,10 @@ namespace Umbraco.Extensions
             services.AddSingleton(httpContextAccessor);
 
             var requestCache = new HttpContextRequestAppCache(httpContextAccessor);
-            var appCaches = AppCaches.Create(requestCache);
-            services.AddUnique(appCaches);
+            var appCaches = AppCaches.Create(requestCache);            
 
             IProfiler profiler = GetWebProfiler(config);
-            services.AddUnique(profiler);
-
+            
             ILoggerFactory loggerFactory = LoggerFactory.Create(cfg => cfg.AddSerilog(Log.Logger, false));
             TypeLoader typeLoader = services.AddTypeLoader(Assembly.GetEntryAssembly(), tempHostingEnvironment, loggerFactory, appCaches, config, profiler);
 
@@ -114,7 +112,7 @@ namespace Umbraco.Extensions
             // other start filters are applied (depending on the ordering of IStartupFilters in DI).
             services.AddTransient<IStartupFilter, UmbracoApplicationServicesCapture>();
 
-            return new UmbracoBuilder(services, config, typeLoader, loggerFactory);
+            return new UmbracoBuilder(services, config, typeLoader, loggerFactory, profiler, appCaches, tempHostingEnvironment);
         }
 
         /// <summary>

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -108,7 +108,7 @@ namespace Umbraco.Extensions
             services.AddUnique(profiler);
 
             ILoggerFactory loggerFactory = LoggerFactory.Create(cfg => cfg.AddSerilog(Log.Logger, false));
-            TypeLoader typeLoader = services.AddTypeLoader(Assembly.GetEntryAssembly(), webHostEnvironment, tempHostingEnvironment, loggerFactory, appCaches, config, profiler);
+            TypeLoader typeLoader = services.AddTypeLoader(Assembly.GetEntryAssembly(), tempHostingEnvironment, loggerFactory, appCaches, config, profiler);
 
             // adds the umbraco startup filter which will call UseUmbraco early on before
             // other start filters are applied (depending on the ordering of IStartupFilters in DI).


### PR DESCRIPTION
we are calculating the runtime hash incorrectly in v9. Have a look at the code in AddTypeFinder we do:

```cs
var runtimeHashPaths = new RuntimeHashPaths().AddFolder(new DirectoryInfo(Path.Combine(webHostEnvironment.ContentRootPath, "bin")));
```

There is no 'bin' folder so this will just be the same and we'll never type scan again. We need to re-think this for netcore based on the current environment. For example, if it's a published project, in which case everything exists in the root, else if it's a development project, in which case the binaries live in the /bin/....

So this fix just uses the Assembly provider to use returned assemblies for calculating the hash.

But wait... there's more! This also fixes the issue https://github.com/umbraco/Umbraco-CMS/issues/10554 where for custom apps that need to search for types based on a different entry assembly it was almost impossible (although I thought it was at the time). So this changes a few things:

* Changes some dependency chain issues with TypeFinder/Loader and others
* Allows for configuring additional entry point assemblies for the TypeFinder
* Exposes startup services on the IUmbracoBuilder if people absolutely require those services since it's impossible to reference them otherwise 
* Fixes issue with TypeLoader to use a cache key dependant on the passed in runtime hash value so that if additional TypeLoaders are created they can co-exist
* Allows for creating a ProfilingLogger with a generic logger so that it logs under a specific type instead of just "ProfilingLogger" which is mostly unhelpful.
* Some additional code to prevent re-allocating strings and collections.