### PR TITLE
Removed obsolete method

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/UmbracoPocoDataBuilder.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoPocoDataBuilder.cs
@@ -18,6 +18,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence
     /// <para>So far, this is very manual. We don't try to be clever and figure out whether the
     /// columns exist already. We just ignore it.</para>
     /// <para>Beware, the application MUST restart when this class behavior changes.</para>
+    /// <para>You can override the GetColmunnInfo method to control which columns this includes</para>
     /// </remarks>
     internal class UmbracoPocoDataBuilder : PocoDataBuilder
     {
@@ -27,20 +28,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence
             : base(type, mapper)
         {
             _upgrading = upgrading;
-        }
-
-        protected override ColumnInfo GetColumnInfo(MemberInfo mi, Type type)
-        {
-            var columnInfo = base.GetColumnInfo(mi, type);
-
-            // TODO: Is this upgrade flag still relevant? It's a lot of hacking to just set this value
-            // including the interface method ConfigureForUpgrade for this one circumstance.
-            if (_upgrading)
-            {
-                if (type == typeof(UserDto) && mi.Name == "TourData") columnInfo.IgnoreColumn = true;
-            }
-
-            return columnInfo;
         }
     }
 }


### PR DESCRIPTION
# Notes
- Removed obsolete migration method from UmbracoPocoDataBuilder

# How to test
- Run a clean install
- When the tour popup shows, press "do not show again"
- Reload the page and verify that the popup doesn't show
- Create a migration class, I used this: 
```
namespace Umbraco.Cms.Infrastructure.Migrations
{
    public class MyMigration : MigrationBase
    {
        public MyMigration(IMigrationContext context) : base(context)
        {
        }

        protected override void Migrate()
        {
            
        }
    }
}
```
- Create a fake migration in UmbracoPlan.cs with `To<MyMigration>("47C4C7DF-4977-45F6-A6D4-8DC727BC8FE7");`
- Run Umbraco and run the migration by pressing continue
- Verify that the tour popup doesn't show