### PR TITLE
V8: fix umb-form-check icon z-index to bring icon to top

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -98,6 +98,7 @@
     .icon,
     .umb-icon {
         font-size: 1.2rem;
+        z-index: 1;
     }
 
     &__state {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Relates to #10805 

### Description

The tick icon in the umb-form-check was sitting underneath the ::before pseudo element, so was not visible. Setting the z-index to a non-zero value bumps it back to the top.

@nul800sebastiaan given this was introduced in #10805, it should be included in the same release, being 8.17.
