### PR TITLE
v9: Fixed a bug where validation didnt update properly

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
@@ -368,7 +368,45 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             if (created.Succeeded == false)
             {
-                return ValidationProblem(created.Errors.ToErrorMessage());
+                MemberDisplay forDisplay = _umbracoMapper.Map<MemberDisplay>(contentItem.PersistedContent);
+                foreach (IdentityError error in created.Errors)
+                {
+                    switch (error.Code)
+                    {
+                        case nameof(IdentityErrorDescriber.InvalidUserName):
+                            ModelState.AddPropertyError(
+                                new ValidationResult(error.Description, new[] { "value" }),
+                                string.Format("{0}login", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                            break;
+                        case nameof(IdentityErrorDescriber.PasswordMismatch):
+                        case nameof(IdentityErrorDescriber.PasswordRequiresDigit):
+                        case nameof(IdentityErrorDescriber.PasswordRequiresLower):
+                        case nameof(IdentityErrorDescriber.PasswordRequiresNonAlphanumeric):
+                        case nameof(IdentityErrorDescriber.PasswordRequiresUniqueChars):
+                        case nameof(IdentityErrorDescriber.PasswordRequiresUpper):
+                        case nameof(IdentityErrorDescriber.PasswordTooShort):
+                            ModelState.AddPropertyError(
+                                new ValidationResult(error.Description, new[] { "value" }),
+                                string.Format("{0}password", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                            break;
+                        case nameof(IdentityErrorDescriber.InvalidEmail):
+                            ModelState.AddPropertyError(
+                                new ValidationResult(error.Description, new[] { "value" }),
+                                string.Format("{0}email", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                            break;
+                        case nameof(IdentityErrorDescriber.DuplicateUserName):
+                            ModelState.AddPropertyError(
+                                new ValidationResult(error.Description, new[] { "value" }),
+                                string.Format("{0}login", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                            break;
+                        case nameof(IdentityErrorDescriber.DuplicateEmail):
+                            ModelState.AddPropertyError(
+                                new ValidationResult(error.Description, new[] { "value" }),
+                                string.Format("{0}email", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
+                            break;
+                    }
+                }
+                return ValidationProblem(forDisplay, ModelState);
             }
 
             // now re-look up the member, which will now exist


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/pull/10688#issuecomment-880683722

# Notes
- Updated CreateMemberAsync function to properly send back the ModelState
- This issue was caused because of this code which weren't migrated https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Editors/MemberController.cs#L719-L764
# How to test
- Create a member witha invalid login/password/email
- Change the invalid login/password/email to a valid one
