### PR TITLE
fixes border and overflow on media grid cards

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -1,11 +1,11 @@
 .umb-media-grid {
-   display: flex;
-   flex-wrap: wrap;
-   flex-direction: row;
-   flex-wrap: wrap;
-   align-items: center;
-   width: 100%;
-   margin-bottom: 30px;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 30px;
 }
 
 .umb-media-grid__item {
@@ -24,95 +24,107 @@
     margin: 10px;
     position: relative;
     user-select: none;
-    box-shadow: 0 1px 1px 0 rgba(0,0,0,.2);
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .2);
     transition: box-shadow 150ms ease-in-out;
 
-    > div {
+    &:hover {
+        text-decoration: none;
+
+        .umb-media-grid__edit {
+            opacity: 1;
+            text-decoration: none;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, .2);
+        }
+
+        .umb-media-grid__item-overlay {
+            opacity: 1;
+        
+            i {
+                text-decoration: none;
+            }
+        }
+    }
+
+    > div:not(.umb-media-grid__item-overlay),
+    img {
         overflow: hidden;
         border-radius: @baseBorderRadius;
     }
 
-}
+    &.-selectable,
+    &.-folder {
+        // If folders isnt selectable, they opens if clicked, therefor...
+        cursor: pointer;
+    }
 
-.umb-media-grid__item.-selectable, 
-.umb-media-grid__item.-folder {// If folders isnt selectable, they opens if clicked, therefor...
-    cursor: pointer;
-}
+    &.-file {
+        background-color: @white;
+    }
 
