### PR TITLE
UmbracoRouteValueTransformer fixes

### DIFF
--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
@@ -92,28 +93,28 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Routing
             => Mock.Of<IPublishedRouter>(x => x.RouteRequestAsync(It.IsAny<IPublishedRequestBuilder>(), It.IsAny<RouteRequestOptions>()) == Task.FromResult(request));
 
         [Test]
-        public async Task Noop_When_Runtime_Level_Not_Run()
+        public async Task Null_When_Runtime_Level_Not_Run()
         {
             UmbracoRouteValueTransformer transformer = GetTransformer(
                 Mock.Of<IUmbracoContextAccessor>(),
                 Mock.Of<IRuntimeState>());
 
             RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
-            Assert.AreEqual(0, result.Count);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public async Task Noop_When_No_Umbraco_Context()
+        public async Task Null_When_No_Umbraco_Context()
         {
             UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
                 Mock.Of<IUmbracoContextAccessor>());
 
             RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
-            Assert.AreEqual(0, result.Count);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public async Task Noop_When_Not_Document_Request()
+        public async Task Null_When_Not_Document_Request()
         {
             var umbracoContext = Mock.Of<IUmbracoContext>();
             UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
@@ -121,7 +122,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Routing
                 Mock.Of<IRoutableDocumentFilter>(x => x.IsDocumentRequest(It.IsAny<string>()) == false));
 
             RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
-            Assert.AreEqual(0, result.Count);
+            Assert.IsNull(result);
         }
 
         [Test]
@@ -173,10 +174,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Routing
         }
 
         [Test]
-        public async Task Assigns_Values_To_RouteValueDictionary()
+        public async Task Assigns_Values_To_RouteValueDictionary_When_Content()
         {
             IUmbracoContext umbracoContext = GetUmbracoContext(true);
-            IPublishedRequest request = Mock.Of<IPublishedRequest>();
+            IPublishedRequest request = Mock.Of<IPublishedRequest>(x => x.PublishedContent == Mock.Of<IPublishedContent>());
             UmbracoRouteValues routeValues = GetRouteValues(request);
 
             UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
@@ -188,6 +189,23 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Routing
 
             Assert.AreEqual(routeValues.ControllerName, result[ControllerToken]);
             Assert.AreEqual(routeValues.ActionName, result[ActionToken]);
+        }
+
+        [Test]
+        public async Task Returns_Null_RouteValueDictionary_When_No_Content()
+        {
+            IUmbracoContext umbracoContext = GetUmbracoContext(true);
+            IPublishedRequest request = Mock.Of<IPublishedRequest>(x => x.PublishedContent == null);
+            UmbracoRouteValues routeValues = GetRouteValues(request);
+
+            UmbracoRouteValueTransformer transformer = GetTransformerWithRunState(
+                Mock.Of<IUmbracoContextAccessor>(x => x.TryGetUmbracoContext(out umbracoContext)),
+                router: GetRouter(request),
+                routeValuesFactory: GetRouteValuesFactory(request));
+
+            RouteValueDictionary result = await transformer.TransformAsync(new DefaultHttpContext(), new RouteValueDictionary());
+
+            Assert.IsNull(result);
         }
 
         private class TestController : RenderController

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Infrastructure.DependencyInjection;
@@ -11,6 +13,7 @@ using Umbraco.Cms.Web.Website.Middleware;
 using Umbraco.Cms.Web.Website.Models;
 using Umbraco.Cms.Web.Website.Routing;
 using Umbraco.Cms.Web.Website.ViewEngines;
+using static Microsoft.Extensions.DependencyInjection.ServiceDescriptor;
 
 namespace Umbraco.Extensions
 {
@@ -40,6 +43,7 @@ namespace Umbraco.Extensions
 
             builder.Services.AddSingleton<UmbracoRouteValueTransformer>();
             builder.Services.AddSingleton<IControllerActionSearcher, ControllerActionSearcher>();
+            builder.Services.TryAddEnumerable(Singleton<MatcherPolicy, NotFoundSelectorPolicy>());
             builder.Services.AddSingleton<IUmbracoRouteValuesFactory, UmbracoRouteValuesFactory>();
             builder.Services.AddSingleton<IRoutableDocumentFilter, RoutableDocumentFilter>();
 

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Extensions
             builder.Services.AddDataProtection();
             builder.Services.AddAntiforgery();
 
-            builder.Services.AddScoped<UmbracoRouteValueTransformer>();
+            builder.Services.AddSingleton<UmbracoRouteValueTransformer>();
             builder.Services.AddSingleton<IControllerActionSearcher, ControllerActionSearcher>();
             builder.Services.AddSingleton<IUmbracoRouteValuesFactory, UmbracoRouteValuesFactory>();
             builder.Services.AddSingleton<IRoutableDocumentFilter, RoutableDocumentFilter>();

--- a/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,8 +34,8 @@ namespace Umbraco.Cms.Web.Website.Routing
             {
                 // return the endpoint for the RenderController.Index action.
                 ControllerActionDescriptor descriptor = x.Metadata?.GetMetadata<ControllerActionDescriptor>();
-                return descriptor.ControllerTypeInfo == typeof(RenderController)
-                    && descriptor.ActionName == nameof(RenderController.Index);
+                return descriptor?.ControllerTypeInfo == typeof(RenderController)
+                    && descriptor?.ActionName == nameof(RenderController.Index);
             });
             return e;
         }

