### PR TITLE
Don't cache AuthenticationController calls including GetRemainingTimeoutSeconds

### DIFF
--- a/src/Umbraco.Web/Editors/AuthenticationController.cs
+++ b/src/Umbraco.Web/Editors/AuthenticationController.cs
@@ -17,7 +17,6 @@ using Umbraco.Core.Models.Identity;
 using Umbraco.Core.Services;
 using Umbraco.Web.Models;
 using Umbraco.Web.Models.ContentEditing;
-using Umbraco.Web.Mvc;
 using Umbraco.Web.Security;
 using Umbraco.Web.WebApi;
 using Umbraco.Web.WebApi.Filters;
@@ -34,10 +33,11 @@ namespace Umbraco.Web.Editors
     /// <summary>
     /// The API controller used for editing content
     /// </summary>
-    [PluginController("UmbracoApi")]
+    [Mvc.PluginController("UmbracoApi")]
     [ValidationFilter]
     [AngularJsonOnlyConfiguration]
     [IsBackOffice]
+    [DisableBrowserCache]
     public class AuthenticationController : UmbracoApiController
     {
         private BackOfficeUserManager<BackOfficeIdentityUser> _userManager;

--- a/src/Umbraco.Web/Security/GetUserSecondsMiddleWare.cs
+++ b/src/Umbraco.Web/Security/GetUserSecondsMiddleWare.cs
@@ -62,7 +62,7 @@ namespace Umbraco.Web.Security
 
                         response.ContentType = "application/json; charset=utf-8";
                         response.StatusCode = 200;
-                        response.Headers.Add("Cache-Control", new[] { "no-cache" });
+                        response.Headers.Add("Cache-Control", new[] { "no-store", "must-revalidate", "no-cache", "max-age=0" });
                         response.Headers.Add("Pragma", new[] { "no-cache" });
                         response.Headers.Add("Expires", new[] { "-1" });
                         response.Headers.Add("Date", new[] { _authOptions.SystemClock.UtcNow.ToString("R") });


### PR DESCRIPTION
### Prerequisites

1. Login to the backoffice
2. Look for the `Cache-control` response header on requests made to the `AuthenticationController` (`/umbraco/backoffice/UmbracoApi/Authentication/`)
3. Verify the value is always `no-store, must-revalidate, no-cache, max-age=0`

Example for the `IsAuthenticated` request:
![image](https://user-images.githubusercontent.com/61198085/131843956-f5fbfeec-c65f-4cc6-8520-0cd821ef03e3.png)

Example for the `GetRemainingTimeoutSeconds` request:
![image](https://user-images.githubusercontent.com/61198085/131844058-0b8af5ba-90dd-47d3-9152-8b4f4032df20.png)


Fixes #11011 

### Description
I added the `[DisableBrowserCache]` attribute on the `AuthenticationController` because the controller doesn't inherit from `UmbracoAuthorizedApiController ` as @Shazwazza mentionned in the linked issue.

For the `GetRemainingTimeoutSeconds` request specifically, I added the missing parts of the `Cache-control` header manually in the string array that already existed.

So now, when a caching server is setup in front of an Umbraco website, user-specific requests will never be cached.
