### PR TITLE
Umbraco 9 - LoginProvider Duplicate Key

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTableIndexes.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTableIndexes.cs
@@ -45,8 +45,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
                 Create
                      .Index(indexName1)
                      .OnTable(ExternalLoginDto.TableName)
-                     .OnColumn("loginProvider")
-                     .Ascending()
+                     .OnColumn("loginProvider").Ascending()
+                     .OnColumn("userId").Ascending()
                      .WithOptions()
                      .Unique()
                      .WithOptions()

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginDto.cs
@@ -25,9 +25,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos
         public int UserId { get; set; }
 
         [Column("loginProvider")]
-        [Length(4000)] // TODO: This value seems WAY too high, this is just a name
+        [Length(400)]
         [NullSetting(NullSetting = NullSettings.NotNull)]
-        [Index(IndexTypes.UniqueNonClustered, Name = "IX_" + TableName + "_LoginProvider")]
+        [Index(IndexTypes.UniqueNonClustered, ForColumns = "loginProvider,userId", Name = "IX_" + TableName + "_LoginProvider")]
         public string LoginProvider { get; set; }
 
         [Column("providerKey")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginDto.cs
@@ -24,12 +24,18 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos
         [Index(IndexTypes.NonClustered)]
         public int UserId { get; set; }
 
+        /// <summary>
+        /// Used to store the name of the provider (i.e. Facebook, Google)
+        /// </summary>
         [Column("loginProvider")]
         [Length(400)]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         [Index(IndexTypes.UniqueNonClustered, ForColumns = "loginProvider,userId", Name = "IX_" + TableName + "_LoginProvider")]
         public string LoginProvider { get; set; }
 
+        /// <summary>
+        /// Stores the key the provider uses to lookup the login
+        /// </summary>
         [Column("providerKey")]
         [Length(4000)]
         [NullSetting(NullSetting = NullSettings.NotNull)]


### PR DESCRIPTION
### Prerequisites

- [X ] I have added steps to test this contribution in the description below

This PR fixes #10656 

### Description
This PR updates the IX_umbracoExternalLogin_LoginProvider to include both loginProvider and userId. It also shortens the loginProvider to 400 chars instead of 4000 which was throwing a warning regarding the index anyway. 

I updated the V9 migration to make the same change to the index; however, I didn't want to shorten anybody's existing loginProvider column so I didn't change the length of that column in the migration.

This change allows more than one back office user to be able to use the same external login provider.

### Testing:
 * Ran all unit tests (all passed)
 * Ran all integration tests (all passed)
 * Test on a new site:
   * Build and run Umbraco.Web.UI.Netcore
   * Provision a new site with a new database
   * Check that IX_umbracoExternalLogin_LoginProvider now indexes both loginProvider and userId
 * Link two BackOffice user accounts to the same login provider and do not observe the duplicate key exception

