### PR TITLE
Combine GetUrl requests when loading a MNTP with many entries

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/entity.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/entity.mocks.js
@@ -34,6 +34,15 @@ angular.module('umbraco.mocks').
           return [200, nodes, null];
       }
 
+      function returnUrlsbyUdis(status, data, headers) {
+
+          if (!mocksUtils.checkAuth()) {
+              return [401, null, null];
+          }
+
+          return [200, {}, null];
+      }
+
       function returnEntitybyIdsPost(method, url, data, headers) {
 
           if (!mocksUtils.checkAuth()) {
@@ -72,6 +81,10 @@ angular.module('umbraco.mocks').
               $httpBackend
                   .whenPOST(mocksUtils.urlRegex('/umbraco/UmbracoApi/Entity/GetByIds'))
                   .respond(returnEntitybyIdsPost);
+
+              $httpBackend
+                  .whenPOST(mocksUtils.urlRegex('/umbraco/UmbracoApi/Entity/GetUrlsByUdis'))
+                  .respond(returnUrlsbyUdis);
 
               $httpBackend
                   .whenGET(mocksUtils.urlRegex('/umbraco/UmbracoApi/Entity/GetAncestors'))

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -127,6 +127,21 @@ function entityResource($q, $http, umbRequestHelper) {
                'Failed to retrieve url for id:' + id);
         },
 
+        getUrlsByUdis: function(ids, culture) {
+          var query = "culture=" + (culture || "");
+
+          return umbRequestHelper.resourcePromise(
+             $http.post(
+                 umbRequestHelper.getApiUrl(
+                     "entityApiBaseUrl",
+                     "GetUrlsByUdis",
+                     query),
+                 {
+                     ids: ids
+                 }),
+             'Failed to retrieve url map for ids ' + ids);
+        },
+
         getUrlByUdi: function (udi, culture) {
 
             if (!udi) {

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -127,7 +127,7 @@ function entityResource($q, $http, umbRequestHelper) {
                'Failed to retrieve url for id:' + id);
         },
 
-        getUrlsByUdis: function(ids, culture) {
+        getUrlsByUdis: function(udis, culture) {
           var query = "culture=" + (culture || "");
 
           return umbRequestHelper.resourcePromise(
@@ -137,9 +137,9 @@ function entityResource($q, $http, umbRequestHelper) {
                      "GetUrlsByUdis",
                      query),
                  {
-                     ids: ids
+                     udis: udis
                  }),
-             'Failed to retrieve url map for ids ' + ids);
+             'Failed to retrieve url map for udis ' + udis);
         },
 
         getUrlByUdi: function (udi, culture) {

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -238,7 +238,7 @@ namespace Umbraco.Web.Editors
         /// <summary>
         /// Get entity URLs by UDIs
         /// </summary>
-        /// <param name="ids">
+        /// <param name="udis">
         /// A list of UDIs to lookup items by
         /// </param>
         /// <param name="culture">The culture to fetch the URL for</param>
@@ -248,14 +248,9 @@ namespace Umbraco.Web.Editors
         /// </remarks>
         [HttpGet]
         [HttpPost]
-        public IDictionary<Udi, string> GetUrlsByUdis([FromJsonPath] Udi[] ids, string culture = null)
+        public IDictionary<Udi, string> GetUrlsByUdis([FromJsonPath] Udi[] udis, string culture = null)
         {
-            if (ids == null)
-            {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
-            }
-
-            if (ids.Length == 0)
+            if (udis == null || udis.Length == 0)
             {
                 return new Dictionary<Udi, string>();
             }
@@ -277,7 +272,7 @@ namespace Umbraco.Web.Editors
                 };
             }
 
-            return ids
+            return udis
                 .Select(udi => new {
                     Udi = udi,
                     Url = MediaOrDocumentUrl(udi)

--- a/src/Umbraco.Web/Editors/EntityController.cs
+++ b/src/Umbraco.Web/Editors/EntityController.cs
@@ -236,6 +236,55 @@ namespace Umbraco.Web.Editors
         }
 
         /// <summary>
+        /// Get entity URLs by UDIs
+        /// </summary>
+        /// <param name="ids">
+        /// A list of UDIs to lookup items by
+        /// </param>
+        /// <param name="culture">The culture to fetch the URL for</param>
+        /// <returns>Dictionary mapping Udi -> Url</returns>
+        /// <remarks>
+        /// We allow for POST because there could be quite a lot of Ids.
+        /// </remarks>
+        [HttpGet]
+        [HttpPost]
+        public IDictionary<Udi, string> GetUrlsByUdis([FromJsonPath] Udi[] ids, string culture = null)
+        {
+            if (ids == null)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
+
+            if (ids.Length == 0)
+            {
+                return new Dictionary<Udi, string>();
+            }
+
+            // TODO: PMJ 2021-09-27 - Should GetUrl(Udi) exist as an extension method on UrlProvider/IUrlProvider (in v9)
+            string MediaOrDocumentUrl(Udi udi)
+            {
+                if (udi is not GuidUdi guidUdi)
+                {
+                    return null;
+                }
+
+                return guidUdi.EntityType switch
+                {
+                    Constants.UdiEntityType.Document => UmbracoContext.UrlProvider.GetUrl(guidUdi.Guid, culture: culture ?? ClientCulture()),
+                    // NOTE: If culture is passed here we get an empty string rather than a media item URL WAT
+                    Constants.UdiEntityType.Media => UmbracoContext.UrlProvider.GetMediaUrl(guidUdi.Guid, culture: null),
+                    _ => null
+                };
+            }
+
+            return ids
+                .Select(udi => new {
+                    Udi = udi,
+                    Url = MediaOrDocumentUrl(udi)
+                }).ToDictionary(x => x.Udi, x => x.Url);
+        }
+
+        /// <summary>
         /// Gets the URL of an entity
         /// </summary>
         /// <param name="id">Int id of the entity to fetch URL for</param>


### PR DESCRIPTION
When loading MNTP's in the backoffice with existing entities associated, a request was made per entity to umbraco/backoffice/UmbracoApi/Entity/GetUrl

All URLs are now resolved in a single request.

Tested
+ Media
+ Content (including vary by culture URL changes, items in recycle bin)
+ Members (no urls expected to render)

![image](https://user-images.githubusercontent.com/2056399/134922952-eda4cbdf-f008-4554-9e76-a1f473231c55.png)


