### PR TITLE
Upgrade to noUiSlider v15.3.0

### DIFF
--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -41,7 +41,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.22.2",
     "ng-file-upload": "12.2.13",
-    "nouislider": "15.2.0",
+    "nouislider": "15.3.0",
     "npm": "^6.14.7",
     "signalr": "2.4.0",
     "spectrum-colorpicker2": "2.0.8",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
No real changes from noUiSlider v15.2.0 expect it now has a `keyboardMultiplier` option.
https://github.com/leongersen/noUiSlider/releases

It can potential be useful, when having a slider with a small step size as in the example here:
https://github.com/leongersen/noUiSlider/issues/992