### PR TITLE
Cyclehack: Dynamic runtime change of LogLevel

### DIFF
--- a/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
@@ -28,7 +28,8 @@ namespace Umbraco.Extensions
         public static LoggerConfiguration MinimalConfiguration(
             this LoggerConfiguration logConfig,
             IHostingEnvironment hostingEnvironment,
-            ILoggingConfiguration loggingConfiguration)
+            ILoggingConfiguration loggingConfiguration,
+            LoggingLevelSwitch logLevelSwitch)
         {
             global::Serilog.Debugging.SelfLog.Enable(msg => System.Diagnostics.Debug.WriteLine(msg));
 
@@ -38,7 +39,7 @@ namespace Umbraco.Extensions
             Environment.SetEnvironmentVariable("UMBLOGDIR", loggingConfiguration.LogDirectory, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("MACHINENAME", Environment.MachineName, EnvironmentVariableTarget.Process);
 
-            logConfig.MinimumLevel.Verbose() //Set to highest level of logging (as any sinks may want to restrict it to Errors only)
+            logConfig.MinimumLevel.ControlledBy(logLevelSwitch)
                 .Enrich.WithProcessId()
                 .Enrich.WithProcessName()
                 .Enrich.WithThreadId()

--- a/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Extensions;
@@ -39,10 +40,11 @@ namespace Umbraco.Cms.Core.Logging.Serilog
         public static SerilogLogger CreateWithDefaultConfiguration(
             IHostingEnvironment hostingEnvironment,
             ILoggingConfiguration loggingConfiguration,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            LoggingLevelSwitch logLevelSwitch)
         {
             var loggerConfig = new LoggerConfiguration()
-                .MinimalConfiguration(hostingEnvironment, loggingConfiguration)
+                .MinimalConfiguration(hostingEnvironment, loggingConfiguration, logLevelSwitch)
                 .ReadFrom.Configuration(configuration);
 
             return new SerilogLogger(loggerConfig);

--- a/src/Umbraco.Infrastructure/Logging/Viewer/CountingFilter.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/CountingFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Serilog.Events;
 
 namespace Umbraco.Cms.Core.Logging.Viewer
@@ -17,6 +17,10 @@ namespace Umbraco.Cms.Core.Logging.Viewer
 
             switch (e.Level)
             {
+                case LogEventLevel.Verbose:
+                    Counts.Verbose++;
+                    break;
+
                 case LogEventLevel.Debug:
                     Counts.Debug++;
                     break;
@@ -36,8 +40,7 @@ namespace Umbraco.Cms.Core.Logging.Viewer
                 case LogEventLevel.Fatal:
                     Counts.Fatal++;
                     break;
-                case LogEventLevel.Verbose:
-                    break;
+                
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Serilog.Events;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Logging.Viewer
@@ -45,6 +46,13 @@ namespace Umbraco.Cms.Core.Logging.Viewer
         /// </summary>
         /// <returns></returns>
         string GetLogLevel();
+
+        /// <summary>
+        /// Sets the LogEvent Level Switch at runtime
+        /// Allowing until next site restart to change the minimum log level
+        /// </summary>
+        /// <param name="eventLevel"></param>
+        void SetLogLevel(LogEventLevel eventLevel);
 
         /// <summary>
         /// Returns the collection of logs

--- a/src/Umbraco.Infrastructure/Logging/Viewer/LogLevelCounts.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/LogLevelCounts.cs
@@ -1,10 +1,12 @@
-﻿namespace Umbraco.Cms.Core.Logging.Viewer
+namespace Umbraco.Cms.Core.Logging.Viewer
 {
     public class LogLevelCounts
     {
-        public int Information { get; set; }
+        public int Verbose { get; set; }
 
         public int Debug { get; set; }
+
+        public int Information { get; set; }
 
         public int Warning { get; set; }
 

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogJsonLogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogJsonLogViewer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.Logging.Viewer
             ILogViewerConfig logViewerConfig,
             ILoggingConfiguration loggingConfiguration,
             global::Serilog.ILogger serilogLog)
-            : base(logViewerConfig, serilogLog)
+            : base(logViewerConfig, serilogLog, new global::Serilog.Core.LoggingLevelSwitch())
         {
             _logger = logger;
             _logsPath = loggingConfiguration.LogDirectory;

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogJsonLogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogJsonLogViewer.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Serilog.Events;
 using Serilog.Formatting.Compact.Reader;
-using Umbraco.Cms.Core.Logging;
 
 namespace Umbraco.Cms.Core.Logging.Viewer
 {

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Serilog.Core;
 using Serilog.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Extensions;
@@ -11,11 +12,13 @@ namespace Umbraco.Cms.Core.Logging.Viewer
     {
         private readonly ILogViewerConfig _logViewerConfig;
         private readonly global::Serilog.ILogger _serilogLog;
+        private readonly LoggingLevelSwitch _levelSwitch;
 
-        protected SerilogLogViewerSourceBase(ILogViewerConfig logViewerConfig, global::Serilog.ILogger serilogLog)
+        protected SerilogLogViewerSourceBase(ILogViewerConfig logViewerConfig, global::Serilog.ILogger serilogLog, LoggingLevelSwitch levelSwitch)
         {
             _logViewerConfig = logViewerConfig;
             _serilogLog = serilogLog;
+            _levelSwitch = levelSwitch;
         }
 
         public abstract bool CanHandleLargeLogs { get; }
@@ -130,6 +133,12 @@ namespace Umbraco.Cms.Core.Logging.Viewer
             };
         }
 
-
+        public void SetLogLevel(LogEventLevel eventLevel)
+        {
+            // change the injected logging level
+            // Next time app restarts it will read from config again
+            // Used as a temp way to change the LogLevel when needed to do investigation work
+            _levelSwitch.MinimumLevel = eventLevel;
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -42,8 +42,8 @@
       <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.5" />
       <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-      <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
-      <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+      <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
       <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
+++ b/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 

--- a/src/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/src/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -212,7 +212,7 @@ namespace Umbraco.Cms.Tests.Integration.Testing
                 TestHelper.Profiler);
             var builder = new UmbracoBuilder(services, Configuration, typeLoader, TestHelper.ConsoleLoggerFactory, TestHelper.Profiler, AppCaches.NoCache, hostingEnvironment);
 
-            builder.Services.AddLogger(TestHelper.GetHostingEnvironment(), TestHelper.GetLoggingConfiguration(), Configuration);
+            builder.Services.AddLogger(TestHelper.GetHostingEnvironment(), TestHelper.GetLoggingConfiguration(), Configuration, new Serilog.Core.LoggingLevelSwitch());
 
             builder.AddConfiguration()
                 .AddUmbracoCore()

--- a/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -84,7 +84,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 

--- a/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
@@ -22,12 +22,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
     public class LogViewerController : BackOfficeNotificationsController
     {
         private readonly ILogViewer _logViewer;
-        private readonly LoggingLevelSwitch _levelSwitch;
 
-        public LogViewerController(ILogViewer logViewer, LoggingLevelSwitch levelSwitch)
+        public LogViewerController(ILogViewer logViewer)
         {
             _logViewer = logViewer ?? throw new ArgumentNullException(nameof(logViewer));
-            _levelSwitch = levelSwitch;
         }
 
         private bool CanViewLogs(LogTimePeriod logTimePeriod)
@@ -148,11 +146,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         [HttpPost]
         public ActionResult SetLogLevel(LogEventLevel eventLevel)
         {
-            // change the injected logging level
-            // Next time app restarts it will read from config again
-            // Used as a temp way to change the LogLevel when needed to do investigation work
-            _levelSwitch.MinimumLevel = eventLevel;
-
+            _logViewer.SetLogLevel(eventLevel);
             return Ok();
         }
     }

--- a/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Serilog.Core;
+using Serilog.Events;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Logging.Viewer;
 using Umbraco.Cms.Core.Models;
@@ -20,10 +22,12 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
     public class LogViewerController : BackOfficeNotificationsController
     {
         private readonly ILogViewer _logViewer;
+        private readonly LoggingLevelSwitch _levelSwitch;
 
-        public LogViewerController(ILogViewer logViewer)
+        public LogViewerController(ILogViewer logViewer, LoggingLevelSwitch levelSwitch)
         {
             _logViewer = logViewer ?? throw new ArgumentNullException(nameof(logViewer));
+            _levelSwitch = levelSwitch;
         }
 
         private bool CanViewLogs(LogTimePeriod logTimePeriod)
@@ -139,6 +143,17 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         public string GetLogLevel()
         {
             return _logViewer.GetLogLevel();
+        }
+
+        [HttpPost]
+        public ActionResult SetLogLevel(LogEventLevel eventLevel)
+        {
+            // change the injected logging level
+            // Next time app restarts it will read from config again
+            // Used as a temp way to change the LogLevel when needed to do investigation work
+            _levelSwitch.MinimumLevel = eventLevel;
+
+            return Ok();
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Serilog.Core;
 using Serilog.Events;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Logging.Viewer;

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
+using Serilog.Core;
 using Smidge;
 using Smidge.FileProcessors;
 using Smidge.InMemory;
@@ -58,6 +59,7 @@ using Umbraco.Cms.Web.Common.RuntimeMinification;
 using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Cms.Web.Common.Templates;
 using Umbraco.Cms.Web.Common.UmbracoContext;
+using Constants = Umbraco.Cms.Core.Constants;
 using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Extensions
@@ -92,7 +94,11 @@ namespace Umbraco.Extensions
             var loggingDir = tempHostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.LogFiles);
             var loggingConfig = new LoggingConfiguration(loggingDir);
 
-            services.AddLogger(tempHostingEnvironment, loggingConfig, config);
+            // Add the logging level switch so we can change it at runtime
+            var loggingLevelSwitch = new LoggingLevelSwitch(initialMinimumLevel: Serilog.Events.LogEventLevel.Verbose);
+            services.AddSingleton(loggingLevelSwitch);
+
+            services.AddLogger(tempHostingEnvironment, loggingConfig, config, loggingLevelSwitch);
 
             // Manually create and register the HttpContextAccessor. In theory this should not be registered
             // again by the user but if that is the case it's not the end of the world since HttpContextAccessor

--- a/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Serilog;
+using Serilog.Core;
 using Serilog.Extensions.Hosting;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
@@ -26,10 +27,11 @@ namespace Umbraco.Extensions
             this IServiceCollection services,
             IHostingEnvironment hostingEnvironment,
             ILoggingConfiguration loggingConfiguration,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            LoggingLevelSwitch logLevelSwitch)
         {
             // Create a serilog logger
-            var logger = SerilogLogger.CreateWithDefaultConfiguration(hostingEnvironment, loggingConfiguration, configuration);
+            var logger = SerilogLogger.CreateWithDefaultConfiguration(hostingEnvironment, loggingConfiguration, configuration, logLevelSwitch);
 
             // This is nessasary to pick up all the loggins to MS ILogger.
             Log.Logger = logger.SerilogLog;

--- a/src/Umbraco.Web.UI.Client/src/common/resources/logviewer.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/logviewer.resource.js
@@ -44,6 +44,9 @@ function logViewerResource($q, $http, umbRequestHelper) {
         deleteSavedSearch: (name, query) =>
             request('POST', 'DeleteSavedSearch', { 'name': name, 'query': query }, 'Failed to delete saved search'),
 
+        setLogLevel: (logLevel) =>
+          request('POST', 'SetLogLevel', { 'logLevel': logLevel }, 'Failed to set new log level'),
+
         getLogs: options => {
 
             var defaults = {

--- a/src/Umbraco.Web.UI.Client/src/views/logViewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logViewer/overview.html
@@ -110,6 +110,13 @@
                             </umb-box>
                         </div>
 
+                        <umb-box>
+                          <umb-box-header title="Change Log level"></umb-box-header>
+                          <umb-box-content class="block-form">
+                            <select ng-model="vm.selectedLogLevel" ng-options="level for level in vm.logLevels" ng-change="vm.changeLogLevel(vm.selectedLogLevel)"></select>
+                          </umb-box-content>
+                        </umb-box>
+
                         <!-- Chart of diff log types -->
                         <umb-box>
                             <umb-box-header title="Log Types"></umb-box-header>


### PR DESCRIPTION
## Feature
This is a cyclehack project where it adds a UI dropdown in the LogViewer section of the backoffice to allow dynamic changing of the minimum LogLevel.

## Blog Post
https://brynt.hashnode.dev/serilog-with-filters-and-logging-level-switching-in-net-5

## Preview
![image](https://user-images.githubusercontent.com/1389894/128362988-a8f30239-8711-417c-8292-b2973179e377.png)



## Testing Notes
- By default Umbraco logging level in AppSettings is set to Information
- Browse to LogViewer section
- Change Minimum LogLevel from dropdown in right column to Verbose or Debug
- Goto Content Node - Save & Publish it
- Go back to LogViewer and see new Debug logs are now visible
- NOTE: The current log level box incorrectly still reports Information

## TODO
- [ ] Figure out why the current reported LogLevel after changing reports incorrectly