### PR TITLE
11048: Bugfix for groups and properties that get replaced

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
@@ -328,6 +328,10 @@
                     rebindCallback: function (origContentType, savedContentType) {
                         vm.contentType.ModelState = savedContentType.ModelState;
                         vm.contentType.id = savedContentType.id;
+                        //Don't rebind the groups and properties when an error has occurred. Otherwise properties with the same alias could get the same IDs
+                        if (savedContentType.ModelState) {
+                            return;
+                        }
                         vm.contentType.groups.forEach(function (group) {
                             if (!group.name) return;
                             var k = 0;


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11048

Steps for reproducing the bug can be found in the issue.

The issue was that whenever the save API call would return an error (due to the duplicate aliases here), it would still rebind the properties & groups based on their alias. So if you have a duplicate alias, they would both get the same id which eventually makes it so that the last property will override the first one. 
I am not really sure why the code is rebinding on an error as there isn't anything saved at that point. However, I have not encountered any issues with not rebinding the properties & groups on an error. If there is a scenario that I haven't tested yet where this is important, then please let me know and I'll take a look at it.
![ValidProperties](https://user-images.githubusercontent.com/11466511/135769077-8bb23d8a-4364-415e-b06b-8738ee1c9507.gif)

