### PR TITLE
V9/feature/cancellation now works on content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -68,6 +68,10 @@ function ContentDeleteController($scope, $timeout, contentResource, treeService,
                 // TODO: All YSOD handling should be done with an interceptor
                 overlayService.ysod(err);
             }
+
+            if(err.data && err.data.notifications && err.data.notifications.length > 0) {
+                navigationService.hideDialog();
+            }
         });
 
     };

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -67,6 +67,7 @@ function ContentDeleteController($scope, $timeout, contentResource, treeService,
             if (err.status && err.status >= 500) {
                 // TODO: All YSOD handling should be done with an interceptor
                 overlayService.ysod(err);
+                navigationService.hideDialog();
             }
 
             if(err.data && err.data.notifications && err.data.notifications.length > 0) {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10980
# Notes
- Added commit 598b5cf0fca77c4095abbb0d25970b25f563b2c4
- Added commit 36ba30fcbdabd2e9f896f200d098561f1ab0efa0

# How to test
 ```
public class CannotDeleteContentNotification : INotificationHandler<ContentMovingToRecycleBinNotification>
  {


      public void Handle(ContentMovingToRecycleBinNotification notification)
      {

          foreach (var moveEventInfo in notification.MoveInfoCollection)
          {
              notification.CancelOperation(new EventMessage("cancel", "lorem ipsum"));

          }
      }
  }
```
- Add the above NotificationHandler (Thanks to the original issue creator for the snippet 💪 )
- Make a doc type and some content
- Try to delete the content, the right message should now pop up, and the content should not be deleted
