### PR TITLE
Update Serilog dependencies

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -32,16 +32,16 @@
                 <dependency id="MiniProfiler" version="[4.0.138,4.999999)" />
                 <dependency id="Newtonsoft.Json" version="[12.0.1,12.999999)" />
                 <dependency id="Semver" version="[2.0.4,2.999999)" />
-                <dependency id="Serilog" version="[2.8.0,2.999999)" />
+                <dependency id="Serilog" version="[2.10.0,2.999999)" />
                 <dependency id="Serilog.Enrichers.Process" version="[2.0.1,2.999999)" />
-                <dependency id="Serilog.Enrichers.Thread" version="[3.0.0,3.999999)" />
-                <dependency id="Serilog.Filters.Expressions" version="[2.0.0,2.999999)" />
-                <dependency id="Serilog.Formatting.Compact" version="[1.0.0,1.999999)" />
-                <dependency id="Serilog.Formatting.Compact.Reader" version="[1.0.3,1.999999)" />
+                <dependency id="Serilog.Enrichers.Thread" version="[3.1.0,3.999999)" />
+                <dependency id="Serilog.Filters.Expressions" version="[2.1.0,2.999999)" />
+                <dependency id="Serilog.Formatting.Compact" version="[1.1.0,1.999999)" />
+                <dependency id="Serilog.Formatting.Compact.Reader" version="[1.0.5,1.999999)" />
                 <dependency id="Serilog.Settings.AppSettings" version="[2.2.2,2.999999)" />
-                <dependency id="Serilog.Sinks.File" version="[4.0.0,4.999999)" />
-                <dependency id="Serilog.Sinks.Map" version="[1.0.0,1.999999)" />
-                <dependency id="Serilog.Sinks.Async" version="[1.3.0,1.999999)" />
+                <dependency id="Serilog.Sinks.File" version="[4.1.0,4.999999)" />
+                <dependency id="Serilog.Sinks.Map" version="[1.0.2,1.999999)" />
+                <dependency id="Serilog.Sinks.Async" version="[1.5.0,1.999999)" />
                 <dependency id="Umbraco.SqlServerCE" version="[4.0.0.1,4.999999)" />
                 <dependency id="NPoco" version="[3.9.4,3.999999)" />
             </group>

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -67,10 +67,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.Async">
-      <Version>1.3.0</Version>
+      <Version>1.5.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.Map">
-      <Version>1.0.0</Version>
+      <Version>1.0.2</Version>
     </PackageReference>
     <PackageReference Include="Umbraco.Code">
       <Version>1.0.5</Version>
@@ -94,28 +94,28 @@
     <PackageReference Include="NPoco" Version="3.9.4" />
     <PackageReference Include="Semver" Version="2.0.4" />
     <PackageReference Include="Serilog">
-      <Version>2.8.0</Version>
+      <Version>2.10.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Enrichers.Process">
       <Version>2.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Enrichers.Thread">
-      <Version>3.0.0</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Filters.Expressions">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Formatting.Compact">
-      <Version>1.0.0</Version>
+      <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Formatting.Compact.Reader">
-      <Version>1.0.3</Version>
+      <Version>1.0.5</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Settings.AppSettings">
       <Version>2.2.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
-      <Version>4.0.0</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Umbraco.SqlServerCE" Version="4.0.0.1" />
   </ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10793

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This should at least fix #10793 because of a memory leak fix in Serilog.Sinks.Map 1.0.2. Also updated the rest for good measure.

Note that Serilog.Sinks.File is not upgraded to the latest version because it is a new major (4.1.0 -> 5.0.0). Also note that Serilog.Filters.Expressions is deprecated and should be replaced by Serilog.Expressions. I considered both out of scope for this fix.

For testing steps, see the linked issue.

<!-- Thanks for contributing to Umbraco CMS! -->
