### PR TITLE
Fixes a couple of issues with the Umbraco Package dotnet new template.

### DIFF
--- a/build/templates/UmbracoPackage/.template.config/template.json
+++ b/build/templates/UmbracoPackage/.template.config/template.json
@@ -30,13 +30,53 @@
         },
         "namespaceReplacer": {
             "type": "generated",
-            "generator": "coalesce",
+            "generator": "regex",
+            "dataType": "string",
+            "replaces": "UmbracoPackage",
             "parameters": {
-                "sourceVariableName": "name",
-                "defaultValue": "UmbracoPackage",
-                "fallbackVariableName": "name"
-            },
-            "replaces":"UmbracoPackage"
+                "source": "name",
+                "steps": [
+                    {
+                        "regex": "\\s",
+                        "replacement": "_"
+                    },
+                    {
+                        "regex": "-",
+                        "replacement": "_"
+                    },
+                    {
+                        "regex": "^[^a-zA-Z_]+",
+                        "replacement": "_"
+                    }
+                ]
+            }
+        },
+        "msbuildReplacer": {
+            "type": "generated",
+            "generator": "regex",
+            "dataType": "string",
+            "replaces": "UmbracoPackageMsBuild",
+            "parameters": {
+                "source": "name",
+                "steps": [
+                    {
+                        "regex": "\\s",
+                        "replacement": ""
+                    },
+                    {
+                        "regex": "\\.",
+                        "replacement": ""
+                    },
+                    {
+                        "regex": "-",
+                        "replacement": ""
+                    },
+                    {
+                        "regex": "^[^a-zA-Z_]+",
+                        "replacement": ""
+                    }
+                ]
+            }
         },
         "Framework": {
             "type": "parameter",

--- a/build/templates/UmbracoPackage/UmbracoPackage.csproj
+++ b/build/templates/UmbracoPackage/UmbracoPackage.csproj
@@ -8,6 +8,7 @@
         <Description>...</Description>
         <Product>...</Product>
         <PackageTags>umbraco plugin package</PackageTags>
+        <RootNamespace>UmbracoPackage</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/build/templates/UmbracoPackage/build/UmbracoPackage.targets
+++ b/build/templates/UmbracoPackage/build/UmbracoPackage.targets
@@ -1,27 +1,27 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <UmbracoPackageContentFilesPath>$(MSBuildThisFileDirectory)..\App_Plugins\UmbracoPackage\**\*.*</UmbracoPackageContentFilesPath>
+        <UmbracoPackageMsBuildContentFilesPath>$(MSBuildThisFileDirectory)..\App_Plugins\UmbracoPackage\**\*.*</UmbracoPackageMsBuildContentFilesPath>
     </PropertyGroup>
 
-    <Target Name="CopyUmbracoPackageAssets" BeforeTargets="Build">
+    <Target Name="CopyUmbracoPackageMsBuildAssets" BeforeTargets="Build">
         <ItemGroup>
-            <UmbracoPackageContentFiles Include="$(UmbracoPackageContentFilesPath)" />
+            <UmbracoPackageMsBuildContentFiles Include="$(UmbracoPackageMsBuildContentFilesPath)" />
         </ItemGroup>
-        <Message Text="Copying UmbracoPackage files: $(UmbracoPackageContentFilesPath) - #@(UmbracoPackageContentFiles->Count()) files"  Importance="high" />
+        <Message Text="Copying UmbracoPackage files: $(UmbracoPackageMsBuildContentFilesPath) - #@(UmbracoPackageMsBuildContentFiles->Count()) files"  Importance="high" />
         <Copy
-            SourceFiles="@(UmbracoPackageContentFiles)"
-            DestinationFiles="@(UmbracoPackageContentFiles->'$(MSBuildProjectDirectory)\App_Plugins\UmbracoPackage\%(RecursiveDir)%(Filename)%(Extension)')"
+            SourceFiles="@(UmbracoPackageMsBuildContentFiles)"
+            DestinationFiles="@(UmbracoPackageMsBuildContentFiles->'$(MSBuildProjectDirectory)\App_Plugins\UmbracoPackage\%(RecursiveDir)%(Filename)%(Extension)')"
             SkipUnchangedFiles="true" />
 
     </Target>
 
-    <Target Name="ClearUmbracoPackageAssets" BeforeTargets="Clean">
+    <Target Name="ClearUmbracoPackageMsBuildAssets" BeforeTargets="Clean">
         <ItemGroup>
-            <UmbracoPackageDir Include="$(MSBuildProjectDirectory)\App_Plugins\UmbracoPackage\" />
+            <UmbracoPackageMsBuildDir Include="$(MSBuildProjectDirectory)\App_Plugins\UmbracoPackage\" />
         </ItemGroup>
         <Message Text="Clear old UmbracoPackage data"  Importance="high" />
-        <RemoveDir Directories="@(UmbracoPackageDir)"  />
+        <RemoveDir Directories="@(UmbracoPackageMsBuildDir)"  />
     </Target>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/10641

- Fixed issues with invalid namespace, when using characters like "-"
- Fixed issues with invalid characters in MSBuilder property names, like "."

## Test 
- Build the templates using build.ps1
- Uninstall existing templates: `dotnet new -u Umbraco.Templates`
- Install new templates: `dotnet new -i Umbraco.Templates::9.0.0-* --nuget-source={Repo Path}\build.out`
   - Replace {Repo Path} with your repo path
 - Install the Umbraco Package template using crazy names, like:
   - Umbraco.MyPackage
   - Umbraco.MyPackage.a12313asd
   - U-m-b-r-a-c-o
   ....
 - Ensure the build/*.targets are valid.
 - Create a class and ensure the namespace are valid
    