### PR TITLE
Only encode text once

### DIFF
--- a/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/textstring.cshtml
+++ b/src/Umbraco.Web.UI.NetCore/Views/Partials/grid/editors/textstring.cshtml
@@ -4,7 +4,7 @@
 @if (Model.editor.config.markup != null)
 {
     string markup = Model.editor.config.markup.ToString();
-    markup = markup.Replace("#value#", Html.ReplaceLineBreaks(HttpUtility.HtmlEncode((string)Model.value.ToString())).ToString());
+    markup = markup.Replace("#value#", Html.ReplaceLineBreaks((string)Model.value.ToString()).ToString());
 
     if (Model.editor.config.style != null)
     {


### PR DESCRIPTION
Html.ReplaceLineBreaks calls WebUtility.HtmlEncode internally, so the text gets encoded by this method.

As far as I know, WebUtility.HtmlEncode and HttpUtility.HtmlEncode produces the same result (unlike WebUtility.UrlEncode and HttpUtility.UrlEncode which produces different results; see https://edi.wang/post/2018/11/25/netcore-webutility-urlencode-httputility-urlencode), so it should be safe to omit HttpUtility.HtmlEncode here.

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: #10841

### Description
The steps to reproduce the error is mentioned in the issue above.

<!-- Thanks for contributing to Umbraco CMS! -->
