### PR TITLE
Caching: Add GetOrInsertCacheItem() as extra extension to bridge get and insert methods

### DIFF
--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Core.Cache
             var result = provider.GetCacheItem<T>(cacheKey);
             if (result == null
                 || (cacheValue is int // Handle case where the non nullable integer type can't handle null as empty value, but returns "0" instead.
-                    && cacheValue.ToString() is "0")))
+                    && cacheValue.ToString() is "0"))
             {
                 result = getCacheItem();
                 provider.InsertCacheItem<T>(cacheKey, () => result, timeout, isSliding, priority, removedCallback, dependentFiles);

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -78,8 +78,7 @@ namespace Umbraco.Core.Cache
         {
             var result = provider.GetCacheItem<T>(cacheKey);
             if (result == null
-                || (cacheValue is int // Handle case where the non nullable integer type can't handle null as empty value, but returns "0" instead.
-                    && cacheValue.ToString() is "0"))
+                || (result is int && result.ToString() is "0")) // Handle case where the non nullable integer type can't handle null as empty value, but returns "0" instead.
             {
                 result = getCacheItem();
                 provider.InsertCacheItem<T>(cacheKey, () => result, timeout, isSliding, priority, removedCallback, dependentFiles);

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -66,5 +66,23 @@ namespace Umbraco.Core.Cache
             }
             return result.TryConvertTo<T>().Result;
         }
+
+        public static T GetOrInsertCacheItem<T>(this IAppPolicyCache provider,
+            string cacheKey,
+            Func<T> getCacheItem,
+            TimeSpan? timeout = null,
+            bool isSliding = false,
+            CacheItemPriority priority = CacheItemPriority.Normal,
+            CacheItemRemovedCallback removedCallback = null,
+            string[] dependentFiles = null)
+        {
+            var result = provider.GetCacheItem<T>(cacheKey);
+            if (result == null || result == default(T))
+            {
+                result = getCacheItem();
+                provider.InsertCacheItem<T>(cacheKey, () => result, timeout, isSliding, priority, removedCallback, dependentFiles);
+            }
+            return result;
+        }
     }
 }

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Core.Cache
             string[] dependentFiles = null)
         {
             var result = provider.GetCacheItem<T>(cacheKey);
-            if (result == null || result == default(T))
+            if (result == null)
             {
                 result = getCacheItem();
                 provider.InsertCacheItem<T>(cacheKey, () => result, timeout, isSliding, priority, removedCallback, dependentFiles);

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -77,7 +77,9 @@ namespace Umbraco.Core.Cache
             string[] dependentFiles = null)
         {
             var result = provider.GetCacheItem<T>(cacheKey);
-            if (result == null)
+            if (result == null
+                || (cacheValue is int // Handle case where the non nullable integer type can't handle null as empty value, but returns "0" instead.
+                    && cacheValue.ToString() is "0")))
             {
                 result = getCacheItem();
                 provider.InsertCacheItem<T>(cacheKey, () => result, timeout, isSliding, priority, removedCallback, dependentFiles);


### PR DESCRIPTION
As an Umbraco developer, I want a general extension method for getting or updating items to the cache so that it's easier to use the AppCache.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Instead of writing writing custom code for getting or inserting items to the AppCache, let's add an extra method that combines get and insert.