### PR TITLE
Updates to latest Examine version

### DIFF
--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
@@ -63,7 +63,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
                 {
 
                     var rootDir = _hostingEnvironment.ApplicationPhysicalPath;
-                    d[nameof(UmbracoExamineIndex.LuceneIndexFolder)] = fsDir.Directory.ToString().ToLowerInvariant().TrimStart(rootDir.ToLowerInvariant()).Replace("\\", "/").EnsureStartsWith('/');
+                    d["LuceneIndexFolder"] = fsDir.Directory.ToString().ToLowerInvariant().TrimStart(rootDir.ToLowerInvariant()).Replace("\\", " /").EnsureStartsWith('/');
                 }
 
                 if (_indexOptions != null)

--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
             LuceneIndex index,
             ILogger<LuceneIndexDiagnostics> logger,
             IHostingEnvironment hostingEnvironment,
-            IOptionsSnapshot<LuceneDirectoryIndexOptions> indexOptions)
+            IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions)
         {
             _hostingEnvironment = hostingEnvironment;
             _indexOptions = indexOptions.Get(index.Name);

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -21,7 +21,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="2.0.0-beta.168" />
+    <PackageReference Include="Examine" Version="2.0.0-beta.169" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -21,7 +21,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="2.0.0-beta.169" />
+    <PackageReference Include="Examine" Version="2.0.0-beta.170" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -21,7 +21,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="2.0.0-beta.154" />
+    <PackageReference Include="Examine" Version="2.0.0-beta.168" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
         public UmbracoContentIndex(
             ILoggerFactory loggerFactory,
             string name,
-            IOptionsSnapshot<LuceneDirectoryIndexOptions> indexOptions,
+            IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions,
             IHostingEnvironment hostingEnvironment,
             IRuntimeState runtimeState,
             ILocalizationService languageService = null)

--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
         protected UmbracoExamineIndex(
             ILoggerFactory loggerFactory,
             string name,
-            IOptionsSnapshot<LuceneDirectoryIndexOptions> indexOptions,
+            IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions,
             IHostingEnvironment hostingEnvironment,
             IRuntimeState runtimeState)
             : base(loggerFactory, name, indexOptions)

--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndexDiagnostics.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
             UmbracoExamineIndex index,
             ILogger<UmbracoExamineIndexDiagnostics> logger,
             IHostingEnvironment hostingEnvironment,
-            IOptionsSnapshot<LuceneDirectoryIndexOptions> indexOptions)
+            IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions)
             : base(index, logger, hostingEnvironment, indexOptions)
         {
             _index = index;

--- a/src/Umbraco.Examine.Lucene/UmbracoMemberIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoMemberIndex.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
         public UmbracoMemberIndex(
             ILoggerFactory loggerFactory,
             string name,
-            IOptionsSnapshot<LuceneDirectoryIndexOptions> indexOptions,
+            IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions,
             IHostingEnvironment hostingEnvironment,
             IRuntimeState runtimeState)
             : base(loggerFactory, name, indexOptions, hostingEnvironment, runtimeState)

--- a/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
+++ b/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.154" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.168" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
+++ b/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.168" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.169" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
+++ b/src/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.169" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.170" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
@@ -241,8 +241,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
         //    return i;
         //}
 
-        public static IOptionsSnapshot<LuceneDirectoryIndexOptions> GetOptions(string indexName, LuceneDirectoryIndexOptions options)
-            => Mock.Of<IOptionsSnapshot<LuceneDirectoryIndexOptions>>(x => x.Get(indexName) == options);
+        public static IOptionsMonitor<LuceneDirectoryIndexOptions> GetOptions(string indexName, LuceneDirectoryIndexOptions options)
+            => Mock.Of<IOptionsMonitor<LuceneDirectoryIndexOptions>>(x => x.Get(indexName) == options);
 
         internal void IndexingError(object sender, IndexingErrorEventArgs e) => throw new ApplicationException(e.Message, e.Exception);
 

--- a/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.169" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.170" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.154" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.168" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/src/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.168" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.0-beta.169" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -35,8 +35,8 @@
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
       <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.3" />
-      <PackageReference Include="Smidge.Nuglify" Version="4.0.0-beta.352" />
-      <PackageReference Include="Smidge.InMemory" Version="4.0.0-beta.352" />
+      <PackageReference Include="Smidge.Nuglify" Version="4.0.0-beta.370" />
+      <PackageReference Include="Smidge.InMemory" Version="4.0.0-beta.370" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
       <PackageReference Include="Umbraco.Code" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -35,8 +35,8 @@
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
       <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.3" />
-      <PackageReference Include="Smidge.Nuglify" Version="4.0.0-beta.370" />
-      <PackageReference Include="Smidge.InMemory" Version="4.0.0-beta.370" />
+      <PackageReference Include="Smidge.Nuglify" Version="4.0.0-beta.376" />
+      <PackageReference Include="Smidge.InMemory" Version="4.0.0-beta.376" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
       <PackageReference Include="Umbraco.Code" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
The latest Examine version has some API breaking changes - namely it shouldn't have been relying on IOptionsSnapshot and instead IOptionsMonitor.
