### PR TITLE
Suggestion: Make the overlay size width in multiurlpicker configurable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -83,6 +83,7 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
             dataTypeKey: $scope.model.dataTypeKey,
             ignoreUserStartNodes : ($scope.model.config && $scope.model.config.ignoreUserStartNodes) ? $scope.model.config.ignoreUserStartNodes : "0",
             hideAnchor: $scope.model.config && $scope.model.config.hideAnchor ? true : false,
+            size: $scope.model.config.overlayWidthSize,
             submit: function (model) {
                 if (model.target.url || model.target.anchor) {
                     // if an anchor exists, check that it is appropriately prefixed

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.controller.js
@@ -1,0 +1,6 @@
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiUrlPickerController",
+    function ($scope) {
+        if (!$scope.model.value) {
+            $scope.model.value = "small";
+        }
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.html
@@ -1,0 +1,9 @@
+﻿<div ng-controller="Umbraco.PrevalueEditors.MultiUrlPickerController">
+    <div class="vertical-align-items">
+        <select ng-model="model.value">
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+        </select>
+    </div>
+</div>

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerConfiguration.cs
@@ -11,6 +11,9 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("maxNumber", "Maximum number of items", "number")]
         public int MaxNumber { get; set; }
 
+        [ConfigurationField("overlayWidthSize", "Overlay Width Size", "views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.html")]
+        public string OverlayWidthSize { get; set; }
+
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,
             "Ignore User Start Nodes", "boolean",
             Description = "Selecting this option allows a user to choose nodes that they normally don't have access to.")]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR is a suggestion to add a configuration option for the size of the overlay width when using the multiurlpicker - Currently it's always displayed using the small width overlay. Recently I have found it a wee bit frustrating to work with since it can be hard to actually see the full url in the link input field and then it hit me - With the block list editor we can define whether the size should be "Small", "Medium" or "Large" and I figured why not do the same for the multiurlpicker property editor as well? So therefore I made this PR enabling us to define the desired size - What do you think about the idea?

If one does not change the configuration the size defaults to "small".

Below you can see a GIF illustrating how it all works 👍🏻 

![overlaysize-mup](https://user-images.githubusercontent.com/1932158/131467384-c5a57205-4f71-4b09-998c-f70dc72f7141.gif)
