### PR TITLE
Set correct sort order on converted tab

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenttypehelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenttypehelper.service.js
@@ -90,6 +90,9 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
         },
 
         convertGroupToTab: function (groups, group) {
+            const tabs = groups.filter(group => group.type === this.TYPE_TAB).sort((a, b) => a.sortOrder - b.sortOrder);
+            const nextSortOrder = tabs && tabs.length > 0 ? tabs[tabs.length - 1].sortOrder + 1 : 0;
+
             group.convertingToTab = true;
 
             group.type = this.TYPE_TAB;
@@ -100,7 +103,7 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
 
             group.alias = this.isAliasUnique(otherGroups, newAlias) ? newAlias : this.createUniqueAlias(otherGroups, newAlias);
             group.parentAlias = null;
-
+            group.sortOrder = nextSortOrder;
             group.convertingToTab = false;
         },
 

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/content-type-helper.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/content-type-helper.spec.js
@@ -173,13 +173,13 @@ describe('contentTypeHelper tests', function () {
 
   describe('convertGroupToTab', function () {
 
-    const groups = [
-      { type: 0, alias: 'hero', name: 'Hero' }, 
-      { type: 0, alias: 'content' }, 
-      { type: 0, alias: 'footer' }
-    ];
-
     it('should convert group to tab', function () {
+      const groups = [
+        { type: 0, alias: 'hero', name: 'Hero' }, 
+        { type: 0, alias: 'content' }, 
+        { type: 0, alias: 'footer' }
+      ];
+
       const newTab = groups[0];
 
       contentTypeHelper.convertGroupToTab(groups, newTab);
@@ -187,6 +187,29 @@ describe('contentTypeHelper tests', function () {
       expect(newTab.type).toBe(contentTypeHelper.TYPE_TAB);
       expect(newTab.alias).toBe('hero');
       expect(newTab.parentAlias).toBeNull();
+    });
+
+    it('should set sort order to 0 if it is the first tab', function () {
+      const groups = [
+        { type: 0, alias: 'hero', name: 'Hero' }
+      ];
+      
+      const newTab = groups[0];
+      contentTypeHelper.convertGroupToTab(groups, newTab);
+
+      expect(newTab.sortOrder).toBe(0);
+    });
+
+    it('should set sort order to 1 higher than the last tab', function () {
+      const groups = [
+        { type: 0, alias: 'settings', name: 'Settings', sortOrder: 100 },
+        { type: 1, alias: 'content', name: 'Content', sortOrder: 5 }
+      ];
+      
+      const newTab = groups[0];
+      contentTypeHelper.convertGroupToTab(groups, newTab);
+
+      expect(newTab.sortOrder).toBe(6);
     });
 
   });


### PR DESCRIPTION
When converting a group to a tab, we need to change the group sortOrder to fit into the tab's sortOrder.

This PR sets the correct sort order on the new tab.

How to test:
- Create a doctype with a couple of groups
- Drag one of the groups to the "Convert to Tab"-area next to the compositions button. It is only visible when you drag a group.


https://user-images.githubusercontent.com/6078361/132348005-608d38e4-74ae-4618-a08e-2dcb7b15e0f7.mp4

