### PR TITLE
Removes `inert` attribute when `editorService.closeAll()` is called

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
@@ -126,7 +126,9 @@
                 // close all editors
                 if (args && !args.editor && args.editors.length === 0) {
                     editorCount = 0;
-                    scope.editors = [];
+                    scope.editors = [];                    
+                    // Remove the inert attribute from the #mainwrapper
+                    focusLockService.removeInertAttribute();
                 }
             }));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10708

### Description
Removes the `inert` attribute on `#mainWrapper` when `editorService.closeAll()` is called.

This code is necessary because when `closeAll` is called, there is no editor passed in `args`, and so `removeEditor` is never called, and so the `focusLockService.removeInertAttribute();` method isn't called either. 

This ensures `focusLockService.removeInertAttribute();` is called if the editor arg is null, meaning it's come from a `closeAll` call.

To test, open a dialog via `editorService.open` and then call `editorService.closeAll`. The main editor window should have the `inert` attribute added and then removed once closed.

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
