### PR TITLE
Remove all ImageSharp.Web Processors and the re-add in the correct order

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.ImageSharp.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.ImageSharp.cs
@@ -54,8 +54,14 @@ namespace Umbraco.Extensions
                 .Configure<PhysicalFileSystemCacheOptions>(options => options.CacheFolder = builder.BuilderHostingEnvironment.MapPathContentRoot(imagingSettings.Cache.CacheFolder))
                 // We need to add CropWebProcessor before ResizeWebProcessor (until https://github.com/SixLabors/ImageSharp.Web/issues/182 is fixed)
                 .RemoveProcessor<ResizeWebProcessor>()
+                .RemoveProcessor<FormatWebProcessor>()
+                .RemoveProcessor<BackgroundColorWebProcessor>()
+                .RemoveProcessor<JpegQualityWebProcessor>()
                 .AddProcessor<CropWebProcessor>()
-                .AddProcessor<ResizeWebProcessor>();
+                .AddProcessor<ResizeWebProcessor>()
+                .AddProcessor<FormatWebProcessor>()
+                .AddProcessor<BackgroundColorWebProcessor>()
+                .AddProcessor<JpegQualityWebProcessor>();
 
             builder.Services.AddTransient<IConfigureOptions<ImageSharpMiddlewareOptions>, ImageSharpConfigurationOptions>();
 


### PR DESCRIPTION
Currently, the order in which the ImageSharp processors are registered determines the order of processing so in Umbraco we currently lose the ability, for example, to set the background colour as the resize command comes after the bgcolor processor.

e.g. sample.png?width=503&height=300&rmode=pad&bgcolor=red does not work, it does with this PR

It's likely in ImageSharp.Web 1.0.4 the order will be determined by the querystrings but not currently with 1.0.3 https://github.com/SixLabors/ImageSharp.Web/issues/182

This PR removes and re-adds all the built-in processors in the correct order so all commands work.