### PR TITLE
Fixes Nested Content not rendering

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -535,7 +535,7 @@
                     // remove all tabs except the specified tab
                     var tabs = scaffold.variants[0].tabs;
                     var tab = _.find(tabs, function (tab) {
-                        return tab.id !== 0 && (tab.alias.toLowerCase() === contentType.ncTabAlias.toLowerCase() || contentType.ncTabAlias === "");
+                        return tab.id !== 0 && (tab.label.toLowerCase() === contentType.ncTabAlias.toLowerCase() || contentType.ncTabAlias === "");
                     });
                     scaffold.variants[0].tabs = [];
                     if (tab) {

--- a/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Umbraco.Web.Editors;
 using Umbraco.Web.Mvc;
@@ -22,7 +23,7 @@ namespace Umbraco.Web.PropertyEditors
                     name = x.Name,
                     alias = x.Alias,
                     icon = x.Icon,
-                    tabs = x.CompositionPropertyGroups.Where(y => y.Type == Core.Models.PropertyGroupType.Group && !y.Alias.Contains("/")).Select(y => y.Name).Distinct()
+                    tabs = x.CompositionPropertyGroups.Where(x => x.Type == PropertyGroupType.Group && x.GetParentAlias() == null).Select(y => y.Name).Distinct()
                 });
         }
     }

--- a/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentController.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Web.PropertyEditors
                     name = x.Name,
                     alias = x.Alias,
                     icon = x.Icon,
-                    tabs = x.CompositionPropertyGroups.Select(y => y.Name).Distinct()
+                    tabs = x.CompositionPropertyGroups.Where(y => y.Type == Core.Models.PropertyGroupType.Group && !y.Alias.Contains("/")).Select(y => y.Name).Distinct()
                 });
         }
     }


### PR DESCRIPTION
This PR fixes the rendering of nested content after the tabs feature has been added. To prevent any breaking changes, we had to limit the allowed nested content groups to generic groups. Tabs and groups inside a tab are not supported in nested content. The Block List Editor can be used if tab support is needed.

**How to test:**
* Create an element type with a generic group, a tab, and a group inside the tab
* Set up a doctype with nested content.
* Make sure you can only select the group from "Generic" in nested content.
* Make sure nested content renders correctly in the content section. 

fixes #11114