### PR TITLE
11269: Make sure TemplateId is set correctly from cache

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1232,12 +1232,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 {
                     // need templates
                     var templateId = dto.DocumentVersionDto.TemplateId;
-                    if (templateId.HasValue && templateId.Value > 0)
+                    if (templateId.HasValue)
                         templateIds.Add(templateId.Value);
                     if (dto.Published)
                     {
                         templateId = dto.PublishedVersionDto.TemplateId;
-                        if (templateId.HasValue && templateId.Value > 0)
+                        if (templateId.HasValue)
                             templateIds.Add(templateId.Value);
                     }
                 }
@@ -1334,7 +1334,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 content.DisableChangeTracking();
 
                 // get template
-                if (dto.DocumentVersionDto.TemplateId.HasValue && dto.DocumentVersionDto.TemplateId.Value > 0)
+                if (dto.DocumentVersionDto.TemplateId.HasValue)
                     content.TemplateId = dto.DocumentVersionDto.TemplateId;
 
                 // get properties - indexed by version id

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.ContentDataSerializer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.ContentDataSerializer.cs
@@ -22,15 +22,22 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache.DataSource
 
         public ContentData ReadFrom(Stream stream)
         {
+            var published = PrimitiveSerializer.Boolean.ReadFrom(stream);
+            var name = PrimitiveSerializer.String.ReadFrom(stream);
+            var urlSegment = PrimitiveSerializer.String.ReadFrom(stream);
+            var versionId = PrimitiveSerializer.Int32.ReadFrom(stream);
+            var versionDate = PrimitiveSerializer.DateTime.ReadFrom(stream);
+            var writerId = PrimitiveSerializer.Int32.ReadFrom(stream);
+            var templateId = PrimitiveSerializer.Int32.ReadFrom(stream);
             return new ContentData
             {
-                Published = PrimitiveSerializer.Boolean.ReadFrom(stream),
-                Name = PrimitiveSerializer.String.ReadFrom(stream),
-                UrlSegment = PrimitiveSerializer.String.ReadFrom(stream),
-                VersionId = PrimitiveSerializer.Int32.ReadFrom(stream),
-                VersionDate = PrimitiveSerializer.DateTime.ReadFrom(stream),
-                WriterId = PrimitiveSerializer.Int32.ReadFrom(stream),
-                TemplateId = PrimitiveSerializer.Int32.ReadFrom(stream),
+                Published = published,
+                Name = name,
+                UrlSegment = urlSegment,
+                VersionId = versionId,
+                VersionDate = versionDate,
+                WriterId = writerId,
+                TemplateId = templateId == 0 ? (int?)null : templateId,
                 Properties = _dictionaryOfPropertyDataSerializer.ReadFrom(stream), // TODO: We don't want to allocate empty arrays
                 CultureInfos = DefaultCultureVariationsSerializer.ReadFrom(stream) // TODO: We don't want to allocate empty arrays
             };
@@ -44,10 +51,7 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache.DataSource
             PrimitiveSerializer.Int32.WriteTo(value.VersionId, stream);
             PrimitiveSerializer.DateTime.WriteTo(value.VersionDate, stream);
             PrimitiveSerializer.Int32.WriteTo(value.WriterId, stream);
-            if (value.TemplateId.HasValue)
-            {
-                PrimitiveSerializer.Int32.WriteTo(value.TemplateId.Value, stream);
-            }
+            PrimitiveSerializer.Int32.WriteTo(value.TemplateId ?? 0, stream);
             _dictionaryOfPropertyDataSerializer.WriteTo(value.Properties, stream);
             DefaultCultureVariationsSerializer.WriteTo(value.CultureInfos, stream);
         }

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/ContentSourceDto.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/ContentSourceDto.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Infrastructure.PublishedCache.DataSource

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -824,7 +824,7 @@ AND cmsContentNu.nodeId IS NULL
                     {
                         Name = dto.EditName,
                         Published = published,
-                        TemplateId = dto.EditTemplateId,
+                        TemplateId = dto.EditTemplateId == 0 ? (int?)null : dto.EditTemplateId,
                         VersionId = dto.VersionId,
                         VersionDate = dto.EditVersionDate,
                         WriterId = dto.EditWriterId,
@@ -856,7 +856,7 @@ AND cmsContentNu.nodeId IS NULL
                         Name = dto.PubName,
                         UrlSegment = deserializedContent.UrlSegment,
                         Published = published,
-                        TemplateId = dto.PubTemplateId,
+                        TemplateId = dto.PubTemplateId == 0 ? (int?)null : dto.PubTemplateId,
                         VersionId = dto.VersionId,
                         VersionDate = dto.PubVersionDate,
                         WriterId = dto.PubWriterId,


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11269

Way to reproduce bug can be found in the issue.
The issue here was that the id was saved as 0 in the Nucache instead of NULL. I am not sure if the way that I did this is the best way to fix it. I tried setting the template ids to int? within ContentSourceDto, but that then gave issues with the serialization. Ideally, I would want a serializer for nullable ints, but I couldn't find a lot of documentation about the serialization there (Or perhaps I was looking at the wrong place).

This way, it will still store the template ids as 0 in the Nucache, but it'll translate that back to NULL when loading the data.

Would love to implement any suggestions on how to fix this in a more efficient way.
