### PR TITLE
Replace angular.forEach with Utilities.forEach

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbutton.directive.js
@@ -135,7 +135,7 @@ Use this directive to render an umbraco button. The directive can be used to gen
             if (vm.buttonStyle) {
 
                 // make it possible to pass in multiple styles
-                if(vm.buttonStyle.startsWith("[") && vm.buttonStyle.endsWith("]")) {
+                if (vm.buttonStyle.startsWith("[") && vm.buttonStyle.endsWith("]")) {
 
                     // when using an attr it will always be a string so we need to remove square brackets
                     // and turn it into and array
@@ -143,16 +143,16 @@ Use this directive to render an umbraco button. The directive can be used to gen
                     // split array by , + make sure to catch whitespaces
                     var array = withoutBrackets.split(/\s?,\s?/g);
 
-                    angular.forEach(array, function(item){
+                    Utilities.forEach(array, item => {
                         vm.style = vm.style + " " + "btn-" + item;
-                        if(item === "block") {
+                        if (item === "block") {
                             vm.blockElement = true;
                         }
                     });
 
                 } else {
                     vm.style = "btn-" + vm.buttonStyle;
-                    if(vm.buttonStyle === "block") {
+                    if (vm.buttonStyle === "block") {
                         vm.blockElement = true;
                     }
                 }
@@ -167,7 +167,7 @@ Use this directive to render an umbraco button. The directive can be used to gen
 
             // watch for state changes
             if (changes.state) {
-                if(changes.state.currentValue) {
+                if (changes.state.currentValue) {
                     vm.innerState = changes.state.currentValue;
                 }
                 if (changes.state.currentValue === 'success' || changes.state.currentValue === 'error') {
@@ -179,25 +179,25 @@ Use this directive to render an umbraco button. The directive can be used to gen
             }
 
             // watch for disabled changes
-            if(changes.disabled) {
-                if(changes.disabled.currentValue) {
+            if (changes.disabled) {
+                if (changes.disabled.currentValue) {
                     vm.disabled = changes.disabled.currentValue;
                 }
             }
 
             // watch for label changes
-            if(changes.label && changes.label.currentValue) {
+            if (changes.label && changes.label.currentValue) {
                 vm.buttonLabel = changes.label.currentValue;
                 setButtonLabel();
             }
 
             // watch for label key changes
-            if(changes.labelKey && changes.labelKey.currentValue) {
+            if (changes.labelKey && changes.labelKey.currentValue) {
                 setButtonLabel();
             }
 
             // watch for type changes
-            if(changes.type) {
+            if (changes.type) {
                 if (!vm.type) {
                     vm.type = "button";// set the default
                 }
@@ -206,23 +206,23 @@ Use this directive to render an umbraco button. The directive can be used to gen
         }
 
         function clickButton(event) {
-            if(vm.action) {
+            if (vm.action) {
                 vm.action({$event: event});
             }
         }
 
         function setButtonLabel() {
             // if the button opens a dialog add "..." to the label
-            if(vm.addEllipsis === "true") {
+            if (vm.addEllipsis === "true") {
                 vm.buttonLabel = vm.buttonLabel + "...";
             }
 
             // look up localization key
-            if(vm.labelKey) {
-                localizationService.localize(vm.labelKey).then(function(value){
+            if (vm.labelKey) {
+                localizationService.localize(vm.labelKey).then(value => {
                     vm.buttonLabel = value;
                     // if the button opens a dialog add "..." to the label
-                    if(vm.addEllipsis === "true") {
+                    if (vm.addEllipsis === "true") {
                         vm.buttonLabel = vm.buttonLabel + "...";
                     }
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -206,11 +206,11 @@
                 scope.loadingAuditTrail = true;
 
                 logResource.getPagedEntityLog(scope.auditTrailOptions)
-                    .then(function (data) {
+                    .then(data => {
 
                         // get current backoffice user and format dates
-                        userService.getCurrentUser().then(function (currentUser) {
-                            angular.forEach(data.items, function (item) {
+                        userService.getCurrentUser().then(currentUser => {
+                            Utilities.forEach(data.items, item => {
                                 item.timestampFormatted = dateHelper.getLocalDate(item.timestamp, currentUser.locale, 'LLL');
                             });
                         });
@@ -232,12 +232,12 @@
             function loadRedirectUrls() {
                 scope.loadingRedirectUrls = true;
                 //check if Redirect URL Management is enabled
-                redirectUrlsResource.getEnableState().then(function (response) {
+                redirectUrlsResource.getEnableState().then(response => {
                     scope.urlTrackerDisabled = response.enabled !== true;
                     if (scope.urlTrackerDisabled === false) {
 
                         redirectUrlsResource.getRedirectsForContentItem(scope.node.udi)
-                            .then(function (data) {
+                            .then(data => {
                                 scope.redirectUrls = data.searchResults;
                                 scope.hasRedirects = (typeof data.searchResults !== 'undefined' && data.searchResults.length > 0);
                                 scope.loadingRedirectUrls = false;
@@ -250,7 +250,7 @@
             }
 
             function setAuditTrailLogTypeColor(auditTrail) {
-                angular.forEach(auditTrail, function (item) {
+                Utilities.forEach(auditTrail, item => {
 
                     switch (item.logType) {
                         case "Save":
@@ -304,7 +304,7 @@
 
             function formatDatesToLocal() {
                 // get current backoffice user and format dates
-                userService.getCurrentUser().then(function (currentUser) {
+                userService.getCurrentUser().then(currentUser => {
                     scope.currentVariant.createDateFormatted = dateHelper.getLocalDate(scope.currentVariant.createDate, currentUser.locale, 'LLL');
                     scope.currentVariant.releaseDateFormatted = dateHelper.getLocalDate(scope.currentVariant.releaseDate, currentUser.locale, 'LLL');
                     scope.currentVariant.expireDateFormatted = dateHelper.getLocalDate(scope.currentVariant.expireDate, currentUser.locale, 'LLL');

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigation.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditornavigation.directive.js
@@ -17,19 +17,19 @@
                 name: "More"
             };
 
-            scope.openNavigationItem = function(item) {
+            scope.openNavigationItem = item => {
                 
                 scope.showDropdown = false;
                 runItemAction(item);
                 setItemToActive(item);
-                if(scope.onSelect) {
+                if (scope.onSelect) {
                     scope.onSelect({"item": item});
                 }
                 eventsService.emit("app.tabChange", item);
             };
 
-            scope.openAnchorItem = function(item, anchor) {
-                if(scope.onAnchorSelect) {
+            scope.openAnchorItem = (item, anchor) => {
+                if (scope.onAnchorSelect) {
                     scope.onAnchorSelect({"item": item, "anchor": anchor});
                 }
                 if (item.active !== true) {
@@ -37,11 +37,11 @@
                 }
             };
 
-            scope.toggleDropdown = function () {
+            scope.toggleDropdown = () => {
                 scope.showDropdown = !scope.showDropdown;
             };
 
-            scope.hideDropdown = function() {
+            scope.hideDropdown = () => {
                 scope.showDropdown = false;
             };
 
@@ -60,7 +60,7 @@
             function calculateVisibleItems(windowWidth) {
 
                 // if we don't get a windowWidth stick with the default item limit
-                if(!windowWidth) {
+                if (!windowWidth) {
                     return;
                 }
 
@@ -94,7 +94,7 @@
                 if (selectedItem.view) {
                     
                     // deselect all items
-                    angular.forEach(scope.navigation, function(item, index){
+                    Utilities.forEach(scope.navigation, item => {
                         item.active = false;
                     });
                     
@@ -112,8 +112,8 @@
                 }
             }
 
-            var resizeCallback = function(size) {
-                if(size && size.width) {
+            var resizeCallback = size => {
+                if (size && size.width) {
                     calculateVisibleItems(size.width);
                 }
             };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -25,13 +25,12 @@
             scope.memberOptions.entityType = "MEMBER";
             scope.hasMemberReferences = false;
 
-
             function onInit() {
 
-                userService.getCurrentUser().then(function(user){
+                userService.getCurrentUser().then(user => {
                     // only allow change of media type if user has access to the settings sections
-                    angular.forEach(user.sections, function(section){
-                        if(section.alias === "settings") {
+                    Utilities.forEach(user.sections, section => {
+                        if (section.alias === "settings") {
                             scope.allowChangeMediaType = true;
                         }
                     });
@@ -52,7 +51,7 @@
 
             function formatDatesToLocal() {
                 // get current backoffice user and format dates
-                userService.getCurrentUser().then(function (currentUser) {
+                userService.getCurrentUser().then(currentUser => {
                     scope.node.createDateFormatted = dateHelper.getLocalDate(scope.node.createDate, currentUser.locale, 'LLL');
                     scope.node.updateDateFormatted = dateHelper.getLocalDate(scope.node.updateDate, currentUser.locale, 'LLL');
                 });
@@ -73,20 +72,20 @@
                 scope.node.extension = mediaHelper.getFileExtension(scope.nodeUrl);
             }
 
-            scope.openMediaType = function (mediaType) {
+            scope.openMediaType = mediaType => {
                 var editor = {
                     id: mediaType.id,
-                    submit: function(model) {
+                    submit: model => {
                         editorService.close();
                     },
-                    close: function() {
+                    close: () => {
                         editorService.close();
                     }
                 };
                 editorService.mediaTypeEditor(editor);
             };
 
-            scope.openSVG = function () {
+            scope.openSVG = () => {
                 var popup = window.open('', '_blank');
                 var html = '<!DOCTYPE html><body><img src="' + scope.nodeUrl + '"/>' +
                     '<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
@@ -136,7 +135,7 @@
 
             function loadMediaRelations() {
                 return mediaResource.getPagedReferences(scope.node.id, scope.mediaOptions)
-                    .then(function (data) {
+                    .then(data => {
                         scope.mediaReferences = data;
                         scope.hasMediaReferences = data.items.length > 0;
                     });
@@ -144,7 +143,7 @@
 
             function loadMemberRelations() {
                 return mediaResource.getPagedReferences(scope.node.id, scope.memberOptions)
-                    .then(function (data) {
+                    .then(data => {
                         scope.memberReferences = data;
                         scope.hasMemberReferences = data.items.length > 0;
                     });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbaceeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbaceeditor.directive.js
@@ -115,7 +115,7 @@
             }
 
             // onLoad callbacks
-            angular.forEach(opts.callbacks, function(cb) {
+            Utilities.forEach(opts.callbacks, cb => {
                 if (Utilities.isFunction(cb)) {
                     cb(acee);
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbchildselector.directive.js
@@ -126,14 +126,14 @@ Use this directive to render a ui component for selecting child items to a paren
             scope.dialogModel = {};
             scope.showDialog = false;
 
-            scope.removeChild = function(selectedChild, $index) {
-               if(scope.onRemove) {
+            scope.removeChild = (selectedChild, $index) => {
+               if (scope.onRemove) {
                   scope.onRemove(selectedChild, $index);
                }
             };
 
-            scope.addChild = function($event) {
-               if(scope.onAdd) {
+            scope.addChild = $event => {
+               if (scope.onAdd) {
                   scope.onAdd($event);
                }
             };
@@ -141,16 +141,16 @@ Use this directive to render a ui component for selecting child items to a paren
             function syncParentName() {
 
               // update name on available item
-              angular.forEach(scope.availableChildren, function(availableChild){
-                if(availableChild.id === scope.parentId) {
-                  availableChild.name = scope.parentName;
+              Utilities.forEach(scope.availableChildren, availableChild => {
+                if (availableChild.id === scope.parentId) {
+                   availableChild.name = scope.parentName;
                 }
               });
 
               // update name on selected child
-              angular.forEach(scope.selectedChildren, function(selectedChild){
-                if(selectedChild.id === scope.parentId) {
-                  selectedChild.name = scope.parentName;
+              Utilities.forEach(scope.selectedChildren, selectedChild => {
+                if (selectedChild.id === scope.parentId) {
+                   selectedChild.name = scope.parentName;
                 }
               });
 
@@ -159,16 +159,16 @@ Use this directive to render a ui component for selecting child items to a paren
             function syncParentIcon() {
 
               // update icon on available item
-              angular.forEach(scope.availableChildren, function(availableChild){
-                if(availableChild.id === scope.parentId) {
-                  availableChild.icon = scope.parentIcon;
+              Utilities.forEach(scope.availableChildren, availableChild => {
+                if (availableChild.id === scope.parentId) {
+                   availableChild.icon = scope.parentIcon;
                 }
               });
 
               // update icon on selected child
-              angular.forEach(scope.selectedChildren, function(selectedChild){
-                if(selectedChild.id === scope.parentId) {
-                  selectedChild.icon = scope.parentIcon;
+              Utilities.forEach(scope.selectedChildren, selectedChild => {
+                if (selectedChild.id === scope.parentId) {
+                   selectedChild.icon = scope.parentIcon;
                 }
               });
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgridselector.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgridselector.directive.js
@@ -91,7 +91,7 @@
                 }
 
                 // update selected items
-                angular.forEach(scope.selectedItems, function (selectedItem) {
+                Utilities.forEach(scope.selectedItems, selectedItem => {
                     if (selectedItem.placeholder) {
 
                         selectedItem.name = scope.name;
@@ -99,12 +99,11 @@
                         if (scope.alias !== null && scope.alias !== undefined) {
                             selectedItem.alias = scope.alias;
                         }
-
                     }
                 });
 
                 // update availableItems
-                angular.forEach(scope.availableItems, function (availableItem) {
+                Utilities.forEach(scope.availableItems, availableItem => {
                     if (availableItem.placeholder) {
 
                         availableItem.name = scope.name;
@@ -112,7 +111,6 @@
                         if (scope.alias !== null && scope.alias !== undefined) {
                             availableItem.alias = scope.alias;
                         }
-
                     }
                 });
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -25,7 +25,7 @@
 
                 // set placeholder property on each group
                 if (scope.model.groups.length !== 0) {
-                    angular.forEach(scope.model.groups, function (group) {
+                    Utilities.forEach(scope.model.groups, group => {
                         addInitProperty(group);
                     });
                 }
@@ -36,11 +36,11 @@
                 activateFirstGroup(scope.model.groups);
 
                 // localize texts
-                localizationService.localize("validation_validation").then(function (value) {
+                localizationService.localize("validation_validation").then(value => {
                     validationTranslated = value;
                 });
 
-                localizationService.localize("contentTypeEditor_tabHasNoSortOrder").then(function (value) {
+                localizationService.localize("contentTypeEditor_tabHasNoSortOrder").then(value => {
                     tabNoSortOrderTranslated = value;
                 });
             }
@@ -179,12 +179,11 @@
 
             function updatePropertiesSortOrder() {
 
-                angular.forEach(scope.model.groups, function (group) {
+                Utilities.forEach(scope.model.groups, group => {
                     if (group.tabState !== "init") {
                         group.properties = contentTypeHelper.updatePropertiesSortOrder(group.properties);
                     }
                 });
-
             }
 
             function setupAvailableContentTypesModel(result) {
@@ -242,7 +241,6 @@
 
                     scope.sortingMode = true;
                     scope.sortingButtonKey = "general_reorderDone";
-
                 }
 
             };
@@ -254,20 +252,19 @@
                     compositeContentTypes: scope.model.compositeContentTypes,
                     view: "views/common/infiniteeditors/compositions/compositions.html",
                     size: "small",
-                    submit: function () {
+                    submit: () => {
 
                         // make sure that all tabs has an init property
                         if (scope.model.groups.length !== 0) {
-                            angular.forEach(scope.model.groups, function (group) {
+                            Utilities.forEach(scope.model.groups, group => {
                                 addInitProperty(group);
                             });
                         }
 
                         // remove overlay
                         editorService.close();
-
                     },
-                    close: function (oldModel) {
+                    close: oldModel => {
 
                         // reset composition changes
                         scope.model.groups = oldModel.contentType.groups;
@@ -277,7 +274,7 @@
                         editorService.close();
 
                     },
-                    selectCompositeContentType: function (selectedContentType) {
+                    selectCompositeContentType: selectedContentType => {
 
                         var deferred = $q.defer();
 
@@ -291,7 +288,7 @@
                             //use a different resource lookup depending on the content type type
                             var resourceLookup = scope.contentType === "documentType" ? contentTypeResource.getById : mediaTypeResource.getById;
 
-                            resourceLookup(selectedContentType.id).then(function (composition) {
+                            resourceLookup(selectedContentType.id).then(composition => {
                                 //based on the above filtering we shouldn't be able to select an invalid one, but let's be safe and
                                 // double check here.
                                 var overlappingAliases = contentTypeHelper.validateAddingComposition(scope.model, composition);
@@ -414,7 +411,7 @@
             scope.activateGroup = function (selectedGroup) {
 
                 // set all other groups that are inactive to active
-                angular.forEach(scope.model.groups, function (group) {
+                Utilities.forEach(scope.model.groups, group => {
                     // skip init tab
                     if (group.tabState !== "init") {
                         group.tabState = "inActive";
@@ -452,7 +449,7 @@
                 // check i init tab already exists
                 var addGroup = true;
 
-                angular.forEach(groups, function (group) {
+                Utilities.forEach(groups, group => {
                     if (group.tabState === "init") {
                         addGroup = false;
                     }
@@ -653,7 +650,7 @@
                 };
 
                 // check if there already is an init property
-                angular.forEach(group.properties, function (property) {
+                Utilities.forEach(group.properties, property => {
                     if (property.propertyState === "init") {
                         addInitPropertyBool = false;
                     }
@@ -669,8 +666,8 @@
             function updateSameDataTypes(newProperty) {
 
                 // find each property
-                angular.forEach(scope.model.groups, function (group) {
-                    angular.forEach(group.properties, function (property) {
+                Utilities.forEach(scope.model.groups, group => {
+                    Utilities.forEach(group.properties, property => {
 
                         if (property.dataTypeId === newProperty.dataTypeId) {
 
@@ -681,9 +678,7 @@
                             property.dataTypeId = newProperty.dataTypeId;
                             property.dataTypeIcon = newProperty.dataTypeIcon;
                             property.dataTypeName = newProperty.dataTypeName;
-
                         }
-
                     });
                 });
             }
@@ -691,8 +686,8 @@
             function hasPropertyOfDataTypeId(dataTypeId) {
 
                 // look at each property
-                var result = _.filter(scope.model.groups, function (group) {
-                    return _.filter(group.properties, function (property) {
+                var result = _.filter(scope.model.groups, group => {
+                    return _.filter(group.properties, property => {
                         return (property.dataTypeId === dataTypeId);
                     });
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -34,14 +34,16 @@
                 addInitGroup(scope.model.groups);
 
                 activateFirstGroup(scope.model.groups);
+                
+                var labelKeys = [
+                    "validation_validation",
+                    "contentTypeEditor_tabHasNoSortOrder"
+                ];
 
                 // localize texts
-                localizationService.localize("validation_validation").then(value => {
-                    validationTranslated = value;
-                });
-
-                localizationService.localize("contentTypeEditor_tabHasNoSortOrder").then(value => {
-                    tabNoSortOrderTranslated = value;
+                localizationService.localizeMany(labelKeys).then(data => {
+                    validationTranslated = data[0];
+                    tabNoSortOrderTranslated = data[1];
                 });
             }
 
@@ -129,7 +131,6 @@
 
                         // store this tabs sort order as reference for the next
                         prevSortOrder = group.sortOrder;
-
                     }
 
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbminilistview.directive.js
@@ -135,11 +135,11 @@
                 var found = false;
                 scope.listViewAnimation = "out";
 
-                angular.forEach(miniListViewsHistory, function(historyItem, index){
+                Utilities.forEach(miniListViewsHistory, (historyItem, index) => {
                     // We need to make sure we can compare the two id's. 
                     // Some id's are integers and others are strings.
                     // Members have string ids like "all-members".
-                    if(historyItem.node.id.toString() === ancestor.id.toString()) {
+                    if (historyItem.node.id.toString() === ancestor.id.toString()) {
                         // load the list view from history
                         scope.miniListViews = [];
                         scope.miniListViews.push(historyItem);
@@ -149,7 +149,7 @@
                     }
                 });
 
-                if(!found) {
+                if (!found) {
                     // if we can't find the view in the history - close the list view
                     scope.exitMiniListView();
                 }
@@ -161,7 +161,7 @@
 
             scope.showBackButton = function() {
                 // don't show the back button if the start node is a list view
-                if(scope.node.metaData && scope.node.metaData.IsContainer || scope.node.isContainer) {
+                if (scope.node.metaData && scope.node.metaData.IsContainer || scope.node.isContainer) {
                     return false;
                 } else {
                     return true;
@@ -178,7 +178,7 @@
 
             function makeBreadcrumb() {
                 scope.breadcrumb = [];
-                angular.forEach(miniListViewsHistory, function(historyItem){
+                Utilities.forEach(miniListViewsHistory, historyItem => {
                     scope.breadcrumb.push(historyItem.node);
                 });
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnestedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbnestedcontent.directive.js
@@ -15,7 +15,7 @@
             var selectedTab = $scope.model.variants[0].tabs[0];
 
             if ($scope.tabAlias) {
-                angular.forEach($scope.model.variants[0].tabs, function (tab) {
+                Utilities.forEach($scope.model.variants[0].tabs, tab => {
                     if (tab.alias.toLowerCase() === $scope.tabAlias.toLowerCase()) {
                         selectedTab = tab;
                         return;
@@ -33,20 +33,19 @@
                     $scope.$broadcast("formSubmitting", { scope: $scope });
 
                     // Sync the values back
-                    angular.forEach($scope.ngModel.variants[0].tabs, function (tab) {
+                    Utilities.forEach($scope.ngModel.variants[0].tabs, tab => {
                         if (tab.alias.toLowerCase() === selectedTab.alias.toLowerCase()) {
 
-                            var localPropsMap = selectedTab.properties.reduce(function (map, obj) {
+                            var localPropsMap = selectedTab.properties.reduce((map, obj) => {
                                 map[obj.alias] = obj;
                                 return map;
                             }, {});
 
-                            angular.forEach(tab.properties, function (prop) {
+                            Utilities.forEach(tab.properties, prop => {
                                 if (localPropsMap.hasOwnProperty(prop.alias)) {
                                     prop.value = localPropsMap[prop.alias].value;
                                 }
                             });
-
                         }
                     });
                     

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -64,8 +64,7 @@ angular.module("umbraco.directives")
 
                     function _filesQueued(files, event) {
                         //Push into the queue
-                        angular.forEach(files,
-                            function(file) {
+                        Utilities.forEach(files, file => {
 
                                 if (_filterFile(file) === true) {
 
@@ -81,7 +80,7 @@ angular.module("umbraco.directives")
                         if (!scope.working) {
                             // Upload not allowed
                             if (!scope.acceptedMediatypes || !scope.acceptedMediatypes.length) {
-                                files.map(function(file) {
+                                files.map(file => {
                                     file.uploadStatus = "error";
                                     file.serverErrorMessage = "File type is not allowed here";
                                     scope.rejected.push(file);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/disabletabindex.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/disabletabindex.directive.js
@@ -29,7 +29,7 @@ angular.module("umbraco.directives")
                                 var childInputs = tabbableService.tabbable(mutation.target);
 
                                 //For each item in childInputs - override or set HTML attribute tabindex="-1"
-                                angular.forEach(childInputs, function (element) {
+                                Utilities.forEach(childInputs, element => {
                                     $(element).attr('tabindex', '-1');
                                 });
                             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
@@ -62,7 +62,7 @@ angular.module('umbraco.directives')
                     var found = false;
 
                     // check if any element has focus
-                    angular.forEach(listItems, function (item, index) {
+                    Utilities.forEach(listItems, (item, index) => {
                         if ($(item).is(":focus")) {
                             // if an element already has focus set the
                             // currentIndex so we navigate from that element

--- a/src/Umbraco.Web.UI.Client/src/common/services/retryqueue.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/retryqueue.service.js
@@ -21,7 +21,7 @@
             push: function (retryItem) {
                 retryQueue.push(retryItem);
                 // Call all the onItemAdded callbacks
-                angular.forEach(service.onItemAddedCallbacks, function (cb) {
+                Utilities.forEach(service.onItemAddedCallbacks, cb => {
                     try {
                         cb(retryItem);
                     } catch (e) {

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
@@ -88,9 +88,9 @@ function startUpDynamicContentController($q, $timeout, $scope, dashboardResource
 
     evts.push(eventsService.on("appState.tour.complete", function (name, completedTour) {
         $timeout(function(){
-            angular.forEach(vm.tours, function (tourGroup) {
-                angular.forEach(tourGroup, function (tour) {
-                    if(tour.alias === completedTour.alias) {
+            Utilities.forEach(vm.tours, tourGroup => {
+                angular.forEach(tourGroup, tour => {
+                    if (tour.alias === completedTour.alias) {
                         tour.completed = true;
                     }
                 });
@@ -100,24 +100,24 @@ function startUpDynamicContentController($q, $timeout, $scope, dashboardResource
 
     //proxy remote css through the local server
     assetsService.loadCss(dashboardResource.getRemoteDashboardCssUrl("content"), $scope);
-    dashboardResource.getRemoteDashboardContent("content").then(
-        function (data) {
 
-            vm.loading = false;
+    dashboardResource.getRemoteDashboardContent("content").then(data => {
 
-            //test if we have received valid data
-            //we capture it like this, so we avoid UI errors - which automatically triggers ui based on http response code
-            if (data && data.sections) {
-                vm.dashboard = data;
-            } else {
-                vm.showDefault = true;
-            }
-        },
-        function (exception) {
-            console.error(exception);
-            vm.loading = false;
+        vm.loading = false;
+
+        //test if we have received valid data
+        //we capture it like this, so we avoid UI errors - which automatically triggers ui based on http response code
+        if (data && data.sections) {
+            vm.dashboard = data;
+        } else {
             vm.showDefault = true;
-        });
+        }
+    },
+    function (exception) {
+        console.error(exception);
+        vm.loading = false;
+        vm.showDefault = true;
+    });
 
     onInit();
 

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/dashboard.tabs.controller.js
@@ -89,7 +89,7 @@ function startUpDynamicContentController($q, $timeout, $scope, dashboardResource
     evts.push(eventsService.on("appState.tour.complete", function (name, completedTour) {
         $timeout(function(){
             Utilities.forEach(vm.tours, tourGroup => {
-                angular.forEach(tourGroup, tour => {
+                Utilities.forEach(tourGroup, tour => {
                     if (tour.alias === completedTour.alias) {
                         tour.completed = true;
                     }

--- a/src/Umbraco.Web.UI.Client/test/lib/angular/angular-mocks.js
+++ b/src/Umbraco.Web.UI.Client/test/lib/angular/angular-mocks.js
@@ -81,7 +81,7 @@ angular.mock.$Browser = function () {
     self.defer.cancel = function (deferId) {
         var fnIndex;
 
-        angular.forEach(self.deferredFns, function (fn, index) {
+        Utilities.forEach(self.deferredFns, function (fn, index) {
             if (fn.id === deferId) fnIndex = index;
         });
 
@@ -141,7 +141,7 @@ angular.mock.$Browser.prototype = {
       * run all fns in pollFns
       */
     poll: function poll() {
-        angular.forEach(this.pollFns, function (pollFn) {
+        Utilities.forEach(this.pollFns, function (pollFn) {
             pollFn();
         });
     },
@@ -388,9 +388,9 @@ angular.mock.$LogProvider = function () {
          */
         $log.assertEmpty = function () {
             var errors = [];
-            angular.forEach(['error', 'warn', 'info', 'log'], function (logLevel) {
-                angular.forEach($log[logLevel].logs, function (log) {
-                    angular.forEach(log, function (logItem) {
+            Utilities.forEach(['error', 'warn', 'info', 'log'], function (logLevel) {
+                Utilities.forEach($log[logLevel].logs, function (log) {
+                    Utilities.forEach(log, function (logItem) {
                         errors.push('MOCK $log (' + logLevel + '): ' + String(logItem) + '\n' + (logItem.stack || ''));
                     });
                 });
@@ -598,7 +598,7 @@ angular.mock.$LogProvider = function () {
             'setYear', 'toDateString', 'toGMTString', 'toJSON', 'toLocaleFormat', 'toLocaleString',
             'toLocaleTimeString', 'toSource', 'toString', 'toTimeString', 'toUTCString', 'valueOf'];
 
-        angular.forEach(unimplementedMethods, function (methodName) {
+        Utilities.forEach(unimplementedMethods, function (methodName) {
             self[methodName] = function () {
                 throw Error("Method '" + methodName + "' is not implemented in the TzDate mock");
             };
@@ -688,13 +688,13 @@ angular.mock.dump = function (object) {
         if (angular.isElement(object)) {
             object = $(object);
             out = $('<div></div>');
-            angular.forEach(object, function (element) {
+            Utilities.forEach(object, function (element) {
                 out.append($(element).clone());
             });
             out = out.html();
         } else if (Utilities.isArray(object)) {
             out = [];
-            angular.forEach(object, function (o) {
+            Utilities.forEach(object, function (o) {
                 out.push(serialize(o));
             });
             out = '[ ' + out.join(', ') + ' ]';
@@ -1343,13 +1343,13 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
 
 
     function createShortMethods(prefix) {
-        angular.forEach(['GET', 'DELETE', 'JSONP'], function (method) {
+        Utilities.forEach(['GET', 'DELETE', 'JSONP'], function (method) {
             $httpBackend[prefix + method] = function (url, headers) {
                 return $httpBackend[prefix](method, url, undefined, headers)
             }
         });
 
-        angular.forEach(['PUT', 'POST', 'PATCH'], function (method) {
+        Utilities.forEach(['PUT', 'POST', 'PATCH'], function (method) {
             $httpBackend[prefix + method] = function (url, data, headers) {
                 return $httpBackend[prefix](method, url, data, headers)
             }
@@ -1425,7 +1425,7 @@ function MockXhr() {
         if (header) return header;
 
         header = undefined;
-        angular.forEach(this.$$respHeaders, function (headerVal, headerName) {
+        Utilities.forEach(this.$$respHeaders, function (headerVal, headerName) {
             if (!header && headerName.toLowerCase() == name) header = headerVal;
         });
         return header;
@@ -1434,7 +1434,7 @@ function MockXhr() {
     this.getAllResponseHeaders = function () {
         var lines = [];
 
-        angular.forEach(this.$$respHeaders, function (value, key) {
+        Utilities.forEach(this.$$respHeaders, function (value, key) {
             lines.push(key + ': ' + value);
         });
         return lines.join('\n');
@@ -1723,7 +1723,7 @@ window.jstestdriver && (function (window) {
      */
     window.dump = function () {
         var args = [];
-        angular.forEach(arguments, function (arg) {
+        Utilities.forEach(arguments, function (arg) {
             args.push(angular.mock.dump(arg));
         });
         jstestdriver.console.log.apply(jstestdriver.console, args);
@@ -1757,13 +1757,13 @@ window.jstestdriver && (function (window) {
         angular.mock.clearDataCache();
 
         // clean up jquery's fragment cache
-        angular.forEach(angular.element.fragments, function (val, key) {
+        Utilities.forEach(angular.element.fragments, function (val, key) {
             delete angular.element.fragments[key];
         });
 
         MockXhr.$$lastInstance = null;
 
-        angular.forEach(angular.callbacks, function (val, key) {
+        Utilities.forEach(angular.callbacks, function (val, key) {
             delete angular.callbacks[key];
         });
         angular.callbacks.counter = 0;
@@ -1798,7 +1798,7 @@ window.jstestdriver && (function (window) {
                 throw Error('Injector already created, can not register a module!');
             } else {
                 var modules = currentSpec.$modules || (currentSpec.$modules = []);
-                angular.forEach(moduleFns, function (module) {
+                Utilities.forEach(moduleFns, function (module) {
                     modules.push(module);
                 });
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7718

### Description
Previous this PR https://github.com/umbraco/Umbraco-CMS/pull/7928 was submitted to replace `angular.forEach`
However it seems not all references has been replaced or maybe because other PRs has been merged afterwards.

It can use vanilla JS `array.forEach` or `Utilities.forEach`.
Current both versions are used in core, but `Utilities.forEach` is a bit safer as it only iterate if array variable not is null or undefined.
