### PR TITLE
Remove restricted image size when opening media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.html
@@ -75,7 +75,7 @@
                                 ng-class="{'trashed': vm.media.trashed}"
                                 extension="{{vm.media.extension}}"
                                 icon="{{vm.media.icon}}"
-                                size="s"
+                                size="m"
                                 text="{{vm.media.name}}">
                             </umb-file-icon>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.less
@@ -84,6 +84,7 @@
                 width: 4px;
             }
         }
+
         &.--is-defined {
 
         }
@@ -109,14 +110,16 @@
 }
 
 .umb-media-entry-editor__imageholder {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: relative;
     height: calc(100% - 50px);
 }
+
 .umb-media-entry-editor__imageholder-actions {
-    background-color: white;
+    background-color: @white;
     height: 50px;
     display: flex;
     justify-content: center;
 }
-

--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
@@ -3,8 +3,8 @@
 	<div class="gravity-container" ng-show="vm.loaded">
         <div class="viewport">
 
-            <img ng-show="vm.isCroppable" ng-src="{{vm.src}}" draggable="false" />
-            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" draggable="false" class="cursor-default" />
+            <img ng-show="vm.isCroppable" ng-src="{{vm.src}}" src="" alt="" draggable="false" />
+            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" src="" alt="" draggable="false" class="cursor-default" />
 
         </div>
         <div class="overlayViewport">

--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
@@ -4,7 +4,7 @@
         <div class="viewport">
 
             <img ng-show="vm.isCroppable" ng-src="{{vm.src}}" draggable="false" />
-            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" draggable="false" style="cursor: default;" />
+            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" draggable="false" class="cursor-default" />
 
         </div>
         <div class="overlayViewport">

--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
@@ -4,7 +4,7 @@
         <div class="viewport">
 
             <img ng-show="vm.isCroppable" ng-src="{{vm.src}}" draggable="false" />
-            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" width="200" height="200" draggable="false" style="cursor: default;" />
+            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" draggable="false" style="cursor: default;" />
 
         </div>
         <div class="overlayViewport">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With Media Picker 3 and opening e.g. a SVG image (which doesn't have dimensions) I noticed the image preview is quite small (limited to max 200px with and 200px height).

**Before**

![image](https://user-images.githubusercontent.com/2919859/130647520-819fed3e-2dac-41f3-b46a-0d9021de541c.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/130647335-577cc875-ebba-4231-bf5a-a8e890b94868.png)
