### PR TITLE
V8: Improve nested content optimization in the backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -642,6 +642,24 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                     return $q.when(umbDataFormatter.formatContentGetData(result));
                 });
         },
+
+        getScaffolds: function(parentId, aliases){
+            return umbRequestHelper.resourcePromise(
+                $http.post(
+                    umbRequestHelper.getApiUrl(
+                        "contentApiBaseUrl",
+                        "GetEmptyByAliases"),
+                        { parentId: parentId, contentTypeAliases: aliases }
+                    ),
+                    'Failed to retrieve data for empty content item aliases ' + aliases.join(", ")
+                ).then(function(result) {
+                    Object.keys(result).map(function(key){
+                        result[key] = umbDataFormatter.formatContentGetData(result[key]);
+                    });
+
+                    return $q.when(result);
+                });
+        },
         /**
          * @ngdoc method
          * @name umbraco.resources.contentResource#getScaffoldByKey

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -564,46 +564,6 @@
             initNestedContent();
         });
 
-        // _.each(model.config.contentTypes, function (contentType) {
-        //     // Get the scaffold for the contentType
-        //     contentResource.getScaffold(-20, contentType.ncAlias).then(function (scaffold) {
-        //         // make sure it's an element type before allowing the user to create new ones
-        //         if (scaffold.isElement) {
-        //             // remove all tabs except the specified tab
-        //             var tabs = scaffold.variants[0].tabs;
-        //             var tab = _.find(tabs, function (tab) {
-        //                 return tab.id !== 0 && (tab.alias.toLowerCase() === contentType.ncTabAlias.toLowerCase() || contentType.ncTabAlias === "");
-        //             });
-        //             scaffold.variants[0].tabs = [];
-        //             if (tab) {
-        //                 scaffold.variants[0].tabs.push(tab);
-        //
-        //                 tab.properties.forEach(
-        //                     function (property) {
-        //                         if (_.find(notSupported, function (x) { return x === property.editor; })) {
-        //                             property.notSupported = true;
-        //                             // TODO: Not supported message to be replaced with 'content_nestedContentEditorNotSupported' dictionary key. Currently not possible due to async/timing quirk.
-        //                             property.notSupportedMessage = "Property " + property.label + " uses editor " + property.editor + " which is not supported by Nested Content.";
-        //                         }
-        //                     }
-        //                 );
-        //             }
-        //
-        //             // Ensure Culture Data for Complex Validation.
-        //             ensureCultureData(scaffold);
-        //
-        //             // Store the scaffold object
-        //             vm.scaffolds.push(scaffold);
-        //         }
-        //
-        //         scaffoldsLoaded++;
-        //         initIfAllScaffoldsHaveLoaded();
-        //     }, function (error) {
-        //         scaffoldsLoaded++;
-        //         initIfAllScaffoldsHaveLoaded();
-        //     });
-        // });
-
         /**
          * Ensure that the containing content variant language and current property culture is transferred along
          * to the scaffolded content object representing this block.

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -524,8 +524,19 @@
         // Initialize
         var scaffoldsLoaded = 0;
         vm.scaffolds = [];
-        _.each(model.config.contentTypes, function (contentType) {
-            contentResource.getScaffold(-20, contentType.ncAlias).then(function (scaffold) {
+
+        var scaffoldAliases = [];
+        // Gather all aliases
+        model.config.contentTypes.forEach(function(contentType){
+            scaffoldAliases.push(contentType.ncAlias);
+        });
+
+        contentResource.getScaffolds(-20, scaffoldAliases).then(function (scaffolds){
+            // Loop through all the content types
+            _.each(model.config.contentTypes, function (contentType){
+                // Get the scaffold from the result
+                var scaffold = scaffolds[contentType.ncAlias];
+
                 // make sure it's an element type before allowing the user to create new ones
                 if (scaffold.isElement) {
                     // remove all tabs except the specified tab
@@ -557,11 +568,48 @@
 
                 scaffoldsLoaded++;
                 initIfAllScaffoldsHaveLoaded();
-            }, function (error) {
-                scaffoldsLoaded++;
-                initIfAllScaffoldsHaveLoaded();
-            });
+            })
         });
+
+        // _.each(model.config.contentTypes, function (contentType) {
+        //     // Get the scaffold for the contentType
+        //     contentResource.getScaffold(-20, contentType.ncAlias).then(function (scaffold) {
+        //         // make sure it's an element type before allowing the user to create new ones
+        //         if (scaffold.isElement) {
+        //             // remove all tabs except the specified tab
+        //             var tabs = scaffold.variants[0].tabs;
+        //             var tab = _.find(tabs, function (tab) {
+        //                 return tab.id !== 0 && (tab.alias.toLowerCase() === contentType.ncTabAlias.toLowerCase() || contentType.ncTabAlias === "");
+        //             });
+        //             scaffold.variants[0].tabs = [];
+        //             if (tab) {
+        //                 scaffold.variants[0].tabs.push(tab);
+        //
+        //                 tab.properties.forEach(
+        //                     function (property) {
+        //                         if (_.find(notSupported, function (x) { return x === property.editor; })) {
+        //                             property.notSupported = true;
+        //                             // TODO: Not supported message to be replaced with 'content_nestedContentEditorNotSupported' dictionary key. Currently not possible due to async/timing quirk.
+        //                             property.notSupportedMessage = "Property " + property.label + " uses editor " + property.editor + " which is not supported by Nested Content.";
+        //                         }
+        //                     }
+        //                 );
+        //             }
+        //
+        //             // Ensure Culture Data for Complex Validation.
+        //             ensureCultureData(scaffold);
+        //
+        //             // Store the scaffold object
+        //             vm.scaffolds.push(scaffold);
+        //         }
+        //
+        //         scaffoldsLoaded++;
+        //         initIfAllScaffoldsHaveLoaded();
+        //     }, function (error) {
+        //         scaffoldsLoaded++;
+        //         initIfAllScaffoldsHaveLoaded();
+        //     });
+        // });
 
         /**
          * Ensure that the containing content variant language and current property culture is transferred along

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -589,7 +589,7 @@
 
         var initNestedContent = function () {
             // Initialize when all scaffolds have loaded
-            // Sort the scaffold explicitly according the the sort order define by the data type.
+            // Sort the scaffold explicitly according to the sort order defined by the data type.
             vm.scaffolds = $filter("orderBy")(vm.scaffolds, function (s) {
                 return contentTypeAliases.indexOf(s.contentTypeAlias);
             });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -560,7 +560,7 @@
                 }
             });
 
-            // Initialize once all scaffolds has been loaded
+            // Initialize once all scaffolds have been loaded
             initNestedContent();
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -589,8 +589,7 @@
 
         var initNestedContent = function () {
             // Initialize when all scaffolds have loaded
-            // Because we're loading the scaffolds async one at a time, we need to
-            // sort them explicitly according to the sort order defined by the data type.
+            // Sort the scaffold explicitly according the the sort order define by the data type.
             vm.scaffolds = $filter("orderBy")(vm.scaffolds, function (s) {
                 return contentTypeAliases.indexOf(s.contentTypeAlias);
             });

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -364,10 +364,19 @@ namespace Umbraco.Web.Editors
             return GetEmpty(contentType, parentId);
         }
 
+        /// <summary>
+        /// Gets a dictionary containing empty content items for every alias specified in the contentTypeAliases array in the body of the request.
+        /// </summary>
+        /// <remarks>
+        /// This is a post request in order to support a large amount of aliases without hitting the URL length limit.
+        /// </remarks>
+        /// <param name="contentTypesByAliases"></param>
+        /// <returns></returns>
         [OutgoingEditorModelEvent]
         [HttpPost]
         public IDictionary<string, ContentItemDisplay> GetEmptyByAliases(ContentTypesByAliases contentTypesByAliases)
         {
+            // It's important to do this operation within a scope to reduce the amount of readlock queries. 
             using var scope = _scopeProvider.CreateScope(autoComplete: true);
             var contentTypes = contentTypesByAliases.ContentTypeAliases.Select(alias => Services.ContentTypeService.Get(alias));
             return GetEmpties(contentTypes, contentTypesByAliases.ParentId).ToDictionary(x => x.ContentTypeAlias);

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -368,13 +368,8 @@ namespace Umbraco.Web.Editors
         [HttpPost]
         public IDictionary<string, ContentItemDisplay> GetEmptyByAliases(ContentTypesByAliases contentTypesByAliases)
         {
-            List<IContentType> contentTypes = new();
-
-            foreach (var alias in contentTypesByAliases.ContentTypeAliases)
-            {
-                contentTypes.Add(Services.ContentTypeService.Get(alias));
-            }
-
+            using var scope = _scopeProvider.CreateScope(autoComplete: true);
+            var contentTypes = contentTypesByAliases.ContentTypeAliases.Select(alias => Services.ContentTypeService.Get(alias));
             return GetEmpties(contentTypes, contentTypesByAliases.ParentId).ToDictionary(x => x.ContentTypeAlias);
         }
 

--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -364,6 +364,20 @@ namespace Umbraco.Web.Editors
             return GetEmpty(contentType, parentId);
         }
 
+        [OutgoingEditorModelEvent]
+        [HttpPost]
+        public IDictionary<string, ContentItemDisplay> GetEmptyByAliases(ContentTypesByAliases contentTypesByAliases)
+        {
+            List<IContentType> contentTypes = new();
+
+            foreach (var alias in contentTypesByAliases.ContentTypeAliases)
+            {
+                contentTypes.Add(Services.ContentTypeService.Get(alias));
+            }
+
+            return GetEmpties(contentTypes, contentTypesByAliases.ParentId).ToDictionary(x => x.ContentTypeAlias);
+        }
+
 
         /// <summary>
         /// Gets an empty content item for the document type.

--- a/src/Umbraco.Web/Models/ContentEditing/ContentTypesByAliases.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentTypesByAliases.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Web.Models.ContentEditing
+{
+    [DataContract(Name = "contentTypes", Namespace = "")]
+    public class ContentTypesByAliases
+    {
+        [DataMember(Name = "parentId")]
+        [Required]
+        public int ParentId { get; set; }
+
+        [DataMember(Name = "contentTypeAliases")]
+        [Required]
+        public string[] ContentTypeAliases { get; set; }
+    }
+}

--- a/src/Umbraco.Web/Models/ContentEditing/ContentTypesByAliases.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/ContentTypesByAliases.cs
@@ -3,13 +3,22 @@ using System.Runtime.Serialization;
 
 namespace Umbraco.Web.Models.ContentEditing
 {
+    /// <summary>
+    /// A model for retrieving multiple content types based on their aliases.
+    /// </summary>
     [DataContract(Name = "contentTypes", Namespace = "")]
     public class ContentTypesByAliases
     {
+        /// <summary>
+        /// Id of the parent of the content type.
+        /// </summary>
         [DataMember(Name = "parentId")]
         [Required]
         public int ParentId { get; set; }
 
+        /// <summary>
+        /// The alias of every content type to get.
+        /// </summary>
         [DataMember(Name = "contentTypeAliases")]
         [Required]
         public string[] ContentTypeAliases { get; set; }

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Media\UploadAutoFillProperties.cs" />
     <Compile Include="Migrations\PostMigrations\PublishedSnapshotRebuilder.cs" />
     <Compile Include="Models\AnchorsModel.cs" />
+    <Compile Include="Models\ContentEditing\ContentTypesByAliases.cs" />
     <Compile Include="Models\ContentEditing\ContentTypesByKeys.cs" />
     <Compile Include="Models\ContentEditing\DataTypeReferences.cs" />
     <Compile Include="Models\ContentEditing\LinkDisplay.cs" />


### PR DESCRIPTION
This PR is working towards giving nested content the same treatment as the blocklist editor. 

The majority of this is changing it so all the empty content types are requested in a single request, additionally, this also allows us to apply the same mapping optimizations as for blocklist by using the `GetEmpties` method on the controller.

I've also made some additional changes to the frontend side of things before we kept calling `initIfAllScaffoldsHaveLoaded` because we did not know exactly when all the scaffolds had been loaded since we loaded them asynchronously one by one. Now we just call `initNestedContent` once the response from `GetEmptyByAliases` has been processed. 

Additionally, I noticed that we would create an array of content type aliases more than once, I've changed this so we only do this once when the controller is initialized. 

#### The gains

As mentioned before we would call `GetEmpty` separately for every element type in the nested content, each of these calls could take anywhere from 20-60 ms, and produce somewhere between 2 and 11 db queries: 

![image](https://user-images.githubusercontent.com/16456704/129871680-4c7ea275-4ab5-4db3-bde6-dc1a57d03a9c.png)

Now we do it all in a single request, which in my testing with 5 element types took around 20-30 ms, and uses 2 db queries:

![image](https://user-images.githubusercontent.com/16456704/129871761-186e78a1-7d8e-4aff-8fb8-1496b22e742a.png)

Of course this will take longer the more element types you have, but is regardless a significant improvement from before.

#### Testing

Remember to run `npm run build` and do a "Empty Cache and Hard Reload" (I'm only mentioning this because I keep forgetting this myself 😆)

1. Create some element types, I also tested with an element type with a nested content picker as well.
2. Create a doctype with a nested content picker.
3. Ensure that it still works as expected.

Since `EditorModelEventManager` now handles dictionaries, the `SendingContentModel` should still work, but to be on the safe side I also tested it with a snippet similar to #10869:

```C#
using System.Linq;
using System.Web.Http.Filters;
using Umbraco.Core;
using Umbraco.Core.Composing;
using Umbraco.Web.Editors;
using Umbraco.Web.Models.ContentEditing;

namespace Umbraco.Web.UI
{
    public class EventTester : IComponent
    {
        public void Initialize()
        {
            EditorModelEventManager.SendingContentModel += TestSendingContentModelEvent;
        }

        public void Terminate()
        {
            EditorModelEventManager.SendingContentModel -= TestSendingContentModelEvent;
        }

        public void TestSendingContentModelEvent(HttpActionExecutedContext sender, EditorModelEventArgs<ContentItemDisplay> e)
        {
            Current.Logger.Info(GetType(), $"Received SendingContentModelEvent: {e.Model.ContentTypeName}");
            if (e.Model.IsElement)
            {
                var props  = e.Model.Variants.FirstOrDefault()?.Tabs.SelectMany(tab => tab.Properties).ToList();
                foreach (var prop in props)
                {
                    if (prop.Editor.Equals(Constants.PropertyEditors.Aliases.TextBox))
                    {
                        prop.Value = "This is a text box";
                    }
                }
            }
        }
    }


    public class EventComposer : ComponentComposer<EventTester>
    { }
}
```