### PR TITLE
Fix move group to Generic tab only work once

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -143,6 +143,9 @@
                             const dropIndex = groupsInTab.findIndex(group => group.key === groupKey);
 
                             updateSortOrder(groupsInTab, dropIndex);
+
+                            // when a group is dropped we need to reset the requested tab hover alias
+                            scope.sortableRequestedTabAlias = undefined;
                         }
                     }
                 };
@@ -192,7 +195,9 @@
                             const newAlias = contentTypeHelper.updateParentAlias(group.alias || null, hoveredTabAlias);
                             // Check alias is unique
                             if (group.alias !== newAlias && contentTypeHelper.isAliasUnique(scope.model.groups, newAlias) === false) {
-                                // TODO: Missing UI indication of why you cant move here.
+                                localizationService.localize("contentTypeEditor_groupReorderSameAliasError",  [group.name, newAlias]).then((value) => {
+                                    notificationsService.error(value);
+                                });
                                 return;
                             }
                         }

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1670,6 +1670,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
   <area alias="contentTypeEditor">
     <key alias="compositions">Compositions</key>
     <key alias="group">Group</key>
+    <key alias="groupReorderSameAliasError">You can't move the group %0% to this tab because the group will get the same alias as a tab: "%1%". Rename the group to continue.</key>
     <key alias="noGroups">You have not added any groups</key>
     <key alias="addGroup">Add group</key>
     <key alias="inheritedFrom">Inherited from</key>


### PR DESCRIPTION
This PR fixes a bug where you could only drag one group to the generic tab.

It also adds an error notification when you can't drag a group to the generic tab because it will end up with the same alias as a tab.

How To Test:
* set up a doctype with 1 tab and multiple groups. The tab and one of the groups should have the same name, ex: "Content".
* Make sure you can move more than one group to the Generic Tab
* Make sure you can't move the "Content" group to the generic tab


https://user-images.githubusercontent.com/6078361/132518083-86f56a95-378b-4d65-b85f-ffaa44de7eb3.mp4

