### PR TITLE
Supporting multiple databases

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ConnectionStrings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ConnectionStrings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Collections.Generic;
+
 namespace Umbraco.Cms.Core.Configuration.Models
 {
     /// <summary>
@@ -27,5 +29,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// Gets or sets a value for the Umbraco database connection string..
         /// </summary>
         public ConfigConnectionString UmbracoConnectionString { get; set; }
+
+        public List<NamedConnectionString> NamedConnectionStrings { get; set; } = new List<NamedConnectionString>();
     }
 }

--- a/src/Umbraco.Core/Configuration/Models/NamedConnectionString.cs
+++ b/src/Umbraco.Core/Configuration/Models/NamedConnectionString.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Configuration.Models
+{
+    public class NamedConnectionString
+    {
+        /// <summary>
+        /// Gets or sets the named connection string's alias.
+        /// </summary>
+        public string Alias { get; set; }
+
+        /// <summary>
+        /// Gets or sets the named connection string value.
+        /// </summary>
+        public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets the connection string as a <see cref="Configuration.ConfigConnectionString"/>.
+        /// </summary>
+        public ConfigConnectionString ConfigConnectionString => new ConfigConnectionString(Alias, ConnectionString);
+    }
+}

--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -10,6 +10,7 @@ namespace Umbraco.Cms.Core
             public static class Migrations
             {
                 public const string UmbracoUpgradePlanName = "Umbraco.Core";
+                public const string TestPlanName = "Test";
                 public const string KeyValuePrefix = "Umbraco.Core.Upgrader.State+";
                 public const string UmbracoUpgradePlanKey = KeyValuePrefix + UmbracoUpgradePlanName;
             }

