### PR TITLE
Import document type extension

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/import.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/import.controller.js
@@ -6,8 +6,8 @@ angular.module("umbraco")
             vm.state = "upload";
             vm.model = {};
             vm.uploadStatus = "";
-
-            $scope.handleFiles = function (files, event) {
+            
+            $scope.handleFiles = function (files, event, invalidFiles) {
                 if (files && files.length > 0) {
                     $scope.upload(files[0]);
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
@@ -15,7 +15,8 @@
                 ng-model="filesHolder"
                 ngf-change="handleFiles($files, $event, $invalidFiles)"
                 ngf-multiple="true"
-                ngf-pattern="*.udt">
+                ngf-pattern="'*.udt'"
+                accept=".udt" >
                 <localize key="general_import">Import</localize>
             </button>
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/importdocumenttype.html
@@ -13,7 +13,7 @@
                 name="file"
                 ngf-select
                 ng-model="filesHolder"
-                ngf-change="handleFiles($files, $event)"
+                ngf-change="handleFiles($files, $event, $invalidFiles)"
                 ngf-multiple="true"
                 ngf-pattern="*.udt">
                 <localize key="general_import">Import</localize>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Similar to the fix in https://github.com/umbraco/Umbraco-CMS/pull/11061 this also pass in invalidfiles to `handleFiles` function ... and further fix the accepted extension.
https://stackoverflow.com/questions/34128497/ngf-pattern-not-working-for-ng-file-upload/34128573#34128573