### PR TITLE
Check invariant name of custom listview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
@@ -8,9 +8,9 @@
             scope.dataType = {};
             scope.customListViewCreated = false;
 
-            const listViewNamePrefix = "List View";
+            const listViewPrefix = "List View - ";
             
-            const checkForCustomListView = () => invariantEquals(scope.dataType.name, listViewNamePrefix + " - " + scope.modelAlias);
+            const checkForCustomListView = () => invariantEquals(scope.dataType.name, listViewPrefix + scope.modelAlias);
 
             // We also use "localeCompare" a few other places. Should probably be moved to a utility/helper function in future.
             function invariantEquals(a, b) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblistviewsettings.directive.js
@@ -7,8 +7,17 @@
 
             scope.dataType = {};
             scope.customListViewCreated = false;
+
+            const listViewNamePrefix = "List View";
             
-            const checkForCustomListView = () => scope.dataType.name === "List View - " + scope.modelAlias;
+            const checkForCustomListView = () => invariantEquals(scope.dataType.name, listViewNamePrefix + " - " + scope.modelAlias);
+
+            // We also use "localeCompare" a few other places. Should probably be moved to a utility/helper function in future.
+            function invariantEquals(a, b) {
+                return typeof a === "string" && typeof b === "string"
+                    ? a.localeCompare(b, undefined, { sensitivity: "base" }) === 0
+                    : a === b;
+            }
 
             /* ---------- INIT ---------- */ 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9289

### Description
This PR doesn't fixes https://github.com/umbraco/Umbraco-CMS/issues/9289 but it may be good enough for now.
Currently it assume a custom listview is configurated if data type name matches "List View - {alias}" where alias by default is camel case, e.g. "List View - people"

It then cause issues if the data type was renamed to "List View - People" as it would then use default "List View - Content".

With this change it ignore casing, so the datatype can be renamed to "List View - People".

![q2EA75D48G](https://user-images.githubusercontent.com/2919859/128636054-2e7a02a1-ab70-43c7-83cd-f0ce0cdd82d8.gif)

Additionally it could also try create the datatype name in pascal casing in first place:
https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web/Editors/DataTypeController.cs#L179