### PR TITLE
Fixes wrong reference to enterSubmitFolder method in ng-keydown in mediapicker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -90,7 +90,7 @@
                                         class="umb-breadcrumbs__add-ancestor"
                                         ng-show="model.showFolderInput"
                                         ng-model="model.newFolderName"
-                                        ng-keydown="enterSubmitFolder($event)"
+                                        ng-keydown="vm.enterSubmitFolder($event)"
                                         ng-blur="vm.submitFolder()"
                                         focus-when="{{model.showFolderInput}}" />
                             </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When creating a folder in the mediapicker, by clicking the + button, you have to unfocus the input field to make it create the folder. Previously you could press return / enter (13) on your keyboard to make it create the folder.

I found out the ng-keydown attribute was missing `vm.` in the reference to the method.

**To test**
- Open a media picker
- Click the + to start creating a new folder
- Type something and press return /enter
- The folder should be created
