### PR TITLE
Don't squeeze avatar when help panel is open

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -48,6 +48,7 @@
     opacity: 0.8;
     color: @white;
     font-size: 22px;
+    flex-shrink: 0;
 }
 
 .umb-app-header__button:hover .umb-app-header__action-icon,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
On laptop size (1280 x 720 pixels) when opening help panel, the avatar icon is squeezed. It might doesn't have same spacing right to the avatar, but I think it looks nicer and it could optimize it further later. Maybe if "header actions" is added sometime in future: https://github.com/umbraco/Umbraco-CMS/pull/9016

**Before**

![image](https://user-images.githubusercontent.com/2919859/127391536-d4d2774e-6d41-4f14-9f36-04dd96e0ec85.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/127391452-114e2846-0456-4197-8738-87cfb8a9c32e.png)
