### PR TITLE
Fixes (hides) customize button when connection string is already configured

### DIFF
--- a/src/Umbraco.Infrastructure/Install/InstallSteps/NewInstallStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/NewInstallStep.cs
@@ -117,7 +117,8 @@ namespace Umbraco.Cms.Infrastructure.Install.InstallSteps
                 {
                     minCharLength = _passwordConfiguration.RequiredLength,
                     minNonAlphaNumericLength = _passwordConfiguration.GetMinNonAlphaNumericChars(),
-                    quickInstallAvailable = DatabaseConfigureStep.IsSqlCeAvailable()
+                    quickInstallAvailable = DatabaseConfigureStep.IsSqlCeAvailable(),
+                    customInstallAvailable = !GetInstallState().HasFlag(InstallState.ConnectionStringConfigured)
                 };
             }
         }

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.Install.UserController">
+<div ng-controller="Umbraco.Install.UserController">
     <h1>Install Umbraco</h1>
 
     <p>Enter your name, email and password to install Umbraco with its default settings, alternatively you can customize your installation</p>
@@ -59,7 +59,7 @@
                     <div class="control-group" ng-class="{disabled:myForm.$invalid}">
                         <div class="controls">
                             <input ng-if="installer.current.model.quickInstallAvailable" type="submit" ng-disabled="myForm.$invalid" value="Install" class="btn btn-success" />
-                            <button ng-if="installer.current.model.quickInstallAvailable" class="btn btn-info control-customize" ng-disabled="myForm.$invalid" ng-click="validateAndForward()">Customize</button>
+                            <button ng-if="installer.current.model.quickInstallAvailable && installer.current.model.customInstallAvailable" class="btn btn-info control-customize" ng-disabled="myForm.$invalid" ng-click="validateAndForward()">Customize</button>
 
                             <button ng-if="!installer.current.model.quickInstallAvailable" class="btn btn-primary control-customize" ng-disabled="myForm.$invalid" ng-click="validateAndForward()">Next</button>
                         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11187

### Description
Added a new field to the new install view model indicating whether custom install is available. Changed the "Custom" button visibility to depend on this field (as well as the quick install availability)  

#### Tests
- Launch a fresh install of Umbraco, the customize button should be available
- Stop Umbraco and add a connection string to  `appsettings.json`, e.g. `"umbracoDbDSN": "Data Source=|DataDirectory|\\Umbraco.sdf;Flush Interval=1;"`
- Relaunch, the customize button should be hidden

<!-- Thanks for contributing to Umbraco CMS! -->
