### PR TITLE
Fix self-closing tags which should have a end-closing tag

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -153,7 +153,7 @@
                         </div>
                         <div class="umb-control-group clearfix -no-border" ng-if="model.contentType === 'documentType' && model.contentTypeAllowCultureVariant">
 
-                            <h5><localize key="contentTypeEditor_cultureVariantHeading" /></h5>
+                            <h5><localize key="contentTypeEditor_cultureVariantHeading"></localize></h5>
                             <umb-toggle data-element="permissions-allow-culture-variant"
                                         checked="model.property.allowCultureVariant"
                                         on-click="vm.toggleAllowCultureVariants()">
@@ -162,7 +162,7 @@
                         </div>
                         <div class="umb-control-group clearfix" ng-if="model.contentType === 'documentType' && model.contentTypeAllowSegmentVariant">
 
-                            <h5><localize key="contentTypeEditor_segmentVariantHeading" /></h5>
+                            <h5><localize key="contentTypeEditor_segmentVariantHeading"></localize></h5>
 
                             <umb-toggle data-element="permissions-allow-segment-variant"
                                         checked="model.property.allowSegmentVariant"

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -1,11 +1,11 @@
 <div ng-controller="Umbraco.Overlays.UserController">
     <div class="umb-control-group" ng-if="!showPasswordFields">
 
-       <h5><localize key="user_yourProfile" /></h5>
+       <h5><localize key="user_yourProfile"></localize></h5>
 
        <!--<p class="muted">
            <small>
-               <localize key="user_sessionExpires" />: {{remainingAuthSeconds | timespan}}
+               <localize key="user_sessionExpires"></localize>: {{remainingAuthSeconds | timespan}}
            </small>
        </p>-->
 
@@ -81,7 +81,7 @@
 
 
     <div class="umb-control-group" ng-if="!showPasswordFields && history.length">
-        <h5><localize key="user_yourHistory" /></h5>
+        <h5><localize key="user_yourHistory"></localize></h5>
         <ul class="umb-tree">
             <li ng-repeat="item in history | orderBy:'time':true">
                 <a ng-href="{{item.link}}" ng-click="gotoHistory(item.link)" prevent-default>

--- a/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
@@ -39,7 +39,7 @@
                                     <localize key="assignDomain_language"></localize>
                                     <span class="umb-control-required">*</span>
                                 </th>
-                                <th />
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -9,27 +9,27 @@
             <h5 ng-show="selectBlueprint"><localize key="blueprints_selectBlueprint">Select a blueprint</localize></h5>
 
             <div ng-if="allowedTypes && allowedTypes.length === 0">
-                <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noDocumentTypesWithNoSettingsAccess" /></p>
+                <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noDocumentTypesWithNoSettingsAccess"></localize></p>
                 <div ng-if="hasSettingsAccess && currentNode.id >= 0">
                     <p class="abstract">
-                        <localize key="create_noDocumentTypes" />
+                        <localize key="create_noDocumentTypes"></localize>
                     </p>
                     <button type="button" class="btn umb-outline" ng-click="editContentType()">
-                        <localize key="create_noDocumentTypesEditPermissions" />
+                        <localize key="create_noDocumentTypesEditPermissions"></localize>
                     </button>
                 </div>
                 <div ng-if="hasSettingsAccess && currentNode.id < 0">
                     <!-- There are existing document types, but none are allowed at root -->
                     <p class="abstract" ng-if="countTypes > 0">
-                        <localize key="create_noDocumentTypesAllowedAtRoot" />
+                        <localize key="create_noDocumentTypesAllowedAtRoot"></localize>
                     </p>
 
                     <!-- There's no document types, help people create one -->
                     <p class="abstract" ng-if="countTypes === 0">
-                        <localize key="create_noDocumentTypesAtRoot" />
+                        <localize key="create_noDocumentTypesAtRoot"></localize>
                     </p>
                     <button type="button" class="btn umb-outline" ng-click="createContentType()" ng-if="countTypes === 0">
-                        <localize key="create_noDocumentTypesCreateNew" />
+                        <localize key="create_noDocumentTypesCreateNew"></localize>
                     </button>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/createblueprint.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/createblueprint.html
@@ -19,7 +19,7 @@
                            val-server-field="name"
                            required />
                     <span ng-messages="blueprintForm.name.$error" show-validation-on-submit >
-                        <span class="help-inline" ng-message="required"><localize key="required" /></span>
+                        <span class="help-inline" ng-message="required"><localize key="required">Required</localize></span>
                         <span class="help-inline" ng-message="valServerField">{{blueprintForm.name.errorMsg}}</span>
                     </span>           
                 </umb-control-group>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/listview/listview.html
@@ -2,8 +2,8 @@
     <umb-box-content>
         <div class="sub-view-columns">
             <div class="sub-view-column-left">
-                <h5><localize key="contentTypeEditor_enableListViewHeading" /></h5>
-                <small><localize key="contentTypeEditor_enableListViewDescription" /></small>
+                <h5><localize key="contentTypeEditor_enableListViewHeading"></localize></h5>
+                <small><localize key="contentTypeEditor_enableListViewDescription"></localize></small>
             </div>
             <div class="sub-view-column-right">
                 <umb-list-view-settings 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -6,8 +6,8 @@
             <div class="sub-view-columns" ng-hide="model.isElement">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_allowAsRootHeading" /></h5>
