### PR TITLE
Added support for configuring the UmbraocFile "sink", using IConfiguration

### DIFF
--- a/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.Logging.Serilog
             IConfiguration configuration)
         {
             var loggerConfig = new LoggerConfiguration()
-                .MinimalConfiguration(hostingEnvironment, loggingConfiguration)
+                .MinimalConfiguration(hostingEnvironment, loggingConfiguration, configuration)
                 .ReadFrom.Configuration(configuration);
 
             return new SerilogLogger(loggerConfig);

--- a/src/Umbraco.Infrastructure/Logging/Serilog/UmbracoFileConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/UmbracoFileConfiguration.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Events;
+
+namespace Umbraco.Cms.Infrastructure.Logging.Serilog
+{
+    public class UmbracoFileConfiguration
+    {
+        public UmbracoFileConfiguration(IConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var appSettings = configuration.GetSection("Serilog:WriteTo");
+            var umbracoFileAppSettings = appSettings.GetChildren().LastOrDefault(x => x.GetValue<string>("Name") == "UmbracoFile");
+
+            if (umbracoFileAppSettings is not null)
+            {
+                var args = umbracoFileAppSettings.GetSection("Args");
+
+                RestrictedToMinimumLevel = args.GetValue(nameof(RestrictedToMinimumLevel), RestrictedToMinimumLevel);
+                FileSizeLimitBytes = args.GetValue(nameof(FileSizeLimitBytes), FileSizeLimitBytes);
+                RollingInterval = args.GetValue(nameof(RollingInterval), RollingInterval);
+                FlushToDiskInterval = args.GetValue(nameof(FlushToDiskInterval), FlushToDiskInterval);
+                RollOnFileSizeLimit = args.GetValue(nameof(RollOnFileSizeLimit), RollOnFileSizeLimit);
+                RetainedFileCountLimit = args.GetValue(nameof(RetainedFileCountLimit), RetainedFileCountLimit);
+            }
+        }
+
+        public LogEventLevel RestrictedToMinimumLevel { get; set; } = LogEventLevel.Verbose;
+        public long FileSizeLimitBytes { get; set; } = 1073741824;
+        public RollingInterval RollingInterval { get; set; }= RollingInterval.Day;
+        public TimeSpan? FlushToDiskInterval { get; set; } = null;
+        public bool RollOnFileSizeLimit { get; set; } = false;
+        public int RetainedFileCountLimit { get; set; }= 31;
+
+        public string GetPath(string logDirectory)
+        {
+            return Path.Combine(logDirectory, $"UmbracoTraceLog.{Environment.MachineName}..json");
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Logging/Serilog/UmbracoFileConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/UmbracoFileConfiguration.cs
@@ -34,10 +34,10 @@ namespace Umbraco.Cms.Infrastructure.Logging.Serilog
 
         public LogEventLevel RestrictedToMinimumLevel { get; set; } = LogEventLevel.Verbose;
         public long FileSizeLimitBytes { get; set; } = 1073741824;
-        public RollingInterval RollingInterval { get; set; }= RollingInterval.Day;
+        public RollingInterval RollingInterval { get; set; } = RollingInterval.Day;
         public TimeSpan? FlushToDiskInterval { get; set; } = null;
         public bool RollOnFileSizeLimit { get; set; } = false;
-        public int RetainedFileCountLimit { get; set; }= 31;
+        public int RetainedFileCountLimit { get; set; } = 31;
 
         public string GetPath(string logDirectory)
         {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10965

Added support for configuring the Umbraco File "Sink" in appsettings.

```json
{
  "Serilog": {
    "WriteTo": [
      {
        "Name": "UmbracoFile",
        "Args": {
          "RestrictedToMinimumLevel": "Warning",
          "FileSizeLimitBytes": 1073741824,
          "RollingInterval" : "Day",
          "FlushToDiskInterval": null,
          "RollOnFileSizeLimit": false,
          "RetainedFileCountLimit": 31
        }
      }
    ]
  },
}
```

This is not handled by default, because the UmbracoFile  "Sink" is not just a regular File sink due to performance and file-locking concerns. 

Sadly this means reading the serilog configuration ourself. A cool future cycle hack could be to implement the UmbracoFile as a real Sink, and have that in an assembly containing name "Serilog" so it would be picked up by default.


## Testing
- Change the logging configuration, e.g. RestrictedToMinimumLevel.  And ensure the UmbracoFile do not log lower levels.
- Note that the RestrictedToMinimumLevel must be higher than the global minimum level.