### PR TITLE
Allow script, link, and style tags in macro previews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/macro.controller.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
     .controller("Umbraco.PropertyEditors.Grid.MacroController",
-        function ($scope, $timeout, editorService, macroResource, macroService, localizationService, $routeParams) {
+        function ($scope, $timeout, editorService, macroResource, macroService, localizationService, $routeParams, $sce) {
 
             $scope.control.icon = $scope.control.icon || 'icon-settings-alt';
 
@@ -45,7 +45,7 @@ angular.module("umbraco")
                     .then(function (htmlResult) {
                         $scope.title = macro.macroAlias;
                         if (htmlResult.trim().length > 0 && htmlResult.indexOf("Macro:") < 0) {
-                            $scope.preview = htmlResult;
+                            $scope.preview = $sce.trustAsHtml(htmlResult);
                         }
                     });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/5997

### Description

Modify macro controller to use $sce.trustAsHtml on the macro preview, allowing <script>, &lt;link&gt;, and <style> tags to be used inside the preview.

To test, simply create a macro with any of the aforementioned tags in the macro view, or use the sample below

```CSHTML
@inherits Umbraco.Cms.Web.Common.Macros.PartialViewMacroPage

<div>
    <style type="text/css">
        .sce-test {
            color: blue;
            font-weight: bold;
        }
    </style>

    SCE <span class="sce-test">test</span>
</div>
```
The 'test' in 'SCE test' should show bold and in blue on success

<!-- Thanks for contributing to Umbraco CMS! -->
