### PR TITLE
Updates email sender to have some metadata

### DIFF
--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -59,6 +59,15 @@ namespace Umbraco.Cms.Core
                 public const string ActionToken = "action";
                 public const string AreaToken = "area";
             }
+
+            public static class EmailTypes
+            {
+                public const string HealthCheck = "HealthCheck";
+                public const string Notification = "Notification";
+                public const string PasswordReset = "PasswordReset";
+                public const string TwoFactorAuth = "2FA";
+                public const string UserInvite = "UserInvite";
+            }
         }
     }
 }

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
 
 
             var mailMessage = CreateMailMessage(subject, message);
-            await _emailSender.SendAsync(mailMessage, "HealthCheck");
+            await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.HealthCheck);
         }
 
         private EmailMessage CreateMailMessage(string subject, string message)

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -74,7 +74,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
 
 
             var mailMessage = CreateMailMessage(subject, message);
-            await _emailSender.SendAsync(mailMessage);
+            await _emailSender.SendAsync(mailMessage, "HealthCheck");
         }
 
         private EmailMessage CreateMailMessage(string subject, string message)

--- a/src/Umbraco.Core/Mail/IEmailSender.cs
+++ b/src/Umbraco.Core/Mail/IEmailSender.cs
@@ -8,9 +8,9 @@ namespace Umbraco.Cms.Core.Mail
     /// </summary>
     public interface IEmailSender
     {
-        Task SendAsync(EmailMessage message);
+        Task SendAsync(EmailMessage message, string emailType);
 
-        Task SendAsync(EmailMessage message, bool enableNotification);
+        Task SendAsync(EmailMessage message, string emailType, bool enableNotification);
 
         bool CanSendRequiredEmail();
     }

--- a/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
+++ b/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
@@ -6,10 +6,10 @@ namespace Umbraco.Cms.Core.Mail
 {
     internal class NotImplementedEmailSender : IEmailSender
     {
-        public Task SendAsync(EmailMessage message)
+        public Task SendAsync(EmailMessage message, string emailType)
             => throw new NotImplementedException("To send an Email ensure IEmailSender is implemented with a custom implementation");
 
-        public Task SendAsync(EmailMessage message, bool enableNotification) =>
+        public Task SendAsync(EmailMessage message, string emailType, bool enableNotification) =>
             throw new NotImplementedException(
                 "To send an Email ensure IEmailSender is implemented with a custom implementation");
 

--- a/src/Umbraco.Core/Notifications/SendEmailNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendEmailNotification.cs
@@ -4,9 +4,18 @@ namespace Umbraco.Cms.Core.Notifications
 {
     public class SendEmailNotification : INotification
     {
-        public SendEmailNotification(NotificationEmailModel message) => Message = message;
+        public SendEmailNotification(NotificationEmailModel message, string emailType)
+        {
+            Message = message;
+            EmailType = emailType;
+        }
 
         public NotificationEmailModel Message { get; }
+
+        /// <summary>
+        /// Some metadata about the email which can be used by handlers to determine if they should handle the email or not
+        /// </summary>
+        public string EmailType { get; }
 
         /// <summary>
         /// Call to tell Umbraco that the email sending is handled.

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -49,16 +49,16 @@ namespace Umbraco.Cms.Infrastructure.Mail
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        public async Task SendAsync(EmailMessage message) => await SendAsyncInternal(message, false);
+        public async Task SendAsync(EmailMessage message, string emailType) => await SendAsyncInternal(message, emailType, false);
 
-        public async Task SendAsync(EmailMessage message, bool enableNotification) =>
-            await SendAsyncInternal(message, enableNotification);
+        public async Task SendAsync(EmailMessage message, string emailType, bool enableNotification) =>
+            await SendAsyncInternal(message, emailType, enableNotification);
 
-        private async Task SendAsyncInternal(EmailMessage message, bool enableNotification)
+        private async Task SendAsyncInternal(EmailMessage message, string emailType, bool enableNotification)
         {
             if (enableNotification)
             {
-                var notification = new SendEmailNotification(message.ToNotificationEmail(_globalSettings.Smtp?.From));
+                var notification = new SendEmailNotification(message.ToNotificationEmail(_globalSettings.Smtp?.From), emailType);
                 await _eventAggregator.PublishAsync(notification);
 
                 // if a handler handled sending the email then don't continue.

--- a/src/Umbraco.Infrastructure/Services/Implement/NotificationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/NotificationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -519,7 +519,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                     {
                         try
                         {
-                            _emailSender.SendAsync(request.Mail).GetAwaiter().GetResult();
+                            _emailSender.SendAsync(request.Mail, "Notification").GetAwaiter().GetResult();
                             _logger.LogDebug("Notification '{Action}' sent to {Username} ({Email})", request.Action, request.UserName, request.Email);
                         }
                         catch (Exception ex)

--- a/src/Umbraco.Infrastructure/Services/Implement/NotificationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/NotificationService.cs
@@ -519,7 +519,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                     {
                         try
                         {
-                            _emailSender.SendAsync(request.Mail, "Notification").GetAwaiter().GetResult();
+                            _emailSender.SendAsync(request.Mail, Constants.Web.EmailTypes.Notification).GetAwaiter().GetResult();
                             _logger.LogDebug("Notification '{Action}' sent to {Username} ({Email})", request.Action, request.UserName, request.Email);
                         }
                         catch (Exception ex)

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -394,7 +394,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                     var mailMessage = new EmailMessage(from, user.Email, subject, message, true);
 
-                    await _emailSender.SendAsync(mailMessage);
+                    await _emailSender.SendAsync(mailMessage, "PasswordReset");
 
                     _userManager.NotifyForgotPasswordRequested(User, user.Id.ToString());
                 }
@@ -458,7 +458,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             {
                 var mailMessage = new EmailMessage(from, user.Email, subject, message, true);
 
-                await _emailSender.SendAsync(mailMessage);
+                await _emailSender.SendAsync(mailMessage, "2FA");
             }
             else if (provider == "Phone")
             {

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -394,7 +394,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                     var mailMessage = new EmailMessage(from, user.Email, subject, message, true);
 
-                    await _emailSender.SendAsync(mailMessage, "PasswordReset");
+                    await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.PasswordReset);
 
                     _userManager.NotifyForgotPasswordRequested(User, user.Id.ToString());
                 }
@@ -458,7 +458,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             {
                 var mailMessage = new EmailMessage(from, user.Email, subject, message, true);
 
-                await _emailSender.SendAsync(mailMessage, "2FA");
+                await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.TwoFactorAuth);
             }
             else if (provider == "Phone")
             {

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -559,7 +559,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             var mailMessage = new EmailMessage(fromEmail, toMailBoxAddress.ToString(), emailSubject, emailBody, true);
 
-            await _emailSender.SendAsync(mailMessage, true);
+            await _emailSender.SendAsync(mailMessage, "UserInvite", true);
         }
 
         /// <summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -559,7 +559,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             var mailMessage = new EmailMessage(fromEmail, toMailBoxAddress.ToString(), emailSubject, emailBody, true);
 
-            await _emailSender.SendAsync(mailMessage, "UserInvite", true);
+            await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.UserInvite, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Without this there is no way to handle the `SendEmailNotification` when it is triggered (currently only for user invites) to know what the email is for. It is not reasonable to inspect the subject or message body to see if the notification should handle it or not because those things are dynamic based on the current user's culture.

This is just a simple way to know what type of email it is for.