-                    <small><localize key="contentTypeEditor_allowAsRootDescription" /></small>
+                    <h5><localize key="contentTypeEditor_allowAsRootHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_allowAsRootDescription"></localize></small>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-toggle data-element="permissions-allow-as-root"
@@ -22,8 +22,8 @@
             <div class="sub-view-columns" ng-hide="model.isElement">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_childNodesHeading" /></h5>
-                    <small><localize key="contentTypeEditor_childNodesDescription" /></small>
+                    <h5><localize key="contentTypeEditor_childNodesHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_childNodesDescription"></localize></small>
                 </div>
 
                 <div class="sub-view-column-right">
@@ -43,8 +43,8 @@
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_cultureVariantHeading" /></h5>
-                    <small><localize key="contentTypeEditor_cultureVariantDescription" /></small>
+                    <h5><localize key="contentTypeEditor_cultureVariantHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_cultureVariantDescription"></localize></small>
                 </div>
 
                 <div class="sub-view-column-right">
@@ -61,8 +61,8 @@
             <div class="sub-view-columns" ng-if="vm.showAllowSegmentationOption">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_segmentVariantHeading" /></h5>
-                    <small><localize key="contentTypeEditor_segmentVariantDescription" /></small>
+                    <h5><localize key="contentTypeEditor_segmentVariantHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_segmentVariantDescription"></localize></small>
                 </div>
 
                 <div class="sub-view-column-right">
@@ -77,9 +77,9 @@
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_elementHeading" /></h5>
-                    <small><localize key="contentTypeEditor_elementDescription" /></small>
-                    <small ng-if="!vm.canToggleIsElement"><br/><localize key="contentTypeEditor_elementCannotToggle" /></small>
+                    <h5><localize key="contentTypeEditor_elementHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_elementDescription"></localize></small>
+                    <small ng-if="!vm.canToggleIsElement"><br/><localize key="contentTypeEditor_elementCannotToggle"></localize></small>
                 </div>
 
                 <div class="sub-view-column-right">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -4,8 +4,8 @@
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_allowedTemplatesHeading" /></h5>
-                    <small><localize key="contentTypeEditor_allowedTemplatesDescription" /></small>
+                    <h5><localize key="contentTypeEditor_allowedTemplatesHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_allowedTemplatesDescription"></localize></small>
                 </div>
                 
                 <div class="sub-view-column-right">

--- a/src/Umbraco.Web.UI.Client/src/views/media/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/create.html
@@ -5,11 +5,11 @@
 			<h5><localize key="create_createUnder">Create under</localize> {{currentNode.name}}</h5>
 
             <div ng-if="allowedTypes && allowedTypes.length === 0">
-                <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noMediaTypesWithNoSettingsAccess" /></p>
+                <p class="abstract" ng-if="!hasSettingsAccess"><localize key="create_noMediaTypesWithNoSettingsAccess"></localize></p>
                 <div ng-if="hasSettingsAccess">
-                    <p class="abstract"><localize key="create_noMediaTypes" /></p>
-                    <a class="btn" href="#settings/mediaTypes/edit/{{mediaTypeId}}?view=permissions" ng-click="close()">
-                        <localize key="create_noMediaTypesEditPermissions" />
+                    <p class="abstract"><localize key="create_noMediaTypes"></localize></p>
+                    <a class="btn" href="#settings/mediaTypes/edit/{{mediaTypeId}}?view=permissions" role="button" ng-click="close()">
+                        <localize key="create_noMediaTypesEditPermissions"></localize>
                     </a>
                 </div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/listview/listview.html
@@ -2,8 +2,8 @@
     <umb-box-content>
         <div class="sub-view-columns">
             <div class="sub-view-column-left">
-                <h5><localize key="contentTypeEditor_enableListViewHeading" /></h5>
-                <small><localize key="contentTypeEditor_enableListViewDescription" /></small>
+                <h5><localize key="contentTypeEditor_enableListViewHeading"></localize></h5>
+                <small><localize key="contentTypeEditor_enableListViewDescription"></localize></small>
             </div>
             <div class="sub-view-column-right">
                 <umb-list-view-settings 

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
@@ -3,8 +3,8 @@
         <umb-box-content>
             <div class="sub-view-columns">
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_allowAsRootHeading" /></h5>
-                    <small><localize key="contentTypeEditor_allowAsRootDescription" /></small>
+                    <h5><localize key="contentTypeEditor_allowAsRootHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_allowAsRootDescription"></localize></small>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-toggle
@@ -16,8 +16,8 @@
             </div>
             <div class="sub-view-columns">
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_childNodesHeading" /></h5>
-                    <small><localize key="contentTypeEditor_childNodesDescription" /></small>
+                    <h5><localize key="contentTypeEditor_childNodesHeading"></localize></h5>
+                    <small><localize key="contentTypeEditor_childNodesDescription"></localize></small>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-child-selector

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -18,7 +18,7 @@
 
                     <div class="umb-form-settings form-horizontal">
 
-                        <p><localize key="grid_addRowConfigurationDetail" /></p>
+                        <p><localize key="grid_addRowConfigurationDetail"></localize></p>
 
                         <div class="alert alert-warn ng-scope" ng-show="nameChanged">
                             <p>Modifying a row configuration name will result in loss of


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I searched view files and found these references where mostly `<localize>` directive was self-closed, but since it is a custom HTML element it isn't a valid void-element and thus it should have a end-closing tag.