### PR TITLE
Avoid allocating an array every call to IsClientSideRequest()

### DIFF
--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -141,9 +141,9 @@ namespace Umbraco.Core
         /// <summary>
         /// Non Client Side request Extensions <see cref="IsClientSideRequest"/>
         /// </summary>
-        internal readonly static IDictionary<string, bool> NonClientSideRequestExtensions = new Dictionary<string, bool>(5,StringComparer.InvariantCultureIgnoreCase)
+        internal readonly static HashSet<string> NonClientSideRequestExtensions = new (5, StringComparer.InvariantCultureIgnoreCase)
         {
-            { ".aspx",true },{ ".ashx",true},{ ".asmx",true},{ ".axd",true}, {".svc",true}
+            ".aspx", ".ashx", ".asmx", ".axd", ".svc"
         };
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Umbraco.Core
             {
                 var ext = Path.GetExtension(url.LocalPath);
                 if (ext.IsNullOrWhiteSpace()) return false;
-                return !NonClientSideRequestExtensions.ContainsKey(ext);
+                return !NonClientSideRequestExtensions.Contains(ext);
             }
             catch (ArgumentException)
             {

--- a/src/Umbraco.Core/UriExtensions.cs
+++ b/src/Umbraco.Core/UriExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Umbraco.Core.Composing;
@@ -138,6 +139,14 @@ namespace Umbraco.Core
         }
 
         /// <summary>
+        /// Non Client Side request Extensions <see cref="IsClientSideRequest"/>
+        /// </summary>
+        internal readonly static IDictionary<string, bool> NonClientSideRequestExtensions = new Dictionary<string, bool>(5,StringComparer.InvariantCultureIgnoreCase)
+        {
+            { ".aspx",true },{ ".ashx",true},{ ".asmx",true},{ ".axd",true}, {".svc",true}
+        };
+
+        /// <summary>
         /// This is a performance tweak to check if this not an ASP.Net server file
         /// .Net will pass these requests through to the module when in integrated mode.
         /// We want to ignore all of these requests immediately.
@@ -150,8 +159,7 @@ namespace Umbraco.Core
             {
                 var ext = Path.GetExtension(url.LocalPath);
                 if (ext.IsNullOrWhiteSpace()) return false;
-                var toInclude = new[] {".aspx", ".ashx", ".asmx", ".axd", ".svc"};
-                return toInclude.Any(ext.InvariantEquals) == false;
+                return !NonClientSideRequestExtensions.ContainsKey(ext);
             }
             catch (ArgumentException)
             {

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 {
                     // Reset request to use the static login background image
                     var absoluteLoginBackgroundImage = $"{url}/{_contentSection.LoginBackgroundImage}";
-
+                    
                     request = (HttpWebRequest)WebRequest.Create(absoluteLoginBackgroundImage);
                     response = (HttpWebResponse)request.GetResponse();
                 }

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/HttpsCheck.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
                 {
                     // Reset request to use the static login background image
                     var absoluteLoginBackgroundImage = $"{url}/{_contentSection.LoginBackgroundImage}";
-                    
+
                     request = (HttpWebRequest)WebRequest.Create(absoluteLoginBackgroundImage);
                     response = (HttpWebResponse)request.GetResponse();
                 }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes 

### Description
IsClientSideRequest() is called multiple times per request and allocates an array, then loops through all the entries in the array to do an Invariant string comparison.

This PR changes that to an invariant string dictionary lookup to avoid the array allocations.

