### PR TITLE
Avoid array allocations for splitting csv tags

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/TagsValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/TagsValueConverter.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
             }
 
             // Otherwise assume CSV storage type and return as string array
-            return source.ToString().Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            return source.ToString().Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object source, bool preview)


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Avoid array allocations for splitting csv tags by using existing array.
