### PR TITLE
Revert "Optimization by returning the same instance"

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -19,7 +19,6 @@ namespace Umbraco.Core.PropertyEditors
     public class DataEditor : IDataEditor
     {
         private IDictionary<string, object> _defaultConfiguration;
-        private IDataValueEditor _reusableEditor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataEditor"/> class.
@@ -91,8 +90,7 @@ namespace Umbraco.Core.PropertyEditors
         /// simple enough for now.</para>
         /// </remarks>
         // TODO: point of that one? shouldn't we always configure?
-        public IDataValueEditor GetValueEditor() => ExplicitValueEditor ?? (_reusableEditor ?? (_reusableEditor = CreateValueEditor()));
-
+        public IDataValueEditor GetValueEditor() => ExplicitValueEditor ?? CreateValueEditor();
 
         /// <inheritdoc />
         /// <remarks>


### PR DESCRIPTION
This reverts commit 990fc118cbd6df423be2107a75970a834ade1f76.

When using the _reusableEditor field to create a BlockEditorPropertyEditor 
it doesn't matter that content type cache has been invalidated (memory cache)
as the content types are also cached in a private field in the BlockEditorValues class.

Closes #10910