### PR TITLE
Add integration test for MemberService::CreateMemberWithIdentity

### DIFF
--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using NPoco;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
@@ -1305,6 +1305,24 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
             IMember found = MemberService.GetById(customMember.Id);
 
             Assert.IsTrue(found.IsApproved);
+        }
+
+        [Test]
+        public void Can_CreateWithIdentity()
+        {
+            // Arrange
+            IMemberType memberType = MemberTypeBuilder.CreateSimpleMemberType();
+            MemberTypeService.Save(memberType);
+            string username = Path.GetRandomFileName();
+
+            // Act
+            IMember member = MemberService.CreateMemberWithIdentity(username, $"{username}@domain.email", Path.GetFileNameWithoutExtension(username), memberType);
+            IMember found = MemberService.GetById(member.Id);
+
+            // Assert
+            Assert.IsNotNull(member, "Verifying a member instance has been created");
+            Assert.IsNotNull(found, "Verifying the created member instance has been retrieved");
+            Assert.IsTrue(found?.Name == member?.Name, "Verifying the retrieved member instance has the expected name");
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

This PR is in support of #10666 

### Description

Added integration test as requested by @Shazwazza to highlight the issue of MemberService::CreateMemberWithIdentity not persisting a member even though the call produced no error and return a member instance.

The test method assertion will fail until the issue is resolved.