### PR TITLE
Fixes folder creation for doc, data, and media types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
@@ -36,7 +36,7 @@
                         ng-model="model.folderName" 
                         class="umb-textstring textstring input-block-level"
                         focus-when="{{model.creatingFolder}}" 
-                        required umb-auto-focus />
+                        required />
                 </umb-control-group>
 
                 <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/create.html
@@ -24,13 +24,19 @@
             </ul>
         </div>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
+        <div class="umb-pane" ng-show="model.creatingFolder">
             <form novalidate name="createFolderForm"
                 ng-submit="createContainer()"
                 val-form-manager>
 
                 <umb-control-group label="Enter a folder name" hide-label="false">
-                    <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" required umb-auto-focus />
+                    <input 
+                        type="text" 
+                        name="folderName" 
+                        ng-model="model.folderName" 
+                        class="umb-textstring textstring input-block-level"
+                        focus-when="{{model.creatingFolder}}" 
+                        required umb-auto-focus />
                 </umb-control-group>
 
                 <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -54,7 +54,7 @@
             </ul>
         </div>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
+        <div class="umb-pane" ng-show="model.creatingFolder">
             <form novalidate name="createFolderForm"
                   ng-submit="createContainer()"
                   val-form-manager>
@@ -67,7 +67,14 @@
                 </div>
 
                 <umb-control-group label="Enter a folder name" hide-label="false">
-                    <input type="text" name="folderName" maxlength="255" ng-model="model.folderName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
+                    <input 
+                        type="text" 
+                        name="folderName" 
+                        maxlength="255" 
+                        ng-model="model.folderName" 
+                        class="umb-textstring textstring input-block-level" 
+                        focus-when="{{model.creatingFolder}}" 
+                        required />
                 </umb-control-group>
 
                 <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
@@ -24,7 +24,7 @@
             </ul>
         </div>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
+        <div class="umb-pane" ng-show="model.creatingFolder">
             <form novalidate name="createFolderForm"
                 ng-submit="createContainer()"
                 val-form-manager>
@@ -37,7 +37,13 @@
             </div>
 
                 <umb-control-group label="Enter a folder name" hide-label="false">
-                    <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
+                    <input 
+                        type="text" 
+                        name="folderName"
+                        ng-model="model.folderName"
+                        class="umb-textstring textstring input-block-level"
+                        focus-when="{{model.creatingFolder}}"
+                        required />
                 </umb-control-group>
 
                 <button type="submit" class="btn btn-primary"><localize key="general_create">Create</localize></button>


### PR DESCRIPTION
PR: https://github.com/umbraco/Umbraco-CMS/pull/10983 introduces a bug where you can't create folders for doctypes and data types anymore.

I have updated the view to use `ng-show` instead of `ng-if.` Ng-if introduces a new scope that breaks the relation to the form. I have also updated the focus directive to use `focus-when` instead of `auto-focus`. It makes it possible to control when a field should have focus.

How to test:
* Make sure the input field has focus when you create a new folder for doctypes and datatypes
* Make sure you can save and the folder gets created