### PR TITLE
Fixed incorrect node url being returned when no suitable domain exist…

### DIFF
--- a/src/Umbraco.Core/Routing/DomainUtilities.cs
+++ b/src/Umbraco.Core/Routing/DomainUtilities.cs
@@ -190,7 +190,7 @@ namespace Umbraco.Cms.Core.Routing
             }
 
             // look for domains that would be the base of the uri
-            var baseDomains = SelectByBase(considerForBaseDomains, uri);
+            var baseDomains = SelectByBase(considerForBaseDomains, uri, culture);
             if (baseDomains.Count > 0) // found, return
                 return baseDomains.First();
 
@@ -208,12 +208,15 @@ namespace Umbraco.Cms.Core.Routing
         private static bool IsBaseOf(DomainAndUri domain, Uri uri)
             => domain.Uri.EndPathWithSlash().IsBaseOf(uri);
 
-        private static IReadOnlyCollection<DomainAndUri> SelectByBase(IReadOnlyCollection<DomainAndUri> domainsAndUris, Uri uri)
+        private static bool MatchesCulture(DomainAndUri domain, string culture)
+            => culture == null || domain.Culture == culture;
+
+        private static IReadOnlyCollection<DomainAndUri> SelectByBase(IReadOnlyCollection<DomainAndUri> domainsAndUris, Uri uri, string culture)
         {
             // look for domains that would be the base of the uri
             // ie current is www.example.com/foo/bar, look for domain www.example.com
             var currentWithSlash = uri.EndPathWithSlash();
-            var baseDomains = domainsAndUris.Where(d => IsBaseOf(d, currentWithSlash)).ToList();
+            var baseDomains = domainsAndUris.Where(d => IsBaseOf(d, currentWithSlash) && MatchesCulture(d, culture)).ToList();
 
             // if none matches, try again without the port
             // ie current is www.example.com:1234/foo/bar, look for domain www.example.com

--- a/src/Umbraco.Core/Routing/DomainUtilities.cs
+++ b/src/Umbraco.Core/Routing/DomainUtilities.cs
@@ -199,10 +199,6 @@ namespace Umbraco.Cms.Core.Routing
             if (filter != null)
             {
                 var domainAndUri = filter(cultureDomains ?? domainsAndUris, uri, culture, defaultCulture);
-                // if still nothing, pick the first one?
-                // no: move that constraint to the filter, but check
-                if (domainAndUri == null)
-                    throw new InvalidOperationException("The filter returned null.");
                 return domainAndUri;
             }
 

--- a/src/Umbraco.Core/Routing/SiteDomainMapper.cs
+++ b/src/Umbraco.Core/Routing/SiteDomainMapper.cs
@@ -336,8 +336,7 @@ namespace Umbraco.Cms.Core.Routing
             if (qualifiedSites == null)
             {
                 return domainAndUris.FirstOrDefault(x => x.Culture.InvariantEquals(culture))
-                    ?? domainAndUris.FirstOrDefault(x => x.Culture.InvariantEquals(defaultCulture))
-                    ?? domainAndUris.First();
+                    ?? domainAndUris.FirstOrDefault(x => x.Culture.InvariantEquals(defaultCulture));
             }
 
             // find a site that contains the current authority
@@ -350,18 +349,7 @@ namespace Umbraco.Cms.Core.Routing
                 : domainAndUris.FirstOrDefault(d => currentSite.Value.Contains(d.Uri.GetLeftPart(UriPartial.Authority)));
 
             // no match means that either current does not belong to a site, or the site it belongs to
-            // does not contain any of domainAndUris. Yet we have to return something. here, it becomes
-            // a bit arbitrary.
-
-            // look through sites in order and pick the first domainAndUri that belongs to a site
-            ret = ret ?? qualifiedSites
-                .Where(site => site.Key != currentSite.Key)
-                .Select(site => domainAndUris.FirstOrDefault(domainAndUri => site.Value.Contains(domainAndUri.Uri.GetLeftPart(UriPartial.Authority))))
-                .FirstOrDefault(domainAndUri => domainAndUri != null);
-
-            // random, really
-            ret = ret ?? domainAndUris.FirstOrDefault(x => x.Culture.InvariantEquals(culture)) ?? domainAndUris.First();
-
+            // does not contain any of domainAndUris.
             return ret;
         }
 

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -247,6 +247,13 @@ namespace Umbraco.Extensions
                 return Attempt.Succeed(urlInfo);
             }
 
+            // collisions with a different culture of the same content can never be routed.
+            if (!culture.InvariantEquals(pcr.Culture))
+            {
+                var urlInfo = UrlInfo.Message(textService.Localize("content", "routeErrorCannotRoute"), culture);
+                return Attempt.Succeed(urlInfo);
+            }
+
             // no collision
             return Attempt<UrlInfo>.Fail();
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/SiteDomainMapperTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/SiteDomainMapperTests.cs
@@ -191,9 +191,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             siteDomainMapper.AddSite("site3", "domain3.com", "domain3.net", "domain3.org");
             siteDomainMapper.AddSite("site4", "https://domain4.com", "https://domain4.net", "https://domain4.org");
 
-            // this works, but it's purely by chance / arbitrary
-            // don't use the www in tests here!
-            var current = new Uri("https://www.domain1.com/foo/bar");
+            var current = new Uri("https://domain1.com/foo/bar");
             Domain[] domains = new[]
                 {
                     new Domain(1, "domain2.com", -1, s_cultureFr, false),


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10827 

### Description
This changes the code to have a behavior close to what is expected while trying not to change to much.
Instead of always falling back to the first registered domain, we simply don't match one and use the default route.

This will more closely follow the default routing behavior and properly show it in the CMS as well.

<!-- Thanks for contributing to Umbraco CMS! -->
