### PR TITLE
Fix Multi URL Picker in Block List Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -29,7 +29,8 @@
             data-app-anchor="{{group.id}}"
             data-element="group-{{group.alias}}"
             ng-repeat="group in content.tabs track by group.key"
-            ng-show="(group.parentAlias === activeTabAlias && group.type === 0) || tabs.length === 0">
+            ng-if="group.type === 0"
+            ng-show="group.parentAlias === activeTabAlias || tabs.length === 0">
 
             <div class="umb-group-panel__header">
                 <div id="group-{{group.id}}">{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
@@ -29,7 +29,8 @@
         <div class="umb-group-panel"
              data-element="group-{{group.alias}}"
              ng-repeat="group in vm.model.variants[0].tabs track by group.key"
-             ng-show="(group.parentAlias === vm.activeTabAlias && group.type === 0) || vm.tabs.length === 0">
+             ng-if="group.type === 0"
+             ng-show="group.parentAlias === vm.activeTabAlias || vm.tabs.length === 0">
 
             <div class="umb-group-panel__header">
                 <div id="group-{{group.id}}">{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/apps/content/content.html
@@ -21,7 +21,8 @@
         class="umb-group-panel"
         data-element="group-{{group.alias}}"
         ng-repeat="group in content.tabs | filter: { hide : '!' + true } track by group.id"
-        ng-show="(group.parentAlias === vm.activeTabAlias && group.type === 0) || vm.tabs.length === 0">
+        ng-if="group.type === 0"
+        ng-show="group.parentAlias === vm.activeTabAlias || vm.tabs.length === 0">
 
         <div class="umb-group-panel__header">
             <div>{{ group.label }}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
@@ -21,7 +21,8 @@
     class="umb-group-panel"
     data-element="group-{{group.alias}}"
     ng-repeat="group in content.tabs"
-    ng-show="(group.parentAlias === vm.activeTabAlias && group.type === 0) || vm.tabs.length === 0">
+    ng-if="group.type === 0"
+    ng-show="group.parentAlias === vm.activeTabAlias || vm.tabs.length === 0">
 
         <div class="umb-group-panel__header">
             <div>{{ group.label }}</div>


### PR DESCRIPTION
fixes #11100

Properties from tabs were rendered twice. One for direct properties for a tab and one for groups because they are part of the groups' array. This PR prevents a group to be rendered in the groups' array if it is a "tab".

Multi URL Picker listens for a form submit event and sets the value based on a render value. Because the property is rendered twice, when it is a direct property on a tab, it resets its own value. 

The reset only happens in the Block List editor because of how it syncs its values. I have added the fix to the content, media, and members section for performance reasons. We don't want more properties in the DOM than needed.

How to test:
* See the issue for testing instructions for the bug. 
* Please also do some "general" testing of tabs and groups in content, media and member sections and this changes how we render them.