### PR TITLE
Adding [DebuggerDisplay] attribute to core published content classes …

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Umbraco.Core.Models.PublishedContent
@@ -9,6 +10,7 @@ namespace Umbraco.Core.Models.PublishedContent
     /// </summary>
     /// <remarks>Instances of the <see cref="PublishedContentType"/> class are immutable, ie
     /// if the content type changes, then a new class needs to be created.</remarks>
+    [DebuggerDisplay("{Alias}")]
     public class PublishedContentType : IPublishedContentType2
     {
         private readonly IPublishedPropertyType[] _propertyTypes;

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Umbraco.Core.Models.PublishedContent
 {
@@ -18,6 +19,7 @@ namespace Umbraco.Core.Models.PublishedContent
     /// Provides an abstract base class for <c>IPublishedContent</c> implementations that
     /// wrap and extend another <c>IPublishedContent</c>.
     /// </summary>
+    [DebuggerDisplay("{Id}: {Name} ({ContentType?.Alias})")]
     public abstract class PublishedContentWrapped : IPublishedContent
     {
         private readonly IPublishedContent _content;

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedCultureInfos.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedCultureInfos.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Umbraco.Core.Models.PublishedContent
 {
     /// <summary>
     /// Contains culture specific values for <see cref="IPublishedContent"/>.
     /// </summary>
+    [DebuggerDisplay("{Culture}")]
     public class PublishedCultureInfo
     {
         /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedDataType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedDataType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Umbraco.Core.Models.PublishedContent
 {
@@ -10,6 +11,7 @@ namespace Umbraco.Core.Models.PublishedContent
     /// if the data type changes, then a new class needs to be created.</para>
     /// <para>These instances should be created by an <see cref="IPublishedContentTypeFactory"/>.</para>
     /// </remarks>
+    [DebuggerDisplay("{EditorAlias}")]
     public class PublishedDataType
     {
         private readonly Lazy<object> _lazyConfiguration;

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyBase.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Umbraco.Core.PropertyEditors;
 
 namespace Umbraco.Core.Models.PublishedContent
@@ -7,6 +8,7 @@ namespace Umbraco.Core.Models.PublishedContent
     /// Provides a base class for <c>IPublishedProperty</c> implementations which converts and caches
     /// the value source to the actual value to use when rendering content.
     /// </summary>
+    [DebuggerDisplay("{Alias} ({PropertyType?.EditorAlias})")]
     internal abstract class PublishedPropertyBase : IPublishedProperty
     {
         /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Umbraco.Core.PropertyEditors;
@@ -10,6 +11,7 @@ namespace Umbraco.Core.Models.PublishedContent
     /// </summary>
     /// <remarks>Instances of the <see cref="PublishedPropertyType"/> class are immutable, ie
     /// if the property type changes, then a new class needs to be created.</remarks>
+    [DebuggerDisplay("{Alias} ({EditorAlias})")]
     public class PublishedPropertyType : IPublishedPropertyType
     {
         private readonly IPublishedModelFactory _publishedModelFactory;

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedSearchResult.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedSearchResult.cs
@@ -1,5 +1,8 @@
-﻿namespace Umbraco.Core.Models.PublishedContent
+﻿using System.Diagnostics;
+
+namespace Umbraco.Core.Models.PublishedContent
 {
+    [DebuggerDisplay("{Content?.Name} ({Score})")]
     public class PublishedSearchResult
     {
         public PublishedSearchResult(IPublishedContent content, float score)


### PR DESCRIPTION
…to make debugging easier

### Prerequisites

- [x ] I have added steps to test this contribution in the description below

### Description

This adds the `[DebuggerDisplay]` attribute to core published content classes to make debugging content easier. You can read about the [attribute here](https://docs.microsoft.com/en-us/visualstudio/debugger/using-the-debuggerdisplay-attribute?view=vs-2019).

To illustrate this, imagine you want to view the raw data for a particular property on a class that derives from `PublishedContentModel`. I want to inspect the property with the alias "siteName" to check the raw content, but how do I know which property it is? If you try and view the properties in the debugger currently you will just see this:

![Properties_Before](https://user-images.githubusercontent.com/6676168/128562730-16c6a2e9-e95b-4bea-bd92-7358b3ba0c22.png)

Not very helpful. Finding out which of the dozen properties is the one you want to inspect is impossible. But with this change it will now look like this:

![Properties_After](https://user-images.githubusercontent.com/6676168/128562787-eca4b5f7-c7ab-4ef9-be3e-f13d41c9df01.png)

You can now easily identify the property by it's alias and the type of editor used to create the property.

Another example. Viewing a content model currently in the debugger would show you this:

![Home_Before](https://user-images.githubusercontent.com/6676168/128563037-865069e2-f6d5-412c-a1ad-b7b6657cf038.png)

But with this change you get more useful info at a glance:

![Home_After](https://user-images.githubusercontent.com/6676168/128563058-ac918183-306e-48b7-aea0-b1732901644b.png)

I've done this for a number of the core base property classes, so most of the derived classes will benefit.

<!-- Thanks for contributing to Umbraco CMS! -->
