### PR TITLE
Grid: Add button styling fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -565,12 +565,11 @@
 // ICONS
 // -------------------------
 .umb-grid .iconBox {
-    padding: 4px 6px;
-    display: inline-block;
-    cursor: pointer;
+    padding: 6px;
+    display: flex;
     border-radius: 200px;
     border: 1px solid @ui-action-discreet-border;
-    margin: 2px;
+    margin: 0 auto;
 
     &:hover, &:hover * {
         background: @ui-action-discreet-type-hover !important;
@@ -599,19 +598,11 @@
     -webkit-appearance: none;
     background-image: linear-gradient(to bottom,@gray-9,@gray-7);
     background-repeat: repeat-x;
-    zoom: 1;
     border-color: @gray-7 @gray-7 @gray-6;
     border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);
     box-shadow: inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);
     border-radius: 3px;
     background: transparent;
-}
-
-.umb-grid .iconBox i {
-    color: @gray-3;
-    display: block;
-    font-size: 16px;
-    line-height: inherit;
 }
 
 .umb-grid .help-text {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -604,6 +604,13 @@
     background: transparent;
 }
 
+.umb-grid .iconBox i {
+    color: @gray-3;
+    display: block;
+    font-size: 16px;
+    line-height: inherit;
+}
+
 .umb-grid .help-text {
     color: @black;
     font-size: 14px;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -598,7 +598,6 @@
     -webkit-appearance: none;
     background-image: linear-gradient(to bottom,@gray-9,@gray-7);
     background-repeat: repeat-x;
-    border-color: @gray-7 @gray-7 @gray-6;
     border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);
     box-shadow: inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);
     border-radius: 3px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With the current release of version 8.16 I noticed the "Add button" in the grid was no longer a perfect square after the icon was converted to using the `<umb-icon>` directive. That's addressed with a few tweaks to the `.iconBox` class in this PR.

Furthermore some unused classes and uneeded CSS properties have been removed 😃 

**Before**
![plus-button-before](https://user-images.githubusercontent.com/1932158/131305392-512adbcd-33c8-416e-9ea1-13f7a4769660.png)

**After**
![plus-button-after](https://user-images.githubusercontent.com/1932158/131305409-0b71dfda-e7b5-46e1-9bf7-ffdeebff0c71.png)
