### PR TITLE
Fix PhysicalFileSystem.GetRelaitvePath for *nix

### DIFF
--- a/src/Umbraco.Core/IO/PhysicalFileSystem.cs
+++ b/src/Umbraco.Core/IO/PhysicalFileSystem.cs
@@ -258,15 +258,16 @@ namespace Umbraco.Cms.Core.IO
             // test URL
             var path = fullPathOrUrl.Replace('\\', '/'); // ensure URL separator char
 
+            // if it starts with the root path, strip it and trim the starting slash to make it relative
+            // eg "c:/websites/test/root/Media/1234/img.jpg" => "1234/img.jpg"
+            // or on unix systems "/var/wwwroot/test/Meia/1234/img.jpg"
+            if (_ioHelper.PathStartsWith(path, _rootPathFwd, '/'))
+                return path.Substring(_rootPathFwd.Length).TrimStart(Constants.CharArrays.ForwardSlash);
+
             // if it starts with the root URL, strip it and trim the starting slash to make it relative
             // eg "/Media/1234/img.jpg" => "1234/img.jpg"
             if (_ioHelper.PathStartsWith(path, _rootUrl, '/'))
                 return path.Substring(_rootUrl.Length).TrimStart(Constants.CharArrays.ForwardSlash);
-
-            // if it starts with the root path, strip it and trim the starting slash to make it relative
-            // eg "c:/websites/test/root/Media/1234/img.jpg" => "1234/img.jpg"
-            if (_ioHelper.PathStartsWith(path, _rootPathFwd, '/'))
-                return path.Substring(_rootPathFwd.Length).TrimStart(Constants.CharArrays.ForwardSlash);
 
             // unchanged - what else?
             return path;


### PR DESCRIPTION
### Prerequisites

- [X ] I have added steps to test this contribution in the description below

Fixes #10912 

### Description
This PR fixes a problem where GetRelativePath fails on Unix systems. It resolves a fullPathOrUrl as a Path before trying to resolve it as a URL. This is done by simply moving the path handling code above the url handling code.

### Tests
The following tests were run and passed:
- From Umbraco.Tests.Integration I ran Umbraco.Cms.Tests.Integration.Umbraco.Core.IO.FileSystemsTests
- All tests in Umbraco.Tests.UnitTests project

This bug was showing up when choosing a thumbnail for a block list. Here it can be seen working as expected on MacOS
<img width="496" alt="image" src="https://user-images.githubusercontent.com/23444011/130254568-863347ca-bcbd-4ae2-95c6-09b99bf3a76d.png">
And I also tested on a windows system, where the results look also as expected.