### PR TITLE
V9: Fix ApplicationMainUrl not being set from appsettings.json

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -39,6 +39,11 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
 
             SiteName = webHostEnvironment.ApplicationName;
             ApplicationPhysicalPath = webHostEnvironment.ContentRootPath;
+
+            if (_webRoutingSettings.CurrentValue.UmbracoApplicationUrl is not null)
+            {
+                ApplicationMainUrl = new Uri(_webRoutingSettings.CurrentValue.UmbracoApplicationUrl);
+            }
         }
 
         /// <inheritdoc/>
@@ -58,7 +63,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
                 if (_applicationId != null)
                 {
                     return _applicationId;
-                } 
+                }
 
                 var appId = _serviceProvider.GetApplicationUniqueIdentifier();
                 if (appId == null)
@@ -173,13 +178,13 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
             // (this is a simplified version of what was in 7.x)
             // note: should this be optional? is it expensive?
 
-            
+
             if (currentApplicationUrl is null)
             {
                 return;
             }
 
-            if (!(_webRoutingSettings.CurrentValue.UmbracoApplicationUrl is null))
+            if (_webRoutingSettings.CurrentValue.UmbracoApplicationUrl is not null)
             {
                 return;
             }


### PR DESCRIPTION
This fixes an issue where if you specify your umbraco application URL in the appsettings, it would never actually get set as the `AspNetCoreHostingEnvironment.ApplicationMainUrl`, causing `TouchServerTask` to log `No umbracoApplicationUrl for service (yet), skip.` over and over and over again indefinitely.

This was simply just an oversight, in `EnsureApplicationMainUrl` we simply return if `_webRoutingSettings.CurrentValue.UmbracoApplicationUrl is not null` assuming it has been set, however it hadn't, to remedy this I've added a check in the constructor where we set the URL if it's specified in the settings.

### Testing 

Manually specify the UmbracoApplicationUrl in appsettings.json

```json
"WebRouting": {
  "UmbracoApplicationUrl": "https://localhost:44331/umbraco"
}
```

Ensure that `TouchServerTask` doesn't log `No umbracoApplicationUrl for service (yet), skip.` over and over again.