### PR TITLE
Fix ImageSharp.Web Commands

### DIFF
--- a/src/Umbraco.Infrastructure/Media/ImageSharpImageUrlGenerator.cs
+++ b/src/Umbraco.Infrastructure/Media/ImageSharpImageUrlGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using Umbraco.Cms.Core.Media;
@@ -15,48 +15,53 @@ namespace Umbraco.Cms.Infrastructure.Media
         {
             if (options == null) return null;
 
-            var imageProcessorUrl = new StringBuilder(options.ImageUrl ?? string.Empty);
+            var imageSharpWebUrl = new StringBuilder(options.ImageUrl ?? string.Empty);
 
-            if (options.FocalPoint != null) AppendFocalPoint(imageProcessorUrl, options);
-            else if (options.Crop != null) AppendCrop(imageProcessorUrl, options);
-            else if (options.DefaultCrop) imageProcessorUrl.Append("?anchor=center&mode=crop");
+            if (options.FocalPoint != null) AppendFocalPoint(imageSharpWebUrl, options);
+            else if (options.Crop != null) AppendCrop(imageSharpWebUrl, options);
+            else if (options.DefaultCrop) imageSharpWebUrl.Append("?ranchor=center&rmode=crop");
             else
             {
-                imageProcessorUrl.Append("?mode=").Append((options.ImageCropMode ?? ImageCropMode.Crop).ToString().ToLower());
+                imageSharpWebUrl.Append("?rmode=").Append((options.ImageCropMode ?? ImageCropMode.Crop).ToString().ToLower());
 
-                if (options.ImageCropAnchor != null) imageProcessorUrl.Append("&anchor=").Append(options.ImageCropAnchor.ToString().ToLower());
+                if (options.ImageCropAnchor != null) imageSharpWebUrl.Append("&ranchor=").Append(options.ImageCropAnchor.ToString().ToLower());
             }
 
             var hasFormat = options.FurtherOptions != null && options.FurtherOptions.InvariantContains("&format=");
 
             //Only put quality here, if we don't have a format specified.
             //Otherwise we need to put quality at the end to avoid it being overridden by the format.
-            if (options.Quality.HasValue && hasFormat == false) imageProcessorUrl.Append("&quality=").Append(options.Quality);
-            if (options.HeightRatio.HasValue) imageProcessorUrl.Append("&heightratio=").Append(options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
-            if (options.WidthRatio.HasValue) imageProcessorUrl.Append("&widthratio=").Append(options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
-            if (options.Width.HasValue) imageProcessorUrl.Append("&width=").Append(options.Width);
-            if (options.Height.HasValue) imageProcessorUrl.Append("&height=").Append(options.Height);
-            if (options.UpScale == false) imageProcessorUrl.Append("&upscale=false");
-            if (!string.IsNullOrWhiteSpace(options.AnimationProcessMode)) imageProcessorUrl.Append("&animationprocessmode=").Append(options.AnimationProcessMode);
-            if (!string.IsNullOrWhiteSpace(options.FurtherOptions)) imageProcessorUrl.Append(options.FurtherOptions);
+            if (options.Quality.HasValue && hasFormat == false) imageSharpWebUrl.Append("&quality=").Append(options.Quality);
+
+            // ** TO DO **
+            if (options.HeightRatio.HasValue) imageSharpWebUrl.Append("&heightratio=").Append(options.HeightRatio.Value.ToString(CultureInfo.InvariantCulture));
+            // ** TO DO **
+            if (options.WidthRatio.HasValue) imageSharpWebUrl.Append("&widthratio=").Append(options.WidthRatio.Value.ToString(CultureInfo.InvariantCulture));
+
+            if (options.Width.HasValue) imageSharpWebUrl.Append("&width=").Append(options.Width);
+            if (options.Height.HasValue) imageSharpWebUrl.Append("&height=").Append(options.Height);
+            if (options.UpScale == false) imageSharpWebUrl.Append("&upscale=false");
+            if (!string.IsNullOrWhiteSpace(options.AnimationProcessMode)) imageSharpWebUrl.Append("&animationprocessmode=").Append(options.AnimationProcessMode);
+            if (!string.IsNullOrWhiteSpace(options.FurtherOptions)) imageSharpWebUrl.Append(options.FurtherOptions);
 
             //If furtherOptions contains a format, we need to put the quality after the format.
-            if (options.Quality.HasValue && hasFormat) imageProcessorUrl.Append("&quality=").Append(options.Quality);
-            if (!string.IsNullOrWhiteSpace(options.CacheBusterValue)) imageProcessorUrl.Append("&rnd=").Append(options.CacheBusterValue);
+            if (options.Quality.HasValue && hasFormat) imageSharpWebUrl.Append("&quality=").Append(options.Quality);
+            if (!string.IsNullOrWhiteSpace(options.CacheBusterValue)) imageSharpWebUrl.Append("&rnd=").Append(options.CacheBusterValue);
 
-            return imageProcessorUrl.ToString();
+            return imageSharpWebUrl.ToString();
         }
 
         private void AppendFocalPoint(StringBuilder imageProcessorUrl, ImageUrlGenerationOptions options)
         {
-            imageProcessorUrl.Append("?center=");
+            imageProcessorUrl.Append("?rxy=");
             imageProcessorUrl.Append(options.FocalPoint.Top.ToString(CultureInfo.InvariantCulture)).Append(",");
             imageProcessorUrl.Append(options.FocalPoint.Left.ToString(CultureInfo.InvariantCulture));
-            imageProcessorUrl.Append("&mode=crop");
+            imageProcessorUrl.Append("&rmode=crop");
         }
 
         private void AppendCrop(StringBuilder imageProcessorUrl, ImageUrlGenerationOptions options)
         {
+            // ** TO DO **
             imageProcessorUrl.Append("?crop=");
             imageProcessorUrl.Append(options.Crop.X1.ToString(CultureInfo.InvariantCulture)).Append(",");
             imageProcessorUrl.Append(options.Crop.Y1.ToString(CultureInfo.InvariantCulture)).Append(",");

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Media/ImageSharpImageUrlGeneratorTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Media/ImageSharpImageUrlGeneratorTests.cs
@@ -27,21 +27,21 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_WidthHeightTest()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = s_focus1, Width = 200, Height = 300 });
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300", urlString);
+            Assert.AreEqual(MediaPath + "?rxy=0.80827067669172936,0.96&rmode=crop&width=200&height=300", urlString);
         }
 
         [Test]
         public void GetCropUrl_FocalPointTest()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = s_focus1, Width = 100, Height = 100 });
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=100&height=100", urlString);
+            Assert.AreEqual(MediaPath + "?rxy=0.80827067669172936,0.96&rmode=crop&width=100&height=100", urlString);
         }
 
         [Test]
         public void GetCropUrlFurtherOptionsTest()
         {
-            var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = s_focus1, Width = 200, Height = 300, FurtherOptions = "&filter=comic&roundedcorners=radius-26|bgcolor-fff" });
-            Assert.AreEqual(MediaPath + "?center=0.80827067669172936,0.96&mode=crop&width=200&height=300&filter=comic&roundedcorners=radius-26|bgcolor-fff", urlString);
+            var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = s_focus1, Width = 200, Height = 300, FurtherOptions = "&rsampler=robidouxsharp" });
+            Assert.AreEqual(MediaPath + "?rxy=0.80827067669172936,0.96&rmode=crop&width=200&height=300&rsampler=robidouxsharp", urlString);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrlEmptyTest()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(null));
-            Assert.AreEqual("?mode=crop", urlString);
+            Assert.AreEqual("?rmode=crop", urlString);
         }
 
         /// <summary>
