### PR TITLE
Updating Angular and jQuery to the latest available version

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -11,6 +11,12 @@
                 "@babel/highlight": "^7.0.0"
             }
         },
+        "@babel/compat-data": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+            "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+            "dev": true
+        },
         "@babel/core": {
             "version": "7.6.4",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
@@ -129,6 +135,57 @@
                 "@babel/helper-hoist-variables": "^7.4.4",
                 "@babel/traverse": "^7.4.4",
                 "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+            "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.15.0",
+                "@babel/helper-validator-option": "^7.14.5",
+                "browserslist": "^4.16.6",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.17.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+                    "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001254",
+                        "colorette": "^1.3.0",
+                        "electron-to-chromium": "^1.3.830",
+                        "escalade": "^3.1.1",
+                        "node-releases": "^1.1.75"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001257",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
+                    "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.836",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz",
+                    "integrity": "sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "1.1.75",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+                    "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-define-map": {
@@ -281,6 +338,12 @@
                 "@babel/types": "^7.4.4"
             }
         },
+        "@babel/helper-validator-option": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+            "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+            "dev": true
+        },
         "@babel/helper-wrap-function": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
@@ -353,13 +416,42 @@
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
-            "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
+            "version": "7.13.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+            "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+                "@babel/compat-data": "^7.13.8",
+                "@babel/helper-compilation-targets": "^7.13.8",
+                "@babel/helper-plugin-utils": "^7.13.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.13.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+                    "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+                    "dev": true
+                },
+                "@babel/plugin-syntax-object-rest-spread": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+                    "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-transform-parameters": {
+                    "version": "7.15.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+                    "integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.14.5"
+                    }
+                }
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
@@ -1129,9 +1221,9 @@
             "dev": true
         },
         "angular": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
-            "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg=="
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.2.tgz",
+            "integrity": "sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw=="
         },
         "angular-animate": {
             "version": "1.7.5",
@@ -1836,7 +1928,8 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "base64id": {
             "version": "1.0.0",
@@ -2083,6 +2176,7 @@
                     "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
                     "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "p-finally": "^1.0.0"
                     }
@@ -2124,6 +2218,7 @@
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -2133,13 +2228,15 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -2155,6 +2252,7 @@
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -2295,6 +2393,7 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
             "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4"
@@ -2320,7 +2419,8 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "buffer-equal": {
             "version": "1.0.0",
@@ -2511,6 +2611,7 @@
             "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
             "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "get-proxy": "^2.0.0",
                 "isurl": "^1.0.0-alpha5",
@@ -2881,6 +2982,12 @@
             "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
             "dev": true
         },
+        "colorette": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+            "dev": true
+        },
         "colornames": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
@@ -2944,6 +3051,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
             "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "graceful-readlink": ">= 1.0.0"
             }
@@ -3038,6 +3146,7 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
             "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -3093,6 +3202,7 @@
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
             "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "safe-buffer": "5.1.2"
             }
@@ -3536,6 +3646,7 @@
             "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
             "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-tar": "^4.0.0",
                 "decompress-tarbz2": "^4.0.0",
@@ -3552,6 +3663,7 @@
                     "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "pify": "^3.0.0"
                     },
@@ -3560,7 +3672,8 @@
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 }
@@ -3571,6 +3684,7 @@
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "mimic-response": "^1.0.0"
             }
@@ -3580,6 +3694,7 @@
             "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "file-type": "^5.2.0",
                 "is-stream": "^1.1.0",
@@ -3590,7 +3705,8 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
                     "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3599,6 +3715,7 @@
             "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-tar": "^4.1.0",
                 "file-type": "^6.1.0",
@@ -3611,7 +3728,8 @@
                     "version": "6.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
                     "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3620,6 +3738,7 @@
             "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-tar": "^4.1.1",
                 "file-type": "^5.2.0",
