### PR TITLE
Get ancestors by Guid and Udi

### DIFF
--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -72,12 +72,12 @@ namespace Umbraco.Web.Editors
 
                     //This is a special case, we'll accept a String here so that we can get page members when the special "all-members"
                     //id is passed in eventually we'll probably want to support GUID + Udi too
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetAncestors", "id", typeof(int), typeof(Guid), typeof(Udi)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetPagedChildren", "id", typeof(int), typeof(string)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetPath", "id", typeof(int), typeof(Guid), typeof(Udi)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetUrlAndAnchors", "id", typeof(int), typeof(Guid), typeof(Udi)),
                     new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetById", "id", typeof(int), typeof(Guid), typeof(Udi)),
-                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetByIds", "ids", typeof(int[]), typeof(Guid[]), typeof(Udi[])),
-                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetAncestors", "id", typeof(int[]), typeof(Guid[]), typeof(Udi[]))
+                    new ParameterSwapControllerActionSelector.ParameterSwapInfo("GetByIds", "ids", typeof(int[]), typeof(Guid[]), typeof(Udi[]))
                 ));
             }
         }

--- a/src/Umbraco.Web/WebApi/ParameterSwapControllerActionSelector.cs
+++ b/src/Umbraco.Web/WebApi/ParameterSwapControllerActionSelector.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Web.WebApi
         {
             var requestParam = HttpUtility.ParseQueryString(controllerContext.Request.RequestUri.Query).Get(found.ParamName);
 
-            requestParam = (requestParam == null) ? null : requestParam.Trim();
+            requestParam = requestParam?.Trim();
             var paramTypes = found.SupportedTypes;
 
             if (requestParam == string.Empty && paramTypes.Length > 0)

--- a/src/Umbraco.Web/WebApi/ParameterSwapControllerActionSelector.cs
+++ b/src/Umbraco.Web/WebApi/ParameterSwapControllerActionSelector.cs
@@ -90,9 +90,8 @@ namespace Umbraco.Web.WebApi
 
         private bool TryBindFromUri(HttpControllerContext controllerContext, ParameterSwapInfo found, out HttpActionDescriptor method)
         {
-            var requestParam = HttpUtility.ParseQueryString(controllerContext.Request.RequestUri.Query).Get(found.ParamName);
+            var requestParam = HttpUtility.ParseQueryString(controllerContext.Request.RequestUri.Query).Get(found.ParamName)?.Trim();
 
-            requestParam = requestParam?.Trim();
             var paramTypes = found.SupportedTypes;
 
             if (requestParam == string.Empty && paramTypes.Length > 0)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR is related to https://github.com/umbraco/Umbraco-CMS/pull/10958 and an alternative fix for https://github.com/umbraco/Umbraco-CMS/issues/10950 which support Guid and Udi as well.

E.g find a media node preferable at level 2 or deeper, copy id and guid and use these in a controller like a dashboard controller in content section.

```
entityResource.getAncestors("1134", "media")
    .then(function (anc) {
        console.log("getAncestors (id)", anc);
    });

entityResource.getAncestors("1bc5280b-8658-4027-89d9-58e2576e469b", "media")
    .then(function (anc) {
        console.log("getAncestors (guid)", anc);
    });

entityResource.getAncestors("umb://1bc5280b-8658-4027-89d9-58e2576e469b", "media")
    .then(function (anc) {
        console.log("getAncestors (udi)", anc);
    });
```

The requests except the `int` id will fail.

<img width="960" alt="chrome_o1RaN8H4di" src="https://user-images.githubusercontent.com/2919859/131247699-beb0bcd8-5431-49dd-98cf-e3dea2b49029.png">

However with the changes in this PR we get the error, because of the second parameter `type`:

![image](https://user-images.githubusercontent.com/2919859/131247748-b9e798ea-336c-4860-90b3-6aa0e3e74f2c.png)

Not sure if there a way to fix this? Alternative the other methods could by renamed, e.g. `GetAncestorsByGuid()`, `GetAncestorsByUdi()` and maybe `GetAncestorsById()` and obsolete the current `GetAncestors()` method.

We could probably also refactor the `GetResultForAncestors()` overload method a bit, so the shared logic is moved to a separate method.