### PR TITLE
Serializes key for templates in package definition and imports if ava…

### DIFF
--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -1558,7 +1558,15 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 var masterElement = templateElement.Element("Master");
 
                 var existingTemplate = _fileService.GetTemplate(alias) as Template;
+
                 var template = existingTemplate ?? new Template(_shortStringHelper, templateName, alias);
+
+                // For new templates, use the serialized key if avaialble.
+                if (existingTemplate == null && templateElement.Element("Key") != null)
+                {
+                    template.Key = Guid.Parse(templateElement.Element("Key").Value);
+                }
+
                 template.Content = design;
 
                 if (masterElement != null && string.IsNullOrEmpty((string)masterElement) == false)

--- a/src/Umbraco.Infrastructure/Services/Implement/EntityXmlSerializer.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/EntityXmlSerializer.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Xml.Linq;
-using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
@@ -319,6 +317,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             var xml = new XElement("Template");
             xml.Add(new XElement("Name", template.Name));
+            xml.Add(new XElement("Key", template.Key));
             xml.Add(new XElement("Alias", template.Alias));
             xml.Add(new XElement("Design", new XCData(template.Content)));
 

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -233,6 +233,34 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             Assert.That(templates, Is.Not.Null);
             Assert.That(templates.Any(), Is.True);
             Assert.That(templates.Count(), Is.EqualTo(1));
+
+            var template = templates.First();
+            Assert.AreEqual(template.Name, "Articles");
+        }
+
+        [Test]
+        public void Can_Import_Single_Template_With_Key()
+        {
+            // Arrange
+            string strXml = ImportResources.StandardMvc_Package;
+            var xml = XElement.Parse(strXml);
+            XElement element = xml.Descendants("Templates").First();
+
+            var firstTemplateElement = element.Elements("Template").First();
+            var key = Guid.NewGuid();
+            firstTemplateElement.Add(new XElement("Key", key));
+
+            // Act
+            IEnumerable<ITemplate> templates = PackageDataInstallation.ImportTemplate(firstTemplateElement, 0);
+
+            // Assert
+            Assert.That(templates, Is.Not.Null);
+            Assert.That(templates.Any(), Is.True);
+            Assert.That(templates.Count(), Is.EqualTo(1));
+
+            var template = templates.First();
+            Assert.AreEqual(template.Name, "Articles");
+            Assert.AreEqual(template.Key, key);
         }
 
         [Test]


### PR DESCRIPTION
Noticed in testing that whilst most entities serialized to the `package.xml` file have keys provided - so when installed in new environments they have the same unique identifier - for templates this isn't the case.

This can cause issues for Umbraco Deploy, as, if you install a package locally and then deploy, the package migration will run and templates with the same details but different unique Ids will be created in the upstream environment.

This PR adds keys to the serialized XML, and if found on import, uses them to create the new template.

To Test:

- Create and download a package XML file from the back-office with a template in it.
- Delete the template.
- Install the package, check the template has been created.
- Check in the database to see that the unique of the installed package is the same as that serialized to the XML file.

```
select nodeId,alias,uniqueId
from cmsTemplate t
inner join umbracoNode n on n.Id = t.NodeId
```
