### PR TITLE
Fix JsonConfigManipulator causing upgrades to fail when appsettings.json files are not present

### DIFF
--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -2,10 +2,12 @@ using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Core.Configuration
 {
@@ -17,7 +19,7 @@ namespace Umbraco.Cms.Core.Configuration
 
         [Obsolete]
         public JsonConfigManipulator(IConfiguration configuration)
-            : this(configuration, null)
+            : this(configuration, StaticServiceProvider.Instance.GetRequiredService<ILogger<JsonConfigManipulator>>())
         { }
 
         public JsonConfigManipulator(
@@ -36,7 +38,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger?.LogWarning("Failed to remove connection string from JSON configuration.");
+                _logger.LogWarning("Failed to remove connection string from JSON configuration.");
                 return;
             }
 
@@ -52,7 +54,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger?.LogWarning("Failed to save connection string in JSON configuration.");
+                _logger.LogWarning("Failed to save connection string in JSON configuration.");
                 return;
             }
 
@@ -71,7 +73,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger?.LogWarning("Failed to save configuration key \"{Key}\" in JSON configuration.", key);
+                _logger.LogWarning("Failed to save configuration key \"{Key}\" in JSON configuration.", key);
                 return;
             }
 
@@ -102,7 +104,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger?.LogWarning("Failed to save enabled/disabled state for redirect URL tracking in JSON configuration.");
+                _logger.LogWarning("Failed to save enabled/disabled state for redirect URL tracking in JSON configuration.");
                 return;
             }
 
@@ -120,7 +122,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger?.LogWarning("Failed to save global identifier in JSON configuration.");
+                _logger.LogWarning("Failed to save global identifier in JSON configuration.");
                 return;
             }
 
@@ -239,7 +241,7 @@ namespace Umbraco.Cms.Core.Configuration
                 }
                 catch (FileNotFoundException)
                 {
-                    _logger?.LogWarning("JSON configuration file does not exist: {path}", jsonFilePath);
+                    _logger.LogWarning("JSON configuration file does not exist: {path}", jsonFilePath);
                     return null;
                 }
             }

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -36,7 +36,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to remove connection string from JSON configuration.");
+                _logger?.LogWarning("Failed to remove connection string from JSON configuration.");
                 return;
             }
 
@@ -52,7 +52,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save connection string in JSON configuration.");
+                _logger?.LogWarning("Failed to save connection string in JSON configuration.");
                 return;
             }
 
@@ -71,7 +71,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save configuration key \"{Key}\" in JSON configuration.", key);
+                _logger?.LogWarning("Failed to save configuration key \"{Key}\" in JSON configuration.", key);
                 return;
             }
 
@@ -102,7 +102,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save enabled/disabled state for redirect URL tracking in JSON configuration.");
+                _logger?.LogWarning("Failed to save enabled/disabled state for redirect URL tracking in JSON configuration.");
                 return;
             }
 
@@ -120,7 +120,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save global identifier in JSON configuration.");
+                _logger?.LogWarning("Failed to save global identifier in JSON configuration.");
                 return;
             }
 
@@ -239,7 +239,7 @@ namespace Umbraco.Cms.Core.Configuration
                 }
                 catch (FileNotFoundException)
                 {
-                    _logger.LogWarning("JSON configuration file does not exist: {path}", jsonFilePath);
+                    _logger?.LogWarning("JSON configuration file does not exist: {path}", jsonFilePath);
                     return null;
                 }
             }

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Configuration;
@@ -12,9 +13,16 @@ namespace Umbraco.Cms.Core.Configuration
     public class JsonConfigManipulator : IConfigManipulator
     {
         private readonly IConfiguration _configuration;
+        private readonly ILogger<JsonConfigManipulator> _logger;
         private readonly object _locker = new object();
 
-        public JsonConfigManipulator(IConfiguration configuration) => _configuration = configuration;
+        public JsonConfigManipulator(
+            IConfiguration configuration,
+            ILogger<JsonConfigManipulator> logger)
+        {
+            _configuration = configuration;
+            _logger = logger;
+        }
 
         public string UmbracoConnectionPath { get; } = $"ConnectionStrings:{ Cms.Core.Constants.System.UmbracoConnectionName}";
         public void RemoveConnectionString()
@@ -24,6 +32,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
+                _logger.LogWarning("Failed to remove connection string from JSON configuration");
                 return;
             }
 
@@ -39,6 +48,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
+                _logger.LogWarning("Failed to save connection string in JSON configuration");
                 return;
             }
 
@@ -57,6 +67,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
+                _logger.LogWarning("Failed to save configuration key \"{key}\" in JSON configuration", key);
                 return;
             }
 
