### PR TITLE
V9: Fix multi url picker

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -258,16 +258,16 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <summary>
         /// Gets the URL of an entity
         /// </summary>
-        /// <param name="udi">UDI of the entity to fetch URL for</param>
+        /// <param name="id">UDI of the entity to fetch URL for</param>
         /// <param name="culture">The culture to fetch the URL for</param>
         /// <returns>The URL or path to the item</returns>
-        public IActionResult GetUrl(Udi udi, string culture = "*")
+        public IActionResult GetUrl(Udi id, string culture = "*")
         {
-            var intId = _entityService.GetId(udi);
+            var intId = _entityService.GetId(id);
             if (!intId.Success)
                 return NotFound();
             UmbracoEntityTypes entityType;
-            switch (udi.EntityType)
+            switch (id.EntityType)
             {
                 case Constants.UdiEntityType.Document:
                     entityType = UmbracoEntityTypes.Document;

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -142,7 +142,7 @@ function entityResource($q, $http, umbRequestHelper) {
                    umbRequestHelper.getApiUrl(
                        "entityApiBaseUrl",
                        "GetUrl",
-                       [{ udi: udi }, {culture: culture }])),
+                       [{ id: udi }, {culture: culture }])),
                'Failed to retrieve url for UDI:' + udi);
         },
 


### PR DESCRIPTION
This PR fixes #10694.

Using the multi url picker would result in a 404 error when it was rendered to the front page.

The cause was that the UDI parameter was named `udi`, and with our `EntityController` we use a custom attribute `ParameterSwapControllerActionSelector` to handle ambiguous actions, however, this doesn't work if the parameters differ in name between the two actions. Since the we have a `GetUrl` action with a parameter `id` and the action is registered as such: `[ParameterSwapControllerActionSelector(nameof(GetUrl), "id", typeof(int), typeof(Udi))]`, the attribute was unable to resolve the request when the parameter was `udi`.

To fix this I renamed the `udi` parameter to `id` and reflected the change in the javascript code as well, after this the action is invoked correctly and we don't get any more 404's

### Testing
Follow the steps in #10694, after the PR this should no longer fail, remember to rebuild the client project though for the javascript changes to take effect.