### PR TITLE
Examine dashboard search adjustments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbsearchfilter.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbsearchfilter.directive.js
@@ -40,6 +40,8 @@
 
         vm.$onInit = onInit;
         vm.change = change;
+        vm.keyDown = keyDown;
+        vm.blur = blur;
 
         function onInit() {
             vm.inputId = vm.inputId || "umb-search-filter_" + String.CreateGuid();
@@ -63,6 +65,23 @@
                 }, 0);
             }
         }
+
+        function blur() {
+            if (vm.onBlur) {
+                vm.onBlur();
+            }
+        }
+
+        function keyDown(evt) {
+            //13: enter
+            switch (evt.keyCode) {
+                case 13:
+                    if (vm.onSearch) {
+                        vm.onSearch();
+                    }
+                    break;
+            }
+        }
     }
 
     var component = {
@@ -76,6 +95,8 @@
             text: "@",
             labelKey: "@?",
             onChange: "&?",
+            onSearch: "&?",
+            onBlur: "&?",
             autoFocus: "<?",
             preventSubmitOnEnter: "<?",
             cssClass: "@?"

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-search.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-search.less
@@ -33,7 +33,7 @@
     height: 70px;
 }
 
-.umb-search-input.umb-search-input {
+.umb-search-input {
     width: 100%;
     height: 70px;
     border: none;

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_spacing.less
@@ -40,6 +40,14 @@
     margin-left: auto; 
     margin-right: auto;
 }
+
+.my-auto {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
+.mt-auto { margin-top: auto; }
+.mb-auto { margin-bottom: auto; }
 .ml-auto { margin-left: auto; }
 .mr-auto { margin-right: auto; }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -18,7 +18,7 @@
 
                 <div class="umb-control-group" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
                     <umb-search-filter
-                        input-id="icon-search"
+                        input-id="block-search"
                         model="vm.filter.searchTerm"
                         label-key="placeholders_filter"
                         text="Type to filter..."

--- a/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/forms/umb-search-filter.html
@@ -5,6 +5,8 @@
         <input type="text"
                id="{{vm.inputId}}"
                ng-change="vm.change()"
+               ng-keydown="vm.keyDown($event)"
+               ng-blur="vm.blur($event)"
                ng-model="vm.model"
                class="umb-search-filter__input"
                placeholder="{{vm.text}}"

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -1,4 +1,4 @@
-function ExamineManagementController($scope, $http, $q, $timeout, $location, umbRequestHelper, localizationService, overlayService, editorService) {
+function ExamineManagementController($http, $q, $timeout, umbRequestHelper, localizationService, overlayService, editorService) {
 
     var vm = this;
 

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -1,7 +1,5 @@
 <div id="examineManagement" class="examine-management" ng-controller="Umbraco.Dashboard.ExamineManagementController as vm">
 
-    {{vm.selectedSearcher}}
-
     <div ng-show="vm.loading">
         <umb-load-indicator></umb-load-indicator>
     </div>
@@ -127,7 +125,7 @@
                                                             <umb-search-filter
                                                                 input-id="examine-search"
                                                                 model="vm.searchText"
-                                                                on-search="vm.search(vm.selectedSearcher, $event)"
+                                                                on-search="vm.search(vm.selectedIndex, $event)"
                                                                 label-key="placeholders_filter"
                                                                 text="Type to filter..."
                                                                 css-class="w-100">
@@ -273,7 +271,7 @@
                                                             <umb-search-filter
                                                                 input-id="examine-search"
                                                                 model="vm.searchText"
-                                                                on-search="vm.search(vm.selectedSearcher, $event)"
+                                                                on-search="vm.search(vm.selectedIndex, $event)"
                                                                 label-key="placeholders_filter"
                                                                 text="Type to filter..."
                                                                 css-class="w-100">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -24,7 +24,7 @@
 
                             <div class="umb-panel-group__details-status-icon-container">
                                 <umb-icon icon="{{indexer.isHealthy ? 'icon-check' : 'icon-delete'}}"
-                                          class="umb-panel-status-icon"
+                                          class="umb-panel-status-icon mt1"
                                           ng-class="{'icon-check color-green' : indexer.isHealthy, 'icon-delete color-red' : !indexer.isHealthy}">
                                 </umb-icon>
                             </div>
@@ -61,7 +61,7 @@
                         <div class="umb-panel-group__details-status" ng-repeat="searcher in vm.searcherDetails">
 
                             <div class="umb-panel-group__details-status-icon-container">
-                                <umb-icon icon="icon-info" class="icon-info umb-panel-status-icon"></umb-icon>
+                                <umb-icon icon="icon-info" class="icon-info umb-panel-status-icon mt1"></umb-icon>
                             </div>
 
                             <div class="umb-panel-group__details-status-content">
@@ -227,7 +227,7 @@
 
                                 <div class="umb-panel-group__details-status-icon-container">
                                     <umb-icon icon="{{indexer.isHealthy ? 'icon-check' : 'icon-delete'}}"
-                                              class="umb-panel-status-icon"
+                                              class="umb-panel-status-icon mt1"
                                               ng-class="{'icon-check color-green' : indexer.isHealthy, 'icon-delete color-red' : !indexer.isHealthy}">
                                     </umb-icon>
                                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -226,9 +226,9 @@
                             <div class="umb-panel-group__details-status">
 
                                 <div class="umb-panel-group__details-status-icon-container">
-                                    <umb-icon icon="{{indexer.isHealthy ? 'icon-check' : 'icon-delete'}}"
+                                    <umb-icon icon="{{vm.selectedIndex.isHealthy ? 'icon-check' : 'icon-delete'}}"
                                               class="umb-panel-status-icon mt1"
-                                              ng-class="{'icon-check color-green' : indexer.isHealthy, 'icon-delete color-red' : !indexer.isHealthy}">
+                                              ng-class="{'icon-check color-green' : vm.selectedIndex.isHealthy, 'icon-delete color-red' : !vm.selectedIndex.isHealthy}">
                                     </umb-icon>
                                 </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -134,14 +134,6 @@
                                                             </umb-search-filter>
                                                         </div>
 
-                                                        <!--<umb-icon icon="icon-search" class="icon icon-search"></umb-icon>
-
-                                                        <input type="text" class="search-query"
-                                                               placeholder="@placeholders_search"
-                                                               localize="placeholder"
-                                                               ng-model="vm.searchText" no-dirty-check
-                                                               ng-keypress="vm.search(vm.selectedSearcher, $event)" />-->
-
                                                         <umb-button disabled="vm.selectedSearcher.isProcessing"
                                                                     type="button"
                                                                     button-style="success"
@@ -287,13 +279,6 @@
                                                                 css-class="w-100">
                                                             </umb-search-filter>
                                                         </div>
-
-                                                        <!--<umb-icon icon="icon-search" class="icon icon-search"></umb-icon>
-                                                        <input type="text" class="search-query"
-                                                               placeholder="@placeholders_search"
-                                                               localize="placeholder"
-                                                               ng-model="vm.searchText" no-dirty-check
-                                                               ng-keypress="vm.search(vm.selectedIndex, $event)" />-->
 
                                                         <umb-button disabled="vm.selectedIndex.isProcessing"
                                                                     type="button"

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -25,8 +25,10 @@
                         <div class="umb-panel-group__details-status" ng-repeat="indexer in vm.indexerDetails">
 
                             <div class="umb-panel-group__details-status-icon-container">
-                                <i class="umb-panel-status-icon" aria-hidden="true"
-                                   ng-class="{'icon-check color-green' : indexer.isHealthy, 'icon-delete color-red' : !indexer.isHealthy}"></i>
+                                <umb-icon icon="{{indexer.isHealthy ? 'icon-check' : 'icon-delete'}}"
+                                          class="umb-panel-status-icon"
+                                          ng-class="{'icon-check color-green' : indexer.isHealthy, 'icon-delete color-red' : !indexer.isHealthy}">
+                                </umb-icon>
                             </div>
 
                             <div class="umb-panel-group__details-status-content">
@@ -61,7 +63,7 @@
                         <div class="umb-panel-group__details-status" ng-repeat="searcher in vm.searcherDetails">
 
                             <div class="umb-panel-group__details-status-icon-container">
-                                <i class="umb-panel-status-icon icon-info" aria-hidden="true"></i>
+                                <umb-icon icon="icon-info" class="icon-info umb-panel-status-icon"></umb-icon>
                             </div>
 
                             <div class="umb-panel-group__details-status-content">
@@ -234,8 +236,10 @@
                             <div class="umb-panel-group__details-status">
 
                                 <div class="umb-panel-group__details-status-icon-container">
-                                    <i class="umb-panel-status-icon" aria-hidden="true"
-                                       ng-class="{'icon-check color-green' : vm.selectedIndex.isHealthy, 'icon-delete color-red' : !vm.selectedIndex.isHealthy}"></i>
+                                    <umb-icon icon="{{indexer.isHealthy ? 'icon-check' : 'icon-delete'}}"
+                                              class="umb-panel-status-icon"
+                                              ng-class="{'icon-check color-green' : indexer.isHealthy, 'icon-delete color-red' : !indexer.isHealthy}">
+                                    </umb-icon>
                                 </div>
 
                                 <div class="umb-panel-group__details-status-content">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -1,5 +1,7 @@
 <div id="examineManagement" class="examine-management" ng-controller="Umbraco.Dashboard.ExamineManagementController as vm">
 
+    {{vm.selectedSearcher}}
+
     <div ng-show="vm.loading">
         <umb-load-indicator></umb-load-indicator>
     </div>
@@ -116,15 +118,27 @@
                                         <div class="umb-panel-group__details-status-action">
                                             <ng-form name="searchTools">
 
-                                                <div class="row form-search">
-                                                    <div class="inner-addon left-addon flex">
-                                                        <umb-icon icon="icon-search" class="icon icon-search"></umb-icon>
+                                                <div class="row">
+                                                    <div class="flex">
+
+                                                        <div class="flex-auto">
+                                                            <umb-search-filter
+                                                                input-id="examine-search"
+                                                                model="vm.searchText"
+                                                                on-search="vm.search(vm.selectedSearcher, $event)"
+                                                                label-key="placeholders_filter"
+                                                                text="Type to filter..."
+                                                                css-class="w-100">
+                                                            </umb-search-filter>
+                                                        </div>
+
+                                                        <!--<umb-icon icon="icon-search" class="icon icon-search"></umb-icon>
 
                                                         <input type="text" class="search-query"
                                                                placeholder="@placeholders_search"
                                                                localize="placeholder"
                                                                ng-model="vm.searchText" no-dirty-check
-                                                               ng-keypress="vm.search(vm.selectedSearcher, $event)" />
+                                                               ng-keypress="vm.search(vm.selectedSearcher, $event)" />-->
 
                                                         <umb-button disabled="vm.selectedSearcher.isProcessing"
                                                                     type="button"
@@ -256,14 +270,26 @@
                                         <div class="umb-panel-group__details-status-action">
                                             <ng-form name="searchTools">
 
-                                                <div class="row form-search">
-                                                    <div class="inner-addon left-addon flex">
-                                                        <umb-icon icon="icon-search" class="icon icon-search"></umb-icon>
+                                                <div class="row">
+                                                    <div class="flex">
+
+                                                        <div class="flex-auto">
+                                                            <umb-search-filter
+                                                                input-id="examine-search"
+                                                                model="vm.searchText"
+                                                                on-search="vm.search(vm.selectedSearcher, $event)"
+                                                                label-key="placeholders_filter"
+                                                                text="Type to filter..."
+                                                                css-class="w-100">
+                                                            </umb-search-filter>
+                                                        </div>
+
+                                                        <!--<umb-icon icon="icon-search" class="icon icon-search"></umb-icon>
                                                         <input type="text" class="search-query"
                                                                placeholder="@placeholders_search"
                                                                localize="placeholder"
                                                                ng-model="vm.searchText" no-dirty-check
-                                                               ng-keypress="vm.search(vm.selectedIndex, $event)" />
+                                                               ng-keypress="vm.search(vm.selectedIndex, $event)" />-->
 
                                                         <umb-button disabled="vm.selectedIndex.isProcessing"
                                                                     type="button"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add a few adjustments to Examine dashboard in Settings section:

- Replace search input with `<umb-search-filter>` component.
- Replace icons with `<umb-icon>` component.

Currently `<umb-search-filter>` only acted on change, but not on a keypress/keydown event, e.g. search on enter.
I have handled this a bit similar to have it works in `umbMiniSearch` which has an `onSearch` function.
https://github.com/umbraco/Umbraco-CMS/blob/d428a4543f33bb7094cf7db5f6b6fdc2d1de3063/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminisearch.component.js#L13

We could in this case call the function `onFilter`, but I thought it might be to close to the `onChange` function.


## Test notes
- Check Examine search works searching via enter in search input and when clicking Search button. With default starter kit search e.g. on "home".
- Test filtering on e.g. Icon Picker still works.
