### PR TITLE
v9: Fixed Profilling logger to correctly send args in call

### DIFF
--- a/src/Umbraco.Core/Logging/DisposableTimer.cs
+++ b/src/Umbraco.Core/Logging/DisposableTimer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
@@ -73,7 +73,7 @@ namespace Umbraco.Cms.Core.Logging
                             var args = new object[startMessageArgs.Length + 1];
                             startMessageArgs.CopyTo(args, 0);
                             args[startMessageArgs.Length] = _timingId;
-                            logger.LogDebug(startMessage + " [Timing {TimingId}]", args);
+                            logger.LogInformation(startMessage + " [Timing {TimingId}]", args);
                         }
                         break;
                     default:

--- a/src/Umbraco.Core/Logging/ProfilingLogger.cs
+++ b/src/Umbraco.Core/Logging/ProfilingLogger.cs
@@ -40,10 +40,10 @@ namespace Umbraco.Cms.Core.Logging
             => TraceDuration<T>(startMessage, "Completed.", startMessageArgs: startMessageArgs);
 
         public DisposableTimer TraceDuration<T>(string startMessage, string completeMessage, string failMessage = null, object[] startMessageArgs = null, object[] endMessageArgs = null, object[] failMessageArgs = null)
-            => new DisposableTimer(Logger, LogLevel.Information, Profiler, typeof(T), startMessage, completeMessage, failMessage);
+            => new DisposableTimer(Logger, LogLevel.Information, Profiler, typeof(T), startMessage, completeMessage, failMessage, startMessageArgs, endMessageArgs, failMessageArgs);
 
         public DisposableTimer TraceDuration(Type loggerType, string startMessage, string completeMessage, string failMessage = null, object[] startMessageArgs = null, object[] endMessageArgs = null, object[] failMessageArgs = null)
-            => new DisposableTimer(Logger, LogLevel.Information, Profiler, loggerType, startMessage, completeMessage, failMessage);
+            => new DisposableTimer(Logger, LogLevel.Information, Profiler, loggerType, startMessage, completeMessage, failMessage, startMessageArgs, endMessageArgs, failMessageArgs);
 
         public DisposableTimer DebugDuration<T>(string startMessage, object[] startMessageArgs = null)
             => Logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug)


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco-CMS/issues/11033

Turns out we weren't sending our startMessageArgs in the constructor, while digging i also found that even if we were sending the
args, we wouldn't see the message in the log, cause it was LogLevel Debug, so i corrected it to LogLevel Information so it will display when using IProflingLogger
# Notes
- Updated call to correctly have startMessageArgs & endMessageArgs
- Updated LogLevel so it correctly is also LogInformation so you can actually see the logmessage

# How to test
- Set up a NotificationHandler to alert you when saving content
I used: 
```
public class NotificationTester : INotificationHandler<ContentTypeSavedNotification>
    {
        private IProfilingLogger _profilingLogger;

        public NotificationTester(IProfilingLogger profilingLogger)
        {
            _profilingLogger = profilingLogger;
        }
        public void Handle(ContentTypeSavedNotification notification)
        {
            _profilingLogger.TraceDuration<NotificationTester>("Fetching data with Type Id: {typeId} from {catalog}", new object[] { 1, "assorted" });
        }
    }
```

- Go to startup.cs and in the ConfigureServices method change 
```
services.AddUmbraco(_env, _config)
                .AddBackOffice()
                .AddWebsite()
                .AddComposers()
                .Build();
```

to

```
services.AddUmbraco(_env, _config)
                .AddBackOffice()
                .AddWebsite()
                .AddComposers()
                .AddNotificationHandler<ContentTypeSavedNotification, NotificationTester>()
                .Build();
```
- Now open up umbraco, make a random document type and save it
- Go to your logviewer and view all logs, you should now see the message `Fetching data with Type Id: 1 from assorted" [Timing "X*X*X*X"]`
