### PR TITLE
V9: Fix validation messages

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UmbracoAuthorizedApiController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UmbracoAuthorizedApiController.cs
@@ -120,7 +120,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             => new ValidationErrorResult(value, statusCode);
 
         /// <summary>
-        /// Returns an Umbraco compatible validation problem for the object result
+        /// Returns an Umbraco compatible validation problem for the given notification model
         /// </summary>
         /// <param name="model"></param>
         /// <param name="statusCode"></param>

--- a/src/Umbraco.Web.BackOffice/Controllers/UmbracoAuthorizedApiController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UmbracoAuthorizedApiController.cs
@@ -116,7 +116,16 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <param name="value"></param>
         /// <param name="statusCode"></param>
         /// <returns></returns>
-        protected virtual ActionResult ValidationProblem(object value, int statusCode = StatusCodes.Status400BadRequest)
+        protected virtual ActionResult ValidationProblem(object value, int statusCode)
             => new ValidationErrorResult(value, statusCode);
+
+        /// <summary>
+        /// Returns an Umbraco compatible validation problem for the object result
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="statusCode"></param>
+        /// <returns></returns>
+        protected virtual ActionResult ValidationProblem(INotificationModel model, int statusCode = StatusCodes.Status400BadRequest)
+            => new ValidationErrorResult(model, statusCode);
     }
 }


### PR DESCRIPTION
This fixes #10658 and #10667.

As Shannon explains in #10667 this was due to ambiguous methods in `UmbracoAuthorizedApiController`, to fix this I removed the default value from the `statusCode` parameter.

After removing the default I noticed that `ValidationProblem` is used in a lot of places with some sort of `INotificationModel`, so I added another method that explicitly takes in an `INotificationModel` which still have the default status code, just to make everything a bit easier to use. 