### PR TITLE
Refactor NPoco queries to use constants and dtos

### DIFF
--- a/src/Umbraco.Core/Persistence/Dtos/DictionaryDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/DictionaryDto.cs
@@ -11,6 +11,7 @@ namespace Umbraco.Core.Persistence.Dtos
     internal class DictionaryDto
     {
         public const string TableName = Constants.DatabaseSchema.Tables.DictionaryEntry;
+
         [Column("pk")]
         [PrimaryKeyColumn]
         public int PrimaryKey { get; set; }

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -134,7 +134,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             if (objectTypes.Any())
             {
-                sql = sql.Where("umbracoNode.nodeObjectType IN (@objectTypes)", new { objectTypes = objectTypes });
+                sql = sql.WhereIn<NodeDto>(dto => dto.NodeObjectType, objectTypes);
             }
 
             return Database.Fetch<string>(sql);
@@ -173,7 +173,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoNode.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Node}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -58,10 +58,10 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IEnumerable<IDictionaryItem> PerformGetAll(params int[] ids)
         {
-            var sql = GetBaseQuery(false).Where("cmsDictionary.pk > 0");
+            var sql = GetBaseQuery(false).Where<DictionaryDto>(x => x.PrimaryKey > 0);
             if (ids.Any())
             {
-                sql.Where("cmsDictionary.pk in (@ids)", new { /*ids =*/ ids });
+                sql.WhereIn<DictionaryDto>(x => x.PrimaryKey, ids);
             }
 
             return Database
@@ -105,7 +105,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "cmsDictionary.pk = @id";
+            return $"{Constants.DatabaseSchema.Tables.DictionaryEntry}.pk = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/DomainRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/DomainRepository.cs
@@ -34,10 +34,10 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IEnumerable<IDomain> PerformGetAll(params int[] ids)
         {
-            var sql = GetBaseQuery(false).Where("umbracoDomain.id > 0");
+            var sql = GetBaseQuery(false).Where<DomainDto>(x => x.Id > 0);
             if (ids.Any())
             {
-                sql.Where("umbracoDomain.id in (@ids)", new { ids = ids });
+                sql.WhereIn<DomainDto>(x => x.Id, ids);
             }
 
             return Database.Fetch<DomainDto>(sql).Select(ConvertFromDto);
@@ -68,7 +68,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoDomain.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Domain}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -160,7 +160,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoExternalLogin.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.ExternalLogin}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -41,15 +41,15 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override IEnumerable<ILanguage> PerformGetAll(params int[] ids)
         {
-            var sql = GetBaseQuery(false).Where("umbracoLanguage.id > 0");
+            var sql = GetBaseQuery(false).Where<LanguageDto>(x => x.Id > 0);
             if (ids.Any())
             {
-                sql.Where("umbracoLanguage.id in (@ids)", new { ids = ids });
+                sql.WhereIn<LanguageDto>(x => x.Id, ids);
             }
 
             //this needs to be sorted since that is the way legacy worked - default language is the first one!!
             //even though legacy didn't sort, it should be by id
-            sql.OrderBy<LanguageDto>(dto => dto.Id);
+            sql.OrderBy<LanguageDto>(x => x.Id);
 
             // get languages
             var languages = Database.Fetch<LanguageDto>(sql).Select(ConvertFromDto).OrderBy(x => x.Id).ToList();
@@ -90,14 +90,14 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 ? sql.SelectCount()
                 : sql.Select<LanguageDto>();
 
-            sql
-               .From<LanguageDto>();
+            sql.From<LanguageDto>();
+
             return sql;
         }
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoLanguage.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Language}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MacroRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MacroRepository.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         public IMacro Get(Guid id)
         {
-            var sql = GetBaseQuery().Where("uniqueId=@Id", new { Id = id });
+            var sql = GetBaseQuery().Where<MacroDto>(x => x.UniqueId == id);
             return GetBySql(sql);
         }
 
