### PR TITLE
v9: Making backoffice path absolute

### DIFF
--- a/src/Umbraco.Tests.Integration/Implementations/TestHelper.cs
+++ b/src/Umbraco.Tests.Integration/Implementations/TestHelper.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Cms.Tests.Integration.Implementations
             {
                 var globalSettings = new GlobalSettings();
                 IOptionsMonitor<GlobalSettings> mockedOptionsMonitorOfGlobalSettings = Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == globalSettings);
-                _backOfficeInfo = new AspNetCoreBackOfficeInfo(mockedOptionsMonitorOfGlobalSettings, null);
+                _backOfficeInfo = new AspNetCoreBackOfficeInfo(mockedOptionsMonitorOfGlobalSettings, GetHostingEnvironment());
             }
 
             return _backOfficeInfo;

--- a/src/Umbraco.Tests.Integration/Implementations/TestHelper.cs
+++ b/src/Umbraco.Tests.Integration/Implementations/TestHelper.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Cms.Tests.Integration.Implementations
             {
                 var globalSettings = new GlobalSettings();
                 IOptionsMonitor<GlobalSettings> mockedOptionsMonitorOfGlobalSettings = Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == globalSettings);
-                _backOfficeInfo = new AspNetCoreBackOfficeInfo(mockedOptionsMonitorOfGlobalSettings);
+                _backOfficeInfo = new AspNetCoreBackOfficeInfo(mockedOptionsMonitorOfGlobalSettings, null);
             }
 
             return _backOfficeInfo;

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreBackOfficeInfo.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreBackOfficeInfo.cs
@@ -16,7 +16,6 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
         {
             _globalSettings = globalSettings;
             _hostingEnvironment = hostingEnviroment;
-            //GetAbsoluteUrl= WebPath.Combine(hostingEnviroment.ApplicationMainUrl.ToString(), globalSettings.CurrentValue.UmbracoPath.TrimStart(CharArrays.TildeForwardSlash));
 
         }
 

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreBackOfficeInfo.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreBackOfficeInfo.cs
@@ -1,17 +1,39 @@
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Routing;
+using static Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Web.Common.AspNetCore
 {
     public class AspNetCoreBackOfficeInfo : IBackOfficeInfo
     {
-        public AspNetCoreBackOfficeInfo(IOptionsMonitor<GlobalSettings> globalSettings)
+        private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private string _getAbsoluteUrl;
+        public AspNetCoreBackOfficeInfo(IOptionsMonitor<GlobalSettings> globalSettings, IHostingEnvironment hostingEnviroment)
         {
-            GetAbsoluteUrl = globalSettings.CurrentValue.UmbracoPath;
+            _globalSettings = globalSettings;
+            _hostingEnvironment = hostingEnviroment;
+            //GetAbsoluteUrl= WebPath.Combine(hostingEnviroment.ApplicationMainUrl.ToString(), globalSettings.CurrentValue.UmbracoPath.TrimStart(CharArrays.TildeForwardSlash));
+
         }
 
-        public string GetAbsoluteUrl { get; } // TODO make absolute
-
+        public string GetAbsoluteUrl
+        {
+            get
+            {
+                if (_getAbsoluteUrl is null)
+                {
+                    if(_hostingEnvironment.ApplicationMainUrl is null)
+                    {
+                        return "";
+                    }
+                    _getAbsoluteUrl = WebPath.Combine(_hostingEnvironment.ApplicationMainUrl.ToString(), _globalSettings.CurrentValue.UmbracoPath.TrimStart(CharArrays.TildeForwardSlash));
+                }
+                return _getAbsoluteUrl;
+            }
+        }
     }
 }


### PR DESCRIPTION
# Notes
- Updated AspNetCoreBackOffice to have a backing field
- Will set if AbsoluteUrl is null

# How to test
- Make an empty doctype with a template
- Make a blank content page'
- In the template, inject the IBackOfficeInfo
- insert @IBackOfficeInfo.GetAbsoluteUrl in the template
- Navigate to the empty content page url
- It should give you an absolute url for your backoffice
