### PR TITLE
Support member names using Down-Level Logon Name format

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -15,6 +15,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         internal const bool StaticHideDisabledUsersInBackOffice = false;
         internal const bool StaticAllowPasswordReset = true;
         internal const string StaticAuthCookieName = "UMB_UCONTEXT";
+        internal const string StaticAllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\";
 
         /// <summary>
         /// Gets or sets a value indicating whether to keep the user logged in.
@@ -49,6 +50,12 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// Gets or sets a value indicating whether the user's email address is to be considered as their username.
         /// </summary>
         public bool UsernameIsEmail { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the set of allowed characters for a username
+        /// </summary>
+        [DefaultValue(StaticAllowedUserNameCharacters)]
+        public string AllowedUserNameCharacters { get; set; } = StaticAllowedUserNameCharacters;
 
         /// <summary>
         /// Gets or sets a value for the user password settings.

--- a/src/Umbraco.Web.Common/Security/ConfigureMemberIdentityOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureMemberIdentityOptions.cs
@@ -10,9 +10,13 @@ namespace Umbraco.Cms.Web.Common.Security
     public sealed class ConfigureMemberIdentityOptions : IConfigureOptions<IdentityOptions>
     {
         private readonly MemberPasswordConfigurationSettings _memberPasswordConfiguration;
+        private readonly SecuritySettings _securitySettings;
 
-        public ConfigureMemberIdentityOptions(IOptions<MemberPasswordConfigurationSettings> memberPasswordConfiguration)
-            => _memberPasswordConfiguration = memberPasswordConfiguration.Value;
+        public ConfigureMemberIdentityOptions(IOptions<MemberPasswordConfigurationSettings> memberPasswordConfiguration, IOptions<SecuritySettings> securitySettings)
+        {
+            _memberPasswordConfiguration = memberPasswordConfiguration.Value;
+            _securitySettings = securitySettings.Value;
+        }
 
         public void Configure(IdentityOptions options)
         {
@@ -21,6 +25,9 @@ namespace Umbraco.Cms.Web.Common.Security
             options.SignIn.RequireConfirmedPhoneNumber = false;     // not implemented
 
             options.User.RequireUniqueEmail = true;
+
+            // Support validation of member names using Down-Level Logon Name format
+            options.User.AllowedUserNameCharacters = _securitySettings.AllowedUserNameCharacters;
 
             options.Lockout.AllowedForNewUsers = true;
             // TODO: Implement this

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -46,6 +46,7 @@
         "KeepUserLoggedIn": false,
         "UsernameIsEmail": true,
         "HideDisabledUsersInBackoffice": false,
+        "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\",
         "UserPassword": {
           "RequiredLength": 10,
           "RequireNonLetterOrDigit": false,


### PR DESCRIPTION
### Prerequisites

This fixes #10665

### Description

Added new config option **AllowedUserNameCharacters** to the **Security** section. This value is used when configuring         IdentityOptions for a Member to override the default member name character validation.

- Default value includes the backslash character [in addition to all characters as presently defined by ASP.NET Core]
- Value can be overridden in config

Tested using a v9 test site:

- With no local application config changes, can a username of "DOMAIN\user" be successfully a) created b) edited
- Adding the setting value of "abcd1234"application config changes, are the following usernames able to be added:
  - "DOMAIN\user" - Invalid
  - "abc\123" - Invalid
  - "abc123" - Valid