### PR TITLE
Check if umbFileDropzone has queued items before showing ChooseMediaTypeDialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -187,6 +187,11 @@ angular.module("umbraco.directives")
 
                     function _requestChooseMediaTypeDialog() {
 
+                        if (scope.queue.length === 0) {
+                            // if queue has no items so there is nothing to choose a type for
+                            return false;
+                        }
+                        
                         if (scope.acceptedMediatypes.length === 1) {
                             // if only one accepted type, then we wont ask to choose.
                             return false;


### PR DESCRIPTION
The ChooseMediaTypeDialog is shown even if there are no queue items, for example due file errors. 
Checking the queue lenght in _requestChooseMediaTypeDialog prevents showing the dialog unnecessary.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

When a user uploads an file that exceeds the maxFileSize an error is shown but also the ChooseMediaTypeDialog.
Checking the queue length before showing prevents this.

To test: upload an file to media via the dropzone that exceeds the maxFileSize.
