### PR TITLE
11251: Don't add default dashboard to url

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.controller.js
@@ -50,14 +50,17 @@ function DashboardController($scope, $q, $routeParams, $location, dashboardResou
         // Check the query parameter for a dashboard alias
         const dashboardAlias = $location.search()[DASHBOARD_QUERY_PARAM];
         const dashboardIndex = $scope.dashboard.tabs.findIndex(tab => tab.alias === dashboardAlias);
+        const showDefaultDashboard = dashboardIndex === -1;
 
         // Set the first dashboard to active if there is no query parameter or we can't find a matching dashboard for the alias
-        const activeIndex = dashboardIndex !== -1 ? dashboardIndex : 0;
+        const activeIndex = showDefaultDashboard ? 0 : dashboardIndex;
 
         const tab = $scope.dashboard.tabs[activeIndex];
 
         tab.active = true;
-        $location.search(DASHBOARD_QUERY_PARAM, tab.alias);
+        if (!showDefaultDashboard) {
+            $location.search(DASHBOARD_QUERY_PARAM, tab.alias);
+        }
     }
 }
 


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11251

The fix is to not load the dashboard to the URL when no dashboard URL is found (when you navigate towards it from the navigation).

Old situation:
![oldSituation](https://user-images.githubusercontent.com/11466511/135724631-0ccf52a8-fd8a-4b88-a6ba-0979b4fe7871.gif)

New situation:
![newSituation](https://user-images.githubusercontent.com/11466511/135724643-cecf1a46-22b8-4c39-a37c-91f3170bfaed.gif)

