### PR TITLE
Align sortable handle vertically in multivalues prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -45,15 +45,15 @@
 
     &.ui-sortable-handle,
     .ui-sortable-handle,
-    .handle
-    {
+    .handle {
         cursor: move;
     }
 
-    i {
+    .umb-icon,
+    i.icon {
         display: flex;
-        align-items: center;
-        margin-right: 5px
+        align-self: center;
+        margin-right: 5px;
     }
 
     a {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the sortable handle wasn't aligned in multivalues prevalue editor.


