### PR TITLE
Avoid creating a new string for the log level every log message

### DIFF
--- a/src/Umbraco.Core/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
+++ b/src/Umbraco.Core/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
@@ -28,15 +28,15 @@ namespace Umbraco.Core.Logging.Serilog.Enrichers
                     break;
 
                 case LogEventLevel.Information:
-                    log4NetLevel = "INFO ";//Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
+                    log4NetLevel = "INFO "; //Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
                     break;
 
                 case LogEventLevel.Verbose:
-                    log4NetLevel = "ALL  ";//Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
+                    log4NetLevel = "ALL  "; //Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
                     break;
 
                 case LogEventLevel.Warning:
-                    log4NetLevel = "WARN ";//Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
+                    log4NetLevel = "WARN "; //Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
                     break;
                 default:
                     log4NetLevel = string.Empty;

--- a/src/Umbraco.Core/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
+++ b/src/Umbraco.Core/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Core.Logging.Serilog.Enrichers
     {
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            var log4NetLevel = string.Empty;
+            string log4NetLevel;
 
             switch (logEvent.Level)
             {
@@ -28,20 +28,20 @@ namespace Umbraco.Core.Logging.Serilog.Enrichers
                     break;
 
                 case LogEventLevel.Information:
-                    log4NetLevel = "INFO";
+                    log4NetLevel = "INFO ";//Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
                     break;
 
                 case LogEventLevel.Verbose:
-                    log4NetLevel = "ALL";
+                    log4NetLevel = "ALL  ";//Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
                     break;
 
                 case LogEventLevel.Warning:
-                    log4NetLevel = "WARN";
+                    log4NetLevel = "WARN ";//Padded string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
+                    break;
+                default:
+                    log4NetLevel = string.Empty;
                     break;
             }
-
-            //Pad string so that all log levels are 5 chars long (needed to keep the txt log file lined up nicely)
-            log4NetLevel = log4NetLevel.PadRight(5);
 
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("Log4NetLevel", log4NetLevel));
         }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Avoid creating a new string for the log level every log message. 
Each log message ends up padding the Log4Net log level, if the log level does match, the assignment of string.Empty is unused.
Avoided the padding call by including the padding in the string, allowing for compile time string interning. Moved the string.Empty assignment to the default case in the switch.


