### PR TITLE
V9: Fix grid editor config values in package manifest

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -281,6 +281,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         }
 
         [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
+        [AngularJsonOnlyConfiguration]
         [HttpGet]
         public IEnumerable<IGridEditorConfig> GetGridConfig()
         {


### PR DESCRIPTION
This fixes #10644.

The problem here has to do with the way `System.Text.Json` serializes `Dictionary<string, object>`, to fix this my goal was to instead use Newtonsoft to serialize the grid editor values. 

After looking around for a while I think that using a `IResultFilter` is the best approach to achieve this. However I did notice an additional thing when looking into this, the response from `GetGridConfig` does not contain the angular protection bit `)]}',`, that all other calls like `GetById` has. This seems like a mistake to me since this should be a resource for angular and there should have it.

In this PR I'm currently just applying the `AngularJsonOnlyConfiguration` to the `GetGridConfig`. this means that the config values now serialize correctly (no more [[]]), and that the response starts with `)]}',`.

When this is all said, I have to admit that I'm not super well experienced in creating custom grid editors, so I'm hoping to get some feedback from people who actually use feature regularly, in regards to whether the additional `)]}',`, breaks anything for you, if that's the case I have been tinkering with a filter that does not add the `)]}',` part, which should work as well. 

### Testing

1. Try adding a custom grid editor with an allowedDocumentTypes config value like in the issue
2. Ensure the string array gets serialized correctly

My package.manifest looked like this 

```C#
{
  "gridEditors": [
    {
      "name": "Code",
      "alias": "code",
      "view": "/App_Plugins/CustomGrid/editor.html",
      "render": "/App_Plugins/CustomGrid/editor.cshtml",
      "icon": "icon-code",
      "config": {
        "color": "red",
        "text-align": "right",
        "allowedDocTypes": ["Home", "home"]
      }
    }
  ]
}
```