### PR TITLE
10718 Enables more configured Blocks in Block List Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -694,7 +694,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                     $http.post(
                         umbRequestHelper.getApiUrl(
                             "contentApiBaseUrl",
-                            "PostEmptyByKeys"),
+                            "GetEmptyByKeys"),
                         { contentTypeKeys: scaffoldKeys, parentId: parentId }
                     ),
                     'Failed to retrieve data for empty content items ids' + scaffoldKeys.join(", "))

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -57,7 +57,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
         *       Do stuff...
         *    });
         * </pre>
-        * 
+        *
         * @returns {Promise} resourcePromise object.
         *
         */
@@ -691,11 +691,12 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
         getScaffoldByKeys: function (parentId, scaffoldKeys) {
 
             return umbRequestHelper.resourcePromise(
-                    $http.get(
+                    $http.post(
                         umbRequestHelper.getApiUrl(
                             "contentApiBaseUrl",
-                            "GetEmptyByKeys",
-                            { contentTypeKeys: scaffoldKeys, parentId: parentId })),
+                            "PostEmptyByKeys"),
+                        { contentTypeKeys: scaffoldKeys, parentId: parentId }
+                    ),
                     'Failed to retrieve data for empty content items ids' + scaffoldKeys.join(", "))
                 .then(function (result) {
                     Object.keys(result).map(function(key) {
@@ -804,7 +805,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
             else if (options.orderDirection === "desc") {
                 options.orderDirection = "Descending";
             }
-            
+
             //converts the value to a js bool
             function toBool(v) {
                 if (Utilities.isNumber(v)) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -487,7 +487,7 @@
              * @returns {Object | null} Scaffold model for the that content type. Or null if the scaffolding model dosnt exist in this context.
              */
             getScaffoldFromKey: function (contentTypeKey) {
-                return this.scaffolds.find(o => o.contentTypeKey === contentTypeKey);
+                return this.scaffolds.find(o => o.contentTypeKey === contentTypeKey) || null;
             },
 
             /**
@@ -499,7 +499,7 @@
              * @returns {Object | null} Scaffold model for the that content type. Or null if the scaffolding model dosnt exist in this context.
              */
             getScaffoldFromAlias: function (contentTypeAlias) {
-                return this.scaffolds.find(o => o.contentTypeAlias === contentTypeAlias);
+                return this.scaffolds.find(o => o.contentTypeAlias === contentTypeAlias) || null;
             },
 
             /**
@@ -609,10 +609,14 @@
                         blockObject.settingsData = settingsData;
 
                         // make basics from scaffold
-                        blockObject.settings = Utilities.copy(settingsScaffold);
-                        ensureUdiAndKey(blockObject.settings, settingsUdi);
+                        if (settingsScaffold !== null) {// We might not have settingsScaffold
+                            blockObject.settings = Utilities.copy(settingsScaffold);
+                            ensureUdiAndKey(blockObject.settings, settingsUdi);
 
-                        mapToElementModel(blockObject.settings, settingsData);
+                            mapToElementModel(blockObject.settings, settingsData);
+                        } else {
+                            blockObject.settings = null;
+                        }
 
                         // add settings content-app
                         appendSettingsContentApp(blockObject.content, this.__labels.settingsName);

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -449,6 +449,13 @@ namespace Umbraco.Web.Editors
             return result;
         }
 
+        private IDictionary<Guid, ContentItemDisplay> GetEmptyByKeysInternal(Guid[] contentTypeKeys, int parentId)
+        {
+            using var scope = _scopeProvider.CreateScope(autoComplete: true);
+            var contentTypes = Services.ContentTypeService.GetAll(contentTypeKeys).ToList();
+            return GetEmpties(contentTypes, parentId).ToDictionary(x => x.ContentTypeKey);
+        }
+
         /// <summary>
         /// Gets a collection of empty content items for all document types.
         /// </summary>
@@ -457,9 +464,14 @@ namespace Umbraco.Web.Editors
         [OutgoingEditorModelEvent]
         public IDictionary<Guid, ContentItemDisplay> GetEmptyByKeys([FromUri] Guid[] contentTypeKeys, [FromUri] int parentId)
         {
-            using var scope = _scopeProvider.CreateScope(autoComplete: true);
-            var contentTypes = Services.ContentTypeService.GetAll(contentTypeKeys).ToList();
-            return GetEmpties(contentTypes, parentId).ToDictionary(x => x.ContentTypeKey);
+            return GetEmptyByKeysInternal(contentTypeKeys, parentId);
+        }
+
+        [HttpPost]
+        [OutgoingEditorModelEvent]
+        public IDictionary<Guid, ContentItemDisplay> PostEmptyByKeys(ContentTypesByKeys contentTypeByKeys)
+        {
+            return GetEmptyByKeysInternal(contentTypeByKeys.ContentTypeKeys, contentTypeByKeys.ParentId);
         }
 
         [OutgoingEditorModelEvent]

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -470,11 +470,14 @@ namespace Umbraco.Web.Editors
         /// <summary>
         /// Gets a collection of empty content items for all document types.
         /// </summary>
+        /// <remarks>
+        /// This is a post request in order to support a large amount of GUIDs without hitting the URL length limit.
+        /// </remarks>
         /// <param name="contentTypeByKeys"></param>
         /// <returns></returns>
         [HttpPost]
         [OutgoingEditorModelEvent]
-        public IDictionary<Guid, ContentItemDisplay> PostEmptyByKeys(ContentTypesByKeys contentTypeByKeys)
+        public IDictionary<Guid, ContentItemDisplay> GetEmptyByKeys(ContentTypesByKeys contentTypeByKeys)
         {
             return GetEmptyByKeysInternal(contentTypeByKeys.ContentTypeKeys, contentTypeByKeys.ParentId);
         }

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -467,6 +467,11 @@ namespace Umbraco.Web.Editors
             return GetEmptyByKeysInternal(contentTypeKeys, parentId);
         }
 
+        /// <summary>
+        /// Gets a collection of empty content items for all document types.
+        /// </summary>
+        /// <param name="contentTypeByKeys"></param>
+        /// <returns></returns>
         [HttpPost]
         [OutgoingEditorModelEvent]
         public IDictionary<Guid, ContentItemDisplay> PostEmptyByKeys(ContentTypesByKeys contentTypeByKeys)

--- a/src/Umbraco.Web/Models/ContentEditing/ContentTypesByKeys.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentTypesByKeys.cs
@@ -4,13 +4,22 @@ using System.Runtime.Serialization;
 
 namespace Umbraco.Web.Models.ContentEditing
 {
+    /// <summary>
+    /// A model for retrieving multiple content types based on their keys.
+    /// </summary>
     [DataContract(Name = "contentTypes", Namespace = "")]
     public class ContentTypesByKeys
     {
+        /// <summary>
+        /// ID of the parent of the content type.
+        /// </summary>
         [DataMember(Name = "parentId")]
         [Required]
         public int ParentId { get; set; }
 
+        /// <summary>
+        /// The id of every content type to get.
+        /// </summary>
         [DataMember(Name = "contentTypeKeys")]
         [Required]
         public Guid[] ContentTypeKeys { get; set; }

--- a/src/Umbraco.Web/Models/ContentEditing/ContentTypesByKeys.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentTypesByKeys.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Web.Models.ContentEditing
+{
+    [DataContract(Name = "contentTypes", Namespace = "")]
+    public class ContentTypesByKeys
+    {
+        [DataMember(Name = "parentId")]
+        [Required]
+        public int ParentId { get; set; }
+
+        [DataMember(Name = "contentTypeKeys")]
+        [Required]
+        public Guid[] ContentTypeKeys { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Media\UploadAutoFillProperties.cs" />
     <Compile Include="Migrations\PostMigrations\PublishedSnapshotRebuilder.cs" />
     <Compile Include="Models\AnchorsModel.cs" />
+    <Compile Include="Models\ContentEditing\ContentTypesByKeys.cs" />
     <Compile Include="Models\ContentEditing\DataTypeReferences.cs" />
     <Compile Include="Models\ContentEditing\LinkDisplay.cs" />
     <Compile Include="Models\ContentEditing\MacroDisplay.cs" />


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10718

The issue was caused by URI length of GETs requests was exceeded, to eliminate it this PR changed the call to a POST.

As well JS changes are made to ensure that the UI displays if ElementTypes are missing or didn't load properly, enhancing the experience if something isn't right.

**Test notes:**
* Test a blocklist editor property with a lot of configured Blocks, 35+(or 18+ with a Settings model for each) should reach the limit. It needs to be different ElementTypes used for each, meaning that we need 35+ unique Element Types.