### PR TITLE
Avoid generating the maindom hash twice to get the Id.

### DIFF
--- a/src/Umbraco.Core/Runtime/MainDomSemaphoreLock.cs
+++ b/src/Umbraco.Core/Runtime/MainDomSemaphoreLock.cs
@@ -20,10 +20,11 @@ namespace Umbraco.Core.Runtime
 
         public MainDomSemaphoreLock(ILogger logger)
         {
-            var lockName = "UMBRACO-" + MainDom.GetMainDomId() + "-MAINDOM-LCK";
+            var mainDomId = MainDom.GetMainDomId();
+            var lockName = "UMBRACO-" + mainDomId + "-MAINDOM-LCK";
             _systemLock = new SystemLock(lockName);
 
-            var eventName = "UMBRACO-" + MainDom.GetMainDomId() + "-MAINDOM-EVT";
+            var eventName = "UMBRACO-" + mainDomId + "-MAINDOM-EVT";
             _signal = new EventWaitHandle(false, EventResetMode.AutoReset, eventName);
             _logger = logger;
         }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes

### Description
Store and reuse the MainDomId, avoids having to recalculate the Hash.
