### PR TITLE
Falling back to contentTypeName when Block List label is empty

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -103,7 +103,7 @@
          */
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
-                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
+                var labelVars = Object.assign({"$contentTypeName": blockObject.content.contentTypeName, "$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
                 var label = blockObject.labelInterpolator(labelVars);
                 if (label) {
                     return label;

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -97,7 +97,6 @@
             }
         }
 
-
         /**
          * Generate label for Block, uses either the labelInterpolator or falls back to the contentTypeName.
          * @param {Object} blockObject BlockObject to recive data values from.
@@ -105,11 +104,13 @@
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
                 var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
-                return blockObject.labelInterpolator(labelVars);
+                var label = blockObject.labelInterpolator(labelVars);
+                if (label) {
+                    return label;
+                }
             }
             return blockObject.content.contentTypeName;
         }
-
 
         /**
          * Used to add watchers on all properties in a content or settings model


### PR DESCRIPTION
I'm a big fan of the Block List Editor! And especially love how powerful the label templating feature is, allowing us to give our editors more context. Where a block content has a title / heading property we usually opt for this as our label.

However, sometimes properties are optional... and therefore the label can be empty...

The way to combat this is to have a condition in the label template `{{title || 'My Block Name'}}` but this means hardcoding content type names...

This PR adds a null check around the result of the label interpolator, and if there is no output falls back to the default value: the block list content type name.

There are some cases where hardcoding the content type names is necessary, such as `Block name: {{title}}`. This PR also introduces a variable to easily access the name in label templates: `$contentTypeName`