### PR TITLE
Ensure dependency order for Deploy artifacts

### DIFF
--- a/src/Umbraco.Core/Udi.cs
+++ b/src/Umbraco.Core/Udi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Linq;
 
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Core
 
         public int CompareTo(Udi other)
         {
-            return string.Compare(UriValue.ToString(), other.UriValue.ToString(), StringComparison.InvariantCultureIgnoreCase);
+            return string.Compare(UriValue.ToString(), other.UriValue.ToString(), StringComparison.OrdinalIgnoreCase);
         }
 
         public override string ToString()

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
@@ -27,6 +28,33 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Deploy
 
             var expected = "{\"Udi\":\"umb://test/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
             Assert.AreEqual(expected, serialized);
+        }
+
+        [Test]
+        public void Dependencies_Are_Correctly_Ordered()
+        {
+            // This test was introduced following: https://github.com/umbraco/Umbraco.Deploy.Issues/issues/72 to verify
+            // that consistent ordering rules are used across platforms.
+            var udi = new GuidUdi("test", Guid.Parse("3382d5433b5749d08919bc9961422a1f"));
+            var artifact = new TestArtifact(udi, new List<ArtifactDependency>())
+            {
+                Name = "Test Name",
+                Alias = "testAlias",
+            };
+
+            var dependencies = new ArtifactDependencyCollection();
+
+            var dependencyUdi1 = new GuidUdi("template", Guid.Parse("d4651496fad24c1290a53ea4d55d945b"));
+            dependencies.Add(new ArtifactDependency(dependencyUdi1, true, ArtifactDependencyMode.Exist));
+
+            var dependencyUdi2 = new StringUdi(Constants.UdiEntityType.TemplateFile, "TestPage.cshtml");
+            dependencies.Add(new ArtifactDependency(dependencyUdi2, true, ArtifactDependencyMode.Exist));
+
+            artifact.Dependencies = dependencies;
+
+            Assert.AreEqual(
+                "umb://template-file/TestPage.cshtml,umb://template/d4651496fad24c1290a53ea4d55d945b",
+                string.Join(",", artifact.Dependencies.Select(x => x.Udi.ToString())));
         }
 
         private class TestArtifact : ArtifactBase<GuidUdi>


### PR DESCRIPTION
This issue raised this this should resolve is [here](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/72), where it seemed to matter whether or not a template had a master template defined or not as to whether you could successfully deploy content.

After a bit of digging I found that Deploy was reporting a schema mismatch between two entities that were identical, due to differences in how the dependencies were ordered within the serialized output.  This wasn't reproducible between two local environments, only between local and Cloud.

Initially I thought we weren't ensuring the order and were relying on the collection to come back in a particular way, but actually we are doing this.  However the difference in behaviour looks to be due to differences in globalization settings (as we've seen in other contexts, related to [this](https://jimmybogard.com/mind-your-strings-with-net-5-0/)).

I've been able to demonstrate that the ordering of the string representations of these two UDIs comes back one way locally, and the opposite way in Cloud:

```
  var dependencies = new List<string>
  {
      "umb://template/d4651496fad24c1290a53ea4d55d945b",
      "umb://template-file/TestPage.cshtml"
  };
  foreach(var dependency in dependencies.OrderBy(x => x, StringComparer.InvariantCultureIgnoreCase))
  {
      <div>@dependency</div>
  }
```

Using `OrdinalIgnoreCase` makes them consistent though in both environments.  Hence I've applied the same setting for the ordering we do in core.

In the end think we've just been quite unlucky in having two entities that happen to be ordered by `-` v `/`.