### PR TITLE
Show listview children when opening media entry editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.controller.js
@@ -10,6 +10,16 @@ angular.module("umbraco")
             vm.mediaEntry = vm.model.mediaEntry;
             vm.currentCrop = null;
 
+            vm.focalPointChanged = focalPointChanged;
+            vm.onImageLoaded = onImageLoaded;
+            vm.openMedia = openMedia;
+            vm.repickMedia = repickMedia;
+            vm.selectCrop = selectCrop;
+            vm.deselectCrop = deselectCrop;
+            vm.resetCrop = resetCrop;
+            vm.submitAndClose = submitAndClose;
+            vm.close = close;
+
             localizationService.localizeMany([
                 vm.model.createFlow ? "general_cancel" : "general_close",
                 vm.model.createFlow ? "general_create" : "buttons_submitChanges"
@@ -59,14 +69,11 @@ angular.module("umbraco")
                 });
             }
 
-            vm.onImageLoaded = onImageLoaded;
             function onImageLoaded(isCroppable, hasDimensions) {
                 vm.isCroppable = isCroppable;
                 vm.hasDimensions = hasDimensions;
-            };
+            }
 
-
-            vm.repickMedia = repickMedia;
             function repickMedia() {
                 vm.model.propertyEditor.changeMediaFor(vm.model.mediaEntry, onMediaReplaced);
             }
@@ -83,7 +90,6 @@ angular.module("umbraco")
                 updateMedia();
             }
 
-            vm.openMedia = openMedia;
             function openMedia() {
 
                 var mediaEditor = {
@@ -95,11 +101,11 @@ angular.module("umbraco")
                         editorService.close();
                     }
                 };
+
                 editorService.mediaEditor(mediaEditor);
             }
 
-
-            vm.focalPointChanged = function(left, top) {
+            function focalPointChanged(left, top) {
                 //update the model focalpoint value
                 vm.mediaEntry.focalPoint = {
                     left: left,
@@ -110,21 +116,16 @@ angular.module("umbraco")
                 setDirty();
             }
 
-
-
-            vm.selectCrop = selectCrop;
             function selectCrop(targetCrop) {
                 vm.currentCrop = targetCrop;
                 setDirty();
                 // TODO: start watchin values of crop, first when changed set to dirty.
-            };
+            }
 
-            vm.deselectCrop = deselectCrop;
             function deselectCrop() {
                 vm.currentCrop = null;
-            };
+            }
 
-            vm.resetCrop = resetCrop;
             function resetCrop() {
                 if (vm.currentCrop) {
                     $scope.$evalAsync( () => {
@@ -138,14 +139,13 @@ angular.module("umbraco")
                 vm.imageCropperForm.$setDirty();
             }
 
-
-            vm.submitAndClose = function () {
+            function submitAndClose() {
                 if (vm.model && vm.model.submit) {
                     vm.model.submit(vm.model);
                 }
             }
 
-            vm.close = function () {
+            function close() {
                 if (vm.model && vm.model.close) {
                     if (vm.model.createFlow === true || vm.imageCropperForm.$dirty === true) {
                         var labels = vm.model.createFlow === true ? ["mediaPicker_confirmCancelMediaEntryCreationHeadline", "mediaPicker_confirmCancelMediaEntryCreationMessage"] : ["prompt_discardChanges", "mediaPicker_confirmCancelMediaEntryHasChanges"];
@@ -175,9 +175,9 @@ angular.module("umbraco")
             }
 
             init();
+
             $scope.$on("$destroy", function () {
                 unsubscribe.forEach(x => x());
             });
-
         }
     );

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -713,7 +713,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
         }
 
         // Get current id for node to load it's children
-        $scope.contentId = editorState.current.id ? editorState.current.id : id;
+        $scope.contentId = editorState.current ? editorState.current.id : id;
         $scope.isTrashed = editorState.current ? editorState.current.trashed : id === "-20" || id === "-21";
 
         $scope.options.allowBulkPublish = $scope.options.allowBulkPublish && !$scope.isTrashed;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -67,7 +67,6 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     $scope.createAllowedButtonSingleWithBlueprints = false;
     $scope.createAllowedButtonMultiWithBlueprints = false;
 
-
     //when this is null, we don't check permissions
     $scope.currentNodePermissions = null;
 
@@ -146,6 +145,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     var listParamsForCurrent = $routeParams.id == $routeParams.list;
+
     $scope.options = {
         useInfiniteEditor: $scope.model.config.useInfiniteEditor === true,
         pageSize: $scope.model.config.pageSize ? $scope.model.config.pageSize : 10,
@@ -598,13 +598,13 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                         forceReload: true,
                         activate: false
                     })
-                        .then(function (args) {
-                            //get the currently edited node (if any)
-                            var activeNode = appState.getTreeState("selectedNode");
-                            if (activeNode) {
-                                navigationService.reloadNode(activeNode);
-                            }
-                        });
+                    .then(function (args) {
+                        //get the currently edited node (if any)
+                        var activeNode = appState.getTreeState("selectedNode");
+                        if (activeNode) {
+                            navigationService.reloadNode(activeNode);
+                        }
+                    });
                 }
             });
     }
@@ -712,7 +712,8 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             return;
         }
 
-        $scope.contentId = id;
+        // Get current id for node to load it's children
+        $scope.contentId = editorState.current.id ? editorState.current.id : id;
         $scope.isTrashed = editorState.current ? editorState.current.trashed : id === "-20" || id === "-21";
 
         $scope.options.allowBulkPublish = $scope.options.allowBulkPublish && !$scope.isTrashed;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10943

### Description
When opening media from media entry editor via the new media picker 3, it didn't show the children in the listview, because it used id from `$routeParams` which in this case was the current content node it and not the media node id the load it children from in listview.

Unlike other places in code we here don't have access to `infiniteMode` property directly from `$scope.model`, e.g.

```
var infiniteMode = $scope.model && $scope.model.infiniteMode;
$scope.contentId = infiniteMode ? $scope.model.id : id;
```

It seems we can get the id from `editorState.current` though.

![wtgFL5ipLX](https://user-images.githubusercontent.com/2919859/131092706-e66cc8ec-b362-44a6-a109-e378c47d1785.gif)

