### PR TITLE
v9: Implement IOptionsMonitor or IOptionsSnapshot instead of IOptions

### DIFF
--- a/src/Umbraco.Core/Composing/TypeFinderConfig.cs
+++ b/src/Umbraco.Core/Composing/TypeFinderConfig.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Configuration.UmbracoSettings;

--- a/src/Umbraco.Core/Events/UserNotificationsHandler.cs
+++ b/src/Umbraco.Core/Events/UserNotificationsHandler.cs
@@ -124,7 +124,7 @@ namespace Umbraco.Cms.Core.Events
             private readonly INotificationService _notificationService;
             private readonly IUserService _userService;
             private readonly ILocalizedTextService _textService;
-            private readonly GlobalSettings _globalSettings;
+            private GlobalSettings _globalSettings;
             private readonly ILogger<Notifier> _logger;
 
             /// <summary>
@@ -146,6 +146,8 @@ namespace Umbraco.Cms.Core.Events
                 _textService = textService;
                 _globalSettings = globalSettings.CurrentValue;
                 _logger = logger;
+
+                globalSettings.OnChange(x => _globalSettings = x);
             }
 
             public void Notify(IAction action, params IContent[] entities)

--- a/src/Umbraco.Core/Events/UserNotificationsHandler.cs
+++ b/src/Umbraco.Core/Events/UserNotificationsHandler.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Cms.Core.Events
                 INotificationService notificationService,
                 IUserService userService,
                 ILocalizedTextService textService,
-                IOptions<GlobalSettings> globalSettings,
+                IOptionsMonitor<GlobalSettings> globalSettings,
                 ILogger<Notifier> logger)
             {
                 _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -144,7 +144,7 @@ namespace Umbraco.Cms.Core.Events
                 _notificationService = notificationService;
                 _userService = userService;
                 _textService = textService;
-                _globalSettings = globalSettings.Value;
+                _globalSettings = globalSettings.CurrentValue;
                 _logger = logger;
             }
 

--- a/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
+++ b/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.Handlers
         private readonly IEntityService _entityService;
         private readonly IIpResolver _ipResolver;
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly IMemberService _memberService;
 
         public AuditNotificationsHandler(
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Core.Handlers
             IUserService userService,
             IEntityService entityService,
             IIpResolver ipResolver,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
             IMemberService memberService)
         {
@@ -48,7 +48,8 @@ namespace Umbraco.Cms.Core.Handlers
             _ipResolver = ipResolver;
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
             _memberService = memberService;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         private IUser CurrentPerformingUser

--- a/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
+++ b/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.Handlers
         private readonly IEntityService _entityService;
         private readonly IIpResolver _ipResolver;
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
-        private GlobalSettings _globalSettings;
+        private readonly GlobalSettings _globalSettings;
         private readonly IMemberService _memberService;
 
         public AuditNotificationsHandler(
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Core.Handlers
             IUserService userService,
             IEntityService entityService,
             IIpResolver ipResolver,
-            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
             IMemberService memberService)
         {
@@ -48,8 +48,7 @@ namespace Umbraco.Cms.Core.Handlers
             _ipResolver = ipResolver;
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
             _memberService = memberService;
-            _globalSettings = globalSettings.CurrentValue;
-            globalSettings.OnChange(x => _globalSettings = x);
+            _globalSettings = globalSettings.Value;
         }
 
         private IUser CurrentPerformingUser

--- a/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
+++ b/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Core.Handlers
             IUserService userService,
             IEntityService entityService,
             IIpResolver ipResolver,
-            IOptionsSnapshot<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
             IMemberService memberService)
         {
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Core.Handlers
             _ipResolver = ipResolver;
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
             _memberService = memberService;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
         }
 
         private IUser CurrentPerformingUser

--- a/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
+++ b/src/Umbraco.Core/Handlers/AuditNotificationsHandler.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Core.Handlers
             IUserService userService,
             IEntityService entityService,
             IIpResolver ipResolver,
-            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
             IMemberService memberService)
         {
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Core.Handlers
             _ipResolver = ipResolver;
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
             _memberService = memberService;
-            _globalSettings = globalSettings.CurrentValue;
+            _globalSettings = globalSettings.Value;
         }
 
         private IUser CurrentPerformingUser

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
@@ -24,8 +24,8 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
             ILocalizedTextService textService,
             IHostingEnvironment hostingEnvironment,
             IEmailSender emailSender,
-            IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
-            IOptionsMonitor<ContentSettings> contentSettings,
+            IOptionsSnapshot<HealthChecksSettings> healthChecksSettings,
+            IOptionsSnapshot<ContentSettings> contentSettings,
             IMarkdownToHtmlConverter markdownToHtmlConverter)
             : base(healthChecksSettings)
         {
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
             _hostingEnvironment = hostingEnvironment;
             _emailSender = emailSender;
             _markdownToHtmlConverter = markdownToHtmlConverter;
-            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
         }
 
         public string RecipientEmail { get; }

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
@@ -24,8 +24,8 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
             ILocalizedTextService textService,
             IHostingEnvironment hostingEnvironment,
             IEmailSender emailSender,
-            IOptions<HealthChecksSettings> healthChecksSettings,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IMarkdownToHtmlConverter markdownToHtmlConverter)
             : base(healthChecksSettings)
         {
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
             _hostingEnvironment = hostingEnvironment;
             _emailSender = emailSender;
             _markdownToHtmlConverter = markdownToHtmlConverter;
-            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
         }
 
         public string RecipientEmail { get; }

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/EmailNotificationMethod.cs
@@ -17,15 +17,14 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IEmailSender _emailSender;
         private readonly IMarkdownToHtmlConverter _markdownToHtmlConverter;
