### PR TITLE
V9: Fix translations not shown everywhere

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -225,17 +224,25 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <returns></returns>
         [HttpGet]
         [AllowAnonymous]
-        public Dictionary<string, Dictionary<string, string>> LocalizedText(string culture = null)
+        public async Task<Dictionary<string, Dictionary<string, string>>> LocalizedText(string culture = null)
         {
-            var isAuthenticated = _backofficeSecurityAccessor.BackOfficeSecurity.IsAuthenticated();
+            CultureInfo cultureInfo;
+            if (string.IsNullOrWhiteSpace(culture))
+            {
+                // Force authentication to occur since this is not an authorized endpoint, we need this to get a user.
+                AuthenticateResult authenticationResult = await this.AuthenticateBackOfficeAsync();
+                // We have to get the culture from the Identity, we can't rely on thread culture
+                // It's entirely likely for a user to have a different culture in the backoffice, than their system.
+                var user = authenticationResult.Principal?.Identity;
 
-            var cultureInfo = string.IsNullOrWhiteSpace(culture)
-                //if the user is logged in, get their culture, otherwise default to 'en'
-                ? isAuthenticated
-                    //current culture is set at the very beginning of each request
-                    ? Thread.CurrentThread.CurrentCulture
-                    : CultureInfo.GetCultureInfo(_globalSettings.DefaultUILanguage)
-                : CultureInfo.GetCultureInfo(culture);
+                cultureInfo = (authenticationResult.Succeeded && user is not null)
+                    ? user.GetCulture()
+                    : CultureInfo.GetCultureInfo(_globalSettings.DefaultUILanguage);
+            }
+            else
+            {
+                cultureInfo = CultureInfo.GetCultureInfo(culture);
+            }
 
             var allValues = _textService.GetAllStoredValues(cultureInfo);
             var pathedValues = allValues.Select(kv =>


### PR DESCRIPTION
This fixes #10645, the problem was that translations would only be shown in some places in the backoffice.

The problem was in the `BackOfficeController` `LocalizedText` endpoint that is used to get localized text for javascript. I found two problems here.

The first was that we used `_backofficeSecurityAccessor.BackOfficeSecurity.IsAuthenticated();` to try and authenticate the user, but since this is not an authorized endpoint this would always return false. I changed it to use `this.AuthenticateBackOfficeAsync()` like in the other actions. 

The other issue I found was that we used `Thread.CurrentThread.CurrentCulture` to try and get the users culture, however this won't work, because a user's backoffice language (and therefore culture), is not necessarily the same as their system, for instance, I typically have the backoffice language set to en-US, but `Thread.CurrentThread.CurrentCulture` will return `da-DK` because my system culture in Danish, leading to a very interesting looking half Danish half English backoffice.

To fix this aspect I changed it over so that we now get the culture using the Identity, we get when authenticating the backoffice user, which returns the correct culture info.


### Testing
1. Change a user's language to something other than English
2. Log out and in again
3. Verify that everything that should be translated is

As with anything front-end adjacent, you might have to clear your cache and do a hard reload