### PR TITLE
Block List Editor - update settingsData with correct contentTypeKey when settings model is changed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -606,6 +606,12 @@
                             return null;
                         }
 
+                        // the Settings model has been changed to a new Element Type.
+                        // we need to update the settingsData with the new Content Type key
+                        if (settingsData.contentTypeKey !== settingsScaffold.contentTypeKey) {
+                            settingsData.contentTypeKey = settingsScaffold.contentTypeKey;
+                        }
+
                         blockObject.settingsData = settingsData;
 
                         // make basics from scaffold


### PR DESCRIPTION
This PR updates the settingsData to contain the correct contentTypeKey for a settingsModel if it has been changed after a value has been saved.

How to test:
See testing details on the issue: https://github.com/umbraco/Umbraco-CMS/issues/10373#issuecomment-906490036

fixes #10373 