### PR TITLE
Fixes #10751 - ConcurrentHashSet updates

### DIFF
--- a/src/Umbraco.Web/Install/Controllers/InstallApiController.cs
+++ b/src/Umbraco.Web/Install/Controllers/InstallApiController.cs
@@ -74,12 +74,7 @@ namespace Umbraco.Web.Install.Controllers
         {
             if (installModel == null) throw new ArgumentNullException(nameof(installModel));
 
-            var status = InstallStatusTracker.GetStatus().ToArray();
-            //there won't be any statuses returned if the app pool has restarted so we need to re-read from file.
-            if (status.Any() == false)
-            {
-                status = InstallStatusTracker.InitializeFromFile(installModel.InstallId).ToArray();
-            }
+            var status = InstallStatusTracker.GetOrderedStatus(installModel.InstallId);
 
             //create a new queue of the non-finished ones
             var queue = new Queue<InstallTrackingItem>(status.Where(x => x.IsComplete == false));

--- a/src/Umbraco.Web/Install/InstallSteps/DatabaseUpgradeStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/DatabaseUpgradeStep.cs
@@ -29,8 +29,7 @@ namespace Umbraco.Web.Install.InstallSteps
 
         public override Task<InstallSetupResult> ExecuteAsync(object model)
         {
-            var installSteps = InstallStatusTracker.GetStatus().ToArray();
-            var previousStep = installSteps.Single(x => x.Name == "DatabaseInstall");
+            var previousStep = InstallStatusTracker.GetRequiredStep("DatabaseInstall");
             var upgrade = previousStep.AdditionalData.ContainsKey("upgrade");
 
             if (upgrade)
@@ -59,9 +58,9 @@ namespace Umbraco.Web.Install.InstallSteps
             if (_runtime.Level == RuntimeLevel.Run)
                 return false;
 
-            var installSteps = InstallStatusTracker.GetStatus().ToArray();
+            var dbInstallStep = InstallStatusTracker.GetStep("DatabaseInstall");
             //this step relies on the previous one completed - because it has stored some information we need
-            if (installSteps.Any(x => x.Name == "DatabaseInstall" && x.AdditionalData.ContainsKey("upgrade")) == false)
+            if (dbInstallStep == null || !dbInstallStep.AdditionalData.ContainsKey("upgrade"))
             {
                 return false;
             }

--- a/src/Umbraco.Web/Install/InstallSteps/StarterKitCleanupStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/StarterKitCleanupStep.cs
@@ -14,8 +14,7 @@ namespace Umbraco.Web.Install.InstallSteps
     {
         public override Task<InstallSetupResult> ExecuteAsync(object model)
         {
-            var installSteps = InstallStatusTracker.GetStatus().ToArray();
-            var previousStep = installSteps.Single(x => x.Name == "StarterKitDownload");
+            var previousStep = InstallStatusTracker.GetRequiredStep("StarterKitDownload");
             var packageId = Convert.ToInt32(previousStep.AdditionalData["packageId"]);
             var packageFile = (string)previousStep.AdditionalData["packageFile"];
 
@@ -34,9 +33,9 @@ namespace Umbraco.Web.Install.InstallSteps
 
         public override bool RequiresExecution(object model)
         {
-            var installSteps = InstallStatusTracker.GetStatus().ToArray();
+            var starterKitDownloadStep = InstallStatusTracker.GetStep("StarterKitDownload");
             //this step relies on the previous one completed - because it has stored some information we need
-            if (installSteps.Any(x => x.Name == "StarterKitDownload" && x.AdditionalData.ContainsKey("packageId")) == false)
+            if (starterKitDownloadStep == null || !starterKitDownloadStep.AdditionalData.ContainsKey("packageId"))
             {
                 return false;
             }

--- a/src/Umbraco.Web/Install/InstallSteps/StarterKitInstallStep.cs
+++ b/src/Umbraco.Web/Install/InstallSteps/StarterKitInstallStep.cs
@@ -28,8 +28,7 @@ namespace Umbraco.Web.Install.InstallSteps
 
         public override Task<InstallSetupResult> ExecuteAsync(object model)
         {
-            var installSteps = InstallStatusTracker.GetStatus().ToArray();
-            var previousStep = installSteps.Single(x => x.Name == "StarterKitDownload");
+            var previousStep = InstallStatusTracker.GetRequiredStep("StarterKitDownload");
             var packageId = Convert.ToInt32(previousStep.AdditionalData["packageId"]);
 
             InstallBusinessLogic(packageId);
@@ -51,9 +50,9 @@ namespace Umbraco.Web.Install.InstallSteps
 
         public override bool RequiresExecution(object model)
         {
-            var installSteps = InstallStatusTracker.GetStatus().ToArray();
+            var startKitDownloadStep = InstallStatusTracker.GetStep("StarterKitDownload");
             //this step relies on the previous one completed - because it has stored some information we need
-            if (installSteps.Any(x => x.Name == "StarterKitDownload" && x.AdditionalData.ContainsKey("packageId")) == false)
+            if (startKitDownloadStep == null || !startKitDownloadStep.AdditionalData.ContainsKey("packageId"))
             {
                 return false;
             }

--- a/src/Umbraco.Web/Install/Models/InstallTrackingItem.cs
+++ b/src/Umbraco.Web/Install/Models/InstallTrackingItem.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Umbraco.Web.Install.Models
 {
-    internal class InstallTrackingItem
+    internal class InstallTrackingItem : IEquatable<InstallTrackingItem>
     {
         public InstallTrackingItem(string name, int serverOrder)
         {
@@ -17,22 +18,20 @@ namespace Umbraco.Web.Install.Models
         public bool IsComplete { get; set; }
         public IDictionary<string, object> AdditionalData { get; set; }
 
-        protected bool Equals(InstallTrackingItem other)
-        {
-            return string.Equals(Name, other.Name);
-        }
-
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((InstallTrackingItem) obj);
+            return Equals(obj as InstallTrackingItem);
+        }
+
+        public bool Equals(InstallTrackingItem other)
+        {
+            return other != null &&
+                   Name == other.Name;
         }
 
         public override int GetHashCode()
         {
-            return Name.GetHashCode();
+            return 539060726 + EqualityComparer<string>.Default.GetHashCode(Name);
         }
     }
 }


### PR DESCRIPTION
Fixes #10751 - ConcurrentHashSet updates to not use disposable locks. Fixes the installer steps for easier lookups and also always ensuring ordering is done with the ServerOrder value.

The issue with #10751 is because the installer tracker code was using a hashset and assumed that it was ordered but hashsets by nature are not ordered. Previously it was ordering by `ServerOrder` which is required, however, when the app would restart midway through the installer, the installer steps would be read in from the file but they would not be returned as ordered. However, the previous version of ConcurrentHashSet by pure fluke was maintaining the order of items that existed in the file.

This PR fixes the installer steps logic, always ensures the items are ordered, removes the usage of ConcurrentHashSet entirely, makes the static class thread safe and uses a dictionary for faster step lookup.