### PR TITLE
Allows replacing MainDom with alternate DB

### DIFF
--- a/src/Umbraco.Core/Runtime/MainDom.cs
+++ b/src/Umbraco.Core/Runtime/MainDom.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Core.Runtime
     /// <para>When an AppDomain starts, it tries to acquire the main domain status.</para>
     /// <para>When an AppDomain stops (eg the application is restarting) it should release the main domain status.</para>
     /// </remarks>
-    internal class MainDom : IMainDom, IRegisteredObject, IDisposable
+    public class MainDom : IMainDom, IRegisteredObject, IDisposable
     {
         #region Vars
 

--- a/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Core/Runtime/SqlMainDomLock.cs
@@ -18,7 +18,7 @@ using MapperCollection = Umbraco.Core.Persistence.Mappers.MapperCollection;
 
 namespace Umbraco.Core.Runtime
 {
-    internal class SqlMainDomLock : IMainDomLock
+    public class SqlMainDomLock : IMainDomLock
     {
         private readonly TimeSpan _lockTimeout;
         private string _lockId;
@@ -33,14 +33,14 @@ namespace Umbraco.Core.Runtime
         private object _locker = new object();
         private bool _hasTable = false;
 
-        public SqlMainDomLock(ILogger logger)
+        public SqlMainDomLock(ILogger logger, string connectionStringName = Constants.System.UmbracoConnectionName)
         {
             // unique id for our appdomain, this is more unique than the appdomain id which is just an INT counter to its safer
             _lockId = Guid.NewGuid().ToString();
             _logger = logger;
 
             _dbFactory = new UmbracoDatabaseFactory(
-               Constants.System.UmbracoConnectionName,
+               connectionStringName,
                _logger,
                new Lazy<IMapperCollection>(() => new MapperCollection(Enumerable.Empty<BaseMapper>())));
 

--- a/src/Umbraco.Web/UmbracoApplication.cs
+++ b/src/Umbraco.Web/UmbracoApplication.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Web
         /// <summary>
         /// Returns a new MainDom
         /// </summary>
-        protected IMainDom GetMainDom(ILogger logger)
+        protected virtual IMainDom GetMainDom(ILogger logger)
         {
             // Determine if we should use the sql main dom or the default
             var appSettingMainDomLock = ConfigurationManager.AppSettings[Constants.AppSettings.MainDomLock];


### PR DESCRIPTION
There are some cases where there is a complex hosting strategy and folks want a readonly database and are hosting on Azure. In that case, it is not entirely possible to have a readonly Umbraco database because SqlMainDom is required and part of that requirement is to have read/write access to the umbraco key value table.
This PR allows for the default MainDom to be replaced and to allow for an SqlMainDomLock to use an alternate connection string so that a separate read/write database can be used.

This is specifically regarding these docs: https://our.umbraco.com/Documentation/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced#front-end-servers---read-only-database-access

> SQL Server Replica databases cannot be used as they are read-only without replacing the default MainDomLock with a custom provider.

But without this PR it's impossible to replace the default MainDomLock. 

To replace it with this PR, you would:

```cs
public class MyUmbracoApplication : UmbracoApplication
{
    protected override IMainDom GetMainDom(ILogger logger)
    {
        // TODO: return custom IMainDom
    }
}
```

then in global.asax, replace with your custom `MyUmbracoApplication`:

```
<%@ Application Inherits="MyApplication.MyUmbracoApplication " Language="C#" %>
```

To continue using the SqlMainDom lock but with a diff connection string, return this in `GetMainDom`:

```cs
return new MainDom(logger, new SqlMainDomLock(logger, "MyConnectionStringName"));
```

Where "MyConnectionStringName" is an alternate connection string in your web.config.
in `GetMainDomLock` create `new SqlMainDomLock(logger, "MyConnectionStringName")`