### PR TITLE
Error message has incorrect location to find the error logs v9

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/error.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/error.html
@@ -3,7 +3,7 @@
 
     <p class="message">{{installer.current.model.message}}</p>
 
-    <p><small>See the log for full details (logs can typically be found in the App_Data\Logs folder).</small></p>
+    <p><small>See the log for full details (logs can typically be found in the umbraco\Logs folder).</small></p>
 
     <button class="btn btn-success" ng-click="restart()">Go back</button>
 </div>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

Error during installation the error log location is now under **umbraco\Logs** as opposed to App_Data\Logs

<img width="532" alt="Screenshot 2021-07-15 at 17 31 41" src="https://user-images.githubusercontent.com/4864638/125824649-1379e87b-4e43-4be0-8115-3b09d2afde05.png">



<!-- Thanks for contributing to Umbraco CMS! -->
