### PR TITLE
v9: Implemented new asserts

### DIFF
--- a/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -148,16 +148,34 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
                 Name = "test",
             };
             bool result = PackageBuilder.SavePackage(def);
-
+            //Update values and save
             def.Name = "updated";
+            def.ContentNodeId = "test";
+            def.Languages.Add("Danish");
+            def.Languages.Add("English");
+            def.Scripts.Add("TestScript1");
+            def.Scripts.Add("TestScript2");
             result = PackageBuilder.SavePackage(def);
             Assert.IsTrue(result);
-
             // re-get
             def = PackageBuilder.GetById(def.Id);
             Assert.AreEqual("updated", def.Name);
-
-            // TODO: There's a whole lot more assertions to be done
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual("updated", def.Name);
+                Assert.AreEqual("test", def.ContentNodeId);
+                Assert.AreEqual(2, def.Languages.Count());
+                Assert.AreEqual(2, def.Scripts.Count());
+                Assert.AreEqual(0, def.DataTypes.Count());
+                Assert.AreEqual(0, def.DictionaryItems.Count());
+                Assert.AreEqual(0, def.DocumentTypes.Count());
+                Assert.AreEqual(0, def.Macros.Count());
+                Assert.AreEqual(0, def.MediaTypes.Count());
+                Assert.AreEqual(0, def.MediaUdis.Count());
+                Assert.AreEqual(0, def.PartialViews.Count());
+                Assert.AreEqual(0, def.Stylesheets.Count());
+                Assert.AreEqual(0, def.Templates.Count());
+            });
         }
 
         [Test]
@@ -259,15 +277,24 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
             using (FileStream packageZipStream = File.OpenRead(packageXmlPath))
             using (ZipArchive zipArchive = PackageMigrationResource.GetPackageDataManifest(packageZipStream, out XDocument packageXml))
             {
-                Assert.AreEqual("umbPackage", packageXml.Root.Name.ToString());
-                Assert.IsNotNull(zipArchive.GetEntry("media/media/test-file.txt"));
-
-                Assert.AreEqual(
-                    $"<MediaItems><MediaSet><testImage id=\"{m1.Id}\" key=\"{m1.Key}\" parentID=\"-1\" level=\"1\" creatorID=\"-1\" sortOrder=\"0\" createDate=\"{m1.CreateDate.ToString("s")}\" updateDate=\"{m1.UpdateDate.ToString("s")}\" nodeName=\"Test File\" urlName=\"test-file\" path=\"{m1.Path}\" isDoc=\"\" nodeType=\"{mt.Id}\" nodeTypeAlias=\"testImage\" writerName=\"\" writerID=\"0\" udi=\"{m1.GetUdi()}\" mediaFilePath=\"/media/test-file.txt\"><umbracoFile><![CDATA[/media/test-file.txt]]></umbracoFile><umbracoBytes><![CDATA[100]]></umbracoBytes><umbracoExtension><![CDATA[png]]></umbracoExtension></testImage></MediaSet></MediaItems>",
-                    packageXml.Element("umbPackage").Element("MediaItems").ToString(SaveOptions.DisableFormatting));
-
-                // TODO: There's a whole lot more assertions to be done
-
+                string test = "test-file.txt";
+                Assert.Multiple(() =>
+                {
+                    Assert.AreEqual("umbPackage", packageXml.Root.Name.ToString());
+                    Assert.IsNotNull(zipArchive.GetEntry("media/media/test-file.txt"));
+                    Assert.IsNotNull(zipArchive.GetEntry("package.xml"));
+                    Assert.AreEqual(
+                        $"<MediaItems><MediaSet><testImage id=\"{m1.Id}\" key=\"{m1.Key}\" parentID=\"-1\" level=\"1\" creatorID=\"-1\" sortOrder=\"0\" createDate=\"{m1.CreateDate.ToString("s")}\" updateDate=\"{m1.UpdateDate.ToString("s")}\" nodeName=\"Test File\" urlName=\"test-file\" path=\"{m1.Path}\" isDoc=\"\" nodeType=\"{mt.Id}\" nodeTypeAlias=\"testImage\" writerName=\"\" writerID=\"0\" udi=\"{m1.GetUdi()}\" mediaFilePath=\"/media/test-file.txt\"><umbracoFile><![CDATA[/media/test-file.txt]]></umbracoFile><umbracoBytes><![CDATA[100]]></umbracoBytes><umbracoExtension><![CDATA[png]]></umbracoExtension></testImage></MediaSet></MediaItems>",
+                        packageXml.Element("umbPackage").Element("MediaItems").ToString(SaveOptions.DisableFormatting));
+                    Assert.AreEqual(2, zipArchive.Entries.Count());
+                    Assert.AreEqual(ZipArchiveMode.Read, zipArchive.Mode);
+                    Assert.IsNull(packageXml.DocumentType);
+                    Assert.IsNull(packageXml.NextNode);
+                    Assert.IsNull(packageXml.Parent);
+                    Assert.IsNull(packageXml.PreviousNode);
+                    Assert.AreEqual(test, zipArchive.Entries.Last().Name);
+                    Assert.AreEqual(7, zipArchive.Entries.Last().Length);
+                });
             }
         }
 
