### PR TITLE
Add Eye Dropper prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.controller.js
@@ -24,21 +24,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.EyeDropperColorPic
             angularHelper.safeApply($scope, function () {
                 vm.color = color ? color.toString() : null;
                 $scope.model.value = vm.color;
-                $scope.propertyForm.selectedColor.$setViewValue(vm.color);
             });
-        };
-
-        // Method required by the valPropertyValidator directive (returns true if the property editor has at least one color selected)
-        $scope.validateMandatory = function () {
-            var isValid = !$scope.model.validation.mandatory || (
-                $scope.model.value != null
-                && $scope.model.value != "");
-
-            return {
-                isValid: isValid,
-                errorMsg: $scope.model.validation.mandatoryMessage || "Value cannot be empty",
-                errorKey: "required"
-            };
         };
 
     });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.controller.js
@@ -1,0 +1,44 @@
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.EyeDropperColorPickerController",
+    function ($scope) {
+
+        var vm = this;
+
+        //setup the default config
+        var config = {
+            showAlpha: true,
+            showPalette: true,
+            allowEmpty: true
+        };
+
+        // map the user config
+        Utilities.extend(config, $scope.model.config);
+
+        // map back to the model
+        $scope.model.config = config;
+
+        vm.options = $scope.model.config;
+
+        vm.color = $scope.model.value || null;
+
+        vm.selectColor = function (color) {
+            angularHelper.safeApply($scope, function () {
+                vm.color = color ? color.toString() : null;
+                $scope.model.value = vm.color;
+                $scope.propertyForm.selectedColor.$setViewValue(vm.color);
+            });
+        };
+
+        // Method required by the valPropertyValidator directive (returns true if the property editor has at least one color selected)
+        $scope.validateMandatory = function () {
+            var isValid = !$scope.model.validation.mandatory || (
+                $scope.model.value != null
+                && $scope.model.value != "");
+
+            return {
+                isValid: isValid,
+                errorMsg: $scope.model.validation.mandatoryMessage || "Value cannot be empty",
+                errorKey: "required"
+            };
+        };
+
+    });

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.controller.js
@@ -1,5 +1,5 @@
 angular.module("umbraco").controller("Umbraco.PrevalueEditors.EyeDropperColorPickerController",
-    function ($scope) {
+    function ($scope, angularHelper) {
 
         var vm = this;
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.html
@@ -6,5 +6,4 @@
         on-change="vm.selectColor(color)">
     </umb-color-picker>
 
-    <input type="hidden" name="selectedColor" ng-model="model.selectedColor" val-property-validator="validateMandatory" />
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/eyedropper.html
@@ -1,0 +1,10 @@
+<div ng-controller="Umbraco.PrevalueEditors.EyeDropperColorPickerController as vm">
+
+    <umb-color-picker
+        ng-model="vm.color"
+        options="vm.options"
+        on-change="vm.selectColor(color)">
+    </umb-color-picker>
+
+    <input type="hidden" name="selectedColor" ng-model="model.selectedColor" val-property-validator="validateMandatory" />
+</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add an Eye Dropper prevalue editor, so we easily can reuse eyedropper in e.g. Grid settings and styles, it property editors etc.

```
[
  {
    "label": "Background Color",
    "description": "Choose a background color",
    "key": "background-color",
    "view": "eyedropper"
  },
  {
    "label": "Text Color",
    "description": "Choose a text color",
    "key": "color",
    "view": "eyedropper"
  }
]
```

![image](https://user-images.githubusercontent.com/2919859/133574519-0d538c97-534d-4f90-ac8c-b367c774a4cb.png)

![image](https://user-images.githubusercontent.com/2919859/133574728-14c5f9e7-42ec-4664-8665-422fc290cf72.png)
