### PR TITLE
V9: Reuse value editors for validation

### DIFF
--- a/src/Umbraco.Core/Cache/IValueEditorCache.cs
+++ b/src/Umbraco.Core/Cache/IValueEditorCache.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Core.Cache
+{
+    public interface IValueEditorCache
+    {
+        public IDataValueEditor GetValueEditor(IDataEditor dataEditor, IDataType dataType);
+    }
+}

--- a/src/Umbraco.Core/Cache/IValueEditorCache.cs
+++ b/src/Umbraco.Core/Cache/IValueEditorCache.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Models;
+﻿using System.Collections.Generic;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Cms.Core.Cache
@@ -6,5 +7,6 @@ namespace Umbraco.Cms.Core.Cache
     public interface IValueEditorCache
     {
         public IDataValueEditor GetValueEditor(IDataEditor dataEditor, IDataType dataType);
+        public void ClearCache(IEnumerable<int> dataTypeIds);
     }
 }

--- a/src/Umbraco.Core/Cache/ValueEditorCache.cs
+++ b/src/Umbraco.Core/Cache/ValueEditorCache.cs
@@ -1,15 +1,10 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Cms.Core.Cache
 {
-    public class ValueEditorCache : IValueEditorCache,
-        INotificationHandler<DataTypeSavedNotification>,
-        INotificationHandler<DataTypeDeletedNotification>
+    public class ValueEditorCache : IValueEditorCache
     {
         private readonly Dictionary<string, Dictionary<int, IDataValueEditor>> _valueEditorCache;
         private readonly object _dictionaryLocker;
@@ -47,13 +42,7 @@ namespace Umbraco.Cms.Core.Cache
             }
         }
 
