### PR TITLE
Decouple NuCache.Property from NuCache.PublishedSnapshot

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/Property.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/Property.cs
@@ -124,7 +124,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
         private CacheValues GetCacheValues(PropertyCacheLevel cacheLevel)
         {
             CacheValues cacheValues;
-            PublishedSnapshot publishedSnapshot;
+            IPublishedSnapshot publishedSnapshot;
             IAppCache cache;
             switch (cacheLevel)
             {
@@ -141,7 +141,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     // elements cache (if we don't want to pollute the elements cache with short-lived
                     // data) depending on settings
                     // for members, always cache in the snapshot cache - never pollute elements cache
-                    publishedSnapshot = (PublishedSnapshot) _publishedSnapshotAccessor.PublishedSnapshot;
+                    publishedSnapshot = _publishedSnapshotAccessor.PublishedSnapshot;
                     cache = publishedSnapshot == null
                         ? null
                         : ((_isPreviewing == false || PublishedSnapshotService.FullCacheWhenPreviewing) && (_isMember == false)
@@ -151,7 +151,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                     break;
                 case PropertyCacheLevel.Snapshot:
                     // cache within the snapshot cache
-                    publishedSnapshot = (PublishedSnapshot) _publishedSnapshotAccessor.PublishedSnapshot;
+                    publishedSnapshot = _publishedSnapshotAccessor.PublishedSnapshot;
                     cache = publishedSnapshot?.SnapshotCache;
                     cacheValues = GetCacheValues(cache);
                     break;


### PR DESCRIPTION
### Description

`NuCache.Property` is unnecessarily tight coupled to `NuCache.PublishedSnapshot`.  
This prevents unit-testing parts of NuCache.

With this change, I'm actually able to use NuCache from btree file on disk to proper published content via the NuCache implementations. A few stubs for sure, but not that bad. Content types must be set up _before_ we "boot" per test, but otherwise the perf. & api seems quite good!

![image](https://user-images.githubusercontent.com/350918/126150620-900b13c4-527d-4192-ba74-ad44485134cf.png)

This is just a minor fix to see if we can get going with more unit testing again.  
I think the state is pretty much "as bad" still for v9, but I'm getting somewhere.  

See https://github.com/lars-erik/umbraco-unit-testing-samples/blob/master-v8/UmbracoV8.Testing.Tests/Can_I_Haz_The_Content_Cache.cs

Cross posting a bit on #10106.