@@ -297,12 +324,16 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
             using (var packageXmlStream = File.OpenRead(packageXmlPath))
             {
                 var xml = XDocument.Load(packageXmlStream);
-                Assert.AreEqual("umbPackage", xml.Root.Name.ToString());
-
-                Assert.AreEqual($"<Templates><Template><Name>Text page</Name><Alias>textPage</Alias><Design><![CDATA[@using Umbraco.Cms.Web.Common.PublishedModels;{Environment.NewLine}@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage{Environment.NewLine}@{{{Environment.NewLine}\tLayout = null;{Environment.NewLine}}}]]></Design></Template></Templates>", xml.Element("umbPackage").Element("Templates").ToString(SaveOptions.DisableFormatting));
-
-                // TODO: There's a whole lot more assertions to be done
-
+                Assert.Multiple(() =>
+                {
+                    Assert.AreEqual("umbPackage", xml.Root.Name.ToString());
+                    Assert.AreEqual($"<Templates><Template><Name>Text page</Name><Alias>textPage</Alias><Design><![CDATA[@using Umbraco.Cms.Web.Common.PublishedModels;{Environment.NewLine}@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage{Environment.NewLine}@{{{Environment.NewLine}\tLayout = null;{Environment.NewLine}}}]]></Design></Template></Templates>", xml.Element("umbPackage").Element("Templates").ToString(SaveOptions.DisableFormatting));
+                    Assert.AreEqual(xml.FirstNode, xml.LastNode);
+                    Assert.IsNull(xml.DocumentType);
+                    Assert.IsNull(xml.Parent);
+                    Assert.IsNull(xml.NextNode);
+                    Assert.IsNull(xml.PreviousNode);
+                });
             }
         }
     }

--- a/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -280,8 +280,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
                 string test = "test-file.txt";
                 Assert.Multiple(() =>
                 {
+                    var mediaEntry = zipArchive.GetEntry("media/media/test-file.txt");
                     Assert.AreEqual("umbPackage", packageXml.Root.Name.ToString());
-                    Assert.IsNotNull(zipArchive.GetEntry("media/media/test-file.txt"));
+                    Assert.IsNotNull(mediaEntry);
+                    Assert.AreEqual(test, mediaEntry.Name);
                     Assert.IsNotNull(zipArchive.GetEntry("package.xml"));
                     Assert.AreEqual(
                         $"<MediaItems><MediaSet><testImage id=\"{m1.Id}\" key=\"{m1.Key}\" parentID=\"-1\" level=\"1\" creatorID=\"-1\" sortOrder=\"0\" createDate=\"{m1.CreateDate.ToString("s")}\" updateDate=\"{m1.UpdateDate.ToString("s")}\" nodeName=\"Test File\" urlName=\"test-file\" path=\"{m1.Path}\" isDoc=\"\" nodeType=\"{mt.Id}\" nodeTypeAlias=\"testImage\" writerName=\"\" writerID=\"0\" udi=\"{m1.GetUdi()}\" mediaFilePath=\"/media/test-file.txt\"><umbracoFile><![CDATA[/media/test-file.txt]]></umbracoFile><umbracoBytes><![CDATA[100]]></umbracoBytes><umbracoExtension><![CDATA[png]]></umbracoExtension></testImage></MediaSet></MediaItems>",
@@ -292,8 +294,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
                     Assert.IsNull(packageXml.NextNode);
                     Assert.IsNull(packageXml.Parent);
                     Assert.IsNull(packageXml.PreviousNode);
-                    Assert.AreEqual(test, zipArchive.Entries.Last().Name);
-                    Assert.AreEqual(7, zipArchive.Entries.Last().Length);
                 });
             }
         }
