### PR TITLE
Automatically create emtpy SQL CE database with unattended install

### DIFF
--- a/src/Umbraco.Core/Persistence/IUmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/IUmbracoDatabaseFactory.cs
@@ -36,6 +36,12 @@ namespace Umbraco.Core.Persistence
         string ConnectionString { get; }
 
         /// <summary>
+        /// Gets the provider name.
+        /// </summary>
+        /// <remarks>May return <c>null</c> if the database factory is not configured.</remarks>
+        string ProviderName { get; }
+
+        /// <summary>
         /// Gets a value indicating whether the database factory is configured (see <see cref="Configured"/>),
         /// and it is possible to connect to the database. The factory may however not be initialized (see
         /// <see cref="Initialized"/>).

--- a/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabaseFactory.cs
@@ -125,6 +125,9 @@ namespace Umbraco.Core.Persistence
         public string ConnectionString => _connectionString;
 
         /// <inheritdoc />
+        public string ProviderName => _providerName;
+
+        /// <inheritdoc />
         public bool CanConnect =>
             // actually tries to connect to the database (regardless of configured/initialized)
             !_connectionString.IsNullOrWhiteSpace() && !_providerName.IsNullOrWhiteSpace() &&

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -367,9 +367,8 @@ namespace Umbraco.Core.Runtime
                 var dataSource = new SqlCeConnectionStringBuilder(databaseFactory.ConnectionString).DataSource;
                 var dbFilePath = dataSource.Replace("|DataDirectory|", AppDomain.CurrentDomain.GetData("DataDirectory").ToString());
 
-                if(!File.Exists(dbFilePath))
+                if(File.Exists(dbFilePath) == false)
                 {
-
                     var engine = new SqlCeEngine(databaseFactory.ConnectionString);
                     engine.CreateDatabase();
                 }

--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -170,7 +170,7 @@ namespace Umbraco.Core.Runtime
                 // run handlers
                 RuntimeOptions.DoRuntimeEssentials(composition, appCaches, typeLoader, databaseFactory);
 
-                
+
 
                 // register runtime-level services
                 // there should be none, really - this is here "just in case"
@@ -180,7 +180,7 @@ namespace Umbraco.Core.Runtime
                 AcquireMainDom(MainDom);
 
                 // determine our runtime level
-                //DetermineRuntimeLevel(databaseFactory, ProfilingLogger);
+                DetermineRuntimeLevel(databaseFactory, ProfilingLogger);
 
                 // get composers, and compose
                 var composerTypes = ResolveComposerTypes(typeLoader);
@@ -274,7 +274,7 @@ namespace Umbraco.Core.Runtime
                 || unattendedEmail.IsNullOrWhiteSpace()
                 || unattendedPassword.IsNullOrWhiteSpace())
             {
-                
+
                 fileExists = File.Exists(filePath);
                 if (fileExists == false)
                 {
@@ -340,7 +340,7 @@ namespace Umbraco.Core.Runtime
 
             Current.Services.UserService.Save(admin);
 
-            // Delete JSON file if it existed to tidy 
+            // Delete JSON file if it existed to tidy
             if (fileExists)
             {
                 File.Delete(filePath);
@@ -375,8 +375,6 @@ namespace Umbraco.Core.Runtime
                 }
             }
 
-            DetermineRuntimeLevel(databaseFactory, ProfilingLogger);
-
             var tries = 5;
             var connect = false;
             for (var i = 0;;)
@@ -399,7 +397,7 @@ namespace Umbraco.Core.Runtime
 
                 // all conditions fulfilled, do the install
                 Logger.Info<CoreRuntime>("Starting unattended install.");
-                
+
                 try
                 {
                     database.BeginTransaction();


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

1. Set a connectionString to a non-existing SQL CE database
2. Enable unattended install
3. See that the  empty SQL CE database is created before unattended install will create the schema

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

When using unattended install an empty database must be manually created before you start up the application. 

This PR will automatically create an empty SQL CE database on the location configured in the connectionString if the provider name is "System.Data.SqlServerCe.4.0" before the unattended install tries to create the schema.


<!-- Thanks for contributing to Umbraco CMS! -->
