### PR TITLE
Fixed missing null check in BlockEditorPropertyEditor

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -264,7 +263,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                         _textService.Localize("validation", "entriesShort", new[]
                         {
                             validationLimit.Min.ToString(),
-                            (validationLimit.Min - blockEditorData.Layout.Count()).ToString()
+                            (validationLimit.Min - (blockEditorData?.Layout.Count() ?? 0)).ToString()
                         }),
                         new[] { "minCount" });
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10095

### Description
Added a null check to the `Validate` method of the `BlockEditorPropertyEditor`.

I was able to reproduce the issue mentioned in #10095 by doing the following steps:

1. Create a document type containing a block list property that has a minimum amount set.
2. Create a new block list, select any block as an available block and set the settings model to the document created in the previous step
3. Select `Inline editing mode`
4. Save
5. Add the block list you just created to a document type and try to add a block to a node of that type (without filling in the settings)
6. Try to publish and see the error reported in [#10095](https://github.com/umbraco/Umbraco-CMS/issues/10095)
