### PR TITLE
Fixes issue with dotnet new template if you did not specify a connection string

### DIFF
--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -282,6 +282,10 @@
                 ]
               }
         },
+        "HasConnectionString":{
+            "type": "computed",
+            "value": "(ConnectionString != \"\")"
+        },
         "HasNoNodesViewPath":{
             "type": "computed",
             "value": "(NoNodesViewPath != \"\")"

--- a/build/templates/UmbracoProject/appsettings.Development.json
+++ b/build/templates/UmbracoProject/appsettings.Development.json
@@ -17,9 +17,11 @@
       }
     ]
   },
+  //#if (HasConnectionString)
   "ConnectionStrings": {
     "umbracoDbDSN": "CONNECTION_FROM_TEMPLATE"
   },
+  //#endif
   "Umbraco": {
     "CMS": {
       "Content": {


### PR DESCRIPTION
Fixes issue with dotnet new template if you did not specify a connection string it was adding an empty one in appsettings.dev

----

To Test (at least this is how I did it):

- Check out the PR and amend your local `src\Directory.Build.props` file to create a new version, e.g. `<InformationalVersion>9.0.0-rc003abc</InformationalVersion>`
- Run `build\build.ps`
- Copy the resulting `Umbraco.Templates.9.0.0-rc003abc.nupkg` from `build.out` into a local folder set up as a NuGet feed
- Run:

```
dotnet new -i Umbraco.Templates::9.0.0-rc003abc
dotnet new umbraco --name NoConnectionString"
cd .\NoConnectionString\
code .
```

And check that the `appSettings.Development.json` file does not include `ConnectionStrings:umbracoDbDSN`

Retest with the following and verify something does get set for the connection string
```
dotnet new umbraco --name WithConnectionString --connection-string "server=localhost;database=learnathon;user id=sa;password='P@ssw0rd'"
cd .\WithConnectionString \
code .
```

