### PR TITLE
Set content type form to dirty when add tab, delete tab, add group, and delete group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -534,6 +534,8 @@
 
                 scope.openTabAlias = tab.alias;
 
+                notifyChanged();
+
                 scope.$broadcast('umbOverflowChecker.checkOverflow');
                 scope.$broadcast('umbOverflowChecker.scrollTo', { position: 'end' });
             };
@@ -570,6 +572,8 @@
                             });
 
                             scope.$broadcast('umbOverflowChecker.checkOverflow');
+
+                            notifyChanged();
 
                             overlayService.close();
                         }
@@ -712,6 +716,8 @@
                 scope.model.groups = [...scope.model.groups, group];
 
                 scope.activateGroup(group);
+
+                notifyChanged();
             };
 
             scope.activateGroup = selectedGroup => {
@@ -758,6 +764,7 @@
                             scope.model.groups.splice(index, 1);
 
                             overlayService.close();
+                            notifyChanged();
                         }
                     });
                 });
@@ -1022,7 +1029,6 @@
 
                 return (result.length > 0);
             }
-
 
             eventBindings.push(scope.$watch('model', (newValue, oldValue) => {
                 if (newValue !== undefined && newValue.groups !== undefined) {


### PR DESCRIPTION
Fixes: #11070

The PR sets the content type form to dirty when adding a new tab, deleting a tab, adding a group, and deleting a group.

How to test:
* Add tab (don't enter a name) - navigate to another node. Make sure the discard changes dialog is shown
* Do the same for delete tab, add group, delete group.