### PR TITLE
v9: Changed HashSet to ConcurrentHashSet to fix concurrency issues https://github.com/umbraco/Umbraco-CMS/issues/10699

### DIFF
--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/AspNetCoreHostingEnvironmentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/AspNetCoreHostingEnvironmentTests.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Tests.UnitTests.AutoFixture;
@@ -35,6 +36,16 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website
             Assert.AreEqual("~/Views/Template.cshtml", PathUtility.EnsurePathIsApplicationRootPrefixed("Views/Template.cshtml"));
             Assert.AreEqual("~/Views/Template.cshtml", PathUtility.EnsurePathIsApplicationRootPrefixed("/Views/Template.cshtml"));
             Assert.AreEqual("~/Views/Template.cshtml", PathUtility.EnsurePathIsApplicationRootPrefixed("~/Views/Template.cshtml"));
+        }
+
+        [AutoMoqData]
+        [Test]
+        public void EnsureApplicationMainUrl(AspNetCoreHostingEnvironment sut)
+        {
+            var url = new Uri("http://localhost:5000");
+            sut.EnsureApplicationMainUrl(url);
+            Assert.AreEqual(sut.ApplicationMainUrl, url);
+
         }
     }
 }


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/10699

# Notes
- Changed HashSet<Uri> to ConcurrentHashSet<Uri>
- Changed Add to TryAdd in AspNetHostingEnviroment.EnsureApplicationMainUrl
- Added new Unit Test in AspNetCoreHostingEnviromentTest to ensure the method works

# How to test

- I used this UnitTest: 
```
[AutoMoqData]
[Test]
public void EnsureApplicationMainUrl_Parralel(AspNetCoreHostingEnvironment sut)
{
     Parallel.For(0, 10, i => sut.EnsureApplicationMainUrl(new Uri("http://localhost:5000/")));
}
```
And in the AspNetCoreHostingEnviroment.EnsureApplicationMainUrl method i used a Thread.Sleep(50) between Contains and Add to make sure the threads all came at once