### PR TITLE
Exit early in setupViewModel function

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -26,12 +26,21 @@ function booleanEditorController($scope) {
         $scope.renderModel = {
             value: false
         };
-
-        if ($scope.model.config && $scope.model.config.default && Object.toBoolean($scope.model.config.default) && $scope.model && !$scope.model.value) {
-            $scope.renderModel.value = true;
+        
+        // if no model, the subsequent conditions will both fail
+        // so instead let's exit early
+        if (!$scope.model) {
+            return;
         }
 
-        if ($scope.model && $scope.model.value && Object.toBoolean($scope.model.value)) {
+        if ($scope.model.config && $scope.model.config.default && Object.toBoolean($scope.model.config.default) && !$scope.model.value) {
+            $scope.renderModel.value = true;
+            // no need to check the final condition as
+            // the value is already set to true
+            return;
+        }
+
+        if ($scope.model.value && Object.toBoolean($scope.model.value)) {
             $scope.renderModel.value = true;
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Noticed this when merging #10634 - there's no need to check both value-setting conditions. If the first is true, we can exit as the second will have no effect on the model value. Similarly, exits if $scope.model is null, since both value-setting conditions will fail.

Given the order of the checks in the first condition, I think this would have potentially thrown errors as $scope.model was checked after attempting to access $scope.model.config. Not sure if it would have been possible to have no model, but in the interest of clarity, should still be checking for $scope.model before attempting to access its properties.

Nothing specific to test, boolean property editor should work as normal, just fractionally more performant.
