### PR TITLE
Fixes #9661 boolean conversion

### DIFF
--- a/src/Umbraco.Core/CustomBooleanTypeConverter.cs
+++ b/src/Umbraco.Core/CustomBooleanTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace Umbraco.Cms.Core
@@ -24,6 +24,8 @@ namespace Umbraco.Cms.Core
                 var str = (string)value;
                 if (str == null || str.Length == 0 || str == "0") return false;
                 if (str == "1") return true;
+                if (str.Equals("Yes", StringComparison.OrdinalIgnoreCase)) return true;
+                if (str.Equals("No", StringComparison.OrdinalIgnoreCase)) return false;
             }
 
             return base.ConvertFrom(context, culture, value);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/TryConvertToTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/TryConvertToTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -10,6 +10,42 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.CoreThings
     [TestFixture]
     public class TryConvertToTests
     {
+        [Test]
+        public void ConvertToBoolTest()
+        {
+            var conv = 1.TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(true, conv.Result);
+
+            conv = "1".TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(true, conv.Result);
+
+            conv = 0.TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(false, conv.Result);
+
+            conv = "0".TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(false, conv.Result);
+
+            conv = "Yes".TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(true, conv.Result);
+
+            conv = "yes".TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(true, conv.Result);
+
+            conv = "No".TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(false, conv.Result);
+
+            conv = "no".TryConvertTo<bool>();
+            Assert.IsTrue(conv);
+            Assert.AreEqual(false, conv.Result);
+        }
+
         [Test]
         public void ConvertToIntegerTest()
         {


### PR DESCRIPTION
Fixes #9661 boolean conversion issue where the property editor is passing in "No" or "Yes" for the value but its not getting converted. The fix is easy to just allow for this conversion with our custom boolean converter.

This may need to be backported, though if this was an issue in v8 we'd surely know about it since it would mean you couldn't lock or unlock members.