### PR TITLE
Raise SendingContentModel event for each element type in blocklist

### DIFF
--- a/src/Umbraco.Web/WebApi/Filters/OutgoingEditorModelEventAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/OutgoingEditorModelEventAttribute.cs
@@ -1,10 +1,8 @@
-﻿using System;
+﻿using System.Collections;
 using System.Net.Http;
 using System.Web.Http.Filters;
-using Umbraco.Core;
 using Umbraco.Web.Composing;
 using Umbraco.Web.Editors;
-using Umbraco.Web.Models.ContentEditing;
 
 namespace Umbraco.Web.WebApi.Filters
 {
@@ -23,18 +21,37 @@ namespace Umbraco.Web.WebApi.Filters
             if (actionExecutedContext.Response.Content is ObjectContent objectContent)
             {
                 var model = objectContent.Value;
-
                 if (model != null)
                 {
-                    var args = new EditorModelEventArgs(
-                        model,
-                        Current.UmbracoContext);
-                    EditorModelEventManager.EmitEvent(actionExecutedContext, args);
-                    objectContent.Value = args.Model;
+                    if (model is IDictionary modelDict)
+                    {
+                        foreach (var entity in modelDict)
+                        {
+                            if (entity is DictionaryEntry entry)
+                            {
+                                var args = CreateArgs(entry.Value);
+                                EditorModelEventManager.EmitEvent(actionExecutedContext, args);
+                                entry.Value = args.Model;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var args = CreateArgs(model);
+                        EditorModelEventManager.EmitEvent(actionExecutedContext, args);
+                        objectContent.Value = args.Model;
+                    }
                 }
             }
 
             base.OnActionExecuted(actionExecutedContext);
+        }
+
+        private EditorModelEventArgs CreateArgs(object model)
+        {
+            return new EditorModelEventArgs(
+                model,
+                Current.UmbracoContext);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #10792: `SendingContentModel` event is not raised for blocklist blocks.

The problem is that after the optimizations to the BlockList editor (#10235), we request all empty models for a blocklist in one call with `GetEmptyByKeys`, this broke the `EditorModelEventManager` because we return `IDictionary<Guid, ContentItemDisplay>`, instead of a `ContentItemDisplay`.

To fix this I've updated `OutgoingEditorModelEventAttribute` to now check if we're returning an `IDictionary`, if we are, we iterate through each `DictionaryEntry`, and raise an event with the value. 


### Testing

1. Create a component and listen to the `EditorModelEventManager.SendingContentModel` event
2. Create a document type with a blocklist property with at least one available block
3. Create a piece of content using the document type.
4. Ensure that the event is raised for each allowed block in your blocklist editor. 
5. Ensure that changes made when handling the events are reflected in the frontend, for instance, if you set a default value in a property.


I used this snippet for testing (Note: this snippet only works if your element type name contains "block" and 1 or more text strings/text boxes): 

```C#
using System.Linq;
using System.Web.Http.Filters;
using Umbraco.Core;
using Umbraco.Core.Composing;
using Umbraco.Web.Editors;
using Umbraco.Web.Models.ContentEditing;

namespace Umbraco.Web.UI
{
    public class EventTester : IComponent
    {
        public void Initialize()
        {
            EditorModelEventManager.SendingContentModel += TestSendingContentModelEvent;
        }

        public void Terminate()
        {
            EditorModelEventManager.SendingContentModel -= TestSendingContentModelEvent;
        }

        public void TestSendingContentModelEvent(HttpActionExecutedContext sender, EditorModelEventArgs<ContentItemDisplay> e)
        {
            Current.Logger.Info(GetType(), $"Received SendingContentModelEvent: {e.Model.ContentTypeName}");
            var props  = e.Model.Variants.FirstOrDefault()?.Tabs.SelectMany(tab => tab.Properties).ToList();

            if (e.Model.ContentTypeName.ToLower().Contains("block"))
            {
                foreach (var prop in props)
                {
                    if (prop.Editor.Equals(Constants.PropertyEditors.Aliases.TextBox))
                    {
                        prop.Value = "This is a text box";
                    }
                }
            }
        }
    }


    public class EventComposer : ComponentComposer<EventTester>
    { }
}

``` 