### PR TITLE
V9: Fix packages overflow

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/html/umb-expansion-panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/html/umb-expansion-panel.less
@@ -6,6 +6,7 @@
 }
 
 .umb-expansion-panel__header {
+    box-sizing: border-box;
     padding: 10px 20px;
     font-weight: bold;
     display: flex;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In Umbraco v8 the packages panel header was an `<button>` element, which inherited `box-sizing: border-box`.

![image](https://user-images.githubusercontent.com/2919859/129399362-eb030e5f-9224-4c78-bafd-21fb9b6e4d1a.png)

In Umbraco v8 this is no longer the case as the header is just a `<div>` element, which by default has `box-sizing: content-box` and thus cause page owerflow.

![image](https://user-images.githubusercontent.com/2919859/129399471-f657cfc9-58a2-4ac0-aec1-168aae5b394c.png)

With this change it looks much nicer.

![image](https://user-images.githubusercontent.com/2919859/129399579-85e11388-3d18-40f8-b5f0-893be214f002.png)

![image](https://user-images.githubusercontent.com/2919859/129399688-f664fb31-7654-48fd-887f-f0bb8e131f77.png)