@@ -115,7 +115,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "cmsMacro.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Macro}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoNode.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Node}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -257,7 +257,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 .InnerJoin<Member2MemberGroupDto>()
                 .On<NodeDto, Member2MemberGroupDto>(dto => dto.NodeId, dto => dto.MemberGroup)
                 .Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId)
-                .Where("cmsMember2MemberGroup.Member in (@ids)", new { ids = memberIds });
+                .WhereIn<Member2MemberGroupDto>(x => x.Member, memberIds);
 
             var currentlyAssigned = Database.Fetch<AssignedRolesDto>(assignedSql).ToArray();
 
@@ -271,6 +271,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 var found = currentlyAssigned.Where(x => x.MemberId == mId).ToArray();
                 var assignedRoles = found.Where(x => roleNames.Contains(x.RoleName, StringComparer.CurrentCultureIgnoreCase)).Select(x => x.RoleName);
                 var nonAssignedRoles = roleNames.Except(assignedRoles, StringComparer.CurrentCultureIgnoreCase);
+
                 foreach (var toAssign in nonAssignedRoles)
                 {
                     var groupId = rolesForNames.First(x => x.Text.InvariantEquals(toAssign)).NodeId;

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 .Where<NodeDto>(dto => dto.NodeObjectType == NodeObjectTypeId);
 
             if (ids.Any())
-                sql.Where("umbracoNode.id in (@ids)", new { /*ids =*/ ids });
+                sql.WhereIn<NodeDto>(x => x.NodeId, ids);
 
             return Database.Fetch<NodeDto>(sql).Select(x => MemberGroupFactory.BuildEntity(x));
         }
@@ -118,7 +118,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
         public IMemberGroup Get(Guid uniqueId)
         {
             var sql = GetBaseQuery(false);
-            sql.Where("umbracoNode.uniqueId = @uniqueId", new { uniqueId });
+            sql.Where<NodeDto>(x => x.UniqueId == uniqueId);
 
             var dto = Database.Fetch<NodeDto>(SqlSyntax.SelectTop(sql, 1)).FirstOrDefault();
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberRepository.cs
@@ -437,9 +437,11 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             foreach (var batch in inGroups)
             {
                 var memberIdBatch = batch.Select(x => x.Id);
+
                 var sql = Sql().SelectAll().From<Member2MemberGroupDto>()
                     .Where<Member2MemberGroupDto>(dto => dto.MemberGroup == memberGroup.Id)
-                    .Where("Member IN (@memberIds)", new { memberIds = memberIdBatch });
+                    .WhereIn<Member2MemberGroupDto>(dto => dto.Member, memberIdBatch);
+
                 var memberIdsInGroup = Database.Fetch<Member2MemberGroupDto>(sql)
                     .Select(x => x.Member).ToArray();
 

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoNode.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Node}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/PublicAccessRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/PublicAccessRepository.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
             if (ids.Any())
             {
-                sql.Where("umbracoAccess.id IN (@ids)", new { ids });
+                sql.WhereIn<AccessDto>(x => x.Id, ids);
             }
 
             sql.OrderBy<AccessDto>(x => x.NodeId);
@@ -66,7 +66,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoAccess.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Access}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationRepository.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoRelation.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Relation}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/RelationTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/RelationTypeRepository.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoRelationType.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.RelationType}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -116,7 +116,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return Constants.DatabaseSchema.Tables.Node + ".id = @id";
+            return $"{Constants.DatabaseSchema.Tables.Node}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -271,7 +271,7 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoUserGroup.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.UserGroup}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/UserRepository.cs
@@ -420,7 +420,7 @@ ORDER BY colName";
 
         protected override string GetBaseWhereClause()
         {
-            return "umbracoUser.id = @id";
+            return $"{Constants.DatabaseSchema.Tables.User}.id = @id";
         }
 
         protected override IEnumerable<string> GetDeleteClauses()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed some SQL querying which combined some strongly typed qyerying using NPoco and static text. While we still can construct sql as strings many places we can use the constants or dto classes to avoid making typos.

There `WhereIn<T>` method makes it very easy to construct sql `IN` queries with less code.