### PR TITLE
Localize using the provided culture rather than the thread culture (#3)

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceExtensions.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Extensions
             => manager.Localize(area, alias, Thread.CurrentThread.CurrentUICulture, tokens);
 
         /// <summary>
-        /// Localize a key without any variables
+        /// Localize a key with variables using the provided culture
         /// </summary>
         /// <param name="manager"></param>
         /// <param name="area"></param>
@@ -55,7 +55,7 @@ namespace Umbraco.Extensions
         /// <param name="tokens"></param>
         /// <returns></returns>
         public static string Localize(this ILocalizedTextService manager, string area, string alias, CultureInfo culture, string[] tokens)
-            => manager.Localize(area, alias, Thread.CurrentThread.CurrentUICulture, ConvertToDictionaryVars(tokens));
+            => manager.Localize(area, alias, culture, ConvertToDictionaryVars(tokens));
 
          /// <summary>
          /// Convert an array of strings to a dictionary of indices -> values


### PR DESCRIPTION
Localize method accepted a CultureInfo parameter, but passed `Thread.CurrentThread.CurrentUICulture` to the internal localization function. 

This means that if I requested (in code) localization to dn-DK, I'd still get back an English string, based on my UI culture. That's an issue if I'm localizing strings for users other than the logged in user - for example when creating a batch of workflow emails to users whose culture can differ from mine.
