### PR TITLE
8.15RC Compress Umbraco.TrueFalse properties from int32 to bool.

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/UnPublishedContentPropertyCacheCompressionOptions.cs
+++ b/src/Umbraco.Core/PropertyEditors/UnPublishedContentPropertyCacheCompressionOptions.cs
@@ -14,6 +14,11 @@ namespace Umbraco.Core.PropertyEditors
                 //Only compress non published content that supports publishing and the property is text
                 return true;
             }
+            if (propertyType.ValueStorageType == ValueStorageType.Integer && Umbraco.Core.Constants.PropertyEditors.Aliases.Boolean.Equals(dataEditor.Alias))
+            {
+                //Compress boolean values from int to bool
+                return true;
+            }
             return false;
         }
     }

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MsgPackContentNestedDataSerializer.cs
@@ -101,6 +101,10 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
                     {
                         property.Value = LZ4Pickler.Pickle(Encoding.UTF8.GetBytes((string)property.Value), LZ4Level.L00_FAST);
                     }
+                    foreach (var property in propertyAliasToData.Value.Where(x => x.Value != null && x.Value is int intVal))
+                    {
+                        property.Value = Convert.ToBoolean((int)property.Value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Compress Umbraco.TrueFalse properties from int32 to bool.
