### PR TITLE
Implement icon parameter for doctype editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -51,39 +51,54 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
 
             });
         }
-    };   
+    };
+
+    function createDocType( config ) {
+
+        $location.search("create", null);
+        $location.search("notemplate", null);
+        $location.search("iscomposition", null);
+        $location.search("iselement", null);
+        $location.search("icon", null);
+
+        var icon = null;
+
+        if (config.icon) {
+            var icon = config.icon;
+            if (config.color) {
+                icon += " " + config.color;
+            }
+        }
+
+        $location
+            .path("/settings/documenttypes/edit/" + node.id)
+            .search("create", "true")
+            .search("notemplate", config.notemplate ? "true" : null)
+            .search("iscomposition", config.iscomposition ? "true" : null)
+            .search("iselement", config.iselement ? "true" : null)
+            .search("icon", icon);
+
+        navigationService.hideMenu();
+    }
+
 
     // Disabling logic for creating document type with template if disableTemplates is set to true
     if (!disableTemplates) {
-        $scope.createDocType = function () {
-            $location.search('create', null);
-            $location.search('notemplate', null);
-            $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true");
-            navigationService.hideMenu();
+        $scope.createDocType = function (icon, color) {
+            createDocType({ icon: icon, color: color });
         };
     }
 
-    $scope.createComponent = function () {
-        $location.search('create', null);
-        $location.search('notemplate', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true");
-        navigationService.hideMenu();
+    $scope.createComponent = function (icon, color) {
+        createDocType({ notemplate: true, icon:icon, color:color });
     };
 
-    $scope.createComposition = function () {
-        $location.search('create', null);
-        $location.search('notemplate', null);
-        $location.search('iscomposition', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true").search("iscomposition", "true");
-        navigationService.hideMenu();
+    $scope.createComposition = function (icon, color) {
+        createDocType({ iscomposition: true, iselement: true, icon: icon, color: color });
     };
 
-    $scope.createElement = function () {
-        $location.search('create', null);
-        $location.search('notemplate', null);
-        $location.search('iselement', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true").search("iselement", "true");
-        navigationService.hideMenu();
+    $scope.createElement = function (icon, color) {
+        createDocType({ iselement: true, icon: icon, color: color });
     };
 
     $scope.close = function() {

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -5,8 +5,8 @@
 
             <ul class="umb-actions umb-actions-child">
                 <li data-element="action-documentType" class="umb-action" ng-hide="model.disableTemplates">
-                    <button type="button" ng-click="createDocType()" class="umb-action-link umb-outline btn-reset" umb-auto-focus>
-                        <umb-icon icon="icon-document" class="icon large"></umb-icon>
+                    <button type="button" ng-click="createDocType('icon-document', 'color-blue')" class="umb-action-link umb-outline btn-reset" umb-auto-focus>
+                        <umb-icon icon="icon-document color-blue" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_documentTypeWithTemplate">Document Type with Template</localize>
                             <small><localize key="create_documentTypeWithTemplateDescription">The data definition for a content page that can be created by editors in the content tree and is directly accessible via a URL.</localize></small>
@@ -14,8 +14,8 @@
                     </button>
                 </li>
                 <li data-element="action-documentTypeWithoutTemplate" class="umb-action">
-                    <button type="button" ng-click="createComponent()" class="umb-action-link umb-outline btn-reset">
-                        <umb-icon icon="icon-item-arrangement" class="icon large"></umb-icon>
+                    <button type="button" ng-click="createComponent('icon-item-arrangement','color-purple')" class="umb-action-link umb-outline btn-reset">
+                        <umb-icon icon="icon-item-arrangement color-purple" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_documentType">Document Type</localize>
                             <small><localize key="create_documentTypeDescription">The data definition for a content component that can be created by editors in the content tree and be picked on other pages but has no direct URL.</localize></small>
@@ -23,8 +23,8 @@
                     </button>
                 </li>
                 <li data-element="action-documentTypeWithIsElementTypeChecked" class="umb-action">
-                    <button type="button" ng-click="createElement()" class="umb-action-link umb-outline btn-reset">
-                        <umb-icon icon="icon-science" class="icon large"></umb-icon>
+                    <button type="button" ng-click="createElement('icon-science', 'color-green')" class="umb-action-link umb-outline btn-reset">
+                        <umb-icon icon="icon-science color-green" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_elementType">Element Type</localize>
                             <small><localize key="create_elementTypeDescription">Defines the schema for a repeating set of properties, for example, in a 'Block List' or 'Nested Content' property editor.</localize></small>
@@ -32,8 +32,8 @@
                     </button>
                 </li>
                 <li data-element="action-documentTypeWithoutTemplateForComposition" class="umb-action">
-                    <button type="button" ng-click="createComposition()" class="umb-action-link umb-outline btn-reset">
-                        <umb-icon icon="icon-defrag" class="icon large"></umb-icon>
+                    <button type="button" ng-click="createComposition('icon-defrag', 'color-pink')" class="umb-action-link umb-outline btn-reset">
+                        <umb-icon icon="icon-defrag color-pink" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_composition">Composition</localize>
                             <small><localize key="create_compositionDescription">Defines a re-usable set of properties that can be included in the definition of multiple other Document Types. For example, a set of 'Common Page Settings'.</localize></small>
@@ -42,7 +42,7 @@
                 </li>
                 <li data-element="action-folder" ng-if="model.allowCreateFolder" class="umb-action">
                     <button type="button" ng-click="showCreateFolder()" class="umb-action-link umb-outline btn-reset">
-                        <umb-icon icon="icon-folder" class="icon large"></umb-icon>
+                        <umb-icon icon="icon-folder color-black" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_folder">Folder</localize>
                             <small>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -22,6 +22,7 @@
         var create = $routeParams.create;
         var noTemplate = $routeParams.notemplate;
         var isElement = $routeParams.iselement;
+        var icon = $routeParams.icon;
         var allowVaryByCulture = $routeParams.culturevary;
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
         var documentTypeIcon = "";
@@ -71,6 +72,7 @@
                 if (create && !documentTypeId) documentTypeId = -1;
                 noTemplate = $scope.model.notemplate || $scope.model.noTemplate;
                 isElement = $scope.model.isElement;
+                icon = $scope.model.icon;
                 allowVaryByCulture = $scope.model.allowVaryByCulture;
                 vm.submitButtonKey = "buttons_saveAndClose";
                 vm.generateModelsKey = "buttons_generateModelsAndClose";
@@ -403,6 +405,12 @@
             if (isElement) {
                 contentType.isElement = true;
             }
+
+            // set isElement checkbox by default
+            if (icon !== null) {
+                contentType.icon = icon;
+            }
+
             // set vary by culture checkbox by default
             if (allowVaryByCulture) {
                 contentType.allowCultureVariant = true;


### PR DESCRIPTION
This PR aims to resolve issue #10108

By enabling a parameter for the icon (+color), we can mimic the new icons introduced in the "create document type dialog".

_In this example I have also added colors to the icons_
![image](https://user-images.githubusercontent.com/359492/131675627-4332e51b-7c5f-486e-b303-b4aeec9463d0.png)

The icon and color are passed in as parameters in the actions triggered by clicking the different types. The icon + color are then passed in to the model being passed to the document type editor.