@@ -3630,7 +3749,8 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
                     "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3639,6 +3759,7 @@
             "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "file-type": "^3.8.0",
                 "get-stream": "^2.2.0",
@@ -3650,13 +3771,15 @@
                     "version": "3.9.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
                     "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "get-stream": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
                     "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "object-assign": "^4.0.1",
                         "pinkie-promise": "^2.0.0"
@@ -3666,7 +3789,8 @@
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3948,7 +4072,8 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3965,7 +4090,8 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "duplexify": {
             "version": "3.7.1",
@@ -4292,6 +4418,12 @@
                 "es6-symbol": "^3.1.1"
             }
         },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4568,6 +4700,7 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "cross-spawn": "^5.0.1",
                 "get-stream": "^3.0.0",
@@ -4583,6 +4716,7 @@
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "lru-cache": "^4.0.1",
                         "shebang-command": "^1.2.0",
@@ -4722,6 +4856,7 @@
             "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
             "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "mime-db": "^1.28.0"
             }
@@ -4731,6 +4866,7 @@
             "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
             "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "ext-list": "^2.0.0",
                 "sort-keys-length": "^1.0.0"
@@ -4965,6 +5101,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "pend": "~1.2.0"
             }
@@ -5003,13 +5140,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
             "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "filenamify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
             "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "filename-reserved-regex": "^2.0.0",
                 "strip-outer": "^1.0.0",
@@ -5196,9 +5335,9 @@
             }
         },
         "flatpickr": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.5.2.tgz",
-            "integrity": "sha1-R8itRyoJbl+350uAmwcDU1OD8g0="
+            "version": "4.6.9",
+            "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.9.tgz",
+            "integrity": "sha512-F0azNNi8foVWKSF+8X+ZJzz8r9sE1G4hl06RyceIaLvyltKvDl6vqk9Lm/6AUUCi5HWaIjiUbk7UpeE/fOXOpw=="
         },
         "flatted": {
             "version": "2.0.1",
@@ -5370,7 +5509,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "fs-mkdirp-stream": {
             "version": "1.0.0",
@@ -5417,7 +5557,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -5438,12 +5579,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -5458,17 +5601,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -5585,7 +5731,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -5597,6 +5744,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -5611,6 +5759,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -5618,12 +5767,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -5642,6 +5793,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5722,7 +5874,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5734,6 +5887,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -5819,7 +5973,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -5855,6 +6010,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5874,6 +6030,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -5917,12 +6074,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -5949,6 +6108,7 @@
             "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
             "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "npm-conf": "^1.1.0"
             }
@@ -5957,13 +6117,15 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "get-stream": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "get-value": {
             "version": "2.0.6",
@@ -6278,7 +6440,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "growly": {
             "version": "1.3.0",
@@ -7049,7 +7212,8 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
             "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "has-symbols": {
             "version": "1.0.0",
@@ -7062,6 +7226,7 @@
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
             "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "has-symbol-support-x": "^1.4.1"
             }
@@ -7261,7 +7426,8 @@
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "ignore": {
             "version": "4.0.6",
@@ -7391,6 +7557,7 @@
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "repeating": "^2.0.0"
             }
@@ -7718,6 +7885,7 @@
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -7770,7 +7938,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
             "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-negated-glob": {
             "version": "1.0.0",
@@ -7808,13 +7977,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
             "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -7884,13 +8055,15 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
             "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-svg": {
             "version": "3.0.0",
@@ -7987,6 +8160,7 @@
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
             "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "has-to-string-tag-x": "^1.2.0",
                 "is-object": "^1.0.1"
@@ -8011,9 +8185,9 @@
             }
         },
         "jquery": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+            "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
         },
         "jquery-ui-dist": {
             "version": "1.12.1",
@@ -8899,7 +9073,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
             "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "lpad-align": {
             "version": "1.1.2",
@@ -8969,7 +9144,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "map-visit": {
             "version": "1.0.0",
@@ -9139,7 +9315,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
             "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -9362,9 +9539,9 @@
             "dev": true
         },
         "nouislider": {
-            "version": "14.6.4",
-            "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.6.4.tgz",
-            "integrity": "sha512-PVCGYl+aC7/nVEbW61ypJWfuW3UCpvctz/luxpt4byxxli1FFyjBX9NIiy4Yak9AaO6a5BkPGfFYMCW4eg3eeQ=="
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.4.0.tgz",
+            "integrity": "sha512-AV7UMhGhZ4Mj6ToMT812Ib8OJ4tAXR2/Um7C4l4ZvvsqujF0WpQTpqqHJ+9xt4174R7ueQOUrBR4yakJpAIPCA=="
         },
         "now-and-later": {
             "version": "2.0.1",
@@ -12474,6 +12651,7 @@
             "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
             "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "config-chain": "^1.1.11",
                 "pify": "^3.0.0"
@@ -12483,7 +12661,8 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -12492,6 +12671,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "path-key": "^2.0.0"
             }
@@ -12853,7 +13033,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "p-is-promise": {
             "version": "1.1.0",
@@ -12890,6 +13071,7 @@
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
             "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "p-finally": "^1.0.0"
             }
@@ -13080,7 +13262,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "performance-now": {
             "version": "2.1.0",
@@ -13588,7 +13771,8 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "prr": {
             "version": "1.0.1",
@@ -13944,6 +14128,7 @@
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-finite": "^1.0.0"
             }
@@ -14305,6 +14490,7 @@
             "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "commander": "~2.8.1"
             }
@@ -14707,6 +14893,7 @@
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-plain-obj": "^1.0.0"
             }
@@ -14716,6 +14903,7 @@
             "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
             "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "sort-keys": "^1.0.0"
             }
