### PR TITLE
Fixes 10730 - Route hijacking with public access

### DIFF
--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -8,8 +8,6 @@ using Umbraco.Cms.Infrastructure.DependencyInjection;
 using Umbraco.Cms.Web.Common.Middleware;
 using Umbraco.Cms.Web.Common.Routing;
 using Umbraco.Cms.Web.Website.Collections;
-using Umbraco.Cms.Web.Website.Controllers;
-using Umbraco.Cms.Web.Website.Middleware;
 using Umbraco.Cms.Web.Website.Models;
 using Umbraco.Cms.Web.Website.Routing;
 using Umbraco.Cms.Web.Website.ViewEngines;
@@ -51,7 +49,7 @@ namespace Umbraco.Extensions
 
             builder.Services.AddSingleton<MemberModelBuilderFactory>();
 
-            builder.Services.AddSingleton<PublicAccessMiddleware>();
+            builder.Services.AddSingleton<IPublicAccessRequestHandler, PublicAccessRequestHandler>();
             builder.Services.AddSingleton<BasicAuthenticationMiddleware>();
 
             builder

--- a/src/Umbraco.Web.Website/Extensions/UmbracoApplicationBuilder.Website.cs
+++ b/src/Umbraco.Web.Website/Extensions/UmbracoApplicationBuilder.Website.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 using Umbraco.Cms.Web.Common.Middleware;
-using Umbraco.Cms.Web.Website.Middleware;
 using Umbraco.Cms.Web.Website.Routing;
 
 namespace Umbraco.Extensions
@@ -20,7 +19,6 @@ namespace Umbraco.Extensions
         /// <returns></returns>
         public static IUmbracoApplicationBuilderContext UseWebsite(this IUmbracoApplicationBuilderContext builder)
         {
-            builder.AppBuilder.UseMiddleware<PublicAccessMiddleware>();
             builder.AppBuilder.UseMiddleware<BasicAuthenticationMiddleware>();
             return builder;
         }

--- a/src/Umbraco.Web.Website/Routing/IPublicAccessRequestHandler.cs
+++ b/src/Umbraco.Web.Website/Routing/IPublicAccessRequestHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Umbraco.Cms.Web.Common.Routing;
+
+namespace Umbraco.Cms.Web.Website.Routing
+{
+    public interface IPublicAccessRequestHandler
+    {
+        /// <summary>
+        /// Ensures that access to current node is permitted.
+        /// </summary>
+        /// <param name="httpContext"></param>
+        /// <param name="routeValues">The current route values</param>
+        /// <returns>Updated route values if public access changes the rendered content, else the original route values.</returns>
+        /// <remarks>Redirecting to a different site root and/or culture will not pick the new site root nor the new culture.</remarks>
+        Task<UmbracoRouteValues> RewriteForPublishedContentAccessAsync(HttpContext httpContext, UmbracoRouteValues routeValues);
+    }
+}


### PR DESCRIPTION
Fixes #10730 - Route hijacking with public access

The reason why it doesn't work is because DynamicRouteValueTransformer is responsible for assigning the controller/action tokens. ASP.NET then uses it's response to map to an endpoint (controller/action). Our public access middleware executes after the transformer and re-assigns our own UmbracoRouteValues so that the correct page is rendered, but this doesn't affect the results returned from our transformer - which is why the original endpoint is selected.

The endpoint selection is stored in the HttpContext as a feature: IEndpointFeature. It may be possible to replace this before endpoint is executed within the middleware but this is against best practices (undocumented) and will probably result in some caching not being done behind the scenes in aspnet.

The only real way to deal with this is going to be to move the public access code directly up into the original routing pipeline and not use middleware so that we can return the correct route values from within our route transformer so aspnet selects the correct endpoint from that data.

* Changes PublicAccessMiddleware to IPublicAccessRequestHandler and puts the logic for this directly inside of the transformer
* The IPublicAccessRequestHandler no longer sets the httpfeature for UmbracoRouteValues, it just returns new ones or the original ones
* The transformer logic rearranged a bit:
  *  We were checking for posted values even if there was no content matched, so the no content check was moved above
  * We check public access before checking posted values - since this would have also occurred with the old middleware solution

## Testing

* Follow the repro steps in #10730 and make sure it works
* Make sure that a surface controller POST form still works as expected

