### PR TITLE
Fixes various issues with javascript services

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -358,7 +358,7 @@ function umbTreeDirective($q, treeService, navigationService, notificationsServi
             */
             $scope.select = function (n, ev) {
 
-                navigationService.closeBackdrop();
+                navigationService.hideMenu();
                 
                 if (n.metaData && n.metaData.noAccess === true) {
                     ev.preventDefault();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
@@ -38,7 +38,7 @@ angular.module('umbraco.directives')
                 var currentIndex = 0;
                 var focusSet = false;
 
-                $timeout(function () {
+                $timeout(function() {
                     // get list of all links in the list
                     listItems = element.find("li :tabbable");
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
@@ -32,7 +32,7 @@ angular.module('umbraco.directives')
 
         return {
             restrict: 'A',
-            link: function (scope, element, attr) {
+            link: function (scope, element) {
 
                 var listItems = [];
                 var currentIndex = 0;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/umbkeyboardlist.directive.js
@@ -38,14 +38,14 @@ angular.module('umbraco.directives')
                 var currentIndex = 0;
                 var focusSet = false;
 
-                $timeout(function(){
+                $timeout(function () {
                     // get list of all links in the list
                     listItems = element.find("li :tabbable");
                 });
 
                 // Handle keydown events
                 function keydown(event) {
-                    $timeout(function(){
+                    $timeout(function() {
                         checkFocus();
                         // arrow down
                         if (event.keyCode === 40) {
@@ -109,7 +109,6 @@ angular.module('umbraco.directives')
 
                 // Stop listening when scope is destroyed.
                 scope.$on('$destroy', stopListening);
-
             }
         };
     }]);

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -148,15 +148,6 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
 
         /**
          * @ngdoc method
-         * @name umbraco.services.navigationService#closeBackdrop
-         * @methodOf umbraco.services.navigationService
-         * @description
-         * Closes backdrop shown when navigation is open.
-        */
-        closeBackdrop: closeBackdrop,
-
-        /**
-         * @ngdoc method
          * @name umbraco.services.navigationService#isRouteChangingNavigation
          * @methodOf umbraco.services.navigationService
          *

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -127,7 +127,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
         var aboveClass = "above-backdrop";
         var leftColumn = document.getElementById("leftcolumn");
 
-        if(leftColumn !== null) {
+        if(leftColumn) {
             var isLeftColumnOnTop = leftColumn.classList.contains(aboveClass);
 
             if (isLeftColumnOnTop) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -148,6 +148,15 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
 
         /**
          * @ngdoc method
+         * @name umbraco.services.navigationService#closeBackdrop
+         * @methodOf umbraco.services.navigationService
+         * @description
+         * Closes backdrop shown when navigation is open.
+        */
+        closeBackdrop: closeBackdrop,
+
+        /**
+         * @ngdoc method
          * @name umbraco.services.navigationService#isRouteChangingNavigation
          * @methodOf umbraco.services.navigationService
          *

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-search.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-search.less
@@ -16,7 +16,7 @@
     box-shadow: 0 10px 20px rgba(0,0,0,.12),0 6px 6px rgba(0,0,0,.14);
 }
 
-.umb-search__label{
+.umb-search__label {
     margin: 0;
 }
 
@@ -33,7 +33,7 @@
     height: 70px;
 }
 
-.umb-search-input {
+input.umb-search-input {
     width: 100%;
     height: 70px;
     border: none;

--- a/src/Umbraco.Web.UI.Client/src/utilities.js
+++ b/src/Umbraco.Web.UI.Client/src/utilities.js
@@ -110,7 +110,7 @@
      * Not equivalent to angular.forEach. But like the angularJS method this does not fail on null or undefined.
      */
     const forEach = (obj, iterator) => {
-        if (obj) {
+        if (obj && isArray(obj)) {
             return obj.forEach(iterator);
         }
         return obj;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This fixes some issues after recent PRs has been merged, e.g. `closeBackdrop` in `navigationService` which wasn't a public function. However instead of exposing `closeBackdrop` in `navigationService` I think it makes more sense the call `navigationService.hideMenu()` which also close backdrop. In fact I think `backdropService`should be responsible for logic regarding backdrops.
