### PR TITLE
v9 enable nucache in memory only

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
@@ -32,5 +32,18 @@ namespace Umbraco.Cms.Core.Configuration.Models
         public int SqlPageSize { get; set; } = StaticSqlPageSize;
 
         public bool UnPublishedContentCompression { get; set; } = false;
+
+        /// <summary>
+        /// <para>
+        /// When set to true NuCache.*.db files are not written to disk.
+        /// </para>
+        /// <para>
+        /// For larger sites this may result in a slower boot, however this may be a desirable trade off if you are experiencing locking issues with the NuCache files.
+        /// </para>
+        /// <para>
+        /// Defaults to false.
+        /// </para>
+        /// </summary>
+        public bool InMemoryOnly { get; set; } = false;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Steps to test
+ Delete NuCache.Content.db
+ Set "Umbraco:Cms:NuCache:InMemoryOnly = true
+ Start site, add content, preview content, assert no NuCache.Content.db created
--
+ Delete key "Umbraco:Cms:NuCache:InMemoryOnly (or set false)
+ Start site, add content, preview content, assert NuCache.Content.db is created and modified
