### PR TITLE
reset confirmDiscardChanges on save

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.rights.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.rights.controller.js
@@ -154,9 +154,10 @@
                     currentForm.$dirty = false;
                   }
                 });
-
+                $scope.dialog.confirmDiscardChanges = false;
                 vm.saveState = "success";
                 vm.saveSuccces = true;
+
             }, function(error){
                 vm.saveState = "error";
                 vm.saveError = error;


### PR DESCRIPTION
Fixes #10043

confirmDiscardChanges that holds the state of the dialog was not reset when saving permission changes. This PR changes that. 

## Test Notes

- Create a simple content type
- Create a content node
- Right-click on the node and click Permissions...;
- Then click Set permissions for...;
- Pick a user group and enable or disable an action;
- Click Save.
- Now You will not see the "You have unsaved changes" dialog and if you click discard you can see that the changes are not persisted