### PR TITLE
Fix incorrect attribute in hidden prevalue attribute

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/hidden.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/hidden.html
@@ -1,1 +1,1 @@
-<input name="hidden" type="hidden" ng-model="model.value" name="{{model.alias}}" /> 
+<input name="hidden" type="hidden" ng-model="model.value" id="{{model.alias}}" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
At some point the hidden prevalue editor has changed, so it set name attribute twice and not id attribute.

Strange nobody has noticed this since in was added in https://github.com/umbraco/Umbraco-CMS/commit/5b289a4971ccb0f6d431377e9e199c6d27bb2839#diff-5712c2b4c44f9e8368d7437b866a916290dfcd5814e062c74ed99362329ca19eR1

It seems the latter one would be ignored https://stackoverflow.com/a/26341866/1693918 .. but you never know if that's the case in future browsers.