### PR TITLE
Introduce UrlProviderSettings to avoid memory allocations from repeated reads of WebRouting section

### DIFF
--- a/src/Umbraco.Tests/Cache/DistributedCacheBinderTests.cs
+++ b/src/Umbraco.Tests/Cache/DistributedCacheBinderTests.cs
@@ -156,10 +156,10 @@ namespace Umbraco.Tests.Cache
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
-                TestObjects.GetGlobalSettings(),
+                new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting), 
                 new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
+                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor()),
+                TestObjects.GetGlobalSettings(),
                 Mock.Of<IUserService>());
 
             // just assert it does not throw

--- a/src/Umbraco.Tests/Cache/PublishedCache/PublishedContentCacheTests.cs
+++ b/src/Umbraco.Tests/Cache/PublishedCache/PublishedContentCacheTests.cs
@@ -75,13 +75,15 @@ namespace Umbraco.Tests.Cache.PublishedCache
             var publishedSnapshotService = new Mock<IPublishedSnapshotService>();
             publishedSnapshotService.Setup(x => x.CreatePublishedSnapshot(It.IsAny<string>())).Returns(publishedShapshot);
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+               new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+               new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             _umbracoContext = new UmbracoContext(
                 _httpContextFactory.HttpContext,
                 publishedSnapshotService.Object,
                 new WebSecurity(_httpContextFactory.HttpContext, Current.Services.UserService, globalSettings),
-                umbracoSettings,
-                Enumerable.Empty<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 globalSettings,
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentSnapshotTestBase.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentSnapshotTestBase.cs
@@ -65,13 +65,15 @@ namespace Umbraco.Tests.PublishedContent
             var globalSettings = TestObjects.GetGlobalSettings();
 
             var httpContext = GetHttpContextFactory("http://umbraco.local/", routeData).HttpContext;
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+               new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+               new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContext = new UmbracoContext(
                 httpContext,
                 publishedSnapshotService.Object,
                 new WebSecurity(httpContext, Current.Services.UserService, globalSettings),
-                TestObjects.GetUmbracoSettings(),
-                Enumerable.Empty<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 globalSettings,
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
+++ b/src/Umbraco.Tests/Scoping/ScopedNuCacheTests.cs
@@ -113,13 +113,17 @@ namespace Umbraco.Tests.Scoping
             var httpContext = GetHttpContextFactory(url, routeData).HttpContext;
 
             var globalSettings = TestObjects.GetGlobalSettings();
+
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(
+                new UrlProviderSettings((umbracoSettings ?? SettingsForTests.GetDefaultUmbracoSettings()).WebRouting),
+              new UrlProviderCollection(urlProviders ?? Enumerable.Empty<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContext = new UmbracoContext(
                 httpContext,
                 service,
                 new WebSecurity(httpContext, Current.Services.UserService, globalSettings),
-                umbracoSettings ?? SettingsForTests.GetDefaultUmbracoSettings(),
-                urlProviders ?? Enumerable.Empty<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+               urlProviderFactory,
                 globalSettings,
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Tests/Security/BackOfficeCookieManagerTests.cs
+++ b/src/Umbraco.Tests/Security/BackOfficeCookieManagerTests.cs
@@ -30,11 +30,16 @@ namespace Umbraco.Tests.Security
             ConfigurationManager.AppSettings.Set(Constants.AppSettings.ConfigurationStatus, "");
 
             var globalSettings = TestObjects.GetGlobalSettings();
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(
+                new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+              new UrlProviderCollection(new List<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContext = new UmbracoContext(
                 Mock.Of<HttpContextBase>(),
                 Mock.Of<IPublishedSnapshotService>(),
                 new WebSecurity(Mock.Of<HttpContextBase>(), Current.Services.UserService, globalSettings),
-                TestObjects.GetUmbracoSettings(), new List<IUrlProvider>(), Enumerable.Empty<IMediaUrlProvider>(), globalSettings,
+                urlProviderFactory, globalSettings,
                 new TestVariationContextAccessor());
 
             var runtime = Mock.Of<IRuntimeState>(x => x.Level == RuntimeLevel.Install);
@@ -50,11 +55,17 @@ namespace Umbraco.Tests.Security
         public void ShouldAuthenticateRequest_When_Configured()
         {
             var globalSettings = TestObjects.GetGlobalSettings();
+
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(
+                new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+              new UrlProviderCollection(new List<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbCtx = new UmbracoContext(
                 Mock.Of<HttpContextBase>(),
                 Mock.Of<IPublishedSnapshotService>(),
                 new WebSecurity(Mock.Of<HttpContextBase>(), Current.Services.UserService, globalSettings),
-                TestObjects.GetUmbracoSettings(), new List<IUrlProvider>(), Enumerable.Empty<IMediaUrlProvider>(), globalSettings,
+                urlProviderFactory, globalSettings,
                 new TestVariationContextAccessor());
 
             var runtime = Mock.Of<IRuntimeState>(x => x.Level == RuntimeLevel.Run);

--- a/src/Umbraco.Tests/TestHelpers/ControllerTesting/TestControllerActivatorBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/ControllerTesting/TestControllerActivatorBase.cs
@@ -142,8 +142,6 @@ namespace Umbraco.Tests.TestHelpers.ControllerTesting
                 new UmbracoContextUrlProviderFactory(new UrlProviderSettings(Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
               new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
               new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor()),
-                Enumerable.Empty<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
                 globalSettings,
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Tests/TestHelpers/ControllerTesting/TestControllerActivatorBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/ControllerTesting/TestControllerActivatorBase.cs
@@ -134,10 +134,14 @@ namespace Umbraco.Tests.TestHelpers.ControllerTesting
 
             var umbracoContextAccessor = Umbraco.Web.Composing.Current.UmbracoContextAccessor;
 
+            
+
             var umbCtx = new UmbracoContext(httpContext,
                 publishedSnapshotService.Object,
                 webSecurity.Object,
-                Mock.Of<IUmbracoSettingsSection>(section => section.WebRouting == Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
+                new UmbracoContextUrlProviderFactory(new UrlProviderSettings(Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
+              new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor()),
                 Enumerable.Empty<IUrlProvider>(),
                 Enumerable.Empty<IMediaUrlProvider>(),
                 globalSettings,

--- a/src/Umbraco.Tests/TestHelpers/TestObjects-Mocks.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestObjects-Mocks.cs
@@ -127,15 +127,18 @@ namespace Umbraco.Tests.TestHelpers
 
             if (accessor == null) accessor = new TestUmbracoContextAccessor();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(
+                new UrlProviderSettings(umbracoSettings.WebRouting),
+              urlProviders,
+              mediaUrlProviders, new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 accessor,
                 publishedSnapshotService,
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                umbracoSettings,
+                urlProviderFactory,
                 globalSettings,
-                urlProviders,
-                mediaUrlProviders,
                 Mock.Of<IUserService>());
 
             return umbracoContextFactory.EnsureUmbracoContext(httpContext).UmbracoContext;

--- a/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
+++ b/src/Umbraco.Tests/TestHelpers/TestWithDatabaseBase.cs
@@ -374,14 +374,17 @@ namespace Umbraco.Tests.TestHelpers
 
             var httpContext = GetHttpContextFactory(url, routeData).HttpContext;
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(
+                new UrlProviderSettings((umbracoSettings ?? Factory.GetInstance<IUmbracoSettingsSection>()).WebRouting),
+              urlProviders ?? Enumerable.Empty<IUrlProvider>(),
+              mediaUrlProviders ?? Enumerable.Empty<IMediaUrlProvider>(), new TestVariationContextAccessor());
+
             var umbracoContext = new UmbracoContext(
                 httpContext,
                 service,
                 new WebSecurity(httpContext, Factory.GetInstance<IUserService>(),
                     Factory.GetInstance<IGlobalSettings>()),
-                umbracoSettings ?? Factory.GetInstance<IUmbracoSettingsSection>(),
-                urlProviders ?? Enumerable.Empty<IUrlProvider>(),
-                mediaUrlProviders ?? Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 globalSettings ?? Factory.GetInstance<IGlobalSettings>(),
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Tests/Testing/Objects/TestUmbracoContextFactory.cs
+++ b/src/Umbraco.Tests/Testing/Objects/TestUmbracoContextFactory.cs
@@ -30,17 +30,19 @@ namespace Umbraco.Tests.Testing.Objects
             snapshot.Setup(x => x.Content).Returns(contentCache.Object);
             snapshot.Setup(x => x.Media).Returns(mediaCache.Object);
             var snapshotService = new Mock<IPublishedSnapshotService>();
-            snapshotService.Setup(x => x.CreatePublishedSnapshot(It.IsAny<string>())).Returns(snapshot.Object);            
-            
+            snapshotService.Setup(x => x.CreatePublishedSnapshot(It.IsAny<string>())).Returns(snapshot.Object);
+
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
+                new UrlProviderCollection(new[] { urlProvider }),
+               new MediaUrlProviderCollection(new[] { mediaUrlProvider }), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 umbracoContextAccessor,
                 snapshotService.Object,
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                Mock.Of<IUmbracoSettingsSection>(section => section.WebRouting == Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(new[] { urlProvider }),
-                new MediaUrlProviderCollection(new[] { mediaUrlProvider }),
                 Mock.Of<IUserService>());
 
             return umbracoContextFactory;

--- a/src/Umbraco.Tests/Web/Mvc/RenderIndexActionSelectorAttributeTests.cs
+++ b/src/Umbraco.Tests/Web/Mvc/RenderIndexActionSelectorAttributeTests.cs
@@ -63,16 +63,17 @@ namespace Umbraco.Tests.Web.Mvc
             var globalSettings = TestObjects.GetGlobalSettings();
             var attr = new RenderIndexActionSelectorAttribute();
             var req = new RequestContext();
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+              new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
 
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());
@@ -94,15 +95,17 @@ namespace Umbraco.Tests.Web.Mvc
             var attr = new RenderIndexActionSelectorAttribute();
             var req = new RequestContext();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());
@@ -124,15 +127,17 @@ namespace Umbraco.Tests.Web.Mvc
             var attr = new RenderIndexActionSelectorAttribute();
             var req = new RequestContext();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());
@@ -154,15 +159,17 @@ namespace Umbraco.Tests.Web.Mvc
             var attr = new RenderIndexActionSelectorAttribute();
             var req = new RequestContext();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());

--- a/src/Umbraco.Tests/Web/Mvc/SurfaceControllerTests.cs
+++ b/src/Umbraco.Tests/Web/Mvc/SurfaceControllerTests.cs
@@ -39,15 +39,17 @@ namespace Umbraco.Tests.Web.Mvc
         {
             var globalSettings = TestObjects.GetGlobalSettings();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
+               urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());
@@ -67,15 +69,17 @@ namespace Umbraco.Tests.Web.Mvc
         {
             var globalSettings = TestObjects.GetGlobalSettings();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                TestObjects.GetUmbracoSettings(),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());
@@ -98,15 +102,17 @@ namespace Umbraco.Tests.Web.Mvc
             var publishedSnapshotService = new Mock<IPublishedSnapshotService>();
             var globalSettings = TestObjects.GetGlobalSettings();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 publishedSnapshotService.Object,
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                Mock.Of<IUmbracoSettingsSection>(section => section.WebRouting == Mock.Of<IWebRoutingSection>(routingSection => routingSection.UrlProviderMode == "Auto")),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());
@@ -136,15 +142,17 @@ namespace Umbraco.Tests.Web.Mvc
             var webRoutingSettings = Mock.Of<IWebRoutingSection>(section => section.UrlProviderMode == "Auto");
             var globalSettings = TestObjects.GetGlobalSettings();
 
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(webRoutingSettings),
+             new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+             new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbracoContextFactory = new UmbracoContextFactory(
                 Current.UmbracoContextAccessor,
                 Mock.Of<IPublishedSnapshotService>(),
                 new TestVariationContextAccessor(),
                 new TestDefaultCultureAccessor(),
-                Mock.Of<IUmbracoSettingsSection>(section => section.WebRouting == webRoutingSettings),
+                urlProviderFactory,
                 globalSettings,
-                new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
-                new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()),
                 Mock.Of<IUserService>());
 
             var umbracoContextReference = umbracoContextFactory.EnsureUmbracoContext(Mock.Of<HttpContextBase>());

--- a/src/Umbraco.Tests/Web/Mvc/UmbracoViewPageTests.cs
+++ b/src/Umbraco.Tests/Web/Mvc/UmbracoViewPageTests.cs
@@ -433,14 +433,15 @@ namespace Umbraco.Tests.Web.Mvc
             var http = GetHttpContextFactory(url, routeData).HttpContext;
 
             var globalSettings = TestObjects.GetGlobalSettings();
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+               new UrlProviderCollection(Enumerable.Empty<IUrlProvider>()),
+               new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
 
             var ctx = new UmbracoContext(
                 http,
                 _service,
                 new WebSecurity(http, Current.Services.UserService, globalSettings),
-                TestObjects.GetUmbracoSettings(),
-                Enumerable.Empty<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 globalSettings,
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Tests/Web/WebExtensionMethodTests.cs
+++ b/src/Umbraco.Tests/Web/WebExtensionMethodTests.cs
@@ -26,13 +26,15 @@ namespace Umbraco.Tests.Web
         [Test]
         public void RouteDataExtensions_GetUmbracoContext()
         {
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+              new UrlProviderCollection(new List<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbCtx = new UmbracoContext(
                 Mock.Of<HttpContextBase>(),
                 Mock.Of<IPublishedSnapshotService>(),
                 new WebSecurity(Mock.Of<HttpContextBase>(), Current.Services.UserService, TestObjects.GetGlobalSettings()),
-                TestObjects.GetUmbracoSettings(),
-                new List<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 TestObjects.GetGlobalSettings(),
                 new TestVariationContextAccessor());
             var r1 = new RouteData();
@@ -45,13 +47,14 @@ namespace Umbraco.Tests.Web
         [Test]
         public void ControllerContextExtensions_GetUmbracoContext_From_RouteValues()
         {
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+               new UrlProviderCollection(new List<IUrlProvider>()),
+               new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
             var umbCtx = new UmbracoContext(
                 Mock.Of<HttpContextBase>(),
                 Mock.Of<IPublishedSnapshotService>(),
                 new WebSecurity(Mock.Of<HttpContextBase>(), Current.Services.UserService, TestObjects.GetGlobalSettings()),
-                TestObjects.GetUmbracoSettings(),
-                new List<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 TestObjects.GetGlobalSettings(),
                 new TestVariationContextAccessor());
 
@@ -74,13 +77,15 @@ namespace Umbraco.Tests.Web
         [Test]
         public void ControllerContextExtensions_GetUmbracoContext_From_Current()
         {
+            var urlProviderFactory = new UmbracoContextUrlProviderFactory(new UrlProviderSettings(TestObjects.GetUmbracoSettings().WebRouting),
+              new UrlProviderCollection(new List<IUrlProvider>()),
+              new MediaUrlProviderCollection(Enumerable.Empty<IMediaUrlProvider>()), new TestVariationContextAccessor());
+
             var umbCtx = new UmbracoContext(
                 Mock.Of<HttpContextBase>(),
                 Mock.Of<IPublishedSnapshotService>(),
                 new WebSecurity(Mock.Of<HttpContextBase>(), Current.Services.UserService, TestObjects.GetGlobalSettings()),
-                TestObjects.GetUmbracoSettings(),
-                new List<IUrlProvider>(),
-                Enumerable.Empty<IMediaUrlProvider>(),
+                urlProviderFactory,
                 TestObjects.GetGlobalSettings(),
                 new TestVariationContextAccessor());
 

--- a/src/Umbraco.Web/Routing/IUmbracoContextUrlProviderFactory.cs
+++ b/src/Umbraco.Web/Routing/IUmbracoContextUrlProviderFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Web.Routing
+{
+    public interface IUmbracoContextUrlProviderFactory
+    {
+        /// <summary>
+        /// Creates an instance of UrlProvider for the given Context
+        /// </summary>
+        /// <param name="umbracoContext">Umbraco Context</param>
+        /// <returns>Url Provider</returns>
+        UrlProvider Create(UmbracoContext umbracoContext);
+    }
+}

--- a/src/Umbraco.Web/Routing/UmbracoContextUrlProviderFactory.cs
+++ b/src/Umbraco.Web/Routing/UmbracoContextUrlProviderFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Web.Routing
+{
+    public class UmbracoContextUrlProviderFactory : IUmbracoContextUrlProviderFactory
+    {
+        private readonly UrlProviderSettings _urlProviderSettings;
+        private readonly IEnumerable<IUrlProvider> _urlProviders;
+        private readonly IEnumerable<IMediaUrlProvider> _mediaUrlProviders;
+        private readonly IVariationContextAccessor _variationContextAccessor;
+
+        public UmbracoContextUrlProviderFactory(
+            UrlProviderSettings urlProviderSettings,
+            IEnumerable<IUrlProvider> urlProviders,
+            IEnumerable<IMediaUrlProvider> mediaUrlProviders,
+            IVariationContextAccessor variationContextAccessor)
+        {
+            _urlProviderSettings = urlProviderSettings;
+            _urlProviders = urlProviders;
+            _mediaUrlProviders = mediaUrlProviders;
+            _variationContextAccessor = variationContextAccessor;
+        }
+
+        /// <summary>
+        /// Creates an instance of UrlProvider for the given Context
+        /// </summary>
+        /// <param name="umbracoContext">Umbraco Context</param>
+        /// <returns>Url Provider</returns>
+        public UrlProvider Create(UmbracoContext umbracoContext)
+        {
+            return new UrlProvider(umbracoContext, _urlProviderSettings, _urlProviders, _mediaUrlProviders, _variationContextAccessor);
+        }
+    }
+}

--- a/src/Umbraco.Web/Routing/UrlProvider.cs
+++ b/src/Umbraco.Web/Routing/UrlProvider.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Routing
         /// <param name="urlProviders">The list of URL providers.</param>
         /// <param name="mediaUrlProviders">The list of media URL providers.</param>
         /// <param name="variationContextAccessor">The current variation accessor.</param>
-        public UrlProvider(UmbracoContext umbracoContext, IWebRoutingSection routingSettings, IEnumerable<IUrlProvider> urlProviders, IEnumerable<IMediaUrlProvider> mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
+        public UrlProvider(UmbracoContext umbracoContext, UrlProviderSettings routingSettings, IEnumerable<IUrlProvider> urlProviders, IEnumerable<IMediaUrlProvider> mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
         {
             if (routingSettings == null) throw new ArgumentNullException(nameof(routingSettings));
 
@@ -31,13 +31,8 @@ namespace Umbraco.Web.Routing
             _urlProviders = urlProviders;
             _mediaUrlProviders = mediaUrlProviders;
             _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
-            var provider = UrlMode.Auto;
-            Mode = provider;
 
-            if (Enum<UrlMode>.TryParse(routingSettings.UrlProviderMode, out provider))
-            {
-                Mode = provider;
-            }
+            Mode = routingSettings.Mode;
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Routing/UrlProviderSettings.cs
+++ b/src/Umbraco.Web/Routing/UrlProviderSettings.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core;
+using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Umbraco.Web.Routing
+{
+    public class UrlProviderSettings
+    {
+        public UrlMode Mode { get; set; }
+        public UrlProviderSettings(IWebRoutingSection routingSettings)
+        {
+            var provider = UrlMode.Auto;
+            Mode = provider;
+
+            if (Enum<UrlMode>.TryParse(routingSettings.UrlProviderMode, out provider))
+            {
+                Mode = provider;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -185,6 +185,9 @@ namespace Umbraco.Web.Runtime
             composition.FilteredControllerFactory()
                 .Append<RenderControllerFactory>();
 
+            composition.Register<UrlProviderSettings, UrlProviderSettings>(Lifetime.Singleton);
+            composition.Register<IUmbracoContextUrlProviderFactory,UmbracoContextUrlProviderFactory>(Lifetime.Singleton);
+
             composition.UrlProviders()
                 .Append<AliasUrlProvider>()
                 .Append<DefaultUrlProvider>();

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -316,8 +316,11 @@
     <Compile Include="Routing\DefaultMediaUrlProvider.cs" />
     <Compile Include="Routing\IMediaUrlProvider.cs" />
     <Compile Include="Routing\IPublishedRouter.cs" />
+    <Compile Include="Routing\IUmbracoContextUrlProviderFactory.cs" />
     <Compile Include="Routing\MediaUrlProviderCollection.cs" />
     <Compile Include="Routing\MediaUrlProviderCollectionBuilder.cs" />
+    <Compile Include="Routing\UmbracoContextUrlProviderFactory.cs" />
+    <Compile Include="Routing\UrlProviderSettings.cs" />
     <Compile Include="Scheduling\SimpleTask.cs" />
     <Compile Include="Scheduling\TempFileCleanup.cs" />
     <Compile Include="Search\BackgroundIndexRebuilder.cs" />
@@ -1182,7 +1185,9 @@
     <Compile Include="PublishedCache\IPublishedMediaCache.cs" />
     <Compile Include="PublishedContentExtensions.cs" />
     <Compile Include="ExamineExtensions.cs" />
-    <Compile Include="FormlessPage.cs" />
+    <Compile Include="FormlessPage.cs">
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
     <Compile Include="HtmlHelperRenderExtensions.cs" />
     <Compile Include="Scheduling\SchedulerComponent.cs" />
     <Compile Include="ModelStateExtensions.cs" />

--- a/src/Umbraco.Web/UmbracoContext.cs
+++ b/src/Umbraco.Web/UmbracoContext.cs
@@ -33,18 +33,14 @@ namespace Umbraco.Web
         internal UmbracoContext(HttpContextBase httpContext,
             IPublishedSnapshotService publishedSnapshotService,
             WebSecurity webSecurity,
-            IUmbracoSettingsSection umbracoSettings,
-            IEnumerable<IUrlProvider> urlProviders,
-            IEnumerable<IMediaUrlProvider> mediaUrlProviders,
+            IUmbracoContextUrlProviderFactory urlProviderfactory,
             IGlobalSettings globalSettings,
             IVariationContextAccessor variationContextAccessor)
         {
             if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
             if (publishedSnapshotService == null) throw new ArgumentNullException(nameof(publishedSnapshotService));
             if (webSecurity == null) throw new ArgumentNullException(nameof(webSecurity));
-            if (umbracoSettings == null) throw new ArgumentNullException(nameof(umbracoSettings));
-            if (urlProviders == null) throw new ArgumentNullException(nameof(urlProviders));
-            if (mediaUrlProviders == null) throw new ArgumentNullException(nameof(mediaUrlProviders));
+            if (urlProviderfactory == null) throw new ArgumentNullException(nameof(urlProviderfactory));
             VariationContextAccessor = variationContextAccessor ??  throw new ArgumentNullException(nameof(variationContextAccessor));
             _globalSettings = globalSettings ?? throw new ArgumentNullException(nameof(globalSettings));
 
@@ -75,7 +71,8 @@ namespace Umbraco.Web
             //
             OriginalRequestUrl = GetRequestFromContext()?.Url ?? new Uri("http://localhost");
             CleanedUmbracoUrl = UriUtility.UriToUmbraco(OriginalRequestUrl);
-            UrlProvider = new UrlProvider(this, umbracoSettings.WebRouting, urlProviders, mediaUrlProviders, variationContextAccessor);
+
+            UrlProvider = urlProviderfactory.Create(this);
         }
 
         /// <summary>

--- a/src/Umbraco.Web/UmbracoContextFactory.cs
+++ b/src/Umbraco.Web/UmbracoContextFactory.cs
@@ -26,26 +26,24 @@ namespace Umbraco.Web
         private readonly IVariationContextAccessor _variationContextAccessor;
         private readonly IDefaultCultureAccessor _defaultCultureAccessor;
 
-        private readonly IUmbracoSettingsSection _umbracoSettings;
+        private readonly IUmbracoContextUrlProviderFactory _urlProviderFactory;
         private readonly IGlobalSettings _globalSettings;
-        private readonly UrlProviderCollection _urlProviders;
-        private readonly MediaUrlProviderCollection _mediaUrlProviders;
         private readonly IUserService _userService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoContextFactory"/> class.
         /// </summary>
-        public UmbracoContextFactory(IUmbracoContextAccessor umbracoContextAccessor, IPublishedSnapshotService publishedSnapshotService, IVariationContextAccessor variationContextAccessor, IDefaultCultureAccessor defaultCultureAccessor, IUmbracoSettingsSection umbracoSettings, IGlobalSettings globalSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IUserService userService)
+        public UmbracoContextFactory(IUmbracoContextAccessor umbracoContextAccessor, IPublishedSnapshotService publishedSnapshotService,
+            IVariationContextAccessor variationContextAccessor, IDefaultCultureAccessor defaultCultureAccessor,
+            IUmbracoContextUrlProviderFactory urlProviderFactory, IGlobalSettings globalSettings, IUserService userService)
         {
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
             _publishedSnapshotService = publishedSnapshotService ?? throw new ArgumentNullException(nameof(publishedSnapshotService));
             _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
             _defaultCultureAccessor = defaultCultureAccessor ?? throw new ArgumentNullException(nameof(defaultCultureAccessor));
 
-            _umbracoSettings = umbracoSettings ?? throw new ArgumentNullException(nameof(umbracoSettings));
+            _urlProviderFactory = urlProviderFactory ?? throw new ArgumentNullException(nameof(urlProviderFactory));
             _globalSettings = globalSettings ?? throw new ArgumentNullException(nameof(globalSettings));
-            _urlProviders = urlProviders ?? throw new ArgumentNullException(nameof(urlProviders));
-            _mediaUrlProviders = mediaUrlProviders ?? throw new ArgumentNullException(nameof(mediaUrlProviders));
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
         }
 
@@ -65,7 +63,7 @@ namespace Umbraco.Web
 
             var webSecurity = new WebSecurity(httpContext, _userService, _globalSettings);
 
-            return new UmbracoContext(httpContext, _publishedSnapshotService, webSecurity, _umbracoSettings, _urlProviders, _mediaUrlProviders, _globalSettings, _variationContextAccessor);
+            return new UmbracoContext(httpContext, _publishedSnapshotService, webSecurity, _urlProviderFactory, _globalSettings, _variationContextAccessor);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

The WebRouting section was being read per request, allocating xml classes even though it was not changing.
This pr introduces UrlProviderSettings and IUmbracoContextUrlProviderFactory to avoid memory allocations from repeated reads of WebRouting section.

