### PR TITLE
Umbraco v9 devcontainer: Generate a local certificate for Kestrel https

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,3 +43,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # https://docs.npmjs.com/cli/v6/using-npm/config#unsafe-perm
 # Default: false if running as root, true otherwise (we are ROOT)
 RUN npm -g config set user vscode && npm -g config set unsafe-perm
+
+# Generate and trust a local developer certificate for Kestrel
+# This is needed for Kestrel to bind on https
+RUN dotnet dev-certs https --trust


### PR DESCRIPTION
Fixes #10981

### Description

This adds and trusts a local developer certificate inside the devcontainer, which Kestrel needs to bind for https.

This fix is based on the log message you get when trying to build a fresh container:

```
Unable to start Kestrel.
System.InvalidOperationException: Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.
To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
```