### PR TITLE
Fix Image Cropper media path parsing

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaUrlGeneratorCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models;
@@ -6,32 +7,28 @@ namespace Umbraco.Cms.Core.PropertyEditors
 {
     public class MediaUrlGeneratorCollection : BuilderCollectionBase<IMediaUrlGenerator>
     {
-        public MediaUrlGeneratorCollection(System.Func<IEnumerable<IMediaUrlGenerator>> items) : base(items)
-        {
-        }
+        public MediaUrlGeneratorCollection(Func<IEnumerable<IMediaUrlGenerator>> items)
+            : base(items)
+        { }
 
         public bool TryGetMediaPath(string propertyEditorAlias, object value, out string mediaPath)
         {
             // We can't get a media path from a null value
-            // The value will be null when uploading a brand new image, since we try to get the "old path" which doesn't exist yet.
-            if (value is null)
+            // The value will be null when uploading a brand new image, since we try to get the "old path" which doesn't exist yet
+            if (value is not null)
             {
-                mediaPath = null;
-                return false;
-            }
-
-            foreach(IMediaUrlGenerator generator in this)
-            {
-                if (generator.TryGetMediaPath(propertyEditorAlias, value, out var mp))
+                foreach (IMediaUrlGenerator generator in this)
                 {
-                    mediaPath = mp;
-                    return true;
+                    if (generator.TryGetMediaPath(propertyEditorAlias, value, out var generatorMediaPath))
+                    {
+                        mediaPath = generatorMediaPath;
+                        return true;
+                    }
                 }
             }
+
             mediaPath = null;
             return false;
         }
-
-
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
@@ -12,9 +11,7 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
-using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors
@@ -71,11 +68,14 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
         public bool TryGetMediaPath(string propertyEditorAlias, object value, out string mediaPath)
         {
-            if (propertyEditorAlias == Alias)
+            if (propertyEditorAlias == Alias &&
+                value?.ToString() is var mediaPathValue &&
+                !string.IsNullOrWhiteSpace(mediaPathValue))
             {
-                mediaPath = value?.ToString();
+                mediaPath = mediaPathValue;
                 return true;
             }
+
             mediaPath = null;
             return false;
         }
@@ -84,11 +84,10 @@ namespace Umbraco.Cms.Core.PropertyEditors
         /// Gets a value indicating whether a property is an upload field.
         /// </summary>
         /// <param name="property">The property.</param>
-        /// <returns>A value indicating whether a property is an upload field, and (optionally) has a non-empty value.</returns>
-        private static bool IsUploadField(IProperty property)
-        {
-            return property.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.UploadField;
-        }
+        /// <returns>
+        ///   <c>true</c> if the specified property is an upload field; otherwise, <c>false</c>.
+        /// </returns>
+        private static bool IsUploadField(IProperty property) => property.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.UploadField;
 
         /// <summary>
         /// The paths to all file upload property files contained within a collection of content entities

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -14,9 +14,7 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
-using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors
@@ -70,11 +68,14 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
         public bool TryGetMediaPath(string propertyEditorAlias, object value, out string mediaPath)
         {
-            if (propertyEditorAlias == Alias)
+            if (propertyEditorAlias == Alias &&
+                GetFileSrcFromPropertyValue(value, out _, false) is var mediaPathValue &&
+                !string.IsNullOrWhiteSpace(mediaPathValue))
             {
-                mediaPath = GetFileSrcFromPropertyValue(value, out _, false);
+                mediaPath = mediaPathValue;
                 return true;
             }
+
             mediaPath = null;
             return false;
         }
@@ -95,11 +96,10 @@ namespace Umbraco.Cms.Core.PropertyEditors
         /// Gets a value indicating whether a property is an image cropper field.
         /// </summary>
         /// <param name="property">The property.</param>
-        /// <returns>A value indicating whether a property is an image cropper field, and (optionally) has a non-empty value.</returns>
-        private static bool IsCropperField(IProperty property)
-        {
-            return property.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.ImageCropper;
-        }
+        /// <returns>
+        ///   <c>true</c> if the specified property is an image cropper field; otherwise, <c>false</c>.
+        /// </returns>
+        private static bool IsCropperField(IProperty property) => property.PropertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.ImageCropper;
 
         /// <summary>
         /// Parses the property value into a json object.

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -167,10 +167,23 @@ namespace Umbraco.Cms.Core.PropertyEditors
         {
             deserializedValue = null;
             if (propVal == null || !(propVal is string str)) return null;
-            if (!str.DetectIsJson()) return null;
-            deserializedValue = GetJObject(str, true);
+
+            if (!str.DetectIsJson())
+            {
+                // Assume the value is a plain string with the file path
+                deserializedValue = new JObject()
+                {
+                    { "src", str }
+                };
+            }
+            else
+            {
+                deserializedValue = GetJObject(str, true);
+            }
+
             if (deserializedValue?["src"] == null) return null;
             var src = deserializedValue["src"].Value<string>();
+
             return relative ? _mediaFileManager.FileSystem.GetRelativePath(src) : src;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After installing the Starter Kit on a clean `v9/dev` installation (`dotnet add package Umbraco.TheStarterKit --version 9.0.0-rc001`), the front-end throws an `ArgumentException` on every page that tries to get the media path from an Image Cropper:

```
System.ArgumentException: path cannot be null or whitespace (Parameter 'path')
   at Umbraco.Cms.Core.Routing.DefaultMediaUrlProvider.AssembleUrl(String path, Uri current, UrlMode mode)
   at Umbraco.Cms.Core.Routing.DefaultMediaUrlProvider.GetMediaUrl(IPublishedContent content, String propertyAlias, UrlMode mode, String culture, Uri current)
   at Umbraco.Cms.Core.Routing.UrlProvider.<>c__DisplayClass19_0.<GetMediaUrl>b__0(IMediaUrlProvider provider)
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Umbraco.Cms.Core.Routing.UrlProvider.GetMediaUrl(IPublishedContent content, UrlMode mode, String culture, String propertyAlias, Uri current)
   at Umbraco.Extensions.PublishedContentExtensions.Url(IPublishedContent content, IPublishedUrlProvider publishedUrlProvider, String culture, UrlMode mode)
   at Umbraco.Cms.Core.PropertyEditors.ValueConverters.MediaPickerWithCropsValueConverter.ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, Object inter, Boolean preview)
   at Umbraco.Cms.Core.Models.PublishedContent.PublishedPropertyType.ConvertInterToObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, Object inter, Boolean preview)
   at Umbraco.Cms.Infrastructure.PublishedCache.Property.GetValue(String culture, String segment)
   at Umbraco.Extensions.PublishedPropertyExtension.Value[T](IPublishedProperty property, IPublishedValueFallback publishedValueFallback, String culture, String segment, Fallback fallback, T defaultValue)
   at Umbraco.Extensions.PublishedContentExtensions.Value[T](IPublishedContent content, IPublishedValueFallback publishedValueFallback, String alias, String culture, String segment, Fallback fallback, T defaultValue)
...
```

This is because the media added by the Starter Kit has `umbracoFile` property values set to the plain media path (`/media/...`), instead of the JSON value expected by the Image Cropper (`{src:"/media/..."}`). 

With the introduction of the `MediaUrlGeneratorCollection` in https://github.com/umbraco/Umbraco-CMS/commit/13a56eb08549f196eeb8039b656c24cf91c452aa, the support for plain media paths seems to be removed. A similar issue was reported in https://github.com/umbraco/Umbraco-CMS/pull/10676, but that doesn't fix the underlying issue.

To test this PR:
1. Install the Starter Kit on the latest `v9/dev` and ensure the package migration is run (and content/media is added)
2. Open the Home page on the frontend: you should see the `ArgumentException` because it requests the media URL to render the Hero Background image
3. If you re-save this image in the media section ('Design\Umbraco Campari Meeting Room'), the `umbracoFile` property will be updated to the JSON value
4. The Home page will now render correctly (both all other pages using media will still throw the exception)
5. Apply this PR
6. All other pages will now correctly render the images and the updated Hero Background image on the Home page will still work