### PR TITLE
Tour backdrop missing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -3,7 +3,7 @@
 * @name umbraco.directives.directive:umbTree
 * @restrict E
 **/
-function umbTreeDirective($q, $rootScope, treeService, notificationsService, userService, backdropService) {
+function umbTreeDirective($q, treeService, navigationService, notificationsService) {
 
     return {
         restrict: 'E',
@@ -318,18 +318,6 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
                 }
             }
 
-            // Close any potential backdrop and remove the #leftcolumn modifier class
-            function closeBackdrop() {
-                var aboveClass = 'above-backdrop';
-                var leftColumn = $('#leftcolumn');
-                var isLeftColumnOnTop = leftColumn.hasClass(aboveClass);
-
-                if(isLeftColumnOnTop){
-                    backdropService.close();
-                    leftColumn.removeClass(aboveClass);
-                }
-            }
-
             /** Returns the css classses assigned to the node (div element) */
             $scope.getNodeCssClass = function (node) {
                 if (!node) {
@@ -370,7 +358,7 @@ function umbTreeDirective($q, $rootScope, treeService, notificationsService, use
             */
             $scope.select = function (n, ev) {
 
-                closeBackdrop()
+                navigationService.closeBackdrop()
                 
                 if (n.metaData && n.metaData.noAccess === true) {
                     ev.preventDefault();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -358,7 +358,7 @@ function umbTreeDirective($q, treeService, navigationService, notificationsServi
             */
             $scope.select = function (n, ev) {
 
-                navigationService.closeBackdrop()
+                navigationService.closeBackdrop();
                 
                 if (n.metaData && n.metaData.noAccess === true) {
                     ev.preventDefault();

--- a/src/Umbraco.Web.UI.Client/src/common/services/backdrop.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/backdrop.service.js
@@ -35,11 +35,11 @@
 		 */
         function open(options) {
 
-            if(options && options.element) {
+            if (options && options.element) {
                 args.element = options.element;
             }
 
-            if(options && options.disableEventsOnClick) {
+            if (options && options.disableEventsOnClick) {
                 args.disableEventsOnClick = options.disableEventsOnClick;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/backdrop.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/backdrop.service.js
@@ -58,11 +58,11 @@
          * 
 		 */
         function close() {
-            args.opacity = null,
-            args.element = null,
-            args.elementPreventClick = false,
-            args.disableEventsOnClick = false,
-            args.show = false
+            args.opacity = null;
+            args.element = null;
+            args.elementPreventClick = false;
+            args.disableEventsOnClick = false;
+            args.show = false;
             eventsService.emit("appState.backdrop", args);
         }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -136,7 +136,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
 
     function showBackdrop() {
         var backDropOptions = {
-            'element': $('#leftcolumn')[0]
+            'element': document.getElementById('leftcolumn')
         };
         backdropService.open(backDropOptions);
     }

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -118,13 +118,19 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
     }
 
     function closeBackdrop() {
-        var aboveClass = 'above-backdrop';
-        var leftColumn = $('#leftcolumn');
-        var isLeftColumnOnTop = leftColumn.hasClass(aboveClass);
 
-        if(isLeftColumnOnTop){
+        var tourIsOpen = document.body.classList.contains("umb-tour-is-visible");
+        if (tourIsOpen) {
+            return;
+        }
+
+        var aboveClass = "above-backdrop";
+        var leftColumn = document.getElementById("leftcolumn");
+        var isLeftColumnOnTop = leftColumn.classList.contains(aboveClass);
+
+        if (isLeftColumnOnTop) {
             backdropService.close();
-            leftColumn.removeClass(aboveClass);
+            leftColumn.classList.remove(aboveClass);
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js
@@ -51,7 +51,12 @@
 
         function close() {
             focusLockService.removeInertAttribute();
-            backdropService.close();
+
+            var tourIsOpen = document.body.classList.contains("umb-tour-is-visible");
+            if (!tourIsOpen) {
+                backdropService.close();
+            }
+            
             currentOverlay = null;
             eventsService.emit("appState.overlay", null);
         }

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-backdrop.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-backdrop.html
@@ -10,7 +10,7 @@
 
     <!-- Full screen backdrop -->
     <div ng-if="!highlightElement || loading" class="umb-backdrop__backdrop">
-        <div  class="umb-backdrop__rect" ng-style="{'opacity': backdropOpacity }"></div>
+        <div class="umb-backdrop__rect" ng-style="{'opacity': backdropOpacity }"></div>
     </div>
 
     <!-- Prevent clicks in highlighted area -->


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10754

### Description
Various changes to context menu and other has caused backdrop from being hidden/removed e.g. when selecting a menu item in context menu. This is okay in the regular flow, but not in tour mode, where we want focus/highlight on the specific context.

I have also adjust some code to just use vanilla js and the exact same `closeBackdrop` function existed twice in code.

![jbPDUcBYBY](https://user-images.githubusercontent.com/2919859/127382924-ac12dc5b-26f9-4e2a-aed7-ca555f96cbbf.gif)
