### PR TITLE
Fixed cultures to now both seperately in the backoffice and frontend …

### DIFF
--- a/src/Umbraco.Web.Common/Localization/UmbracoBackOfficeIdentityCultureProvider.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoBackOfficeIdentityCultureProvider.cs
@@ -36,13 +36,20 @@ namespace Umbraco.Cms.Web.Common.Localization
             lock (_locker)
             {
                 // We need to dynamically change the supported cultures since we won't ever know what languages are used since
-                // they are dynamic within Umbraco.
+                // they are dynamic within Umbraco. We have to handle this for both UI and Region cultures, in case people run different region and UI languages
                 var cultureExists = _localizationOptions.SupportedCultures.Contains(culture);
 
                 if (!cultureExists)
                 {
                     // add this as a supporting culture
                     _localizationOptions.SupportedCultures.Add(culture);
+                }
+
+                var uiCultureExists = _localizationOptions.SupportedCultures.Contains(culture);
+
+                if (!uiCultureExists)
+                {
+                    // add this as a supporting culture
                     _localizationOptions.SupportedUICultures.Add(culture);
                 }
 

--- a/src/Umbraco.Web.Common/Localization/UmbracoPublishedContentCultureProvider.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoPublishedContentCultureProvider.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Cms.Web.Common.Localization
                     lock (_locker)
                     {
                         // We need to dynamically change the supported cultures since we won't ever know what languages are used since
-                        // they are dynamic within Umbraco.
+                        // they are dynamic within Umbraco. We have to handle this for both UI and Region cultures, in case people run different region and UI languages
                         // This code to check existence is borrowed from aspnetcore to avoid creating a CultureInfo
                         // https://github.com/dotnet/aspnetcore/blob/b795ac3546eb3e2f47a01a64feb3020794ca33bb/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs#L165
                         CultureInfo existingCulture = _localizationOptions.SupportedCultures.FirstOrDefault(supportedCulture =>
@@ -47,6 +47,15 @@ namespace Umbraco.Cms.Web.Common.Localization
                             // add this as a supporting culture
                             var ci = CultureInfo.GetCultureInfo(culture);
                             _localizationOptions.SupportedCultures.Add(ci);
+                        }
+
+                        CultureInfo existingUICulture = _localizationOptions.SupportedUICultures.FirstOrDefault(supportedCulture =>
+                            StringSegment.Equals(supportedCulture.Name, culture, StringComparison.OrdinalIgnoreCase));
+
+                        if (existingUICulture == null)
+                        {
+                            // add this as a supporting culture
+                            var ci = CultureInfo.GetCultureInfo(culture);
                             _localizationOptions.SupportedUICultures.Add(ci);
                         }
                     }


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/10977
# Notes
- Added checks for both region and UI cultures in both the BackOfficeProvider and the PublishedContentProvider
# How to test
- Set up your languages on your windows PC like shown: 
![image](https://user-images.githubusercontent.com/70372949/133975192-75600160-8209-4b28-a48f-00dad9e0dcab.png)
- Run umbraco and the installer
- Go so settings, and under languages, add "English(New Zealand)" as your default language
- add "Danish (Denmark) as a language
- Delete English(US) as a language
- Go to the translation section and add an item called "My Key"
- Add translations for both English(New Zealand) and Danish
- Create a new document type with a template
- Allow as root and allow variants by culture
- Edit the template like so: 
```
@inject UmbracoHelper umbraco

<h1>@umbraco.GetDictionaryValue("My Key")</h1>


<h2>@System.Globalization.CultureInfo.CurrentUICulture</h2>
```
- Make some content with the new document type
- Add custom domains for both languages
- Visit both sites and assure they display the right translation and cultureInfo
