### PR TITLE
Update styles on editor-header icon picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor.less
@@ -79,12 +79,16 @@
 }
 
 .umb-editor-header__back {
-    background: transparent;
-    border: 0;
+	font-size:20px;
+	display:flex;
     color: @gray-6;
-    margin: 0 0 1px 0;
+    margin-right: 15px;
     padding: 0;
 	transition: color 0.1s ease-in-out;
+
+	&:hover {
+		color:@gray-7;
+	}
 }
 
 .umb-editor-header__name-wrapper {
@@ -97,6 +101,7 @@
 }
 
 .umb-editor-header__name-and-description {
+	flex:1 1 auto;
     margin-right: 20px;
     .umb-panel-header-description {
     	padding: 0 10px;

--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -351,15 +351,13 @@
   cursor: pointer;
   font-size: 2rem;
   margin-right: 5px;
-  margin-top: -6px;
   height: 50px;
   display: flex;
   justify-content: center;
   align-items: center;
   background: @white;
-  border: 1px solid @ui-action-discreet-border;
+  border: 1px solid @gray-8;
   animation: fadeIn 0.5s;
-  border-radius: 3px;
   width: 50px;
   &:hover {
       .icon {
@@ -427,7 +425,7 @@ input.umb-panel-header-name-input.name-is-empty {
 input.umb-panel-header-description {
   background: transparent;
   border-color: transparent;
-  margin-bottom: 0;
+  margin:-1px 0 0;
   font-size: 13px;
   box-sizing: border-box;
   height: 22px;

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_flexbox.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_flexbox.less
@@ -33,10 +33,10 @@
 .content-around  { align-content: space-around; }
 .content-stretch { align-content: stretch; }
 
+.flex-1,
 .flx-i {
   flex: 1;
 }
-
 
 .flx-g0 {
   flex-grow: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_width.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_width.less
@@ -24,3 +24,8 @@
 .w-100 { width: 100%; }
 
 .w-auto { width: auto; }
+
+/* adding related height utilities */
+
+.h-100 { height: 100%; }
+.h-auto { height: auto;}

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -1,17 +1,17 @@
 <div data-element="editor-header" class="umb-editor-header" ng-class="{'-split-view-active': splitViewOpen === true}">
 
-    <div class="flex items-center" style="height: 100%;">
+    <div class="flex items-center h-100">
 
-        <div ng-if="showBackButton === true && splitViewOpen !== true" style="margin-right: 15px;">
-            <button type="button" class="umb-editor-header__back" ng-click="goBack()" prevent-default>
-                <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                <span class="sr-only"><localize key="visuallyHiddenTexts_goBack">Go back</localize></span>
-            </button>
-        </div>
+        <button type="button" 
+                ng-if="showBackButton === true && splitViewOpen !== true"
+                class="btn-reset umb-editor-header__back"
+                ng-click="goBack()">
+            <umb-icon icon="icon-arrow-left"></umb-icon>
+            <span class="sr-only"><localize key="visuallyHiddenTexts_goBack">Go back</localize></span>
+        </button>
 
-        <div class="flex items-center" style="flex: 1;">
-
-            <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1 1 auto;">
+        <div class="flex flex-1">
+            <div id="nameField" class="umb-editor-header__name-and-description">
                 <div>
                     <p tabindex="0" class="sr-only">
                         {{a11yMessage}}

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -1,15 +1,16 @@
 ﻿<div data-element="editor-header" class="umb-editor-header" ng-class="{'-split-view-active': splitViewOpen === true}">
     <umb-loader ng-show="loading"></umb-loader>
-    <div class="flex items-center" style="height: 100%;" ng-hide="loading">
+    <div class="flex items-center h-100" ng-hide="loading">
 
-        <div ng-if="showBackButton === true && splitViewOpen !== true" style="margin-right: 15px;">
-            <button type="button" class="umb-editor-header__back" ng-click="goBack()" prevent-default>
-                <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                <span class="sr-only"><localize key="visuallyHiddenTexts_goBack">Go back</localize></span>
-            </button>
-        </div>
+        <button type="button"  
+                class="btn-reset umb-editor-header__back"
+                ng-if="showBackButton === true && splitViewOpen !== true" 
+                ng-click="goBack()">
+            <umb-icon icon="icon-arrow-left"></umb-icon>
+            <span class="sr-only"><localize key="visuallyHiddenTexts_goBack">Go back</localize></span>
+        </button>
 
-        <div class="flex items-center" style="flex: 1;">
+        <div class="flex flex-1">
 
             <ng-form data-element="editor-icon" name="iconForm">
                 <button
@@ -25,7 +26,7 @@
                 </button>
             </ng-form>
 
-            <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1 1 auto;">
+            <div id="nameField" class="umb-editor-header__name-and-description">
                 <div>
                     <p tabindex="0" class="sr-only" ng-show="accessibility.a11yMessageVisible">
                         {{accessibility.a11yMessage}}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Updates the border color and radius on the icon picker in the editor header, to match the styling of the name input. Also removes some inline styles and unnecessary markup, and update the back button to remove the font-awesome icon in favor of the same icon from the backoffice set.

Didn't look quite right having rounded corners beside the squared input, and the slightly different border color triggered my OCD.

Before:
![before](https://user-images.githubusercontent.com/3248070/128806669-65e9f595-a02c-4c41-ad8b-b682991ca3a2.jpg)
After:
![after](https://user-images.githubusercontent.com/3248070/128806672-fa313bdf-2239-4c77-9aba-ce8997b1530f.jpg)

And the back button, before:
![backbtn-before](https://user-images.githubusercontent.com/3248070/128806693-1fd63b3a-1cf0-42df-81b3-958d565ce02d.jpg)
After:
![backbtn-after](https://user-images.githubusercontent.com/3248070/128806699-fd05688c-2fd0-4e75-b35c-c94583db6b6f.jpg)

To test, verify the header renders correctly on a content node, a content node accessed from a list view, a media item, a content type, a user and a media/content/blocklist picker. It is used in a stack more places (70+), but these will cover the variations.