### PR TITLE
Exclude "Server" header from excessive check if the value is "cloudflare"

### DIFF
--- a/src/Umbraco.Web/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/ExcessiveHeadersCheck.cs
@@ -58,7 +58,15 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
             {
                 var response = request.GetResponse();
                 var allHeaders = response.Headers.AllKeys;
-                var headersToCheckFor = new [] {"Server", "X-Powered-By", "X-AspNet-Version", "X-AspNetMvc-Version"};
+
+                var headersToCheckFor = new List<string> {"Server", "X-Powered-By", "X-AspNet-Version", "X-AspNetMvc-Version" };
+
+                // Ignore if server header is present and it's set to cloudflare
+                if (allHeaders.InvariantContains("Server") && response.Headers["Server"].InvariantEquals("cloudflare"))
+                {
+                    headersToCheckFor.Remove("Server");
+                }
+
                 var headersFound = allHeaders
                     .Intersect(headersToCheckFor)
                     .ToArray();


### PR DESCRIPTION
Cloudflare adds the header "Server" with the value "cloudflare". As this header cannot be removed it should be excluded from the healthcheck excessive headers check - https://community.cloudflare.com/t/how-to-remove-server-cloudflare-header/133417

All UmbracoCloud sites that have been migrated to the new infrastructure currently show this healthcheck warning.