### PR TITLE
Show UI errors for invalid files in media upload

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -65,16 +65,15 @@ angular.module("umbraco.directives")
                     function _filesQueued(files, event) {
                         //Push into the queue
                         Utilities.forEach(files, file => {
+                            if (_filterFile(file) === true) {
 
-                                if (_filterFile(file) === true) {
-
-                                    if (file.$error) {
-                                        scope.rejected.push(file);
-                                    } else {
-                                        scope.queue.push(file);
-                                    }
+                                if (file.$error) {
+                                    scope.rejected.push(file);
+                                } else {
+                                    scope.queue.push(file);
                                 }
-                            });
+                            }
+                        });
 
                         //when queue is done, kick the uploader
                         if (!scope.working) {
@@ -247,11 +246,13 @@ angular.module("umbraco.directives")
                         return true;// yes, we did open the choose-media dialog, therefor we return true.
                     }
 
-                    scope.handleFiles = function(files, event) {
+                    scope.handleFiles = function(files, event, invalidFiles) {
+                        const allFiles = [...files, ...invalidFiles];
+
                         if (scope.filesQueued) {
-                            scope.filesQueued(files, event);
+                            scope.filesQueued(allFiles, event);
                         }
-                        _filesQueued(files, event);
+                        _filesQueued(allFiles, event);
                     };
                 }
             };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -172,6 +172,8 @@ angular.module("umbraco.directives")
                                     }
                                 } else if (evt.Message) {
                                     file.serverErrorMessage = evt.Message;
+                                } else if (evt && typeof evt === 'string') {
+                                    file.serverErrorMessage = evt;
                                 }
                                 // If file not found, server will return a 404 and display this message
                                 if (status === 404) {
@@ -248,6 +250,11 @@ angular.module("umbraco.directives")
 
                     scope.handleFiles = function(files, event, invalidFiles) {
                         const allFiles = [...files, ...invalidFiles];
+
+                        // add unique key for each files to use in ng-repeats
+                        allFiles.forEach(file => {
+                            file.key = String.CreateGuid();
+                        });
 
                         if (scope.filesQueued) {
                             scope.filesQueued(allFiles, event);

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -30,7 +30,7 @@
                      class="file-select"
                      ngf-select
                      ng-model="filesHolder"
-                     ngf-change="handleFiles($newFiles, $event, $invalidFiles)"
+                     ngf-change="handleFiles($files, $event, $invalidFiles)"
                      ngf-multiple="true"
                      ngf-pattern="{{ accept }}"
                      ngf-max-size="{{ maxFileSize }}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -6,7 +6,7 @@
         <div ngf-drop
             ng-hide="hideDropzone === 'true'"
             ng-model="filesHolder"
-            ngf-change="handleFiles($files, $event)"
+            ngf-change="handleFiles($files, $event, $invalidFiles)"
             class="dropzone"
             ngf-drag-over-class="'drag-over'"
             ngf-multiple="true"
@@ -30,7 +30,7 @@
                      class="file-select"
                      ngf-select
                      ng-model="filesHolder"
-                     ngf-change="handleFiles($newFiles, $event)"
+                     ngf-change="handleFiles($newFiles, $event, $invalidFiles)"
                      ngf-multiple="true"
                      ngf-pattern="{{ accept }}"
                      ngf-max-size="{{ maxFileSize }}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -43,7 +43,7 @@
         <ul class="file-list" ng-show="done.length > 0 || queue.length > 0 || rejected.length > 0 || filesHolder.length > 0">
 
             <!-- make list sort order the same as photo grid. The last uploaded photo in the top -->
-            <li class="file" ng-repeat="file in done">
+            <li class="file" ng-repeat="file in done track by file.key">
 
                 <!-- file name -->
                 <div class="file-description">{{ file.name }}</div>
@@ -68,13 +68,13 @@
             </li>
 
             <!-- make list sort order the same as photo grid. The last uploaded photo in the top -->
-            <li class="file" ng-repeat="queued in queue">
+            <li class="file" ng-repeat="queued in queue track by queued.key">
 
                 <!-- file name -->
                 <div class="file-name">{{queued.name}}</div>
             </li>
 
-            <li class="file" ng-repeat="file in rejected">
+            <li class="file" ng-repeat="file in rejected track by file.key">
 
                 <!-- file name -->
                 <div class="file-description">


### PR DESCRIPTION
We don't get the invalid files from the uploader as part of the "files"-array anymore but instead as a separate array. I am not sure when this has changed.

This PR handles the new array of invalid files. It combines it with the files array, so everything works the way it used to.

After the PR is applied the errors are back in the UI.
<img width="1418" alt="Screenshot 2021-09-09 at 13 25 16" src="https://user-images.githubusercontent.com/6078361/132677538-13fe38cc-51e0-407e-a76d-a924f4b544b6.png">

Relates to #10920