### PR TITLE
Removes `inert` attribute when `editorService.closeAll()` is called

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
@@ -128,7 +128,7 @@
                     editorCount = 0;
                     scope.editors = [];
                     // Inert content in the #mainwrapper
-                    focusLockService.addInertAttribute();
+                    focusLockService.removeInertAttribute();
                 }
             }));
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditors.directive.js
@@ -127,6 +127,8 @@
                 if (args && !args.editor && args.editors.length === 0) {
                     editorCount = 0;
                     scope.editors = [];
+                    // Inert content in the #mainwrapper
+                    focusLockService.addInertAttribute();
                 }
             }));
 


### PR DESCRIPTION
Same as #10710 but re-applied for v9 which seems to have the same issue.