### PR TITLE
Fixes empty recycle bin performance with indexing

### DIFF
--- a/src/Umbraco.Infrastructure/Search/IUmbracoIndexingHandler.cs
+++ b/src/Umbraco.Infrastructure/Search/IUmbracoIndexingHandler.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Infrastructure.Search
         void DeleteDocumentsForContentTypes(IReadOnlyCollection<int> removedContentTypes);
 
         /// <summary>
-        /// Remove items from an index
+        /// Remove an item from an index
         /// </summary>
         /// <param name="entityId"></param>
         /// <param name="keepIfUnpublished">
@@ -33,5 +33,15 @@ namespace Umbraco.Cms.Infrastructure.Search
         /// If false it will delete this from all indexes regardless.
         /// </param>
         void DeleteIndexForEntity(int entityId, bool keepIfUnpublished);
+
+        /// <summary>
+        /// Remove items from an index
+        /// </summary>
+        /// <param name="entityIds"></param>
+        /// <param name="keepIfUnpublished">
+        /// If true, indicates that we will only delete this item from indexes that don't support unpublished content.
+        /// If false it will delete this from all indexes regardless.
+        /// </param>
+        void DeleteIndexForEntities(IReadOnlyCollection<int> entityIds, bool keepIfUnpublished);
     }
 }


### PR DESCRIPTION
Currently when the recycle bin is empty, it is going to individually delete each item from the index. This is going to cause tons of allocations in Umbraco for DeferedDeleteIndex objects for each item and then down within Examine is going to process each one individually instead of just doing it in bulk. There will be a lot of allocations made there too along with a bunch of extra and unnecessary threads.

@nul800sebastiaan I haven't looked at v8 but it's most likely doing the same thing and this logic should be back ported.