### PR TITLE
Fix BackOfficeServerVariables GetMaxRequestLength

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -529,9 +530,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             return app;
         }
 
-        private string GetMaxRequestLength()
-        {
-            return _runtimeSettings.MaxRequestLength.HasValue ? _runtimeSettings.MaxRequestLength.Value.ToString() : string.Empty;
-        }
+        private string GetMaxRequestLength() => _httpContextAccessor.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize != null ? (_httpContextAccessor.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize / 1024).ToString() : string.Empty;
+    
     }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -529,8 +529,12 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             return app;
         }
-
-        private string GetMaxRequestLength() => _httpContextAccessor.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize != null ? (_httpContextAccessor.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize / 1024).ToString() : string.Empty;
+        
+        private string GetMaxRequestLength() => _runtimeSettings.MaxRequestLength.HasValue ?
+            _runtimeSettings.MaxRequestLength.Value.ToString()
+            : _httpContextAccessor.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize != null ?
+                (_httpContextAccessor.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize / 1024).ToString() // Convert bytes to kilobytes
+                : string.Empty;
     
     }
 }


### PR DESCRIPTION
_runtimeSettings.MaxRequestLength returned always null so the GetMaxRequestLength method returned always an empty string. 
Now it returns the MaxRequestBodySize in kilobytes (as a string).

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10920

### Description

The Media upload dropzone did not show a warning when the filesize of the upload exceeded the max request length.
To test upload a file larger than 30 megabyte.

![afbeelding](https://user-images.githubusercontent.com/18665536/130524060-3b6489bb-062c-4a4d-a9c3-8d9803f44722.png)

I'm pretty new to .NetCore so please double check if this works ok.

<!-- Thanks for contributing to Umbraco CMS! -->
