### PR TITLE
V8: Improve text styles in umb-empty-state

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-empty-state.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-empty-state.less
@@ -1,23 +1,29 @@
 .umb-empty-state {
-	font-size: @fontSizeMedium;
-	line-height: 1.8em;
-	color: @gray-4;
-	text-align: center;
-}
+    font-size: @fontSizeMedium;
+    line-height: 1.5;
+    color: @gray-4;
+    text-align: center;
 
-.umb-empty-state.-small {
-	font-size: 14px;
-}
+    small {
+        display: inline-block;
+        margin-top: 0.5rem;
+        line-height: 1.6;
+    }
 
-.umb-empty-state.-large {
-	font-size: @fontSizeLarge;
-}
+    &.-small {
+        font-size: 14px;
+    }
 
-.umb-empty-state.-center {
-	position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%,-50%);
-    width: 80%;
-    max-width: 400px;
+    &.-large {
+        font-size: @fontSizeLarge;
+    }
+
+    &.-center {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 80%;
+        max-width: 400px;
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A little UI tweak - noticed the line height for the secondary text in the umb-empty-state directive was uncomfortably large, so have reduced it. Because the line-height was set in `em` on the parent element, the same line-height was applied to the large and small text, which resulted in excessive line-height on the smaller text size:

Before:
![before](https://user-images.githubusercontent.com/3248070/128954902-d5366437-a88b-4b1b-9937-985868f1367b.jpg)
After:
![after](https://user-images.githubusercontent.com/3248070/128954907-7ef09c27-ea11-4173-85fe-600804c471f4.jpg)

Changed to use unitless line-height rather than `em`, so that it's relative to the element's font size instead of inherited.

To test, verify umb-empty-state renders per the After image