### PR TITLE
Only make umb-button-ellipsis visible when above backdrop

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/buttons/umb-button-ellipsis.less
@@ -1,4 +1,4 @@
-.umb-button-ellipsis{
+.umb-button-ellipsis {
     padding: 0 5px;
     text-align: center;
     margin: 0 auto;
@@ -28,13 +28,13 @@
     }
 
     .umb-button-ellipsis--tab,
-    .umb-tour-is-visible .umb-tree &,
+    .umb-tour-is-visible .umb-tree .umb-tree-item.above-backdrop &,
     &:hover,
-    &:focus{
+    &:focus {
         opacity: 1;
     }
 
-    &--hidden{
+    &--hidden {
         opacity: 0;
 
         &:hover,
@@ -55,7 +55,7 @@
 
         .umb-button-ellipsis--tab & {
             margin: 0 0 7px;
-         }
+        }
 
         .umb-button-ellipsis--small & {
             font-size: 8px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After `<umb-button-ellipsis>` was implemented and used in tree I have noticed when starting a tour all "options" buttons in tree become visible.

I think this should be a bit more specific when the tree get focus.

In content section run tour "Create content -> Creating content".

**Before**

![image](https://user-images.githubusercontent.com/2919859/127213210-0a974179-20a8-46fc-bd17-e8dd768c4454.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/127213041-0b25e72b-51ac-431a-bed1-81b9198dd76b.png)

![image](https://user-images.githubusercontent.com/2919859/127212976-f06463cf-d616-4e5e-95cd-46cceb21aaff.png)

Could be improved further, but at least it doesn't show all `<umb-button-ellipsis>` when tour is active, but only then the tree is above backdrop.

When running this tour I also noticed the issue reported here: https://github.com/umbraco/Umbraco-CMS/issues/10754