### PR TITLE
Umbraco TagHelpers

### DIFF
--- a/src/Umbraco.Web.Common/TagHelpers/IncludeIfTagHelper.cs
+++ b/src/Umbraco.Web.Common/TagHelpers/IncludeIfTagHelper.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Umbraco.Cms.Web.Common.TagHelpers
+{
+    [HtmlTargetElement("*", Attributes = "umb-include-if")]
+    public class IncludeIfTagHelper : TagHelper
+    {
+        [HtmlAttributeName("umb-include-if")]
+        public bool Predicate { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (!Predicate)
+            {
+                output.SuppressOutput();
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/TagHelpers/SurfaceControllerFormTagHelper.cs
+++ b/src/Umbraco.Web.Common/TagHelpers/SurfaceControllerFormTagHelper.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Umbraco.Cms.Web.Common.Security;
+
+namespace Umbraco.Cms.Web.Common.TagHelpers
+{
+    [HtmlTargetElement("form")]
+    public class SurfaceControllerFormTagHelper : TagHelper
+    {
+        private readonly IDataProtectionProvider _dataProtectionProvider;
+        private IDictionary<string, string> _routeValues;
+
+        /// <summary>
+        /// The name of the action method.
+        /// </summary>
+        [HtmlAttributeName("umb-action")]
+        public string ControllerAction { get; set; }
+
+        /// <summary>
+        /// The name of the controller minus the 'Controller' suffix.
+        /// </summary>
+        [HtmlAttributeName("umb-controller")]
+        public string ControllerName { get; set; }
+
+        /// <summary>
+        /// The name of the area.
+        /// </summary>
+        [HtmlAttributeName("umb-area")]
+        public string Area { get; set; } = "";
+
+        /// <summary>
+        /// Additional parameters for the route.
+        /// </summary>
+        [HtmlAttributeName("umb-route-vals", DictionaryAttributePrefix = "umb-route-val")]
+        public IDictionary<string, string> RouteValues
+        {
+            get
+            {
+                if (_routeValues == null)
+                {
+                    _routeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                return _routeValues;
+            }
+            set
+            {
+                _routeValues = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
+        public SurfaceControllerFormTagHelper( IDataProtectionProvider dataProtectionProvider)
+        {
+            _dataProtectionProvider = dataProtectionProvider;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            if(string.IsNullOrEmpty(ControllerName) || string.IsNullOrEmpty(ControllerAction))
+                return;
+            
+            var encryptedString = EncryptionHelper.CreateEncryptedRouteString(_dataProtectionProvider,
+                ControllerName,
+                ControllerAction,
+                Area,
+                RouteValues);
+
+            // Use new TagBuilder to help generate the HTML hidden input field
+            // As opposed to do string formatting/concatantion 
+            var surfaceControllerHiddenInput = new TagBuilder("input")
+            {
+                TagRenderMode = TagRenderMode.SelfClosing                
+            };
+
+            surfaceControllerHiddenInput.MergeAttribute("name", "ufprt");
+            surfaceControllerHiddenInput.MergeAttribute("type", "hidden");
+            surfaceControllerHiddenInput.MergeAttribute("value", encryptedString);
+
+            // Append hidden input ufprt before closing </form>
+            // The value contains a magical string on how to route the request to the surface controller
+            output.PostContent.AppendHtml(surfaceControllerHiddenInput);
+
+            // Note: We do not need to add the HTMLAntiforgeryToken
+            // As the existing Microsoft Form taghelper will add it before the end of the form
+        }
+    }
+}

--- a/src/Umbraco.Web.UI/Views/_ViewImports.cshtml
+++ b/src/Umbraco.Web.UI/Views/_ViewImports.cshtml
@@ -5,5 +5,6 @@
 @using Umbraco.Cms.Core.Models.PublishedContent
 @using Microsoft.AspNetCore.Html
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Umbraco.Web.Common
 @addTagHelper *, Smidge
 @inject Smidge.SmidgeHelper SmidgeHelper


### PR DESCRIPTION
This is a draft PR containing TagHelpers to help developers life's better

## Include-If
This is an attribute `umb-include-if` that can be applied to any HTML DOM element and will it include the HTML element and its children if the bool predicate evaluates to true

### Simple Example
```cshtml
<div umb-include-if="(DateTime.UtcNow.Minute % 2) == 0">This will only render during <strong>even</strong> minutes.</div>
<div umb-include-if="(DateTime.UtcNow.Minute % 2) == 1">This will only render during <strong>odd</strong> minutes.</div>
```

### Example Before
```cshtml
@if (Model.ContentPickerThing != null)
{
    <a href="Model.ContentPickerThing.Url()" class="btn btn-action">
        <span>@Model.ContentPickerThing.Name</span>

        @if (Model.LinkMediaPicker != null)
        {
            <img src="@Model.LinkMediaPicker.Url()" class="img-circle" />
        }
    </a>
}
```

### Example After
```cshtml
<a umb-if="Model.ContentPickerThing != null" href="@Model.ContentPickerThing?.Url()" class="btn btn-action">
    <span>@Model.ContentPickerThing.Name</span>
    <img umb-if="Model.LinkMediaPicker != null" src="@Model.LinkMediaPicker?.Url()" class="img-circle" />
</a>
```

## BeginUmbracoForm replacement
This is to make it easier to create a form that uses an Umbraco SurfaceController

### Example Before
```cshtml
@if (Model.ContentPickerThing != null)
{
    <a href="Model.ContentPickerThing.Url()" class="btn btn-action">
        <span>@Model.ContentPickerThing.Name</span>

        @if (Model.LinkMediaPicker != null)
        {
            <img src="@Model.LinkMediaPicker.Url()" class="img-circle" />
        }
    </a>
}
```

### Example After
```cshtml
<a umb-if="Model.ContentPickerThing != null" href="@Model.ContentPickerThing?.Url()" class="btn btn-action">
    <span>@Model.ContentPickerThing.Name</span>
    <img umb-if="Model.LinkMediaPicker != null" src="@Model.LinkMediaPicker?.Url()" class="img-circle" />
</a>
```