### PR TITLE
Fixed issue with culture not set when doing internal redirects due to public access

### DIFF
--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -237,7 +237,7 @@ namespace Umbraco.Cms.Core.Routing
 
             // re-route
             await RouteRequestInternalAsync(builder);
-            
+
             // return if we are redirect
             if (builder.IsRedirect())
             {
@@ -250,6 +250,11 @@ namespace Umbraco.Cms.Core.Routing
                 // means the engine could not find a proper document to handle 404
                 // restore the saved content so we know it exists
                 builder.SetPublishedContent(content);
+            }
+
+            if (!builder.HasDomain())
+            {
+                FindDomain(builder);
             }
 
             return BuildRequest(builder);


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/11227

When rewriting the published content due to public access. E.g. redirect to login page, the culture was not specified. Thereby the dictionary item culture falled back to the default from config. If is not the correct one, no translations was shown.