### PR TITLE
Fix examine overview not working as expected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -166,17 +166,17 @@ function ExamineManagementController($scope, $http, $q, $timeout, $location, umb
                 vm.searchResults.totalPages = Math.ceil(vm.searchResults.totalRecords / 20);
                 // add URLs to edit well known entities
                 _.each(vm.searchResults.results, function (result) {
-                    var section = result.values["__IndexType"];
+                    var section = result.values["__IndexType"][0];
                     switch (section) {
                         case "content":
                         case "media":
-                            result.editUrl = "/" + section + "/" + section + "/edit/" + result.values["__NodeId"];
-                            result.editId = result.values["__NodeId"];
+                            result.editUrl = "/" + section + "/" + section + "/edit/" + result.values["__NodeId"][0];
+                            result.editId = result.values["__NodeId"][0];
                             result.editSection = section;
                             break;
                         case "member":
-                            result.editUrl = "/member/member/edit/" + result.values["__Key"];
-                            result.editId = result.values["__Key"];
+                            result.editUrl = "/member/member/edit/" + result.values["__Key"][0];
+                            result.editId = result.values["__Key"][0];
                             result.editSection = section;
                             break;
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -153,8 +153,8 @@
                                                                 <td>{{result.score}}</td>
                                                                 <td>{{result.id}}</td>
                                                                 <td>
-                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName']}}</a>
-                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName']}}</span>
+                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</a>
+                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</span>
                                                                     <button type="button" class="table__action-overlay color-green" ng-click="vm.showSearchResultDialog(result.values)">({{result.fieldCount}} <localize key="examineManagement_fields">fields</localize>)</button>
                                                                 </td>
                                                             </tr>
@@ -292,8 +292,8 @@
                                                                 <td>{{result.score}}</td>
                                                                 <td>{{result.id}}</td>
                                                                 <td>
-                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName']}}</a>
-                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName']}}</span>
+                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</a>
+                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</span>
                                                                     <button type="button" class="table__action-overlay color-green" ng-click="vm.showSearchResultDialog(result.values)">({{result.fieldCount}} <localize key="examineManagement_fields">fields</localize>)</button>
                                                                 </td>
                                                             </tr>


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10526

With one of the recent Examine changes, the values are now returned as an array. This new response was already working well for the overview of values but was missing from the overview of the results.

I've added the same logic as in the overview of the values and fixed the logic with the editUrl.

![ExamineOverviewFi](https://user-images.githubusercontent.com/11466511/125512176-2028f7bf-8c00-4abf-a847-c6cf135a42a8.gif)

Can be tested by going to the Examine Overview and searching.