### PR TITLE
Include MediaService extensions in project

### DIFF
--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -1491,6 +1491,7 @@
     <Compile Include="Services\Implement\ConsentService.cs" />
     <Compile Include="Services\Implement\ContentService.cs" />
     <Compile Include="Services\ContentServiceExtensions.cs" />
+    <Compile Include="Services\MediaServiceExtensions.cs" />
     <Compile Include="Services\Implement\ContentTypeService.cs" />
     <Compile Include="Services\Implement\ContentTypeServiceBase.cs" />
     <Compile Include="Services\Implement\ContentTypeServiceBaseOfTItemTService.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The project include extensions for `ContentService` and ` MediaService` to get by `Udi[]`.
However `MediaServiceExtensions.cs` wasn't included in project and thus not compiled.

![image](https://user-images.githubusercontent.com/2919859/129860116-fc2e6f85-94a5-42fe-91a5-1f368b2120d1.png)

Originally included in PR https://github.com/umbraco/Umbraco-CMS/pull/9465 but should be safe to include, so the extension is available to use. It was orignally added in https://github.com/umbraco/Umbraco-CMS/commit/d54658009cdeb676257747bf0992599feee24554#diff-0703ef93a614d4373794998ca03f46e6c6703b6abe0cdfaecf5642f36f0ea30e, but actually not used anywhere in core. However in PR https://github.com/umbraco/Umbraco-CMS/pull/9465 it is used to fetch media by `int[]`, `Guid[]` and `Udi[]`.

Furthermore it would also be great to look at this PR https://github.com/umbraco/Umbraco-CMS/pull/9467 we can fetch member groups by `Guid` and `Udi` as well.