### PR TITLE
Added option to set NoNodesViewPath in umbraco template.

### DIFF
--- a/build/templates/UmbracoProject/.template.config/dotnetcli.host.json
+++ b/build/templates/UmbracoProject/.template.config/dotnetcli.host.json
@@ -28,6 +28,10 @@
         "ConnectionString":{
             "longName": "connection-string",
             "shortName": ""
+        },
+        "NoNodesViewPath":{
+            "longName": "no-nodes-view-path",
+            "shortName": ""
         }
     },
     "usageExamples": [

--- a/build/templates/UmbracoProject/.template.config/ide.host.json
+++ b/build/templates/UmbracoProject/.template.config/ide.host.json
@@ -55,6 +55,13 @@
                 "text": "Optional: Database connection string when using Unattended install"
             },
             "isVisible": "true"
+        },
+        {
+            "id": "NoNodesViewPath",
+            "name": {
+                "text": "Optional: Path to a custom view presented with the Umbraco installation contains no published content"
+            },
+            "isVisible": "true"
         }
     ]
 }

--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -253,7 +253,7 @@
             "type": "parameter",
             "datatype":"text",
             "description": "Path to a custom view presented with the Umbraco installation contains no published content",
-            "defaultValue": "",
+            "defaultValue": ""
         },
         "NoNodesViewPathReplaced":{
             "type": "generated",

--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -249,6 +249,43 @@
                 ]
               }
         },
+        "NoNodesViewPath":{
+            "type": "parameter",
+            "datatype":"text",
+            "description": "Path to a custom view presented with the Umbraco installation contains no published content",
+            "defaultValue": "",
+        },
+        "NoNodesViewPathReplaced":{
+            "type": "generated",
+            "generator": "regex",
+            "dataType": "string",
+            "replaces": "NO_NODES_VIEW_PATH_FROM_TEMPLATE",
+            "parameters": {
+                "source": "NoNodesViewPath",
+                "steps": [
+                    {
+                        "regex": "\\\\",
+                        "replacement": "\\\\"
+                    },
+                    {
+                        "regex": "\\\"",
+                        "replacement": "\\\""
+                    },
+                    {
+                        "regex": "\\\n",
+                        "replacement": "\\\n"
+                    },
+                    {
+                        "regex": "\\\t",
+                        "replacement": "\\\t"
+                    }
+                ]
+              }
+        },
+        "HasNoNodesViewPath":{
+            "type": "computed",
+            "value": "(NoNodesViewPath != \"\")"
+        },
         "UsingUnattenedInstall":{
             "type": "computed",
             "value": "(FriendlyName != \"\" && Email != \"\" && Password != \"\" && ConnectionString != \"\")"

--- a/build/templates/UmbracoProject/appsettings.Development.json
+++ b/build/templates/UmbracoProject/appsettings.Development.json
@@ -34,9 +34,6 @@
       },
       //#endif
       "Global": {
-        //#if (HasNoNodesViewPath)
-        "NoNodesViewPath": "NO_NODES_VIEW_PATH_FROM_TEMPLATE",
-        //#endif
         "Smtp": {
           "From": "your@email.here",
           "Host": "localhost",

--- a/build/templates/UmbracoProject/appsettings.Development.json
+++ b/build/templates/UmbracoProject/appsettings.Development.json
@@ -34,6 +34,9 @@
       },
       //#endif
       "Global": {
+        //#if (HasNoNodesViewPath)
+        "NoNodesViewPath": "NO_NODES_VIEW_PATH_FROM_TEMPLATE",
+        //#endif
         "Smtp": {
           "From": "your@email.here",
           "Host": "localhost",

--- a/build/templates/UmbracoProject/appsettings.json
+++ b/build/templates/UmbracoProject/appsettings.json
@@ -15,6 +15,11 @@
   },
   "Umbraco": {
     "CMS": {
+      //#if (HasNoNodesViewPath)
+      "Global": {
+        "NoNodesViewPath": "NO_NODES_VIEW_PATH_FROM_TEMPLATE"
+      },
+      //#endif
       "Hosting": {
         "Debug": false
       }


### PR DESCRIPTION
This is required for Cloud to be able to create a project with the necessary configuration for the custom "no nodes" page that's presented when you first restore a project.

To Test (at least this is how I did it):

- Check out the PR and amend your local `src\Directory.Build.props` file to create a new version, e.g. `<InformationalVersion>9.0.0-rc003a</InformationalVersion>`
- Run `builf\build.ps`
- Copy the resulting `Umbraco.Templates.9.0.0-rc003a.nupkg` from `build.out` into a local folder set up as a NuGet feed
- Run:

```
dotnet new -i Umbraco.Templates::9.0.0-rc003a
dotnet new umbraco --name TestWithNoNodes --no-nodes-view-path "/my-custom-path"
cd .\TestWithNoNodes\
code .
```

And check that the `appSettings.Development.json` file has the appropriate setting for `Umbraco:CMS:Global:NoNodesViewPath`.
