### PR TITLE
Abstracts out IIndexRebuilder so it can be replaced.

### DIFF
--- a/src/Umbraco.Examine/IIndexRebuilder.cs
+++ b/src/Umbraco.Examine/IIndexRebuilder.cs
@@ -1,0 +1,29 @@
+﻿using Examine;
+
+namespace Umbraco.Examine
+{
+    /// <summary>
+    /// Used to rebuild Umbraco indexes.
+    /// </summary>
+    public interface IIndexRebuilder
+    {
+        /// <summary>
+        /// Checks if the index has a populator assigned and can be rebuilt.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        bool CanRebuild(IIndex index);
+
+        /// <summary>
+        /// Rebuilds a single index.
+        /// </summary>
+        /// <param name="indexName"></param>
+        void RebuildIndex(string indexName);
+
+        /// <summary>
+        /// Rebuilds all indexes.
+        /// </summary>
+        /// <param name="onlyEmptyIndexes"></param>
+        void RebuildIndexes(bool onlyEmptyIndexes);
+    }
+}

--- a/src/Umbraco.Examine/IndexRebuilder.cs
+++ b/src/Umbraco.Examine/IndexRebuilder.cs
@@ -7,12 +7,12 @@ using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
 
 namespace Umbraco.Examine
-{   
-
+{
+    /// <inheritdoc />
     /// <summary>
     /// Utility to rebuild all indexes ensuring minimal data queries
     /// </summary>
-    public class IndexRebuilder
+    public class IndexRebuilder : IIndexRebuilder
     {
         private readonly IProfilingLogger _logger;
         private readonly IEnumerable<IIndexPopulator> _populators;
@@ -31,11 +31,13 @@ namespace Umbraco.Examine
             ExamineManager = examineManager;
         }
 
+        /// <inheritdoc/>
         public bool CanRebuild(IIndex index)
         {
             return _populators.Any(x => x.IsRegistered(index));
         }
 
+        /// <inheritdoc/>
         public void RebuildIndex(string indexName)
         {
             if (!ExamineManager.TryGetIndex(indexName, out var index))
@@ -47,6 +49,7 @@ namespace Umbraco.Examine
             }
         }
 
+        /// <inheritdoc/>
         public void RebuildIndexes(bool onlyEmptyIndexes)
         {
             var indexes = (onlyEmptyIndexes
@@ -61,7 +64,7 @@ namespace Umbraco.Examine
             }
 
             // run each populator over the indexes
-            foreach(var populator in _populators)
+            foreach (var populator in _populators)
             {
                 try
                 {
@@ -69,7 +72,7 @@ namespace Umbraco.Examine
                 }
                 catch (Exception e)
                 {
-                    _logger.Error<IndexRebuilder,Type>(e, "Index populating failed for populator {Populator}", populator.GetType());                    
+                    _logger.Error<IndexRebuilder, Type>(e, "Index populating failed for populator {Populator}", populator.GetType());
                 }
             }
         }

--- a/src/Umbraco.Examine/Umbraco.Examine.csproj
+++ b/src/Umbraco.Examine/Umbraco.Examine.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ExamineExtensions.cs" />
     <Compile Include="IContentValueSetBuilder.cs" />
     <Compile Include="IContentValueSetValidator.cs" />
+    <Compile Include="IIndexRebuilder.cs" />
     <Compile Include="IUmbracoContentIndex.cs" />
     <Compile Include="IUmbracoIndexConfig.cs" />
     <Compile Include="IIndexCreator.cs" />

--- a/src/Umbraco.Web/Editors/ExamineManagementController.cs
+++ b/src/Umbraco.Web/Editors/ExamineManagementController.cs
@@ -23,11 +23,13 @@ namespace Umbraco.Web.Editors
         private readonly IExamineManager _examineManager;
         private readonly ILogger _logger;
         private readonly IAppPolicyCache _runtimeCache;
-        private readonly IndexRebuilder _indexRebuilder;
+        private readonly IIndexRebuilder _indexRebuilder;
 
-        public ExamineManagementController(IExamineManager examineManager, ILogger logger,
+        public ExamineManagementController(
+            IExamineManager examineManager,
+            ILogger logger,
             AppCaches appCaches,
-            IndexRebuilder indexRebuilder)
+            IIndexRebuilder indexRebuilder)
         {
             _examineManager = examineManager;
             _logger = logger;

--- a/src/Umbraco.Web/Search/ExamineComposer.cs
+++ b/src/Umbraco.Web/Search/ExamineComposer.cs
@@ -29,7 +29,9 @@ namespace Umbraco.Web.Search
             composition.Register<PublishedContentIndexPopulator>(Lifetime.Singleton);
             composition.Register<MediaIndexPopulator>(Lifetime.Singleton);
 
+            // TODO: Remove this concrete registration in netcore - this is here only for backwards compat.
             composition.Register<IndexRebuilder>(Lifetime.Singleton);
+            composition.Register<IIndexRebuilder, IndexRebuilder>(Lifetime.Singleton);
             composition.RegisterUnique<IUmbracoIndexConfig, UmbracoIndexConfig>();
             composition.RegisterUnique<IUmbracoIndexesCreator, UmbracoIndexesCreator>();
             composition.RegisterUnique<IPublishedContentValueSetBuilder>(factory =>

--- a/src/Umbraco.Web/Suspendable.cs
+++ b/src/Umbraco.Web/Suspendable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Examine;
 using Examine.Providers;
+using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Composing;
 using Umbraco.Examine;
@@ -72,7 +73,7 @@ namespace Umbraco.Web
                 _suspended = true;
             }
 
-            public static void ResumeIndexers(IndexRebuilder indexRebuilder, ILogger logger)
+            public static void ResumeIndexers(IIndexRebuilder indexRebuilder, ILogger logger)
             {
                 _suspended = false;
 
@@ -82,7 +83,7 @@ namespace Umbraco.Web
                 _tried = false;
 
                 // TODO: when resuming do we always want a full rebuild of all indexes?
-                ExamineComponent.RebuildIndexes(indexRebuilder, logger, false);
+                Current.Factory.GetInstance<BackgroundIndexRebuilder>().RebuildIndexes(false, 0);
             }
         }
 


### PR DESCRIPTION
Currently there is no way to control externally how index rebuilds occur (without a ton of hacks). This PR creates an abstraction for IIndexRebuilder so that it can be replaced if necessary by extensions. Currently in ExamineX there is an issue because Umbraco force rebuilds indexes on a cold boot which requires a lot of hacks to deal with. https://github.com/SDKits/ExamineX/issues/46