### PR TITLE
Needs a null check so it doesn't explode when saving content during a migration.

### DIFF
--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
@@ -29,6 +30,7 @@ namespace Umbraco.Cms.Core.Routing
         INotificationHandler<ContentMovingNotification>,
         INotificationHandler<ContentMovedNotification>
     {
+        private readonly ILogger<RedirectTrackingHandler> _logger;
         private readonly IOptionsMonitor<WebRoutingSettings> _webRoutingSettings;
         private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
         private readonly IRedirectUrlService _redirectUrlService;
@@ -36,8 +38,14 @@ namespace Umbraco.Cms.Core.Routing
 
         private const string NotificationStateKey = "Umbraco.Cms.Core.Routing.RedirectTrackingHandler";
 
-        public RedirectTrackingHandler(IOptionsMonitor<WebRoutingSettings> webRoutingSettings, IPublishedSnapshotAccessor publishedSnapshotAccessor, IRedirectUrlService redirectUrlService, IVariationContextAccessor variationContextAccessor)
+        public RedirectTrackingHandler(
+            ILogger<RedirectTrackingHandler> logger,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IRedirectUrlService redirectUrlService,
+            IVariationContextAccessor variationContextAccessor)
         {
+            _logger = logger;
             _webRoutingSettings = webRoutingSettings;
             _publishedSnapshotAccessor = publishedSnapshotAccessor;
             _redirectUrlService = redirectUrlService;
@@ -112,7 +120,13 @@ namespace Umbraco.Cms.Core.Routing
 
         private void CreateRedirects(OldRoutesDictionary oldRoutes)
         {
-            var contentCache = _publishedSnapshotAccessor.PublishedSnapshot.Content;
+            var contentCache = _publishedSnapshotAccessor.PublishedSnapshot?.Content;
+
+            if (contentCache == null)
+            {
+                _logger.LogWarning("Could not track redirects because there is no current published snapshot available.");
+                return;
+            } 
 
             foreach (var oldRoute in oldRoutes)
             {


### PR DESCRIPTION
The problem is that `RedirectTrackingHandler` is using the IPublishedSnapshotAccessor but not checking for null which is always required when using any 'accessor' that returns a scoped based instance.

I'm unsure if this issue only occurs when the system is in Upgrade mode, or if this will throw an exception if any IContent operations are done in a background thread. But since a published snapshot is dependent on an UmbracoContext which is scoped, I suspect this will always throw if any operations are performed on background threads. 

To force a published snapshot we would need to force an Umbraco context with the IUmbracoContextFactory if we wanted this to always works.

This problem describes exactly why it can be dangerous to create accessors for scoped based instances like what has been proposed here https://github.com/umbraco/Umbraco-CMS/pull/10789#issuecomment-892717732. IMO, if we have accessors for scoped based instances, we should either:

* Have the accessor have a `bool TryGetValue` method to return the underlying object therefor forcing developers to check or
* if it's null, we need to throw a very helpful exception instead of no exception which ends up with the generic Null ref

This is the stack trace

```
An unhandled exception occurred while processing the request.
BootFailedException: Boot failed: Umbraco cannot run. See Umbraco's log file for more details.

-> Umbraco.Cms.Core.Exceptions.BootFailedException: Unattended package migration failed for Articulate

-> Umbraco.Cms.Core.Exceptions.UnattendedInstallException: Unattended package migration failed for Articulate

-> System.NullReferenceException: Object reference not set to an instance of an object.
at Umbraco.Cms.Core.Routing.RedirectTrackingHandler.CreateRedirects(OldRoutesDictionary oldRoutes)
at Umbraco.Cms.Core.Routing.RedirectTrackingHandler.CreateRedirectsForOldRoutes(IStatefulNotification notification)
at Umbraco.Cms.Core.Routing.RedirectTrackingHandler.Handle(ContentPublishedNotification notification)
at Umbraco.Cms.Core.Events.EventAggregator.PublishCore(IEnumerable`1 allHandlers, INotification notification)
at Umbraco.Cms.Core.Events.EventAggregator.Publish[TNotification](TNotification notification)
at Umbraco.Cms.Core.Events.ScopedNotificationPublisher.ScopeExit(Boolean completed)
at Umbraco.Cms.Core.Scoping.Scope.<>c__DisplayClass91_0.<RobustExit>b__1()
at Umbraco.Cms.Core.Scoping.Scope.TryFinally(Int32 index, Action[] actions)
at Umbraco.Cms.Core.Scoping.Scope.TryFinally(Int32 index, Action[] actions)
at Umbraco.Cms.Core.Scoping.Scope.TryFinally(Action[] actions)
at Umbraco.Cms.Core.Scoping.Scope.RobustExit(Boolean completed, Boolean onException)
at Umbraco.Cms.Core.Scoping.Scope.DisposeLastScope()
at Umbraco.Cms.Core.Scoping.Scope.Dispose()
at Umbraco.Cms.Infrastructure.Migrations.Upgrade.Upgrader.Execute(IMigrationPlanExecutor migrationPlanExecutor, IScopeProvider scopeProvider, IKeyValueService keyValueService)
at Umbraco.Cms.Infrastructure.Install.UnattendedUpgrader.HandleAsync(RuntimeUnattendedUpgradeNotification notification, CancellationToken cancellationToken)
```