### PR TITLE
Changes all collections from collection builders to resolve the concrete instances lazily.

### DIFF
--- a/src/Umbraco.Core/Actions/ActionCollection.cs
+++ b/src/Umbraco.Core/Actions/ActionCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models.Membership;
@@ -8,15 +9,12 @@ namespace Umbraco.Cms.Core.Actions
 {
     public class ActionCollection : BuilderCollectionBase<IAction>
     {
-        public ActionCollection(IEnumerable<IAction> items)
-            : base(items)
-        { }
+        public ActionCollection(Func<IEnumerable<IAction>> items) : base(items)
+        {
+        }
 
         public T GetAction<T>()
-            where T : IAction
-        {
-            return this.OfType<T>().FirstOrDefault();
-        }
+            where T : IAction => this.OfType<T>().FirstOrDefault();
 
         public IEnumerable<IAction> GetByLetters(IEnumerable<string> letters)
         {

--- a/src/Umbraco.Core/Cache/CacheRefresherCollection.cs
+++ b/src/Umbraco.Core/Cache/CacheRefresherCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Cms.Core.Composing;
@@ -7,11 +7,11 @@ namespace Umbraco.Cms.Core.Cache
 {
     public class CacheRefresherCollection : BuilderCollectionBase<ICacheRefresher>
     {
-        public CacheRefresherCollection(IEnumerable<ICacheRefresher> items)
-            : base(items)
-        { }
+        public CacheRefresherCollection(Func<IEnumerable<ICacheRefresher>> items) : base(items)
+        {
+        }
 
         public ICacheRefresher this[Guid id]
-            =>  this.FirstOrDefault(x => x.RefresherUniqueId == id);
+            => this.FirstOrDefault(x => x.RefresherUniqueId == id);
     }
 }

--- a/src/Umbraco.Core/Composing/BuilderCollectionBase.cs
+++ b/src/Umbraco.Core/Composing/BuilderCollectionBase.cs
@@ -1,43 +1,34 @@
-﻿using System.Collections;
+using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Umbraco.Cms.Core.Composing
 {
+
     /// <summary>
     /// Provides a base class for builder collections.
     /// </summary>
     /// <typeparam name="TItem">The type of the items.</typeparam>
     public abstract class BuilderCollectionBase<TItem> : IBuilderCollection<TItem>
     {
-        private readonly TItem[] _items;
+        private readonly LazyReadOnlyCollection<TItem> _items;
 
-        /// <summary>
         /// Initializes a new instance of the <see cref="BuilderCollectionBase{TItem}"/> with items.
         /// </summary>
         /// <param name="items">The items.</param>
-        protected BuilderCollectionBase(IEnumerable<TItem> items)
-        {
-            _items = items.ToArray();
-        }
+        public BuilderCollectionBase(Func<IEnumerable<TItem>> items) => _items = new LazyReadOnlyCollection<TItem>(items);
 
         /// <inheritdoc />
-        public int Count => _items.Length;
+        public int Count => _items.Count;
 
         /// <summary>
         /// Gets an enumerator.
         /// </summary>
-        public IEnumerator<TItem> GetEnumerator()
-        {
-            return ((IEnumerable<TItem>) _items).GetEnumerator();
-        }
+        public IEnumerator<TItem> GetEnumerator() => ((IEnumerable<TItem>)_items).GetEnumerator();
 
         /// <summary>
         /// Gets an enumerator.
         /// </summary>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Umbraco.Core/Composing/CollectionBuilderBase.cs
+++ b/src/Umbraco.Core/Composing/CollectionBuilderBase.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Composing
     /// <typeparam name="TCollection">The type of the collection.</typeparam>
     /// <typeparam name="TItem">The type of the items.</typeparam>
     public abstract class CollectionBuilderBase<TBuilder, TCollection, TItem> : ICollectionBuilder<TCollection, TItem>
-        where TBuilder: CollectionBuilderBase<TBuilder, TCollection, TItem>
+        where TBuilder : CollectionBuilderBase<TBuilder, TCollection, TItem>
         where TCollection : class, IBuilderCollection<TItem>
     {
         private readonly List<Type> _types = new List<Type>();
@@ -73,7 +73,8 @@ namespace Umbraco.Cms.Core.Composing
         {
             lock (_locker)
             {
-                if (_registeredTypes != null) return;
+                if (_registeredTypes != null)
+                    return;
 
                 var types = GetRegisteringTypes(_types).ToArray();
 
@@ -110,7 +111,7 @@ namespace Umbraco.Cms.Core.Composing
         /// Creates a collection item.
         /// </summary>
         protected virtual TItem CreateItem(IServiceProvider factory, Type itemType)
-            => (TItem) factory.GetRequiredService(itemType);
+            => (TItem)factory.GetRequiredService(itemType);
 
         /// <summary>
         /// Creates a collection.
@@ -118,9 +119,10 @@ namespace Umbraco.Cms.Core.Composing
         /// <returns>A collection.</returns>
         /// <remarks>Creates a new collection each time it is invoked.</remarks>
         public virtual TCollection CreateCollection(IServiceProvider factory)
-        {
-            return factory.CreateInstance<TCollection>(  CreateItems(factory));
-        }
+            => factory.CreateInstance<TCollection>(CreateItemsFactory(factory));
+
+        // used to resolve a Func<IEnumerable<TItem>> parameter
+        private Func<IEnumerable<TItem>> CreateItemsFactory(IServiceProvider factory) => () => CreateItems(factory);
 
         protected Type EnsureType(Type type, string action)
         {
@@ -139,7 +141,7 @@ namespace Umbraco.Cms.Core.Composing
         public virtual bool Has<T>()
             where T : TItem
         {
-            return _types.Contains(typeof (T));
+            return _types.Contains(typeof(T));
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Composing/ComponentCollection.cs
+++ b/src/Umbraco.Core/Composing/ComponentCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Core.Composing
         private readonly IProfilingLogger _profilingLogger;
         private readonly ILogger<ComponentCollection> _logger;
 
-        public ComponentCollection(IEnumerable<IComponent> items, IProfilingLogger profilingLogger, ILogger<ComponentCollection> logger)
+        public ComponentCollection(Func<IEnumerable<IComponent>> items, IProfilingLogger profilingLogger, ILogger<ComponentCollection> logger)
             : base(items)
         {
             _profilingLogger = profilingLogger;

--- a/src/Umbraco.Core/Composing/LazyCollectionBuilderBase.cs
+++ b/src/Umbraco.Core/Composing/LazyCollectionBuilderBase.cs
@@ -10,6 +10,9 @@ namespace Umbraco.Cms.Core.Composing
     /// <typeparam name="TBuilder">The type of the builder.</typeparam>
     /// <typeparam name="TCollection">The type of the collection.</typeparam>
     /// <typeparam name="TItem">The type of the items.</typeparam>
+    /// <remarks>
+    /// This type of collection builder is typically used when type scanning is required (i.e. plugins).
+    /// </remarks>
     public abstract class LazyCollectionBuilderBase<TBuilder, TCollection, TItem> : CollectionBuilderBase<TBuilder, TCollection, TItem>
         where TBuilder : LazyCollectionBuilderBase<TBuilder, TCollection, TItem>
         where TCollection : class, IBuilderCollection<TItem>
@@ -29,7 +32,7 @@ namespace Umbraco.Cms.Core.Composing
             {
                 types.Clear();
                 _producers.Clear();
-               _excluded.Clear();
+                _excluded.Clear();
             });
             return This;
         }
@@ -45,7 +48,8 @@ namespace Umbraco.Cms.Core.Composing
             Configure(types =>
             {
                 var type = typeof(T);
-                if (types.Contains(type) == false) types.Add(type);
+                if (types.Contains(type) == false)
+                    types.Add(type);
             });
             return This;
         }
@@ -60,7 +64,8 @@ namespace Umbraco.Cms.Core.Composing
             Configure(types =>
             {
                 EnsureType(type, "register");
-                if (types.Contains(type) == false) types.Add(type);
+                if (types.Contains(type) == false)
+                    types.Add(type);
             });
             return This;
         }
@@ -90,7 +95,8 @@ namespace Umbraco.Cms.Core.Composing
             Configure(types =>
             {
                 var type = typeof(T);
-                if (_excluded.Contains(type) == false) _excluded.Add(type);
+                if (_excluded.Contains(type) == false)
+                    _excluded.Add(type);
             });
             return This;
         }
@@ -105,7 +111,8 @@ namespace Umbraco.Cms.Core.Composing
             Configure(types =>
             {
                 EnsureType(type, "exclude");
-                if (_excluded.Contains(type) == false) _excluded.Add(type);
+                if (_excluded.Contains(type) == false)
+                    _excluded.Add(type);
             });
             return This;
         }

--- a/src/Umbraco.Core/Composing/LazyReadOnlyCollection.cs
+++ b/src/Umbraco.Core/Composing/LazyReadOnlyCollection.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Umbraco.Cms.Core.Composing
+{
+    public sealed class LazyReadOnlyCollection<T> : IReadOnlyCollection<T>
+    {
+        private readonly Lazy<IEnumerable<T>> _lazyCollection;
+        private int? _count;
+
+        public LazyReadOnlyCollection(Lazy<IEnumerable<T>> lazyCollection) => _lazyCollection = lazyCollection;
+
+        public LazyReadOnlyCollection(Func<IEnumerable<T>> lazyCollection) => _lazyCollection = new Lazy<IEnumerable<T>>(lazyCollection);
+
+        public IEnumerable<T> Value => EnsureCollection();
+
+        private IEnumerable<T> EnsureCollection()
+        {
+            if (_lazyCollection == null)
+            {
+                _count = 0;
+                return Enumerable.Empty<T>();
+            }
+
+            IEnumerable<T> val = _lazyCollection.Value;
+            if (_count == null)
+            {
+                _count = val.Count();
+            }
+            return val;
+        }
+
+        public int Count
+        {
+            get
+            {
+                EnsureCollection();
+                return _count.Value;
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator() => Value.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Umbraco.Core/Composing/TypeCollectionBuilderBase.cs
+++ b/src/Umbraco.Core/Composing/TypeCollectionBuilderBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Extensions;
@@ -37,7 +37,11 @@ namespace Umbraco.Cms.Core.Composing
 
         public TBuilder Add(IEnumerable<Type> types)
         {
-            foreach (var type in types) Add(type);
+            foreach (var type in types)
+            {
+                Add(type);
+            }
+
             return This;
         }
 
@@ -54,13 +58,12 @@ namespace Umbraco.Cms.Core.Composing
         }
 
         public TCollection CreateCollection(IServiceProvider factory)
-        {
-            return factory.CreateInstance<TCollection>(_types);
-        }
+            => factory.CreateInstance<TCollection>(CreateItemsFactory());
 
         public void RegisterWith(IServiceCollection services)
-        {
-            services.Add(new ServiceDescriptor(typeof(TCollection), CreateCollection, ServiceLifetime.Singleton));
-        }
+            => services.Add(new ServiceDescriptor(typeof(TCollection), CreateCollection, ServiceLifetime.Singleton));
+
+        // used to resolve a Func<IEnumerable<TItem>> parameter
+        private Func<IEnumerable<Type>> CreateItemsFactory() => () => _types;
     }
 }

--- a/src/Umbraco.Core/ContentApps/ContentAppFactoryCollection.cs
+++ b/src/Umbraco.Core/ContentApps/ContentAppFactoryCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Composing;
@@ -14,7 +15,7 @@ namespace Umbraco.Cms.Core.ContentApps
         private readonly ILogger<ContentAppFactoryCollection> _logger;
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-        public ContentAppFactoryCollection(IEnumerable<IContentAppFactory> items, ILogger<ContentAppFactoryCollection> logger, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        public ContentAppFactoryCollection(Func<IEnumerable<IContentAppFactory>> items, ILogger<ContentAppFactoryCollection> logger, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
             : base(items)
         {
             _logger = logger;

--- a/src/Umbraco.Core/ContentApps/ContentAppFactoryCollectionBuilder.cs
+++ b/src/Umbraco.Core/ContentApps/ContentAppFactoryCollectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +21,9 @@ namespace Umbraco.Cms.Core.ContentApps
             // get the logger factory just-in-time - see note below for manifest parser
             var loggerFactory = factory.GetRequiredService<ILoggerFactory>();
             var backOfficeSecurityAccessor = factory.GetRequiredService<IBackOfficeSecurityAccessor>();
-            return new ContentAppFactoryCollection(CreateItems(factory), loggerFactory.CreateLogger<ContentAppFactoryCollection>(), backOfficeSecurityAccessor);
+            return new ContentAppFactoryCollection(
+                () => CreateItems(factory),
+                loggerFactory.CreateLogger<ContentAppFactoryCollection>(), backOfficeSecurityAccessor);
         }
 
         protected override IEnumerable<IContentAppFactory> CreateItems(IServiceProvider factory)

--- a/src/Umbraco.Core/Dashboards/DashboardCollection.cs
+++ b/src/Umbraco.Core/Dashboards/DashboardCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Dashboards
 {
     public class DashboardCollection : BuilderCollectionBase<IDashboard>
     {
-        public DashboardCollection(IEnumerable<IDashboard> items)
-            : base(items)
-        { }
+        public DashboardCollection(Func<IEnumerable<IDashboard>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Editors/EditorValidatorCollection.cs
+++ b/src/Umbraco.Core/Editors/EditorValidatorCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Editors
 {
     public class EditorValidatorCollection : BuilderCollectionBase<IEditorValidator>
     {
-        public EditorValidatorCollection(IEnumerable<IEditorValidator> items)
-            : base(items)
-        { }
+        public EditorValidatorCollection(Func<IEnumerable<IEditorValidator>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/HealthChecks/HealthCheckCollection.cs
+++ b/src/Umbraco.Core/HealthChecks/HealthCheckCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.HealthChecks
 {
     public class HealthCheckCollection : BuilderCollectionBase<HealthCheck>
     {
-        public HealthCheckCollection(IEnumerable<HealthCheck> items)
-            : base(items)
-        { }
+        public HealthCheckCollection(Func<IEnumerable<HealthCheck>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/HealthChecks/HealthCheckNotificationMethodCollection.cs
+++ b/src/Umbraco.Core/HealthChecks/HealthCheckNotificationMethodCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 
@@ -6,8 +7,8 @@ namespace Umbraco.Cms.Core.HealthChecks
 {
     public class HealthCheckNotificationMethodCollection : BuilderCollectionBase<IHealthCheckNotificationMethod>
     {
-        public HealthCheckNotificationMethodCollection(IEnumerable<IHealthCheckNotificationMethod> items)
-            : base(items)
-        { }
+        public HealthCheckNotificationMethodCollection(Func<IEnumerable<IHealthCheckNotificationMethod>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Manifest/ManifestFilterCollection.cs
+++ b/src/Umbraco.Core/Manifest/ManifestFilterCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Manifest
@@ -8,12 +9,9 @@ namespace Umbraco.Cms.Core.Manifest
     /// </summary>
     public class ManifestFilterCollection : BuilderCollectionBase<IManifestFilter>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ManifestFilterCollection"/> class.
-        /// </summary>
-        public ManifestFilterCollection(IEnumerable<IManifestFilter> items)
-            : base(items)
-        { }
+        public ManifestFilterCollection(Func<IEnumerable<IManifestFilter>> items) : base(items)
+        {
+        }
 
         /// <summary>
         /// Filters package manifests.

--- a/src/Umbraco.Core/Mapping/MapDefinitionCollection.cs
+++ b/src/Umbraco.Core/Mapping/MapDefinitionCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Mapping
 {
     public class MapDefinitionCollection : BuilderCollectionBase<IMapDefinition>
     {
-        public MapDefinitionCollection(IEnumerable<IMapDefinition> items)
-            : base(items)
-        { }
+        public MapDefinitionCollection(Func<IEnumerable<IMapDefinition>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Media/EmbedProviders/EmbedProvidersCollection.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/EmbedProvidersCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Media.EmbedProviders
 {
     public class EmbedProvidersCollection : BuilderCollectionBase<IEmbedProvider>
     {
-        public EmbedProvidersCollection(IEnumerable<IEmbedProvider> items)
-            : base(items)
-        { }
+        public EmbedProvidersCollection(Func<IEnumerable<IEmbedProvider>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataEditorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditorCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.PropertyEditors
 {
     public class DataEditorCollection : BuilderCollectionBase<IDataEditor>
     {
-        public DataEditorCollection(IEnumerable<IDataEditor> items)
-            : base(items)
-        { }
+        public DataEditorCollection(Func<IEnumerable<IDataEditor>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -7,9 +7,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
 {
     public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataValueReferenceFactory>
     {
-        public DataValueReferenceFactoryCollection(IEnumerable<IDataValueReferenceFactory> items)
-            : base(items)
-        { }
+        public DataValueReferenceFactoryCollection(System.Func<IEnumerable<IDataValueReferenceFactory>> items) : base(items)
+        {
+        }
 
         // TODO: We could further reduce circular dependencies with PropertyEditorCollection by not having IDataValueReference implemented
         // by property editors and instead just use the already built in IDataValueReferenceFactory and/or refactor that into a more normal collection

--- a/src/Umbraco.Core/PropertyEditors/ManifestValueValidatorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/ManifestValueValidatorCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Cms.Core.Composing;
@@ -8,9 +8,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
 {
     public class ManifestValueValidatorCollection : BuilderCollectionBase<IManifestValueValidator>
     {
-        public ManifestValueValidatorCollection(IEnumerable<IManifestValueValidator> items)
-            : base(items)
-        { }
+        public ManifestValueValidatorCollection(Func<IEnumerable<IManifestValueValidator>> items) : base(items)
+        {
+        }
 
         public IManifestValueValidator Create(string name)
         {

--- a/src/Umbraco.Core/PropertyEditors/ManifestValueValidatorCollectionBuilder.cs
+++ b/src/Umbraco.Core/PropertyEditors/ManifestValueValidatorCollectionBuilder.cs
@@ -1,8 +1,8 @@
-﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.PropertyEditors
 {
-    public class ManifestValueValidatorCollectionBuilder : LazyCollectionBuilderBase<ManifestValueValidatorCollectionBuilder, ManifestValueValidatorCollection, IManifestValueValidator>
+    public class ManifestValueValidatorCollectionBuilder : SetCollectionBuilderBase<ManifestValueValidatorCollectionBuilder, ManifestValueValidatorCollection, IManifestValueValidator>
     {
         protected override ManifestValueValidatorCollectionBuilder This => this;
     }

--- a/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollection.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
 {
     public class MediaUrlGeneratorCollection : BuilderCollectionBase<IMediaUrlGenerator>
     {
-        public MediaUrlGeneratorCollection(IEnumerable<IMediaUrlGenerator> items) : base(items)
+        public MediaUrlGeneratorCollection(System.Func<IEnumerable<IMediaUrlGenerator>> items) : base(items)
         {
         }
 

--- a/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollectionBuilder.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollectionBuilder.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.PropertyEditors
 {
-    public class MediaUrlGeneratorCollectionBuilder : LazyCollectionBuilderBase<MediaUrlGeneratorCollectionBuilder, MediaUrlGeneratorCollection, IMediaUrlGenerator>
+    public class MediaUrlGeneratorCollectionBuilder : SetCollectionBuilderBase<MediaUrlGeneratorCollectionBuilder, MediaUrlGeneratorCollection, IMediaUrlGenerator>
     {
         protected override MediaUrlGeneratorCollectionBuilder This => this;
     }

--- a/src/Umbraco.Core/PropertyEditors/ParameterEditorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/ParameterEditorCollection.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Manifest;
 
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
     public class ParameterEditorCollection : BuilderCollectionBase<IDataEditor>
     {
         public ParameterEditorCollection(DataEditorCollection dataEditors, IManifestParser manifestParser)
-            : base(dataEditors
+            : base(() => dataEditors
                 .Where(x => (x.Type & EditorType.MacroParameter) > 0)
                 .Union(manifestParser.Manifest.PropertyEditors))
         { }

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorCollection.cs
@@ -7,13 +7,13 @@ namespace Umbraco.Cms.Core.PropertyEditors
     public class PropertyEditorCollection : BuilderCollectionBase<IDataEditor>
     {
         public PropertyEditorCollection(DataEditorCollection dataEditors, IManifestParser manifestParser)
-            : base(dataEditors
+            : base(() => dataEditors
                 .Where(x => (x.Type & EditorType.PropertyValue) > 0)
                 .Union(manifestParser.Manifest.PropertyEditors))
         { }
 
         public PropertyEditorCollection(DataEditorCollection dataEditors)
-            : base(dataEditors
+            : base(() => dataEditors
                 .Where(x => (x.Type & EditorType.PropertyValue) > 0))
         { }
 

--- a/src/Umbraco.Core/PropertyEditors/PropertyValueConverterCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyValueConverterCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Cms.Core.Composing;
@@ -8,9 +8,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
 {
     public class PropertyValueConverterCollection : BuilderCollectionBase<IPropertyValueConverter>
     {
-        public PropertyValueConverterCollection(IEnumerable<IPropertyValueConverter> items)
-            : base(items)
-        { }
+        public PropertyValueConverterCollection(Func<IEnumerable<IPropertyValueConverter>> items) : base(items)
+        {
+        }
 
         private readonly object _locker = new object();
         private Dictionary<IPropertyValueConverter, Type[]> _defaultConverters;

--- a/src/Umbraco.Core/Routing/ContentFinderCollection.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Routing
 {
     public class ContentFinderCollection : BuilderCollectionBase<IContentFinder>
     {
-        public ContentFinderCollection(IEnumerable<IContentFinder> items)
-            : base(items)
-        { }
+        public ContentFinderCollection(Func<IEnumerable<IContentFinder>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Routing/MediaUrlProviderCollection.cs
+++ b/src/Umbraco.Core/Routing/MediaUrlProviderCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Routing
 {
     public class MediaUrlProviderCollection : BuilderCollectionBase<IMediaUrlProvider>
     {
-        public MediaUrlProviderCollection(IEnumerable<IMediaUrlProvider> items)
-            : base(items)
-        { }
+        public MediaUrlProviderCollection(Func<IEnumerable<IMediaUrlProvider>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Routing/UrlProviderCollection.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Routing
 {
     public class UrlProviderCollection : BuilderCollectionBase<IUrlProvider>
     {
-        public UrlProviderCollection(IEnumerable<IUrlProvider> items)
-            : base(items)
-        { }
+        public UrlProviderCollection(Func<IEnumerable<IUrlProvider>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Sections/SectionCollection.cs
+++ b/src/Umbraco.Core/Sections/SectionCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Sections
 {
     public class SectionCollection : BuilderCollectionBase<ISection>
     {
-        public SectionCollection(IEnumerable<ISection> items)
-            : base(items)
-        { }
+        public SectionCollection(Func<IEnumerable<ISection>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Strings/UrlSegmentProviderCollection.cs
+++ b/src/Umbraco.Core/Strings/UrlSegmentProviderCollection.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Strings
 {
     public class UrlSegmentProviderCollection : BuilderCollectionBase<IUrlSegmentProvider>
     {
-        public UrlSegmentProviderCollection(IEnumerable<IUrlSegmentProvider> items)
-            : base(items)
-        { }
+        public UrlSegmentProviderCollection(Func<IEnumerable<IUrlSegmentProvider>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Tour/TourFilterCollection.cs
+++ b/src/Umbraco.Core/Tour/TourFilterCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Tour
@@ -8,11 +9,8 @@ namespace Umbraco.Cms.Core.Tour
     /// </summary>
     public class TourFilterCollection : BuilderCollectionBase<BackOfficeTourFilter>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TourFilterCollection"/> class.
-        /// </summary>
-        public TourFilterCollection(IEnumerable<BackOfficeTourFilter> items)
-            : base(items)
-        { }
+        public TourFilterCollection(Func<IEnumerable<BackOfficeTourFilter>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/Trees/SearchableTreeCollection.cs
+++ b/src/Umbraco.Core/Trees/SearchableTreeCollection.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.Trees
     {
         private readonly Dictionary<string, SearchableApplicationTree> _dictionary;
 
-        public SearchableTreeCollection(IEnumerable<ISearchableTree> items, ITreeService treeService)
+        public SearchableTreeCollection(Func<IEnumerable<ISearchableTree>> items, ITreeService treeService)
             : base(items)
         {
             _dictionary = CreateDictionary(treeService);

--- a/src/Umbraco.Core/Trees/TreeCollection.cs
+++ b/src/Umbraco.Core/Trees/TreeCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Trees
@@ -8,8 +9,9 @@ namespace Umbraco.Cms.Core.Trees
     /// </summary>
     public class TreeCollection : BuilderCollectionBase<Tree>
     {
-        public TreeCollection(IEnumerable<Tree> items)
-            : base(items)
-        { }
+
+        public TreeCollection(Func<IEnumerable<Tree>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/UmbracoApiControllerTypeCollection.cs
+++ b/src/Umbraco.Core/UmbracoApiControllerTypeCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
@@ -6,8 +6,8 @@ namespace Umbraco.Cms.Core
 {
     public class UmbracoApiControllerTypeCollection : BuilderCollectionBase<Type>
     {
-        public UmbracoApiControllerTypeCollection(IEnumerable<Type> items)
-            : base(items)
-        { }
+        public UmbracoApiControllerTypeCollection(Func<IEnumerable<Type>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollection.cs
+++ b/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
@@ -5,8 +6,8 @@ namespace Umbraco.Cms.Core.WebAssets
 {
     public class CustomBackOfficeAssetsCollection : BuilderCollectionBase<IAssetFile>
     {
-        public CustomBackOfficeAssetsCollection(IEnumerable<IAssetFile> items)
-           : base(items)
-        { }
+        public CustomBackOfficeAssetsCollection(Func<IEnumerable<IAssetFile>> items) : base(items)
+        {
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_8_0_0/DataTypes/PreValueMigratorCollection.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_8_0_0/DataTypes/PreValueMigratorCollection.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Composing;
@@ -9,11 +11,10 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_0_0.DataTypes
     {
         private readonly ILogger<PreValueMigratorCollection> _logger;
 
-        public PreValueMigratorCollection(IEnumerable<IPreValueMigrator> items, ILogger<PreValueMigratorCollection> logger)
+        public PreValueMigratorCollection(Func<IEnumerable<IPreValueMigrator>> items, ILogger<PreValueMigratorCollection> logger)
             : base(items)
         {
             _logger = logger;
-            _logger.LogDebug("Migrators: " + string.Join(", ", items.Select(x => x.GetType().Name)));
         }
 
         public IPreValueMigrator GetMigrator(string editorAlias)

--- a/src/Umbraco.Infrastructure/Packaging/PackageMigrationPlanCollection.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageMigrationPlanCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.Packaging
@@ -8,7 +9,7 @@ namespace Umbraco.Cms.Core.Packaging
     /// </summary>
     public class PackageMigrationPlanCollection : BuilderCollectionBase<PackageMigrationPlan>
     {
-        public PackageMigrationPlanCollection(IEnumerable<PackageMigrationPlan> items) : base(items)
+        public PackageMigrationPlanCollection(Func<IEnumerable<PackageMigrationPlan>> items) : base(items)
         {
         }
     }

--- a/src/Umbraco.Infrastructure/Persistence/DbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DbProviderFactoryCreator.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using NPoco;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
 
 namespace Umbraco.Cms.Infrastructure.Persistence
@@ -73,7 +74,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
                 return mapperFactory.Mappers;
             }
 
-            return new NPocoMapperCollection(Array.Empty<IMapper>());
+            return new NPocoMapperCollection(() => Enumerable.Empty<IMapper>());
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Mappers/MapperCollection.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Mappers/MapperCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Mappers
 {
     public class MapperCollection : BuilderCollectionBase<BaseMapper>, IMapperCollection
     {
-        public MapperCollection(IEnumerable<BaseMapper> items)
+        public MapperCollection(Func<IEnumerable<BaseMapper>> items)
             : base(items)
         {
 

--- a/src/Umbraco.Infrastructure/Persistence/NPocoMapperCollection.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoMapperCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NPoco;
 using Umbraco.Cms.Core.Composing;
@@ -6,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
 {
     public sealed class NPocoMapperCollection : BuilderCollectionBase<IMapper>
     {
-        public NPocoMapperCollection(IEnumerable<IMapper> items) : base(items)
+        public NPocoMapperCollection(Func<IEnumerable<IMapper>> items) : base(items)
         {
         }
     }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -37,7 +37,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         where TEntity : class, IContentBase
         where TRepository : class, IRepository
     {
-        private readonly Lazy<PropertyEditorCollection> _propertyEditors;
         private readonly DataValueReferenceFactoryCollection _dataValueReferenceFactories;
         private readonly IEventAggregator _eventAggregator;
 
@@ -58,7 +57,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             ILanguageRepository languageRepository,
             IRelationRepository relationRepository,
             IRelationTypeRepository relationTypeRepository,
-            Lazy<PropertyEditorCollection> propertyEditors,
+            PropertyEditorCollection propertyEditors,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,
             IEventAggregator eventAggregator)
@@ -68,7 +67,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             LanguageRepository = languageRepository;
             RelationRepository = relationRepository;
             RelationTypeRepository = relationTypeRepository;
-            _propertyEditors = propertyEditors;
+            PropertyEditors = propertyEditors;
             _dataValueReferenceFactories = dataValueReferenceFactories;
             _eventAggregator = eventAggregator;
         }
@@ -85,7 +84,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         protected IRelationRepository RelationRepository { get; }
         protected IRelationTypeRepository RelationTypeRepository { get; }
 
-        protected PropertyEditorCollection PropertyEditors => _propertyEditors.Value;
+        protected PropertyEditorCollection PropertyEditors { get; }
 
         #region Versions
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -29,14 +29,14 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
     /// </summary>
     internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataTypeRepository
     {
-        private readonly Lazy<PropertyEditorCollection> _editors;
+        private readonly PropertyEditorCollection _editors;
         private readonly IConfigurationEditorJsonSerializer _serializer;
         private readonly ILogger<IDataType> _dataTypeLogger;
 
         public DataTypeRepository(
             IScopeAccessor scopeAccessor,
             AppCaches cache,
-            Lazy<PropertyEditorCollection> editors,
+            PropertyEditorCollection editors,
             ILogger<DataTypeRepository> logger,
             ILoggerFactory loggerFactory,
             IConfigurationEditorJsonSerializer serializer)
@@ -68,7 +68,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             }
 
             var dtos = Database.Fetch<DataTypeDto>(dataTypeSql);
-            return dtos.Select(x => DataTypeFactory.BuildEntity(x, _editors.Value, _dataTypeLogger, _serializer)).ToArray();
+            return dtos.Select(x => DataTypeFactory.BuildEntity(x, _editors, _dataTypeLogger, _serializer)).ToArray();
         }
 
         protected override IEnumerable<IDataType> PerformGetByQuery(IQuery<IDataType> query)
@@ -79,7 +79,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
             var dtos = Database.Fetch<DataTypeDto>(sql);
 
-            return dtos.Select(x => DataTypeFactory.BuildEntity(x, _editors.Value, _dataTypeLogger, _serializer)).ToArray();
+            return dtos.Select(x => DataTypeFactory.BuildEntity(x, _editors, _dataTypeLogger, _serializer)).ToArray();
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             ILanguageRepository languageRepository,
             IRelationRepository relationRepository,
             IRelationTypeRepository relationTypeRepository,
-            Lazy<PropertyEditorCollection> propertyEditorCollection,
+            PropertyEditorCollection propertyEditorCollection,
             IDataTypeService dataTypeService,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IJsonSerializer serializer,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             ILanguageRepository languageRepository,
             IRelationRepository relationRepository,
             IRelationTypeRepository relationTypeRepository,
-            Lazy<PropertyEditorCollection> propertyEditors,
+            PropertyEditorCollection propertyEditors,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,
             IJsonSerializer serializer,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             ILanguageRepository languageRepository,
             IRelationRepository relationRepository,
             IRelationTypeRepository relationTypeRepository,
-            Lazy<PropertyEditorCollection> propertyEditorCollection,
+            PropertyEditorCollection propertyEditorCollection,
             MediaUrlGeneratorCollection mediaUrlGenerators,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             IRelationRepository relationRepository,
             IRelationTypeRepository relationTypeRepository,
             IPasswordHasher passwordHasher,
-            Lazy<PropertyEditorCollection> propertyEditors,
+            PropertyEditorCollection propertyEditors,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,
             IJsonSerializer serializer,

--- a/src/Umbraco.Infrastructure/Persistence/SqlContext.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlContext.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Linq;
 using NPoco;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Infrastructure.Persistence.Mappers;
 using Umbraco.Cms.Infrastructure.Persistence.Querying;
@@ -14,8 +15,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence
     /// </summary>
     public class SqlContext : ISqlContext
     {
-        private readonly Lazy<IMapperCollection> _mappers;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlContext"/> class.
         /// </summary>
@@ -23,21 +22,10 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         /// <param name="pocoDataFactory">The Poco data factory.</param>
         /// <param name="databaseType">The database type.</param>
         /// <param name="mappers">The mappers.</param>
-        public SqlContext(ISqlSyntaxProvider sqlSyntax, DatabaseType databaseType, IPocoDataFactory pocoDataFactory, IMapperCollection mappers = null)
-            : this(sqlSyntax, databaseType, pocoDataFactory, new Lazy<IMapperCollection>(() => mappers ?? new MapperCollection(Enumerable.Empty<BaseMapper>())))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SqlContext"/> class.
-        /// </summary>
-        /// <param name="sqlSyntax">The sql syntax provider.</param>
-        /// <param name="pocoDataFactory">The Poco data factory.</param>
-        /// <param name="databaseType">The database type.</param>
-        /// <param name="mappers">The mappers.</param>
-        public SqlContext(ISqlSyntaxProvider sqlSyntax, DatabaseType databaseType, IPocoDataFactory pocoDataFactory, Lazy<IMapperCollection> mappers)
+        public SqlContext(ISqlSyntaxProvider sqlSyntax, DatabaseType databaseType, IPocoDataFactory pocoDataFactory, IMapperCollection mappers = null)            
         {
             // for tests
-            _mappers = mappers;
+            Mappers = mappers;
 
             SqlSyntax = sqlSyntax ?? throw new ArgumentNullException(nameof(sqlSyntax));
             PocoDataFactory = pocoDataFactory ?? throw new ArgumentNullException(nameof(pocoDataFactory));
@@ -67,6 +55,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         public IPocoDataFactory PocoDataFactory { get; }
 
         /// <inheritdoc />
-        public IMapperCollection Mappers => _mappers.Value;
+        public IMapperCollection Mappers { get; }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/SqlServerDbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlServerDbProviderFactoryCreator.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.Data.Common;
+using System.Linq;
 using Microsoft.Extensions.Options;
 using NPoco;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
 
@@ -49,10 +51,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         }
 
         public void CreateDatabase(string providerName)
-        {
-            throw new NotSupportedException("Embedded databases are not supported");
-        }
+            => throw new NotSupportedException("Embedded databases are not supported");
 
-        public NPocoMapperCollection ProviderSpecificMappers(string providerName) => new NPocoMapperCollection(Array.Empty<IMapper>());
+        public NPocoMapperCollection ProviderSpecificMappers(string providerName)
+            => new NPocoMapperCollection(() => Enumerable.Empty<IMapper>());
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         private readonly DatabaseSchemaCreatorFactory _databaseSchemaCreatorFactory;
         private readonly NPocoMapperCollection _npocoMappers;
         private readonly IOptions<GlobalSettings> _globalSettings;
-        private readonly Lazy<IMapperCollection> _mappers;
+        private readonly IMapperCollection _mappers;
         private readonly ILogger<UmbracoDatabaseFactory> _logger;
         private readonly ILoggerFactory _loggerFactory;
 
@@ -81,7 +81,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             ILoggerFactory loggerFactory,
             IOptions<GlobalSettings> globalSettings,
             IOptions<ConnectionStrings> connectionStrings,
-            Lazy<IMapperCollection> mappers,
+            IMapperCollection mappers,
             IDbProviderFactoryCreator dbProviderFactoryCreator,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
             NPocoMapperCollection npocoMappers)

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -26,18 +26,14 @@ namespace Umbraco.Cms.Core.PropertyEditors
     {
         public const string ContentTypeKeyPropertyKey = "contentTypeKey";
         public const string UdiPropertyKey = "udi";
-        private readonly Lazy<PropertyEditorCollection> _propertyEditors;
 
         public BlockEditorPropertyEditor(
             IDataValueEditorFactory dataValueEditorFactory,
-            Lazy<PropertyEditorCollection> propertyEditors)
+            PropertyEditorCollection propertyEditors)
             : base(dataValueEditorFactory)
-        {
-            _propertyEditors = propertyEditors;
-        }
+            => PropertyEditors = propertyEditors;
 
-        // has to be lazy else circular dep in ctor
-        private PropertyEditorCollection PropertyEditors => _propertyEditors.Value;
+        private PropertyEditorCollection PropertyEditors { get; }
 
         #region Value Editor
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
         public BlockListPropertyEditor(
             IDataValueEditorFactory dataValueEditorFactory,
-            Lazy<PropertyEditorCollection> propertyEditors,
+            PropertyEditorCollection propertyEditors,
             IIOHelper ioHelper)
             : base(dataValueEditorFactory, propertyEditors)
         {

--- a/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NPoco;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Runtime;
@@ -61,7 +62,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                 loggerFactory,
                 _globalSettings,
                connectionStrings,
-               new Lazy<IMapperCollection>(() => new MapperCollection(Enumerable.Empty<BaseMapper>())),
+               new MapperCollection(() => Enumerable.Empty<BaseMapper>()),
                dbProviderFactoryCreator,
                databaseSchemaCreatorFactory,
                npocoMappers);

--- a/src/Umbraco.Persistence.SqlCe/SqlCeSpecificMapperFactory.cs
+++ b/src/Umbraco.Persistence.SqlCe/SqlCeSpecificMapperFactory.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Persistence.SqlCe
@@ -6,6 +6,6 @@ namespace Umbraco.Cms.Persistence.SqlCe
     public class SqlCeSpecificMapperFactory : IProviderSpecificMapperFactory
     {
         public string ProviderName => Constants.DatabaseProviders.SqlCe;
-        public NPocoMapperCollection Mappers => new NPocoMapperCollection(new[] {new SqlCeImageMapper()});
+        public NPocoMapperCollection Mappers => new NPocoMapperCollection(() => new[] {new SqlCeImageMapper()});
     }
 }

--- a/src/Umbraco.Tests.Common/TestHelpers/PublishedContent/AutoPublishedContentType.cs
+++ b/src/Umbraco.Tests.Common/TestHelpers/PublishedContent/AutoPublishedContentType.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -34,7 +35,7 @@ namespace Umbraco.Cms.Tests.Common.TestHelpers.PublishedContent
             };
             dataTypeServiceMock.Setup(x => x.GetAll()).Returns(dataType.Yield);
 
-            var factory = new PublishedContentTypeFactory(Mock.Of<IPublishedModelFactory>(), new PropertyValueConverterCollection(Array.Empty<IPropertyValueConverter>()), dataTypeServiceMock.Object);
+            var factory = new PublishedContentTypeFactory(Mock.Of<IPublishedModelFactory>(), new PropertyValueConverterCollection(() => Enumerable.Empty<IPropertyValueConverter>()), dataTypeServiceMock.Object);
             Default = factory.CreatePropertyType("*", 666);
         }
 

--- a/src/Umbraco.Tests.Integration/Testing/TestUmbracoDatabaseFactoryProvider.cs
+++ b/src/Umbraco.Tests.Integration/Testing/TestUmbracoDatabaseFactoryProvider.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Tests.Integration.Testing
         private readonly ILoggerFactory _loggerFactory;
         private readonly IOptions<GlobalSettings> _globalSettings;
         private readonly IOptions<ConnectionStrings> _connectionStrings;
-        private readonly Lazy<IMapperCollection> _mappers;
+        private readonly IMapperCollection _mappers;
         private readonly IDbProviderFactoryCreator _dbProviderFactoryCreator;
         private readonly DatabaseSchemaCreatorFactory _databaseSchemaCreatorFactory;
         private readonly NPocoMapperCollection _npocoMappers;
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Tests.Integration.Testing
             ILoggerFactory loggerFactory,
             IOptions<GlobalSettings> globalSettings,
             IOptions<ConnectionStrings> connectionStrings,
-            Lazy<IMapperCollection> mappers,
+            IMapperCollection mappers,
             IDbProviderFactoryCreator dbProviderFactoryCreator,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
             NPocoMapperCollection npocoMappers)

--- a/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
         {
             var contentValueSetBuilder = new ContentValueSetBuilder(
                 _propertyEditors,
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider(_shortStringHelper) }),
+                new UrlSegmentProviderCollection(() => new[] { new DefaultUrlSegmentProvider(_shortStringHelper) }),
                 GetMockUserService(),
                 _shortStringHelper,
                 _scopeProvider,
@@ -85,7 +85,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
         {
             var mediaValueSetBuilder = new MediaValueSetBuilder(
                 _propertyEditors,
-                new UrlSegmentProviderCollection(new[] { new DefaultUrlSegmentProvider(_shortStringHelper) }),
+                new UrlSegmentProviderCollection(() => new[] { new DefaultUrlSegmentProvider(_shortStringHelper) }),
                 _mediaUrlGenerators,
                 GetMockUserService(),
                 _shortStringHelper,

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -10,6 +10,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
@@ -99,8 +100,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
             appCaches ??= AppCaches;
 
             DocumentRepository ctRepository = CreateRepository(scopeAccessor, out contentTypeRepository, out TemplateRepository tr);
-            var editors = new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>()));
-            dtdRepository = new DataTypeRepository(scopeAccessor, appCaches, new Lazy<PropertyEditorCollection>(() => editors), LoggerFactory.CreateLogger<DataTypeRepository>(), LoggerFactory, ConfigurationEditorJsonSerializer);
+            var editors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
+            dtdRepository = new DataTypeRepository(scopeAccessor, appCaches, editors, LoggerFactory.CreateLogger<DataTypeRepository>(), LoggerFactory, ConfigurationEditorJsonSerializer);
             return ctRepository;
         }
 
@@ -121,8 +122,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
             var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
             var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
             var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);
-            var propertyEditors = new Lazy<PropertyEditorCollection>(() => new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>())));
-            var dataValueReferences = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>());
+            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
+            var dataValueReferences = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>());
             var repository = new DocumentRepository(
                 scopeAccessor,
                 appCaches,
@@ -775,7 +776,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
 
             // One variant (by culture) content type named "umbVariantTextPage"
             // with properties, every 2nd one being variant (by culture), the other being invariant
-            ContentType variantCt = ContentTypeBuilder.CreateSimpleContentType("umbVariantTextpage", "Variant Textpage",  defaultTemplateId: template.Id);
+            ContentType variantCt = ContentTypeBuilder.CreateSimpleContentType("umbVariantTextpage", "Variant Textpage", defaultTemplateId: template.Id);
             variantCt.Variations = ContentVariation.Culture;
             var propTypes = variantCt.PropertyTypes.ToList();
             for (int i = 0; i < propTypes.Count; i++)

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
@@ -9,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
@@ -63,9 +64,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
             var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
             var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
             var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);
-            var propertyEditors = new Lazy<PropertyEditorCollection>(() => new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>())));
-            var mediaUrlGenerators = new MediaUrlGeneratorCollection(Enumerable.Empty<IMediaUrlGenerator>());
-            var dataValueReferences = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>());
+            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
+            var mediaUrlGenerators = new MediaUrlGeneratorCollection(() => Enumerable.Empty<IMediaUrlGenerator>());
+            var dataValueReferences = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>());
             var repository = new MediaRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaRepository>(), LoggerFactory, mediaTypeRepository, tagRepository, Mock.Of<ILanguageRepository>(), relationRepository, relationTypeRepository, propertyEditors, mediaUrlGenerators, dataValueReferences, DataTypeService, JsonSerializer, Mock.Of<IEventAggregator>());
             return repository;
         }

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberRepositoryTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberRepositoryTest.cs
@@ -12,6 +12,7 @@ using NPoco;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
@@ -55,8 +56,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
             ITagRepository tagRepo = GetRequiredService<ITagRepository>();
             IRelationTypeRepository relationTypeRepository = GetRequiredService<IRelationTypeRepository>();
             IRelationRepository relationRepository = GetRequiredService<IRelationRepository>();
-            var propertyEditors = new Lazy<PropertyEditorCollection>(() => new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>())));
-            var dataValueReferences = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>());
+            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
+            var dataValueReferences = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>());
             return new MemberRepository(
                 accessor,
                 AppCaches.Disabled,

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -11,6 +11,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
@@ -267,8 +268,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
                 var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
                 var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
                 var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);
-                var propertyEditors = new Lazy<PropertyEditorCollection>(() => new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>())));
-                var dataValueReferences = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>());
+                var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
+                var dataValueReferences = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>());
                 var contentRepo = new DocumentRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<DocumentRepository>(), LoggerFactory, contentTypeRepository, templateRepository, tagRepository, languageRepository, relationRepository, relationTypeRepository, propertyEditors, dataValueReferences, dataTypeService, serializer, Mock.Of<IEventAggregator>());
 
                 Template template = TemplateBuilder.CreateTextPageTemplate();

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using NPoco;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
@@ -107,7 +108,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
             member = MemberService.GetById(member.Id);
             Assert.AreEqual("xemail", member.Email);
 
-            var contentTypeFactory = new PublishedContentTypeFactory(new NoopPublishedModelFactory(), new PropertyValueConverterCollection(Enumerable.Empty<IPropertyValueConverter>()), GetRequiredService<IDataTypeService>());
+            var contentTypeFactory = new PublishedContentTypeFactory(new NoopPublishedModelFactory(), new PropertyValueConverterCollection(() => Enumerable.Empty<IPropertyValueConverter>()), GetRequiredService<IDataTypeService>());
             var pmemberType = new PublishedContentType(memberType, contentTypeFactory);
 
             var publishedSnapshotAccessor = new TestPublishedSnapshotAccessor();

--- a/src/Umbraco.Tests.UnitTests/AutoFixture/AutoMoqDataAttribute.cs
+++ b/src/Umbraco.Tests.UnitTests/AutoFixture/AutoMoqDataAttribute.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using System;
+using System.Linq;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using AutoFixture.Kernel;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Moq;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
@@ -74,7 +76,7 @@ namespace Umbraco.Cms.Tests.UnitTests.AutoFixture
                             Options.Create(new GlobalSettings()),
                             Mock.Of<IHostingEnvironment>(x => x.ToAbsolute(It.IsAny<string>()) == "/umbraco" && x.ApplicationVirtualPath == string.Empty),
                             Mock.Of<IRuntimeState>(x => x.Level == RuntimeLevel.Run),
-                            new UmbracoApiControllerTypeCollection(Array.Empty<Type>()))));
+                            new UmbracoApiControllerTypeCollection(() => Enumerable.Empty<Type>()))));
 
                     fixture.Customize<PreviewRoutes>(u => u.FromFactory(
                         () => new PreviewRoutes(

--- a/src/Umbraco.Tests.UnitTests/TestHelpers/BaseUsingSqlSyntax.cs
+++ b/src/Umbraco.Tests.UnitTests/TestHelpers/BaseUsingSqlSyntax.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Tests.UnitTests.TestHelpers
             };
             var pocoDataFactory = new FluentPocoDataFactory((type, iPocoDataFactory) => new PocoDataBuilder(type, pocoMappers).Init());
             var sqlSyntax = new SqlServerSyntaxProvider(Options.Create(new GlobalSettings()));
-            SqlContext = new SqlContext(sqlSyntax, DatabaseType.SqlServer2012, pocoDataFactory, new Lazy<IMapperCollection>(() => factory.GetRequiredService<IMapperCollection>()));
+            SqlContext = new SqlContext(sqlSyntax, DatabaseType.SqlServer2012, pocoDataFactory, factory.GetRequiredService<IMapperCollection>());
             Mappers = factory.GetRequiredService<IMapperCollection>();
         }
     }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DistributedCache/DistributedCacheTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DistributedCache/DistributedCacheTests.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Cache.DistributedCache
             ServerRegistrar = new TestServerRegistrar();
             ServerMessenger = new TestServerMessenger();
 
-            var cacheRefresherCollection = new CacheRefresherCollection(new[]
+            var cacheRefresherCollection = new CacheRefresherCollection(() => new[]
             {
                 new TestCacheRefresher()
             });

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -49,13 +49,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
             ILogger logger = loggerFactory.CreateLogger("GenericLogger");
             var globalSettings = new GlobalSettings();
             var connectionStrings = new ConnectionStrings();
-            var mapperCollection = new NPocoMapperCollection(new[] { new NullableDateMapper() });
+            var mapperCollection = new NPocoMapperCollection(() => new[] { new NullableDateMapper() });
             var f = new UmbracoDatabaseFactory(
                 loggerFactory.CreateLogger<UmbracoDatabaseFactory>(),
                 loggerFactory,
                 Options.Create(globalSettings),
                 Options.Create(connectionStrings),
-                new Lazy<IMapperCollection>(() => new MapperCollection(Enumerable.Empty<BaseMapper>())),
+                new MapperCollection(() => Enumerable.Empty<BaseMapper>()),
                 TestHelper.DbProviderFactoryCreator,
                 new DatabaseSchemaCreatorFactory(loggerFactory.CreateLogger<DatabaseSchemaCreator>(), loggerFactory, new UmbracoVersion(), Mock.Of<IEventAggregator>()),
                 mapperCollection);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/CollectionBuildersTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/CollectionBuildersTests.cs
@@ -406,9 +406,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
             using (IServiceScope scope = serviceProvider.CreateScope())
             {
                 col2 = scope.ServiceProvider.GetRequiredService<TestCollection>();
-            }
 
-            AssertCollection(col2, typeof(Resolved1), typeof(Resolved2));
+                // NOTE: We must assert here so that the lazy collection is resolved
+                // within this service provider scope, else if you resolve the collection
+                // after the service provider scope is disposed, you'll get an object
+                // disposed error (expected).
+                AssertCollection(col2, typeof(Resolved1), typeof(Resolved2));
+            }
+            
             AssertNotSameCollection(col1A, col2);
         }
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/CollectionBuildersTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/CollectionBuildersTests.cs
@@ -537,8 +537,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
         // ReSharper disable once ClassNeverInstantiated.Local
         private class TestCollection : BuilderCollectionBase<Resolved>
         {
-            public TestCollection(IEnumerable<Resolved> items)
-                : base(items)
+            public TestCollection(Func<IEnumerable<Resolved>> items) : base(items)
             {
             }
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/LazyCollectionBuilderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/LazyCollectionBuilderTests.cs
@@ -184,8 +184,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Composing
         // ReSharper disable once ClassNeverInstantiated.Local
         private class TestCollection : BuilderCollectionBase<ITestInterface>
         {
-            public TestCollection(IEnumerable<ITestInterface> items)
-                : base(items)
+            public TestCollection(Func<IEnumerable<ITestInterface>> items) : base(items)
             {
             }
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/ManifestParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/ManifestParserTests.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Manifest;
@@ -44,8 +45,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Manifest
             NullLoggerFactory loggerFactory = NullLoggerFactory.Instance;
             _parser = new ManifestParser(
                 AppCaches.Disabled,
-                new ManifestValueValidatorCollection(validators),
-                new ManifestFilterCollection(Array.Empty<IManifestFilter>()),
+                new ManifestValueValidatorCollection(() => validators),
+                new ManifestFilterCollection(() => Enumerable.Empty<IManifestFilter>()),
                 loggerFactory.CreateLogger<ManifestParser>(),
                 _ioHelper,
                 TestHelper.GetHostingEnvironment(),

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -599,7 +599,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
             Mock.Get(dataTypeService).Setup(x => x.GetDataType(It.Is<int>(y => y == Constants.DataTypes.Textbox)))
                 .Returns(new DataType(textBoxEditor, serializer));
 
-            var propertyEditorCollection = new PropertyEditorCollection(new DataEditorCollection(new[] { textBoxEditor }));
+            var propertyEditorCollection = new PropertyEditorCollection(new DataEditorCollection(() => new[] { textBoxEditor }));
             return new PropertyValidationService(
                 propertyEditorCollection,
                 dataTypeService,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Packaging/PendingPackageMigrationsTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Packaging/PendingPackageMigrationsTests.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Packaging
         private PendingPackageMigrations GetPendingPackageMigrations()
             => new PendingPackageMigrations(
                 Mock.Of<ILogger<PendingPackageMigrations>>(),
-                new PackageMigrationPlanCollection(new[]
+                new PackageMigrationPlanCollection(() => new[]
                 {
                     new TestPackageMigrationPlan()
                 }));

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -36,13 +37,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors
         [Test]
         public void GetAllReferences_All_Variants_With_IDataValueReferenceFactory()
         {
-            var collection = new DataValueReferenceFactoryCollection(new TestDataValueReferenceFactory().Yield());
+            var collection = new DataValueReferenceFactoryCollection(() => new TestDataValueReferenceFactory().Yield());
 
             // label does not implement IDataValueReference
             var labelEditor = new LabelPropertyEditor(
                 DataValueEditorFactory,
                 IOHelper);
-            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(labelEditor.Yield()));
+            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => labelEditor.Yield()));
             var trackedUdi1 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
             var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
             var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
@@ -102,13 +103,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors
         [Test]
         public void GetAllReferences_All_Variants_With_IDataValueReference_Editor()
         {
-            var collection = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>());
+            var collection = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>());
 
             // mediaPicker does implement IDataValueReference
             var mediaPicker = new MediaPickerPropertyEditor(
                 DataValueEditorFactory,
                 IOHelper);
-            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(mediaPicker.Yield()));
+            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => mediaPicker.Yield()));
             var trackedUdi1 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
             var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
             var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
@@ -168,13 +169,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors
         [Test]
         public void GetAllReferences_Invariant_With_IDataValueReference_Editor()
         {
-            var collection = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>());
+            var collection = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>());
 
             // mediaPicker does implement IDataValueReference
             var mediaPicker = new MediaPickerPropertyEditor(
                 DataValueEditorFactory,
                 IOHelper);
-            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(mediaPicker.Yield()));
+            var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => mediaPicker.Yield()));
             var trackedUdi1 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
             var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
             var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -102,7 +102,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors
             var publishedPropType = new PublishedPropertyType(
                 new PublishedContentType(Guid.NewGuid(), 1234, "test", PublishedItemType.Content, Enumerable.Empty<string>(), Enumerable.Empty<PublishedPropertyType>(), ContentVariation.Nothing),
                 new PropertyType(Mock.Of<IShortStringHelper>(),  "test", ValueStorageType.Nvarchar) { DataTypeId = 123 },
-                new PropertyValueConverterCollection(Enumerable.Empty<IPropertyValueConverter>()),
+                new PropertyValueConverterCollection(() => Enumerable.Empty<IPropertyValueConverter>()),
                 Mock.Of<IPublishedModelFactory>(),
                 mockPublishedContentTypeFactory.Object);
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/ConvertersTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/ConvertersTests.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
         [Test]
         public void SimpleConverter1Test()
         {
-            var converters = new PropertyValueConverterCollection(new IPropertyValueConverter[]
+            var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[]
             {
                 new SimpleConverter1(),
             });
@@ -107,7 +107,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
             publishedSnapshotAccessorMock.Setup(x => x.PublishedSnapshot).Returns(publishedSnapshotMock.Object);
             IPublishedSnapshotAccessor publishedSnapshotAccessor = publishedSnapshotAccessorMock.Object;
 
-            var converters = new PropertyValueConverterCollection(new IPropertyValueConverter[]
+            var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[]
             {
                 new SimpleConverter2(publishedSnapshotAccessor),
             });

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/NestedContentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/NestedContentTests.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
 
             PropertyEditorCollection editors = null;
             var editor = new NestedContentPropertyEditor(Mock.Of<IDataValueEditorFactory>(),Mock.Of<IIOHelper>());
-            editors = new PropertyEditorCollection(new DataEditorCollection(new DataEditor[] { editor }));
+            editors = new PropertyEditorCollection(new DataEditorCollection(() => new DataEditor[] { editor }));
 
             var serializer = new ConfigurationEditorJsonSerializer();
 
@@ -126,7 +126,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
                 .Setup(x => x.PublishedSnapshot)
                 .Returns(publishedSnapshot.Object);
 
-            var converters = new PropertyValueConverterCollection(new IPropertyValueConverter[]
+            var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[]
             {
                 new NestedContentSingleValueConverter(publishedSnapshotAccessor.Object, publishedModelFactory.Object, proflog),
                 new NestedContentManyValueConverter(publishedSnapshotAccessor.Object, publishedModelFactory.Object, proflog),

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/PropertyCacheLevelTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Published/PropertyCacheLevelTests.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
         {
             var converter = new CacheConverter1(cacheLevel);
 
-            var converters = new PropertyValueConverterCollection(new IPropertyValueConverter[]
+            var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[]
             {
                 converter,
             });
@@ -119,7 +119,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
         {
             var converter = new CacheConverter1(converterCacheLevel);
 
-            var converters = new PropertyValueConverterCollection(new IPropertyValueConverter[]
+            var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[]
             {
                 converter,
             });
@@ -199,7 +199,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
         {
             var converter = new CacheConverter1(PropertyCacheLevel.Unknown);
 
-            var converters = new PropertyValueConverterCollection(new IPropertyValueConverter[]
+            var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[]
             {
                 converter,
             });

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -82,8 +82,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
                 Options.Create(webRoutingSettings),
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(new[] { mediaUrlProvider.Object }),
+                new UrlProviderCollection(() => Enumerable.Empty<IUrlProvider>()),
+                new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());
             using (UmbracoContextReference reference = umbracoContextFactory.EnsureUmbracoContext())
             {

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -79,8 +79,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
                 Microsoft.Extensions.Options.Options.Create(webRoutingSettings),
-                new UrlProviderCollection(new[] { contentUrlProvider.Object }),
-                new MediaUrlProviderCollection(new[] { mediaUrlProvider.Object }),
+                new UrlProviderCollection(() => new[] { contentUrlProvider.Object }),
+                new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());
             using (UmbracoContextReference reference = umbracoContextFactory.EnsureUmbracoContext())
             {

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
@@ -124,7 +124,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                     new DisabledHealthCheckSettings { Id = Guid.Parse(Check2Id) }
                 }
             };
-            var checks = new HealthCheckCollection(new List<HealthCheck>
+            var checks = new HealthCheckCollection(() => new List<HealthCheck>
             {
                 new TestHealthCheck1(),
                 new TestHealthCheck2(),
@@ -133,7 +133,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 
             _mockNotificationMethod = new Mock<IHealthCheckNotificationMethod>();
             _mockNotificationMethod.SetupGet(x => x.Enabled).Returns(notificationEnabled);
-            var notifications = new HealthCheckNotificationMethodCollection(new List<IHealthCheckNotificationMethod> { _mockNotificationMethod.Object });
+            var notifications = new HealthCheckNotificationMethodCollection(() => new List<IHealthCheckNotificationMethod> { _mockNotificationMethod.Object });
 
             var mockRunTimeState = new Mock<IRuntimeState>();
             mockRunTimeState.SetupGet(x => x.Level).Returns(runtimeLevel);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Test]
         public void SimpleMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition1(),
             });
@@ -67,7 +67,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Test]
         public void EnumerableMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition1(),
             });
@@ -101,7 +101,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Test]
         public void InheritedMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition1(),
             });
@@ -126,7 +126,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Test]
         public void CollectionsMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition2(),
             });
@@ -141,7 +141,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Explicit]
         public void ConcurrentMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition1(),
                 new MapperDefinition3(),
@@ -201,7 +201,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Test]
         public void EnumMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition4(),
             });
@@ -225,7 +225,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
         [Test]
         public void NullPropertyMap()
         {
-            var definitions = new MapDefinitionCollection(new IMapDefinition[]
+            var definitions = new MapDefinitionCollection(() => new IMapDefinition[]
             {
                 new MapperDefinition5(),
             });

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
 
             _fakeMemberStore = new MemberUserStore(
                 _mockMemberService.Object,
-                new UmbracoMapper(new MapDefinitionCollection(mapDefinitions), scopeProvider),
+                new UmbracoMapper(new MapDefinitionCollection(() => mapDefinitions), scopeProvider),
                 scopeProvider,
                 new IdentityErrorDescriber(),
                 Mock.Of<IPublishedSnapshotAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
 
             return new MemberUserStore(
                 _mockMemberService.Object,
-                new UmbracoMapper(new MapDefinitionCollection(new List<IMapDefinition>()), mockScopeProvider.Object),
+                new UmbracoMapper(new MapDefinitionCollection(() => new List<IMapDefinition>()), mockScopeProvider.Object),
                 mockScopeProvider.Object,
                 new IdentityErrorDescriber(),
                 Mock.Of<IPublishedSnapshotAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Services
             Mock.Get(dataEditor).Setup(x => x.GetValueEditor(It.IsAny<object>()))
                 .Returns(new CustomTextOnlyValueEditor(new DataEditorAttribute(Constants.PropertyEditors.Aliases.TextBox, "Test Textbox", "textbox"),   textService.Object, Mock.Of<IShortStringHelper>(), new JsonNetSerializer(), Mock.Of<IIOHelper>()));
 
-            var propEditors = new PropertyEditorCollection(new DataEditorCollection(new[] { dataEditor }));
+            var propEditors = new PropertyEditorCollection(new DataEditorCollection(() => new[] { dataEditor }));
 
             validationService = new PropertyValidationService(propEditors, dataTypeService.Object, Mock.Of<ILocalizedTextService>());
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
@@ -453,7 +453,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
             var mockContentAppFactoryCollection = new Mock<ILogger<ContentAppFactoryCollection>>();
             var hybridBackOfficeSecurityAccessor = new BackOfficeSecurityAccessor(httpContextAccessor);
             var contentAppFactoryCollection = new ContentAppFactoryCollection(
-                contentAppFactories.Object,
+                () => contentAppFactories.Object,
                 mockContentAppFactoryCollection.Object,
                 hybridBackOfficeSecurityAccessor);
             var mockUserService = new Mock<IUserService>();
@@ -471,7 +471,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
                      && x.Alias == Constants.PropertyEditors.Aliases.Label);
             Mock.Get(dataEditor).Setup(x => x.GetValueEditor()).Returns(new TextOnlyValueEditor( new DataEditorAttribute(Constants.PropertyEditors.Aliases.TextBox, "Test Textbox", "textbox"), textService.Object, Mock.Of<IShortStringHelper>(), Mock.Of<IJsonSerializer>(), Mock.Of<IIOHelper>()));
 
-            var propertyEditorCollection = new PropertyEditorCollection(new DataEditorCollection(new[] { dataEditor }));
+            var propertyEditorCollection = new PropertyEditorCollection(new DataEditorCollection(() => new[] { dataEditor }));
 
             IMapDefinition memberMapDefinition = new MemberMapDefinition(
                 commonMapper,
@@ -487,7 +487,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
                     contentTypeBaseServiceProvider.Object,
                     propertyEditorCollection));
 
-            var map = new MapDefinitionCollection(new List<IMapDefinition>()
+            var map = new MapDefinitionCollection(() => new List<IMapDefinition>()
             {
                 new global::Umbraco.Cms.Core.Models.Mapping.MemberMapDefinition(),
                 memberMapDefinition,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/BackOfficeAreaRoutesTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/BackOfficeAreaRoutesTests.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Routing
                 Options.Create(globalSettings),
                 Mock.Of<IHostingEnvironment>(x => x.ToAbsolute(It.IsAny<string>()) == "/umbraco" && x.ApplicationVirtualPath == string.Empty),
                 Mock.Of<IRuntimeState>(x => x.Level == level),
-                new UmbracoApiControllerTypeCollection(new[] { typeof(Testing1Controller) }));
+                new UmbracoApiControllerTypeCollection(() => new[] { typeof(Testing1Controller) }));
 
             return routes;
         }

--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
     {
         private readonly List<Tree> _trees = new List<Tree>();
 
-        public TreeCollection CreateCollection(IServiceProvider factory) => new TreeCollection(_trees);
+        public TreeCollection CreateCollection(IServiceProvider factory) => new TreeCollection(() => _trees);
 
         public void RegisterWith(IServiceCollection services) => services.Add(new ServiceDescriptor(typeof(TreeCollection), CreateCollection, ServiceLifetime.Singleton));
 

--- a/src/Umbraco.Web.Common/Controllers/UmbracoApiControllerTypeCollectionBuilder.cs
+++ b/src/Umbraco.Web.Common/Controllers/UmbracoApiControllerTypeCollectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Web.Common.Controllers

--- a/src/Umbraco.Web.Website/Collections/SurfaceControllerTypeCollection.cs
+++ b/src/Umbraco.Web.Website/Collections/SurfaceControllerTypeCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 
@@ -6,8 +6,8 @@ namespace Umbraco.Cms.Web.Website.Collections
 {
     public class SurfaceControllerTypeCollection : BuilderCollectionBase<Type>
     {
-        public SurfaceControllerTypeCollection(IEnumerable<Type> items)
-            : base(items)
-        { }
+        public SurfaceControllerTypeCollection(Func<IEnumerable<Type>> items) : base(items)
+        {
+        }
     }
 }


### PR DESCRIPTION
This means we don't have to inject Lazy<T> all over the place when dealing with
collection builders and circular references since this will automatically just work OOTB.
This in theory should also allocate less instances during startup.

## Testing

Ensure all of the back office and front-end works. Test upgrading from v8 to ensure that those collections all resolve correctly. It will be pretty clear when something doesn't work because it will just explode. 