### PR TITLE
Use umb-icon component in user history

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -86,12 +86,12 @@
         <ul class="umb-tree">
             <li ng-repeat="item in history | orderBy:'time':true">
                 <a ng-href="{{item.link}}" ng-click="gotoHistory(item.link)" prevent-default>
-                    <i class="{{item.icon}}"></i> {{item.name}}
+                    <umb-icon icon="{{item.icon}}" class="{{item.icon}}"></umb-icon>
+                    {{item.name}}
                 </a>
             </li>
         </ul>
     </div>
-
 
     <div ng-if="showPasswordFields && !denyLocalLogin">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed in user history it wasn't showing node icons, if using custom SVG icons.
This PR fixes that by using the `<umb-icon>` component.

**Before**

![image](https://user-images.githubusercontent.com/2919859/127206093-b45c2022-0e1f-4a7d-b2a1-16f7f5ec813b.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/127205510-d3bf304d-a173-4648-b9cb-5552bfa9a642.png)

