### PR TITLE
Added url mode parameter to the GetCropUrl extension methods

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -22,16 +22,18 @@ namespace Umbraco.Extensions
         /// </summary>
         /// <param name="mediaItem">The IPublishedContent item.</param>
         /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
-            string cropAlias) =>
-            mediaItem.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+            string cropAlias,
+            UrlMode urlMode = UrlMode.Default) =>
+            mediaItem.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
 
-        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias)
-            => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, UrlMode urlMode = UrlMode.Default)
+            => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
 
         /// <summary>
         /// Gets the crop URL by using only the specified <paramref name="imageCropperValue" />.
@@ -39,14 +41,16 @@ namespace Umbraco.Extensions
         /// <param name="mediaItem">The media item.</param>
         /// <param name="imageCropperValue">The image cropper value.</param>
         /// <param name="cropAlias">The crop alias.</param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The image crop URL.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
             ImageCropperValue imageCropperValue,
-            string cropAlias)
-            => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, imageCropperValue, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+            string cropAlias,
+            UrlMode urlMode = UrlMode.Default)
+            => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaItem, imageCropperValue, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
 
         /// <summary>
         /// Gets the underlying image processing service URL by the crop alias using the specified property containing the image cropper JSON data on the IPublishedContent item.
@@ -54,17 +58,19 @@ namespace Umbraco.Extensions
         /// <param name="mediaItem">The IPublishedContent item.</param>
         /// <param name="propertyAlias">The property alias of the property containing the JSON data e.g. umbracoFile.</param>
         /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The URL of the cropped image.
         /// </returns>
         public static string GetCropUrl(
             this IPublishedContent mediaItem,
             string propertyAlias,
-            string cropAlias) =>
-            mediaItem.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+            string cropAlias,
+            UrlMode urlMode = UrlMode.Default) =>
+            mediaItem.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
 
-        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias)
-            => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider);
+        public static string GetCropUrl(this MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias, UrlMode urlMode = UrlMode.Default)
+            => ImageCropperTemplateCoreExtensions.GetCropUrl(mediaWithCrops, propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
 
         /// <summary>
         /// Gets the underlying image processing service URL from the IPublishedContent item.
@@ -84,6 +90,7 @@ namespace Umbraco.Extensions
         /// <example><![CDATA[
         /// furtherOptions: "bgcolor=fff"
         /// ]]></example></param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The URL of the cropped image.
         /// </returns>
@@ -99,7 +106,8 @@ namespace Umbraco.Extensions
             bool preferFocalPoint = false,
             bool useCropDimensions = false,
             bool cacheBuster = true,
-            string furtherOptions = null)
+            string furtherOptions = null,
+            UrlMode urlMode = UrlMode.Default)
             => mediaItem.GetCropUrl(
                 ImageUrlGenerator,
                 PublishedValueFallback,
@@ -114,7 +122,8 @@ namespace Umbraco.Extensions
                 preferFocalPoint,
                 useCropDimensions,
                 cacheBuster,
-                furtherOptions
+                furtherOptions,
+                urlMode
             );
 
         /// <summary>

--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -20,6 +20,7 @@ namespace Umbraco.Extensions
         /// <param name="imageUrlGenerator">The image URL generator.</param>
         /// <param name="publishedValueFallback">The published value fallback.</param>
         /// <param name="publishedUrlProvider">The published URL provider.</param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The URL of the cropped image.
         /// </returns>
@@ -28,14 +29,16 @@ namespace Umbraco.Extensions
             string cropAlias,
             IImageUrlGenerator imageUrlGenerator,
             IPublishedValueFallback publishedValueFallback,
