### PR TITLE
Option to delete unattended.user.json fil after unattended install

### DIFF
--- a/src/Umbraco.Core/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Core/Runtime/CoreRuntime.cs
@@ -343,7 +343,7 @@ namespace Umbraco.Core.Runtime
             Current.Services.UserService.Save(admin);
 
             // Delete JSON file if it existed to tidy 
-            if (fileExists)
+            if (fileExists && RuntimeOptions.DeleteUnattendedUserFile)
             {
                 File.Delete(filePath);
             }

--- a/src/Umbraco.Core/RuntimeOptions.cs
+++ b/src/Umbraco.Core/RuntimeOptions.cs
@@ -68,6 +68,15 @@ namespace Umbraco.Core
         }
 
         /// <summary>
+        /// Gets a value indicating whether the <c>unattended.user.json</c> file should be deleted after unattended install.
+        /// </summary>
+        public static bool DeleteUnattendedUserFile
+        {
+            get => _upgradeUnattended ?? BoolSetting("Umbraco.Core.RuntimeState.DeleteUnattendedUserFile", true);
+            set => _upgradeUnattended = value;
+        }
+
+        /// <summary>
         /// Gets a value indicating whether unattended upgrade is enabled.
         /// </summary>
         public static bool UpgradeUnattended


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

1. Enable unattended install
2. add the following appSetting in web.config `<add key="Umbraco.Core.RuntimeState.DeleteUnattendedUserFile" value="false"/>`
3. See that the unattended.user.json user file is not deleted

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

We use unattended install to quickly setup local environments when developers should start working on other projects. 

For that we use the new feature to automatically create a user, but in our local environment we don't want the unattended.user.json file to be deleted every we setup the solution, we only want the unattended.user.json file to be deleted on our test, preproduction and production environments.

This PR add a new option to indicate if the unattended.user.json file should be deleted or not during the unattended install. The default value is true

<!-- Thanks for contributing to Umbraco CMS! -->
