### PR TITLE
Do not use the guid when calling the breadcrumbs to get ancestors on …

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.edit.controller.js
@@ -256,7 +256,7 @@ function mediaEditController($scope, $routeParams, $location, $http, $q, appStat
 
                 if ($scope.content.parentId && $scope.content.parentId !== -1 && $scope.content.parentId !== -21) {
                     //We fetch all ancestors of the node to generate the footer breadcrump navigation
-                    entityResource.getAncestors(nodeId, "media")
+                    entityResource.getAncestors(data.id, "media")
                         .then(function (anc) {
                             $scope.ancestors = anc;
                         });


### PR DESCRIPTION
…media items for the library blade, fixes #10950

This fixes https://github.com/umbraco/Umbraco-CMS/issues/10950

1. Create content type with media picker property
2. Select media item
3. Go back to item, item title to open slide out view
4. Press open in media library -> error occurs due to breadcrumbs error for getting ancestors due to GUID being used not ID
