### PR TITLE
v9: Added missing namespaces to viewimports https://github.com/umbrac…

### DIFF
--- a/build/templates/UmbracoProject/Views/_ViewImports.cshtml
+++ b/build/templates/UmbracoProject/Views/_ViewImports.cshtml
@@ -1,4 +1,6 @@
 ﻿@using Umbraco.Web.UI.NetCore
 @using Umbraco.Extensions
 @using Umbraco.Web.PublishedModels
+@using Umbraco.Cms.Core.Models.PublishedContent
+@using Microsoft.AspNetCore.Html
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/Umbraco.Web.UI.NetCore/Views/_ViewImports.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/_ViewImports.cshtml
@@ -2,4 +2,6 @@
 @using Umbraco.Cms.Web.UI.NetCore
 @using Umbraco.Cms.Web.Common.PublishedModels
 @using Umbraco.Cms.Web.Common.Views
+@using Umbraco.Cms.Core.Models.PublishedContent
+@using Microsoft.AspNetCore.Html
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/10776 

# Notes 
- Added Umbraco.Cms.Core.Models.PublishedContent namespace to _Viewimports, as the Fallback class uses this namespace and Fallback is used commonly
- Added Microsoft.AspNetCore.Html to _ViewImports, as the HtmlString class uses this namespace and HtmlString is used commonly

# How to test
- Try building the website using the build/build.ps1 powershell script
- Install the program using the console
- Use the generated Templates to create a website
- See how to replicate the bug from here in the in issue thread

