### PR TITLE
9908: No parentheses & language picker with only 1 language

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorcontentheader.directive.js
@@ -105,8 +105,8 @@
                     }
                 });
 
-                scope.vm.hasVariants = (scope.vm.hasCulture || scope.vm.hasSegments);
-                scope.vm.hasSubVariants = (scope.vm.hasCulture && scope.vm.hasSegments);
+                scope.vm.hasVariants = scope.content.variants.length > 1 && (scope.vm.hasCulture || scope.vm.hasSegments);
+                scope.vm.hasSubVariants = scope.content.variants.length > 1 &&(scope.vm.hasCulture && scope.vm.hasSegments);
 
                 updateVaraintErrors();
 

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -208,11 +208,11 @@ namespace Umbraco.Web.Trees
 
         protected override IEnumerable<IEntitySlim> GetChildEntities(string id, FormDataCollection queryStrings)
         {
-            var result = base.GetChildEntities(id, queryStrings);
+            var result = base.GetChildEntities(id, queryStrings).ToArray(;
             var culture = queryStrings["culture"].TryConvertTo<string>();
 
             //if this is null we'll set it to the default.
-            var cultureVal = (culture.Success ? culture.Result : null) ?? Services.LocalizationService.GetDefaultLanguageIsoCode();
+            var cultureVal = (culture.Success ? culture.Result : null).IfNullOrWhiteSpace(Services.LocalizationService.GetDefaultLanguageIsoCode());
 
             // set names according to variations
             foreach (var entity in result)

--- a/src/Umbraco.Web/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web/Trees/ContentTreeController.cs
@@ -208,7 +208,7 @@ namespace Umbraco.Web.Trees
 
         protected override IEnumerable<IEntitySlim> GetChildEntities(string id, FormDataCollection queryStrings)
         {
-            var result = base.GetChildEntities(id, queryStrings).ToArray(;
+            var result = base.GetChildEntities(id, queryStrings).ToArray();
             var culture = queryStrings["culture"].TryConvertTo<string>();
 
             //if this is null we'll set it to the default.


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/9908

### Description
The issue here was that because the language wasn't passed, it would set the language to check with to an empty string. It would then try to find an empty string culture on the content item (which was of course not present) and add the parentheses on the name. Adding a fallback to the default language id solves this issue.

For the language picker, I had to update a bit of JavaScript code that checks if it has a variant or not. Updating this check to always check above 1 fixes the issue here. It'll still show the language picker if there is one 1 published variant and 1 unpublished variant.

How to test:

1. Use starter kit
2. Set the homepage doc type to variant by culture
3. Observe the homepage. In a past version, it would now show parentheses around the homepage and it would show the language picker.
4. Add a second language
5. You'll see that the parentheses logic still works when switching between main languages as well as the language picker.
