### PR TITLE
Adjust icon size in umb-checkbox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -97,7 +97,8 @@
 
     .icon,
     .umb-icon {
-        font-size: 1.2rem;
+        font-size: 0.9rem;
+        line-height: 1;
     }
 
     &__state {
@@ -110,6 +111,8 @@
 
     &__check {
         display: flex;
+        align-items: center;
+        justify-content: center;
         position: relative;
         background: @white;
         border: 1px solid @inputBorder;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I think the check icon in `<umb-checkbox>` with recent changes was a bit too large compared to the size of the surrounding box.
I have adjusted this a bit.

**Before**

![image](https://user-images.githubusercontent.com/2919859/133926843-aa592fa8-2bf4-41fa-986b-5c0d9b90e46e.png)

![image](https://user-images.githubusercontent.com/2919859/133926827-4bb95b82-9d77-42dc-b9a0-8ff44b0d52e2.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/133926790-e6ffab4e-786b-4612-8e73-6f10487883b4.png)

![image](https://user-images.githubusercontent.com/2919859/133926808-b8f6d04f-4afe-4cde-ac5c-d9d7aba50aee.png)