-        public void Handle(DataTypeSavedNotification notification) =>
-            ClearCache(notification.SavedEntities.Select(x => x.Id));
-
-        public void Handle(DataTypeDeletedNotification notification) =>
-            ClearCache(notification.DeletedEntities.Select(x => x.Id));
-
-        private void ClearCache(IEnumerable<int> dataTypeIds)
+        public void ClearCache(IEnumerable<int> dataTypeIds)
         {
             lock (_dictionaryLocker)
             {

--- a/src/Umbraco.Core/Cache/ValueEditorCache.cs
+++ b/src/Umbraco.Core/Cache/ValueEditorCache.cs
@@ -15,7 +15,9 @@ namespace Umbraco.Cms.Core.Cache
 
         public IDataValueEditor GetValueEditor(IDataEditor editor, IDataType dataType)
         {
-            // Instead of creating a value editor immediately check if we've already created one and use that.
+            // We try and get the dictionary based on the IDataEditor alias,
+            // this is here just in case a data type can have more than one value data editor.
+            // If this is not the case this could be simplified quite a bit, by just using the inner dictionary only.
             IDataValueEditor valueEditor;
             if (_valueEditorCache.TryGetValue(editor.Alias, out Dictionary<int, IDataValueEditor> dataEditorCache))
             {

--- a/src/Umbraco.Core/Cache/ValueEditorCache.cs
+++ b/src/Umbraco.Core/Cache/ValueEditorCache.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Core.Cache
+{
+    public class ValueEditorCache : IValueEditorCache,
+        INotificationHandler<DataTypeSavedNotification>,
+        INotificationHandler<DataTypeDeletedNotification>
+    {
+        private readonly Dictionary<string, Dictionary<int, IDataValueEditor>> _valueEditorCache = new();
+
+        public IDataValueEditor GetValueEditor(IDataEditor editor, IDataType dataType)
+        {
+            // Instead of creating a value editor immediately check if we've already created one and use that.
+            IDataValueEditor valueEditor;
+            if (_valueEditorCache.TryGetValue(editor.Alias, out Dictionary<int, IDataValueEditor> dataEditorCache))
+            {
+                if (dataEditorCache.TryGetValue(dataType.Id, out valueEditor))
+                {
+                    return valueEditor;
+                }
+
+                valueEditor = editor.GetValueEditor(dataType.Configuration);
+                dataEditorCache[dataType.Id] = valueEditor;
+                return valueEditor;
+
+            }
+
+            valueEditor = editor.GetValueEditor(dataType.Configuration);
+            _valueEditorCache[editor.Alias] = new Dictionary<int, IDataValueEditor> { [dataType.Id] = valueEditor };
+            return valueEditor;
+        }
+
+        public void Handle(DataTypeSavedNotification notification) =>
+            ClearCache(notification.SavedEntities.Select(x => x.Id));
+
+        public void Handle(DataTypeDeletedNotification notification) =>
+            ClearCache(notification.DeletedEntities.Select(x => x.Id));
+
+        private void ClearCache(IEnumerable<int> dataTypeIds)
+        {
+            // If a datatype is saved or deleted we have to clear any value editors based on their ID from the cache,
+            // since it could mean that their configuration has changed.
+            foreach (var id in dataTypeIds)
+            {
+                foreach (Dictionary<int, IDataValueEditor> editors in _valueEditorCache.Values)
+                {
+                    editors.Remove(id);
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Core/Cache/ValueEditorCache.cs
+++ b/src/Umbraco.Core/Cache/ValueEditorCache.cs
@@ -11,30 +11,40 @@ namespace Umbraco.Cms.Core.Cache
         INotificationHandler<DataTypeSavedNotification>,
         INotificationHandler<DataTypeDeletedNotification>
     {
-        private readonly Dictionary<string, Dictionary<int, IDataValueEditor>> _valueEditorCache = new();
+        private readonly Dictionary<string, Dictionary<int, IDataValueEditor>> _valueEditorCache;
+        private readonly object _dictionaryLocker;
+
+        public ValueEditorCache()
+        {
+            _valueEditorCache = new Dictionary<string, Dictionary<int, IDataValueEditor>>();
+            _dictionaryLocker = new object();
+        }
 
         public IDataValueEditor GetValueEditor(IDataEditor editor, IDataType dataType)
         {
-            // We try and get the dictionary based on the IDataEditor alias,
-            // this is here just in case a data type can have more than one value data editor.
-            // If this is not the case this could be simplified quite a bit, by just using the inner dictionary only.
-            IDataValueEditor valueEditor;
-            if (_valueEditorCache.TryGetValue(editor.Alias, out Dictionary<int, IDataValueEditor> dataEditorCache))
+            // Lock just in case multiple threads uses the cache at the same time.
+            lock (_dictionaryLocker)
             {
-                if (dataEditorCache.TryGetValue(dataType.Id, out valueEditor))
+                // We try and get the dictionary based on the IDataEditor alias,
+                // this is here just in case a data type can have more than one value data editor.
+                // If this is not the case this could be simplified quite a bit, by just using the inner dictionary only.
+                IDataValueEditor valueEditor;
+                if (_valueEditorCache.TryGetValue(editor.Alias, out Dictionary<int, IDataValueEditor> dataEditorCache))
                 {
+                    if (dataEditorCache.TryGetValue(dataType.Id, out valueEditor))
+                    {
+                        return valueEditor;
+                    }
+
+                    valueEditor = editor.GetValueEditor(dataType.Configuration);
+                    dataEditorCache[dataType.Id] = valueEditor;
                     return valueEditor;
                 }
 
                 valueEditor = editor.GetValueEditor(dataType.Configuration);
-                dataEditorCache[dataType.Id] = valueEditor;
+                _valueEditorCache[editor.Alias] = new Dictionary<int, IDataValueEditor> { [dataType.Id] = valueEditor };
                 return valueEditor;
-
             }
-
-            valueEditor = editor.GetValueEditor(dataType.Configuration);
-            _valueEditorCache[editor.Alias] = new Dictionary<int, IDataValueEditor> { [dataType.Id] = valueEditor };
-            return valueEditor;
         }
 
         public void Handle(DataTypeSavedNotification notification) =>
@@ -45,13 +55,16 @@ namespace Umbraco.Cms.Core.Cache
 
         private void ClearCache(IEnumerable<int> dataTypeIds)
         {
-            // If a datatype is saved or deleted we have to clear any value editors based on their ID from the cache,
-            // since it could mean that their configuration has changed.
-            foreach (var id in dataTypeIds)
+            lock (_dictionaryLocker)
             {
-                foreach (Dictionary<int, IDataValueEditor> editors in _valueEditorCache.Values)
+                // If a datatype is saved or deleted we have to clear any value editors based on their ID from the cache,
+                // since it could mean that their configuration has changed.
+                foreach (var id in dataTypeIds)
                 {
-                    editors.Remove(id);
+                    foreach (Dictionary<int, IDataValueEditor> editors in _valueEditorCache.Values)
+                    {
+                        editors.Remove(id);
+                    }
                 }
             }
         }

--- a/src/Umbraco.Core/Cache/ValueEditorCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/ValueEditorCacheRefresher.cs
@@ -1,21 +1,57 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.Cache
 {
-    public class ValueEditorCacheRefresher :
-        INotificationHandler<DataTypeSavedNotification>,
-        INotificationHandler<DataTypeDeletedNotification>
+    public sealed  class ValueEditorCacheRefresher : PayloadCacheRefresherBase<DataTypeCacheRefresherNotification, DataTypeCacheRefresher.JsonPayload>
     {
         private readonly IValueEditorCache _valueEditorCache;
 
-        public ValueEditorCacheRefresher(IValueEditorCache valueEditorCache) => _valueEditorCache = valueEditorCache;
+        public ValueEditorCacheRefresher(
+            AppCaches appCaches,
+            IJsonSerializer serializer,
+            IEventAggregator eventAggregator,
+            ICacheRefresherNotificationFactory factory,
+            IValueEditorCache valueEditorCache) : base(appCaches, serializer, eventAggregator, factory)
+        {
+            _valueEditorCache = valueEditorCache;
+        }
 
-        public void Handle(DataTypeSavedNotification notification) =>
-            _valueEditorCache.ClearCache(notification.SavedEntities.Select(x => x.Id));
+        public static readonly Guid UniqueId = Guid.Parse("D28A1DBB-2308-4918-9A92-2F8689B6CBFE");
+        public override Guid RefresherUniqueId => UniqueId;
+        public override string Name => "ValueEditorCacheRefresher";
 
-        public void Handle(DataTypeDeletedNotification notification) =>
-            _valueEditorCache.ClearCache(notification.DeletedEntities.Select(x => x.Id));
+        public override void Refresh(DataTypeCacheRefresher.JsonPayload[] payloads)
+        {
+            IEnumerable<int> ids = payloads.Select(x => x.Id);
+            _valueEditorCache.ClearCache(ids);
+        }
+
+        // these events should never trigger
+        // everything should be PAYLOAD/JSON
+
+        public override void RefreshAll()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Refresh(int id)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Refresh(Guid id)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Remove(int id)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/Umbraco.Core/Cache/ValueEditorCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/ValueEditorCacheRefresher.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Umbraco.Cms.Core.Cache
+{
+    public class ValueEditorCacheRefresher :
+        INotificationHandler<DataTypeSavedNotification>,
+        INotificationHandler<DataTypeDeletedNotification>
+    {
+        private readonly IValueEditorCache _valueEditorCache;
+
+        public ValueEditorCacheRefresher(IValueEditorCache valueEditorCache) => _valueEditorCache = valueEditorCache;
+
+        public void Handle(DataTypeSavedNotification notification) =>
+            _valueEditorCache.ClearCache(notification.SavedEntities.Select(x => x.Id));
+
+        public void Handle(DataTypeDeletedNotification notification) =>
+            _valueEditorCache.ClearCache(notification.DeletedEntities.Select(x => x.Id));
+    }
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -253,6 +253,12 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             // register a basic/noop published snapshot service to be replaced
             Services.AddSingleton<IPublishedSnapshotService, InternalPublishedSnapshotService>();
+
+            // Register ValueEditorCache used for validation
+            Services.AddSingleton<IValueEditorCache, ValueEditorCache>();
+            Services
+                .AddNotificationHandler<DataTypeSavedNotification, ValueEditorCache>()
+                .AddNotificationHandler<DataTypeDeletedNotification, ValueEditorCache>();
         }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -256,9 +256,6 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             // Register ValueEditorCache used for validation
             Services.AddSingleton<IValueEditorCache, ValueEditorCache>();
-            Services
-                .AddNotificationHandler<DataTypeSavedNotification, ValueEditorCacheRefresher>()
-                .AddNotificationHandler<DataTypeDeletedNotification, ValueEditorCacheRefresher>();
         }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -257,8 +257,8 @@ namespace Umbraco.Cms.Core.DependencyInjection
             // Register ValueEditorCache used for validation
             Services.AddSingleton<IValueEditorCache, ValueEditorCache>();
             Services
-                .AddNotificationHandler<DataTypeSavedNotification, ValueEditorCache>()
-                .AddNotificationHandler<DataTypeDeletedNotification, ValueEditorCache>();
+                .AddNotificationHandler<DataTypeSavedNotification, ValueEditorCacheRefresher>()
+                .AddNotificationHandler<DataTypeDeletedNotification, ValueEditorCacheRefresher>();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -130,6 +130,7 @@ namespace Umbraco.Cms.Core.Cache
             {
                 _distributedCache.RefreshDataTypeCache(entity);
             }
+            _distributedCache.RefreshValueEditorCache(notification.SavedEntities);
         }
 
         public void Handle(DataTypeDeletedNotification notification)
@@ -138,6 +139,7 @@ namespace Umbraco.Cms.Core.Cache
             {
                 _distributedCache.RemoveDataTypeCache(entity);
             }
+            _distributedCache.RefreshValueEditorCache(notification.DeletedEntities);
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
@@ -102,6 +103,21 @@ namespace Umbraco.Extensions
             if (dataType == null) return;
             var payloads = new[] { new DataTypeCacheRefresher.JsonPayload(dataType.Id, dataType.Key, true) };
             dc.RefreshByPayload(DataTypeCacheRefresher.UniqueId, payloads);
+        }
+
+        #endregion
+
+        #region ValueEditorCache
+
+        public static void RefreshValueEditorCache(this DistributedCache dc, IEnumerable<IDataType> dataTypes)
+        {
+            if (dataTypes is null)
+            {
+                return;
+            }
+
+            var payloads = dataTypes.Select(x => new DataTypeCacheRefresher.JsonPayload(x.Id, x.Key, false));
+            dc.RefreshByPayload(ValueEditorCacheRefresher.UniqueId, payloads);
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Services/Implement/PropertyValidationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PropertyValidationService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
@@ -13,12 +14,18 @@ namespace Umbraco.Cms.Core.Services.Implement
         private readonly PropertyEditorCollection _propertyEditors;
         private readonly IDataTypeService _dataTypeService;
         private readonly ILocalizedTextService _textService;
+        private readonly IValueEditorCache _valueEditorCache;
 
-        public PropertyValidationService(PropertyEditorCollection propertyEditors, IDataTypeService dataTypeService, ILocalizedTextService textService)
+        public PropertyValidationService(
+            PropertyEditorCollection propertyEditors,
+            IDataTypeService dataTypeService,
+            ILocalizedTextService textService,
+            IValueEditorCache valueEditorCache)
         {
             _propertyEditors = propertyEditors;
             _dataTypeService = dataTypeService;
             _textService = textService;
+            _valueEditorCache = valueEditorCache;
         }
 
         /// <inheritdoc />
@@ -58,7 +65,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                     _textService.Localize("validation", "invalidPattern"),
                 };
 
-            var valueEditor = editor.GetValueEditor(dataType.Configuration);
+            IDataValueEditor valueEditor = _valueEditorCache.GetValueEditor(editor, dataType);
             foreach (var validationResult in valueEditor.Validate(postedValue, isRequired, validationRegExp))
             {
                 // If we've got custom error messages, we'll replace the default ones that will have been applied in the call to Validate().

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTests.cs
@@ -81,9 +81,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         protected override void CustomTestSetup(IUmbracoBuilder builder) => builder
             .AddNotificationHandler<ContentPublishingNotification, ContentNotificationHandler>()
             .AddNotificationHandler<ContentCopyingNotification, ContentNotificationHandler>()
-            .AddNotificationHandler<ContentCopiedNotification, ContentNotificationHandler>()
-            .AddNotificationHandler<DataTypeSavedNotification, ValueEditorCacheRefresher>()
-            .AddNotificationHandler<DataTypeDeletedNotification, ValueEditorCacheRefresher>();
+            .AddNotificationHandler<ContentCopiedNotification, ContentNotificationHandler>();
 
         [TearDown]
         public void Teardown() => ContentRepositoryBase.ThrowOnWarning = false;

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
@@ -72,13 +73,17 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
 
         private IJsonSerializer Serializer => GetRequiredService<IJsonSerializer>();
 
+        private IValueEditorCache ValueEditorCache => GetRequiredService<IValueEditorCache>();
+
         [SetUp]
         public void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
 
         protected override void CustomTestSetup(IUmbracoBuilder builder) => builder
             .AddNotificationHandler<ContentPublishingNotification, ContentNotificationHandler>()
             .AddNotificationHandler<ContentCopyingNotification, ContentNotificationHandler>()
-            .AddNotificationHandler<ContentCopiedNotification, ContentNotificationHandler>();
+            .AddNotificationHandler<ContentCopiedNotification, ContentNotificationHandler>()
+            .AddNotificationHandler<DataTypeSavedNotification, ValueEditorCacheRefresher>()
+            .AddNotificationHandler<DataTypeDeletedNotification, ValueEditorCacheRefresher>();
 
         [TearDown]
         public void Teardown() => ContentRepositoryBase.ThrowOnWarning = false;
@@ -1162,7 +1167,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
             Assert.IsFalse(content.HasIdentity);
 
             // content cannot publish values because they are invalid
-            var propertyValidationService = new PropertyValidationService(PropertyEditorCollection, DataTypeService, TextService);
+            var propertyValidationService = new PropertyValidationService(PropertyEditorCollection, DataTypeService, TextService, ValueEditorCache);
             bool isValid = propertyValidationService.IsPropertyDataValid(content, out IProperty[] invalidProperties, CultureImpact.Invariant);
             Assert.IsFalse(isValid);
             Assert.IsNotEmpty(invalidProperties);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ValueEditorCacheTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ValueEditorCacheTests.cs
@@ -1,0 +1,133 @@
+﻿using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Cache
+{
+    [TestFixture]
+    public class ValueEditorCacheTests
+    {
+
+        [Test]
+        public void Caches_ValueEditor()
+        {
+            var sut = new ValueEditorCache();
+
+            var dataEditor = new FakeDataEditor("TestEditor");
+            IDataType dataType = CreateDataTypeMock(1).Object;
+
+            // Request the same value editor twice
+            IDataValueEditor firstEditor = sut.GetValueEditor(dataEditor, dataType);
+            IDataValueEditor secondEditor = sut.GetValueEditor(dataEditor, dataType);
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreSame(firstEditor, secondEditor);
+                Assert.AreEqual(1, dataEditor.ValueEditorCount, "GetValueEditor invoked more than once.");
+            });
+        }
+
+        [Test]
+        public void Different_Data_Editors_Returns_Different_Value_Editors()
+        {
+            var sut = new ValueEditorCache();
+
+            var dataEditor1 = new FakeDataEditor("Editor1");
+            var dataEditor2 = new FakeDataEditor("Editor2");
+            IDataType dataType = CreateDataTypeMock(1).Object;
+
+            IDataValueEditor firstEditor = sut.GetValueEditor(dataEditor1, dataType);
+            IDataValueEditor secondEditor = sut.GetValueEditor(dataEditor2, dataType);
+
+            Assert.AreNotSame(firstEditor, secondEditor);
+        }
+
+        [Test]
+        public void Different_Data_Types_Returns_Different_Value_Editors()
+        {
+            var sut = new ValueEditorCache();
+            var dataEditor = new FakeDataEditor("Editor");
+            IDataType dataType1 = CreateDataTypeMock(1).Object;
+            IDataType dataType2 = CreateDataTypeMock(2).Object;
+
+            IDataValueEditor firstEditor = sut.GetValueEditor(dataEditor, dataType1);
+            IDataValueEditor secondEditor = sut.GetValueEditor(dataEditor, dataType2);
+
+            Assert.AreNotSame(firstEditor, secondEditor);
+        }
+
+        [Test]
+        public void Clear_Cache_Removes_Specific_Editors()
+        {
+            var sut = new ValueEditorCache();
+
+            var dataEditor1 = new FakeDataEditor("Editor 1");
+            var dataEditor2 = new FakeDataEditor("Editor 2");
+
+            IDataType dataType1 = CreateDataTypeMock(1).Object;
+            IDataType dataType2 = CreateDataTypeMock(2).Object;
+
+            // Load the editors into cache
+            IDataValueEditor editor1DataType1 = sut.GetValueEditor(dataEditor1, dataType1);
+            IDataValueEditor editor1Datatype2 = sut.GetValueEditor(dataEditor1, dataType2);
+            IDataValueEditor editor2DataType1 = sut.GetValueEditor(dataEditor2, dataType1);
+            IDataValueEditor editor2Datatype2 = sut.GetValueEditor(dataEditor2, dataType2);
+
+            sut.ClearCache(new []{dataType1.Id});
+
+            // New value editor objects should be created after it's cleared
+            Assert.AreNotSame(editor1DataType1, sut.GetValueEditor(dataEditor1, dataType1), "Value editor was not cleared from cache");
+            Assert.AreNotSame(editor2DataType1, sut.GetValueEditor(dataEditor2, dataType1), "Value editor was not cleared from cache");
+
+            // But the value editors for data type 2 should be the same
+            Assert.AreSame(editor1Datatype2, sut.GetValueEditor(dataEditor1, dataType2), "Too many editors was cleared from cache");
+            Assert.AreSame(editor2Datatype2, sut.GetValueEditor(dataEditor2, dataType2), "Too many editors was cleared from cache");
+        }
+
+
+        private Mock<IDataType> CreateDataTypeMock(int id)
+        {
+            var mock = new Mock<IDataType>();
+            mock.Setup(x => x.Id).Returns(id);
+            return mock;
+        }
+
+        /// <summary>
+        /// A fake IDataEditor
+        /// </summary>
+        /// <remarks>
+        /// This is necessary to ensure that different objects are returned from GetValueEditor
+        /// </remarks>
+        private class FakeDataEditor : IDataEditor
+        {
+            public FakeDataEditor(string alias)
+            {
+                Alias = alias;
+            }
+
+            public string Alias { get; }
+            public EditorType Type { get; }
+            public string Name { get; }
+            public string Icon { get; }
+            public string Group { get; }
+            public bool IsDeprecated { get; }
+
+            public IDataValueEditor GetValueEditor()
+            {
+                ValueEditorCount++;
+                return Mock.Of<IDataValueEditor>();
+            }
+            public IDataValueEditor GetValueEditor(object configuration) => GetValueEditor();
+
+            public IDictionary<string, object> DefaultConfiguration { get; }
+            public IConfigurationEditor GetConfigurationEditor() => throw new System.NotImplementedException();
+
+            public IPropertyIndexValueFactory PropertyIndexValueFactory { get; }
+
+            public int ValueEditorCount;
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -603,7 +604,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
             return new PropertyValidationService(
                 propertyEditorCollection,
                 dataTypeService,
-                localizedTextService);
+                localizedTextService,
+                new ValueEditorCache());
         }
     }
 }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -45,7 +46,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Services
 
             var propEditors = new PropertyEditorCollection(new DataEditorCollection(() => new[] { dataEditor }));
 
-            validationService = new PropertyValidationService(propEditors, dataTypeService.Object, Mock.Of<ILocalizedTextService>());
+            validationService = new PropertyValidationService(propEditors, dataTypeService.Object, Mock.Of<ILocalizedTextService>(), new ValueEditorCache());
         }
 
         [Test]


### PR DESCRIPTION
This PR introduces a ValueEditorCache, this cache will be used by the `PropertyValidationService`, meaning that we no longer create a new `valueEditor` every time something needs to be validated.  This should optimize validation for all data types, but in particular for nested content and the blocklist editor, since these calls validate on their children recursively.

To ensure that the value editors are up to date I've also added a `ValueEditorCacheRefresher` which listens to `DataTypeSavedNotification` and `DataTypeDeletedNoticiation`, and clears the cache accordingly. 

### Testing

Since everything should be the same it can be kind of hard to test, but a good thing to test is to try and create a document type with some custom data types like blocklist and nested content, create a content node, and then try and update the custom data types and ensure that the validation gets updated as well. A handy tip is to place a breakpoint in `ValueEditorCache.GetValueEditor` and verify whether a new value editor gets created or not.