### PR TITLE
Added missing GetCropUrl overload for MediaWithCrops

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -126,6 +126,39 @@ namespace Umbraco.Extensions
                 urlMode
             );
 
+        public static string GetCropUrl(
+            this MediaWithCrops mediaWithCrops,
+            int? width = null,
+            int? height = null,
+            string propertyAlias = Cms.Core.Constants.Conventions.Media.File,
+            string cropAlias = null,
+            int? quality = null,
+            ImageCropMode? imageCropMode = null,
+            ImageCropAnchor? imageCropAnchor = null,
+            bool preferFocalPoint = false,
+            bool useCropDimensions = false,
+            bool cacheBuster = true,
+            string furtherOptions = null,
+            UrlMode urlMode = UrlMode.Default)
+            => ImageCropperTemplateCoreExtensions.GetCropUrl(
+                mediaWithCrops,
+                ImageUrlGenerator,
+                PublishedValueFallback,
+                PublishedUrlProvider,
+                width,
+                height,
+                propertyAlias,
+                cropAlias,
+                quality,
+                imageCropMode,
+                imageCropAnchor,
+                preferFocalPoint,
+                useCropDimensions,
+                cacheBuster,
+                furtherOptions,
+                urlMode
+            );
+
         /// <summary>
         /// Gets the underlying image processing service URL from the image path.
         /// </summary>


### PR DESCRIPTION
The missing overload would mean that if anyone tried to use the extra options with MediaWithCrops, they would be using the IPublishedContent extension method instead.
This would cause several issues, like not loading the local crops and returning null for a lot of scenarios that should work.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Without this change the following line of code wouldn't work properly:
```
MediaWithCrops image = ...;
string localCropAlias = ...;
image.GetCropUrl(cropAlias: localCropAlias, useCropDimensions: true, imageCropMode: ImageCropMode.Crop, quality: quality, urlMode: urlMode);
```
Kept the same structure as the already existing overloads for consistency sake.