@@ -87,6 +98,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
+                _logger.LogWarning("Failed to save \"DisableRedirectUrlTracking\" in JSON configuration");
                 return;
             }
 
@@ -104,6 +116,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
+                _logger.LogWarning("Failed to save global identifier in JSON configuration");
                 return;
             }
 
@@ -222,6 +235,7 @@ namespace Umbraco.Cms.Core.Configuration
                 }
                 catch (FileNotFoundException)
                 {
+                    _logger.LogWarning("JSON configuration file does not exist: {path}", jsonFilePath);
                     return null;
                 }
             }

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -209,13 +209,20 @@ namespace Umbraco.Cms.Core.Configuration
                 {
                     var jsonFilePath = Path.Combine(physicalFileProvider.Root, provider.Source.Path);
 
-                    using (var sw = new StreamWriter(jsonFilePath, false))
-                    using (var jsonTextWriter = new JsonTextWriter(sw)
+                    try
                     {
-                        Formatting = Formatting.Indented,
-                    })
+                        using (var sw = new StreamWriter(jsonFilePath, false))
+                        using (var jsonTextWriter = new JsonTextWriter(sw)
+                        {
+                            Formatting = Formatting.Indented,
+                        })
+                        {
+                            json?.WriteTo(jsonTextWriter);
+                        }
+                    }
+                    catch (IOException exception)
                     {
-                        json?.WriteTo(jsonTextWriter);
+                        _logger.LogWarning(exception, "JSON configuration could not be written: {path}", jsonFilePath);
                     }
                 }
             }
@@ -239,9 +246,9 @@ namespace Umbraco.Cms.Core.Configuration
                     using var jsonTextReader = new JsonTextReader(sr);
                     return serializer.Deserialize<JObject>(jsonTextReader);
                 }
-                catch (FileNotFoundException)
+                catch (IOException exception)
                 {
-                    _logger.LogWarning("JSON configuration file does not exist: {path}", jsonFilePath);
+                    _logger.LogWarning(exception, "JSON configuration could not be read: {path}", jsonFilePath);
                     return null;
                 }
             }

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -22,6 +22,10 @@ namespace Umbraco.Cms.Core.Configuration
             var provider = GetJsonConfigurationProvider(UmbracoConnectionPath);
 
             var json = GetJson(provider);
+            if (json is null)
+            {
+                return;
+            }
 
             RemoveJsonKey(json, UmbracoConnectionPath);
 
@@ -33,6 +37,10 @@ namespace Umbraco.Cms.Core.Configuration
             var provider = GetJsonConfigurationProvider();
 
             var json = GetJson(provider);
+            if (json is null)
+            {
+                return;
+            }
 
             var item = GetConnectionItem(connectionString, providerName);
 
@@ -47,6 +55,10 @@ namespace Umbraco.Cms.Core.Configuration
             var provider = GetJsonConfigurationProvider();
 
             var json = GetJson(provider);
+            if (json is null)
+            {
+                return;
+            }
 
             JToken token = json;
             foreach (var propertyName in key.Split(new[] { ':' }))
@@ -73,6 +85,10 @@ namespace Umbraco.Cms.Core.Configuration
             var provider = GetJsonConfigurationProvider();
 
             var json = GetJson(provider);
+            if (json is null)
+            {
+                return;
+            }
 
             var item = GetDisableRedirectUrlItem(disable);
 
@@ -86,6 +102,10 @@ namespace Umbraco.Cms.Core.Configuration
             var provider = GetJsonConfigurationProvider();
 
             var json = GetJson(provider);
+            if (json is null)
+            {
+                return;
+            }
 
             var item = GetGlobalIdItem(id);
 

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Umbraco.Cms.Core.Configuration;
 
 namespace Umbraco.Cms.Core.Configuration
 {

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -186,19 +186,24 @@ namespace Umbraco.Cms.Core.Configuration
         {
             lock (_locker)
             {
-                if (provider.Source.FileProvider is PhysicalFileProvider physicalFileProvider)
+                if (provider.Source.FileProvider is not PhysicalFileProvider physicalFileProvider)
                 {
-                    var jsonFilePath = Path.Combine(physicalFileProvider.Root, provider.Source.Path);
-
-                    var serializer = new JsonSerializer();
-                    using (var sr = new StreamReader(jsonFilePath))
-                    using (var jsonTextReader = new JsonTextReader(sr))
-                    {
-                        return serializer.Deserialize<JObject>(jsonTextReader);
-                    }
+                    return null;
                 }
 
-                return null; 
+                var jsonFilePath = Path.Combine(physicalFileProvider.Root, provider.Source.Path);
+
+                try
+                {
+                    var serializer = new JsonSerializer();
+                    using var sr = new StreamReader(jsonFilePath);
+                    using var jsonTextReader = new JsonTextReader(sr);
+                    return serializer.Deserialize<JObject>(jsonTextReader);
+                }
+                catch (FileNotFoundException)
+                {
+                    return null;
+                }
             }
         }
 

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -15,6 +15,11 @@ namespace Umbraco.Cms.Core.Configuration
         private readonly ILogger<JsonConfigManipulator> _logger;
         private readonly object _locker = new object();
 
+        [Obsolete]
+        public JsonConfigManipulator(IConfiguration configuration)
+            : this(configuration, null)
+        { }
+
         public JsonConfigManipulator(
             IConfiguration configuration,
             ILogger<JsonConfigManipulator> logger)

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Core.Configuration
             _logger = logger;
         }
 
