### PR TITLE
Hide backdrop when closing/select navigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -358,7 +358,7 @@ function umbTreeDirective($q, treeService, navigationService, notificationsServi
             */
             $scope.select = function (n, ev) {
 
-                navigationService.hideMenu();
+                navigationService.hideBackdrop();
                 
                 if (n.metaData && n.metaData.noAccess === true) {
                     ev.preventDefault();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tree/umbtree.directive.js
@@ -3,7 +3,7 @@
 * @name umbraco.directives.directive:umbTree
 * @restrict E
 **/
-function umbTreeDirective($q, treeService, navigationService, notificationsService) {
+function umbTreeDirective($q, treeService, notificationsService) {
 
     return {
         restrict: 'E',
@@ -357,8 +357,6 @@ function umbTreeDirective($q, treeService, navigationService, notificationsServi
               defined on the tree
             */
             $scope.select = function (n, ev) {
-
-                navigationService.hideBackdrop();
                 
                 if (n.metaData && n.metaData.noAccess === true) {
                     ev.preventDefault();

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -148,26 +148,6 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
 
         /**
          * @ngdoc method
-         * @name umbraco.services.navigationService#hideBackdrop
-         * @methodOf umbraco.services.navigationService
-         *
-         * @description
-         * hide backdrop
-         */
-        hideBackdrop: closeBackdrop,
-
-        /**
-         * @ngdoc method
-         * @name umbraco.services.navigationService#showBackdrop
-         * @methodOf umbraco.services.navigationService
-         *
-         * @description
-         * show backdrop
-         */
-        showBackdrop: showBackdrop,
-
-        /**
-         * @ngdoc method
          * @name umbraco.services.navigationService#isRouteChangingNavigation
          * @methodOf umbraco.services.navigationService
          *

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -127,7 +127,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
         var aboveClass = "above-backdrop";
         var leftColumn = document.getElementById("leftcolumn");
 
-        if(leftColumn) {
+        if (leftColumn) {
             var isLeftColumnOnTop = leftColumn.classList.contains(aboveClass);
 
             if (isLeftColumnOnTop) {
@@ -145,6 +145,26 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
     }
 
     var service = {
+
+        /**
+         * @ngdoc method
+         * @name umbraco.services.navigationService#hideBackdrop
+         * @methodOf umbraco.services.navigationService
+         *
+         * @description
+         * hide backdrop
+         */
+        hideBackdrop: closeBackdrop,
+
+        /**
+         * @ngdoc method
+         * @name umbraco.services.navigationService#showBackdrop
+         * @methodOf umbraco.services.navigationService
+         *
+         * @description
+         * show backdrop
+         */
+        showBackdrop: showBackdrop,
 
         /**
          * @ngdoc method


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10903

### Description
While optimizing some duplicate code in https://github.com/umbraco/Umbraco-CMS/pull/10762 I also changed to call `hideMenu()` method from navigationService.

However this method also do some other stuff like changing menu state.

Besides this I think it goes longer back as it originally hide backdrop in `select()` function, but may also make sense when the dialog is closed. However in copy and move action when selecting root node, the dialog isn't closed, but the backdrop is hidden.

![NdCdrq07Qd](https://user-images.githubusercontent.com/2919859/130104200-f4c6d2af-dcc8-4f07-a515-23c9d41667ad.gif)
