### PR TITLE
append a input with ng-model which matches the field coming from mode…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html
@@ -52,6 +52,7 @@
 
     </div>
 
+    <input type="hidden" name="modelValue" ng-model="vm.model.value" val-server="value" />
     <input type="hidden" name="minCount" ng-model="vm.model.value" val-server="minCount" />
     <input type="hidden" name="maxCount" ng-model="vm.model.value" val-server="maxCount" />
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10788

Server validation issues were tagged to the field `value`, therefore we need to ensure there is a connection between the data-model and the definition in model-state. So when there is changes to the data-model the model state message gets reset.

This is done by adding a hidden input with the data-model as ng-model and server-val set to "value" as the model state definition(key) was set to this field.

Test scenario from issue, notice the issue is limited to only be a problem with Media Picker 3.