### PR TITLE
V9: Fix recursive localize when resetting password

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Extensions
         /// <param name="tokens"></param>
         /// <returns></returns>
         public static string Localize(this ILocalizedTextService manager, string area, string alias, CultureInfo culture, string[] tokens)
-            => manager.Localize(area, alias, Thread.CurrentThread.CurrentUICulture, tokens);
+            => manager.Localize(area, alias, Thread.CurrentThread.CurrentUICulture, ConvertToDictionaryVars(tokens));
 
          /// <summary>
          /// Convert an array of strings to a dictionary of indices -> values
@@ -88,7 +88,7 @@ namespace Umbraco.Extensions
 
              var areaAndKey = text.Split('_');
 
-             if (areaAndKey.Length < 2) 
+             if (areaAndKey.Length < 2)
                 return text;
 
              value = manager.Localize(areaAndKey[0], areaAndKey[1]);


### PR DESCRIPTION
This fixes #10668.

The problem was that during a merge the `Localize` extension on `ILocalizedTextService` which takes a string array of tokens was accidentally made to call itself, resulting in an endless recursion, which meant we'd get a stack overflow.

This PR calls `ConvertToDictionaryVars` before calling `Manager.Localize`, so no more recursion.

One thing I noticed while here is that we always use `Thread.CurrentThread.CurrentUICulture` even though we take `CultureInfo` as a parameter, wouldn't it make more sense to use that if available? And use `Thread.CurrentThread.CurrentUICulture` as a fallback?

See issue for steps to test