### PR TITLE
Suggestion: Change size of iconpickers in backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -251,6 +251,7 @@ Use this directive to construct a header inside the main editor window.
                 var iconPicker = {
                     icon: scope.icon.split(' ')[0],
                     color: scope.icon.split(' ')[1],
+                    size: "medium",
                     submit: function (model) {
                         if (model.icon) {
                             if (model.color) {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -22,6 +22,16 @@
             box-shadow: 0 1px 3px fade(@black, 12%), 0 1px 2px fade(@black, 24%);
         }
 
+        &.umb-color-box--xs {
+            width: 27px;
+            height: 27px;
+        }
+
+        &.umb-color-box--s {
+            width: 30px;
+            height: 30px;
+        }
+
         &.umb-color-box--m {
             width: 40px;
             height: 40px;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -28,12 +28,12 @@
                     </umb-search-filter>
                 </div>
 
-                <div class="umb-control-group">
+                <div class="umb-control-group mt3">
                     <umb-color-swatches
                         use-color-class="true"
                         colors="vm.colors"
                         selected-color="vm.color"
-                        size="s"
+                        size="xs"
                         on-select="vm.selectColor(color)">
                     </umb-color-swatches>
                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/icon.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/icon.prevalues.controller.js
@@ -12,6 +12,7 @@ function iconPreValsController($scope, editorService) {
         var iconPicker = {
             icon: $scope.icon,
             color: $scope.color,
+            size: "medium",
             submit: function (model) {
                 if (model.icon) {
                     if (model.color) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts.prevalues.controller.js
@@ -61,6 +61,7 @@
             var iconPicker = {
                 icon: layout.icon.split(' ')[0],
                 color: layout.icon.split(' ')[1],
+                size: "medium",
                 submit: function (model) {
                     if (model.icon) {
                         if (model.color) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

There is a current PR where some changes were suggested in #11004, which I have chosen to do in a new PR since there has been some weirdness around the commit history when creating the PR. I have checked my git log but only see the commits made so made a fresh clone and started over to see if that would fix it - It appears to do so. But keep track of the history for this PR in #11004 which is now closed.

In this new PR I have added a new "xs" modifier so the swatch can be made a wee bit smaller than the original size "s", which ensures we don't end up breaking something.

Also as suggested I moved the setting of the size into the object being passed to the iconpicker method instead so we don't force package creators, and developer relying on the iconpicker method in their own extensions to use the new overlay with size if they don't want to - Ensuring it's fully configurable on the object passed.

Furthermore I made this change in the datatype for configuring custom list views as well so it's all aligned where ever the iconpicker overlay is used in the backoffice 👍🏻 