-.umb-media-grid__item.-file {
-    background-color: @white;
-}
-
-.umb-media-grid__item.-folder {
-    &.-selectable {
+    &.-folder.-selectable {
         .media-grid-item-edit:hover .umb-media-grid__item-name,
         .media-grid-item-edit:focus .umb-media-grid__item-name {
             text-decoration: underline;
         }
     }
-}
 
-
-.umb-media-grid__item.-selected {
-    color:@ui-selected-type;
-    .umb-media-grid__item-overlay {
+    &.-selected {
         color: @ui-selected-type;
+
+        .umb-media-grid__item-overlay {
+            color: @ui-selected-type;
+        }
     }
-}
-.umb-media-grid__item.-selected, 
-.umb-media-grid__item.-selectable:hover {
-    .umb-media-grid__item-select {
-        position: absolute;
-        z-index:2;
-        top: -2px;
-        left: -2px;
-        right: -2px;
-        bottom: -2px;
-        border: 2px solid @ui-selected-border;
-        border-radius: 5px;
-        box-shadow: 0 0 4px 0 darken(@ui-selected-border, 20), inset 0 0 2px 0 darken(@ui-selected-border, 20);
-        pointer-events: none;
+
+    &.-selected,
+    &.-selectable:hover {
+        .umb-media-grid__item-select {
+            position: absolute;
+            z-index: 2;
+            top: -2px;
+            left: -2px;
+            right: -2px;
+            bottom: -2px;
+            border: 2px solid @ui-selected-border;
+            border-radius: 5px;
+            box-shadow: 0 0 4px 0 darken(@ui-selected-border, 20), inset 0 0 2px 0 darken(@ui-selected-border, 20);
+            pointer-events: none;
+        }
     }
-}
-.umb-media-grid__item.-selectable:hover {
-    .umb-media-grid__item-select {
+
+    &.-selectable:hover .umb-media-grid__item-select {
         opacity: .33;
     }
-}
-.umb-media-grid__item.-selected:hover {
-    .umb-media-grid__item-select {
+
+    &.-selected:hover .umb-media-grid__item-select {
         opacity: .75;
     }
-}
-.umb-media-grid__item.-filtered:not(.-folder) {
-    cursor:not-allowed;
-    * {
-        pointer-events: none;
+
+    &.-filtered:not(.-folder) {
+        cursor: not-allowed;
+
+        * {
+            pointer-events: none;
+        }
     }
 }
 
 .umb-media-grid__item-file-icon {
-    transform: translate(-50%,-50%);
+    transform: translate(-50%, -50%);
     position: absolute;
     top: 45%;
     left: 50%;
 }
 
-.umb-media-grid__item:hover {
-   text-decoration: none;
-}
-
-.umb-media-grid__item-image {
-   position: relative;
-   object-fit: contain;
-   height: 100%;
+.umb-media-grid__item-image,
+.umb-media-grid__item-image-placeholder {
+    position: relative;
+    object-fit: contain;
+    height: 100%;
 }
 
 .umb-media-grid__item-image-placeholder {
     width: 100%;
-    position: relative;
-    object-fit: contain;
-    height: 100%;
 }
 
 .umb-media-grid__image-background {
@@ -127,70 +139,51 @@
 }
 
 .umb-media-grid__item-overlay {
-   display: flex;
-   align-items: center;
-   width: 100%;
-   opacity: 0;
-   position: absolute;
-   right: 0;
-   bottom: 0;
-   left: 0;
-   z-index: 1;
-   padding: 5px 10px;
-   box-sizing: border-box;
-   font-size: 12px;
-   overflow: hidden;
-   color: @black;
-   white-space: nowrap;
-   border-top:1px solid fade(@black, 4%);
-   background: fade(@white, 92%);
-   transition: opacity 150ms;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    padding: 5px 10px;
+    box-sizing: border-box;
+    font-size: 12px;
+    overflow: hidden;
+    color: @black;
+    white-space: nowrap;
+    border-top: 1px solid fade(@black, 4%);
+    background: fade(@white, 92%);
+    transition: opacity 150ms;
+    border-radius: 0 0 3px 3px;
+    cursor: pointer;
 
-   &.-can-open:hover {
-       text-decoration: underline;
-   }
-   
-   .tabbing-active &:focus {
-       opacity: 1;
-   }
+    &:hover .umb-media-grid__item-name,
+    &.-can-open:hover {
+        text-decoration: underline;
+    }
+
+    &:not(.-selected):hover + .umb-media-grid__item-select {
+        display: none;        
+    }
+
+    &.-locked,
+    .tabbing-active &:focus {
+        opacity: 1;
+    }
 }
 
 .umb-media-grid__info {
-    margin-right: 5px;
-}
-
-.umb-media-grid__item-overlay.-locked {
-    opacity: 1;
-}
-
-.umb-media-grid__item:hover .umb-media-grid__item-overlay {
-   opacity: 1;
-   i {
-       text-decoration: none;
-   }
-}
-
-.umb-media-grid__item-overlay {
-    cursor: pointer;
-
-    &:hover .umb-media-grid__item-name{
-        text-decoration: underline;
-    }
-}
-
-.umb-media-grid__item-overlay:not(.-selected) {
-    &:hover + .umb-media-grid__item-select {
-        display: none;
-    }
+    margin: -4px 0 5px;
 }
 
 .umb-media-grid__item-name {
-   white-space: nowrap;
-   overflow: hidden;
-   text-overflow: ellipsis;
-
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-
 
 .umb-media-grid__edit {
     position: absolute;
@@ -208,34 +201,32 @@
     align-items: center;
     color: @black;
     transition: opacity 150ms;
-    
+
     &:hover {
         color: @ui-action-discreet-type-hover;
     }
 }
 
-.umb-media-grid__item:hover .umb-media-grid__edit {
-    opacity: 1;
-    text-decoration: none;
-    box-shadow: 0 1px 2px rgba(0,0,0,.2);
-}
-
 /*for the listview*/
-
-.umb-media-grid__list-item.selected, .umb-media-grid__list-item.selected:hover, .umb-media-grid__list-item.selected:focus {
-    border: 2px solid #f5c1bc !important;
+.umb-media-grid__list-item {
+    &.selected,
+    &.selected:hover,
+    &.selected:focus {
+        border: 2px solid @pinkLight !important;
+    }
 }
 
 .umb-media-grid__list-view .umb-table-cell.umb-table__name {
     flex: 1 1 25%;
     max-width: none;
     white-space: normal;
-}
 
-.umb-media-grid__list-view .umb-table-cell.umb-table__name .item-name {
-    white-space:normal;
-}
-.umb-media-grid__list-view .umb-table-cell.umb-table__name ins {
-    text-decoration: none;
-    margin-top: 3px;
+    .item-name {
+        white-space: normal;
+    }
+
+    ins {
+        text-decoration: none;
+        margin-top: 3px;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -14,7 +14,11 @@
                     ng-class="{'-locked': item.selected || !item.file || !item.thumbnail, '-can-open': (item.isFolder ? allowOpenFolder : allowOpenFile)}"
                     ng-click="clickItemName(item, $event, $index)"
                     tabindex="{{item.isFolder && item.selectable ? '0' : '-1'}}">
-                <i ng-if="onDetailsHover" class="icon-info umb-media-grid__info" ng-mouseover="hoverItemDetails(item, $event, true)" ng-mouseleave="hoverItemDetails(item, $event, false)"></i>
+                <umb-icon ng-if="onDetailsHover" 
+                            icon="icon-info" 
+                            class="umb-media-grid__info" 
+                            ng-mouseover="hoverItemDetails(item, $event, true)" 
+                            ng-mouseleave="hoverItemDetails(item, $event, false)"></umb-icon>
                 <div class="umb-media-grid__item-name">{{item.name}}</div>
             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Noticed the styling on the media grid cards was a bit wonky - note the image corners overflowing the radiused container, and the overlay having rounded corners on all four sides:

![before](https://user-images.githubusercontent.com/3248070/128797628-fa5eb2db-fab3-4dfd-b80e-200fa221b601.jpg)

Changes here fix that CSS and tidy the related less partial (cleans up a lot of repeated class names, in favour of some sensible nesting instead), and adds the umb-icon directive in the media list view:

![after](https://user-images.githubusercontent.com/3248070/128797750-9009b6c0-3fd1-4a9e-9312-07af763fb56b.jpg)

Second image is from the media list-view, so has the icon, and shows the hover state.

To test, verify the hover/selected/selectable states all still work as normal, and the image stays inside the container.