### PR TITLE
Add migration for isMaster column to isSchedulingPublisher in UmbracoServer table

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -246,6 +246,9 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade
                 .To<DictionaryTablesIndexes>("{12DCDE7F-9AB7-4617-804F-AB66BF360980}")
             .As("{5AAE6276-80DB-4ACF-B845-199BC6C37538}");
 
+            // TO 9.0.0-rc4
+            To<UmbracoServerColumn>("5E02F241-5253-403D-B5D3-7DB00157E20F");
+
             // TO 9.0.0
 
         }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/UmbracoServerColumn.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/UmbracoServerColumn.cs
@@ -1,0 +1,20 @@
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
+{
+    public class UmbracoServerColumn : MigrationBase
+    {
+        public UmbracoServerColumn(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Adds new columns to members table
+        /// </summary>
+        protected override void Migrate()
+        {
+            ReplaceColumn<ServerRegistrationDto>(Cms.Core.Constants.DatabaseSchema.Tables.Server, "isMaster", "isSchedulingPublisher");
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ServerRegistrationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ServerRegistrationDto.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos
         [Index(IndexTypes.NonClustered)]
         public bool IsActive { get; set; }
 
-        [Column("isMaster")]
+        [Column("isSchedulingPublisher")]
         public bool IsSchedulingPublisher { get; set; }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
@@ -121,7 +121,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             var timeoutDate = DateTime.Now.Subtract(staleTimeout);
 
-            Database.Update<ServerRegistrationDto>("SET isActive=0, isMaster=0 WHERE lastNotifiedDate < @timeoutDate", new { /*timeoutDate =*/ timeoutDate });
+            Database.Update<ServerRegistrationDto>("SET isActive=0, isSchedulingPublisher=0 WHERE lastNotifiedDate < @timeoutDate", new { /*timeoutDate =*/ timeoutDate });
             ClearCache();
         }
     }

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoBulkInsertTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoBulkInsertTests.cs
@@ -175,7 +175,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.NPoco
             // Assert
             Assert.That(
                 commands[0].CommandText,
-                Is.EqualTo("INSERT INTO [umbracoServer] ([umbracoServer].[address], [umbracoServer].[computerName], [umbracoServer].[registeredDate], [umbracoServer].[lastNotifiedDate], [umbracoServer].[isActive], [umbracoServer].[isMaster]) VALUES (@0,@1,@2,@3,@4,@5), (@6,@7,@8,@9,@10,@11)"));
+                Is.EqualTo("INSERT INTO [umbracoServer] ([umbracoServer].[address], [umbracoServer].[computerName], [umbracoServer].[registeredDate], [umbracoServer].[lastNotifiedDate], [umbracoServer].[isActive], [umbracoServer].[isSchedulingPublisher]) VALUES (@0,@1,@2,@3,@4,@5), (@6,@7,@8,@9,@10,@11)"));
         }
 
         [Test]


### PR DESCRIPTION
Following on from https://github.com/umbraco/Umbraco-CMS/pull/10480 In this PR I added a migration for isMaster column to isSchedulingPublisher in UmbracoServer table

Creating this as a draft PR for now as my local v9 is having problems so I've not yet verified it works