-        public string UmbracoConnectionPath { get; } = $"ConnectionStrings:{ Cms.Core.Constants.System.UmbracoConnectionName}";
+        public string UmbracoConnectionPath { get; } = $"ConnectionStrings:{Cms.Core.Constants.System.UmbracoConnectionName}";
         public void RemoveConnectionString()
         {
             var provider = GetJsonConfigurationProvider(UmbracoConnectionPath);

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to remove connection string from JSON configuration");
+                _logger.LogWarning("Failed to remove connection string from JSON configuration.");
                 return;
             }
 
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save connection string in JSON configuration");
+                _logger.LogWarning("Failed to save connection string in JSON configuration.");
                 return;
             }
 
@@ -66,7 +66,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save configuration key \"{key}\" in JSON configuration", key);
+                _logger.LogWarning("Failed to save configuration key \"{Key}\" in JSON configuration.", key);
                 return;
             }
 
@@ -97,7 +97,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save \"DisableRedirectUrlTracking\" in JSON configuration");
+                _logger.LogWarning("Failed to save enabled/disabled state for redirect URL tracking in JSON configuration.");
                 return;
             }
 
@@ -115,7 +115,7 @@ namespace Umbraco.Cms.Core.Configuration
             var json = GetJson(provider);
             if (json is null)
             {
-                _logger.LogWarning("Failed to save global identifier in JSON configuration");
+                _logger.LogWarning("Failed to save global identifier in JSON configuration.");
                 return;
             }
 


### PR DESCRIPTION
### Description

Database upgrades currently fail when no JSON configuration file is present (e.g. `appsettings.json`).

This is because `JsonConfigManipulator` always expects a JSON configuration file to be present, which isn't consistent with `Host.CreateDefaultBuilder` which considers the JSON files to be optional.

All of the public methods defined in `JsonConfigManipulator` and `IConfigManipulator` are susceptible to this crash.

Exceptions are also being encountered during fresh installs, but unlike upgrades, the install can still proceed:

![image](https://user-images.githubusercontent.com/4223195/135384694-2c37bf45-229c-438f-89c7-6d3f35fc9d7b.png)


## Replication

I encountered this issue when running Umbraco `9.0.0` under a Docker container and trying to configure the application purely with environment variables.

Presumably, using any configuration method that is **not** JSON files is affected by this (command line arguments, environment variables).

JSON configuration files are not desirable in Docker containers, as we want to configure it only by providing environment variables.

It should be replicable under Visual Studio by just removing `appsettings.json` files and using the `launchSettings.json` => `environmentVariables` section.

As a workaround, creating a dummy `appsettings.json` in my Docker containers with no contents works.

**Raw stack trace:**

```
System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
System.IO.FileStream..ctor(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
System.IO.StreamReader.ValidateArgsAndOpenPath(string path, Encoding encoding, int bufferSize)
System.IO.StreamReader..ctor(string path)
Umbraco.Cms.Core.Configuration.JsonConfigManipulator.GetJson(JsonConfigurationProvider provider)
Umbraco.Cms.Core.Configuration.JsonConfigManipulator.SaveConfigValue(string key, object value)
Umbraco.Cms.Web.Common.RuntimeMinification.SmidgeRuntimeMinifier.Reset()
Umbraco.Cms.Web.BackOffice.Install.InstallController.Index()
```

![image](https://user-images.githubusercontent.com/4223195/135382523-7e9fe6b8-8ec0-49b2-bac7-a48f62209527.png)


## Changes

`FileNotFoundException` exceptions are now caught when attempting to open `appsettings.json`, and a logger warning is emitted.

New logger output looks like this:

![image](https://user-images.githubusercontent.com/4223195/135383240-69d53fc3-2ffa-44a4-8e0e-46a4edcfb43e.png)

