### PR TITLE
Update umbeditorview.directive.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorview.directive.js
@@ -59,6 +59,8 @@ Use this directive to construct the main editor window.
     <li>{@link umbraco.directives.directive:umbEditorContainer umbEditorContainer}</li>
     <li>{@link umbraco.directives.directive:umbEditorFooter umbEditorFooter}</li>
 </ul>
+
+@param {boolean} footer Whether the directive should make place for a {@link umbraco.directives.directive:umbEditorFooter umbEditorFooter} at the bottom (`true` by default).
 **/
 
 (function() {


### PR DESCRIPTION
The `<umb-editor-view />` directive has a "hidden" parameter as it's only used in the view (and not in the JS, which may be why it has been overlooked.

By default, `<umb-editor-view />` creates a bit of distance to the bottom so there is space for a `<umb-editor-footer/>` element. For editors that don't have a footer, the `footer` parameter of `<umb-editor-view />` can be set to `false`.

This commit targets `v8/contrib`, but the parameter is also missing in `v9/dev`.



