### PR TITLE
SystemLock - Update link to msdn blog

### DIFF
--- a/src/Umbraco.Core/SystemLock.cs
+++ b/src/Umbraco.Core/SystemLock.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Umbraco.Cms.Core
 {
-    // http://blogs.msdn.com/b/pfxteam/archive/2012/02/12/10266988.aspx
+    // https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-6-asynclock/
     //
     // notes:
     // - this is NOT a reader/writer lock


### PR DESCRIPTION
Updating old broken link to Stephen Toub's
"Building Async Coordination Primitives, Part 6: AsyncLock"
