### PR TITLE
V9 Serilog - Remove old XML settings nuget

### DIFF
--- a/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 using Serilog.Events;

--- a/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Serilog;
@@ -14,17 +14,6 @@ namespace Umbraco.Cms.Core.Logging.Serilog
     public class SerilogLogger : IDisposable
     {
         public global::Serilog.ILogger SerilogLog { get; }
-
-        /// <summary>
-        /// Initialize a new instance of the <see cref="SerilogLogger"/> class with a configuration file.
-        /// </summary>
-        /// <param name="logConfigFile"></param>
-        public SerilogLogger(FileInfo logConfigFile)
-        {
-            SerilogLog = new LoggerConfiguration()
-                .ReadFrom.AppSettings(filePath: logConfigFile.FullName)
-                .CreateLogger();
-        }
 
         public SerilogLogger(LoggerConfiguration logConfig)
         {

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -46,6 +46,7 @@
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
       <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+      <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -41,7 +41,6 @@
       <PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
       <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
       <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.5" />
-      <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
       <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />


### PR DESCRIPTION
Remove unused package of `Serilog.Settings.AppSettings` that was reading the config of Serilog from XML files

NOTE: Had to add back `System.Configuration.ConfigurationManager` as the Serilog package pulled this in as a dependency and currently there are places in the CMS codebase that depend on ConfigManager still 🙈 