-            IPublishedUrlProvider publishedUrlProvider) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, cropAlias: cropAlias, useCropDimensions: true);
+            IPublishedUrlProvider publishedUrlProvider,
+            UrlMode urlMode = UrlMode.Default) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
 
         public static string GetCropUrl(
             this MediaWithCrops mediaWithCrops,
             string cropAlias,
             IImageUrlGenerator imageUrlGenerator,
             IPublishedValueFallback publishedValueFallback,
-            IPublishedUrlProvider publishedUrlProvider) => mediaWithCrops.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, cropAlias: cropAlias, useCropDimensions: true);
+            IPublishedUrlProvider publishedUrlProvider,
+            UrlMode urlMode = UrlMode.Default) => mediaWithCrops.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
 
         /// <summary>
         /// Gets the crop URL by using only the specified <paramref name="imageCropperValue" />.
@@ -46,6 +49,7 @@ namespace Umbraco.Extensions
         /// <param name="imageUrlGenerator">The image URL generator.</param>
         /// <param name="publishedValueFallback">The published value fallback.</param>
         /// <param name="publishedUrlProvider">The published URL provider.</param>
+        /// <param name="urlMode">The url mode.s</param>
         /// <returns>
         /// The image crop URL.
         /// </returns>
@@ -55,7 +59,8 @@ namespace Umbraco.Extensions
             string cropAlias,
             IImageUrlGenerator imageUrlGenerator,
             IPublishedValueFallback publishedValueFallback,
-            IPublishedUrlProvider publishedUrlProvider) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, imageCropperValue, true, cropAlias: cropAlias, useCropDimensions: true);
+            IPublishedUrlProvider publishedUrlProvider,
+            UrlMode urlMode = UrlMode.Default) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, imageCropperValue, true, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
 
         /// <summary>
         /// Gets the underlying image processing service URL by the crop alias using the specified property containing the image cropper JSON data on the IPublishedContent item.
@@ -66,6 +71,7 @@ namespace Umbraco.Extensions
         /// <param name="imageUrlGenerator">The image URL generator.</param>
         /// <param name="publishedValueFallback">The published value fallback.</param>
         /// <param name="publishedUrlProvider">The published URL provider.</param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The URL of the cropped image.
         /// </returns>
@@ -75,14 +81,16 @@ namespace Umbraco.Extensions
             string cropAlias,
             IImageUrlGenerator imageUrlGenerator,
             IPublishedValueFallback publishedValueFallback,
-            IPublishedUrlProvider publishedUrlProvider) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
+            IPublishedUrlProvider publishedUrlProvider,
+            UrlMode urlMode = UrlMode.Default) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
 
         public static string GetCropUrl(this MediaWithCrops mediaWithCrops,
             IPublishedValueFallback publishedValueFallback,
             IPublishedUrlProvider publishedUrlProvider,
             string propertyAlias,
             string cropAlias,
-            IImageUrlGenerator imageUrlGenerator) => mediaWithCrops.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
+            IImageUrlGenerator imageUrlGenerator,
+            UrlMode urlMode = UrlMode.Default) => mediaWithCrops.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
 
         /// <summary>
         /// Gets the underlying image processing service URL from the IPublishedContent item.
@@ -105,6 +113,7 @@ namespace Umbraco.Extensions
         /// <example><![CDATA[
         /// furtherOptions: "bgcolor=fff"
         /// ]]></example></param>
+        /// <param name="urlMode">The url mode.</param>
         /// <returns>
         /// The URL of the cropped image.
         /// </returns>
@@ -123,7 +132,8 @@ namespace Umbraco.Extensions
              bool preferFocalPoint = false,
              bool useCropDimensions = false,
              bool cacheBuster = true,
