### PR TITLE
Ability to remove trees in the backoffice

### DIFF
--- a/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/CollectionBuilders/TreeCollectionBuilderTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/CollectionBuilders/TreeCollectionBuilderTests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Trees;
+using Umbraco.Cms.Web.BackOffice.Trees;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.CollectionBuilders
+{
+    public class TreeCollectionBuilderTests
+    {
+        [Test]
+        public void Adding_Tree_To_Collection_Builder()
+        {
+            var collectionBuilder = new TreeCollectionBuilder();
+            var treeDefinition = new Tree(0, "test", "test", "test", "test", TreeUse.Main, typeof(LanguageTreeController), false);
+
+            collectionBuilder.AddTree(treeDefinition);
+            var collection = collectionBuilder.CreateCollection(null);
+
+            Assert.AreEqual(1, collection.Count);
+            Assert.AreEqual(treeDefinition, collection.FirstOrDefault());
+        }
+
+        [Test]
+        public void Remove_Tree_From_Collection_Builder()
+        {
+            var collectionBuilder = new TreeCollectionBuilder();
+            var treeDefinition = new Tree(0, "test", "test", "test", "test", TreeUse.Main, typeof(LanguageTreeController), false);
+
+            collectionBuilder.AddTree(treeDefinition);
+            collectionBuilder.RemoveTreeController<LanguageTreeController>();
+            var collection = collectionBuilder.CreateCollection(null);
+
+            Assert.AreEqual(0, collection.Count);
+        }
+    }
+}

--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Trees;
@@ -55,6 +56,17 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         {
             foreach (var controllerType in controllerTypes)
                 AddTreeController(controllerType);
+        }
+
+        public void RemoveTreeController<T>() => RemoveTreeController(typeof(T));
+
+        public void RemoveTreeController(Type type)
+        {
+            var tree = _trees.FirstOrDefault(it => it.TreeControllerType == type);
+            if (tree != null)
+            {
+                _trees.Remove(tree);
+            }
         }
     }
 }


### PR DESCRIPTION
During one of my developments on a website, I had to replace a tree within Umbraco and replace it with my own copy due to some extensions that weren't possible.
However, I learned that you are currently not able to remove a tree from the backoffice. As a workaround, I started to hide the tree with some CSS classes.

This PR includes some logic to be able to remove trees within a composer so that you are able to replace them with your own implementation.

Code you can use to test:
```
public class TestComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.Trees().RemoveTreeController<DictionaryTreeController>();
        }
    }
```

This will remove the tree controller responsible for the dictionary items. So after running this code, you can go to the translation section to check it. The translation section should be completely empty.