### PR TITLE
v9: If you didnt have a member group, restricting acces to the public would always lead to error page

### DIFF
--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/PublicAccessCheckerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/PublicAccessCheckerTests.cs
@@ -117,6 +117,23 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
 
         [AutoMoqData]
         [Test]
+        public async Task GivenMemberLoggedIn_WhenMemberHasNoRoles_ThenAccessDeniedResult(
+            IMemberManager memberManager,
+            IPublicAccessService publicAccessService,
+            IContentService contentService)
+        {
+            PublicAccessChecker sut = CreateSut(memberManager, publicAccessService, contentService, out HttpContext httpContext);
+
+            httpContext.User = GetLoggedInUser();
+            MockGetUserAsync(memberManager, new MemberIdentityUser());
+            MockGetRolesAsync(memberManager, Enumerable.Empty<string>());
+
+            var result = await sut.HasMemberAccessToContentAsync(123);
+            Assert.AreEqual(PublicAccessStatus.AccessDenied, result);
+        }
+
+        [AutoMoqData]
+        [Test]
         public async Task GivenMemberLoggedIn_WhenMemberIsLockedOut_ThenLockedOutResult(
             IMemberManager memberManager,
             IPublicAccessService publicAccessService,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/PublicAccessCheckerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/PublicAccessCheckerTests.cs
@@ -117,23 +117,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
 
         [AutoMoqData]
         [Test]
-        public async Task GivenMemberLoggedIn_WhenMemberHasNoRoles_ThenAccessDeniedResult(
-            IMemberManager memberManager,
-            IPublicAccessService publicAccessService,
-            IContentService contentService)
-        {
-            PublicAccessChecker sut = CreateSut(memberManager, publicAccessService, contentService, out HttpContext httpContext);
-
-            httpContext.User = GetLoggedInUser();
-            MockGetUserAsync(memberManager, new MemberIdentityUser());
-            MockGetRolesAsync(memberManager, Enumerable.Empty<string>());
-
-            var result = await sut.HasMemberAccessToContentAsync(123);
-            Assert.AreEqual(PublicAccessStatus.AccessDenied, result);
-        }
-
-        [AutoMoqData]
-        [Test]
         public async Task GivenMemberLoggedIn_WhenMemberIsLockedOut_ThenLockedOutResult(
             IMemberManager memberManager,
             IPublicAccessService publicAccessService,

--- a/src/Umbraco.Web.Common/Security/PublicAccessChecker.cs
+++ b/src/Umbraco.Web.Common/Security/PublicAccessChecker.cs
@@ -39,11 +39,6 @@ namespace Umbraco.Cms.Web.Common.Security
             var username = currentMember.UserName;
             IList<string> userRoles = await memberManager.GetRolesAsync(currentMember);
 
-            if (userRoles.Count == 0)
-            {
-                return PublicAccessStatus.AccessDenied;
-            }
-
             if (!currentMember.IsApproved)
             {
                 return PublicAccessStatus.NotApproved;


### PR DESCRIPTION
fixes an issue, where if you had a member, but no member groups. Restricting public access and giving permission to a member would always yield in the error page, even when you logged in as the correct member that had access.


# Notes
- Removed if statement in `PublicAccessChecker.HasMemberAccessToContentAsync`

# How to test
- Create a doc type and call it home page, then create an empty content page called "Home Page"
- Create a new member and choose your username and password(remember it though)
- Create a doc type with a Grid Layout property and call it GridProp
- Create a partial view macros from snippet from `Login`
- Go to the Login macro and enable "Use in rich text editor and the grid"
- Make a content page using the Grid Doc, and call it "Login"
- Choose 1 Coloum and headline, and then add a macro, choose the "Login" macro
- Make a content page using the grid doc, and call it "Error"
- Choose 1 coloumn and headline and then add a headline "Error!!"
- right click your "Home Page" in content and choose "Restric public access"
- Choose "Specific members protection
- Add your newly created member, and add the login & error pages respectively
- Try navigating to the "Home Page" url, and login, this should lead you to the home page and not the error screen
