### PR TITLE
UserService.SavedUserGroup event returns wrong list of AddedUsers 

### DIFF
--- a/src/Umbraco.Core/Services/Implement/UserService.cs
+++ b/src/Umbraco.Core/Services/Implement/UserService.cs
@@ -857,8 +857,9 @@ namespace Umbraco.Core.Services.Implement
                     var groupUsers = userGroup.HasIdentity ? _userRepository.GetAllInGroup(userGroup.Id).ToArray() : empty;
                     var xGroupUsers = groupUsers.ToDictionary(x => x.Id, x => x);
                     var groupIds = groupUsers.Select(x => x.Id).ToArray();
+                    var addedUserIds = userIds.Except(groupIds);
 
-                    addedUsers = userIds.Except(groupIds).Count() > 0 ? _userRepository.GetMany(userIds.Except(groupIds).ToArray()).Where(x => x.Id != 0).ToArray() : new IUser[] { };
+                    addedUsers = addedUserIds.Count() > 0 ? _userRepository.GetMany(addedUserIds.ToArray()).Where(x => x.Id != 0).ToArray() : new IUser[] { };
                     removedUsers = groupIds.Except(userIds).Select(x => xGroupUsers[x]).Where(x => x.Id != 0).ToArray();
                 }
 

--- a/src/Umbraco.Core/Services/Implement/UserService.cs
+++ b/src/Umbraco.Core/Services/Implement/UserService.cs
@@ -858,7 +858,7 @@ namespace Umbraco.Core.Services.Implement
                     var xGroupUsers = groupUsers.ToDictionary(x => x.Id, x => x);
                     var groupIds = groupUsers.Select(x => x.Id).ToArray();
 
-                    addedUsers = _userRepository.GetMany(userIds.Except(groupIds).ToArray()).Where(x => x.Id != 0).ToArray();
+                    addedUsers = userIds.Except(groupIds).Count() > 0 ? _userRepository.GetMany(userIds.Except(groupIds).ToArray()).Where(x => x.Id != 0).ToArray() : new IUser[] { };
                     removedUsers = groupIds.Except(userIds).Select(x => xGroupUsers[x]).Where(x => x.Id != 0).ToArray();
                 }
 


### PR DESCRIPTION
When no new users are  added, the _userRepository.GetMany is called with an empty array. The empty array causes that all backoffice users are returned instead of 0 users.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes  https://github.com/umbraco/Umbraco-CMS/issues/10679

### Description

- Create a component to catch the UserService.SavedUserGroup event.

```
    public class UserGroupComponent: IComponent
    {

        public UserGroupComponent()
        {

        }

        public void Initialize()
        {
            UserService.SavedUserGroup += UserService_SavedUserGroup;
        }

        private void UserService_SavedUserGroup(Umbraco.Core.Services.IUserService sender, Umbraco.Core.Events.SaveEventArgs<Umbraco.Core.Events.UserGroupWithUsers> e)
        {

            foreach (var group in e.SavedEntities)
            {

                int addedUsersCount = group.AddedUsers.Count();

                int removedUsersCount = group.RemovedUsers.Count();

            }

        }

        public void Terminate()
        {

        }


    }


    public class UserGroupComposer : IUserComposer
    {

        public void Compose(Composition composition)
        {
            composition.Components().Append<UserGroupComponent>();
        }

    }
```

- Create a usergroup and add a few users.
- Save the group
- Remove 1 user
- Save the group
- The length of AddedUsers should be 0




<!-- Thanks for contributing to Umbraco CMS! -->