@@ -328,7 +328,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
                 {
                     Assert.AreEqual("umbPackage", xml.Root.Name.ToString());
                     Assert.AreEqual($"<Templates><Template><Name>Text page</Name><Alias>textPage</Alias><Design><![CDATA[@using Umbraco.Cms.Web.Common.PublishedModels;{Environment.NewLine}@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage{Environment.NewLine}@{{{Environment.NewLine}\tLayout = null;{Environment.NewLine}}}]]></Design></Template></Templates>", xml.Element("umbPackage").Element("Templates").ToString(SaveOptions.DisableFormatting));
-                    Assert.AreEqual(xml.FirstNode, xml.LastNode);
                     Assert.IsNull(xml.DocumentType);
                     Assert.IsNull(xml.Parent);
                     Assert.IsNull(xml.NextNode);

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageInstallationTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageInstallationTest.cs
@@ -32,9 +32,12 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var testPackageFile = new FileInfo(Path.Combine(HostingEnvironment.MapPathContentRoot("~/TestData/Packages"), DocumentTypePickerPackage));
             using var fileStream = testPackageFile.OpenRead();
             CompiledPackage package = PackageInstallation.ReadPackage(XDocument.Load(fileStream));
-            Assert.IsNotNull(package);
-            Assert.AreEqual("Document Type Picker", package.Name);
-            Assert.AreEqual(1, package.DataTypes.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(package);
+                Assert.AreEqual("Document Type Picker", package.Name);
+                Assert.AreEqual(1, package.DataTypes.Count());
+            });
         }
 
         [Test]
@@ -43,12 +46,15 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var testPackageFile = new FileInfo(Path.Combine(HostingEnvironment.MapPathContentRoot("~/TestData/Packages"), HelloPackage));
             using var fileStream = testPackageFile.OpenRead();
             CompiledPackage package = PackageInstallation.ReadPackage(XDocument.Load(fileStream));
-            Assert.IsNotNull(package);
-            Assert.AreEqual("Hello", package.Name);
-            Assert.AreEqual(1, package.Documents.Count());
-            Assert.AreEqual(1, package.DocumentTypes.Count());
-            Assert.AreEqual(1, package.Templates.Count());
-            Assert.AreEqual(1, package.DataTypes.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(package);
+                Assert.AreEqual("Hello", package.Name);
+                Assert.AreEqual(1, package.Documents.Count());
+                Assert.AreEqual(1, package.DocumentTypes.Count());
+                Assert.AreEqual(1, package.Templates.Count());
+                Assert.AreEqual(1, package.DataTypes.Count());
+            });
         }
 
         [Test]
@@ -66,9 +72,17 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             using var fileStream = File.OpenRead(packageFile);
             CompiledPackage package = PackageInstallation.ReadPackage(XDocument.Load(fileStream));
             InstallWarnings preInstallWarnings = package.Warnings;
-            Assert.IsNotNull(preInstallWarnings);
-
-            // TODO: More Asserts
+            var dataType = package.DataTypes.First();
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual("Document Type Picker", package.Name);
+                Assert.AreEqual("3593d8e7-8b35-47b9-beda-5e830ca8c93c", dataType.LastAttribute.Value);
+                Assert.AreEqual("Document Type Picker", dataType.FirstAttribute.Value);
+                Assert.IsNotNull(preInstallWarnings);
+                Assert.AreEqual(0, preInstallWarnings.ConflictingMacros.Count());
+                Assert.AreEqual(0, preInstallWarnings.ConflictingStylesheets.Count());
+                Assert.AreEqual(0, preInstallWarnings.ConflictingTemplates.Count());
+            });
         }
 
         [Test]

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageInstallationTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageInstallationTest.cs
@@ -76,8 +76,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             Assert.Multiple(() =>
             {
                 Assert.AreEqual("Document Type Picker", package.Name);
-                Assert.AreEqual("3593d8e7-8b35-47b9-beda-5e830ca8c93c", dataType.LastAttribute.Value);
-                Assert.AreEqual("Document Type Picker", dataType.FirstAttribute.Value);
+                Assert.AreEqual("3593d8e7-8b35-47b9-beda-5e830ca8c93c", dataType.LastAttribute?.Value);
+                Assert.AreEqual("Document Type Picker", dataType.FirstAttribute?.Value);
                 Assert.IsNotNull(preInstallWarnings);
                 Assert.AreEqual(0, preInstallWarnings.ConflictingMacros.Count());
                 Assert.AreEqual(0, preInstallWarnings.ConflictingStylesheets.Count());


### PR DESCRIPTION
# Notes
- Updated CreatedPackagesRepositoryTests.Update() to use Assert.Multiple so it is easyer to debug
- Updated CreatedPackagesRepositoryTests.Export_Zip()
- Updated CreatedPackagesRepositoryTests.Export_Xml()
- Updated PackageInstallationTest.Can_Read_Compiled_Package_1()
- Updated PackageInstallationTest.Can_Read_Compiled_Package_2()
- Updated PackageInstallationTest.Can_Read_Compiled_Package_Warnings()
# How to test
- Run the unit test to see if they pass