### PR TITLE
V9: Fix drag and drop image upload

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollection.cs
@@ -12,6 +12,14 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
         public bool TryGetMediaPath(string propertyEditorAlias, object value, out string mediaPath)
         {
+            // We can't get a media path from a null value
+            // The value will be null when uploading a brand new image, since we try to get the "old path" which doesn't exist yet.
+            if (value is null)
+            {
+                mediaPath = null;
+                return false;
+            }
+
             foreach(IMediaUrlGenerator generator in this)
             {
                 if (generator.TryGetMediaPath(propertyEditorAlias, value, out var mp))


### PR DESCRIPTION
This PR fixes an issue where you can't upload an image by drag and drop, after the new zip package. 

The problem was that when uploading an image with drag and drop we use `SetValue`, this would try to get the old path with the new media URL generators, but because this is a brand new media the `Umbraco.ImageCropper` property will be empty, so when calling the media URL generators, the `GetValue` will return null, leading to the `value` parameter of  `TryGetMediaPath` being null, the `MediaUrlGeneratorCollection` didn't handle this, so it would return true with a null mediaPath, causing a null reference exception because we called `mediaFileManager.FileSystem.GetRelativePath` with null.

I've added a null check to the `TryGetMediaPath` method of `MediaUrlGeneratorCollection`, so it will return false when the value is null, since we can't get a path from a null value, and now image uploads works fine again.

I've tagged you @Shazwazza since you can probably pretty quickly see if this is a bad idea for some reason I haven't spotted 😄 