### PR TITLE
Add redirect to /umbraco if you are not in run state.

### DIFF
--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
@@ -11,8 +11,10 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.UnitTests.AutoFixture;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.BackOffice.Install;
@@ -76,11 +78,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common
             [Frozen] IOptions<GlobalSettings> globalSettings,
             [Frozen] IHostingEnvironment hostingEnvironment,
             [Frozen] ITempDataDictionary tempDataDictionary,
+            [Frozen] IRuntimeState runtimeState,
             BackOfficeController sut)
         {
             globalSettings.Value.UmbracoPath = "/";
             Mock.Get(hostingEnvironment).Setup(x => x.ToAbsolute("/")).Returns("http://localhost/");
             Mock.Get(hostingEnvironment).SetupGet(x => x.ApplicationVirtualPath).Returns("/");
+            Mock.Get(runtimeState).Setup(x => x.Level).Returns(RuntimeLevel.Run);
 
             sut.TempData = tempDataDictionary;
 

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -120,9 +120,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             }
 
             // force authentication to occur since this is not an authorized endpoint
-            var result = await this.AuthenticateBackOfficeAsync();
-
-
+            AuthenticateResult result = await this.AuthenticateBackOfficeAsync();
 
             var viewPath = Path.Combine(Constants.SystemDirectories.Umbraco, Constants.Web.Mvc.BackOfficeArea, nameof(Default) + ".cshtml")
                 .Replace("\\", "/"); // convert to forward slashes since it's a virtual path

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Grid;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -112,11 +113,16 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         [AllowAnonymous]
         public async Task<IActionResult> Default()
         {
-            // TODO: It seems that if you login during an authorize upgrade and the upgrade fails, you can still
-            // access the back office. This should redirect to the installer in that case?
+            // Check if we not are in an run state, if so we need to redirect
+            if (_runtimeState.Level != RuntimeLevel.Run)
+            {
+                return Redirect("/");
+            }
 
             // force authentication to occur since this is not an authorized endpoint
             var result = await this.AuthenticateBackOfficeAsync();
+
+
 
             var viewPath = Path.Combine(Constants.SystemDirectories.Umbraco, Constants.Web.Mvc.BackOfficeArea, nameof(Default) + ".cshtml")
                 .Replace("\\", "/"); // convert to forward slashes since it's a virtual path


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/10650

Added a redirect to root (which redirects to installer) if you are not in runtime state = Run.

### Test
- Open backoffice
- Add a fake migration in Umbraco Plan
- Reboot
- Refresh browser in backoffice 
  -  verify you are redirected to the upgrader.