### PR TITLE
Return tempFiles from PostAddFile result

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -858,7 +858,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 }
             }
 
-            return Ok();
+            return Ok(tempFiles);
         }
 
         private IMedia FindInChildren(int mediaId, string nameToFind, string contentTypeAlias)


### PR DESCRIPTION
Add the response data to the return. Fixes #11278

### Prerequisites

- [ ✔] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/11278

### Description
Response data was not being included in the reutrn of `PostAddFile`, which caused notifications to not show correctly.

