### PR TITLE
Migrate SQL Server ntext columns to NVARCHAR(MAX)

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -209,6 +209,7 @@ namespace Umbraco.Core.Migrations.Upgrade
 
             // to 8.17.0
             To<AddPropertyTypeGroupColumns>("{153865E9-7332-4C2A-9F9D-F20AEE078EC7}");
+            To<UpgradeNtextColumns>("{E07A02BE-20F8-4C94-950D-8797B1872073}");
 
             //FINAL
         }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_17_0/UpgradeNtextColumns.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_17_0/UpgradeNtextColumns.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_17_0
+{
+    public class UpgradeNtextColumns : MigrationBase
+    {
+        public UpgradeNtextColumns(IMigrationContext context)
+           : base(context)
+        { }
+        public override void Migrate()
+        {
+            //Change ntext columns to nvarchar(max)
+            //cmsContentNu.data
+            //umbracoPropertyData.textValue
+            if (DatabaseType.IsSqlCe())
+            {
+                //No Support for nvarchar(max) in SQLCE
+                return;
+            }
+            AlterColumn<CacheInstructionDto>(Constants.DatabaseSchema.Tables.CacheInstruction, "jsonInstruction");
+            AlterColumn<ContentNuDto>(Constants.DatabaseSchema.Tables.NodeData, "data");
+            AlterColumn<DataTypeDto>(Constants.DatabaseSchema.Tables.DataType, "config");
+            AlterColumn<ExternalLoginDto>(Constants.DatabaseSchema.Tables.ExternalLogin, "userData");
+            AlterColumn<PropertyDataDto>(Constants.DatabaseSchema.Tables.PropertyData, "textValue");
+            AlterColumn<UserDto>(Constants.DatabaseSchema.Tables.User, "tourData");
+        }
+
+    }
+}

--- a/src/Umbraco.Core/Persistence/Dtos/CacheInstructionDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/CacheInstructionDto.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Core.Persistence.Dtos
         public DateTime UtcStamp { get; set; }
 
         [Column("jsonInstruction")]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         public string Instructions { get; set; }
 

--- a/src/Umbraco.Core/Persistence/Dtos/ContentNuDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ContentNuDto.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Core.Persistence.Dtos
         /// Pretty much anything that would require a 1:M lookup is serialized here
         /// </remarks>
         [Column("data")]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         [NullSetting(NullSetting = NullSettings.Null)]
         public string Data { get; set; }
 

--- a/src/Umbraco.Core/Persistence/Dtos/DataTypeDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/DataTypeDto.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Core.Persistence.Dtos
         public string DbType { get; set; }
 
         [Column("config")]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         [NullSetting(NullSetting = NullSettings.Null)]
         public string Configuration { get; set; }
 

--- a/src/Umbraco.Core/Persistence/Dtos/ExternalLoginDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/ExternalLoginDto.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Core.Persistence.Dtos
         /// </summary>
         [Column("userData")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         public string UserData { get; set; }
     }
 }

--- a/src/Umbraco.Core/Persistence/Dtos/PropertyDataDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/PropertyDataDto.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("textValue")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         public string TextValue { get; set; }
 
         [ResultColumn]

--- a/src/Umbraco.Core/Persistence/Dtos/UserDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/UserDto.cs
@@ -111,7 +111,7 @@ namespace Umbraco.Core.Persistence.Dtos
         /// </summary>
         [Column("tourData")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         public string TourData { get; set; }
 
         [ResultColumn]

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Migrations\Upgrade\V_8_15_0\UpgradedIncludeIndexes.cs" />
     <Compile Include="Migrations\Upgrade\V_8_10_0\AddPropertyTypeLabelOnTopColumn.cs" />
     <Compile Include="Migrations\Upgrade\V_8_17_0\AddPropertyTypeGroupColumns.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_17_0\UpgradeNtextColumns.cs" />
     <Compile Include="Migrations\Upgrade\V_8_9_0\ExternalLoginTableUserData.cs" />
     <Compile Include="Models\Blocks\BlockEditorDataConverter.cs" />
     <Compile Include="Models\Blocks\BlockEditorData.cs" />


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
It's not possible to set up indexes on ntext columns. This PR migrates ntext columns on SQL server to nvarchar(MAX) which is supported in indexes. SQL CE columns are left as is. There is handling in SQLCE for NVARCHAR(MAX) columns in queries already when using strongly typed queries.

How to test?
Umbraco upgrades the database without error.
Existing functionality still works.
