### PR TITLE
Bugfix: Accessibility in Tabs - Ensure the selected tab is properly exposed to aria-selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,6 +1,6 @@
 <ul role="tablist" class="umb-tabs-nav">
     <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
-        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" aria-selected="{tab.active}" type="button">
+        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" aria-selected="{{tab.active}}" type="button">
             {{ tab.label }}
             <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
         </button>
@@ -23,7 +23,7 @@
                     ng-class="{'dropdown-menu--active': tab.active}"
                     ng-click="vm.clickTab($event, tab)"
                     role="tab"
-                    aria-selected="{tab.active}" >
+                    aria-selected="{{tab.active}}" >
                     {{ tab.label }}
                     <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
                 </button>


### PR DESCRIPTION
…has a proper true/false value

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Playing around with the new tabs I by coincidence noticed that the `aria-selected` value was rendering `{tab.active}` instead of either `true/false` due to the expression missing a set of extra curly braces so the code would read `aria-selected="{{tab.active}}"` in order to render `true/false`.