### PR TITLE
Changed the case of BlockList to blocklist as it breaks on Linux Mint

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/blocklist/default.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/blocklist/default.cshtml
@@ -8,6 +8,6 @@
         if (block?.ContentUdi == null) { continue; }
         var data = block.Content;
 
-        @await Html.PartialAsync("BlockList/Components/" + data.ContentType.Alias, block)
+        @await Html.PartialAsync("blocklist/Components/" + data.ContentType.Alias, block)
     }
 </div>


### PR DESCRIPTION
Changed the case of BlockList to blocklist as it breaks on Linux Mint. Thanks to @craigs100 for spotting this.