### PR TITLE
v9: fixed tabs test on every resolution

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tabs/tabs.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Tabs/tabs.ts
@@ -379,7 +379,12 @@ context('Tabs', () => {
       cy.saveDocumentType(tabsDocType);
       OpenDocTypeFolder();
       cy.get('[alias="reorder"]').click();
-      cy.get('.umb-group-builder__tabs-overflow--right > .caret').click().click();
+      cy.get('body')
+      .then(($body) => {
+        while($body.find('.umb-group-builder__tabs-overflow--right > .caret').hasClass('active')){
+          cy.click();
+        }
+      });
       cy.get('.umb-group-builder__tab').last().click();
       cy.get('.umb-group-builder__group-title-icon').last().trigger('mousedown', { which: 1 })
       cy.get('.umb-group-builder__tab').eq(1).trigger('mousemove', {which: 1, force: true});
@@ -426,7 +431,12 @@ context('Tabs', () => {
       OpenDocTypeFolder();
       cy.get('[alias="reorder"]').click();
       //Scroll right so we can see tab 2
-      cy.get('.umb-group-builder__tabs-overflow--right > .caret').click().click();
+      cy.get('body')
+        .then(($body) => {
+          while($body.find('.umb-group-builder__tabs-overflow--right > .caret').hasClass('active')){
+            cy.click();
+          }
+        });
       cy.get('.umb-group-builder__tab-title-icon').eq(1).trigger('mousedown', { which: 1 })
       cy.get('.umb-group-builder__tab').eq(1).trigger('mousemove', {which: 1, force: true});
       cy.get('.umb-group-builder__tab').eq(1).should('have.class', 'is-active').trigger('mouseup', {force:true});
@@ -473,7 +483,12 @@ context('Tabs', () => {
       OpenDocTypeFolder();
       cy.get('[alias="reorder"]').click();
       //Scroll so we are sure we see tab 2
-      cy.get('.umb-group-builder__tabs-overflow--right > .caret').click().click();
+      cy.get('body')
+      .then(($body) => {
+        while($body.find('.umb-group-builder__tabs-overflow--right > .caret').hasClass('active')){
+          cy.click();
+        }
+      });
       //Navigate to tab 2
       cy.get('.umb-group-builder__tab').last().click();
       cy.get('.umb-group-builder__property-meta > .flex > .icon').eq(1).trigger('mousedown', {which: 1})


### PR DESCRIPTION
# Notes
- Updated tabs test to look for the caret element, and only click it if its active 
# How to test
- Go to Umbraco.Tests.AcceptanceTest and open cypress.json
- Change the height and width of the viewport to 1200 x 1024
- Open up the command prompt in the same folder
- Run `npm install` and `npm run tests`
- All tests should pass