### PR TITLE
5280: Add culture overload for GetDictionaryValue

### DIFF
--- a/src/Umbraco.Core/Dictionary/ICultureDictionary.cs
+++ b/src/Umbraco.Core/Dictionary/ICultureDictionary.cs
@@ -17,6 +17,14 @@ namespace Umbraco.Core.Dictionary
         string this[string key] { get; }
 
         /// <summary>
+        /// Returns the dictionary value based on the key and the culture supplied
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        string GetByCulture(string key, string culture);
+
+        /// <summary>
         /// Returns the current culture
         /// </summary>
         CultureInfo Culture { get; }

--- a/src/Umbraco.Web/UmbracoHelper.cs
+++ b/src/Umbraco.Web/UmbracoHelper.cs
@@ -208,6 +208,14 @@ namespace Umbraco.Web
             return dictionaryValue;
         }
 
+        public string GetDictionaryValue(string key, string altText, string culture)
+        {
+            var dictionaryValue = _cultureDictionary.GetByCulture(key, culture);
+            if (string.IsNullOrWhiteSpace(dictionaryValue))
+                dictionaryValue = altText;
+            return dictionaryValue;
+        }
+
         /// <summary>
         /// Returns the ICultureDictionary for access to dictionary items
         /// </summary>


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/5280

Can be tested through the following steps:

1. Create a new project with starter kit
2. Add a new language (NL)
3. Create a dictionary item where only NL is filled in
4. On the home.cshtml, add the following code:
`Without Culture: @Umbraco.GetDictionaryValue("Test")
<br/>
With Culture: @Umbraco.GetDictionaryValue("Test", "Test", "NL")`

You should see that the first value is empty, but the second one has been filled.

While I am creating this PR, I am not 100% sure that this is the best way of doing it. I wanted to add default properties to the current GetDictionaryValue methods, but I then run into problems regarding overloads being the same. And I can't quite add regular parameters as that'll be a breaking change (quite a big one actually)... 
So, I am open to any feedback!