### PR TITLE
Remove inherited property group id/key when local properties are added

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenttypehelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenttypehelper.service.js
@@ -439,6 +439,45 @@ function contentTypeHelper(contentTypeResource, dataTypeResource, $filter, $inje
 
             array.push(placeholder);
 
+        },
+
+        rebindSavedContentType: function (contentType, savedContentType) {
+            // The saved content type might have updated values (eg. new IDs/keys), so make sure the view model is updated
+            contentType.ModelState = savedContentType.ModelState;
+            contentType.id = savedContentType.id;
+            contentType.groups.forEach(function (group) {
+                if (!group.alias) return;
+
+                var k = 0;
+                while (k < savedContentType.groups.length && savedContentType.groups[k].alias != group.alias)
+                    k++;
+
+                if (k == savedContentType.groups.length) {
+                    group.id = 0;
+                    return;
+                }
+
+                var savedGroup = savedContentType.groups[k];
+                group.id = savedGroup.id;
+                group.key = savedGroup.key;
+                group.contentTypeId = savedGroup.contentTypeId;
+
+                group.properties.forEach(function (property) {
+                    if (property.id || !property.alias) return;
+
+                    k = 0;
+                    while (k < savedGroup.properties.length && savedGroup.properties[k].alias != property.alias)
+                        k++;
+
+                    if (k == savedGroup.properties.length) {
+                        property.id = 0;
+                        return;
+                    }
+
+                    var savedProperty = savedGroup.properties[k];
+                    property.id = savedProperty.id;
+                });
+            });
         }
 
     };

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -72,10 +72,10 @@
                     return g.tabState === "init";
                 });
                 saveModel.groups = _.map(realGroups, function (g) {
-                    var saveGroup = _.pick(g, 'inherited', 'id', 'sortOrder', 'name', 'key', 'alias', 'type');
+                    var saveGroup = _.pick(g, 'id', 'sortOrder', 'name', 'key', 'alias', 'type');
 
                     var realProperties = _.reject(g.properties, function (p) {
-                        // Do not include properties with init state or inherited from compositions
+                        // Do not include properties with init state or inherited from a composition
                         return p.propertyState === "init" || p.inherited === true;
                     });
 
@@ -86,7 +86,7 @@
 
                     saveGroup.properties = saveProperties;
 
-                    if (saveGroup.inherited === true) {
+                    if (g.inherited === true) {
                         if (saveProperties.length === 0) {
                             // All properties are inherited from the compositions, no need to save this group
                             return null;

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -37,7 +37,7 @@
 
         return {
 
-            formatChangePasswordModel: function(model) {
+            formatChangePasswordModel: function (model) {
                 if (!model) {
                     return null;
                 }
@@ -59,26 +59,23 @@
             },
 
             formatContentTypePostData: function (displayModel, action) {
-
-                //create the save model from the display model
+                // Create the save model from the display model
                 var saveModel = _.pick(displayModel,
                     'compositeContentTypes', 'isContainer', 'allowAsRoot', 'allowedTemplates', 'allowedContentTypes',
                     'alias', 'description', 'thumbnail', 'name', 'id', 'icon', 'trashed',
                     'key', 'parentId', 'alias', 'path', 'allowCultureVariant', 'allowSegmentVariant', 'isElement');
 
-                // TODO: Map these
                 saveModel.allowedTemplates = _.map(displayModel.allowedTemplates, function (t) { return t.alias; });
                 saveModel.defaultTemplate = displayModel.defaultTemplate ? displayModel.defaultTemplate.alias : null;
                 var realGroups = _.reject(displayModel.groups, function (g) {
-                    //do not include these tabs
+                    // Do not include groups with init state
                     return g.tabState === "init";
                 });
                 saveModel.groups = _.map(realGroups, function (g) {
-
                     var saveGroup = _.pick(g, 'inherited', 'id', 'sortOrder', 'name', 'key', 'alias', 'type');
 
                     var realProperties = _.reject(g.properties, function (p) {
-                        //do not include these properties
+                        // Do not include properties with init state or inherited from compositions
                         return p.propertyState === "init" || p.inherited === true;
                     });
 
@@ -89,16 +86,21 @@
 
                     saveGroup.properties = saveProperties;
 
-                    //if this is an inherited group and there are not non-inherited properties on it, then don't send up the data
-                    if (saveGroup.inherited === true && saveProperties.length === 0) {
-                        return null;
+                    if (saveGroup.inherited === true) {
+                        if (saveProperties.length === 0) {
+                            // All properties are inherited from the compositions, no need to save this group
+                            return null;
+                        } else if (g.contentTypeId != saveModel.id) {
+                            // We have local properties, but the group id is not local, ensure a new id/key is generated on save
+                            saveGroup = _.omit(saveGroup, 'id', 'key');
+                        }
                     }
 
                     return saveGroup;
                 });
 
-                //we don't want any null groups
                 saveModel.groups = _.reject(saveModel.groups, function (g) {
+                    // Do not include empty/null groups
                     return !g;
                 });
 
@@ -127,17 +129,17 @@
             },
 
             /** formats the display model used to display the dictionary to the model used to save the dictionary */
-            formatDictionaryPostData : function(dictionary, nameIsDirty) {
+            formatDictionaryPostData: function (dictionary, nameIsDirty) {
                 var saveModel = {
                     parentId: dictionary.parentId,
                     id: dictionary.id,
                     name: dictionary.name,
                     nameIsDirty: nameIsDirty,
                     translations: [],
-                    key : dictionary.key
+                    key: dictionary.key
                 };
 
-                for(var i = 0; i < dictionary.translations.length; i++) {
+                for (var i = 0; i < dictionary.translations.length; i++) {
                     saveModel.translations.push({
                         isoCode: dictionary.translations[i].isoCode,
                         languageId: dictionary.translations[i].languageId,
@@ -362,7 +364,7 @@
                     parentId: displayModel.parentId,
                     //set the action on the save model
                     action: action,
-                    variants: _.map(displayModel.variants, function(v) {
+                    variants: _.map(displayModel.variants, function (v) {
                         return {
                             name: v.name || "", //if its null/empty,we must pass up an empty string else we get json converter errors
                             properties: getContentProperties(v.tabs),
@@ -392,7 +394,7 @@
              * @param {} displayModel
              * @returns {}
              */
-            formatContentGetData: function(displayModel) {
+            formatContentGetData: function (displayModel) {
 
                 // We need to check for invariant properties among the variant variants,
                 // as the value of an invariant property is shared between different variants.
@@ -458,12 +460,12 @@
              * Formats the display model used to display the relation type to a model used to save the relation type.
              * @param {Object} relationType
              */
-            formatRelationTypePostData : function(relationType) {
+            formatRelationTypePostData: function (relationType) {
                 var saveModel = {
                     id: relationType.id,
                     name: relationType.name,
                     alias: relationType.alias,
-                    key : relationType.key,
+                    key: relationType.key,
                     isBidirectional: relationType.isBidirectional,
                     parentObjectType: relationType.parentObjectType,
                     childObjectType: relationType.childObjectType

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -324,35 +324,9 @@
                     scope: $scope,
                     content: vm.contentType,
                     infiniteMode: infiniteMode,
-                    // we need to rebind... the IDs that have been created!
-                    rebindCallback: function (origContentType, savedContentType) {
-                        vm.contentType.ModelState = savedContentType.ModelState;
-                        vm.contentType.id = savedContentType.id;
-                        vm.contentType.groups.forEach(function (group) {
-                            if (!group.name) return;
-                            var k = 0;
-                            while (k < savedContentType.groups.length && savedContentType.groups[k].name != group.name)
-                                k++;
-                            if (k == savedContentType.groups.length) {
-                                group.id = 0;
-                                return;
-                            }
-                            var savedGroup = savedContentType.groups[k];
-                            if (!group.id) group.id = savedGroup.id;
-
-                            group.properties.forEach(function (property) {
-                                if (property.id || !property.alias) return;
-                                k = 0;
-                                while (k < savedGroup.properties.length && savedGroup.properties[k].alias != property.alias)
-                                    k++;
-                                if (k == savedGroup.properties.length) {
-                                    property.id = 0;
-                                    return;
-                                }
-                                var savedProperty = savedGroup.properties[k];
-                                property.id = savedProperty.id;
-                            });
-                        });
+                    rebindCallback: function (_, savedContentType) {
+                        // we need to rebind... the IDs that have been created!
+                        contentTypeHelper.rebindSavedContentType(vm.contentType, savedContentType);
                     }
                 }).then(function (data) {
                     // allow UI to access server validation state

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js
@@ -295,38 +295,9 @@
                     saveMethod: mediaTypeResource.save,
                     scope: $scope,
                     content: vm.contentType,
-                    // we need to rebind... the IDs that have been created!
-                    rebindCallback: function (origContentType, savedContentType) {
-                        vm.contentType.id = savedContentType.id;
-                        vm.contentType.groups.forEach(function (group) {
-                            if (!group.name) return;
-
-                            var k = 0;
-                            while (k < savedContentType.groups.length && savedContentType.groups[k].name != group.name)
-                                k++;
-                            if (k == savedContentType.groups.length) {
-                                group.id = 0;
-                                return;
-                            }
-
-                            var savedGroup = savedContentType.groups[k];
-                            if (!group.id) group.id = savedGroup.id;
-
-                            group.properties.forEach(function (property) {
-                                if (property.id || !property.alias) return;
-
-                                k = 0;
-                                while (k < savedGroup.properties.length && savedGroup.properties[k].alias != property.alias)
-                                    k++;
-                                if (k == savedGroup.properties.length) {
-                                    property.id = 0;
-                                    return;
-                                }
-
-                                var savedProperty = savedGroup.properties[k];
-                                property.id = savedProperty.id;
-                            });
-                        });
+                    rebindCallback: function (_, savedContentType) {
+                        // we need to rebind... the IDs that have been created!
+                        contentTypeHelper.rebindSavedContentType(vm.contentType, savedContentType);
                     }
                 }).then(function (data) {
                     //success

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js
@@ -175,11 +175,11 @@
 
             //we are creating so get an empty data type item
             memberTypeResource.getScaffold(memberTypeId)
-				.then(function (dt) {
-				    init(dt);
+                .then(function (dt) {
+                    init(dt);
 
-				    vm.page.loading = false;
-				});
+                    vm.page.loading = false;
+                });
         }
         else {
             loadMemberType();
@@ -215,38 +215,9 @@
                     saveMethod: memberTypeResource.save,
                     scope: $scope,
                     content: vm.contentType,
-                    // we need to rebind... the IDs that have been created!
-                    rebindCallback: function (origContentType, savedContentType) {
-                        vm.contentType.id = savedContentType.id;
-                        vm.contentType.groups.forEach(function (group) {
-                            if (!group.name) return;
-
-                            var k = 0;
-                            while (k < savedContentType.groups.length && savedContentType.groups[k].name != group.name)
-                                k++;
-                            if (k == savedContentType.groups.length) {
-                                group.id = 0;
-                                return;
-                            }
-
-                            var savedGroup = savedContentType.groups[k];
-                            if (!group.id) group.id = savedGroup.id;
-
-                            group.properties.forEach(function (property) {
-                                if (property.id || !property.alias) return;
-
-                                k = 0;
-                                while (k < savedGroup.properties.length && savedGroup.properties[k].alias != property.alias)
-                                    k++;
-                                if (k == savedGroup.properties.length) {
-                                    property.id = 0;
-                                    return;
-                                }
-
-                                var savedProperty = savedGroup.properties[k];
-                                property.id = savedProperty.id;
-                            });
-                        });
+                    rebindCallback: function (_, savedContentType) {
+                        // we need to rebind... the IDs that have been created!
+                        contentTypeHelper.rebindSavedContentType(vm.contentType, savedContentType);
                     }
                 }).then(function (data) {
                     //success


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11221.

### Description
While testing 8.17 RC1 we noticed all property group keys were re-generated on every save, because they weren't posted back to the server (which caused issues in Umbraco Deploy). This was fixed in PR https://github.com/umbraco/Umbraco-CMS/pull/11121 that was part of 8.17 RC2 (and the final 9.0.0 release).

One minor oversight/regression was that when you added properties to an inherited tab or group, we can't use the same id/key, as it needs to store that property into a new group that's local to the content type (and not the composition). This caused an exception while trying to save the new local group with the same uniqueId/key as the group from the composition.

This PR ensures that when a local property is added and the group isn't local (doesn't have the same content type ID as the one you're saving), it will omit these values, so the server can generate new, non-conflicting/unique keys and create the local group 😄 

@nul800sebastiaan We should ensure this is included in the final 8.17.0 release and the next 9.0.1 patch release!