### PR TITLE
Update LocalizedTextServiceExtensions.cs - use the culture parameter, instead of Thread.CurrentThread.CurrentUICulture

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Extensions
         /// <param name="tokens"></param>
         /// <returns></returns>
         public static string Localize(this ILocalizedTextService manager, string area, string alias, CultureInfo culture, string[] tokens)
-            => manager.Localize(area, alias, Thread.CurrentThread.CurrentUICulture, ConvertToDictionaryVars(tokens));
+            => manager.Localize(area, alias, culture, ConvertToDictionaryVars(tokens));
 
          /// <summary>
          /// Convert an array of strings to a dictionary of indices -> values


### PR DESCRIPTION
Use the culture passed in, instead if the static Thread.CurrentThread.CurrentUICulture

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
