### PR TITLE
v9: fixed flaky usergroup test

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Users/userGroups.js
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Users/userGroups.js
@@ -19,7 +19,7 @@ context('User Groups', () => {
 
     // Assign sections
     cy.get('.umb-box:nth-child(1) .umb-property:nth-child(1) localize').click();
-    cy.get('.umb-tree-item span').click({multiple:true});
+    cy.get('.umb-tree-item__inner').click({multiple:true, timeout: 10000});
     cy.get('.btn-success').last().click();
 
     // Save


### PR DESCRIPTION
# Notes
- Updated Usergroup test to get a better element, and made the timeout larger to account for slower run times on azure

# How to test
- Open up umbraco 
- Go to Umbraco.Tests.AcceptanceTest
- open up the cmd and run `npm install` and `npm run test`