### PR TITLE
v9: Added "JetBrains.Annotations" to assembly exclusion list to fix #10801

### DIFF
--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -146,6 +146,7 @@ namespace Umbraco.Cms.Core.Composing
             "HtmlDiff,",
             "ICSharpCode.",
             "Iesi.Collections,", // used by NHibernate
+            "JetBrains.Annotations,",
             "LightInject.", // DI
             "LightInject,",
             "Lucene.",


### PR DESCRIPTION
This adds `JetBrains.Annotations.dll` to Umbraco's assembly exclude list, meaning Umbraco's type finder/loader won't try to resolve types within this assembly.

See issue for more information: https://github.com/umbraco/Umbraco-CMS/issues/10801