### PR TITLE
Fixes reading connection strings after install

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -219,7 +219,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddSingleton<IMainDomLock>(factory =>
             {
                 var globalSettings = factory.GetRequiredService<IOptions<GlobalSettings>>();
-                var connectionStrings = factory.GetRequiredService<IOptions<ConnectionStrings>>();
+                var connectionStrings = factory.GetRequiredService<IOptionsMonitor<ConnectionStrings>>();
                 var hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
 
                 var dbCreator = factory.GetRequiredService<IDbProviderFactoryCreator>();

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -22,37 +22,33 @@ namespace Umbraco.Cms.Infrastructure.Install
 {
     public sealed class InstallHelper
     {
-        private static HttpClient _httpClient;
         private readonly DatabaseBuilder _databaseBuilder;
         private readonly ILogger<InstallHelper> _logger;
         private readonly IUmbracoVersion _umbracoVersion;
-        private readonly ConnectionStrings _connectionStrings;
+        private readonly IOptionsMonitor<ConnectionStrings> _connectionStrings;
         private readonly IInstallationService _installationService;
         private readonly ICookieManager _cookieManager;
         private readonly IUserAgentProvider _userAgentProvider;
         private readonly IUmbracoDatabaseFactory _umbracoDatabaseFactory;
-        private readonly IJsonSerializer _jsonSerializer;
         private InstallationType? _installationType;
 
         public InstallHelper(DatabaseBuilder databaseBuilder,
             ILogger<InstallHelper> logger,
             IUmbracoVersion umbracoVersion,
-            IOptions<ConnectionStrings> connectionStrings,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
             IInstallationService installationService,
             ICookieManager cookieManager,
             IUserAgentProvider userAgentProvider,
-            IUmbracoDatabaseFactory umbracoDatabaseFactory,
-            IJsonSerializer jsonSerializer)
+            IUmbracoDatabaseFactory umbracoDatabaseFactory)
         {
             _logger = logger;
             _umbracoVersion = umbracoVersion;
             _databaseBuilder = databaseBuilder;
-            _connectionStrings = connectionStrings.Value ?? throw new ArgumentNullException(nameof(connectionStrings));
+            _connectionStrings = connectionStrings;
             _installationService = installationService;
             _cookieManager = cookieManager;
             _userAgentProvider = userAgentProvider;
             _umbracoDatabaseFactory = umbracoDatabaseFactory;
-            _jsonSerializer = jsonSerializer;
 
             //We need to initialize the type already, as we can't detect later, if the connection string is added on the fly.
             GetInstallationType();
@@ -118,7 +114,7 @@ namespace Umbraco.Cms.Infrastructure.Install
         {
             get
             {
-                var databaseSettings = _connectionStrings.UmbracoConnectionString;
+                var databaseSettings = _connectionStrings.CurrentValue.UmbracoConnectionString;
                 if (databaseSettings.IsConnectionStringConfigured() == false)
                 {
                     //no version or conn string configured, must be a brand new install

--- a/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseConfigureStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseConfigureStep.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -18,12 +18,12 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
     {
         private readonly DatabaseBuilder _databaseBuilder;
         private readonly ILogger<DatabaseConfigureStep> _logger;
-        private readonly ConnectionStrings _connectionStrings;
+        private readonly IOptionsMonitor<ConnectionStrings> _connectionStrings;
 
-        public DatabaseConfigureStep(DatabaseBuilder databaseBuilder, IOptions<ConnectionStrings> connectionStrings, ILogger<DatabaseConfigureStep> logger)
+        public DatabaseConfigureStep(DatabaseBuilder databaseBuilder, IOptionsMonitor<ConnectionStrings> connectionStrings, ILogger<DatabaseConfigureStep> logger)
         {
             _databaseBuilder = databaseBuilder;
-            _connectionStrings = connectionStrings.Value ?? throw new ArgumentNullException(nameof(connectionStrings));
+            _connectionStrings = connectionStrings;
             _logger = logger;
         }
 
@@ -110,7 +110,7 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
         private bool ShouldDisplayView()
         {
             //If the connection string is already present in web.config we don't need to show the settings page and we jump to installing/upgrading.
-            var databaseSettings = _connectionStrings.UmbracoConnectionString;
+            var databaseSettings = _connectionStrings.CurrentValue.UmbracoConnectionString;
 
             if (databaseSettings.IsConnectionStringConfigured())
             {

--- a/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseUpgradeStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseUpgradeStep.cs
@@ -24,20 +24,20 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
         private readonly IRuntimeState _runtime;
         private readonly ILogger<DatabaseUpgradeStep> _logger;
         private readonly IUmbracoVersion _umbracoVersion;
-        private readonly ConnectionStrings _connectionStrings;
+        private readonly IOptionsMonitor<ConnectionStrings> _connectionStrings;
 
         public DatabaseUpgradeStep(
             DatabaseBuilder databaseBuilder,
             IRuntimeState runtime,
             ILogger<DatabaseUpgradeStep> logger,
             IUmbracoVersion umbracoVersion,
-            IOptions<ConnectionStrings> connectionStrings)
+            IOptionsMonitor<ConnectionStrings> connectionStrings)
         {
             _databaseBuilder = databaseBuilder;
             _runtime = runtime;
             _logger = logger;
             _umbracoVersion = umbracoVersion;
-            _connectionStrings = connectionStrings.Value ?? throw new ArgumentNullException(nameof(connectionStrings));
+            _connectionStrings = connectionStrings;
         }
 
         public override Task<InstallSetupResult> ExecuteAsync(object model)
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
                 return false;
             }
 
-            var databaseSettings = _connectionStrings.UmbracoConnectionString;
+            var databaseSettings = _connectionStrings.CurrentValue.UmbracoConnectionString;
 
             if (databaseSettings.IsConnectionStringConfigured())
             {

--- a/src/Umbraco.Infrastructure/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/NewInstallStep.cs
@@ -30,10 +30,10 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
     {
         private readonly IUserService _userService;
         private readonly DatabaseBuilder _databaseBuilder;
-        private static HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly UserPasswordConfigurationSettings _passwordConfiguration;
         private readonly SecuritySettings _securitySettings;
-        private readonly ConnectionStrings _connectionStrings;
+        private readonly IOptionsMonitor<ConnectionStrings> _connectionStrings;
         private readonly ICookieManager _cookieManager;
         private readonly IBackOfficeUserManager _userManager;
         private readonly IDbProviderFactoryCreator _dbProviderFactoryCreator;
@@ -41,18 +41,20 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
         public NewInstallStep(
             IUserService userService,
             DatabaseBuilder databaseBuilder,
+            IHttpClientFactory httpClientFactory,
             IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
             IOptions<SecuritySettings> securitySettings,
-            IOptions<ConnectionStrings> connectionStrings,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
             ICookieManager cookieManager,
             IBackOfficeUserManager userManager,
             IDbProviderFactoryCreator dbProviderFactoryCreator)
         {
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
             _databaseBuilder = databaseBuilder ?? throw new ArgumentNullException(nameof(databaseBuilder));
+            _httpClientFactory = httpClientFactory;
             _passwordConfiguration = passwordConfiguration.Value ?? throw new ArgumentNullException(nameof(passwordConfiguration));
             _securitySettings = securitySettings.Value ?? throw new ArgumentNullException(nameof(securitySettings));
-            _connectionStrings = connectionStrings.Value ?? throw new ArgumentNullException(nameof(connectionStrings));
+            _connectionStrings = connectionStrings;
             _cookieManager = cookieManager;
             _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
             _dbProviderFactoryCreator = dbProviderFactoryCreator ?? throw new ArgumentNullException(nameof(dbProviderFactoryCreator));
@@ -89,15 +91,14 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
 
             if (user.SubscribeToNewsLetter)
             {
-                if (_httpClient == null)
-                    _httpClient = new HttpClient();
-
                 var values = new NameValueCollection { { "name", admin.Name }, { "email", admin.Email } };
                 var content = new StringContent(JsonConvert.SerializeObject(values), Encoding.UTF8, "application/json");
 
+                HttpClient httpClient = _httpClientFactory.CreateClient();
+
                 try
                 {
-                    var response = _httpClient.PostAsync("https://shop.umbraco.com/base/Ecom/SubmitEmail/installer.aspx", content).Result;
+                    var response = httpClient.PostAsync("https://shop.umbraco.com/base/Ecom/SubmitEmail/installer.aspx", content).Result;
                 }
                 catch { /* fail in silence */ }
             }
@@ -140,7 +141,7 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
             // TODO: we need to do a null check here since this could be entirely missing and we end up with a null ref
             // exception in the installer.
 
-            var databaseSettings = _connectionStrings.UmbracoConnectionString;
+            var databaseSettings = _connectionStrings.CurrentValue.UmbracoConnectionString;
 
             var hasConnString = databaseSettings != null && _databaseBuilder.IsDatabaseConfigured;
             if (hasConnString)

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -80,7 +80,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             ILogger<UmbracoDatabaseFactory> logger,
             ILoggerFactory loggerFactory,
             IOptions<GlobalSettings> globalSettings,
-            IOptions<ConnectionStrings> connectionStrings,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
             IMapperCollection mappers,
             IDbProviderFactoryCreator dbProviderFactoryCreator,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
@@ -95,7 +95,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _loggerFactory = loggerFactory;
 
-            var settings = connectionStrings.Value.UmbracoConnectionString;
+            var settings = connectionStrings.CurrentValue.UmbracoConnectionString;
 
             if (settings == null)
             {

--- a/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             ILogger<SqlMainDomLock> logger,
             ILoggerFactory loggerFactory,
             IOptions<GlobalSettings> globalSettings,
-            IOptions<ConnectionStrings> connectionStrings,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
             IDbProviderFactoryCreator dbProviderFactoryCreator,
             IHostingEnvironment hostingEnvironment,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,

--- a/src/Umbraco.Tests.Integration/Testing/TestUmbracoDatabaseFactoryProvider.cs
+++ b/src/Umbraco.Tests.Integration/Testing/TestUmbracoDatabaseFactoryProvider.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Tests.Integration.Testing
     {
         private readonly ILoggerFactory _loggerFactory;
         private readonly IOptions<GlobalSettings> _globalSettings;
-        private readonly IOptions<ConnectionStrings> _connectionStrings;
+        private readonly IOptionsMonitor<ConnectionStrings> _connectionStrings;
         private readonly IMapperCollection _mappers;
         private readonly IDbProviderFactoryCreator _dbProviderFactoryCreator;
         private readonly DatabaseSchemaCreatorFactory _databaseSchemaCreatorFactory;
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Tests.Integration.Testing
         public TestUmbracoDatabaseFactoryProvider(
             ILoggerFactory loggerFactory,
             IOptions<GlobalSettings> globalSettings,
-            IOptions<ConnectionStrings> connectionStrings,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
             IMapperCollection mappers,
             IDbProviderFactoryCreator dbProviderFactoryCreator,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -22,8 +22,6 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Logging;
-using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
@@ -54,7 +52,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
                 loggerFactory.CreateLogger<UmbracoDatabaseFactory>(),
                 loggerFactory,
                 Options.Create(globalSettings),
-                Options.Create(connectionStrings),
+                Mock.Of<IOptionsMonitor<ConnectionStrings>>(x => x.CurrentValue == connectionStrings),
                 new MapperCollection(() => Enumerable.Empty<BaseMapper>()),
                 TestHelper.DbProviderFactoryCreator,
                 new DatabaseSchemaCreatorFactory(loggerFactory.CreateLogger<DatabaseSchemaCreator>(), loggerFactory, new UmbracoVersion(), Mock.Of<IEventAggregator>()),


### PR DESCRIPTION
The issue was discovered when testing Umbraco Id. If you have an existing install and there is a pending Umbraco migration (upgrade), but you clear out the connection string to force a new install screen, fill out the existing connection string details, it all works and redirects to the back office. This will throw exceptions because the runtime state is in an upgrade state (which is fixed in #11064) but if you then logout and try to log in with an active OAuth provider, it means there is a redirect outside of Umbraco and back again and you'll end up back on the installer screen - but it will not show you the upgrade screen, instead it shows you the normal install screen. This is because we are not using IOptionsMonitor for connection string settings which means it's already read the original empty connection string setting fom the very beginning and isn't reading the current/updated value.

We need to review all IOptions usages. Most of them should be IOptionsMonitor unless its impossible to change the app behavior at runtime with a particular config option.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