-             string furtherOptions = null) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, null, false, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions);
+             string furtherOptions = null,
+             UrlMode urlMode = UrlMode.Default) => mediaItem.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, null, false, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, urlMode);
 
         public static string GetCropUrl(
              this MediaWithCrops mediaWithCrops,
@@ -140,14 +150,15 @@ namespace Umbraco.Extensions
              bool preferFocalPoint = false,
              bool useCropDimensions = false,
              bool cacheBuster = true,
-             string furtherOptions = null)
+             string furtherOptions = null,
+             UrlMode urlMode = UrlMode.Default)
         {
             if (mediaWithCrops == null)
             {
                 throw new ArgumentNullException(nameof(mediaWithCrops));
             }
 
-            return mediaWithCrops.Content.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, mediaWithCrops.LocalCrops, false, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions);
+            return mediaWithCrops.Content.GetCropUrl(imageUrlGenerator, publishedValueFallback, publishedUrlProvider, mediaWithCrops.LocalCrops, false, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, urlMode);
         }
 
         private static string GetCropUrl(
@@ -167,7 +178,8 @@ namespace Umbraco.Extensions
              bool preferFocalPoint = false,
              bool useCropDimensions = false,
              bool cacheBuster = true,
-             string furtherOptions = null)
+             string furtherOptions = null,
+             UrlMode urlMode = UrlMode.Default)
         {
             if (mediaItem == null)
             {
@@ -179,7 +191,7 @@ namespace Umbraco.Extensions
                 return null;
             }
 
-            var mediaItemUrl = mediaItem.MediaUrl(publishedUrlProvider, propertyAlias: propertyAlias);
+            var mediaItemUrl = mediaItem.MediaUrl(publishedUrlProvider, propertyAlias: propertyAlias, mode: urlMode);
 
             // Only get crops from media when required and used
             if (localCropsOnly == false && (imageCropMode == ImageCropMode.Crop || imageCropMode == null))

--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -209,27 +208,27 @@ namespace Umbraco.Extensions
             return $"{version}.{runtimeMinifier.CacheBuster}".GenerateHash();
         }
 
-        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent mediaItem, string cropAlias, bool htmlEncode = true)
+        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent mediaItem, string cropAlias, bool htmlEncode = true, UrlMode urlMode = UrlMode.Default)
         {
             if (mediaItem == null)
             {
                 return HtmlString.Empty;
             }
 
-            var url = mediaItem.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true);
+            var url = mediaItem.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
             return CreateHtmlString(url, htmlEncode);
         }
 
         private static IHtmlContent CreateHtmlString(string url, bool htmlEncode) => htmlEncode ? new HtmlString(HttpUtility.HtmlEncode(url)) : new HtmlString(url);
 
-        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent mediaItem, string propertyAlias, string cropAlias, bool htmlEncode = true)
+        public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent mediaItem, string propertyAlias, string cropAlias, bool htmlEncode = true, UrlMode urlMode = UrlMode.Default)
         {
             if (mediaItem == null)
             {
                 return HtmlString.Empty;
             }
 
-            var url = mediaItem.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true);
+            var url = mediaItem.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
             return CreateHtmlString(url, htmlEncode);
         }
 
@@ -246,7 +245,8 @@ namespace Umbraco.Extensions
             bool useCropDimensions = false,
             bool cacheBuster = true,
             string furtherOptions = null,
-            bool htmlEncode = true)
+            bool htmlEncode = true,
+            UrlMode urlMode = UrlMode.Default)
         {
             if (mediaItem == null)
             {
@@ -254,7 +254,7 @@ namespace Umbraco.Extensions
             }
 
             var url = mediaItem.GetCropUrl(width, height, propertyAlias, cropAlias, quality, imageCropMode,
-                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions);
+                imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, urlMode);
 
             return CreateHtmlString(url, htmlEncode);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I've added a new parameter `urlMode` to the image cropper `.GetCropUrl()` extension methods in order to be able to select which url mode I need in that specific call, like it works now for `.Url()`.
In my case, I have the default url mode set to relative, but for things like the Open Graph image, I need it to be absolute.

I tested my changes by calling some of the extension methods from a view as follows

```
@Model.Image.GetCropUrl(1200, 620)
@Model.Image.GetCropUrl(1200, 620, urlMode: UrlMode.Absolute)
@Model.Image.GetCropUrl("crop1")
@Model.Image.GetCropUrl("crop1", UrlMode.Absolute)
```