--- a/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Web.Website.Routing
         public NotFoundSelectorPolicy(EndpointDataSource endpointDataSource)
         {
             _notFound = new Lazy<Endpoint>(GetNotFoundEndpoint);
-            _endpointDataSource = endpointDataSource;            
+            _endpointDataSource = endpointDataSource;
         }
 
         // return the endpoint for the RenderController.Index action.
@@ -46,7 +46,7 @@ namespace Umbraco.Cms.Web.Website.Routing
         {
             // Don't apply this filter to any endpoint group that is a controller route
             // i.e. only dynamic routes.            
-            foreach(Endpoint endpoint in endpoints)
+            foreach (Endpoint endpoint in endpoints)
             {
                 ControllerAttribute controller = endpoint.Metadata?.GetMetadata<ControllerAttribute>();
                 if (controller != null)
@@ -61,7 +61,7 @@ namespace Umbraco.Cms.Web.Website.Routing
 
         public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
         {
-            if (candidates.Count == 1 && candidates[0].Values == null)
+            if (AllInvalid(candidates))
             {
                 UmbracoRouteValues umbracoRouteValues = httpContext.Features.Get<UmbracoRouteValues>();
                 if (umbracoRouteValues?.PublishedRequest != null
@@ -72,8 +72,20 @@ namespace Umbraco.Cms.Web.Website.Routing
                     httpContext.SetEndpoint(_notFound.Value);
                 }
             }
-            
-            return Task.CompletedTask;            
+
+            return Task.CompletedTask;
+        }
+
+        private static bool AllInvalid(CandidateSet candidates)
+        {
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (candidates.IsValidCandidate(i))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Cms.Web.Common.Routing;
+
+namespace Umbraco.Cms.Web.Website.Routing
+{
+    /// <summary>
+    /// Used to handle 404 routes that haven't been handled by the end user
+    /// </summary>
+    internal class NotFoundSelectorPolicy : MatcherPolicy, IEndpointSelectorPolicy
+    {
+        private readonly Lazy<Endpoint> _notFound;
+        private readonly EndpointDataSource _endpointDataSource;
+
+        public NotFoundSelectorPolicy(EndpointDataSource endpointDataSource)
+        {
+            _notFound = new Lazy<Endpoint>(GetNotFoundEndpoint);
+            _endpointDataSource = endpointDataSource;            
+        }
+
+        // return the endpoint for the RenderController.Index action.
+        private Endpoint GetNotFoundEndpoint()
+        {
+            Endpoint e = _endpointDataSource.Endpoints.First(x =>
+            {
+                // return the endpoint for the RenderController.Index action.
+                ControllerActionDescriptor descriptor = x.Metadata?.GetMetadata<ControllerActionDescriptor>();
+                return descriptor.ControllerTypeInfo == typeof(RenderController)
+                    && descriptor.ActionName == nameof(RenderController.Index);
+            });
+            return e;
+        }
+
+        public override int Order => 0;
+
+        public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+        {
+            // Don't apply this filter to any endpoint group that is a controller route
+            // i.e. only dynamic routes.            
+            foreach(Endpoint endpoint in endpoints)
+            {
+                ControllerAttribute controller = endpoint.Metadata?.GetMetadata<ControllerAttribute>();
+                if (controller != null)
+                {
+                    return false;
+                }
+            }
+
+            // then ensure this is only applied if all endpoints are IDynamicEndpointMetadata
+            return endpoints.All(x => x.Metadata?.GetMetadata<IDynamicEndpointMetadata>() != null);
+        }
+
+        public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+        {
+            if (candidates.Count == 1 && candidates[0].Values == null)
+            {
+                UmbracoRouteValues umbracoRouteValues = httpContext.Features.Get<UmbracoRouteValues>();
+                if (umbracoRouteValues?.PublishedRequest != null
+                    && !umbracoRouteValues.PublishedRequest.HasPublishedContent()
+                    && umbracoRouteValues.PublishedRequest.ResponseStatusCode == StatusCodes.Status404NotFound)
+                {
+                    // not found/404
+                    httpContext.SetEndpoint(_notFound.Value);
+                }
+            }
+            
+            return Task.CompletedTask;            
+        }
+    }
+}

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -28,6 +28,7 @@ using RouteDirection = Umbraco.Cms.Core.Routing.RouteDirection;
 
 namespace Umbraco.Cms.Web.Website.Routing
 {
+
     /// <summary>
     /// The route value transformer for Umbraco front-end routes
     /// </summary>
@@ -138,6 +139,16 @@ namespace Umbraco.Cms.Web.Website.Routing
                 return HandlePostedValues(postedInfo, httpContext);
             }
 
+            if (!umbracoRouteValues?.PublishedRequest?.HasPublishedContent() ?? false)
+            {
+                // No content was found, not by any registered 404 handlers and
+                // not by the IContentLastChanceFinder. In this case we want to return
+                // our default 404 page but we cannot return route values now because
+                // it's possible that a developer is handling dynamic routes too.
+                // Our 404 page will be handled with the NotFoundSelectorPolicy
+                return null;
+            }
+
             // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.routing.dynamicroutevaluetransformer.transformasync?view=aspnetcore-5.0#Microsoft_AspNetCore_Mvc_Routing_DynamicRouteValueTransformer_TransformAsync_Microsoft_AspNetCore_Http_HttpContext_Microsoft_AspNetCore_Routing_RouteValueDictionary_
             // We should apparenlty not be modified these values.
             // So we create new ones.
@@ -149,11 +160,6 @@ namespace Umbraco.Cms.Web.Website.Routing
             {
                 newValues[ActionToken] = umbracoRouteValues.ActionName;
             }
-
-            // NOTE: If we are never returning null it means that it is not possible for another
-            // DynamicRouteValueTransformer to execute to set the route values. This one will
-            // always win even if it is a 404 because we manage all 404s via Umbraco and 404
-            // handlers.
 
             return newValues;
         }


### PR DESCRIPTION
There are some issues with our current implementation which make it almost impossible for other DynamicRouteValueTransformer to play nicely with Umbraco especially those that integrate with Umbraco using `UmbracoRouteValues` (i.e. Articulate).

* UmbracoRouteValueTransformer as singleton - this will save memory, there only needs to be one instance and it doesn't need to be scoped. It was only scoped based on some old example code in the aspnet repo.
* Return `null` when we don't match. See https://github.com/dotnet/aspnetcore/pull/36653.
* Don't execute if there is already `UmbracoRouteValues` available. In this case it would mean that another `DynamicRouteValueTransformer` has already executed and routed an Umbraco route and we shouldn't overwrite it.
* Don't modify the passed in `values`, these should not be changed and we should be returning new values, see: https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.routing.dynamicroutevaluetransformer.transformasync?view=aspnetcore-5.0#parameters 
   > Implementations should not modify values.
* Return null if we are on 404 and no 404 handlers or last chance finders resolved content
* Deal with a true 404 in a custom IEndpointSelectorPolicy

The way we were using DynamicRouteValueTransformer meant that any other DynamicRouteValueTransformer  registered or ordered after ours will not have any affect. It will execute and new values can be returned but they will not be used (by default).

This lead me on some additional investigation - how to make 2 or more DynamicRouteValueTransformer that match the request execute the "last matched"? By default it seems that the first match always wins. Can this be changed? It turns out it can by implementing a `IEndpointSelectorPolicy` for which there are no docs (see: https://github.com/dotnet/AspNetCore.Docs/issues/12593). But there are some examples and mentions of how to make it work here: https://github.com/dotnet/aspnetcore/issues/10574#issuecomment-497195495. Why would we want this? Here's an example:

* Since Umbraco has a catch all dynamic route and never returns null even for 404s, any additional DynamicRouteValueTransformer registered that executes after Umbraco will just not work.
* In some cases, like Articulate, it would be preferable to check if Umbraco matches a real document, else fallback to a custom DynamicRouteValueTransformer to perform additional matching.

So more ideally would be that umbraco's DynamicRouteValueTransformer returns null when there is no content match at all so that any additional DynamicRouteValueTransformer just work as intended. So the final piece of the puzzle is then, how do we direct true 404s (not handled at all by the end user) to our custom 'page is left ugly' route = custom IEndpointSelectorPolicy.

## Testing

* Configure a 404 handler in the content settings like https://our.umbraco.com/Documentation/Tutorials/Custom-Error-Pages/index-v9#set-a-custom-404-page-in-appsettingsjson and make sure it works on a not found page.
* Remove this setting so there is no configured 404 page, then go to a page that doesn't exist and you should still get the 'this page is ugly'...

