### PR TITLE
V9: Fix RedirectToCurrentUmbracoPage when UrlProviderMode is set to "Absolute"

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
@@ -22,6 +23,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
         private readonly IWebHostEnvironment _webHostEnvironment;
         private string _applicationId;
         private string _localTempPath;
+        private UrlMode _urlProviderMode;
 
         public AspNetCoreHostingEnvironment(
             IServiceProvider serviceProvider,
@@ -33,6 +35,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
             _hostingSettings = hostingSettings ?? throw new ArgumentNullException(nameof(hostingSettings));
             _webRoutingSettings = webRoutingSettings ?? throw new ArgumentNullException(nameof(webRoutingSettings));
             _webHostEnvironment = webHostEnvironment ?? throw new ArgumentNullException(nameof(webHostEnvironment));
+            _urlProviderMode = _webRoutingSettings.CurrentValue.UrlProviderMode;
 
             SiteName = webHostEnvironment.ApplicationName;
             ApplicationPhysicalPath = webHostEnvironment.ContentRootPath;
@@ -144,7 +147,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
         /// <inheritdoc/>
         public string ToAbsolute(string virtualPath)
         {
-            if (!virtualPath.StartsWith("~/") && !virtualPath.StartsWith("/"))
+            if (!virtualPath.StartsWith("~/") && !virtualPath.StartsWith("/") && _urlProviderMode != UrlMode.Absolute)
             {
                 throw new InvalidOperationException($"The value {virtualPath} for parameter {nameof(virtualPath)} must start with ~/ or /");
             }

--- a/src/Umbraco.Web.UI.NetCore/appsettings.json
+++ b/src/Umbraco.Web.UI.NetCore/appsettings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./umbraco/config/appsettings-schema.json",
   "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|\\Umbraco.sdf;Flush Interval=1;"
+    "umbracoDbDSN": ""
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
Fixes: #10820

## Details
- `UrlProviderMode` can be set to "Absolute", "Auto" and "Relative";
- When the mode was set to "Absolute', `RedirectToCurrentUmbracoPage()` was not working;
- Adding a check for this case to avoid the exception being thrown - `$"The value {virtualPath} for parameter {nameof(virtualPath)} must start with ~/ or /"`.

## Test
- Follow the steps in the original issue OR
</br>

- Set ⬇️ to appsettings.json
```json
"WebRouting": {
  "UrlProviderMode": "Absolute"
}
```
- Create a test _SurfaceController_ and add a PostMethod like:
```c#
[HttpPost]
public IActionResult PostMethod()
{
    if (!ModelState.IsValid)
    {
        return CurrentUmbracoPage();
    }

    return RedirectToCurrentUmbracoPage();
}
```
- Post to the added surface controller:
  - Create a new Partial View Macro file;
  - Insert the following code:
```cshtml
@inherits Umbraco.Cms.Web.Common.Macros.PartialViewMacroPage

@using Umbraco.Cms.Web.Website.Controllers

@using (Html.BeginUmbracoForm<MyNewController>("PostMethod"))
{
    <button type="submit" class="btn btn-primary">Submit</button>
}
```
- Go to the newly created Macro and enable the **Use in rich text editor and the grid**;
- Create a Document type and add a Rich Text Editor as a property;
- Edit the node's template to render the RTE using `@Model.Value("[RTE alias]")`;
- In the Content section ( in the RTE property) insert the macro you created;
- Save and Publish;
- Navigate to the published link of that content node;
- Clicking the button shouldn't trigger the reported error.

</br>

---
❗ **Note**: The path for the `WebRouting` setting in apsettings.json is `Umbraco:Cms:WebRouting`.

**Bonus**: Removing the mistakenly committed connection string from appsettings.json 😉 