-
-        private readonly ContentSettings _contentSettings;
+        private  ContentSettings _contentSettings;
 
         public EmailNotificationMethod(
             ILocalizedTextService textService,
             IHostingEnvironment hostingEnvironment,
             IEmailSender emailSender,
-            IOptionsSnapshot<HealthChecksSettings> healthChecksSettings,
-            IOptionsSnapshot<ContentSettings> contentSettings,
+            IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IMarkdownToHtmlConverter markdownToHtmlConverter)
             : base(healthChecksSettings)
         {
@@ -42,7 +41,9 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
             _hostingEnvironment = hostingEnvironment;
             _emailSender = emailSender;
             _markdownToHtmlConverter = markdownToHtmlConverter;
-            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
+
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         public string RecipientEmail { get; }

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/NotificationMethodBase.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/NotificationMethodBase.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
 {
     public abstract class NotificationMethodBase : IHealthCheckNotificationMethod
     {
-        protected NotificationMethodBase(IOptionsSnapshot<HealthChecksSettings> healthCheckSettings)
+        protected NotificationMethodBase(IOptionsMonitor<HealthChecksSettings> healthCheckSettings)
         {
             var type = GetType();
             var attribute = type.GetCustomAttribute<HealthCheckNotificationMethodAttribute>();
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
                 return;
             }
 
-            var notificationMethods = healthCheckSettings.Value.Notification.NotificationMethods;
+            var notificationMethods = healthCheckSettings.CurrentValue.Notification.NotificationMethods;
             if (!notificationMethods.TryGetValue(attribute.Alias, out var notificationMethod))
             {
                 Enabled = false;

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/NotificationMethodBase.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/NotificationMethodBase.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
 {
     public abstract class NotificationMethodBase : IHealthCheckNotificationMethod
     {
-        protected NotificationMethodBase(IOptions<HealthChecksSettings> healthCheckSettings)
+        protected NotificationMethodBase(IOptionsMonitor<HealthChecksSettings> healthCheckSettings)
         {
             var type = GetType();
             var attribute = type.GetCustomAttribute<HealthCheckNotificationMethodAttribute>();
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
                 return;
             }
 
-            var notificationMethods = healthCheckSettings.Value.Notification.NotificationMethods;
+            var notificationMethods = healthCheckSettings.CurrentValue.Notification.NotificationMethods;
             if (!notificationMethods.TryGetValue(attribute.Alias, out var notificationMethod))
             {
                 Enabled = false;

--- a/src/Umbraco.Core/HealthChecks/NotificationMethods/NotificationMethodBase.cs
+++ b/src/Umbraco.Core/HealthChecks/NotificationMethods/NotificationMethodBase.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
 {
     public abstract class NotificationMethodBase : IHealthCheckNotificationMethod
     {
-        protected NotificationMethodBase(IOptionsMonitor<HealthChecksSettings> healthCheckSettings)
+        protected NotificationMethodBase(IOptionsSnapshot<HealthChecksSettings> healthCheckSettings)
         {
             var type = GetType();
             var attribute = type.GetCustomAttribute<HealthCheckNotificationMethodAttribute>();
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
                 return;
             }
 
-            var notificationMethods = healthCheckSettings.CurrentValue.Notification.NotificationMethods;
+            var notificationMethods = healthCheckSettings.Value.Notification.NotificationMethods;
             if (!notificationMethods.TryGetValue(attribute.Alias, out var notificationMethod))
             {
                 Enabled = false;

--- a/src/Umbraco.Core/Models/ContentEditing/UserInvite.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/UserInvite.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Core.Models.ContentEditing
             if (UserGroups.Any() == false)
                 yield return new ValidationResult("A user must be assigned to at least one group", new[] { nameof(UserGroups) });
 
-            var securitySettings = validationContext.GetRequiredService<IOptions<SecuritySettings>>();
+            var securitySettings = validationContext.GetRequiredService<IOptionsSnapshot<SecuritySettings>>();
 
             if (securitySettings.Value.UsernameIsEmail == false && Username.IsNullOrWhiteSpace())
                 yield return new ValidationResult("A username cannot be empty", new[] { nameof(Username) });

--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Cms.Core.Packaging
             ILocalizationService languageService,
             IHostingEnvironment hostingEnvironment,
             IEntityXmlSerializer serializer,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IMediaService mediaService,
             IMediaTypeService mediaTypeService,
             MediaFileManager mediaFileManager,
@@ -92,7 +92,7 @@ namespace Umbraco.Cms.Core.Packaging
 
             _tempFolderPath = tempFolderPath ?? Constants.SystemDirectories.TempData.EnsureEndsWith('/') + "PackageFiles";
             _packagesFolderPath = packagesFolderPath ?? Constants.SystemDirectories.Packages;
-            _mediaFolderPath = mediaFolderPath ?? globalSettings.Value.UmbracoMediaPath + "/created-packages";
+            _mediaFolderPath = mediaFolderPath ?? globalSettings.CurrentValue.UmbracoMediaPath + "/created-packages";
 
             _parser = new PackageDefinitionXmlParser();
             _mediaService = mediaService;

--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Cms.Core.Packaging
             ILocalizationService languageService,
             IHostingEnvironment hostingEnvironment,
             IEntityXmlSerializer serializer,
-            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptions<GlobalSettings> globalSettings,
             IMediaService mediaService,
             IMediaTypeService mediaTypeService,
             MediaFileManager mediaFileManager,
@@ -92,7 +92,7 @@ namespace Umbraco.Cms.Core.Packaging
 
             _tempFolderPath = tempFolderPath ?? Constants.SystemDirectories.TempData.EnsureEndsWith('/') + "PackageFiles";
             _packagesFolderPath = packagesFolderPath ?? Constants.SystemDirectories.Packages;
-            _mediaFolderPath = mediaFolderPath ?? globalSettings.CurrentValue.UmbracoMediaPath + "/created-packages";
+            _mediaFolderPath = mediaFolderPath ?? globalSettings.Value.UmbracoMediaPath + "/created-packages";
 
             _parser = new PackageDefinitionXmlParser();
             _mediaService = mediaService;

--- a/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
+++ b/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
@@ -11,17 +11,18 @@ namespace Umbraco.Cms.Core.PublishedCache
     {
         private readonly ILocalizationService _localizationService;
         private readonly IRuntimeState _runtimeState;
-        private readonly GlobalSettings _options;
+        private GlobalSettings _options;
 
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCultureAccessor"/> class.
         /// </summary>
-        public DefaultCultureAccessor(ILocalizationService localizationService, IRuntimeState runtimeState, IOptionsSnapshot<GlobalSettings> options)
+        public DefaultCultureAccessor(ILocalizationService localizationService, IRuntimeState runtimeState, IOptionsMonitor<GlobalSettings> options)
         {
             _localizationService = localizationService;
             _runtimeState = runtimeState;
-            _options = options.Value;
+            _options = options.CurrentValue;
+            options.OnChange(x => _options = x);
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
+++ b/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
@@ -11,23 +11,22 @@ namespace Umbraco.Cms.Core.PublishedCache
     {
         private readonly ILocalizationService _localizationService;
         private readonly IRuntimeState _runtimeState;
-        private readonly IOptions<GlobalSettings> _options;
+        private readonly GlobalSettings _options;
 
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCultureAccessor"/> class.
         /// </summary>
-        public DefaultCultureAccessor(ILocalizationService localizationService, IRuntimeState runtimeState, IOptions<GlobalSettings> options)
+        public DefaultCultureAccessor(ILocalizationService localizationService, IRuntimeState runtimeState, IOptionsSnapshot<GlobalSettings> options)
         {
             _localizationService = localizationService;
             _runtimeState = runtimeState;
-            _options = options;
-
+            _options = options.Value;
         }
 
         /// <inheritdoc />
         public string DefaultCulture => _runtimeState.Level == RuntimeLevel.Run
             ? _localizationService.GetDefaultLanguageIsoCode() ?? "" // fast
-            : _options.Value.DefaultUILanguage; // default for install and upgrade, when the service is n/a
+            : _options.DefaultUILanguage; // default for install and upgrade, when the service is n/a
     }
 }

--- a/src/Umbraco.Core/Routing/AliasUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/AliasUrlProvider.cs
@@ -14,19 +14,21 @@ namespace Umbraco.Cms.Core.Routing
     /// </summary>
     public class AliasUrlProvider : IUrlProvider
     {
-        private readonly RequestHandlerSettings _requestConfig;
+        private RequestHandlerSettings _requestConfig;
         private readonly ISiteDomainMapper _siteDomainMapper;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly UriUtility _uriUtility;
         private readonly IPublishedValueFallback _publishedValueFallback;
 
-        public AliasUrlProvider(IOptions<RequestHandlerSettings> requestConfig, ISiteDomainMapper siteDomainMapper, UriUtility uriUtility, IPublishedValueFallback publishedValueFallback, IUmbracoContextAccessor umbracoContextAccessor)
+        public AliasUrlProvider(IOptionsMonitor<RequestHandlerSettings> requestConfig, ISiteDomainMapper siteDomainMapper, UriUtility uriUtility, IPublishedValueFallback publishedValueFallback, IUmbracoContextAccessor umbracoContextAccessor)
         {
-            _requestConfig = requestConfig.Value;
+            _requestConfig = requestConfig.CurrentValue;
             _siteDomainMapper = siteDomainMapper;
             _uriUtility = uriUtility;
             _publishedValueFallback = publishedValueFallback;
             _umbracoContextAccessor = umbracoContextAccessor;
+
+            requestConfig.OnChange(x => _requestConfig = x);
         }
 
         // note - at the moment we seem to accept pretty much anything as an alias

--- a/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
@@ -18,21 +18,23 @@ namespace Umbraco.Cms.Core.Routing
         private readonly ILogger<ContentFinderByIdPath> _logger;
         private readonly IRequestAccessor _requestAccessor;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private WebRoutingSettings _webRoutingSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentFinderByIdPath"/> class.
         /// </summary>
         public ContentFinderByIdPath(
-            IOptions<WebRoutingSettings> webRoutingSettings,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
             ILogger<ContentFinderByIdPath> logger,
             IRequestAccessor requestAccessor,
             IUmbracoContextAccessor umbracoContextAccessor)
         {
-            _webRoutingSettings = webRoutingSettings.Value ?? throw new System.ArgumentNullException(nameof(webRoutingSettings));
+            _webRoutingSettings = webRoutingSettings.CurrentValue ?? throw new System.ArgumentNullException(nameof(webRoutingSettings));
             _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
             _requestAccessor = requestAccessor ?? throw new System.ArgumentNullException(nameof(requestAccessor));
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new System.ArgumentNullException(nameof(umbracoContextAccessor));
+
+            webRoutingSettings.OnChange(x => _webRoutingSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Core.Routing
         private readonly IFileService _fileService;
 
         private readonly IContentTypeService _contentTypeService;
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private WebRoutingSettings _webRoutingSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentFinderByUrlAndTemplate"/> class.
@@ -33,13 +33,14 @@ namespace Umbraco.Cms.Core.Routing
             IFileService fileService,
             IContentTypeService contentTypeService,
             IUmbracoContextAccessor umbracoContextAccessor,
-            IOptions<WebRoutingSettings> webRoutingSettings)
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings)
             : base(logger, umbracoContextAccessor)
         {
             _logger = logger;
             _fileService = fileService;
             _contentTypeService = contentTypeService;
-            _webRoutingSettings = webRoutingSettings.Value;
+            _webRoutingSettings = webRoutingSettings.CurrentValue;
+            webRoutingSettings.OnChange(x => _webRoutingSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -15,19 +15,20 @@ namespace Umbraco.Cms.Core.Routing
     /// </summary>
     public class DefaultUrlProvider : IUrlProvider
     {
-        private readonly RequestHandlerSettings _requestSettings;
+        private RequestHandlerSettings _requestSettings;
         private readonly ILogger<DefaultUrlProvider> _logger;
         private readonly ISiteDomainMapper _siteDomainMapper;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly UriUtility _uriUtility;
 
-        public DefaultUrlProvider(IOptions<RequestHandlerSettings> requestSettings, ILogger<DefaultUrlProvider> logger, ISiteDomainMapper siteDomainMapper, IUmbracoContextAccessor umbracoContextAccessor, UriUtility uriUtility)
+        public DefaultUrlProvider(IOptionsMonitor<RequestHandlerSettings> requestSettings, ILogger<DefaultUrlProvider> logger, ISiteDomainMapper siteDomainMapper, IUmbracoContextAccessor umbracoContextAccessor, UriUtility uriUtility)
         {
-            _requestSettings = requestSettings.Value;
+            _requestSettings = requestSettings.CurrentValue;
             _logger = logger;
             _siteDomainMapper = siteDomainMapper;
             _uriUtility = uriUtility;
             _umbracoContextAccessor = umbracoContextAccessor;
+            requestSettings.OnChange(x => _requestSettings = x);
         }
 
         #region GetUrl

--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Core.Routing
     /// </summary>
     public class PublishedRouter : IPublishedRouter
     {
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private WebRoutingSettings _webRoutingSettings;
         private readonly ContentFinderCollection _contentFinders;
         private readonly IContentLastChanceFinder _contentLastChanceFinder;
         private readonly IProfilingLogger _profilingLogger;
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Core.Routing
         /// Initializes a new instance of the <see cref="PublishedRouter"/> class.
         /// </summary>
         public PublishedRouter(
-            IOptions<WebRoutingSettings> webRoutingSettings,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
             ContentFinderCollection contentFinders,
             IContentLastChanceFinder contentLastChanceFinder,
             IVariationContextAccessor variationContextAccessor,
@@ -56,7 +56,7 @@ namespace Umbraco.Cms.Core.Routing
             IUmbracoContextAccessor umbracoContextAccessor,
             IEventAggregator eventAggregator)
         {
-            _webRoutingSettings = webRoutingSettings.Value ?? throw new ArgumentNullException(nameof(webRoutingSettings));
+            _webRoutingSettings = webRoutingSettings.CurrentValue ?? throw new ArgumentNullException(nameof(webRoutingSettings));
             _contentFinders = contentFinders ?? throw new ArgumentNullException(nameof(contentFinders));
             _contentLastChanceFinder = contentLastChanceFinder ?? throw new ArgumentNullException(nameof(contentLastChanceFinder));
             _profilingLogger = proflog ?? throw new ArgumentNullException(nameof(proflog));
@@ -69,6 +69,7 @@ namespace Umbraco.Cms.Core.Routing
             _contentTypeService = contentTypeService;
             _umbracoContextAccessor = umbracoContextAccessor;
             _eventAggregator = eventAggregator;
+            webRoutingSettings.OnChange(x => _webRoutingSettings = x);
         }
 
         /// <inheritdoc />
@@ -237,7 +238,7 @@ namespace Umbraco.Cms.Core.Routing
 
             // re-route
             await RouteRequestInternalAsync(builder);
-            
+
             // return if we are redirect
             if (builder.IsRedirect())
             {

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="mediaUrlProviders">The list of media URL providers.</param>
         /// <param name="variationContextAccessor">The current variation accessor.</param>
         /// <param name="propertyEditorCollection"></param>
-        public UrlProvider(IUmbracoContextAccessor umbracoContextAccessor, IOptions<WebRoutingSettings> routingSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
+        public UrlProvider(IUmbracoContextAccessor umbracoContextAccessor, IOptionsSnapshot<WebRoutingSettings> routingSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
         {
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
             _urlProviders = urlProviders;
@@ -122,7 +122,7 @@ namespace Umbraco.Cms.Core.Routing
                 var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
                 current = umbracoContext.CleanedUmbracoUrl;
             }
-            
+
 
             var url = _urlProviders.Select(provider => provider.GetUrl(content, mode, culture, current))
                 .FirstOrDefault(u => u != null);
@@ -230,7 +230,7 @@ namespace Umbraco.Cms.Core.Routing
                 var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
                 current = umbracoContext.CleanedUmbracoUrl;
             }
-                
+
 
             var url = _mediaUrlProviders.Select(provider =>
                     provider.GetMediaUrl(content, propertyAlias, mode, culture, current))

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -25,13 +25,13 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="mediaUrlProviders">The list of media URL providers.</param>
         /// <param name="variationContextAccessor">The current variation accessor.</param>
         /// <param name="propertyEditorCollection"></param>
-        public UrlProvider(IUmbracoContextAccessor umbracoContextAccessor, IOptionsSnapshot<WebRoutingSettings> routingSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
+        public UrlProvider(IUmbracoContextAccessor umbracoContextAccessor, IOptionsMonitor<WebRoutingSettings> routingSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
         {
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
             _urlProviders = urlProviders;
             _mediaUrlProviders = mediaUrlProviders;
             _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
-            Mode = routingSettings.Value.UrlProviderMode;
+            Mode = routingSettings.CurrentValue.UrlProviderMode;
         }
 
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -25,13 +25,14 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="mediaUrlProviders">The list of media URL providers.</param>
         /// <param name="variationContextAccessor">The current variation accessor.</param>
         /// <param name="propertyEditorCollection"></param>
-        public UrlProvider(IUmbracoContextAccessor umbracoContextAccessor, IOptionsMonitor<WebRoutingSettings> routingSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
+        public UrlProvider(IUmbracoContextAccessor umbracoContextAccessor, IOptions<WebRoutingSettings> routingSettings, UrlProviderCollection urlProviders, MediaUrlProviderCollection mediaUrlProviders, IVariationContextAccessor variationContextAccessor)
         {
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
             _urlProviders = urlProviders;
             _mediaUrlProviders = mediaUrlProviders;
             _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
-            Mode = routingSettings.CurrentValue.UrlProviderMode;
+            Mode = routingSettings.Value.UrlProviderMode;
+
         }
 
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;

--- a/src/Umbraco.Core/Runtime/EssentialDirectoryCreator.cs
+++ b/src/Umbraco.Core/Runtime/EssentialDirectoryCreator.cs
@@ -13,11 +13,11 @@ namespace Umbraco.Cms.Core.Runtime
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly GlobalSettings _globalSettings;
 
-        public EssentialDirectoryCreator(IIOHelper ioHelper, IHostingEnvironment hostingEnvironment, IOptions<GlobalSettings> globalSettings)
+        public EssentialDirectoryCreator(IIOHelper ioHelper, IHostingEnvironment hostingEnvironment, IOptionsMonitor<GlobalSettings> globalSettings)
         {
             _ioHelper = ioHelper;
             _hostingEnvironment = hostingEnvironment;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
         }
 
         public void Handle(UmbracoApplicationStartingNotification notification)

--- a/src/Umbraco.Core/Runtime/EssentialDirectoryCreator.cs
+++ b/src/Umbraco.Core/Runtime/EssentialDirectoryCreator.cs
@@ -13,11 +13,11 @@ namespace Umbraco.Cms.Core.Runtime
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly GlobalSettings _globalSettings;
 
-        public EssentialDirectoryCreator(IIOHelper ioHelper, IHostingEnvironment hostingEnvironment, IOptionsMonitor<GlobalSettings> globalSettings)
+        public EssentialDirectoryCreator(IIOHelper ioHelper, IHostingEnvironment hostingEnvironment, IOptions<GlobalSettings> globalSettings)
         {
             _ioHelper = ioHelper;
             _hostingEnvironment = hostingEnvironment;
-            _globalSettings = globalSettings.CurrentValue;
+            _globalSettings = globalSettings.Value;
         }
 
         public void Handle(UmbracoApplicationStartingNotification notification)

--- a/src/Umbraco.Core/Templates/HtmlUrlParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlUrlParser.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core.Templates
 {
     public sealed class HtmlUrlParser
     {
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
         private readonly ILogger<HtmlUrlParser> _logger;
         private readonly IIOHelper _ioHelper;
         private readonly IProfilingLogger _profilingLogger;
@@ -17,12 +17,14 @@ namespace Umbraco.Cms.Core.Templates
         private static readonly Regex ResolveUrlPattern = new Regex("(=[\"\']?)(\\W?\\~(?:.(?![\"\']?\\s+(?:\\S+)=|[>\"\']))+.)[\"\']?",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        public HtmlUrlParser(IOptions<ContentSettings> contentSettings, ILogger<HtmlUrlParser> logger, IProfilingLogger profilingLogger, IIOHelper ioHelper)
+        public HtmlUrlParser(IOptionsMonitor<ContentSettings> contentSettings, ILogger<HtmlUrlParser> logger, IProfilingLogger profilingLogger, IIOHelper ioHelper)
         {
-            _contentSettings = contentSettings.Value;
+            _contentSettings = contentSettings.CurrentValue;
             _logger = logger;
             _ioHelper = ioHelper;
             _profilingLogger = profilingLogger;
+
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Examine.Lucene/DependencyInjection/ConfigureIndexOptions.cs
+++ b/src/Umbraco.Examine.Lucene/DependencyInjection/ConfigureIndexOptions.cs
@@ -16,14 +16,14 @@ namespace Umbraco.Cms.Infrastructure.Examine.DependencyInjection
     public sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
     {
         private readonly IUmbracoIndexConfig _umbracoIndexConfig;
-        private readonly IOptions<IndexCreatorSettings> _settings;
+        private readonly IndexCreatorSettings _settings;
 
         public ConfigureIndexOptions(
             IUmbracoIndexConfig umbracoIndexConfig,
             IOptions<IndexCreatorSettings> settings)
         {
             _umbracoIndexConfig = umbracoIndexConfig;
-            _settings = settings;
+            _settings = settings.Value;
         }
 
         public void Configure(string name, LuceneDirectoryIndexOptions options)
@@ -50,13 +50,13 @@ namespace Umbraco.Cms.Infrastructure.Examine.DependencyInjection
             // ensure indexes are unlocked on startup
             options.UnlockIndex = true;
 
-            if (_settings.Value.LuceneDirectoryFactory == LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory)
+            if (_settings.LuceneDirectoryFactory == LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory)
             {
                 // if this directory factory is enabled then a snapshot deletion policy is required
                 options.IndexDeletionPolicy = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
             }
-            
-            
+
+
         }
 
         public void Configure(LuceneDirectoryIndexOptions options)

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -119,7 +119,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddSingleton<IPublishedContentTypeFactory, PublishedContentTypeFactory>();
 
             builder.Services.AddSingleton<IShortStringHelper>(factory
-                => new DefaultShortStringHelper(new DefaultShortStringHelperConfig().WithDefault(factory.GetRequiredService<IOptions<RequestHandlerSettings>>().Value)));
+                => new DefaultShortStringHelper(new DefaultShortStringHelperConfig().WithDefault(factory.GetRequiredService<IOptionsMonitor<RequestHandlerSettings>>().CurrentValue)));
 
             builder.Services.AddSingleton<IMigrationPlanExecutor, MigrationPlanExecutor>();
             builder.Services.AddSingleton<IMigrationBuilder>(factory => new MigrationBuilder(factory));

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -156,7 +156,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddSingleton<IEmailSender, EmailSender>(
                 services => new EmailSender(
                     services.GetRequiredService<ILogger<EmailSender>>(),
-                    services.GetRequiredService<IOptions<GlobalSettings>>(),
+                    services.GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
                     services.GetRequiredService<IEventAggregator>(),
                     services.GetService<INotificationHandler<SendEmailNotification>>(),
                     services.GetService<INotificationAsyncHandler<SendEmailNotification>>()));

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
                 factory.GetRequiredService<ILocalizationService>(),
                 factory.GetRequiredService<IHostingEnvironment>(),
                 factory.GetRequiredService<IEntityXmlSerializer>(),
-                factory.GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
+                factory.GetRequiredService<IOptions<GlobalSettings>>(),
                 factory.GetRequiredService<IMediaService>(),
                 factory.GetRequiredService<IMediaTypeService>(),
                 factory.GetRequiredService<MediaFileManager>(),

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
                 factory.GetRequiredService<ILocalizationService>(),
                 factory.GetRequiredService<IHostingEnvironment>(),
                 factory.GetRequiredService<IEntityXmlSerializer>(),
-                factory.GetRequiredService<IOptions<GlobalSettings>>(),
+                factory.GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
                 factory.GetRequiredService<IMediaService>(),
                 factory.GetRequiredService<IMediaTypeService>(),
                 factory.GetRequiredService<MediaFileManager>(),

--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
     /// </summary>
     public class HealthCheckNotifier : RecurringHostedServiceBase
     {
-        private HealthChecksSettings _healthChecksSettings;
+        private readonly HealthChecksSettings _healthChecksSettings;
         private readonly HealthCheckCollection _healthChecks;
         private readonly HealthCheckNotificationMethodCollection _notifications;
         private readonly IRuntimeState _runtimeState;
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// <param name="profilingLogger">The profiling logger.</param>
         /// <param name="cronTabParser">Parser of crontab expressions.</param>
         public HealthCheckNotifier(
-            IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
+            IOptions<HealthChecksSettings> healthChecksSettings,
             HealthCheckCollection healthChecks,
             HealthCheckNotificationMethodCollection notifications,
             IRuntimeState runtimeState,
@@ -61,10 +61,10 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IProfilingLogger profilingLogger,
             ICronTabParser cronTabParser)
             : base(
-                healthChecksSettings.CurrentValue.Notification.Period,
-                healthChecksSettings.CurrentValue.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
+                healthChecksSettings.Value.Notification.Period,
+                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
         {
-            _healthChecksSettings = healthChecksSettings.CurrentValue;
+            _healthChecksSettings = healthChecksSettings.Value;
             _healthChecks = healthChecks;
             _notifications = notifications;
             _runtimeState = runtimeState;
@@ -73,7 +73,6 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _scopeProvider = scopeProvider;
             _logger = logger;
             _profilingLogger = profilingLogger;
-            healthChecksSettings.OnChange(x => _healthChecksSettings = x);
         }
 
         public override async Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
     /// </summary>
     public class HealthCheckNotifier : RecurringHostedServiceBase
     {
-        private readonly HealthChecksSettings _healthChecksSettings;
+        private HealthChecksSettings _healthChecksSettings;
         private readonly HealthCheckCollection _healthChecks;
         private readonly HealthCheckNotificationMethodCollection _notifications;
         private readonly IRuntimeState _runtimeState;
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// <param name="profilingLogger">The profiling logger.</param>
         /// <param name="cronTabParser">Parser of crontab expressions.</param>
         public HealthCheckNotifier(
-            IOptions<HealthChecksSettings> healthChecksSettings,
+            IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
             HealthCheckCollection healthChecks,
             HealthCheckNotificationMethodCollection notifications,
             IRuntimeState runtimeState,
@@ -61,10 +61,10 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IProfilingLogger profilingLogger,
             ICronTabParser cronTabParser)
             : base(
-                healthChecksSettings.Value.Notification.Period,
-                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
+                healthChecksSettings.CurrentValue.Notification.Period,
+                healthChecksSettings.CurrentValue.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
         {
-            _healthChecksSettings = healthChecksSettings.Value;
+            _healthChecksSettings = healthChecksSettings.CurrentValue;
             _healthChecks = healthChecks;
             _notifications = notifications;
             _runtimeState = runtimeState;
@@ -73,6 +73,12 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _scopeProvider = scopeProvider;
             _logger = logger;
             _profilingLogger = profilingLogger;
+
+            healthChecksSettings.OnChange(x =>
+            {
+                _healthChecksSettings = x;
+                ChangePeriod(x.Notification.Period);
+            });
         }
 
         public override async Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
     /// </summary>
     public class HealthCheckNotifier : RecurringHostedServiceBase
     {
-        private readonly HealthChecksSettings _healthChecksSettings;
+        private HealthChecksSettings _healthChecksSettings;
         private readonly HealthCheckCollection _healthChecks;
         private readonly HealthCheckNotificationMethodCollection _notifications;
         private readonly IRuntimeState _runtimeState;
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// <param name="profilingLogger">The profiling logger.</param>
         /// <param name="cronTabParser">Parser of crontab expressions.</param>
         public HealthCheckNotifier(
-            IOptions<HealthChecksSettings> healthChecksSettings,
+            IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
             HealthCheckCollection healthChecks,
             HealthCheckNotificationMethodCollection notifications,
             IRuntimeState runtimeState,
@@ -61,10 +61,10 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IProfilingLogger profilingLogger,
             ICronTabParser cronTabParser)
             : base(
-                healthChecksSettings.Value.Notification.Period,
-                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
+                healthChecksSettings.CurrentValue.Notification.Period,
+                healthChecksSettings.CurrentValue.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
         {
-            _healthChecksSettings = healthChecksSettings.Value;
+            _healthChecksSettings = healthChecksSettings.CurrentValue;
             _healthChecks = healthChecks;
             _notifications = notifications;
             _runtimeState = runtimeState;
@@ -73,6 +73,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _scopeProvider = scopeProvider;
             _logger = logger;
             _profilingLogger = profilingLogger;
+            healthChecksSettings.OnChange(x => _healthChecksSettings = x);
         }
 
         public override async Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
     {
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IMainDom _mainDom;
-        private readonly KeepAliveSettings _keepAliveSettings;
+        private KeepAliveSettings _keepAliveSettings;
         private readonly ILogger<KeepAlive> _logger;
         private readonly IProfilingLogger _profilingLogger;
         private readonly IServerRoleAccessor _serverRegistrar;
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         public KeepAlive(
             IHostingEnvironment hostingEnvironment,
             IMainDom mainDom,
-            IOptions<KeepAliveSettings> keepAliveSettings,
+            IOptionsMonitor<KeepAliveSettings> keepAliveSettings,
             ILogger<KeepAlive> logger,
             IProfilingLogger profilingLogger,
             IServerRoleAccessor serverRegistrar,
@@ -52,11 +52,13 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         {
             _hostingEnvironment = hostingEnvironment;
             _mainDom = mainDom;
-            _keepAliveSettings = keepAliveSettings.Value;
+            _keepAliveSettings = keepAliveSettings.CurrentValue;
             _logger = logger;
             _profilingLogger = profilingLogger;
             _serverRegistrar = serverRegistrar;
             _httpClientFactory = httpClientFactory;
+
+            keepAliveSettings.OnChange(x => _keepAliveSettings = x);
         }
 
         public override async Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IMainDom _mainDom;
         private readonly IServerRoleAccessor _serverRegistrar;
         private readonly IAuditService _auditService;
-        private readonly LoggingSettings _settings;
+        private LoggingSettings _settings;
         private readonly IProfilingLogger _profilingLogger;
         private readonly ILogger<LogScrubber> _logger;
         private readonly IScopeProvider _scopeProvider;
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IMainDom mainDom,
             IServerRoleAccessor serverRegistrar,
             IAuditService auditService,
-            IOptions<LoggingSettings> settings,
+            IOptionsMonitor<LoggingSettings> settings,
             IScopeProvider scopeProvider,
             ILogger<LogScrubber> logger,
             IProfilingLogger profilingLogger)
@@ -53,10 +53,11 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _mainDom = mainDom;
             _serverRegistrar = serverRegistrar;
             _auditService = auditService;
-            _settings = settings.Value;
+            _settings = settings.CurrentValue;
             _scopeProvider = scopeProvider;
             _logger = logger;
             _profilingLogger = profilingLogger;
+            settings.OnChange(x => _settings = x);
         }
 
         public override Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// </summary>
         protected static readonly TimeSpan DefaultDelay = TimeSpan.FromMinutes(3);
 
-        private readonly TimeSpan _period;
+        private TimeSpan _period;
         private readonly TimeSpan _delay;
         private Timer _timer;
 
@@ -35,6 +35,12 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _period = period;
             _delay = delay;
         }
+
+        /// <summary>
+        /// Change the period between operations.
+        /// </summary>
+        /// <param name="newPeriod">The new period between tasks</param>
+        protected void ChangePeriod(TimeSpan newPeriod) => _period = newPeriod;
 
         /// <inheritdoc/>
         public Task StartAsync(CancellationToken cancellationToken)

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -16,19 +16,20 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
     {
         private readonly ILogger<ReportSiteTask> _logger;
         private readonly IUmbracoVersion _umbracoVersion;
-        private readonly IOptions<GlobalSettings> _globalSettings;
+        private GlobalSettings _globalSettings;
         private static HttpClient s_httpClient;
 
         public ReportSiteTask(
             ILogger<ReportSiteTask> logger,
             IUmbracoVersion umbracoVersion,
-            IOptions<GlobalSettings> globalSettings)
+            IOptionsMonitor<GlobalSettings> globalSettings)
             : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1))
         {
             _logger = logger;
             _umbracoVersion = umbracoVersion;
-            _globalSettings = globalSettings;
+            _globalSettings = globalSettings.CurrentValue;
             s_httpClient = new HttpClient();
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         public override async Task PerformExecuteAsync(object state)
         {
             // Try & get a value stored in umbracoSettings.config on the backoffice XML element ID attribute
-            var backofficeIdentifierRaw = _globalSettings.Value.Id;
+            var backofficeIdentifierRaw = _globalSettings.Id;
 
             // Parse as a GUID & verify its a GUID and not some random string
             // In case of users may have messed or decided to empty the file contents or put in something random

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         private readonly IServerRegistrationService _serverRegistrationService;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILogger<TouchServerTask> _logger;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchServerTask"/> class.
@@ -37,14 +37,15 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             IServerRegistrationService serverRegistrationService,
             IHostingEnvironment hostingEnvironment,
             ILogger<TouchServerTask> logger,
-            IOptions<GlobalSettings> globalSettings)
-            : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
+            IOptionsMonitor<GlobalSettings> globalSettings)
+            : base(globalSettings.CurrentValue.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
         {
             _runtimeState = runtimeState;
             _serverRegistrationService = serverRegistrationService ?? throw new ArgumentNullException(nameof(serverRegistrationService));
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         public override Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         private readonly IServerRegistrationService _serverRegistrationService;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILogger<TouchServerTask> _logger;
-        private GlobalSettings _globalSettings;
+        private readonly GlobalSettings _globalSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchServerTask"/> class.
@@ -37,15 +37,14 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             IServerRegistrationService serverRegistrationService,
             IHostingEnvironment hostingEnvironment,
             ILogger<TouchServerTask> logger,
-            IOptionsMonitor<GlobalSettings> globalSettings)
-            : base(globalSettings.CurrentValue.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
+            IOptionsSnapshot<GlobalSettings> globalSettings)
+            : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
         {
             _runtimeState = runtimeState;
             _serverRegistrationService = serverRegistrationService ?? throw new ArgumentNullException(nameof(serverRegistrationService));
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
-            _globalSettings = globalSettings.CurrentValue;
-            globalSettings.OnChange(x => _globalSettings = x);
+            _globalSettings = globalSettings.Value;
         }
 
         public override Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -45,7 +45,11 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
             _globalSettings = globalSettings.CurrentValue;
-            globalSettings.OnChange(x => _globalSettings = x);
+            globalSettings.OnChange(x =>
+            {
+                _globalSettings = x;
+                ChangePeriod(x.DatabaseServerRegistrar.WaitTimeBetweenCalls);
+            });
         }
 
         public override Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         private readonly IServerRegistrationService _serverRegistrationService;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILogger<TouchServerTask> _logger;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchServerTask"/> class.
@@ -37,14 +37,15 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             IServerRegistrationService serverRegistrationService,
             IHostingEnvironment hostingEnvironment,
             ILogger<TouchServerTask> logger,
-            IOptionsSnapshot<GlobalSettings> globalSettings)
-            : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
+            IOptionsMonitor<GlobalSettings> globalSettings)
+            : base(globalSettings.CurrentValue.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
         {
             _runtimeState = runtimeState;
             _serverRegistrationService = serverRegistrationService ?? throw new ArgumentNullException(nameof(serverRegistrationService));
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         public override Task PerformExecuteAsync(object state)

--- a/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/ThreadAbortExceptionEnricher.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/ThreadAbortExceptionEnricher.cs
@@ -15,15 +15,16 @@ namespace Umbraco.Cms.Core.Logging.Serilog.Enrichers
     /// </summary>
     public class ThreadAbortExceptionEnricher : ILogEventEnricher
     {
-        private readonly CoreDebugSettings _coreDebugSettings;
+        private CoreDebugSettings _coreDebugSettings;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IMarchal _marchal;
 
-        public ThreadAbortExceptionEnricher(IOptions<CoreDebugSettings> coreDebugSettings, IHostingEnvironment hostingEnvironment, IMarchal marchal)
+        public ThreadAbortExceptionEnricher(IOptionsMonitor<CoreDebugSettings> coreDebugSettings, IHostingEnvironment hostingEnvironment, IMarchal marchal)
         {
-            _coreDebugSettings = coreDebugSettings.Value;
+            _coreDebugSettings = coreDebugSettings.CurrentValue;
             _hostingEnvironment = hostingEnvironment;
             _marchal = marchal;
+            coreDebugSettings.OnChange(x => _coreDebugSettings = x);
         }
 
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -22,27 +22,28 @@ namespace Umbraco.Cms.Infrastructure.Mail
     {
         // TODO: This should encapsulate a BackgroundTaskRunner with a queue to send these emails!
         private readonly IEventAggregator _eventAggregator;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly bool _notificationHandlerRegistered;
         private readonly ILogger<EmailSender> _logger;
 
         public EmailSender(
             ILogger<EmailSender> logger,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IEventAggregator eventAggregator)
             : this(logger, globalSettings, eventAggregator, null, null) { }
 
         public EmailSender(
             ILogger<EmailSender> logger,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IEventAggregator eventAggregator,
             INotificationHandler<SendEmailNotification> handler1,
             INotificationAsyncHandler<SendEmailNotification> handler2)
         {
             _logger = logger;
             _eventAggregator = eventAggregator;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
             _notificationHandlerRegistered = handler1 is not null || handler2 is not null;
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
@@ -33,15 +33,17 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoModelsNotificationHandler"/> class.
         /// </summary>
+        
         public AutoModelsNotificationHandler(
             ILogger<AutoModelsNotificationHandler> logger,
-            IOptions<ModelsBuilderSettings> config,
+            IOptionsMonitor<ModelsBuilderSettings> config,
             ModelsGenerator modelGenerator,
             ModelsGenerationError mbErrors,
             IMainDom mainDom)
         {
             _logger = logger;
-            _config = config.Value ?? throw new ArgumentNullException(nameof(config));
+            //We cant use IOptionsSnapshot here, cause this is used in the Core runtime, and that cannot use a scoped service as it has no scope
+            _config = config.CurrentValue ?? throw new ArgumentNullException(nameof(config));
             _modelGenerator = modelGenerator;
             _mbErrors = mbErrors;
             _mainDom = mainDom;

--- a/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
     {
         private static int s_req;
         private readonly ILogger<AutoModelsNotificationHandler> _logger;
-        private readonly ModelsBuilderSettings _config;
+        private ModelsBuilderSettings _config;
         private readonly ModelsGenerator _modelGenerator;
         private readonly ModelsGenerationError _mbErrors;
         private readonly IMainDom _mainDom;
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
         /// </summary>
         public AutoModelsNotificationHandler(
             ILogger<AutoModelsNotificationHandler> logger,
-            IOptions<ModelsBuilderSettings> config,
+            IOptionsSnapshot<ModelsBuilderSettings> config,
             ModelsGenerator modelGenerator,
             ModelsGenerationError mbErrors,
             IMainDom mainDom)

--- a/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
     {
         private static int s_req;
         private readonly ILogger<AutoModelsNotificationHandler> _logger;
-        private ModelsBuilderSettings _config;
+        private readonly ModelsBuilderSettings _config;
         private readonly ModelsGenerator _modelGenerator;
         private readonly ModelsGenerationError _mbErrors;
         private readonly IMainDom _mainDom;
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
         /// </summary>
         public AutoModelsNotificationHandler(
             ILogger<AutoModelsNotificationHandler> logger,
-            IOptionsSnapshot<ModelsBuilderSettings> config,
+            IOptions<ModelsBuilderSettings> config,
             ModelsGenerator modelGenerator,
             ModelsGenerationError mbErrors,
             IMainDom mainDom)

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/ModelsGenerator.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/ModelsGenerator.cs
@@ -10,16 +10,17 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder.Building
     public class ModelsGenerator
     {
         private readonly UmbracoServices _umbracoService;
-        private readonly ModelsBuilderSettings _config;
+        private ModelsBuilderSettings _config;
         private readonly OutOfDateModelsStatus _outOfDateModels;
         private readonly IHostingEnvironment _hostingEnvironment;
 
-        public ModelsGenerator(UmbracoServices umbracoService, IOptions<ModelsBuilderSettings> config, OutOfDateModelsStatus outOfDateModels, IHostingEnvironment hostingEnvironment)
+        public ModelsGenerator(UmbracoServices umbracoService, IOptionsMonitor<ModelsBuilderSettings> config, OutOfDateModelsStatus outOfDateModels, IHostingEnvironment hostingEnvironment)
         {
             _umbracoService = umbracoService;
-            _config = config.Value;
+            _config = config.CurrentValue;
             _outOfDateModels = outOfDateModels;
             _hostingEnvironment = hostingEnvironment;
+            config.OnChange(x => _config = x);
         }
 
         public void GenerateModels()

--- a/src/Umbraco.Infrastructure/ModelsBuilder/ModelsGenerationError.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/ModelsGenerationError.cs
@@ -10,16 +10,17 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
 {
     public sealed class ModelsGenerationError
     {
-        private readonly ModelsBuilderSettings _config;
+        private ModelsBuilderSettings _config;
         private readonly IHostingEnvironment _hostingEnvironment;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelsGenerationError"/> class.
         /// </summary>
-        public ModelsGenerationError(IOptions<ModelsBuilderSettings> config, IHostingEnvironment hostingEnvironment)
+        public ModelsGenerationError(IOptionsMonitor<ModelsBuilderSettings> config, IHostingEnvironment hostingEnvironment)
         {
-            _config = config.Value;
+            _config = config.CurrentValue;
             _hostingEnvironment = hostingEnvironment;
+            config.OnChange(x => _config = x);
         }
 
         public void Clear()

--- a/src/Umbraco.Infrastructure/ModelsBuilder/OutOfDateModelsStatus.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/OutOfDateModelsStatus.cs
@@ -15,16 +15,17 @@ namespace Umbraco.Cms.Infrastructure.ModelsBuilder
     public sealed class OutOfDateModelsStatus : INotificationHandler<ContentTypeCacheRefresherNotification>,
         INotificationHandler<DataTypeCacheRefresherNotification>
     {
-        private readonly ModelsBuilderSettings _config;
+        private ModelsBuilderSettings _config;
         private readonly IHostingEnvironment _hostingEnvironment;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OutOfDateModelsStatus"/> class.
         /// </summary>
-        public OutOfDateModelsStatus(IOptions<ModelsBuilderSettings> config, IHostingEnvironment hostingEnvironment)
+        public OutOfDateModelsStatus(IOptionsMonitor<ModelsBuilderSettings> config, IHostingEnvironment hostingEnvironment)
         {
-            _config = config.Value;
+            _config = config.CurrentValue;
             _hostingEnvironment = hostingEnvironment;
+            config.OnChange(x => _config = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         INotificationHandler<MemberDeletedNotification>
     {
         private readonly MediaFileManager _mediaFileManager;
-        private readonly ContentSettings _contentSettings;
+        private readonly IOptionsMonitor<ContentSettings> _contentSettings;
         private readonly UploadAutoFillProperties _uploadAutoFillProperties;
         private readonly ILocalizedTextService _localizedTextService;
         private readonly IContentService _contentService;
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         public FileUploadPropertyEditor(
             IDataValueEditorFactory dataValueEditorFactory,
             MediaFileManager mediaFileManager,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             ILocalizedTextService localizedTextService,
             UploadAutoFillProperties uploadAutoFillProperties,
             IContentService contentService,
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             : base(dataValueEditorFactory)
         {
             _mediaFileManager = mediaFileManager ?? throw new ArgumentNullException(nameof(mediaFileManager));
-            _contentSettings = contentSettings.Value;
+            _contentSettings = contentSettings;
             _localizedTextService = localizedTextService;
             _uploadAutoFillProperties = uploadAutoFillProperties;
             _contentService = contentService;
@@ -62,7 +62,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         protected override IDataValueEditor CreateValueEditor()
         {
             var editor = DataValueEditorFactory.Create<FileUploadPropertyValueEditor>(Attribute);
-            editor.Validators.Add(new UploadFileTypeValidator(_localizedTextService, Options.Create(_contentSettings)));
+            editor.Validators.Add(new UploadFileTypeValidator(_localizedTextService, _contentSettings));
             return editor;
         }
 
@@ -182,7 +182,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
             foreach (var property in properties)
             {
-                var autoFillConfig = _contentSettings.GetConfig(property.Alias);
+                var autoFillConfig = _contentSettings.CurrentValue.GetConfig(property.Alias);
                 if (autoFillConfig == null) continue;
 
                 foreach (var pvalue in property.Values)

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
@@ -21,20 +21,21 @@ namespace Umbraco.Cms.Core.PropertyEditors
     internal class FileUploadPropertyValueEditor : DataValueEditor
     {
         private readonly MediaFileManager _mediaFileManager;
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
 
         public FileUploadPropertyValueEditor(
             DataEditorAttribute attribute,
             MediaFileManager mediaFileManager,
             ILocalizedTextService localizedTextService,
             IShortStringHelper shortStringHelper,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper)
             : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
         {
             _mediaFileManager = mediaFileManager ?? throw new ArgumentNullException(nameof(mediaFileManager));
-            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         INotificationHandler<MemberDeletedNotification>
     {
         private readonly MediaFileManager _mediaFileManager;
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
         private readonly IDataTypeService _dataTypeService;
         private readonly IIOHelper _ioHelper;
         private readonly UploadAutoFillProperties _autoFillProperties;
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             IDataValueEditorFactory dataValueEditorFactory,
             ILoggerFactory loggerFactory,
             MediaFileManager mediaFileManager,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IDataTypeService dataTypeService,
             IIOHelper ioHelper,
             UploadAutoFillProperties uploadAutoFillProperties,
@@ -58,12 +58,14 @@ namespace Umbraco.Cms.Core.PropertyEditors
             : base(dataValueEditorFactory)
         {
             _mediaFileManager = mediaFileManager ?? throw new ArgumentNullException(nameof(mediaFileManager));
-            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
             _dataTypeService = dataTypeService ?? throw new ArgumentNullException(nameof(dataTypeService));
             _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
             _autoFillProperties = uploadAutoFillProperties ?? throw new ArgumentNullException(nameof(uploadAutoFillProperties));
             _contentService = contentService;
             _logger = loggerFactory.CreateLogger<ImageCropperPropertyEditor>();
+
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         public bool TryGetMediaPath(string propertyEditorAlias, object value, out string mediaPath)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
     {
         private readonly ILogger<ImageCropperPropertyValueEditor> _logger;
         private readonly MediaFileManager _mediaFileManager;
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
         private readonly IDataTypeService _dataTypeService;
 
         public ImageCropperPropertyValueEditor(
@@ -36,7 +36,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             MediaFileManager mediaFileSystem,
             ILocalizedTextService localizedTextService,
             IShortStringHelper shortStringHelper,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper,
             IDataTypeService dataTypeService)
@@ -44,8 +44,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _mediaFileManager = mediaFileSystem ?? throw new ArgumentNullException(nameof(mediaFileSystem));
-            _contentSettings = contentSettings.Value;
+            _contentSettings = contentSettings.CurrentValue;
             _dataTypeService = dataTypeService;
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/UploadFileTypeValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/UploadFileTypeValidator.cs
@@ -16,12 +16,14 @@ namespace Umbraco.Cms.Core.PropertyEditors
     internal class UploadFileTypeValidator : IValueValidator
     {
         private readonly ILocalizedTextService _localizedTextService;
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
 
-        public UploadFileTypeValidator(ILocalizedTextService localizedTextService, IOptions<ContentSettings> contentSettings)
+        public UploadFileTypeValidator(ILocalizedTextService localizedTextService, IOptionsMonitor<ContentSettings> contentSettings)
         {
             _localizedTextService = localizedTextService;
-            _contentSettings = contentSettings.Value;
+            _contentSettings = contentSettings.CurrentValue;
+
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         public IEnumerable<ValidationResult> Validate(object value, string valueType, object dataTypeConfiguration)

--- a/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
+++ b/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.Routing
     {
         private readonly ILogger<ContentFinderByConfigured404> _logger;
         private readonly IEntityService _entityService;
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
         private readonly IExamineManager _examineManager;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly IVariationContextAccessor _variationContextAccessor;
@@ -31,17 +31,19 @@ namespace Umbraco.Cms.Core.Routing
         public ContentFinderByConfigured404(
             ILogger<ContentFinderByConfigured404> logger,
             IEntityService entityService,
-            IOptions<ContentSettings> contentConfigSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IExamineManager examineManager,
             IVariationContextAccessor variationContextAccessor,
             IUmbracoContextAccessor umbracoContextAccessor)
         {
             _logger = logger;
             _entityService = entityService;
-            _contentSettings = contentConfigSettings.Value;
+            _contentSettings = contentSettings.CurrentValue;
             _examineManager = examineManager;
             _variationContextAccessor = variationContextAccessor;
             _umbracoContextAccessor = umbracoContextAccessor;
+
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs
+++ b/src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Core.Scoping
         private readonly ILoggerFactory _loggerFactory;
         private readonly IRequestCache _requestCache;
         private readonly FileSystems _fileSystems;
-        private readonly CoreDebugSettings _coreDebugSettings;
+        private CoreDebugSettings _coreDebugSettings;
         private readonly MediaFileManager _mediaFileManager;
         private static readonly AsyncLocal<ConcurrentStack<IScope>> s_scopeStack = new AsyncLocal<ConcurrentStack<IScope>>();
         private static readonly AsyncLocal<ConcurrentStack<IScopeContext>> s_scopeContextStack = new AsyncLocal<ConcurrentStack<IScopeContext>>();
@@ -36,11 +36,11 @@ namespace Umbraco.Cms.Core.Scoping
         private static readonly string s_contextItemKey = typeof(ScopeProvider).FullName;
         private readonly IEventAggregator _eventAggregator;
 
-        public ScopeProvider(IUmbracoDatabaseFactory databaseFactory, FileSystems fileSystems, IOptions<CoreDebugSettings> coreDebugSettings, MediaFileManager mediaFileManager, ILogger<ScopeProvider> logger, ILoggerFactory loggerFactory, IRequestCache requestCache, IEventAggregator eventAggregator)
+        public ScopeProvider(IUmbracoDatabaseFactory databaseFactory, FileSystems fileSystems, IOptionsMonitor<CoreDebugSettings> coreDebugSettings, MediaFileManager mediaFileManager, ILogger<ScopeProvider> logger, ILoggerFactory loggerFactory, IRequestCache requestCache, IEventAggregator eventAggregator)
         {
             DatabaseFactory = databaseFactory;
             _fileSystems = fileSystems;
-            _coreDebugSettings = coreDebugSettings.Value;
+            _coreDebugSettings = coreDebugSettings.CurrentValue;
             _mediaFileManager = mediaFileManager;
             _logger = logger;
             _loggerFactory = loggerFactory;
@@ -48,6 +48,8 @@ namespace Umbraco.Cms.Core.Scoping
             _eventAggregator = eventAggregator;
             // take control of the FileSystems
             _fileSystems.IsScoped = () => AmbientScope != null && AmbientScope.ScopedFileSystems;
+
+            coreDebugSettings.OnChange(x => _coreDebugSettings = x);
         }
 
         public IUmbracoDatabaseFactory DatabaseFactory { get; }

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.Security
         private readonly IUserService _userService;
         private readonly IEntityService _entityService;
         private readonly IExternalLoginService _externalLoginService;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly IUmbracoMapper _mapper;
         private readonly AppCaches _appCaches;
 
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Core.Security
             IUserService userService,
             IEntityService entityService,
             IExternalLoginService externalLoginService,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IUmbracoMapper mapper,
             BackOfficeErrorDescriber describer,
             AppCaches appCaches)
@@ -52,11 +52,13 @@ namespace Umbraco.Cms.Core.Security
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
             _entityService = entityService;
             _externalLoginService = externalLoginService ?? throw new ArgumentNullException(nameof(externalLoginService));
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
             _mapper = mapper;
             _appCaches = appCaches;
             _userService = userService;
             _externalLoginService = externalLoginService;
+
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.Security
         private readonly IUserService _userService;
         private readonly IEntityService _entityService;
         private readonly IExternalLoginService _externalLoginService;
-        private GlobalSettings _globalSettings;
+        private readonly GlobalSettings _globalSettings;
         private readonly IUmbracoMapper _mapper;
         private readonly AppCaches _appCaches;
 
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Core.Security
             IUserService userService,
             IEntityService entityService,
             IExternalLoginService externalLoginService,
-            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             IUmbracoMapper mapper,
             BackOfficeErrorDescriber describer,
             AppCaches appCaches)
@@ -52,13 +52,11 @@ namespace Umbraco.Cms.Core.Security
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
             _entityService = entityService;
             _externalLoginService = externalLoginService ?? throw new ArgumentNullException(nameof(externalLoginService));
-            _globalSettings = globalSettings.CurrentValue;
+            _globalSettings = globalSettings.Value;
             _mapper = mapper;
             _appCaches = appCaches;
             _userService = userService;
             _externalLoginService = externalLoginService;
-
-            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -17,13 +17,13 @@ namespace Umbraco.Cms.Core.Security
     {
         private readonly ILocalizedTextService _textService;
         private readonly IEntityService _entityService;
-        private GlobalSettings _globalSettings;
+        private readonly GlobalSettings _globalSettings;
         private readonly AppCaches _appCaches;
 
         public IdentityMapDefinition(
             ILocalizedTextService textService,
             IEntityService entityService,
-            IOptionsSnapshot<GlobalSettings> globalSettings,
+            IOptions<GlobalSettings> globalSettings,
             AppCaches appCaches)
         {
             _textService = textService;

--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -23,15 +23,13 @@ namespace Umbraco.Cms.Core.Security
         public IdentityMapDefinition(
             ILocalizedTextService textService,
             IEntityService entityService,
-            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             AppCaches appCaches)
         {
             _textService = textService;
             _entityService = entityService;
-            _globalSettings = globalSettings.CurrentValue;
+            _globalSettings = globalSettings.Value;
             _appCaches = appCaches;
-
-            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         public void DefineMaps(IUmbracoMapper mapper)

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Core.Security
             IdentityErrorDescriber errors,
             IServiceProvider services,
             ILogger<UserManager<TUser>> logger,
-            IOptionsSnapshot<TPasswordConfig> passwordConfiguration)
+            IOptions<TPasswordConfig> passwordConfiguration)
             : base(store, optionsAccessor, passwordHasher, userValidators, passwordValidators, new NoopLookupNormalizer(), errors, services, logger)
         {
             IpResolver = ipResolver ?? throw new ArgumentNullException(nameof(ipResolver));

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -35,12 +35,11 @@ namespace Umbraco.Cms.Core.Security
             IdentityErrorDescriber errors,
             IServiceProvider services,
             ILogger<UserManager<TUser>> logger,
-            IOptionsMonitor<TPasswordConfig> passwordConfiguration)
+            IOptionsSnapshot<TPasswordConfig> passwordConfiguration)
             : base(store, optionsAccessor, passwordHasher, userValidators, passwordValidators, new NoopLookupNormalizer(), errors, services, logger)
         {
             IpResolver = ipResolver ?? throw new ArgumentNullException(nameof(ipResolver));
-            PasswordConfiguration = passwordConfiguration.CurrentValue ?? throw new ArgumentNullException(nameof(passwordConfiguration));
-            passwordConfiguration.OnChange(x => PasswordConfiguration = x);
+            PasswordConfiguration = passwordConfiguration.Value ?? throw new ArgumentNullException(nameof(passwordConfiguration));
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -35,11 +35,12 @@ namespace Umbraco.Cms.Core.Security
             IdentityErrorDescriber errors,
             IServiceProvider services,
             ILogger<UserManager<TUser>> logger,
-            IOptions<TPasswordConfig> passwordConfiguration)
+            IOptionsMonitor<TPasswordConfig> passwordConfiguration)
             : base(store, optionsAccessor, passwordHasher, userValidators, passwordValidators, new NoopLookupNormalizer(), errors, services, logger)
         {
             IpResolver = ipResolver ?? throw new ArgumentNullException(nameof(ipResolver));
-            PasswordConfiguration = passwordConfiguration.Value ?? throw new ArgumentNullException(nameof(passwordConfiguration));
+            PasswordConfiguration = passwordConfiguration.CurrentValue ?? throw new ArgumentNullException(nameof(passwordConfiguration));
+            passwordConfiguration.OnChange(x => PasswordConfiguration = x);
         }
 
         /// <inheritdoc />
@@ -60,7 +61,7 @@ namespace Umbraco.Cms.Core.Security
         /// <summary>
         /// Gets the password configuration
         /// </summary>
-        public IPasswordConfiguration PasswordConfiguration { get; }
+        public IPasswordConfiguration PasswordConfiguration { get; private set; }
 
         /// <summary>
         /// Gets the IP resolver
@@ -96,7 +97,7 @@ namespace Umbraco.Cms.Core.Security
             string password = _passwordGenerator.GeneratePassword();
             return password;
         }
-        
+
         /// <summary>
         /// Used to validate the password without an identity user
         /// Validation code is based on the default ValidatePasswordAsync code

--- a/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Infrastructure.Sync
             IRequestCache requestCache,
             IRequestAccessor requestAccessor,
             LastSyncedFileManager lastSyncedFileManager,
-            IOptions<GlobalSettings> globalSettings)
+            IOptionsMonitor<GlobalSettings> globalSettings)
             : base(mainDom, cacheRefreshers, serverRoleAccessor, logger, true, syncBootStateAccessor, hostingEnvironment, cacheInstructionService, jsonSerializer, lastSyncedFileManager, globalSettings)
         {
             _requestCache = requestCache;

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -56,7 +56,7 @@ namespace Umbraco.Cms.Infrastructure.Sync
             ICacheInstructionService cacheInstructionService,
             IJsonSerializer jsonSerializer,
             LastSyncedFileManager lastSyncedFileManager,
-            IOptions<GlobalSettings> globalSettings)
+            IOptionsMonitor<GlobalSettings> globalSettings)
             : base(distributedEnabled)
         {
             _cancellationToken = _cancellationTokenSource.Token;
@@ -69,9 +69,11 @@ namespace Umbraco.Cms.Infrastructure.Sync
             CacheInstructionService = cacheInstructionService;
             JsonSerializer = jsonSerializer;
             _lastSyncedFileManager = lastSyncedFileManager;
-            GlobalSettings = globalSettings.Value;
+            GlobalSettings = globalSettings.CurrentValue;
             _lastPruned = _lastSync = DateTime.UtcNow;
             _syncIdle = new ManualResetEvent(true);
+
+            globalSettings.OnChange(x => GlobalSettings = x);
             using (var process = Process.GetCurrentProcess())
             {
                 // See notes on _localIdentity
@@ -85,7 +87,7 @@ namespace Umbraco.Cms.Infrastructure.Sync
 
         }
 
-        public GlobalSettings GlobalSettings { get; }
+        public GlobalSettings GlobalSettings { get; private set; }
 
         protected ILogger<DatabaseServerMessenger> Logger { get; }
 

--- a/src/Umbraco.Infrastructure/Sync/SyncBootStateAccessor.cs
+++ b/src/Umbraco.Infrastructure/Sync/SyncBootStateAccessor.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Infrastructure.Sync
     {
         private readonly ILogger<SyncBootStateAccessor> _logger;
         private readonly LastSyncedFileManager _lastSyncedFileManager;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly ICacheInstructionService _cacheInstructionService;
 
         private SyncBootState _syncBootState;
@@ -21,13 +21,15 @@ namespace Umbraco.Cms.Infrastructure.Sync
         public SyncBootStateAccessor(
             ILogger<SyncBootStateAccessor> logger,
             LastSyncedFileManager lastSyncedFileManager,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             ICacheInstructionService cacheInstructionService)
         {
             _logger = logger;
             _lastSyncedFileManager = lastSyncedFileManager;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
             _cacheInstructionService = cacheInstructionService;
+
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         public SyncBootState GetSyncBootState()

--- a/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets
 
         private readonly IRuntimeMinifier _runtimeMinifier;
         private readonly IManifestParser _parser;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly CustomBackOfficeAssetsCollection _customBackOfficeAssetsCollection;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly PropertyEditorCollection _propertyEditorCollection;
@@ -38,15 +38,17 @@ namespace Umbraco.Cms.Infrastructure.WebAssets
             IManifestParser parser,
             PropertyEditorCollection propertyEditorCollection,
             IHostingEnvironment hostingEnvironment,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             CustomBackOfficeAssetsCollection customBackOfficeAssetsCollection)
         {
             _runtimeMinifier = runtimeMinifier;
             _parser = parser;
             _propertyEditorCollection = propertyEditorCollection;
             _hostingEnvironment = hostingEnvironment;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
             _customBackOfficeAssetsCollection = customBackOfficeAssetsCollection;
+
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         public void CreateBundles()
@@ -170,7 +172,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets
 
                     switch (assetType)
                     {
-                        case AssetType.Javascript:                           
+                        case AssetType.Javascript:
                             _runtimeMinifier.CreateJsBundle(bundleName, BundlingOptions.OptimizedAndComposite, filePaths);
                             break;
                         case AssetType.Css:
@@ -178,7 +180,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets
                             break;
                         default:
                             throw new IndexOutOfRangeException();
-                    }                    
+                    }
                 }
             }
         }

--- a/src/Umbraco.Tests.Common/TestOptionsMonitor.cs
+++ b/src/Umbraco.Tests.Common/TestOptionsMonitor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+
+namespace Umbraco.Cms.Tests.Common
+{
+    public class TestOptionsMonitor<T> : IOptionsMonitor<T> where T : class
+    {
+        public TestOptionsMonitor(T currentValue) => CurrentValue = currentValue;
+
+        public T Get(string name) => CurrentValue;
+
+        public IDisposable OnChange(Action<T, string> listener) => null;
+
+        public T CurrentValue { get; }
+    }
+}

--- a/src/Umbraco.Tests.Common/TestOptionsSnapshot.cs
+++ b/src/Umbraco.Tests.Common/TestOptionsSnapshot.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Umbraco.Cms.Tests.Common
+{
+    public class TestOptionsSnapshot<T> :  IOptionsSnapshot<T> where T : class
+    {
+        public TestOptionsSnapshot(T value) => Value = value;
+        public T Value { get; }
+        public T Get(string name) => Value;
+    }
+}

--- a/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -70,7 +70,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
             LocalizationService,
             HostingEnvironment,
             EntityXmlSerializer,
-            new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()),
+            Microsoft.Extensions.Options.Options.Create(new GlobalSettings()),
             MediaService,
             MediaTypeService,
             MediaFileManager,

--- a/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -15,7 +15,6 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;

--- a/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -9,14 +9,13 @@ using System.Linq;
 using System.Xml.Linq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -71,7 +70,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
             LocalizationService,
             HostingEnvironment,
             EntityXmlSerializer,
-            Microsoft.Extensions.Options.Options.Create(new GlobalSettings()),
+            new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()),
             MediaService,
             MediaTypeService,
             MediaFileManager,

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/BackOfficeUserStoreTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/BackOfficeUserStoreTests.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Security
                     UserService,
                     EntityService,
                     ExternalLoginService,
-                    new TestOptionsMonitor<GlobalSettings>(GlobalSettings),
+                    new TestOptionsSnapshot<GlobalSettings>(GlobalSettings),
                     UmbracoMapper,
                     new BackOfficeErrorDescriber(TextService),
                     AppCaches);

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/BackOfficeUserStoreTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/BackOfficeUserStoreTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -33,7 +34,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Security
                     UserService,
                     EntityService,
                     ExternalLoginService,
-                    Options.Create(GlobalSettings),
+                    new TestOptionsMonitor<GlobalSettings>(GlobalSettings),
                     UmbracoMapper,
                     new BackOfficeErrorDescriber(TextService),
                     AppCaches);

--- a/src/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
+++ b/src/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Cms.Tests.UnitTests.TestHelpers
 
         public static UriUtility UriUtility => s_testHelperInternal.UriUtility;
 
-        public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), Options.Create(new GlobalSettings()), Mock.Of<IEventAggregator>());
+        public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>());
 
         /// <summary>
         /// Some test files are copied to the /bin (/bin/debug) on build, this is a utility to return their physical path based on a virtual path name

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -27,6 +27,7 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Mappers;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.UnitTests.TestHelpers;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
@@ -68,7 +69,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
                 Mock.Of<IServiceProvider>(),
                 Options.Create(new ContentSettings()));
             IEventAggregator eventAggregator = Mock.Of<IEventAggregator>();
-            var scopeProvider = new ScopeProvider(f, fs, Options.Create(coreDebug), mediaFileManager, loggerFactory.CreateLogger<ScopeProvider>(), loggerFactory, NoAppCache.Instance, eventAggregator);
+            var scopeProvider = new ScopeProvider(f, fs, new TestOptionsMonitor<CoreDebugSettings>(coreDebug), mediaFileManager, loggerFactory.CreateLogger<ScopeProvider>(), loggerFactory, NoAppCache.Instance, eventAggregator);
 
             mock.Setup(x => x.GetService(typeof(ILogger))).Returns(logger);
             mock.Setup(x => x.GetService(typeof(ILogger<ComponentCollection>))).Returns(loggerFactory.CreateLogger<ComponentCollection>);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopeEventDispatcherTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopeEventDispatcherTests.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.Common.Builders;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
@@ -91,7 +92,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
             return new ScopeProvider(
                 Mock.Of<IUmbracoDatabaseFactory>(),
                 fileSystems,
-                Options.Create(new CoreDebugSettings()),
+                new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),
                 mediaFileManager,
                 Mock.Of<ILogger<ScopeProvider>>(),
                 instance,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
 {
@@ -92,7 +93,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
             return new ScopeProvider(
                 Mock.Of<IUmbracoDatabaseFactory>(),
                 fileSystems,
-                Options.Create(new CoreDebugSettings()),
+                new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),
                 mediaFileManager,
                 loggerFactory.CreateLogger<ScopeProvider>(),
                 loggerFactory,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var webRoutingSettings = new WebRoutingSettings();
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
-                Options.Create(webRoutingSettings),
+                new TestOptionsSnapshot<WebRoutingSettings>(webRoutingSettings),
                 new UrlProviderCollection(() => Enumerable.Empty<IUrlProvider>()),
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var webRoutingSettings = new WebRoutingSettings();
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
-                new TestOptionsMonitor<WebRoutingSettings>(webRoutingSettings),
+                Options.Create(webRoutingSettings),
                 new UrlProviderCollection(() => Enumerable.Empty<IUrlProvider>()),
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var webRoutingSettings = new WebRoutingSettings();
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
-                new TestOptionsSnapshot<WebRoutingSettings>(webRoutingSettings),
+                new TestOptionsMonitor<WebRoutingSettings>(webRoutingSettings),
                 new UrlProviderCollection(() => Enumerable.Empty<IUrlProvider>()),
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var webRoutingSettings = new WebRoutingSettings();
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
-                new TestOptionsMonitor<WebRoutingSettings>(webRoutingSettings),
+                Options.Create(webRoutingSettings),
                 new UrlProviderCollection(() => new[] { contentUrlProvider.Object }),
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
@@ -78,7 +79,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var webRoutingSettings = new WebRoutingSettings();
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
-                new TestOptionsSnapshot<WebRoutingSettings>(webRoutingSettings),
+                new TestOptionsMonitor<WebRoutingSettings>(webRoutingSettings),
                 new UrlProviderCollection(() => new[] { contentUrlProvider.Object }),
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
             var webRoutingSettings = new WebRoutingSettings();
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
-                Microsoft.Extensions.Options.Options.Create(webRoutingSettings),
+                new TestOptionsSnapshot<WebRoutingSettings>(webRoutingSettings),
                 new UrlProviderCollection(() => new[] { contentUrlProvider.Object }),
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
@@ -20,6 +20,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices;
+using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 {
@@ -149,7 +150,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockProfilingLogger = new Mock<IProfilingLogger>();
 
             return new HealthCheckNotifier(
-                Options.Create(settings),
+                new TestOptionsMonitor<HealthChecksSettings>(settings),
                 checks,
                 notifications,
                 mockRunTimeState.Object,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
@@ -150,7 +150,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockProfilingLogger = new Mock<IProfilingLogger>();
 
             return new HealthCheckNotifier(
-                Options.Create(settings),
+                new TestOptionsMonitor<HealthChecksSettings>(settings),
                 checks,
                 notifications,
                 mockRunTimeState.Object,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
@@ -150,7 +150,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockProfilingLogger = new Mock<IProfilingLogger>();
 
             return new HealthCheckNotifier(
-                new TestOptionsMonitor<HealthChecksSettings>(settings),
+                Options.Create(settings),
                 checks,
                 notifications,
                 mockRunTimeState.Object,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/KeepAliveTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/KeepAliveTests.cs
@@ -18,6 +18,7 @@ using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices;
+using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 {
@@ -107,7 +108,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             return new KeepAlive(
                 mockHostingEnvironment.Object,
                 mockMainDom.Object,
-                Options.Create(settings),
+
+                new TestOptionsMonitor<KeepAliveSettings>(settings),
                 mockLogger.Object,
                 mockProfilingLogger.Object,
                 mockServerRegistrar.Object,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices;
+using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 {
@@ -87,7 +88,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                 mockMainDom.Object,
                 mockServerRegistrar.Object,
                 _mockAuditService.Object,
-                Options.Create(settings),
+                new TestOptionsMonitor<LoggingSettings>(settings),
                 mockScopeProvider.Object,
                 mockLogger.Object,
                 mockProfilingLogger.Object);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
                 _mockServerRegistrationService.Object,
                 mockRequestAccessor.Object,
                 mockLogger.Object,
-                new TestOptionsSnapshot<GlobalSettings>(settings));
+                new TestOptionsMonitor<GlobalSettings>(settings));
         }
 
         private void VerifyServerNotTouched() => VerifyServerTouchedTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
                 _mockServerRegistrationService.Object,
                 mockRequestAccessor.Object,
                 mockLogger.Object,
-                new TestOptionsMonitor<GlobalSettings>(settings));
+                new TestOptionsSnapshot<GlobalSettings>(settings));
         }
 
         private void VerifyServerNotTouched() => VerifyServerTouchedTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration;
+using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.ServerRegistration
 {
@@ -76,7 +77,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
                 _mockServerRegistrationService.Object,
                 mockRequestAccessor.Object,
                 mockLogger.Object,
-                Options.Create(settings));
+                new TestOptionsMonitor<GlobalSettings>(settings));
         }
 
         private void VerifyServerNotTouched() => VerifyServerTouchedTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
@@ -18,6 +18,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 {
@@ -59,7 +60,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
             return new ScopeProvider(
                 databaseFactory.Object,
                 fileSystems,
-                Options.Create(new CoreDebugSettings()),
+                new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),
                 mediaFileManager,
                 loggerFactory.CreateLogger<ScopeProvider>(),
                 loggerFactory,

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
         private Mock<IPasswordHasher<MemberIdentityUser>> _mockPasswordHasher;
         private Mock<IMemberService> _mockMemberService;
         private Mock<IServiceProvider> _mockServiceProviders;
-        private Mock<IOptions<MemberPasswordConfigurationSettings>> _mockPasswordConfiguration;
+        private Mock<IOptionsMonitor<MemberPasswordConfigurationSettings>> _mockPasswordConfiguration;
 
         public MemberManager CreateSut()
         {
@@ -65,8 +65,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
             userValidators.Add(validator.Object);
 
             _mockServiceProviders = new Mock<IServiceProvider>();
-            _mockPasswordConfiguration = new Mock<IOptions<MemberPasswordConfigurationSettings>>();
-            _mockPasswordConfiguration.Setup(x => x.Value).Returns(() =>
+            _mockPasswordConfiguration = new Mock<IOptionsMonitor<MemberPasswordConfigurationSettings>>();
+            _mockPasswordConfiguration.Setup(x => x.CurrentValue).Returns(() =>
                 new MemberPasswordConfigurationSettings()
                 {
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -17,6 +17,7 @@ using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Web.Common.Security;
@@ -43,7 +44,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
                 new IdentityMapDefinition(
                     Mock.Of<ILocalizedTextService>(),
                     Mock.Of<IEntityService>(),
-                    Options.Create(new GlobalSettings()),
+                    new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()),
                     AppCaches.Disabled),
             };
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
         private Mock<IPasswordHasher<MemberIdentityUser>> _mockPasswordHasher;
         private Mock<IMemberService> _mockMemberService;
         private Mock<IServiceProvider> _mockServiceProviders;
-        private Mock<IOptionsMonitor<MemberPasswordConfigurationSettings>> _mockPasswordConfiguration;
+        private Mock<IOptionsSnapshot<MemberPasswordConfigurationSettings>> _mockPasswordConfiguration;
 
         public MemberManager CreateSut()
         {
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
                 new IdentityMapDefinition(
                     Mock.Of<ILocalizedTextService>(),
                     Mock.Of<IEntityService>(),
-                    new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()),
+                    new TestOptionsSnapshot<GlobalSettings>(new GlobalSettings()),
                     AppCaches.Disabled),
             };
 
@@ -65,8 +65,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Security
             userValidators.Add(validator.Object);
 
             _mockServiceProviders = new Mock<IServiceProvider>();
-            _mockPasswordConfiguration = new Mock<IOptionsMonitor<MemberPasswordConfigurationSettings>>();
-            _mockPasswordConfiguration.Setup(x => x.CurrentValue).Returns(() =>
+            _mockPasswordConfiguration = new Mock<IOptionsSnapshot<MemberPasswordConfigurationSettings>>();
+            _mockPasswordConfiguration.Setup(x => x.Value).Returns(() =>
                 new MemberPasswordConfigurationSettings()
                 {
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/RoutableDocumentFilterTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/RoutableDocumentFilterTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Web.Common.Routing;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Routing
@@ -91,7 +92,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Routing
             var endpointDataSource = new DefaultEndpointDataSource(endpoint1, endpoint2);
 
             var routableDocFilter = new RoutableDocumentFilter(
-                Options.Create(globalSettings),
+                new TestOptionsSnapshot<GlobalSettings>(globalSettings),
                 Options.Create(routingSettings),
                 GetHostingEnvironment(),
                 endpointDataSource);
@@ -120,7 +121,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Routing
             var endpointDataSource = new DefaultEndpointDataSource(endpoint1);
 
             var routableDocFilter = new RoutableDocumentFilter(
-                Options.Create(globalSettings),
+                new TestOptionsSnapshot<GlobalSettings>(globalSettings),
                 Options.Create(routingSettings),
                 GetHostingEnvironment(),
                 endpointDataSource);

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -15,6 +15,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
@@ -68,7 +69,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
                     new MembersErrorDescriber(Mock.Of<ILocalizedTextService>()),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<ILogger<UserManager<MemberIdentityUser>>>(),
-                    Options.Create(new MemberPasswordConfigurationSettings()),
+                    new TestOptionsMonitor<MemberPasswordConfigurationSettings>(new MemberPasswordConfigurationSettings()),
                     Mock.Of<IPublicAccessService>(),
                     Mock.Of<IHttpContextAccessor>());
 
@@ -76,7 +77,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
         public async Task WhenPasswordSignInAsyncIsCalled_AndEverythingIsSetup_ThenASignInResultSucceededShouldBeReturnedAsync()
         {
             //arrange
-            var userId = "bo8w3d32q9b98";            
+            var userId = "bo8w3d32q9b98";
             MemberSignInManager sut = CreateSut();
             var fakeUser = new MemberIdentityUser(777)
             {

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -69,7 +69,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security
                     new MembersErrorDescriber(Mock.Of<ILocalizedTextService>()),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<ILogger<UserManager<MemberIdentityUser>>>(),
-                    new TestOptionsMonitor<MemberPasswordConfigurationSettings>(new MemberPasswordConfigurationSettings()),
+                    new TestOptionsSnapshot<MemberPasswordConfigurationSettings>(new MemberPasswordConfigurationSettings()),
                     Mock.Of<IPublicAccessService>(),
                     Mock.Of<IHttpContextAccessor>());
 

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/RenderNoContentControllerTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/RenderNoContentControllerTests.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers
             var mockUmbracoContext = new Mock<IUmbracoContext>();
             mockUmbracoContext.Setup(x => x.Content.HasContent()).Returns(true);
             var mockIOHelper = new Mock<IIOHelper>();
-            var controller = new RenderNoContentController(new TestUmbracoContextAccessor(mockUmbracoContext.Object), mockIOHelper.Object, Options.Create(new GlobalSettings()));
+            var controller = new RenderNoContentController(new TestUmbracoContextAccessor(mockUmbracoContext.Object), mockIOHelper.Object, new TestOptionsSnapshot<GlobalSettings>(new GlobalSettings()));
 
             var result = controller.Index() as RedirectResult;
 
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers
             var mockIOHelper = new Mock<IIOHelper>();
             mockIOHelper.Setup(x => x.ResolveUrl(It.Is<string>(y => y == UmbracoPathSetting))).Returns(UmbracoPath);
 
-            IOptions<GlobalSettings> globalSettings = Options.Create(new GlobalSettings()
+            var globalSettings = new TestOptionsSnapshot<GlobalSettings>(new GlobalSettings()
             {
                 UmbracoPath = UmbracoPathSetting,
                 NoNodesViewPath = ViewPath,

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -60,11 +60,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IUserService _userService;
         private readonly ILocalizedTextService _textService;
         private readonly IUmbracoMapper _umbracoMapper;
-        private GlobalSettings _globalSettings;
-        private SecuritySettings _securitySettings;
+        private readonly GlobalSettings _globalSettings;
+        private readonly SecuritySettings _securitySettings;
         private readonly ILogger<AuthenticationController> _logger;
         private readonly IIpResolver _ipResolver;
-        private UserPasswordConfigurationSettings _passwordConfiguration;
+        private readonly UserPasswordConfigurationSettings _passwordConfiguration;
         private readonly IEmailSender _emailSender;
         private readonly ISmsSender _smsSender;
         private readonly IHostingEnvironment _hostingEnvironment;
@@ -81,11 +81,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IUserService userService,
             ILocalizedTextService textService,
             IUmbracoMapper umbracoMapper,
-            IOptionsMonitor<GlobalSettings> globalSettings,
-            IOptionsMonitor<SecuritySettings> securitySettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
+            IOptionsSnapshot<SecuritySettings> securitySettings,
             ILogger<AuthenticationController> logger,
             IIpResolver ipResolver,
-            IOptionsMonitor<UserPasswordConfigurationSettings> passwordConfiguration,
+            IOptionsSnapshot<UserPasswordConfigurationSettings> passwordConfiguration,
             IEmailSender emailSender,
             ISmsSender smsSender,
             IHostingEnvironment hostingEnvironment,
@@ -99,11 +99,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _userService = userService;
             _textService = textService;
             _umbracoMapper = umbracoMapper;
-            _globalSettings = globalSettings.CurrentValue;
-            _securitySettings = securitySettings.CurrentValue;
+            _globalSettings = globalSettings.Value;
+            _securitySettings = securitySettings.Value;
             _logger = logger;
             _ipResolver = ipResolver;
-            _passwordConfiguration = passwordConfiguration.CurrentValue;
+            _passwordConfiguration = passwordConfiguration.Value;
             _emailSender = emailSender;
             _smsSender = smsSender;
             _hostingEnvironment = hostingEnvironment;

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -60,11 +60,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IUserService _userService;
         private readonly ILocalizedTextService _textService;
         private readonly IUmbracoMapper _umbracoMapper;
-        private readonly GlobalSettings _globalSettings;
-        private readonly SecuritySettings _securitySettings;
+        private GlobalSettings _globalSettings;
+        private SecuritySettings _securitySettings;
         private readonly ILogger<AuthenticationController> _logger;
         private readonly IIpResolver _ipResolver;
-        private readonly UserPasswordConfigurationSettings _passwordConfiguration;
+        private UserPasswordConfigurationSettings _passwordConfiguration;
         private readonly IEmailSender _emailSender;
         private readonly ISmsSender _smsSender;
         private readonly IHostingEnvironment _hostingEnvironment;
@@ -81,11 +81,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IUserService userService,
             ILocalizedTextService textService,
             IUmbracoMapper umbracoMapper,
-            IOptions<GlobalSettings> globalSettings,
-            IOptions<SecuritySettings> securitySettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptionsMonitor<SecuritySettings> securitySettings,
             ILogger<AuthenticationController> logger,
             IIpResolver ipResolver,
-            IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
+            IOptionsMonitor<UserPasswordConfigurationSettings> passwordConfiguration,
             IEmailSender emailSender,
             ISmsSender smsSender,
             IHostingEnvironment hostingEnvironment,
@@ -99,17 +99,18 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _userService = userService;
             _textService = textService;
             _umbracoMapper = umbracoMapper;
-            _globalSettings = globalSettings.Value;
-            _securitySettings = securitySettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
+            _securitySettings = securitySettings.CurrentValue;
             _logger = logger;
             _ipResolver = ipResolver;
-            _passwordConfiguration = passwordConfiguration.Value;
+            _passwordConfiguration = passwordConfiguration.CurrentValue;
             _emailSender = emailSender;
             _smsSender = smsSender;
             _hostingEnvironment = hostingEnvironment;
             _linkGenerator = linkGenerator;
             _externalAuthenticationOptions = externalAuthenticationOptions;
             _backOfficeTwoFactorOptions = backOfficeTwoFactorOptions;
+
         }
 
         /// <summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeAssetsController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeAssetsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
     {
         private readonly IFileSystem _jsLibFileSystem;
 
-        public BackOfficeAssetsController(IIOHelper ioHelper, IHostingEnvironment hostingEnvironment, ILoggerFactory loggerFactory, IOptions<GlobalSettings> globalSettings)
+        public BackOfficeAssetsController(IIOHelper ioHelper, IHostingEnvironment hostingEnvironment, ILoggerFactory loggerFactory, IOptionsSnapshot<GlobalSettings> globalSettings)
         {
             var path = globalSettings.Value.UmbracoPath + Path.DirectorySeparatorChar + "lib";
             _jsLibFileSystem = new PhysicalFileSystem(ioHelper, hostingEnvironment, loggerFactory.CreateLogger<PhysicalFileSystem>(), hostingEnvironment.MapPathWebRoot(path), hostingEnvironment.ToAbsolute(path));

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -92,7 +92,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _userManager = userManager;
             _runtimeState = runtimeState;
             _runtimeMinifier = runtimeMinifier;
-            _globalSettings = globalSettings.CurrentValue;
+            _globalSettings = globalSettings.Value;
             _hostingEnvironment = hostingEnvironment;
             _textService = textService;
             _gridConfig = gridConfig ?? throw new ArgumentNullException(nameof(gridConfig));

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IBackOfficeUserManager _userManager;
         private readonly IRuntimeState _runtimeState;
         private readonly IRuntimeMinifier _runtimeMinifier;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILocalizedTextService _textService;
         private readonly IGridConfig _gridConfig;
@@ -73,7 +73,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IBackOfficeUserManager userManager,
             IRuntimeState runtimeState,
             IRuntimeMinifier runtimeMinifier,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             IHostingEnvironment hostingEnvironment,
             ILocalizedTextService textService,
             IGridConfig gridConfig,
@@ -92,7 +92,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _userManager = userManager;
             _runtimeState = runtimeState;
             _runtimeMinifier = runtimeMinifier;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
             _hostingEnvironment = hostingEnvironment;
             _textService = textService;
             _gridConfig = gridConfig ?? throw new ArgumentNullException(nameof(gridConfig));

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IImageUrlGenerator _imageUrlGenerator;
         private readonly PreviewRoutes _previewRoutes;
         private readonly IEmailSender _emailSender;
-        private readonly MemberPasswordConfigurationSettings _memberPasswordConfigurationSettings;
+        private MemberPasswordConfigurationSettings _memberPasswordConfigurationSettings;
 
         public BackOfficeServerVariables(
             LinkGenerator linkGenerator,
@@ -69,7 +69,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IImageUrlGenerator imageUrlGenerator,
             PreviewRoutes previewRoutes,
             IEmailSender emailSender,
-            IOptions<MemberPasswordConfigurationSettings> memberPasswordConfigurationSettings)
+            IOptionsMonitor<MemberPasswordConfigurationSettings> memberPasswordConfigurationSettings)
         {
             _linkGenerator = linkGenerator;
             _runtimeState = runtimeState;
@@ -87,12 +87,13 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _imageUrlGenerator = imageUrlGenerator;
             _previewRoutes = previewRoutes;
             _emailSender = emailSender;
-            _memberPasswordConfigurationSettings = memberPasswordConfigurationSettings.Value;
+            _memberPasswordConfigurationSettings = memberPasswordConfigurationSettings.CurrentValue;
 
             globalSettings.OnChange(x => _globalSettings = x);
             contentSettings.OnChange(x => _contentSettings = x);
             runtimeSettings.OnChange(x => _runtimeSettings = x);
             securitySettings.OnChange(x => _securitySettings = x);
+            memberPasswordConfigurationSettings.OnChange(x => _memberPasswordConfigurationSettings = x);
         }
 
         /// <summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -37,14 +37,14 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly LinkGenerator _linkGenerator;
         private readonly IRuntimeState _runtimeState;
         private readonly UmbracoFeatures _features;
-        private readonly GlobalSettings _globalSettings;
+        private  GlobalSettings _globalSettings;
         private readonly IUmbracoVersion _umbracoVersion;
-        private readonly ContentSettings _contentSettings;
+        private  ContentSettings _contentSettings;
         private readonly TreeCollection _treeCollection;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IHostingEnvironment _hostingEnvironment;
-        private readonly RuntimeSettings _runtimeSettings;
-        private readonly SecuritySettings _securitySettings;
+        private  RuntimeSettings _runtimeSettings;
+        private  SecuritySettings _securitySettings;
         private readonly IRuntimeMinifier _runtimeMinifier;
         private readonly IBackOfficeExternalLoginProviders _externalLogins;
         private readonly IImageUrlGenerator _imageUrlGenerator;
@@ -56,14 +56,14 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             LinkGenerator linkGenerator,
             IRuntimeState runtimeState,
             UmbracoFeatures features,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IUmbracoVersion umbracoVersion,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             IHttpContextAccessor httpContextAccessor,
             TreeCollection treeCollection,
             IHostingEnvironment hostingEnvironment,
-            IOptions<RuntimeSettings> runtimeSettings,
-            IOptions<SecuritySettings> securitySettings,
+            IOptionsMonitor<RuntimeSettings> runtimeSettings,
+            IOptionsMonitor<SecuritySettings> securitySettings,
             IRuntimeMinifier runtimeMinifier,
             IBackOfficeExternalLoginProviders externalLogins,
             IImageUrlGenerator imageUrlGenerator,
@@ -74,20 +74,25 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _linkGenerator = linkGenerator;
             _runtimeState = runtimeState;
             _features = features;
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
             _umbracoVersion = umbracoVersion;
-            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
             _httpContextAccessor = httpContextAccessor;
             _treeCollection = treeCollection ?? throw new ArgumentNullException(nameof(treeCollection));
             _hostingEnvironment = hostingEnvironment;
-            _runtimeSettings = runtimeSettings.Value;
-            _securitySettings = securitySettings.Value;
+            _runtimeSettings = runtimeSettings.CurrentValue;
+            _securitySettings = securitySettings.CurrentValue;
             _runtimeMinifier = runtimeMinifier;
             _externalLogins = externalLogins;
             _imageUrlGenerator = imageUrlGenerator;
             _previewRoutes = previewRoutes;
             _emailSender = emailSender;
             _memberPasswordConfigurationSettings = memberPasswordConfigurationSettings.Value;
+
+            globalSettings.OnChange(x => _globalSettings = x);
+            contentSettings.OnChange(x => _contentSettings = x);
+            runtimeSettings.OnChange(x => _runtimeSettings = x);
+            securitySettings.OnChange(x => _securitySettings = x);
         }
 
         /// <summary>
@@ -487,11 +492,13 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                 // exclude anything marked with CoreTreeAttribute
                 var coreTree = treeType.GetCustomAttribute<CoreTreeAttribute>(false);
-                if (coreTree != null) continue;
+                if (coreTree != null)
+                    continue;
 
                 // exclude anything not marked with PluginControllerAttribute
                 var pluginController = treeType.GetCustomAttribute<PluginControllerAttribute>(false);
-                if (pluginController == null) continue;
+                if (pluginController == null)
+                    continue;
 
                 yield return new PluginTree { Alias = tree.TreeAlias, PackageFolder = pluginController.AreaName };
             }

--- a/src/Umbraco.Web.BackOffice/Controllers/CodeFileController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/CodeFileController.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             ILocalizedTextService localizedTextService,
             IUmbracoMapper umbracoMapper,
             IShortStringHelper shortStringHelper,
-            IOptions<GlobalSettings> globalSettings)
+            IOptionsSnapshot<GlobalSettings> globalSettings)
         {
             _hostingEnvironment = hostingEnvironment;
             _fileSystems = fileSystems;

--- a/src/Umbraco.Web.BackOffice/Controllers/CurrentUserController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/CurrentUserController.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
         public CurrentUserController(
             MediaFileManager mediaFileManager,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsSnapshot<ContentSettings> contentSettings,
             IHostingEnvironment hostingEnvironment,
             IImageUrlGenerator imageUrlGenerator,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,

--- a/src/Umbraco.Web.BackOffice/Controllers/DashboardController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DashboardController.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IDashboardService _dashboardService;
         private readonly IUmbracoVersion _umbracoVersion;
         private readonly IShortStringHelper _shortStringHelper;
-        private readonly IOptions<ContentDashboardSettings> _dashboardSettings;
+        private readonly ContentDashboardSettings _dashboardSettings;
         /// <summary>
         /// Initializes a new instance of the <see cref="DashboardController"/> with all its dependencies.
         /// </summary>
@@ -51,7 +51,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IDashboardService dashboardService,
             IUmbracoVersion umbracoVersion,
             IShortStringHelper shortStringHelper,
-            IOptions<ContentDashboardSettings> dashboardSettings)
+            IOptionsSnapshot<ContentDashboardSettings> dashboardSettings)
 
         {
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -60,7 +60,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _dashboardService = dashboardService;
             _umbracoVersion = umbracoVersion;
             _shortStringHelper = shortStringHelper;
-            _dashboardSettings = dashboardSettings;
+            _dashboardSettings = dashboardSettings.Value;
         }
 
         //we have just one instance of HttpClient shared for the entire application
@@ -78,7 +78,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             var url = string.Format("{0}{1}?section={2}&allowed={3}&lang={4}&version={5}&admin={6}",
                 baseUrl,
-                _dashboardSettings.Value.ContentDashboardPath,
+                _dashboardSettings.ContentDashboardPath,
                 section,
                 allowedSections,
                 language,

--- a/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         public DataTypeController(
             PropertyEditorCollection propertyEditors,
             IDataTypeService dataTypeService,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsSnapshot<ContentSettings> contentSettings,
             IUmbracoMapper umbracoMapper,
             PropertyEditorCollection propertyEditorCollection,
             IContentTypeService contentTypeService,

--- a/src/Umbraco.Web.BackOffice/Controllers/DictionaryController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DictionaryController.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             ILogger<DictionaryController> logger,
             ILocalizationService localizationService,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             ILocalizedTextService localizedTextService,
             IUmbracoMapper umbracoMapper
             )

--- a/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
         public LanguageController(ILocalizationService localizationService,
             IUmbracoMapper umbracoMapper,
-            IOptions<GlobalSettings> globalSettings)
+            IOptionsSnapshot<GlobalSettings> globalSettings)
         {
             _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
             _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -78,7 +78,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IShortStringHelper shortStringHelper,
             IEventMessagesFactory eventMessages,
             ILocalizedTextService localizedTextService,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsSnapshot<ContentSettings> contentSettings,
             IMediaTypeService mediaTypeService,
             IMediaService mediaService,
             IEntityService entityService,

--- a/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
         public PreviewController(
             UmbracoFeatures features,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             IPublishedSnapshotService publishedSnapshotService,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
             ILocalizationService localizationService,

--- a/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         public TinyMceController(
             IHostingEnvironment hostingEnvironment,
             IShortStringHelper shortStringHelper,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsSnapshot<ContentSettings> contentSettings,
             IIOHelper ioHelper,
             IImageUrlGenerator imageUrlGenerator)
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/TourController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TourController.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         public TourController(
             TourFilterCollection filters,
             IHostingEnvironment hostingEnvironment,
-            IOptions<TourSettings> tourSettings,
+            IOptionsSnapshot<TourSettings> tourSettings,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
             IContentTypeService contentTypeService)
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/UpdateCheckController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UpdateCheckController.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IUmbracoVersion umbracoVersion,
             ICookieManager cookieManager,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
-            IOptions<GlobalSettings> globalSettings)
+            IOptionsSnapshot<GlobalSettings> globalSettings)
         {
             _upgradeService = upgradeService ?? throw new ArgumentNullException(nameof(upgradeService));
             _umbracoVersion = umbracoVersion ?? throw new ArgumentNullException(nameof(umbracoVersion));
@@ -81,7 +81,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             {
                 private readonly GlobalSettings _globalSettings;
 
-                public UpdateCheckResponseFilter(IOptions<GlobalSettings> globalSettings)
+                public UpdateCheckResponseFilter(IOptionsSnapshot<GlobalSettings> globalSettings)
                 {
                     _globalSettings = globalSettings.Value;
                 }

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -78,11 +78,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
         public UsersController(
             MediaFileManager mediaFileManager,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsSnapshot<ContentSettings> contentSettings,
             IHostingEnvironment hostingEnvironment,
             ISqlContext sqlContext,
             IImageUrlGenerator imageUrlGenerator,
-            IOptions<SecuritySettings> securitySettings,
+            IOptionsSnapshot<SecuritySettings> securitySettings,
             IEmailSender emailSender,
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
             AppCaches appCaches,
@@ -90,7 +90,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IUserService userService,
             ILocalizedTextService localizedTextService,
             IUmbracoMapper umbracoMapper,
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsSnapshot<GlobalSettings> globalSettings,
             IBackOfficeUserManager backOfficeUserManager,
             ILoggerFactory loggerFactory,
             LinkGenerator linkGenerator,
@@ -554,7 +554,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             // This needs to be in the correct mailto format including the name, else
             // the name cannot be captured in the email sending notification.
-            // i.e. "Some Person" <hello@example.com>            
+            // i.e. "Some Person" <hello@example.com>
             var toMailBoxAddress = new MailboxAddress(to.Name, to.Email);
 
             var mailMessage = new EmailMessage(fromEmail, toMailBoxAddress.ToString(), emailSubject, emailBody, true);

--- a/src/Umbraco.Web.BackOffice/Filters/CheckIfUserTicketDataIsStaleAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/CheckIfUserTicketDataIsStaleAttribute.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
             private readonly IUserService _userService;
             private readonly IEntityService _entityService;
             private readonly ILocalizedTextService _localizedTextService;
-            private readonly IOptions<GlobalSettings> _globalSettings;
+            private GlobalSettings _globalSettings;
             private readonly IBackOfficeSignInManager _backOfficeSignInManager;
             private readonly IBackOfficeAntiforgery _backOfficeAntiforgery;
             private readonly IScopeProvider _scopeProvider;
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
                 IUserService userService,
                 IEntityService entityService,
                 ILocalizedTextService localizedTextService,
-                IOptions<GlobalSettings> globalSettings,
+                IOptionsSnapshot<GlobalSettings> globalSettings,
                 IBackOfficeSignInManager backOfficeSignInManager,
                 IBackOfficeAntiforgery backOfficeAntiforgery,
                 IScopeProvider scopeProvider,
@@ -61,7 +61,7 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
                 _userService = userService;
                 _entityService = entityService;
                 _localizedTextService = localizedTextService;
-                _globalSettings = globalSettings;
+                _globalSettings = globalSettings.Value;
                 _backOfficeSignInManager = backOfficeSignInManager;
                 _backOfficeAntiforgery = backOfficeAntiforgery;
                 _scopeProvider = scopeProvider;
@@ -136,7 +136,7 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
                         () => user.Username != identity.GetUsername(),
                         () =>
                         {
-                            CultureInfo culture = user.GetUserCulture(_localizedTextService, _globalSettings.Value);
+                            CultureInfo culture = user.GetUserCulture(_localizedTextService, _globalSettings);
                             return culture != null && culture.ToString() != identity.GetCultureString();
                         },
                         () => user.AllowedSections.UnsortedSequenceEqual(identity.GetAllowedApplications()) == false,

--- a/src/Umbraco.Web.BackOffice/Filters/JsonCamelCaseFormatterAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/JsonCamelCaseFormatterAttribute.cs
@@ -18,12 +18,12 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
         private class JsonCamelCaseFormatterFilter : IResultFilter
         {
             private readonly ArrayPool<char> _arrayPool;
-            private readonly IOptions<MvcOptions> _options;
+            private readonly MvcOptions _options;
 
-            public JsonCamelCaseFormatterFilter(ArrayPool<char> arrayPool, IOptions<MvcOptions> options)
+            public JsonCamelCaseFormatterFilter(ArrayPool<char> arrayPool, IOptionsSnapshot<MvcOptions> options)
             {
                 _arrayPool = arrayPool;
-                _options = options;
+                _options = options.Value;
             }
             public void OnResultExecuted(ResultExecutedContext context)
             {
@@ -39,11 +39,9 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
                     };
 
                     objectResult.Formatters.Clear();
-                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options.Value));
+                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options));
                 }
             }
-
-
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Filters/UmbracoRequireHttpsAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/UmbracoRequireHttpsAttribute.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
             // just like the base class does, we'll just resolve the required services from the httpcontext.
             // we want to re-use their code so we don't have much choice, else we have to do some code tricks,
             // this is just easiest.
-            var optionsAccessor = filterContext.HttpContext.RequestServices.GetRequiredService<IOptions<GlobalSettings>>();
+            var optionsAccessor = filterContext.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<GlobalSettings>>();
             if (optionsAccessor.Value.UseHttps)
             {
                 // only continue if this flag is set

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeAntiforgery.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeAntiforgery.cs
@@ -24,9 +24,9 @@ namespace Umbraco.Cms.Web.BackOffice.Security
     public class BackOfficeAntiforgery : IBackOfficeAntiforgery
     {
         private readonly IAntiforgery _internalAntiForgery;
-        private readonly GlobalSettings _globalSettings;
+        private GlobalSettings _globalSettings;
 
-        public BackOfficeAntiforgery(IOptions<GlobalSettings> globalSettings)
+        public BackOfficeAntiforgery(IOptionsMonitor<GlobalSettings> globalSettings)
         {
             // NOTE: This is the only way to create a separate IAntiForgery service :(
             // Everything in netcore is internal. I have logged an issue here https://github.com/dotnet/aspnetcore/issues/22217
@@ -40,7 +40,10 @@ namespace Umbraco.Cms.Web.BackOffice.Security
             });
             ServiceProvider container = services.BuildServiceProvider();
             _internalAntiForgery = container.GetRequiredService<IAntiforgery>();
-            _globalSettings = globalSettings.Value;
+            _globalSettings = globalSettings.CurrentValue;
+            globalSettings.OnChange(x => {
+                _globalSettings = x;
+            });
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSessionIdValidator.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSessionIdValidator.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Cms.Web.BackOffice.Security
         /// <summary>
         /// Initializes a new instance of the <see cref="BackOfficeSessionIdValidator"/> class.
         /// </summary>
-        public BackOfficeSessionIdValidator(ISystemClock systemClock, IOptions<GlobalSettings> globalSettings, IBackOfficeUserManager userManager)
+        public BackOfficeSessionIdValidator(ISystemClock systemClock, IOptionsSnapshot<GlobalSettings> globalSettings, IBackOfficeUserManager userManager)
         {
             _systemClock = systemClock;
             _globalSettings = globalSettings.Value;

--- a/src/Umbraco.Web.BackOffice/Services/IconService.cs
+++ b/src/Umbraco.Web.BackOffice/Services/IconService.cs
@@ -15,18 +15,20 @@ namespace Umbraco.Cms.Web.BackOffice.Services
 {
     public class IconService : IIconService
     {
-        private readonly IOptions<GlobalSettings> _globalSettings;
+        private GlobalSettings _globalSettings;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IAppPolicyCache _cache;
 
         public IconService(
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IHostingEnvironment hostingEnvironment,
             AppCaches appCaches)
         {
-            _globalSettings = globalSettings;
+            _globalSettings = globalSettings.CurrentValue;
             _hostingEnvironment = hostingEnvironment;
             _cache = appCaches.RuntimeCache;
+
+            globalSettings.OnChange(x => _globalSettings = x);
         }
 
         /// <inheritdoc />
@@ -114,7 +116,7 @@ namespace Umbraco.Cms.Web.BackOffice.Services
             }
 
             // add icons from IconsPath if not already added from plugins
-            var coreIconsDirectory = new DirectoryInfo(_hostingEnvironment.MapPathWebRoot($"{_globalSettings.Value.IconsPath}/"));
+            var coreIconsDirectory = new DirectoryInfo(_hostingEnvironment.MapPathWebRoot($"{_globalSettings.IconsPath}/"));
             var coreIcons = coreIconsDirectory.GetFiles("*.svg");
 
             icons.UnionWith(coreIcons);

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
     public class AspNetCoreRequestAccessor : IRequestAccessor, INotificationHandler<UmbracoRequestBeginNotification>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private WebRoutingSettings _webRoutingSettings;
         private readonly ISet<string> _applicationUrls = new HashSet<string>();
         private Uri _currentApplicationUrl;
         private object _initLocker = new object();
@@ -27,10 +27,11 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
         /// </summary>
         public AspNetCoreRequestAccessor(
             IHttpContextAccessor httpContextAccessor,
-            IOptions<WebRoutingSettings> webRoutingSettings)
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings)
         {
             _httpContextAccessor = httpContextAccessor;
-            _webRoutingSettings = webRoutingSettings.Value;
+            _webRoutingSettings = webRoutingSettings.CurrentValue;
+            webRoutingSettings.OnChange(x => _webRoutingSettings = x);
 
         }
 
@@ -40,7 +41,8 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
         private string GetFormValue(string name)
         {
             var request = _httpContextAccessor.GetRequiredHttpContext().Request;
-            if (!request.HasFormContentType) return null;
+            if (!request.HasFormContentType)
+                return null;
             return request.Form[name];
         }
 

--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -109,7 +109,7 @@ namespace Umbraco.Extensions
         public static IApplicationBuilder UseUmbracoPluginsStaticFiles(this IApplicationBuilder app)
         {
             var hostingEnvironment = app.ApplicationServices.GetRequiredService<IHostingEnvironment>();
-            var umbracoPluginSettings = app.ApplicationServices.GetRequiredService<IOptions<UmbracoPluginSettings>>();
+            var umbracoPluginSettings = app.ApplicationServices.GetRequiredService<IOptionsMonitor<UmbracoPluginSettings>>();
 
             var pluginFolder = hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.AppPlugins);
 

--- a/src/Umbraco.Web.Common/Filters/AngularJsonOnlyConfigurationAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/AngularJsonOnlyConfigurationAttribute.cs
@@ -24,11 +24,10 @@ namespace Umbraco.Cms.Web.Common.Filters
             private readonly ArrayPool<char> _arrayPool;
             private MvcOptions _options;
 
-            public AngularJsonOnlyConfigurationFilter(ArrayPool<char> arrayPool, IOptionsMonitor<MvcOptions> options)
+            public AngularJsonOnlyConfigurationFilter(ArrayPool<char> arrayPool, IOptionsSnapshot<MvcOptions> options)
             {
                 _arrayPool = arrayPool;
-                _options = options.CurrentValue;
-                options.OnChange(x => _options = x);
+                _options = options.Value;
             }
 
             public void OnResultExecuted(ResultExecutedContext context)

--- a/src/Umbraco.Web.Common/Filters/AngularJsonOnlyConfigurationAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/AngularJsonOnlyConfigurationAttribute.cs
@@ -22,12 +22,13 @@ namespace Umbraco.Cms.Web.Common.Filters
         private class AngularJsonOnlyConfigurationFilter : IResultFilter
         {
             private readonly ArrayPool<char> _arrayPool;
-            private readonly IOptions<MvcOptions> _options;
+            private MvcOptions _options;
 
-            public AngularJsonOnlyConfigurationFilter(ArrayPool<char> arrayPool, IOptions<MvcOptions> options)
+            public AngularJsonOnlyConfigurationFilter(ArrayPool<char> arrayPool, IOptionsMonitor<MvcOptions> options)
             {
                 _arrayPool = arrayPool;
-                _options = options;
+                _options = options.CurrentValue;
+                options.OnChange(x => _options = x);
             }
 
             public void OnResultExecuted(ResultExecutedContext context)
@@ -45,7 +46,7 @@ namespace Umbraco.Cms.Web.Common.Filters
                     };
 
                     objectResult.Formatters.Clear();
-                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options.Value));
+                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options));
                 }
             }
         }

--- a/src/Umbraco.Web.Common/Filters/JsonDateTimeFormatAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/JsonDateTimeFormatAttribute.cs
@@ -25,12 +25,12 @@ namespace Umbraco.Cms.Web.Common.Filters
             private readonly string _format = "yyyy-MM-dd HH:mm:ss";
 
             private readonly ArrayPool<char> _arrayPool;
-            private readonly IOptions<MvcOptions> _options;
+            private readonly MvcOptions _options;
 
-            public JsonDateTimeFormatFilter(ArrayPool<char> arrayPool, IOptions<MvcOptions> options)
+            public JsonDateTimeFormatFilter(ArrayPool<char> arrayPool, IOptionsSnapshot<MvcOptions> options)
             {
                 _arrayPool = arrayPool;
-                _options = options;
+                _options = options.Value;
             }
 
             public void OnResultExecuted(ResultExecutedContext context)
@@ -47,9 +47,8 @@ namespace Umbraco.Cms.Web.Common.Filters
                         {
                             DateTimeFormat = _format
                         });
-
                     objectResult.Formatters.Clear();
-                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options.Value));
+                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options));
                 }
             }
         }

--- a/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Web.Common.Filters
             private readonly ExceptionFilterSettings _exceptionFilterSettings;
             private readonly IPublishedModelFactory _publishedModelFactory;
 
-            public ModelBindingExceptionFilter(IOptions<ExceptionFilterSettings> exceptionFilterSettings, IPublishedModelFactory publishedModelFactory)
+            public ModelBindingExceptionFilter(IOptionsSnapshot<ExceptionFilterSettings> exceptionFilterSettings, IPublishedModelFactory publishedModelFactory)
             {
                 _exceptionFilterSettings = exceptionFilterSettings.Value;
                 _publishedModelFactory = publishedModelFactory ?? throw new ArgumentNullException(nameof(publishedModelFactory));

--- a/src/Umbraco.Web.Common/Filters/OutgoingNoHyphenGuidFormatAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/OutgoingNoHyphenGuidFormatAttribute.cs
@@ -18,14 +18,13 @@ namespace Umbraco.Cms.Web.Common.Filters
 
         private class OutgoingNoHyphenGuidFormatFilter : IResultFilter
         {
-            private readonly IOptions<MvcNewtonsoftJsonOptions> _mvcNewtonsoftJsonOptions;
             private readonly ArrayPool<char> _arrayPool;
-            private readonly IOptions<MvcOptions> _options;
+            private readonly MvcOptions _options;
 
-            public OutgoingNoHyphenGuidFormatFilter(ArrayPool<char> arrayPool, IOptions<MvcOptions> options)
+            public OutgoingNoHyphenGuidFormatFilter(ArrayPool<char> arrayPool, IOptionsSnapshot<MvcOptions> options)
             {
                 _arrayPool = arrayPool;
-                _options = options;
+                _options = options.Value;
             }
             public void OnResultExecuted(ResultExecutedContext context)
             {
@@ -39,7 +38,7 @@ namespace Umbraco.Cms.Web.Common.Filters
                     serializerSettings.Converters.Add(new GuidNoHyphenConverter());
 
                     objectResult.Formatters.Clear();
-                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options.Value));
+                    objectResult.Formatters.Add(new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options));
                 }
             }
 

--- a/src/Umbraco.Web.Common/Localization/UmbracoRequestLocalizationOptions.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoRequestLocalizationOptions.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Web.Common.Localization
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoRequestLocalizationOptions"/> class.
         /// </summary>
-        public UmbracoRequestLocalizationOptions(IOptionsSnapshot<GlobalSettings> globalSettings)
+        public UmbracoRequestLocalizationOptions(IOptions<GlobalSettings> globalSettings)
         {
             _globalSettings = globalSettings.Value;
         }

--- a/src/Umbraco.Web.Common/Localization/UmbracoRequestLocalizationOptions.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoRequestLocalizationOptions.cs
@@ -16,10 +16,9 @@ namespace Umbraco.Cms.Web.Common.Localization
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoRequestLocalizationOptions"/> class.
         /// </summary>
-        public UmbracoRequestLocalizationOptions(IOptionsMonitor<GlobalSettings> globalSettings)
+        public UmbracoRequestLocalizationOptions(IOptionsSnapshot<GlobalSettings> globalSettings)
         {
-            _globalSettings = globalSettings.CurrentValue;
-            globalSettings.OnChange(x => _globalSettings = x);
+            _globalSettings = globalSettings.Value;
         }
 
         /// <inheritdoc/>

--- a/src/Umbraco.Web.Common/Localization/UmbracoRequestLocalizationOptions.cs
+++ b/src/Umbraco.Web.Common/Localization/UmbracoRequestLocalizationOptions.cs
@@ -11,18 +11,22 @@ namespace Umbraco.Cms.Web.Common.Localization
     /// </summary>
     public class UmbracoRequestLocalizationOptions : IConfigureOptions<RequestLocalizationOptions>
     {
-        private readonly IOptions<GlobalSettings> _globalSettings;
+        private GlobalSettings _globalSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoRequestLocalizationOptions"/> class.
         /// </summary>
-        public UmbracoRequestLocalizationOptions(IOptions<GlobalSettings> globalSettings) => _globalSettings = globalSettings;
+        public UmbracoRequestLocalizationOptions(IOptionsMonitor<GlobalSettings> globalSettings)
+        {
+            _globalSettings = globalSettings.CurrentValue;
+            globalSettings.OnChange(x => _globalSettings = x);
+        }
 
         /// <inheritdoc/>
         public void Configure(RequestLocalizationOptions options)
         {
             // set the default culture to what is in config
-            options.DefaultRequestCulture = new RequestCulture(_globalSettings.Value.DefaultUILanguage);
+            options.DefaultRequestCulture = new RequestCulture(_globalSettings.DefaultUILanguage);
 
             // add a custom provider
             if (options.RequestCultureProviders == null)

--- a/src/Umbraco.Web.Common/Macros/MacroRenderer.cs
+++ b/src/Umbraco.Web.Common/Macros/MacroRenderer.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Web.Common.Macros
         private readonly IProfilingLogger _profilingLogger;
         private readonly ILogger<MacroRenderer> _logger;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
-        private readonly ContentSettings _contentSettings;
+        private ContentSettings _contentSettings;
         private readonly ILocalizedTextService _textService;
         private readonly AppCaches _appCaches;
         private readonly IMacroService _macroService;
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Web.Common.Macros
             IProfilingLogger profilingLogger,
             ILogger<MacroRenderer> logger,
             IUmbracoContextAccessor umbracoContextAccessor,
-            IOptions<ContentSettings> contentSettings,
+            IOptionsMonitor<ContentSettings> contentSettings,
             ILocalizedTextService textService,
             AppCaches appCaches,
             IMacroService macroService,
@@ -57,7 +57,7 @@ namespace Umbraco.Cms.Web.Common.Macros
             _profilingLogger = profilingLogger ?? throw new ArgumentNullException(nameof(profilingLogger));
             _logger = logger;
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
-            _contentSettings = contentSettings.Value ?? throw new ArgumentNullException(nameof(contentSettings));
+            _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
             _textService = textService;
             _appCaches = appCaches ?? throw new ArgumentNullException(nameof(appCaches));
             _macroService = macroService ?? throw new ArgumentNullException(nameof(macroService));
@@ -67,6 +67,8 @@ namespace Umbraco.Cms.Web.Common.Macros
             _requestAccessor = requestAccessor;
             _partialViewMacroEngine = partialViewMacroEngine;
             _httpContextAccessor = httpContextAccessor;
+
+            contentSettings.OnChange(x => _contentSettings = x);
         }
 
         #region MacroContent cache

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -53,7 +53,7 @@ namespace Umbraco.Cms.Web.Common.Middleware
         private readonly IRuntimeState _runtimeState;
         private readonly IVariationContextAccessor _variationContextAccessor;
         private readonly IDefaultCultureAccessor _defaultCultureAccessor;
-        private readonly SmidgeOptions _smidgeOptions;
+        private SmidgeOptions _smidgeOptions;
         private readonly WebProfiler _profiler;
 
         private static bool s_cacheInitialized;
@@ -79,7 +79,7 @@ namespace Umbraco.Cms.Web.Common.Middleware
             IHostingEnvironment hostingEnvironment,
             UmbracoRequestPaths umbracoRequestPaths,
             BackOfficeWebAssets backOfficeWebAssets,
-            IOptions<SmidgeOptions> smidgeOptions,
+            IOptionsMonitor<SmidgeOptions> smidgeOptions,
             IRuntimeState runtimeState,
             IVariationContextAccessor variationContextAccessor,
             IDefaultCultureAccessor defaultCultureAccessor)
@@ -95,8 +95,10 @@ namespace Umbraco.Cms.Web.Common.Middleware
             _runtimeState = runtimeState;
             _variationContextAccessor = variationContextAccessor;
             _defaultCultureAccessor = defaultCultureAccessor;
-            _smidgeOptions = smidgeOptions.Value;
+            _smidgeOptions = smidgeOptions.CurrentValue;
             _profiler = profiler as WebProfiler; // Ignore if not a WebProfiler
+
+            smidgeOptions.OnChange(x => _smidgeOptions = x);
         }
 
         /// <inheritdoc/>

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryModelFactory.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryModelFactory.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
         private readonly Lazy<UmbracoServices> _umbracoServices; // fixme: this is because of circular refs :(
         private static readonly Regex s_assemblyVersionRegex = new Regex("AssemblyVersion\\(\"[0-9]+.[0-9]+.[0-9]+.[0-9]+\"\\)", RegexOptions.Compiled);
         private static readonly string[] s_ourFiles = { "models.hash", "models.generated.cs", "all.generated.cs", "all.dll.path", "models.err", "Compiled" };
-        private readonly ModelsBuilderSettings _config;
+        private ModelsBuilderSettings _config;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IApplicationShutdownRegistry _hostingLifetime;
         private readonly ModelsGenerationError _errors;
@@ -81,6 +81,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
                 return;
             }
 
+            config.OnChange(x => _config = x);
             _pureLiveDirectory = new Lazy<string>(PureLiveDirectoryAbsolute);
 
             if (!Directory.Exists(_pureLiveDirectory.Value))

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryModelFactory.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryModelFactory.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
             Lazy<UmbracoServices> umbracoServices,
             IProfilingLogger profilingLogger,
             ILogger<InMemoryModelFactory> logger,
-            IOptions<ModelsBuilderSettings> config,
+            IOptionsMonitor<ModelsBuilderSettings> config,
             IHostingEnvironment hostingEnvironment,
             IApplicationShutdownRegistry hostingLifetime,
             IPublishedValueFallback publishedValueFallback,
@@ -68,7 +68,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder
             _umbracoServices = umbracoServices;
             _profilingLogger = profilingLogger;
             _logger = logger;
-            _config = config.Value;
+            _config = config.CurrentValue;
             _hostingEnvironment = hostingEnvironment;
             _hostingLifetime = hostingLifetime;
             _publishedValueFallback = publishedValueFallback;

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.Common.Security
             IServiceProvider services,
             IHttpContextAccessor httpContextAccessor,
             ILogger<UserManager<BackOfficeIdentityUser>> logger,
-            IOptionsSnapshot<UserPasswordConfigurationSettings> passwordConfiguration,
+            IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
             IEventAggregator eventAggregator,
             IBackOfficeUserPasswordChecker backOfficeUserPasswordChecker)
             : base(ipResolver, store, optionsAccessor, passwordHasher, userValidators, passwordValidators, errors, services, logger, passwordConfiguration)

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.Common.Security
             IServiceProvider services,
             IHttpContextAccessor httpContextAccessor,
             ILogger<UserManager<BackOfficeIdentityUser>> logger,
-            IOptionsMonitor<UserPasswordConfigurationSettings> passwordConfiguration,
+            IOptionsSnapshot<UserPasswordConfigurationSettings> passwordConfiguration,
             IEventAggregator eventAggregator,
             IBackOfficeUserPasswordChecker backOfficeUserPasswordChecker)
             : base(ipResolver, store, optionsAccessor, passwordHasher, userValidators, passwordValidators, errors, services, logger, passwordConfiguration)

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.Common.Security
             IServiceProvider services,
             IHttpContextAccessor httpContextAccessor,
             ILogger<UserManager<BackOfficeIdentityUser>> logger,
-            IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
+            IOptionsMonitor<UserPasswordConfigurationSettings> passwordConfiguration,
             IEventAggregator eventAggregator,
             IBackOfficeUserPasswordChecker backOfficeUserPasswordChecker)
             : base(ipResolver, store, optionsAccessor, passwordHasher, userValidators, passwordValidators, errors, services, logger, passwordConfiguration)

--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.Common.Security
             IdentityErrorDescriber errors,
             IServiceProvider services,
             ILogger<UserManager<MemberIdentityUser>> logger,
-            IOptionsMonitor<MemberPasswordConfigurationSettings> passwordConfiguration,
+            IOptionsSnapshot<MemberPasswordConfigurationSettings> passwordConfiguration,
             IPublicAccessService publicAccessService,
             IHttpContextAccessor httpContextAccessor)
             : base(ipResolver, store, optionsAccessor, passwordHasher, userValidators, passwordValidators, errors,

--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.Common.Security
             IdentityErrorDescriber errors,
             IServiceProvider services,
             ILogger<UserManager<MemberIdentityUser>> logger,
-            IOptions<MemberPasswordConfigurationSettings> passwordConfiguration,
+            IOptionsMonitor<MemberPasswordConfigurationSettings> passwordConfiguration,
             IPublicAccessService publicAccessService,
             IHttpContextAccessor httpContextAccessor)
             : base(ipResolver, store, optionsAccessor, passwordHasher, userValidators, passwordValidators, errors,

--- a/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
+++ b/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Web.Common.Templates
         private readonly IPublishedRouter _publishedRouter;
         private readonly IFileService _fileService;
         private readonly ILocalizationService _languageService;
-        private readonly WebRoutingSettings _webRoutingSettings;
+        private WebRoutingSettings _webRoutingSettings;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ICompositeViewEngine _viewEngine;
         private readonly IModelMetadataProvider _modelMetadataProvider;
@@ -46,7 +46,7 @@ namespace Umbraco.Cms.Web.Common.Templates
             IPublishedRouter publishedRouter,
             IFileService fileService,
             ILocalizationService textService,
-            IOptions<WebRoutingSettings> webRoutingSettings,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
             IHttpContextAccessor httpContextAccessor,
             ICompositeViewEngine viewEngine,
             IModelMetadataProvider modelMetadataProvider,
@@ -56,11 +56,13 @@ namespace Umbraco.Cms.Web.Common.Templates
             _publishedRouter = publishedRouter ?? throw new ArgumentNullException(nameof(publishedRouter));
             _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
             _languageService = textService ?? throw new ArgumentNullException(nameof(textService));
-            _webRoutingSettings = webRoutingSettings.Value ?? throw new ArgumentNullException(nameof(webRoutingSettings));
+            _webRoutingSettings = webRoutingSettings.CurrentValue ?? throw new ArgumentNullException(nameof(webRoutingSettings));
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
             _viewEngine = viewEngine ?? throw new ArgumentNullException(nameof(viewEngine));
             _modelMetadataProvider = modelMetadataProvider;
             _tempDataDictionaryFactory = tempDataDictionaryFactory;
+
+            webRoutingSettings.OnChange(x => _webRoutingSettings = x);
         }
 
         public async Task RenderAsync(int pageId, int? altTemplateId, StringWriter writer)

--- a/src/Umbraco.Web.UI/Views/Root.cshtml
+++ b/src/Umbraco.Web.UI/Views/Root.cshtml
@@ -1,0 +1,6 @@
+﻿@using Umbraco.Cms.Web.Common.PublishedModels;
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.Root>
+@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
+@{
+	Layout = null;
+}

--- a/src/Umbraco.Web.UI/Views/Root.cshtml
+++ b/src/Umbraco.Web.UI/Views/Root.cshtml
@@ -1,6 +1,0 @@
-﻿@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.Root>
-@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
-@{
-	Layout = null;
-}

--- a/src/Umbraco.Web.Website/Controllers/RenderNoContentController.cs
+++ b/src/Umbraco.Web.Website/Controllers/RenderNoContentController.cs
@@ -13,13 +13,13 @@ namespace Umbraco.Cms.Web.Website.Controllers
     {
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly IIOHelper _ioHelper;
-        private readonly IOptions<GlobalSettings> _globalSettings;
+        private readonly GlobalSettings _globalSettings;
 
-        public RenderNoContentController(IUmbracoContextAccessor umbracoContextAccessor, IIOHelper ioHelper, IOptions<GlobalSettings> globalSettings)
+        public RenderNoContentController(IUmbracoContextAccessor umbracoContextAccessor, IIOHelper ioHelper, IOptionsSnapshot<GlobalSettings> globalSettings)
         {
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
             _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
-            _globalSettings = globalSettings ?? throw new ArgumentNullException(nameof(globalSettings));
+            _globalSettings = globalSettings.Value ?? throw new ArgumentNullException(nameof(globalSettings));
         }
 
         public ActionResult Index()
@@ -34,10 +34,10 @@ namespace Umbraco.Cms.Web.Website.Controllers
 
             var model = new NoNodesViewModel
             {
-                UmbracoPath = _ioHelper.ResolveUrl(_globalSettings.Value.UmbracoPath),
+                UmbracoPath = _ioHelper.ResolveUrl(_globalSettings.UmbracoPath),
             };
 
-            return View(_globalSettings.Value.NoNodesViewPath, model);
+            return View(_globalSettings.NoNodesViewPath, model);
         }
     }
 }


### PR DESCRIPTION
# Notes
-Implemented IOptionsMonitor instead of IOptions for Unique and singleston services, this should allow changes in your config while running the application, so you can update your config on the fly!
- Implemented IOptionsSnapshot instead of IOptions for scoped services, as this will cache the value per request

# How to test
- Use https://our.umbraco.com/documentation/Reference/V9-Config/ for a list of config options
- Try to breakpoint the classes where I've made the change, it helps changing the OnChange to be like:
```
config.OnChange(x =>
                {
                    _myConfig = x;
                });
```
So you can see whenever the settings are changed
