### PR TITLE
V8: Fix IsPublished only working with lowercase.

### DIFF
--- a/src/Umbraco.Core/Serialization/AutoInterningStringKeyCaseInsensitiveDictionaryConverter.cs
+++ b/src/Umbraco.Core/Serialization/AutoInterningStringKeyCaseInsensitiveDictionaryConverter.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Converters;
 namespace Umbraco.Core.Serialization
 {
     /// <summary>
-    /// When applied to a dictionary with a string key, will ensure the deserialized string keys are interned 
+    /// When applied to a dictionary with a string key, will ensure the deserialized string keys are interned
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
     /// <remarks>
@@ -26,7 +26,7 @@ namespace Umbraco.Core.Serialization
         {
             if (reader.TokenType == JsonToken.StartObject)
             {
-                var dictionary = new Dictionary<string, TValue>();
+                var dictionary = Create(objectType);
                 while (reader.Read())
                 {
                     switch (reader.TokenType)

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/ContentCacheDataModel.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/ContentCacheDataModel.cs
@@ -17,11 +17,13 @@ namespace Umbraco.Web.PublishedCache.NuCache.DataSource
         [DataMember(Order = 0)]
         [JsonProperty("pd")]
         [JsonConverter(typeof(AutoInterningStringKeyCaseInsensitiveDictionaryConverter<PropertyData[]>))]
+        [MessagePackFormatter(typeof(MessagePackAutoInterningStringKeyCaseInsensitiveDictionaryFormatter<PropertyData[]>))]
         public Dictionary<string, PropertyData[]> PropertyData { get; set; }
 
         [DataMember(Order = 1)]
         [JsonProperty("cd")]
         [JsonConverter(typeof(AutoInterningStringKeyCaseInsensitiveDictionaryConverter<CultureVariation>))]
+        [MessagePackFormatter(typeof(MessagePackAutoInterningStringKeyCaseInsensitiveDictionaryFormatter<CultureVariation>))]
         public Dictionary<string, CultureVariation> CultureData { get; set; }
 
         [DataMember(Order = 2)]

--- a/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MessagePackAutoInterningStringKeyCaseInsensitiveDictionaryFormatter.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/DataSource/MessagePackAutoInterningStringKeyCaseInsensitiveDictionaryFormatter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using MessagePack;
+using MessagePack.Formatters;
+
+namespace Umbraco.Web.PublishedCache.NuCache.DataSource
+{
+    /// <summary>
+    /// A messagepack formatter (deserializer) for a string key dictionary that uses OrdinalIgnoreCase for the key string comparison
+    /// </summary>
+    /// <typeparam name="TValue"></typeparam>
+    public sealed class MessagePackAutoInterningStringKeyCaseInsensitiveDictionaryFormatter<TValue> : DictionaryFormatterBase<string, TValue, Dictionary<string, TValue>, Dictionary<string, TValue>.Enumerator, Dictionary<string, TValue>>
+    {
+        protected override void Add(Dictionary<string, TValue> collection, int index, string key, TValue value, MessagePackSerializerOptions options)
+        {
+            string.Intern(key);
+            collection.Add(key, value);
+        }
+
+        protected override Dictionary<string, TValue> Complete(Dictionary<string, TValue> intermediateCollection)
+        {
+            return intermediateCollection;
+        }
+
+
+        protected override Dictionary<string, TValue>.Enumerator GetSourceEnumerator(Dictionary<string, TValue> source)
+        {
+            return source.GetEnumerator();
+        }
+
+        protected override Dictionary<string, TValue> Create(int count, MessagePackSerializerOptions options)
+        {
+            return new Dictionary<string, TValue>(count, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}
+
+
+

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -297,6 +297,7 @@
     <Compile Include="PublishedCache\NuCache\DataSource\JsonContentNestedDataSerializer.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\JsonContentNestedDataSerializerFactory.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\LazyCompressedString.cs" />
+    <Compile Include="PublishedCache\NuCache\DataSource\MessagePackAutoInterningStringKeyCaseInsensitiveDictionaryFormatter.cs" />
     <Compile Include="PublishedCache\NuCache\DataSource\MsgPackContentNestedDataSerializer.cs" />
     <Compile Include="PropertyEditors\Validation\ComplexEditorElementTypeValidationResult.cs" />
     <Compile Include="PropertyEditors\Validation\ComplexEditorPropertyTypeValidationResult.cs" />


### PR DESCRIPTION
This fixes #10695 

Turns out the issue was not with MessagePack, but instead with the JsonConverter used when saving the item to the cache after when updating it.

This is also why it seemingly worked the first time after booting, but once you've saved and published it, it stopped working. The fix is fairly straightforward, instead of creating a new dictionary normally, we call `Create` on the parent class which creates a dictionary with `StringComparer.OrdinalIgnoreCase`, making the dictionary case insensitive. 


## Testing 

* Create a document type and make it multi-language 
* Add the following to the template (thanks to the original issue create 😄 )

```html
Published with culture: @Model.IsPublished(Culture)
<br />
Published with en-US: @Model.IsPublished("en-US")
<br />
Published with lower case en-US: @Model.IsPublished("en-us")
```

* Make sure you save & publish the content node
* Ensure that they all output true
* Add `<add key="Umbraco.Web.PublishedCache.NuCache.Serializer" value="JSON"/>` to your `web.config` and ensure that the results are still the same (remember to save & publish)
