### PR TITLE
V9: Eye Dropper property value converter

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Cms.Core
 {
@@ -52,7 +52,7 @@ namespace Umbraco.Cms.Core
                 public const string ColorPicker = "Umbraco.ColorPicker";
 
                 /// <summary>
-                /// EyeDropper Color Picker.
+                /// Eye Dropper Color Picker.
                 /// </summary>
                 public const string ColorPickerEyeDropper = "Umbraco.ColorPicker.EyeDropper";
 

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/EyeDropperValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/EyeDropperValueConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
+{
+    [DefaultPropertyValueConverter]
+    public class EyeDropperValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType)
+            => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.ColorPickerEyeDropper);
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+            => typeof (string);
+
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
+            => PropertyCacheLevel.Element;
+
+        public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object source, bool preview)
+            => source?.ToString() ?? string.Empty;
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/EyeDropperValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/EyeDropperValueConverter.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
             => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.ColorPickerEyeDropper);
 
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-            => typeof (string);
+            => typeof(string);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
             => PropertyCacheLevel.Element;

--- a/src/Umbraco.Infrastructure/PropertyEditors/EyeDropperColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/EyeDropperColorPickerConfigurationEditor.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System.Collections.Generic;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Extensions;
@@ -25,8 +25,6 @@ namespace Umbraco.Cms.Core.PropertyEditors
         /// <inheritdoc />
         public override EyeDropperColorPickerConfiguration FromConfigurationEditor(IDictionary<string, object> editorValues, EyeDropperColorPickerConfiguration configuration)
         {
-            var output = new EyeDropperColorPickerConfiguration();
-
             var showAlpha = true;
             var showPalette = true;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
 {
     [DataEditor(
         Constants.PropertyEditors.Aliases.ColorPickerEyeDropper,
+        EditorType.PropertyValue | EditorType.MacroParameter,
         "Eye Dropper Color Picker",
         "eyedropper",
         Icon = "icon-colorpicker",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add a property value converter for Eye Dropper property editor. It related to this issue in v8 https://github.com/umbraco/Umbraco-CMS/issues/10323 but simplify the value converter to a string. Most probably only need to render the color, e.g. as inline background color.

If you want a more complex property editor and a value converter returning a complex model, you could always create your own property editor using `<umb-color-picker>` component and use `tinyColor` to store a complex JSON object with e.g. properties hex, rgba, alpha, maybe even R, G, B and A splitted in separate properties.

![image](https://user-images.githubusercontent.com/2919859/129377052-8a8cb49d-6c65-4d9d-a6e7-33607f33910e.png)


Furthermore it allow the property editor to be used as macro parameter editor as in this PR for v8:
https://github.com/umbraco/Umbraco-CMS/pull/9988