### PR TITLE
Set isMainPage to true on TemplateRenderer.ExecuteTemplateRendering

### DIFF
--- a/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
+++ b/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
@@ -152,7 +152,7 @@ namespace Umbraco.Cms.Web.Common.Templates
         {
             var httpContext = _httpContextAccessor.GetRequiredHttpContext();
 
-            var viewResult = _viewEngine.GetView(null, $"~/Views/{request.GetTemplateAlias()}.cshtml", false);
+            var viewResult = _viewEngine.GetView(null, $"~/Views/{request.GetTemplateAlias()}.cshtml", true);
 
             if (viewResult.Success == false)
             {

--- a/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
+++ b/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
@@ -152,6 +152,7 @@ namespace Umbraco.Cms.Web.Common.Templates
         {
             var httpContext = _httpContextAccessor.GetRequiredHttpContext();
 
+            // isMainPage is set to true here in order for the _ViewStart.cshtml to be rendered
             var viewResult = _viewEngine.GetView(null, $"~/Views/{request.GetTemplateAlias()}.cshtml", true);
 
             if (viewResult.Success == false)

--- a/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
+++ b/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
@@ -152,8 +152,8 @@ namespace Umbraco.Cms.Web.Common.Templates
         {
             var httpContext = _httpContextAccessor.GetRequiredHttpContext();
 
-            // isMainPage is set to true here in order for the _ViewStart.cshtml to be rendered
-            var viewResult = _viewEngine.GetView(null, $"~/Views/{request.GetTemplateAlias()}.cshtml", true);
+            // isMainPage is set to true here to ensure ViewStart(s) found in the view hierarchy are rendered
+            var viewResult = _viewEngine.GetView(null, $"~/Views/{request.GetTemplateAlias()}.cshtml", isMainPage: true);
 
             if (viewResult.Success == false)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10683

### Description
In the `TemplateRenderer`, on the `ExecuteTemplateRendering` method, when calling `this._viewEngine.GetView`, `isMainPage` was set to `false` resulting in the `_ViewStart.cshtml` never being called. This has now been changed to `true`.
