### PR TITLE
Adds App_Plugins folder to be copied in when using `dotnet publish`

### DIFF
--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -31,6 +31,10 @@
         <EmbeddedResource Remove="umbraco\MediaCache\**" />
     </ItemGroup>
     <ItemGroup>
+		<None Include="App_Plugins\**\*.*">
+            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+            <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+        </None>	
         <None Include="config\**\*.*">
             <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
             <CopyToPublishDirectory>Always</CopyToPublishDirectory>


### PR DESCRIPTION
Fixes #10863

### Prerequisites

- [x] I have added steps to test this contribution in the description below

- Creating a new site `dotnet new umbraco TestSite`
- Install Umbraco 
- Install the starter kit `dotnet add package Umbraco.TheStarterKit --prerelease`
- Run the site again and note that the starter kit is installed with content and the Contact page has a working OpenStreetMap editor on it
- Publish the site with `dotnet publish`
- Run in IIS and notice that OpenStreetMap is missing  ![image](https://user-images.githubusercontent.com/304656/130064159-881adf22-baf7-4df7-a06d-dbb7f1632465.png)

After this PR, when you do `dotnet publish` you will notice that the `App_Plugins` folder is included in the published items and OpenStreetMap works.