--- a/src/Umbraco.Core/Models/ITest.cs
+++ b/src/Umbraco.Core/Models/ITest.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Core.Models
+{
+    public interface ITest : IEntity, IRememberBeingDirty
+    {
+        [DataMember]
+        string Name { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Models/Test.cs
+++ b/src/Umbraco.Core/Models/Test.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.Serialization;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Core.Models
+{
+    [Serializable]
+    [DataContract(IsReference = true)]
+    public class Test : EntityBase, ITest
+    {
+        private string _name;
+
+        public Test(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public string Name
+        {
+            get => _name;
+            set => SetPropertyValueAndDetectChanges(value, ref _name, nameof(Name));
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -54,6 +54,8 @@ namespace Umbraco.Cms.Core
                 public const string ExternalLogin = TableNamePrefix + "ExternalLogin";
                 public const string ExternalLoginToken = TableNamePrefix + "ExternalLoginToken";
 
+                public const string Test = TableNamePrefix + "Test";
+
                 public const string Macro = /*TableNamePrefix*/ "cms" + "Macro";
                 public const string MacroProperty = /*TableNamePrefix*/ "cms" + "MacroProperty";
 

--- a/src/Umbraco.Core/Persistence/Repositories/ITestRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITestRepository.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Persistence.Repositories
+{
+    public interface ITestRepository : IReadWriteQueryRepository<int, ITest>
+    {
+    }
+}

--- a/src/Umbraco.Core/Services/ITestService.cs
+++ b/src/Umbraco.Core/Services/ITestService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services
+{
+    public interface ITestService : IService
+    {
+        IEnumerable<ITest> GetAll();
+    }
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
@@ -45,6 +45,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IServerRegistrationRepository, ServerRegistrationRepository>();
             builder.Services.AddUnique<ITagRepository, TagRepository>();
             builder.Services.AddUnique<ITemplateRepository, TemplateRepository>();
+            builder.Services.AddUnique<ITestRepository, TestRepository>();
             builder.Services.AddUnique<IUserGroupRepository, UserGroupRepository>();
             builder.Services.AddUnique<IUserRepository, UserRepository>();
             builder.Services.AddUnique<IConsentRepository, ConsentRepository>();

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -41,6 +41,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IAuditService, AuditService>();
             builder.Services.AddUnique<ICacheInstructionService, CacheInstructionService>();
             builder.Services.AddUnique<ITagService, TagService>();
+            builder.Services.AddUnique<ITestService, TestService>();
             builder.Services.AddUnique<IContentService, ContentService>();
             builder.Services.AddUnique<IUserService, UserService>();
             builder.Services.AddUnique<IMemberService, MemberService>();

--- a/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Migrations;
 using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.Migrations

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -56,6 +56,12 @@ namespace Umbraco.Cms.Infrastructure.Migrations
         /// Gets the name of the plan.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Gets or sets the connection string alias to use for executing the plan.
+        /// If not set the default database is used.
+        /// </summary>
+        public virtual string ConnectionStringAlias { get; } = null;
 
         // adds a transition
         private MigrationPlan Add(string sourceState, string targetState, Type migration)

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations
                 plan.ThrowOnUnknownInitialState(origState);
             }
 
-            using (IScope scope = _scopeProvider.CreateScope(autoComplete: true))
+            using (IScope scope = _scopeProvider.CreateScope(autoComplete: true, connectionStringAlias: plan.ConnectionStringAlias))
             {
                 var context = new MigrationContext(plan, scope.Database, _loggerFactory.CreateLogger<MigrationContext>());
 

--- a/src/Umbraco.Infrastructure/Migrations/Test/AddTestDto.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Test/AddTestDto.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Test
+{
+    public class AddTestDto : MigrationBase
+    {
+        public AddTestDto(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Adds new columns to members table
+        /// </summary>
+        protected override void Migrate()
+        {
+            IEnumerable<string> tables = SqlSyntax.GetTablesInSchema(Context.Database);
+            if (tables.InvariantContains(TestDto.TableName))
+            {
+                return;
+            }
+
+            Create.Table<TestDto>().Do();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Test/RunTestPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Test/RunTestPlan.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Test
+{
+    public class RunTestPlan : INotificationHandler<UmbracoApplicationStartingNotification>
+    {
+        private readonly IRuntimeState _runtimeState;
+        private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+        private readonly IScopeProvider _scopeProvider;
+        private readonly IKeyValueService _keyValueService;
+
+        public RunTestPlan(
+            IRuntimeState runtimeState,
+            IMigrationPlanExecutor migrationPlanExecutor,
+            IScopeProvider scopeProvider,
+            IKeyValueService keyValueService)
+        {
+            _runtimeState = runtimeState;
+            _migrationPlanExecutor = migrationPlanExecutor;
+            _scopeProvider = scopeProvider;
+            _keyValueService = keyValueService;
+        }
+
+        public void Handle(UmbracoApplicationStartingNotification notification)
+        {
+            if (_runtimeState.Level < RuntimeLevel.Run)
+            {
+                return; // Forms needs to be in run state to update
+            }
+
+            var upgrader = new Upgrader(new TestPlan());
+            try
+            {
+                upgrader.Execute(_migrationPlanExecutor, _scopeProvider, _keyValueService);
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Test/TestPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Test/TestPlan.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Test
+{
+    /// <summary>
+    /// Defines the migration plan for the forms package database tables.
+    /// </summary>
+    public class TestPlan : MigrationPlan
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FormsMigrationPlan"/> class.
+        /// </summary>
+        public TestPlan()
+            : base(Core.Constants.Conventions.Migrations.TestPlanName) => DefinePlan();
+
+        /// <inheritdoc/>
+        public override string InitialState => "{test-init-state}";
+
+        /// <inheritdoc/>
+        public override string ConnectionStringAlias => "Test";
+
+        /// <summary>
+        /// Defines the plan.
+        /// </summary>
+        protected void DefinePlan() =>
+            From("{test-init-state}")
+                .To<AddTestDto>("{9225dc6d-b422-491a-9200-ff12baac2e28}");
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/TestDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/TestDto.cs
@@ -1,0 +1,22 @@
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos
+{
+    [TableName(TableName)]
+    [ExplicitColumns]
+    [PrimaryKey("Id")]
+    internal class TestDto
+    {
+        public const string TableName = Cms.Core.Constants.DatabaseSchema.Tables.Test;
+
+        [Column("id")]
+        [PrimaryKeyColumn]
+        public int Id { get; set; }
+
+        [Column("name")]
+        [Length(255)]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string Name { get; set; }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Factories/TestFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/TestFactory.cs
@@ -1,0 +1,23 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Factories
+{
+    internal static class TestFactory
+    {
+        public static ITest BuildEntity(TestDto dto)
+        {
+            var entity = new Test(dto.Id, dto.Name);
+            // reset dirty initial properties (U4-1946)
+            entity.ResetDirtyProperties(false);
+            return entity;
+        }
+
+        public static TestDto BuildDto(ITest entity) =>
+            new TestDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+            };
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TestRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TestRepository.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NPoco;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Querying;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Persistence.Factories;
+using Umbraco.Cms.Infrastructure.Persistence.Querying;
+using Umbraco.Extensions;
+using static Umbraco.Cms.Core.Persistence.SqlExtensionsStatics;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
+{
+    internal class TestRepository : EntityRepositoryBase<int, ITest>, ITestRepository
+    {
+        public TestRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<TestRepository> logger)
+            : base(scopeAccessor, cache, logger)
+        { }
+
+        protected override Sql<ISqlContext> GetBaseQuery(bool isCount)
+        {
+            return isCount ? Sql().SelectCount().From<TestDto>() : GetBaseQuery();
+        }
+
+        private Sql<ISqlContext> GetBaseQuery()
+        {
+            return Sql().Select<TestDto>().From<TestDto>();
+        }
+
+        protected override string GetBaseWhereClause()
+        {
+            return "id = @id";
+        }
+
+        protected override IEnumerable<string> GetDeleteClauses()
+        {            
+            return new List<string>();
+        }
+
+        protected override ITest PerformGet(int id) => throw new NotImplementedException();
+
+        protected override IEnumerable<ITest> PerformGetAll(params int[] ids)
+        {
+            var dtos = ids.Length == 0
+                ? Database.Fetch<TestDto>(Sql().Select<TestDto>().From<TestDto>())
+                : Database.FetchByGroups<TestDto, int>(ids, 2000, batch => Sql().Select<TestDto>().From<TestDto>().WhereIn<TestDto>(x => x.Id, batch));
+
+            return dtos.Select(TestFactory.BuildEntity).ToList();
+        }
+
+        protected override IEnumerable<ITest> PerformGetByQuery(IQuery<ITest> query) => throw new NotImplementedException();
+        protected override void PersistNewItem(ITest item) => throw new NotImplementedException();
+        protected override void PersistUpdatedItem(ITest item) => throw new NotImplementedException();
+    }
+}

--- a/src/Umbraco.Infrastructure/Scoping/IScopeProvider.cs
+++ b/src/Umbraco.Infrastructure/Scoping/IScopeProvider.cs
@@ -39,7 +39,8 @@ namespace Umbraco.Cms.Core.Scoping
             IScopedNotificationPublisher scopedNotificationPublisher = null,
             bool? scopeFileSystems = null,
             bool callContext = false,
-            bool autoComplete = false);
+            bool autoComplete = false,
+            string connectionStringAlias = null);
 
         /// <summary>
         /// Creates a detached scope.

--- a/src/Umbraco.Infrastructure/Services/Implement/TestService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/TestService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Cms.Core.Services.Implement
+{
+    public class TestService : RepositoryService, ITestService
+    {
+        private readonly ITestRepository _testRepository;
+
+        public TestService(IScopeProvider provider, ILoggerFactory loggerFactory, IEventMessagesFactory eventMessagesFactory,
+            ITestRepository testRepository)
+            : base(provider, loggerFactory, eventMessagesFactory)
+        {
+            _testRepository = testRepository;
+        }
+
+        public IEnumerable<ITest> GetAll()
+        {
+            using (ScopeProvider.CreateScope(autoComplete: true, connectionStringAlias: "Test"))
+            {
+                return _testRepository.GetMany();
+            }
+        }
+    }
+}

--- a/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineBaseTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineBaseTest.cs
@@ -92,7 +92,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
                         It.IsAny<IScopedNotificationPublisher>(),
                         It.IsAny<bool?>(),
                         It.IsAny<bool>(),
-                        It.IsAny<bool>()))
+                        It.IsAny<bool>(),
+                        It.IsAny<string>()))
                     .Returns(Mock.Of<IScope>);
 
                 validator = new ContentValueSetValidator(

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -70,7 +70,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
                 Mock.Of<IServiceProvider>(),
                 Options.Create(new ContentSettings()));
             IEventAggregator eventAggregator = Mock.Of<IEventAggregator>();
-            var scopeProvider = new ScopeProvider(f, fs, Options.Create(coreDebug), mediaFileManager, loggerFactory.CreateLogger<ScopeProvider>(), loggerFactory, NoAppCache.Instance, eventAggregator);
+            var scopeProvider = new ScopeProvider(f, new Dictionary<string, IUmbracoDatabaseFactory>(), fs, Options.Create(coreDebug), mediaFileManager, loggerFactory.CreateLogger<ScopeProvider>(), loggerFactory, NoAppCache.Instance, eventAggregator);
 
             mock.Setup(x => x.GetService(typeof(ILogger))).Returns(logger);
             mock.Setup(x => x.GetService(typeof(ILogger<ComponentCollection>))).Returns(loggerFactory.CreateLogger<ComponentCollection>);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopeEventDispatcherTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopeEventDispatcherTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -90,6 +91,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
 
             return new ScopeProvider(
                 Mock.Of<IUmbracoDatabaseFactory>(),
+                new Dictionary<string, IUmbracoDatabaseFactory>(),
                 fileSystems,
                 Options.Create(new CoreDebugSettings()),
                 mediaFileManager,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -91,6 +92,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
 
             return new ScopeProvider(
                 Mock.Of<IUmbracoDatabaseFactory>(),
+                new Dictionary<string, IUmbracoDatabaseFactory>(),
                 fileSystems,
                 Options.Create(new CoreDebugSettings()),
                 mediaFileManager,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockScope = new Mock<IScope>();
             var mockScopeProvider = new Mock<IScopeProvider>();
             mockScopeProvider
-                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Returns(mockScope.Object);
             var mockLogger = new Mock<ILogger<LogScrubber>>();
             var mockProfilingLogger = new Mock<IProfilingLogger>();

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
@@ -33,7 +33,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping
                     It.IsAny<IScopedNotificationPublisher>(),
                     It.IsAny<bool?>(),
                     It.IsAny<bool>(),
-                    It.IsAny<bool>()))
+                    It.IsAny<bool>(),
+                    It.IsAny<string>()))
                 .Returns(Mock.Of<IScope>);
 
             _scopeProvider = scopeMock.Object;

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationTests.cs
@@ -32,7 +32,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations
                 IScopedNotificationPublisher notificationPublisher = null,
                 bool? scopeFileSystems = null,
                 bool callContext = false,
-                bool autoComplete = false) => _scope;
+                bool autoComplete = false,
+                string connectionStringAlias = null) => _scope;
 
             public IScope CreateDetachedScope(
                 IsolationLevel isolationLevel = IsolationLevel.Unspecified,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
@@ -59,6 +59,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 
             return new ScopeProvider(
                 databaseFactory.Object,
+                new Dictionary<string, IUmbracoDatabaseFactory>(),
                 fileSystems,
                 Options.Create(new CoreDebugSettings()),
                 mediaFileManager,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
             var mockScope = new Mock<IScope>();
             var mockScopeProvider = new Mock<IScopeProvider>();
             mockScopeProvider
-                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IEventDispatcher>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Returns(mockScope.Object);
 
             return new MemberUserStore(

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
@@ -511,7 +511,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
                 It.IsAny<IScopedNotificationPublisher>(),
                 It.IsAny<bool?>(),
                 It.IsAny<bool>(),
-                It.IsAny<bool>()) == Mock.Of<IScope>());
+                It.IsAny<bool>(),
+                It.IsAny<string>()) == Mock.Of<IScope>());
 
             _mapper = new UmbracoMapper(map, scopeProvider);
 


### PR DESCRIPTION
This PR is a spike coming out of this cycle's "hack time" - it may or may not go anywhere in future.

The idea behind it is that for some data, it can be useful to be able to store it in a separate database from the core Umbraco content.  Members is an example, another is the tables for the Umbraco Forms package, and it could be other package developers would find this useful.  Sometimes databases get copied around - e.g. a restore from production into a test environment - and ideally we don't want to copy PII data when we do this.  If such data could be configured to be stored in a separate database, this could be done more safely to get the content, without having to worry about deleting or anonymising PII.

It seemed a little tricky as Umbraco has for years been built on the assumption that there's one database, but I found I could add some seams in a couple of places:

- For a `Scope` - so when created, it's based on a particular database's connection string.
- For a `MigrationPlan` - so a set of migrations created within a plan can all run on a configured database.

Configuration-wise it works like this - where you have the default connection string as normal, plus multiple named connection strings, each identified with a unique alias.

```
  "ConnectionStrings": {
    "umbracoDbDSN": "Server=.\\SQLEXPRESS;Database=TestDbForCms;Integrated Security=true",
    "NamedConnectionStrings": [
      {
        "Alias": "Forms",
        "ConnectionString": "Server=.\\SQLEXPRESS;Database=TestDbForForms;Integrated Security=true"
      }
    ]
  },
```

In start-up we then register an `UmbracoDatabaseFactory` for each connection string.

And then that can be used to ensure the correct database is instantiated within a scope or a migration.

There's some test code in here that can be used for verification - e.g. `Test`, `TestService`, `TestRepository`, `TestPlan` etc. that will be removed later.

Further to consider:

- Nested scopes.  Currently one scope created within another becomes part of the parent scopes transaction, and is only committed when the parent scope completes.  I've had to change that in the case where the parent and child scopes are for different databases (which happens for example with a migration, with the parent scope managing the updates of the `umbracoKeyValue` table and the child scope for the migration potentially now being for a different database).  So in this PR, when the database's are different, the child scope's transaction completes when it completes, not when it's parent does.  Perhaps a transaction across both is possible - from what I read it is fairly easily if they are in the same server instance - but as we are only referencing the databases via a connection string, we don't know for sure that's the case.