### PR TITLE
Moved endpoint to new controller to avoid issue with too hard access requirements

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -280,6 +280,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                                 controller => controller.GetAllTypes())
                         },
                         {
+                            "memberTypeQueryApiBaseUrl", _linkGenerator.GetUmbracoApiServiceBaseUrl<MemberTypeQueryController>(
+                                controller => controller.GetAllTypes())
+                        },
+                        {
                             "memberGroupApiBaseUrl", _linkGenerator.GetUmbracoApiServiceBaseUrl<MemberGroupController>(
                                 controller => controller.GetAllGroups())
                         },

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -182,6 +182,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <summary>
         /// Returns all member types
         /// </summary>
+        [Obsolete("Use MemberTypeQueryController.GetAllTypes instead as it only requires AuthorizationPolicies.TreeAccessMembersOrMemberTypes and not both this and AuthorizationPolicies.TreeAccessMemberTypes")]
         [Authorize(Policy = AuthorizationPolicies.TreeAccessMembersOrMemberTypes)]
         public IEnumerable<ContentTypeBasic> GetAllTypes()
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeQueryController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeQueryController.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Attributes;
+using Umbraco.Cms.Web.Common.Authorization;
+using Constants = Umbraco.Cms.Core.Constants;
+
+namespace Umbraco.Cms.Web.BackOffice.Controllers
+{
+    /// <summary>
+    /// An API controller used for dealing with member types
+    /// </summary>
+    [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMembersOrMemberTypes)]
+    public class MemberTypeQueryController : BackOfficeNotificationsController
+    {
+        private readonly IMemberTypeService _memberTypeService;
+        private readonly IUmbracoMapper _umbracoMapper;
+
+
+        public MemberTypeQueryController(
+            IMemberTypeService memberTypeService,
+            IUmbracoMapper umbracoMapper)
+        {
+            _memberTypeService = memberTypeService ?? throw new ArgumentNullException(nameof(memberTypeService));
+            _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));
+        }
+
+        /// <summary>
+        /// Returns all member types
+        /// </summary>
+        public IEnumerable<ContentTypeBasic> GetAllTypes()
+        {
+            return _memberTypeService.GetAll()
+                               .Select(_umbracoMapper.Map<IMemberType, ContentTypeBasic>);
+        }
+
+    }
+}

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeQueryController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeQueryController.cs
@@ -34,11 +34,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <summary>
         /// Returns all member types
         /// </summary>
-        public IEnumerable<ContentTypeBasic> GetAllTypes()
-        {
-            return _memberTypeService.GetAll()
-                               .Select(_umbracoMapper.Map<IMemberType, ContentTypeBasic>);
-        }
+        public IEnumerable<ContentTypeBasic> GetAllTypes() =>
+            _memberTypeService.GetAll()
+                .Select(_umbracoMapper.Map<IMemberType, ContentTypeBasic>);
 
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -46,10 +46,10 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
             return umbRequestHelper.resourcePromise(
                $http.get(
                    umbRequestHelper.getApiUrl(
-                       "memberTypeApiBaseUrl",
+                       "memberTypeQueryApiBaseUrl",
                        "GetAllTypes")),
                'Failed to retrieve data for member types id');
-        },       
+        },
 
         getById: function (id) {
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/11258

The issue is the auth policies cannot be overridden.. You need all of them, and the old controller requires you to have access to member types