### PR TITLE
Change template helper to use async partials

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/templatehelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/templatehelper.service.js
@@ -16,7 +16,7 @@
                 partialViewName = parentId + "/" + partialViewName;
             }
 
-            return "@Html.Partial(\"" + partialViewName + "\")";
+            return "@await Html.PartialAsync(\"" + partialViewName + "\")";
         }
 
         function getQuerySnippet(queryExpression) {

--- a/src/Umbraco.Web.UI.Client/test/unit/common/services/template-helper.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/services/template-helper.spec.js
@@ -26,28 +26,28 @@ describe('service: templateHelper', function () {
         it('should return the snippet for inserting a partial from the root', function () {
             var parentId = "";
             var nodeName = "Footer.cshtml";
-            var snippet = '@Html.Partial("Footer")';
+            var snippet = '@await Html.PartialAsync("Footer")';
             expect(templateHelper.getInsertPartialSnippet(parentId, nodeName)).toBe(snippet);
         });
 
         it('should return the snippet for inserting a partial from a folder', function () {
             var parentId = "Folder";
             var nodeName = "Footer.cshtml";
-            var snippet = '@Html.Partial("Folder/Footer")';
+            var snippet = '@await Html.PartialAsync("Folder/Footer")';
             expect(templateHelper.getInsertPartialSnippet(parentId, nodeName)).toBe(snippet);
         });
 
         it('should return the snippet for inserting a partial from a nested folder', function () {
             var parentId = "Folder/NestedFolder";
             var nodeName = "Footer.cshtml";
-            var snippet = '@Html.Partial("Folder/NestedFolder/Footer")';
+            var snippet = '@await Html.PartialAsync("Folder/NestedFolder/Footer")';
             expect(templateHelper.getInsertPartialSnippet(parentId, nodeName)).toBe(snippet);
         });
 
         it('should return the snippet for inserting a partial from a folder with spaces in its name', function () {
             var parentId = "Folder with spaces";
             var nodeName = "Footer.cshtml";
-            var snippet = '@Html.Partial("Folder with spaces/Footer")';
+            var snippet = '@await Html.PartialAsync("Folder with spaces/Footer")';
             expect(templateHelper.getInsertPartialSnippet(parentId, nodeName)).toBe(snippet);
         });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11220

### Description
Changes the templatehelper service so that when inserting a partial view in the template editor it uses the recommended approach of async partials.

### Testing
To test this create a new document type with a template and create a content page for it. Now create a partial with some example content. Now return to the document type template and use the editor to insert a partial view and pick the one you just created. You should then save this and view your content page and see that it renders the partial content correctly.
