### PR TITLE
Add property group key to save model

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -75,7 +75,7 @@
                 });
                 saveModel.groups = _.map(realGroups, function (g) {
 
-                    var saveGroup = _.pick(g, 'inherited', 'id', 'sortOrder', 'name', 'alias', 'type');
+                    var saveGroup = _.pick(g, 'inherited', 'id', 'sortOrder', 'name', 'key', 'alias', 'type');
 
                     var realProperties = _.reject(g.properties, function (p) {
                         //do not include these properties


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/11116

### Description
The unique ID/key of property groups wasn't posted back to the server when saving document, media or member types, which caused it to re-generate a new GUID in the database. This fix ensures the existing `key` is used by not filtering it out of the 'save model' (the `alias` and `type` fields were already correctly added here).

Testing can be done by following the reproduction steps on the linked issue.