### PR TITLE
Fix SVG preview without sizing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -621,6 +621,12 @@
             justify-content: center;
             align-items: center;
 
+            > a {
+                display: block;
+                width: 100%;
+                height: 100%;
+            }
+
             img {
                 display: block;
                 max-width: 100%;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11274

### Description
When uploading a SVG file, the previews wasn't shown if the SVG file itself hasn't width and height attributes or inline style to set height and width. In that case the preview was collapsed as the size of the SVG was 0x0 px.

