### PR TITLE
Introduce overlaysize prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1543,7 +1543,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                         dataTypeKey: args.model.dataTypeKey,
                         ignoreUserStartNodes: args.model.config.ignoreUserStartNodes,
                         anchors: anchorValues,
-                        size: args.model.config.editor.overlaySize,
+                        size: args.model.config.overlaySize,
                         submit: model => {
                             self.insertLinkInEditor(args.editor, model.target, anchorElement);
                             editorService.close();

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1536,22 +1536,23 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             //create link picker
             self.createLinkPicker(args.editor, function (currentTarget, anchorElement) {
 
+                entityResource.getAnchors(args.model.value).then(anchorValues => {
 
-                entityResource.getAnchors(args.model.value).then(function (anchorValues) {
-                    var linkPicker = {
+                    const linkPicker = {
                         currentTarget: currentTarget,
                         dataTypeKey: args.model.dataTypeKey,
                         ignoreUserStartNodes: args.model.config.ignoreUserStartNodes,
                         anchors: anchorValues,
-                        size: args.model.config.editor.overlayWidthSize,
-                        submit: function (model) {
+                        size: args.model.config.editor.overlaySize,
+                        submit: model => {
                             self.insertLinkInEditor(args.editor, model.target, anchorElement);
                             editorService.close();
                         },
-                        close: function () {
+                        close: () => {
                             editorService.close();
                         }
                     };
+
                     editorService.linkPicker(linkPicker);
                 });
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/overlaysize.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/overlaysize.controller.js
@@ -1,4 +1,4 @@
-angular.module("umbraco").controller("Umbraco.PrevalueEditors.MarkdownEditorController",
+﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.OverlaySizeController",
     function ($scope) {
         if (!$scope.model.value) {
             $scope.model.value = "small";

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/overlaysize.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/overlaysize.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.PrevalueEditors.MultiUrlPickerController">
+﻿<div class="umb-property-editor umb-prevalues-overlaysize" ng-controller="Umbraco.PrevalueEditors.OverlaySizeController">
     <div class="vertical-align-items">
         <select ng-model="model.value">
             <option value="small">Small</option>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.controller.js
@@ -28,17 +28,19 @@ function MarkdownEditorController($scope, $element, assetsService, editorService
     }
 
     function openLinkPicker(callback) {
-        var linkPicker = {
+
+        const linkPicker = {
             hideTarget: true,
-            size: $scope.model.config.overlayWidthSize,
-            submit: function(model) {
+            size: $scope.model.config.overlaySize,
+            submit: model => {
                 callback(model.target.url, model.target.name);
                 editorService.close();
             },
-            close: function() {
+            close: () => {
                 editorService.close();
             }
         };
+
         editorService.linkPicker(linkPicker);
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/markdowneditor/markdowneditor.prevalues.html
@@ -1,9 +1,0 @@
-﻿<div ng-controller="Umbraco.PrevalueEditors.MarkdownEditorController">
-    <div class="vertical-align-items">
-        <select ng-model="model.value">
-            <option value="small">Small</option>
-            <option value="medium">Medium</option>
-            <option value="large">Large</option>
-        </select>
-    </div>
-</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -29,12 +29,12 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
         }
     };
 
-    $scope.model.value.forEach(function (link) {
+    $scope.model.value.forEach(link => {
         link.icon = iconHelper.convertFromLegacyIcon(link.icon);
         $scope.renderModel.push(link);
     });
 
-    $scope.$on("formSubmitting", function () {
+    $scope.$on("formSubmitting", () => {
         $scope.model.value = $scope.renderModel;
     });
 
@@ -78,13 +78,13 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
             target: link.target
         } : null;
 
-        var linkPicker = {
+        const linkPicker = {
             currentTarget: target,
             dataTypeKey: $scope.model.dataTypeKey,
             ignoreUserStartNodes : ($scope.model.config && $scope.model.config.ignoreUserStartNodes) ? $scope.model.config.ignoreUserStartNodes : "0",
             hideAnchor: $scope.model.config && $scope.model.config.hideAnchor ? true : false,
-            size: $scope.model.config.overlayWidthSize,
-            submit: function (model) {
+            size: $scope.model.config.overlaySize,
+            submit: model => {
                 if (model.target.url || model.target.anchor) {
                     // if an anchor exists, check that it is appropriately prefixed
                     if (model.target.anchor && model.target.anchor[0] !== '?' && model.target.anchor[0] !== '#') {
@@ -108,12 +108,14 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
                     }
 
                     if (link.udi) {
-                        var entityType = model.target.isMedia ? "Media" : "Document";
+                        const entityType = model.target.isMedia ? "Media" : "Document";
 
-                        entityResource.getById(link.udi, entityType).then(function (data) {
+                        entityResource.getById(link.udi, entityType).then(data => {
+
                             link.icon = iconHelper.convertFromLegacyIcon(data.icon);
                             link.published = (data.metaData && data.metaData.IsPublished === false && entityType === "Document") ? false : true;
                             link.trashed = data.trashed;
+
                             if (link.trashed) {
                                 item.url = vm.labels.general_recycleBin;
                             }
@@ -127,10 +129,11 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
                 }
                 editorService.close();
             },
-            close: function () {
+            close: () => {
                 editorService.close();
             }
         };
+
         editorService.linkPicker(linkPicker);
     };
 
@@ -141,8 +144,9 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
     }
 
     function init() {
+
         localizationService.localizeMany(["general_recycleBin"])
-            .then(function (data) {
+            .then(data => {
                 vm.labels.general_recycleBin = data[0];
             });
 
@@ -152,11 +156,11 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
             $scope.model.config.minNumber = 1;
         }
 
-        _.each($scope.model.value, function (item){
+        _.each($scope.model.value, function (item) {
             // we must reload the "document" link URLs to match the current editor culture
             if (item.udi && item.udi.indexOf("/document/") > 0) {
                 item.url = null;
-                entityResource.getUrlByUdi(item.udi).then(function (data) {
+                entityResource.getUrlByUdi(item.udi).then(data => {
                     item.url = data;
                 });
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.controller.js
@@ -1,6 +1,0 @@
-angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiUrlPickerController",
-    function ($scope) {
-        if (!$scope.model.value) {
-            $scope.model.value = "small";
-        }
-    });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -23,10 +23,6 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             $scope.model.value.mode = "classic";
         }
 
-        if(!$scope.model.value.overlayWidthSize) {
-            $scope.model.value.overlayWidthSize = "small";
-        }
-
         tinyMceService.configuration().then(function(config){
             $scope.tinyMceConfig = config;
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -46,14 +46,4 @@
         </div>
     </umb-control-group>
 
-    <umb-control-group label="Overlay width size" description="Select overlay width size">
-        <div class="vertical-align-items">
-            <select ng-model="model.value.overlayWidthSize">
-                <option value="small">Small</option>
-                <option value="medium">Medium</option>
-                <option value="large">Large</option>
-            </select>
-        </div>
-    </umb-control-group>
-
 </div>

--- a/src/Umbraco.Web/PropertyEditors/MarkdownConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MarkdownConfiguration.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Web.PropertyEditors
         public string DefaultValue { get; set; }
 
 
-        [ConfigurationField("overlayWidthSize", "Overlay Width Size", "views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.html")]
-        public string OverlayWidthSize { get; set; }
+        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay.")]
+        public string OverlaySize { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MarkdownConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MarkdownConfiguration.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Web.PropertyEditors
         public string DefaultValue { get; set; }
 
 
-        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay.")]
+        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay (link picker).")]
         public string OverlaySize { get; set; }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerConfiguration.cs
@@ -11,8 +11,8 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("maxNumber", "Maximum number of items", "number")]
         public int MaxNumber { get; set; }
 
-        [ConfigurationField("overlayWidthSize", "Overlay Width Size", "views/propertyeditors/multiurlpicker/multiurlpicker.prevalues.html")]
-        public string OverlayWidthSize { get; set; }
+        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay.")]
+        public string OverlaySize { get; set; }
 
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,
             "Ignore User Start Nodes", "boolean",

--- a/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
@@ -16,6 +16,9 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("hideLabel", "Hide Label", "boolean")]
         public bool HideLabel { get; set; }
 
+        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay.")]
+        public string OverlaySize { get; set; }
+
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,
             "Ignore User Start Nodes", "boolean",
             Description = "Selecting this option allows a user to choose nodes that they normally don't have access to.")]

--- a/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("editor", "Editor", "views/propertyeditors/rte/rte.prevalues.html", HideLabel = true)]
         public JObject Editor { get; set; }
 
-        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay.")]
+        [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay (link picker).")]
         public string OverlaySize { get; set; }
 
         [ConfigurationField("hideLabel", "Hide Label", "boolean")]

--- a/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextConfiguration.cs
@@ -13,11 +13,11 @@ namespace Umbraco.Web.PropertyEditors
         [ConfigurationField("editor", "Editor", "views/propertyeditors/rte/rte.prevalues.html", HideLabel = true)]
         public JObject Editor { get; set; }
 
-        [ConfigurationField("hideLabel", "Hide Label", "boolean")]
-        public bool HideLabel { get; set; }
-
         [ConfigurationField("overlaySize", "Overlay Size", "overlaysize", Description = "Select the width of the overlay.")]
         public string OverlaySize { get; set; }
+
+        [ConfigurationField("hideLabel", "Hide Label", "boolean")]
+        public bool HideLabel { get; set; }
 
         [ConfigurationField(Core.Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes,
             "Ignore User Start Nodes", "boolean",


### PR DESCRIPTION
... instead of redundant prevalue editor for each property editor.

So instead of three redundant prevalue editors, we just need one!
If we later need only to show e.g. "Small" and "Medium" options in prevalues for a specific property editor, we can configurate the prevalue editor further or add a specific prevalue editor for that property editor. But it most scenarios we don't need a specific prevalue for a property editor, but one that can be re-used in other property editors and/or by package developers.

I have renamed the property from "Overlay Size Width" to just "Overlay Size" to keep it simple and instead use the description property to add a more detailed explanation.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I don't like that we now have redundant prevalue editors for each property editor - we should have a global prevalue editor to use.

Relatated to these PRs:
https://github.com/umbraco/Umbraco-CMS/pull/10992
https://github.com/umbraco/Umbraco-CMS/pull/11006
https://github.com/umbraco/Umbraco-CMS/pull/11007

**Multi URL Picker**

![image](https://user-images.githubusercontent.com/2919859/131715377-f6cf21b2-cfeb-4f9f-8f96-6d99025bcf75.png)

**Markdown Editor**

![image](https://user-images.githubusercontent.com/2919859/131715495-eb329201-542c-4681-98ed-750322400a04.png)

**Richtext Editor**

![image](https://user-images.githubusercontent.com/2919859/131715812-3c5b7640-87fb-4e03-81fe-43359f73b022.png)