@@ -116,11 +116,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
             var urlStringMax = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = ImageCropMode.Max, Width = 300, Height = 150 });
             var urlStringStretch = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = ImageCropMode.Stretch, Width = 300, Height = 150 });
 
-            Assert.AreEqual(MediaPath + "?mode=min&width=300&height=150", urlStringMin);
-            Assert.AreEqual(MediaPath + "?mode=boxpad&width=300&height=150", urlStringBoxPad);
-            Assert.AreEqual(MediaPath + "?mode=pad&width=300&height=150", urlStringPad);
-            Assert.AreEqual(MediaPath + "?mode=max&width=300&height=150", urlStringMax);
-            Assert.AreEqual(MediaPath + "?mode=stretch&width=300&height=150", urlStringStretch);
+            Assert.AreEqual(MediaPath + "?rmode=min&width=300&height=150", urlStringMin);
+            Assert.AreEqual(MediaPath + "?rmode=boxpad&width=300&height=150", urlStringBoxPad);
+            Assert.AreEqual(MediaPath + "?rmode=pad&width=300&height=150", urlStringPad);
+            Assert.AreEqual(MediaPath + "?rmode=max&width=300&height=150", urlStringMax);
+            Assert.AreEqual(MediaPath + "?rmode=stretch&width=300&height=150", urlStringStretch);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_UploadTypeTest()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = ImageCropMode.Crop, ImageCropAnchor = ImageCropAnchor.Center, Width = 100, Height = 270 });
-            Assert.AreEqual(MediaPath + "?mode=crop&anchor=center&width=100&height=270", urlString);
+            Assert.AreEqual(MediaPath + "?rmode=crop&ranchor=center&width=100&height=270", urlString);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_PreferFocalPointCenter()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Width = 300, Height = 150 });
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=300&height=150", urlString);
+            Assert.AreEqual(MediaPath + "?ranchor=center&rmode=crop&width=300&height=150", urlString);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_PreDefinedCropNoCoordinatesWithWidthAndFocalPointIgnore()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { FocalPoint = s_focus2, Width = 270, Height = 161 });
-            Assert.AreEqual(MediaPath + "?center=0.41,0.4275&mode=crop&width=270&height=161", urlString);
+            Assert.AreEqual(MediaPath + "?rxy=0.41,0.4275&rmode=crop&width=270&height=161", urlString);
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_WidthOnlyParameter()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Width = 200 });
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&width=200", urlString);
+            Assert.AreEqual(MediaPath + "?ranchor=center&rmode=crop&width=200", urlString);
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_HeightOnlyParameter()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { DefaultCrop = true, Height = 200 });
-            Assert.AreEqual(MediaPath + "?anchor=center&mode=crop&height=200", urlString);
+            Assert.AreEqual(MediaPath + "?ranchor=center&rmode=crop&height=200", urlString);
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Media
         public void GetCropUrl_BackgroundColorParameter()
         {
             var urlString = s_generator.GetImageUrl(new ImageUrlGenerationOptions(MediaPath) { ImageCropMode = ImageCropMode.Pad, Width = 400, Height = 400, FurtherOptions = "&bgcolor=fff" });
-            Assert.AreEqual(MediaPath + "?mode=pad&width=400&height=400&bgcolor=fff", urlString);
+            Assert.AreEqual(MediaPath + "?rmode=pad&width=400&height=400&bgcolor=fff", urlString);
         }
     }
 }


### PR DESCRIPTION
The commands in the ImageSharpImageUrlGenerator.cs are mostly from ImageProcessor.Web and need to be updated for ImageSharp.Web

I have updated the following

- [x]  `center `= `rxy`
- [x] `anchor `= `ranchor`
- [x] `mode `= `rmode`

To Remove or create ImageWebProcessor to handle

- [ ] `upscale`
- [ ] `animationprocessmode`
- [ ] `heightratio`
- [ ] `widthratio`

If removing the various ratio modes then the ImageCropRatioMode.cs should be removed also

To create ImageWebProcessor to handle

- [ ] **`crop`** - ImageSharp.Web doesn't support cropping from coordinates by default a new ImageWebProcessor will be required and the coordinates will need to be translated to a Rectangle - this exists in https://github.com/umbraco/Umbraco-CMS/pull/10623