### PR TITLE
Inherit text color from parent element

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
@@ -32,6 +32,8 @@
     }
 
     &__inner {
+        color: inherit !important;
+
         // Clear pseudo classes
         &::before,
         &::after {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-icon.less
@@ -32,8 +32,6 @@
     }
 
     &__inner {
-        color: inherit !important;
-
         // Clear pseudo classes
         &::before,
         &::after {

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -1,7 +1,7 @@
-
+<div>
     <div class="__showcase"
-        ng-class="{'--error':vm.elementTypeModel === null}"
-        ng-style="{'background-color': vm.blockConfigModel ? vm.blockConfigModel.backgroundColor : '', 'background-image': vm.styleBackgroundImage}">
+         ng-class="{'--error':vm.elementTypeModel === null}"
+         ng-style="{'background-color': vm.blockConfigModel ? vm.blockConfigModel.backgroundColor : '', 'background-image': vm.styleBackgroundImage}">
         <div class="__icon">
             <umb-icon icon="{{vm.icon}}"
                       ng-attr-style="{{'color:' + vm.blockConfigModel.iconColor}}"
@@ -19,4 +19,4 @@
     </div>
 
     <ng-transclude></ng-transclude>
-
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.html
@@ -3,8 +3,8 @@
         ng-class="{'--error':vm.elementTypeModel === null}"
         ng-style="{'background-color': vm.blockConfigModel ? vm.blockConfigModel.backgroundColor : '', 'background-image': vm.styleBackgroundImage}">
         <div class="__icon">
-            <umb-icon icon="{{vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block'}}"
-                      ng-attr-style="{{'color:' + vm.blockConfigModel.iconColor + ' !important'}}"
+            <umb-icon icon="{{vm.icon}}"
+                      ng-attr-style="{{'color:' + vm.blockConfigModel.iconColor}}"
                       ng-if="vm.blockConfigModel == null || vm.blockConfigModel.thumbnail == null">
             </umb-icon>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -47,7 +47,7 @@
             if (path.toLowerCase().endsWith(".svg") === false) {
                 path += "?upscale=false&width=400";
             }
-            vm.styleBackgroundImage = 'url(\'' + path + '\')';
+            vm.styleBackgroundImage = `url('${path}')`;
         };
 
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -16,23 +16,26 @@
 
     function BlockCardController($scope, umbRequestHelper) {
 
-        var vm = this;
+        const vm = this;
         vm.styleBackgroundImage = "none";
 
         var unwatch = $scope.$watch("vm.blockConfigModel.thumbnail", (newValue, oldValue) => {
-            if(newValue !== oldValue) {
+            if (newValue !== oldValue) {
                 vm.updateThumbnail();
             }
         });
 
         vm.$onInit = function () {
-
             vm.updateThumbnail();
+        };
 
-        }
+        vm.$onChanges = function () {
+            vm.icon = vm.elementTypeModel ? vm.elementTypeModel.icon.split(" ")[0] : 'icon-block';
+        };
+
         vm.$onDestroy = function () {
             unwatch();
-        }
+        };
 
         vm.updateThumbnail = function () {
             if (vm.blockConfigModel == null || vm.blockConfigModel.thumbnail == null || vm.blockConfigModel.thumbnail === "") {
@@ -44,8 +47,8 @@
             if (path.toLowerCase().endsWith(".svg") === false) {
                 path += "?upscale=false&width=400";
             }
-            vm.styleBackgroundImage = 'url(\''+path+'\')';
-        }
+            vm.styleBackgroundImage = 'url(\'' + path + '\')';
+        };
 
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After PR https://github.com/umbraco/Umbraco-CMS/pull/10805 was merged I noticed block card didn't show the selected icon color.

The icon name includes color class as well, which is a bit of a mess and color classes are forcing color with `!important` as well. Furthermore the inline color style need `!important` as well to overwrite this 🙀

I could continue the trend with another `!important` rule as in https://github.com/umbraco/Umbraco-CMS/commit/bc5a3815fdd64069e1c8e7d9a5537bc00870e13d to inherit the correct color as well in `<umb-icon>` component.

![image](https://user-images.githubusercontent.com/2919859/129923554-f35b87db-6e6d-45a3-9336-8a5ff737c086.png)

However I think this would be just another hack.

Instead it should just include the icon and furthermore we don't need to use `!important` on the inline style to get the correct color.

![image](https://user-images.githubusercontent.com/2919859/129928600-7f16a27c-dfea-4261-bf0a-4a73d190e254.png)

![image](https://user-images.githubusercontent.com/2919859/129929249-6a24d283-4c12-43f0-aabf-53314bda8dae.png)
