### PR TITLE
Cypress test for textbox max length

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/DataTypes/dataTypes.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/DataTypes/dataTypes.ts
@@ -99,7 +99,7 @@ context('DataTypes', () => {
         cy.umbracoButtonByLabelKey('buttons_saveAndPublish').click();
         cy.get('.property-error').should('be.visible');
 
-        // //Clean
+        // Clean
         cy.umbracoEnsureDataTypeNameNotExists(name);
         cy.umbracoEnsureDocumentTypeNameNotExists(name);
     })

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/DataTypes/dataTypes.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/DataTypes/dataTypes.ts
@@ -2,6 +2,7 @@
 import {
     AliasHelper,
     ApprovedColorPickerDataTypeBuilder,
+    TextBoxDataTypeBuilder,
 } from 'umbraco-cypress-testhelpers';
 
 context('DataTypes', () => {
@@ -60,6 +61,48 @@ context('DataTypes', () => {
         cy.umbracoEnsureDocumentTypeNameNotExists(name);
         cy.umbracoEnsureTemplateNameNotExists(name);
     });
+
+    it('Tests Textbox Maxlength', () => {
+        cy.deleteAllContent();
+        const name = 'Textbox Maxlength Test';
+        const alias = AliasHelper.toAlias(name);
+
+        cy.umbracoEnsureDocumentTypeNameNotExists(name);
+        cy.umbracoEnsureDataTypeNameNotExists(name);
+
+        const textBoxDataType = new TextBoxDataTypeBuilder()
+            .withName(name)
+            .withMaxChars(10)
+            .build()
+
+        cy.umbracoCreateDocTypeWithContent(name, alias, textBoxDataType);
+
+        // Act
+        // Enter content
+        // Assert no helptext with (max-2) chars & can save
+        cy.umbracoRefreshContentTree();
+        cy.umbracoTreeItem("content", [name]).click();
+        cy.get('input[name="textbox"]').type('12345678');
+        cy.get('localize[key="textbox_characters_left"]').should('not.exist');
+        cy.umbracoButtonByLabelKey('buttons_saveAndPublish').click();
+        cy.umbracoSuccessNotification().should('be.visible');
+        cy.get('.property-error').should('not.be.visible');
+
+        // Add char and assert helptext appears - no publish to save time & has been asserted above & below
+        cy.get('input[name="textbox"]').type('9');
+        cy.get('localize[key="textbox_characters_left"]').contains('characters left').should('exist');
+        cy.get('.property-error').should('not.be.visible');
+
+        // Add char and assert errortext appears and can't save
+        cy.get('input[name="textbox"]').type('10'); // 1 char over max
+        cy.get('localize[key="textbox_characters_exceed"]').contains('too many').should('exist');
+        cy.umbracoButtonByLabelKey('buttons_saveAndPublish').click();
+        cy.get('.property-error').should('be.visible');
+
+        // //Clean
+        cy.umbracoEnsureDataTypeNameNotExists(name);
+        cy.umbracoEnsureDocumentTypeNameNotExists(name);
+    })
 
     //   it('Tests Checkbox List', () => {
     //     const name = 'CheckBox List';

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Members/memberGroups.js
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Members/memberGroups.js
@@ -1,4 +1,4 @@
-context('User Groups', () => {
+context('Member Groups', () => {
 
     beforeEach(() => {
         cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Added Cypress test for testing the textbox datatype's maxlength setting.
It roughly does this:

- Creates a doctype with a new textbox datatype with max chars 10
- Creates a content node based on that and add 8 chars to the textbox - asserts no helptext occurs
- Adds another char - assert it tells the user there is only 1 char left
- Adds 2 more - asserts it now errors as we are above the limit

Also renamed the member group test group from user group to member group as that confused me a bit 😁

Let me know if anything here isn't how it should be!

PS: Runs for around 4s on my machine - could probably shave a bit off if we skipped the initial save and publish assertion, already removed the middle one as it seemed unnecessary - the final one is necessary to trigger validation errors and is also fast as it errors before the actual save & publish action runs.

<!-- Thanks for contributing to Umbraco CMS! -->
