### PR TITLE
Use IFileService to save macro partial views in package migration

### DIFF
--- a/src/Umbraco.Core/Packaging/InstallationSummary.cs
+++ b/src/Umbraco.Core/Packaging/InstallationSummary.cs
@@ -23,6 +23,7 @@ namespace Umbraco.Cms.Core.Packaging
         public IEnumerable<ILanguage> LanguagesInstalled { get; set; } = Enumerable.Empty<ILanguage>();
         public IEnumerable<IDictionaryItem> DictionaryItemsInstalled { get; set; } = Enumerable.Empty<IDictionaryItem>();
         public IEnumerable<IMacro> MacrosInstalled { get; set; } = Enumerable.Empty<IMacro>();
+        public IEnumerable<IPartialView> MacroPartialViewsInstalled { get; set; } = Enumerable.Empty<IPartialView>();
         public IEnumerable<ITemplate> TemplatesInstalled { get; set; } = Enumerable.Empty<ITemplate>();
         public IEnumerable<IContentType> DocumentTypesInstalled { get; set; } = Enumerable.Empty<IContentType>();
         public IEnumerable<IMediaType> MediaTypesInstalled { get; set; } = Enumerable.Empty<IMediaType>();

--- a/src/Umbraco.Core/Packaging/InstallationSummary.cs
+++ b/src/Umbraco.Core/Packaging/InstallationSummary.cs
@@ -13,9 +13,9 @@ namespace Umbraco.Cms.Core.Packaging
     public class InstallationSummary
     {
         public InstallationSummary(string packageName)
-        {
-            PackageName = packageName;
-        }
+            => PackageName = packageName;
+
+        public string PackageName { get; }
 
         public InstallWarnings Warnings { get; set; } = new InstallWarnings();
 
@@ -32,73 +32,55 @@ namespace Umbraco.Cms.Core.Packaging
         public IEnumerable<IPartialView> PartialViewsInstalled { get; set; } = Enumerable.Empty<IPartialView>();
         public IEnumerable<IContent> ContentInstalled { get; set; } = Enumerable.Empty<IContent>();
         public IEnumerable<IMedia> MediaInstalled { get; set; } = Enumerable.Empty<IMedia>();
-        public string PackageName { get; }
 
         public override string ToString()
         {
             var sb = new StringBuilder();
-            var macroConflicts = Warnings.ConflictingMacros.ToList();
-            if (macroConflicts.Count > 0)
+
+            void WriteConflicts<T>(IEnumerable<T> source, Func<T, string> selector, string message, bool appendLine = true)
             {
-                sb.Append("Conflicting macros found, they will be overwritten:");
-                foreach(IMacro m in macroConflicts)
+                var result = source.Select(selector).ToList();
+                if (result.Count > 0)
                 {
-                    sb.Append(m.Alias);
-                    sb.Append(',');
+                    sb.Append(message);
+                    sb.Append(string.Join(", ", result));
+
+                    if (appendLine)
+                    {
+                        sb.AppendLine();
+                    }
                 }
-                sb.AppendLine(". ");
-            }
-            var templateConflicts = Warnings.ConflictingTemplates.ToList();
-            if (templateConflicts.Count > 0)
-            {
-                sb.Append("Conflicting templates found, they will be overwritten:");
-                foreach (ITemplate m in templateConflicts)
-                {
-                    sb.Append(m.Alias);
-                    sb.Append(',');
-                }
-                sb.AppendLine(". ");
-            }
-            var stylesheetConflicts = Warnings.ConflictingStylesheets.ToList();
-            if (stylesheetConflicts.Count > 0)
-            {
-                sb.Append("Conflicting stylesheets found, they will be overwritten:");
-                foreach (IFile m in stylesheetConflicts)
-                {
-                    sb.Append(m.Alias);
-                    sb.Append(',');
-                }
-                sb.AppendLine(". ");
             }
 
-            sb.Append("Content items installed: ");
-            sb.Append(ContentInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Media items installed: ");
-            sb.Append(MediaInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Dictionary items installed: ");
-            sb.Append(DictionaryItemsInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Macros installed: ");
-            sb.Append(MacrosInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Stylesheets installed: ");
-            sb.Append(StylesheetsInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Templates installed: ");
-            sb.Append(TemplatesInstalled.Count());
-            sb.AppendLine();
-            sb.Append("Document types installed: ");
-            sb.Append(DocumentTypesInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Media types installed: ");
-            sb.Append(MediaTypesInstalled.Count());
-            sb.AppendLine(". ");
-            sb.Append("Data types items installed: ");
-            sb.Append(DataTypesInstalled.Count());
+            void WriteCount<T>(string message, IEnumerable<T> source, bool appendLine = true)
+            {
+                sb.Append(message);
+                sb.Append(source.Count());
+
+                if (appendLine)
+                {
+                    sb.AppendLine();
+                }
+            }
+
+            WriteConflicts(Warnings.ConflictingMacros, x => x.Alias, "Conflicting macros found, they will be overwritten: ");
+            WriteConflicts(Warnings.ConflictingTemplates, x => x.Alias, "Conflicting templates found, they will be overwritten: ");
+            WriteConflicts(Warnings.ConflictingStylesheets, x => x.Alias, "Conflicting stylesheets found, they will be overwritten: ");
+            WriteCount("Data types installed: ", DataTypesInstalled);
+            WriteCount("Languages installed: ", LanguagesInstalled);
+            WriteCount("Dictionary items installed: ", DictionaryItemsInstalled);
+            WriteCount("Macros installed: ", MacrosInstalled);
+            WriteCount("Macro partial views installed: ", MacroPartialViewsInstalled);
+            WriteCount("Templates installed: ", TemplatesInstalled);
+            WriteCount("Document types installed: ", DocumentTypesInstalled);
+            WriteCount("Media types installed: ", MediaTypesInstalled);
+            WriteCount("Stylesheets installed: ", StylesheetsInstalled);
+            WriteCount("Scripts installed: ", ScriptsInstalled);
+            WriteCount("Partial views installed: ", PartialViewsInstalled);
+            WriteCount("Content items installed: ", ContentInstalled);
+            WriteCount("Media items installed: ", MediaInstalled, false);
+
             return sb.ToString();
         }
     }
-
 }

--- a/src/Umbraco.Core/Packaging/InstallationSummary.cs
+++ b/src/Umbraco.Core/Packaging/InstallationSummary.cs
@@ -39,8 +39,8 @@ namespace Umbraco.Cms.Core.Packaging
 
             void WriteConflicts<T>(IEnumerable<T> source, Func<T, string> selector, string message, bool appendLine = true)
             {
-                var result = source.Select(selector).ToList();
-                if (result.Count > 0)
+                var result = source?.Select(selector).ToList();
+                if (result?.Count > 0)
                 {
                     sb.Append(message);
                     sb.Append(string.Join(", ", result));
@@ -55,7 +55,7 @@ namespace Umbraco.Cms.Core.Packaging
             void WriteCount<T>(string message, IEnumerable<T> source, bool appendLine = true)
             {
                 sb.Append(message);
-                sb.Append(source.Count());
+                sb.Append(source?.Count() ?? 0);
 
                 if (appendLine)
                 {
@@ -63,9 +63,9 @@ namespace Umbraco.Cms.Core.Packaging
                 }
             }
 
-            WriteConflicts(Warnings.ConflictingMacros, x => x.Alias, "Conflicting macros found, they will be overwritten: ");
-            WriteConflicts(Warnings.ConflictingTemplates, x => x.Alias, "Conflicting templates found, they will be overwritten: ");
-            WriteConflicts(Warnings.ConflictingStylesheets, x => x.Alias, "Conflicting stylesheets found, they will be overwritten: ");
+            WriteConflicts(Warnings?.ConflictingMacros, x => x.Alias, "Conflicting macros found, they will be overwritten: ");
+            WriteConflicts(Warnings?.ConflictingTemplates, x => x.Alias, "Conflicting templates found, they will be overwritten: ");
+            WriteConflicts(Warnings?.ConflictingStylesheets, x => x.Alias, "Conflicting stylesheets found, they will be overwritten: ");
             WriteCount("Data types installed: ", DataTypesInstalled);
             WriteCount("Languages installed: ", LanguagesInstalled);
             WriteCount("Dictionary items installed: ", DictionaryItemsInstalled);

--- a/src/Umbraco.Core/Packaging/PackageDefinition.cs
+++ b/src/Umbraco.Core/Packaging/PackageDefinition.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Core.Packaging
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// The full path to the package's xml file
+        /// The full path to the package's XML file.
         /// </summary>
         [ReadOnly(true)]
         [DataMember(Name = "packagePath")]
@@ -71,12 +71,9 @@ namespace Umbraco.Cms.Core.Packaging
         public IList<string> DataTypes { get; set; } = new List<string>();
 
         [DataMember(Name = "mediaUdis")]
-        public IList<GuidUdi> MediaUdis { get; set; } = Array.Empty<GuidUdi>();
+        public IList<GuidUdi> MediaUdis { get; set; } = new List<GuidUdi>();
 
         [DataMember(Name = "mediaLoadChildNodes")]
         public bool MediaLoadChildNodes { get; set; }
-
-
     }
-
 }

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -1270,6 +1270,17 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                     throw new InvalidOperationException("No path attribute found");
                 }
 
+                // Remove prefix to maintain backwards compatibility
+                if (path.StartsWith(Constants.SystemDirectories.MacroPartials))
+                {
+                    path = path.Substring(Constants.SystemDirectories.MacroPartials.Length);
+                }
+                else if (path.StartsWith("~"))
+                {
+                    _logger.LogWarning("Importing macro partial views outside of the Views/MacroPartials directory is not supported: {Path}", path);
+                    continue;
+                }
+
                 IPartialView macroPartialView = _fileService.GetPartialViewMacro(path);
 
                 // only update if it doesn't exist

--- a/src/Umbraco.Infrastructure/Packaging/PackageInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageInstallation.cs
@@ -44,20 +44,29 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             //make sure the definition is up to date with everything
             foreach (var x in installationSummary.DataTypesInstalled)
                 packageDefinition.DataTypes.Add(x.Id.ToInvariantString());
+
             foreach (var x in installationSummary.LanguagesInstalled)
                 packageDefinition.Languages.Add(x.Id.ToInvariantString());
+
             foreach (var x in installationSummary.DictionaryItemsInstalled)
                 packageDefinition.DictionaryItems.Add(x.Id.ToInvariantString());
+
             foreach (var x in installationSummary.MacrosInstalled)
                 packageDefinition.Macros.Add(x.Id.ToInvariantString());
+
             foreach (var x in installationSummary.TemplatesInstalled)
                 packageDefinition.Templates.Add(x.Id.ToInvariantString());
+
             foreach (var x in installationSummary.DocumentTypesInstalled)
                 packageDefinition.DocumentTypes.Add(x.Id.ToInvariantString());
-            foreach (var x in installationSummary.StylesheetsInstalled)
-                packageDefinition.Stylesheets.Add(x.Id.ToInvariantString());
-            var contentInstalled = installationSummary.ContentInstalled.ToList();
-            packageDefinition.ContentNodeId = contentInstalled.Count > 0 ? contentInstalled[0].Id.ToInvariantString() : null;
+
+            foreach (var x in installationSummary.MediaTypesInstalled)
+                packageDefinition.MediaTypes.Add(x.Id.ToInvariantString());
+
+            packageDefinition.ContentNodeId = installationSummary.ContentInstalled.FirstOrDefault()?.Id.ToInvariantString();
+            
+            foreach (var x in installationSummary.MediaInstalled)
+                packageDefinition.MediaUdis.Add(x.GetUdi());
 
             return installationSummary;
         }

--- a/src/Umbraco.Infrastructure/Packaging/PackageInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageInstallation.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Cms.Infrastructure.Packaging
 
             InstallationSummary installationSummary = _packageDataInstallation.InstallPackageData(compiledPackage, userId);
 
-            //make sure the definition is up to date with everything
+            // Make sure the definition is up to date with everything (note: macro partial views are embedded in macros)
             foreach (var x in installationSummary.DataTypesInstalled)
                 packageDefinition.DataTypes.Add(x.Id.ToInvariantString());
 
@@ -62,6 +62,15 @@ namespace Umbraco.Cms.Infrastructure.Packaging
 
             foreach (var x in installationSummary.MediaTypesInstalled)
                 packageDefinition.MediaTypes.Add(x.Id.ToInvariantString());
+
+            foreach (var x in installationSummary.StylesheetsInstalled)
+                packageDefinition.Stylesheets.Add(x.Path);
+
+            foreach (var x in installationSummary.ScriptsInstalled)
+                packageDefinition.Scripts.Add(x.Path);
+
+            foreach (var x in installationSummary.PartialViewsInstalled)
+                packageDefinition.PartialViews.Add(x.Path);
 
             packageDefinition.ContentNodeId = installationSummary.ContentInstalled.FirstOrDefault()?.Id.ToInvariantString();
             

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -650,7 +650,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             // Act
             var macros = PackageDataInstallation.ImportMacros(
                 macrosElement.Elements("macro"),
-                Enumerable.Empty<XElement>(),
                 0).ToList();
 
             // Assert
@@ -674,7 +673,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             // Act
             var macros = PackageDataInstallation.ImportMacros(
                 macrosElement.Elements("macro"),
-                Enumerable.Empty<XElement>(),
                 0).ToList();
 
             // Assert


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When a package migration tried to save macro partial views from an embedded package.xml file (like in The Starter Kit), it directly used `File.WriteAllText()` instead of the `IFileService.SavePartialViewMacro()`. If the `Views/MacroPartials` directory didn't exist yet, this also caused a `DirectoryNotFoundException` to be thrown (which would cause a `BootFailedException` when the migrations are automatically run).

Testing steps:
1. Before applying this PR on a clean install, remove the `Views/MacroPartials` directory and try to install The Starter Kit (`dotnet add package Umbraco.TheStarterKit --version 9.0.0-rc002`): this will throw an exception while booting up;
2. Manually create the `Views/MacroPartials` directory and start the site: the package migration will now successfully run and the `FeaturedProducts.cshtml` and `LatestBlogposts.cshtml` files should be created in this directory;
3. Apply this PR to a clean install and repeat the first step: it should now run the package migration without issues and the macro partial view files should also exist.