### PR TITLE
Cannot copy page with Block List block with property that 'looks like' JSON #10879

### DIFF
--- a/src/Umbraco.Web/Compose/BlockEditorComponent.cs
+++ b/src/Umbraco.Web/Compose/BlockEditorComponent.cs
@@ -18,6 +18,17 @@ namespace Umbraco.Web.Compose
     {
         private ComplexPropertyEditorContentEventHandler _handler;
         private readonly BlockListEditorDataConverter _converter = new BlockListEditorDataConverter();
+        private readonly ILogger _logger;
+
+        [Obsolete("Use the ctor injecting dependencies.")]
+        public BlockEditorComponent() : this(Current.Logger)
+        {
+        }
+
+        public BlockEditorComponent(ILogger logger)
+        {
+            _logger = logger;
+        }
 
         public void Initialize()
         {
@@ -128,7 +139,7 @@ namespace Umbraco.Web.Compose
                                 // We are detecting JSON data by seeing if a string is surrounded by [] or {}
                                 // If people enter text like [PLACEHOLDER] JToken  parsing fails, it's safe to ignore though
                                 // Logging this just in case in the future we find values that are not safe to ignore
-                                Current.Logger.Warn<BlockEditorComponent>(
+                                _logger.Warn<BlockEditorComponent>(
                                     "The property {PropertyAlias} on content type {ContentTypeKey} has a value of: {BlockItemValue} - this was recognized as JSON but could not be parsed",
                                     data.Key, propertyAliasToBlockItemData.Key, asString);
                             }


### PR DESCRIPTION
If our crude JSON detection gives us a false positive, don't throw an exception if it can't be parsed as JSON

Fixes #10879

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

To test, follow the scenario in the related issue #10879 and then test again with this fix applied. Note the message appears in the log as well.

I left the content type as a GUID as I didn't want to add overhead in trying to resolve the content type from the GUID to find the name of the content type just so it could be logged, that seemed a bit overkill.