### PR TITLE
Support custom SVG icons in user groups list

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
@@ -18,7 +18,7 @@
                 <umb-box-content>
 
                     <umb-search-filter
-                        input-id="composition-search"
+                        input-id="usergroup-search"
                         model="searchTerm"
                         label-key="placeholders_filter"
                         text="Type to filter..."

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/usergrouppicker/usergrouppicker.html
@@ -36,7 +36,7 @@
                             </button>
 
                             <div class="umb-user-group-picker-list-item__icon">
-                                <i ng-if="!userGroup.selected" class="{{userGroup.icon}}" aria-hidden="true"></i>
+                                <umb-icon icon="{{userGroup.icon}}" class="{{userGroup.icon}}" ng-if="!userGroup.selected"></umb-icon>
                                 <umb-checkmark ng-if="userGroup.selected" checked="userGroup.selected" size="xs"></umb-checkmark>
                             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/umb-user-group-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/umb-user-group-preview.html
@@ -1,7 +1,7 @@
 <div class="umb-user-group-preview">
-    
-    <i ng-if="icon" class="umb-user-group-preview__icon {{ icon }}"></i>
-    
+
+    <umb-icon icon="{{icon}}" class="umb-user-group-preview__icon"></umb-icon>
+
     <div class="umb-user-group-preview__content">
         <div class="umb-user-group-preview__name">{{ name }}</div>
 
@@ -20,7 +20,7 @@
                 <span ng-if="contentStartNode">{{ contentStartNode.name }}</span>
             </span>
         </div>
-        
+
         <div class="umb-user-group-preview__permissions" ng-if="!hideMediaStartNode">
             <span>
                 <span class="bold"><localize key="user_mediastartnode">Media start node</localize>:</span>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
@@ -81,8 +81,8 @@
                 ng-class="{'-selected': group.selected, '-selectable': group.hasAccess && !group.isSystemUserGroup}">
 
                 <div class="umb-table-cell">
-                    <umb-icon icon="{{group.icon}}" class="{{group.icon}} umb-table-body__icon umb-table-body__fileicon"></umb-icon>
-                    <umb-icon icon="icon-check" class="icon-check umb-table-body__icon umb-table-body__checkicon"></umb-icon>
+                    <umb-icon icon="{{group.icon}}" class="{{group.icon}} umb-table-body__icon umb-table-body__fileicon" ng-if="!group.selected"></umb-icon>
+                    <umb-icon icon="icon-check" class="icon-check umb-table-body__icon umb-table-body__checkicon" ng-if="group.selected"></umb-icon>
                 </div>
                 <div class="umb-table-cell">
                     <a

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
@@ -81,8 +81,8 @@
                 ng-class="{'-selected': group.selected, '-selectable': group.hasAccess && !group.isSystemUserGroup}">
 
                 <div class="umb-table-cell">
-                    <i ng-if="group.icon" class="umb-table-body__icon umb-table-body__fileicon {{ group.icon }}"></i>
-                    <i class="umb-table-body__icon umb-table-body__checkicon icon-check"></i>
+                    <umb-icon icon="{{group.icon}}" class="{{group.icon}} umb-table-body__icon umb-table-body__fileicon"></umb-icon>
+                    <umb-icon icon="icon-check" class="icon-check umb-table-body__icon umb-table-body__checkicon"></umb-icon>
                 </div>
                 <div class="umb-table-cell">
                     <a


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Previous in this PR https://github.com/umbraco/Umbraco-CMS/pull/10345 I fixed the issue when using a custom SVG icon in listviews. However in user groups table it doesn't use listview or `<umb-table>` component, so it wasn't fixed here.

**Before**

![image](https://user-images.githubusercontent.com/2919859/126909706-3d2ba2fc-6cd9-4d28-bcb7-84ca9ed8c78e.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/126909121-de9c2609-1215-4157-9ead-a2a5c409688c.png)


It was also an issue in user group picker:

**Before**

![image](https://user-images.githubusercontent.com/2919859/126909258-9f96dbd2-b3b6-4372-8e39-2000585eea22.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/126909326-6ab485d4-6b28-4ef8-9a9d-6f047512308a.png)
