### PR TITLE
Suggestion: Extend markdown editor settings for overlay width

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -30,6 +30,7 @@ function MarkdownEditorController($scope, $element, assetsService, editorService
     function openLinkPicker(callback) {
         var linkPicker = {
             hideTarget: true,
+            size: $scope.model.config.overlayWidthSize,
             submit: function(model) {
                 callback(model.target.url, model.target.name);
                 editorService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.prevalues.controller.js
@@ -1,0 +1,6 @@
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.MarkdownEditorController",
+    function ($scope) {
+        if (!$scope.model.value) {
+            $scope.model.value = "small";
+        }
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.prevalues.html
@@ -1,0 +1,9 @@
+﻿<div ng-controller="Umbraco.PrevalueEditors.MarkdownEditorController">
+    <div class="vertical-align-items">
+        <select ng-model="model.value">
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+        </select>
+    </div>
+</div>

--- a/src/Umbraco.Web/PropertyEditors/MarkdownConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MarkdownConfiguration.cs
@@ -12,5 +12,9 @@ namespace Umbraco.Web.PropertyEditors
 
         [ConfigurationField("defaultValue", "Default value", "textarea", Description = "If value is blank, the editor will show this")]
         public string DefaultValue { get; set; }
+
+
+        [ConfigurationField("overlayWidthSize", "Overlay Width Size", "views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.html")]
+        public string OverlayWidthSize { get; set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In relation to #10992 being merged I have now extended the config settings on the property editor for the Markdown Editor datatype making it possible to adjust the size of the link picker window as well. See how it works below.

But perhaps we don't need the settings for this and just agree to always use the medium size instead? However it might be nice to be able to configure it? Let me know your thoughts!

![overlaysize-markdowneditor](https://user-images.githubusercontent.com/1932158/131657708-f389497d-5744-4ca5-9f09-4a8c5a2fe850.gif)
