### PR TITLE
Color swatch "selected" state - Icon looks weird

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/check-circle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/check-circle.less
@@ -1,19 +1,17 @@
 .check_circle {
     display: flex;
+    justify-content: center;
+    align-items: center;
     width: 20px;
     height: 20px;
-    margin: 0 auto;
 
     .icon {
         background-color: rgba(0,0,0,.15);
         border-radius: 50%;
+        padding: 3px;
         color: @white;
-        font-size: 1em;
         display: flex;
-        width: 100%;
-        height: 100%;
         align-items: center;
         justify-content: center;
-        float: left;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the "Selected" icon was showing a bit misplaced in the current release and had a stab at the stylesheet to ensure it's centered and showing like it used to 👼🏻 

**Before**
![circle-before](https://user-images.githubusercontent.com/1932158/131648190-013f8508-6caa-4718-84ec-79acac180398.png)

**After**
![circle-after](https://user-images.githubusercontent.com/1932158/131648203-1e023f19-0730-4933-a64a-305719436f1a.png)
