### PR TITLE
Copy static assets during BeforeBuild target to fix Visual Studio "rebuild" failures

### DIFF
--- a/build/NuSpecs/build/Umbraco.Cms.StaticAssets.targets
+++ b/build/NuSpecs/build/Umbraco.Cms.StaticAssets.targets
@@ -6,9 +6,8 @@
         <UmbracoWwwrootName Condition="'$(UmbracoWwwrootName)' == ''">umbraco</UmbracoWwwrootName>
     </PropertyGroup>
 
-    <Target Name="CopyUmbracoAssets" BeforeTargets="Build">
+    <Target Name="CopyUmbracoAssets" BeforeTargets="BeforeBuild">
         <ItemGroup>
-
             <ContentFiles Include="$(ContentFilesPath)" />
             <ContentWwwrootFiles Include="$(ContentWwwrootFilesPath)" />
         </ItemGroup>


### PR DESCRIPTION
### Description

Fixes issue #11215 when using `Rebuild` option in Visual Studio/msbuild where every second rebuild would fail due to missing static asset files

![PZPpEVXscy](https://user-images.githubusercontent.com/4223195/135169302-d6bf3c9a-b63e-4145-9b16-641f018c7236.gif)

msbuild output prior to this change:

```
1>Target _CopyOutOfDateSourceItemsToOutputDirectoryAlways:
1>  Microsoft.Common.CurrentVersion.targets(4996,5): error MSB3030: Could not copy the file "C:\Umbraco9Test\umbraco\config\appsettings-schema.json" because it was not found.
1>  Microsoft.Common.CurrentVersion.targets(4996,5): error MSB3030: Could not copy the file "C:\Umbraco9Test\umbraco\config\lang\cy.xml" because it was not found.
1>  Microsoft.Common.CurrentVersion.targets(4996,5): error MSB3030: Could not copy the file "C:\Umbraco9Test\umbraco\config\lang\en.xml" because it was not found.
1>  Microsoft.Common.CurrentVersion.targets(4996,5): error MSB3030: Could not copy the file "C:\Umbraco9Test\umbraco\config\lang\da.xml" because it was not found.

...

1>Done building target "_CopyOutOfDateSourceItemsToOutputDirectoryAlways" in project "Umbraco9Test.csproj" -- FAILED.
1>
1>Done building project "Umbraco9Test.csproj" -- FAILED.
1>
1>Build FAILED.
```
