### PR TITLE
V9 dotnet new template - allow just setting connection string on its own

### DIFF
--- a/build/templates/UmbracoProject/appsettings.Development.json
+++ b/build/templates/UmbracoProject/appsettings.Development.json
@@ -17,11 +17,9 @@
       }
     ]
   },
-  //#if (UsingUnattenedInstall)
   "ConnectionStrings": {
     "umbracoDbDSN": "CONNECTION_FROM_TEMPLATE"
   },
-  //#endif
   "Umbraco": {
     "CMS": {
       "Content": {


### PR DESCRIPTION
Remove condition around connection string needed to have all unattended arguments in dotnet new template set such as friendly name, email and password just to set a connection string.

This is for Umbraco cloud team as they want to set a connection string with the dotnet new template but not set the rest of the unattended arguments

## Test
`dotnet new umbraco --name mynewproject --SqlCe --connection-string "Data Source=|DataDirectory|\\Umbraco.sdf;Flush Interval=1;"`