@@ -15046,6 +15234,7 @@
             "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-natural-number": "^4.0.1"
             }
@@ -15054,7 +15243,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "strip-indent": {
             "version": "1.0.1",
@@ -15077,6 +15267,7 @@
             "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
             "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "escape-string-regexp": "^1.0.2"
             }
@@ -15202,6 +15393,7 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
             "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "bl": "^1.0.0",
                 "buffer-alloc": "^1.2.0",
@@ -15216,13 +15408,15 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -15238,6 +15432,7 @@
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -15248,13 +15443,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
             "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "tempfile": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
             "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "temp-dir": "^1.0.0",
                 "uuid": "^3.0.1"
@@ -15349,7 +15546,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "timers-ext": {
             "version": "0.1.7",
@@ -15406,7 +15604,8 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
             "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "to-fast-properties": {
             "version": "2.0.0",
@@ -15510,6 +15709,7 @@
             "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
             "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "escape-string-regexp": "^1.0.2"
             }
@@ -15646,6 +15846,7 @@
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
             "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "buffer": "^5.2.1",
                 "through": "^2.3.8"
@@ -15846,7 +16047,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
             "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "use": {
             "version": "3.1.1",
@@ -16342,6 +16544,7 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "ace-builds": "1.4.2",
-    "angular": "1.8.0",
+    "angular": "1.8.2",
     "angular-animate": "1.7.5",
     "angular-aria": "1.7.9",
     "angular-chart.js": "^1.1.1",
@@ -35,7 +35,7 @@
     "diff": "3.5.0",
     "flatpickr": "4.6.9",
     "font-awesome": "4.7.0",
-    "jquery": "^3.5.1",
+    "jquery": "^3.6.0",
     "jquery-ui-dist": "1.12.1",
     "jquery-ui-touch-punch": "0.2.3",
     "lazyload-js": "1.0.0",


### PR DESCRIPTION
This updates:

- jQuery from 3.5.1 to 3.6.0 https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/
- AngularJs from 1.8.0 to 1.8.2 - https://github.com/angular/angular.js/blob/master/CHANGELOG.md

From the changelogs I can't see any conflicts that we would run into so should be good.