### PR TITLE
Icon fallback to `icon-document` for existing document types

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT) #
 
-Copyright (c) 2013-present Umbraco
+Copyright (c) 2005-present Umbraco
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -534,6 +534,8 @@
 
                 scope.openTabAlias = tab.alias;
 
+                notifyChanged();
+
                 scope.$broadcast('umbOverflowChecker.checkOverflow');
                 scope.$broadcast('umbOverflowChecker.scrollTo', { position: 'end' });
             };
@@ -570,6 +572,8 @@
                             });
 
                             scope.$broadcast('umbOverflowChecker.checkOverflow');
+
+                            notifyChanged();
 
                             overlayService.close();
                         }
@@ -712,6 +716,8 @@
                 scope.model.groups = [...scope.model.groups, group];
 
                 scope.activateGroup(group);
+
+                notifyChanged();
             };
 
             scope.activateGroup = selectedGroup => {
@@ -758,6 +764,7 @@
                             scope.model.groups.splice(index, 1);
 
                             overlayService.close();
+                            notifyChanged();
                         }
                     });
                 });
@@ -1022,7 +1029,6 @@
 
                 return (result.length > 0);
             }
-
 
             eventBindings.push(scope.$watch('model', (newValue, oldValue) => {
                 if (newValue !== undefined && newValue.groups !== undefined) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -65,16 +65,15 @@ angular.module("umbraco.directives")
                     function _filesQueued(files, event) {
                         //Push into the queue
                         Utilities.forEach(files, file => {
+                            if (_filterFile(file) === true) {
 
-                                if (_filterFile(file) === true) {
-
-                                    if (file.$error) {
-                                        scope.rejected.push(file);
-                                    } else {
-                                        scope.queue.push(file);
-                                    }
+                                if (file.$error) {
+                                    scope.rejected.push(file);
+                                } else {
+                                    scope.queue.push(file);
                                 }
-                            });
+                            }
+                        });
 
                         //when queue is done, kick the uploader
                         if (!scope.working) {
@@ -173,6 +172,8 @@ angular.module("umbraco.directives")
                                     }
                                 } else if (evt.Message) {
                                     file.serverErrorMessage = evt.Message;
+                                } else if (evt && typeof evt === 'string') {
+                                    file.serverErrorMessage = evt;
                                 }
                                 // If file not found, server will return a 404 and display this message
                                 if (status === 404) {
@@ -247,11 +248,18 @@ angular.module("umbraco.directives")
                         return true;// yes, we did open the choose-media dialog, therefor we return true.
                     }
 
-                    scope.handleFiles = function(files, event) {
+                    scope.handleFiles = function(files, event, invalidFiles) {
+                        const allFiles = [...files, ...invalidFiles];
+
+                        // add unique key for each files to use in ng-repeats
+                        allFiles.forEach(file => {
+                            file.key = String.CreateGuid();
+                        });
+
                         if (scope.filesQueued) {
-                            scope.filesQueued(files, event);
+                            scope.filesQueued(allFiles, event);
                         }
-                        _filesQueued(files, event);
+                        _filesQueued(allFiles, event);
                     };
                 }
             };

--- a/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsJoinArray.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsJoinArray.filter.js
@@ -4,17 +4,20 @@
  * @namespace umbCmsJoinArray
  * 
  * param {array} array of string or objects, if an object use the third argument to specify which prop to list.
- * param {seperator} string containing the seperator to add between joined values.
+ * param {separator} string containing the separator to add between joined values.
  * param {prop} string used if joining an array of objects, set the name of properties to join.
  * 
  * @description
- * Join an array of string or an array of objects, with a costum seperator.
- * 
+ * Join an array of string or an array of objects, with a custom separator.
+ * If the array is null or empty, returns an empty string
+ * If the array is not actually an array (ie a string or number), returns the value of the array
  */
 angular.module("umbraco.filters").filter('umbCmsJoinArray', function () {
     return function join(array, separator, prop) {
-        return (!Utilities.isUndefined(prop) ? array.map(function (item) {
-            return item[prop];
-        }) : array).join(separator || '');
+        if (typeof array !== 'object' || !array) {
+            return array || '';
+        }
+        separator = separator || '';
+        return (!Utilities.isUndefined(prop) ? array.map(item => item[prop]) : array).join(separator);
     };
 });

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -99,19 +99,20 @@
             }
         }
 
-
         /**
          * Generate label for Block, uses either the labelInterpolator or falls back to the contentTypeName.
          * @param {Object} blockObject BlockObject to recive data values from.
          */
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
-                var labelVars = Object.assign({"$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
-                return blockObject.labelInterpolator(labelVars);
+                var labelVars = Object.assign({"$contentTypeName": blockObject.content.contentTypeName, "$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
+                var label = blockObject.labelInterpolator(labelVars);
+                if (label) {
+                    return label;
+                }
             }
             return blockObject.content.contentTypeName;
         }
-
 
         /**
          * Used to add watchers on all properties in a content or settings model

--- a/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/prevalues/multivalues.less
@@ -45,15 +45,15 @@
 
     &.ui-sortable-handle,
     .ui-sortable-handle,
-    .handle
-    {
+    .handle {
         cursor: move;
     }
 
-    i {
+    .umb-icon,
+    i.icon {
         display: flex;
-        align-items: center;
-        margin-right: 5px
+        align-self: center;
+        margin-right: 5px;
     }
 
     a {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-form-check.less
@@ -97,7 +97,8 @@
 
     .icon,
     .umb-icon {
-        font-size: 1.2rem;
+        font-size: 0.9rem;
+        line-height: 1;
     }
 
     &__state {
@@ -110,6 +111,8 @@
 
     &__check {
         display: flex;
+        align-items: center;
+        justify-content: center;
         position: relative;
         background: @white;
         border: 1px solid @inputBorder;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-grid.less
@@ -565,12 +565,11 @@
 // ICONS
 // -------------------------
 .umb-grid .iconBox {
-    padding: 4px 6px;
-    display: inline-block;
-    cursor: pointer;
+    padding: 6px;
+    display: flex;
     border-radius: 200px;
     border: 1px solid @ui-action-discreet-border;
-    margin: 2px;
+    margin: 0 auto;
 
     &:hover, &:hover * {
         background: @ui-action-discreet-type-hover !important;
@@ -599,8 +598,6 @@
     -webkit-appearance: none;
     background-image: linear-gradient(to bottom,@gray-9,@gray-7);
     background-repeat: repeat-x;
-    zoom: 1;
-    border-color: @gray-7 @gray-7 @gray-6;
     border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);
     box-shadow: inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);
     border-radius: 3px;

--- a/src/Umbraco.Web.UI.Client/src/less/dashboards/examine-management.less
+++ b/src/Umbraco.Web.UI.Client/src/less/dashboards/examine-management.less
@@ -13,8 +13,45 @@
         }
     }
 
+    .umb-panel-group__details-status-content{
+        width:50%; // this is to fix flexbox not making the content too wide
+    }
+
     .umb-panel-group__details-status-action{
         background-color:transparent;
         padding-left:0;
     }
+
+    .result-table {
+        overflow-x:auto;
+        border:1px solid @tableBorder;
+
+        > table {
+            margin-bottom:0;
+            border:0;
+        }
+
+        th:first-child,
+        td:first-child {
+            position:sticky;
+            left:0;
+            background-color:@white;
+            border-right:1px solid @tableBorder;
+            border-left:0;
+
+            + td,
+            + th {
+                border-left:0;
+            }
+        }
+
+        th:last-child,
+        td:last-child {
+            position:sticky;
+            right:0;
+            background-color:@white;
+            border-left:1px solid @tableBorder;
+        }
+    }
 }
+

--- a/src/Umbraco.Web.UI.Client/src/less/utilities/_text-align.less
+++ b/src/Umbraco.Web.UI.Client/src/less/utilities/_text-align.less
@@ -2,6 +2,12 @@
   TEXT ALIGN
 */
 
-.tl  { text-align: left; }
-.tr  { text-align: right; }
-.tc  { text-align: center; }
+.tl,
+.table td.tl,
+.table th.tl  { text-align: left; }
+.tr,
+.table td.tr,
+.table th.tr  { text-align: right; }
+.tc,
+.table td.tc,
+.table th.tc  { text-align: center; }

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,6 +1,6 @@
 <ul role="tablist" class="umb-tabs-nav">
     <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
-        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" aria-selected="{tab.active}" type="button">
+        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" aria-selected="{{tab.active}}" type="button">
             {{ tab.label }}
             <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
         </button>
@@ -23,7 +23,7 @@
                     ng-class="{'dropdown-menu--active': tab.active}"
                     ng-click="vm.clickTab($event, tab)"
                     role="tab"
-                    aria-selected="{tab.active}" >
+                    aria-selected="{{tab.active}}" >
                     {{ tab.label }}
                     <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
                 </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -6,7 +6,7 @@
         <div ngf-drop
             ng-hide="hideDropzone === 'true'"
             ng-model="filesHolder"
-            ngf-change="handleFiles($files, $event)"
+            ngf-change="handleFiles($files, $event, $invalidFiles)"
             class="dropzone"
             ngf-drag-over-class="'drag-over'"
             ngf-multiple="true"
@@ -30,7 +30,7 @@
                      class="file-select"
                      ngf-select
                      ng-model="filesHolder"
-                     ngf-change="handleFiles($newFiles, $event)"
+                     ngf-change="handleFiles($files, $event, $invalidFiles)"
                      ngf-multiple="true"
                      ngf-pattern="{{ accept }}"
                      ngf-max-size="{{ maxFileSize }}">
@@ -43,7 +43,7 @@
         <ul class="file-list" ng-show="done.length > 0 || queue.length > 0 || rejected.length > 0 || filesHolder.length > 0">
 
             <!-- make list sort order the same as photo grid. The last uploaded photo in the top -->
-            <li class="file" ng-repeat="file in done">
+            <li class="file" ng-repeat="file in done track by file.key">
 
                 <!-- file name -->
                 <div class="file-description">{{ file.name }}</div>
@@ -68,13 +68,13 @@
             </li>
 
             <!-- make list sort order the same as photo grid. The last uploaded photo in the top -->
-            <li class="file" ng-repeat="queued in queue">
+            <li class="file" ng-repeat="queued in queue track by queued.key">
 
                 <!-- file name -->
                 <div class="file-name">{{queued.name}}</div>
             </li>
 
-            <li class="file" ng-repeat="file in rejected">
+            <li class="file" ng-repeat="file in rejected track by file.key">
 
                 <!-- file name -->
                 <div class="file-description">

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.createblueprint.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.createblueprint.controller.js
@@ -12,7 +12,7 @@
             name: $scope.currentNode.name
         };
 
-        localizationService.localize("blueprints_createBlueprintFrom", ["<em>" + $scope.message.name + "</em>"]).then(function (localizedVal) {
+        localizationService.localize("blueprints_createBlueprintFrom", [$scope.message.name]).then(localizedVal => {
             $scope.title = localizedVal;
         });
 
@@ -33,14 +33,13 @@
 
                         navigationService.hideMenu();
                     },
-                        function (err) {
-                            formHelper.resetForm({ scope: $scope, hasErrors: true });
-                            contentEditingHelper.handleSaveError({
-                                err: err
-                            });
+                    function (err) {
+                        formHelper.resetForm({ scope: $scope, hasErrors: true });
+                        contentEditingHelper.handleSaveError({
+                            err: err
+                        });
 
-                        }
-                    );
+                    });
             }
         };
     }

--- a/src/Umbraco.Web.UI.Client/src/views/content/copy.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/copy.html
@@ -85,10 +85,10 @@
     </div>
 
     <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
-        <a class="btn btn-link" ng-click="closeDialog()" ng-show="!busy">
+        <button type="button" class="btn btn-link" ng-click="closeDialog()" ng-show="!busy">
             <localize key="general_cancel">Cancel</localize>
-        </a>
-        <button class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">
+        </button>
+        <button type="button" class="btn btn-primary" ng-click="copy()" ng-disabled="busy || !target">
             <localize key="actions_copy">Copy</localize>
         </button>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/createblueprint.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/createblueprint.html
@@ -18,7 +18,7 @@
                     <input type="text" name="name" ng-model="message.name" class="umb-textstring textstring input-block-level"
                            val-server-field="name"
                            required />
-                    <span ng-messages="blueprintForm.name.$error" show-validation-on-submit >
+                    <span ng-messages="blueprintForm.name.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="required"><localize key="required">Required</localize></span>
                         <span class="help-inline" ng-message="valServerField">{{blueprintForm.name.errorMsg}}</span>
                     </span>           

--- a/src/Umbraco.Web.UI.Client/src/views/contentblueprints/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/contentblueprints/create.html
@@ -12,7 +12,7 @@
             <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
             <ul class="umb-actions umb-actions-child">
-                <li class="umb-action" ng-repeat="documentType in vm.documentTypes |orderBy:'name':false">
+                <li class="umb-action" ng-repeat="documentType in vm.documentTypes | orderBy:'name':false">
                     <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="vm.createBlueprint(documentType)">
                         <umb-icon icon="{{documentType.icon}}" class="icon large"></umb-icon>
                         <span class="menu-label">

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -9,7 +9,9 @@ function ExamineManagementController($http, $q, $timeout, umbRequestHelper, loca
     vm.selectedIndex = null;
     vm.selectedSearcher = null;
     vm.searchResults = null;
+    vm.showSearchResultFields = [];
 
+    vm.showSelectFieldsDialog = showSelectFieldsDialog;
     vm.showSearchResultDialog = showSearchResultDialog;
     vm.showIndexInfo = showIndexInfo;
     vm.showSearcherInfo = showSearcherInfo;
@@ -23,6 +25,35 @@ function ExamineManagementController($http, $q, $timeout, umbRequestHelper, loca
     vm.goToResult = goToResult;
 
     vm.infoOverlay = null;
+
+    function showSelectFieldsDialog() {
+        if (vm.searchResults) {
+
+            // build list of available fields
+            var availableFields = [];
+            vm.searchResults.results.map(r => Object.keys(r.values).map(key => {
+                if (availableFields.indexOf(key) == -1 && key != "__NodeId" && key != "nodeName") {
+                    availableFields.push(key);
+                }
+            }));
+
+            availableFields.sort();
+
+            editorService.open({
+                title: "Fields",
+                availableFields: availableFields,
+                fieldIsSelected: function(key) {
+                    return vm.showSearchResultFields.indexOf(key) > -1;
+                },
+                toggleField: vm.toggleField,
+                size: "small",
+                view: "views/dashboard/settings/examinemanagementfields.html",
+                close: function () {
+                    editorService.close();
+                }
+            });
+        }
+    }
 
     function showSearchResultDialog(values) {
         if (vm.searchResults) {
@@ -39,6 +70,17 @@ function ExamineManagementController($http, $q, $timeout, umbRequestHelper, loca
             });
         }
     }
+
+    vm.toggleField = function(key) {
+        if (vm.showSearchResultFields.indexOf(key) > -1) {
+            vm.showSearchResultFields = vm.showSearchResultFields.filter(field => field != key);
+        }
+        else {
+            vm.showSearchResultFields.push(key);
+        }
+
+        vm.showSearchResultFields.sort();
+    };
 
     function nextSearchResultPage(pageNumber) {
         search(vm.selectedIndex ? vm.selectedIndex : vm.selectedSearcher, null, pageNumber);

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -158,9 +158,9 @@
                                                                 <td>{{result.score}}</td>
                                                                 <td>{{result.id}}</td>
                                                                 <td>
-                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</a>
-                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</span>
-                                                                    <button type="button" class="table__action-overlay color-green" ng-click="vm.showSearchResultDialog(result.values)">({{result.fieldCount}} <localize key="examineManagement_fields">fields</localize>)</button>
+                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{ ::result.values['nodeName'] | umbCmsJoinArray:', '}}</a>
+                                                                    <span ng-hide="result.editUrl">{{ ::result.values['nodeName'] | umbCmsJoinArray:', '}}</span>
+                                                                    <button type="button" class="table__action-overlay color-green" ng-click="vm.showSearchResultDialog(result.values)">({{ ::result.fieldCount}} <localize key="examineManagement_fields">fields</localize>)</button>
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -288,27 +288,52 @@
 
                                                 <div ng-if="!vm.selectedIndex.isProcessing && vm.searchResults">
                                                     <br />
-
-                                                    <table class="table table-bordered table-condensed">
-                                                        <thead>
-                                                            <tr>
-                                                                <th class="score">Score</th>
-                                                                <th class="id">Id</th>
-                                                                <th><localize key="general_name">Name</localize></th>
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody>
-                                                            <tr ng-repeat="result in vm.searchResults.results track by $index">
-                                                                <td>{{result.score}}</td>
-                                                                <td>{{result.id}}</td>
-                                                                <td>
-                                                                    <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</a>
-                                                                    <span ng-hide="result.editUrl">{{result.values['nodeName'] | umbCmsJoinArray:', '}}</span>
-                                                                    <button type="button" class="table__action-overlay color-green" ng-click="vm.showSearchResultDialog(result.values)">({{result.fieldCount}} <localize key="examineManagement_fields">fields</localize>)</button>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
+                                                    <div class="result-table">
+                                                        <table class="table table-bordered table-condensed">
+                                                            <thead>
+                                                                <tr>
+                                                                    <th class="id nowrap" width="40">Id</th>
+                                                                    <th><localize key="general_name">Name</localize></th>
+                                                                    <th class="nowrap" ng-repeat="field in vm.showSearchResultFields">
+                                                                        <div class="flex justify-between">
+                                                                            <span>{{ field }}</span>
+                                                                            <button type="button" class="btn btn-mini btn-white ml-3" ng-click="vm.toggleField(field)">
+                                                                                &times;
+                                                                            </button>
+                                                                        </div>
+                                                                    </th>
+                                                                    <th class="tr nowrap" width="40">
+                                                                        <button type="button" class="btn btn-reset btn-link" style="font:inherit;color:inherit;" ng-click="vm.showSelectFieldsDialog()">Fields</button>
+                                                                    </th>
+                                                                    <th class="score tr nowrap" width="40">Score</th>
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                                <tr ng-repeat="result in vm.searchResults.results track by $index" valign="top">
+                                                                    <td class="nowrap">{{result.id}}</td>
+                                                                    <td>
+                                                                        <a ng-show="result.editUrl" ng-click="vm.goToResult(result, $event)" ng-href="#{{result.editUrl}}">
+                                                                            {{ ::result.values['nodeName'] | umbCmsJoinArray:', ' }}
+                                                                        </a>
+                                                                        <span ng-hide="result.editUrl">{{ ::result.values['nodeName'] | umbCmsJoinArray:', ' }}</span>
+                                                                    </td>
+                                                                    <td ng-repeat="field in vm.showSearchResultFields">
+                                                                        {{ ::result.values[field] | umbCmsJoinArray:', ' }}
+                                                                    </td>
+                                                                    <td class="tr nowrap">
+                                                                        <button type="button" 
+                                                                            class="table__action-overlay color-green" 
+                                                                            ng-click="vm.showSearchResultDialog(result.values)">({{ ::result.fieldCount }} <localize key="examineManagement_fields">fields</localize>)</button>
+                                                                    </td>
+                                                                    <td class="tr nowrap umb-avatar--white">
+                                                                        <span title="{{ result.score }}">
+                                                                            {{ ::result.score | number:4 }}
+                                                                        </span>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
 
                                                     <div class="flex justify-center">
                                                         <umb-pagination page-number="vm.searchResults.pageNumber"

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementfields.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagementfields.html
@@ -10,20 +10,16 @@
         <umb-editor-container>
             <umb-box>
                 <umb-box-content>
-                    <table class="table table-bordered table-condensed">
-                        <thead>
-                            <tr>
-                                <th class="score"><localize key="general_field">Field</localize></th>
-                                <th class="id"><localize key="general_value">Value</localize></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr ng-repeat="(key, values) in model.searchResultValues track by key">
-                                <td>{{key}}</td>
-                                <td style="word-break: break-word;">{{ ::values | umbCmsJoinArray:', '}}</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <div class="flex mb2" ng-repeat="field in model.availableFields">
+                        <span class="mr2">
+                            <umb-toggle
+                                checked="model.fieldIsSelected(field)"
+                                on-click="model.toggleField(field)"
+                                hide-icons="true">
+                            </umb-toggle>
+                        </span>
+                        <span>{{ field }}</span>
+                    </div>
                 </umb-box-content>
             </umb-box>
         </umb-editor-container>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.controller.js
@@ -6,11 +6,11 @@
  * @description
  * The controller for the doc type creation dialog
  */
-function DocumentTypesCreateController($scope, $location, navigationService, contentTypeResource, formHelper, appState, notificationsService, localizationService, iconHelper) {
+function DocumentTypesCreateController($scope, $location, navigationService, contentTypeResource, formHelper, appState) {
 
     $scope.model = {
-        allowCreateFolder: $scope.currentNode.parentId === null || $scope.currentNode.nodeType === "container",
-        folderName: "",
+        allowCreateFolder: $scope.currentNode.parentId === null || $scope.currentNode.nodeType === 'container',
+        folderName: '',
         creatingFolder: false
     };
 
@@ -31,18 +31,18 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
 
                 navigationService.hideMenu();
 
-                var currPath = node.path ? node.path : "-1";
+                var currPath = node.path ? node.path : '-1';
 
                 navigationService.syncTree({
-                    tree: "documenttypes",
-                    path: currPath + "," + folderId,
+                    tree: 'documenttypes',
+                    path: currPath + ',' + folderId,
                     forceReload: true,
                     activate: true
                 });
 
                 formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm });
 
-                var section = appState.getSectionState("currentSection");
+                var section = appState.getSectionState('currentSection');
 
             }, function (err) {
 
@@ -51,39 +51,54 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
 
             });
         }
-    };   
-
-    // Disabling logic for creating document type with template if disableTemplates is set to true
-    if (!disableTemplates) {
-        $scope.createDocType = function () {
-            $location.search('create', null);
-            $location.search('notemplate', null);
-            $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true");
-            navigationService.hideMenu();
-        };
-    }
-
-    $scope.createComponent = function () {
-        $location.search('create', null);
-        $location.search('notemplate', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true");
-        navigationService.hideMenu();
     };
 
-    $scope.createComposition = function () {
+    function createDocType(config) {
+
         $location.search('create', null);
         $location.search('notemplate', null);
         $location.search('iscomposition', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true").search("iscomposition", "true");
+        $location.search('iselement', null);
+        $location.search('icon', null);
+
+        var icon = null;
+
+        if (config.icon != undefined && config.icon != null) {
+            icon = config.icon;
+            if (config.color) {
+                icon += ' ' + config.color;
+            }
+        }
+
+        $location
+            .path('/settings/documenttypes/edit/' + node.id)
+            .search('create', 'true')
+            .search('notemplate', config.notemplate ? 'true' : null)
+            .search('iscomposition', config.iscomposition ? 'true' : null)
+            .search('iselement', config.iselement ? 'true' : null)
+            .search('icon', icon);
+
         navigationService.hideMenu();
+    }
+
+
+    // Disabling logic for creating document type with template if disableTemplates is set to true
+    if (!disableTemplates) {
+        $scope.createDocType = function (icon) {
+            createDocType({ icon });
+        };
+    }
+
+    $scope.createComponent = function (icon) {
+        createDocType({ notemplate: true, icon });
     };
 
-    $scope.createElement = function () {
-        $location.search('create', null);
-        $location.search('notemplate', null);
-        $location.search('iselement', null);
-        $location.path("/settings/documenttypes/edit/" + node.id).search("create", "true").search("notemplate", "true").search("iselement", "true");
-        navigationService.hideMenu();
+    $scope.createComposition = function (icon) {
+        createDocType({ iscomposition: true, iselement: true, icon });
+    };
+
+    $scope.createElement = function (icon) {
+        createDocType({ iselement: true, icon });
     };
 
     $scope.close = function() {
@@ -92,4 +107,4 @@ function DocumentTypesCreateController($scope, $location, navigationService, con
     };
 }
 
-angular.module('umbraco').controller("Umbraco.Editors.DocumentTypes.CreateController", DocumentTypesCreateController);
+angular.module('umbraco').controller('Umbraco.Editors.DocumentTypes.CreateController', DocumentTypesCreateController);

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/create.html
@@ -5,7 +5,7 @@
 
             <ul class="umb-actions umb-actions-child">
                 <li data-element="action-documentType" class="umb-action" ng-hide="model.disableTemplates">
-                    <button type="button" ng-click="createDocType()" class="umb-action-link umb-outline btn-reset" umb-auto-focus>
+                    <button type="button" ng-click="createDocType('icon-document')" class="umb-action-link umb-outline btn-reset" umb-auto-focus>
                         <umb-icon icon="icon-document" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_documentTypeWithTemplate">Document Type with Template</localize>
@@ -14,7 +14,7 @@
                     </button>
                 </li>
                 <li data-element="action-documentTypeWithoutTemplate" class="umb-action">
-                    <button type="button" ng-click="createComponent()" class="umb-action-link umb-outline btn-reset">
+                    <button type="button" ng-click="createComponent('icon-item-arrangement')" class="umb-action-link umb-outline btn-reset">
                         <umb-icon icon="icon-item-arrangement" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_documentType">Document Type</localize>
@@ -23,7 +23,7 @@
                     </button>
                 </li>
                 <li data-element="action-documentTypeWithIsElementTypeChecked" class="umb-action">
-                    <button type="button" ng-click="createElement()" class="umb-action-link umb-outline btn-reset">
+                    <button type="button" ng-click="createElement('icon-science')" class="umb-action-link umb-outline btn-reset">
                         <umb-icon icon="icon-science" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_elementType">Element Type</localize>
@@ -32,7 +32,7 @@
                     </button>
                 </li>
                 <li data-element="action-documentTypeWithoutTemplateForComposition" class="umb-action">
-                    <button type="button" ng-click="createComposition()" class="umb-action-link umb-outline btn-reset">
+                    <button type="button" ng-click="createComposition('icon-defrag')" class="umb-action-link umb-outline btn-reset">
                         <umb-icon icon="icon-defrag" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="create_composition">Composition</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -22,6 +22,7 @@
         var create = $routeParams.create;
         var noTemplate = $routeParams.notemplate;
         var isElement = $routeParams.iselement;
+        var icon = $routeParams.icon;
         var allowVaryByCulture = $routeParams.culturevary;
         var infiniteMode = $scope.model && $scope.model.infiniteMode;
         var documentTypeIcon = "";
@@ -72,6 +73,7 @@
                 if (create && !documentTypeId) documentTypeId = -1;
                 noTemplate = $scope.model.notemplate || $scope.model.noTemplate;
                 isElement = $scope.model.isElement;
+                icon = $scope.model.icon;
                 allowVaryByCulture = $scope.model.allowVaryByCulture;
                 vm.submitButtonKey = "buttons_saveAndClose";
                 vm.generateModelsKey = "buttons_generateModelsAndClose";
@@ -415,6 +417,12 @@
             if (isElement) {
                 contentType.isElement = true;
             }
+
+            // set icon if one is provided
+            if (icon !== null) {
+                contentType.icon = icon;
+            }
+
             // set vary by culture checkbox by default
             if (allowVaryByCulture) {
                 contentType.allowCultureVariant = true;

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js
@@ -419,7 +419,7 @@
             }
 
             // set icon if one is provided
-            if (icon !== null) {
+            if (icon !== null && icon !== undefined) {
                 contentType.icon = icon;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.controller.js
@@ -6,10 +6,10 @@
  * @description
  * The controller for the content type editor property dialog
  */
-(function() {
+(function () {
     'use strict';
 
-    function PermissionsController($scope, $timeout, contentTypeResource, iconHelper, contentTypeHelper, localizationService, overlayService) {
+    function PermissionsController($scope, $timeout, contentTypeResource, iconHelper, contentTypeHelper, editorService) {
 
         /* ----------- SCOPE VARIABLES ----------- */
 
@@ -34,22 +34,22 @@
 
         function init() {
 
-            contentTypeResource.getAll().then(function(contentTypes){
-                vm.contentTypes = _.where(contentTypes, {isElement: false});
+            contentTypeResource.getAll().then(contentTypes => {
+                vm.contentTypes = contentTypes.filter(x => !x.isElement);
 
                 // convert legacy icons
                 iconHelper.formatContentTypeIcons(vm.contentTypes);
 
                 vm.selectedChildren = contentTypeHelper.makeObjectArrayFromId($scope.model.allowedContentTypes, contentTypes);
 
-                if($scope.model.id === 0) {
-                   contentTypeHelper.insertChildNodePlaceholder(vm.contentTypes, $scope.model.name, $scope.model.icon, $scope.model.id);
+                if ($scope.model.id === 0) {
+                    contentTypeHelper.insertChildNodePlaceholder(vm.contentTypes, $scope.model.name, $scope.model.icon, $scope.model.id);
                 }
             });
 
             // Can only switch to an element type if there are no content nodes already created from the type.
-            if ($scope.model.id > 0 && !$scope.model.isElement ) {
-                contentTypeResource.hasContentNodes($scope.model.id).then(function (result) {
+            if ($scope.model.id > 0 && !$scope.model.isElement) {
+                contentTypeResource.hasContentNodes($scope.model.id).then(result => {
                     vm.canToggleIsElement = !result;
                 });
             } else {
@@ -58,48 +58,42 @@
         }
 
         function addChild($event) {
-            
-            const dialog = {
-                view: "itempicker",
-                availableItems: vm.contentTypes,
-                selectedItems: vm.selectedChildren,
-                position: "target",
-                event: $event,
-                submit: function (model) {
-                    if (model.selectedItem) {
-                        vm.selectedChildren.push(model.selectedItem);
-                        $scope.model.allowedContentTypes.push(model.selectedItem.id);
-                    }
-                    overlayService.close();
+
+            var editor = {
+                multiPicker: true,
+                filterCssClass: 'not-allowed not-published',
+                filter: item => 
+                    !vm.contentTypes.some(x => x.udi == item.udi) || vm.selectedChildren.some(x => x.udi === item.udi),
+                submit: model => {
+                    model.selection.forEach(item =>
+                        contentTypeResource.getById(item.id).then(contentType => {
+                            vm.selectedChildren.push(contentType);
+                            $scope.model.allowedContentTypes.push(item.id);
+                        }));
+
+                    editorService.close();
                 },
-                close: function() {
-                    overlayService.close();
-                }
+                close: () => editorService.close()                
             };
 
-            localizationService.localize("contentTypeEditor_chooseChildNode").then(value => {
-                dialog.title = value;
-                overlayService.open(dialog);
-            });
+            editorService.contentTypePicker(editor);
         }
 
         function removeChild(selectedChild, index) {
-           // remove from vm
-           vm.selectedChildren.splice(index, 1);
+            // remove from vm
+            vm.selectedChildren.splice(index, 1);
 
-           // remove from content type model
-           var selectedChildIndex = $scope.model.allowedContentTypes.indexOf(selectedChild.id);
-           $scope.model.allowedContentTypes.splice(selectedChildIndex, 1);
+            // remove from content type model
+            var selectedChildIndex = $scope.model.allowedContentTypes.indexOf(selectedChild.id);
+            $scope.model.allowedContentTypes.splice(selectedChildIndex, 1);
         }
 
         function sortChildren() {
             // we need to wait until the next digest cycle for vm.selectedChildren to be updated
-            $timeout(function () {
-                $scope.model.allowedContentTypes = _.pluck(vm.selectedChildren, "id");
-            });
+            $timeout(() => $scope.model.allowedContentTypes = vm.selectedChildren.map(x => x.id));
         }
 
-        // note: "safe toggling" here ie handling cases where the value is undefined, etc
+        // note: 'safe toggling' here ie handling cases where the value is undefined, etc
 
         function toggleAllowAsRoot() {
             $scope.model.allowAsRoot = $scope.model.allowAsRoot ? false : true;
@@ -119,5 +113,5 @@
 
     }
 
-    angular.module("umbraco").controller("Umbraco.Editors.DocumentType.PermissionsController", PermissionsController);
+    angular.module('umbraco').controller('Umbraco.Editors.DocumentType.PermissionsController', PermissionsController);
 })();

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.controller.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    function PermissionsController($scope, $timeout, mediaTypeResource, iconHelper, contentTypeHelper, localizationService, overlayService) {
+    function PermissionsController($scope, $timeout, mediaTypeResource, iconHelper, contentTypeHelper, editorService) {
 
         /* ----------- SCOPE VARIABLES ----------- */
 
@@ -21,7 +21,7 @@
 
         function init() {
 
-            mediaTypeResource.getAll().then(function(mediaTypes){
+            mediaTypeResource.getAll().then(mediaTypes => {
 
                 vm.mediaTypes = mediaTypes;
 
@@ -39,29 +39,25 @@
         }
 
         function addChild($event) {
-            
-            var dialog = {
-                view: "itempicker",
-                availableItems: vm.mediaTypes,
-                selectedItems: vm.selectedChildren,
-                position: "target",
-                event: $event,
-                submit: function (model) {
-                    if (model.selectedItem) {
-                        vm.selectedChildren.push(model.selectedItem);
-                        $scope.model.allowedContentTypes.push(model.selectedItem.id);
-                    }
-                    overlayService.close();
+
+            var editor = {
+                multiPicker: true,
+                filterCssClass: 'not-allowed not-published',
+                filter: item => 
+                    !vm.mediaTypes.some(x => x.udi == item.udi) || vm.selectedChildren.some(x => x.udi === item.udi),                
+                submit: model => {
+                    model.selection.forEach(item => 
+                        mediaTypeResource.getById(item.id).then(contentType => {
+                            vm.selectedChildren.push(contentType);
+                            $scope.model.allowedContentTypes.push(item.id);
+                        }));
+
+                    editorService.close();
                 },
-                close: function() {
-                    overlayService.close();
-                }
+                close: () => editorService.close()                
             };
 
-            localizationService.localize("contentTypeEditor_chooseChildNode").then(value => {
-                dialog.title = value;
-                overlayService.open(dialog);
-            });
+            editorService.mediaTypePicker(editor);
         }
 
         function removeChild(selectedChild, index) {
@@ -75,9 +71,7 @@
 
         function sortChildren() {
             // we need to wait until the next digest cycle for vm.selectedChildren to be updated
-            $timeout(function () {
-                $scope.model.allowedContentTypes = _.pluck(vm.selectedChildren, "id");
-            });
+            $timeout(() => $scope.model.allowedContentTypes = vm.selectedChildren.map(x => x.id));
         }
 
         /**
@@ -94,5 +88,5 @@
 
     }
 
-    angular.module("umbraco").controller("Umbraco.Editors.MediaType.PermissionsController", PermissionsController);
+    angular.module('umbraco').controller('Umbraco.Editors.MediaType.PermissionsController', PermissionsController);
 })();

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/hidden.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/hidden.html
@@ -1,1 +1,1 @@
-<input name="hidden" type="hidden" ng-model="model.value" name="{{model.alias}}" /> 
+<input name="hidden" type="hidden" ng-model="model.value" id="{{model.alias}}" />

--- a/src/Umbraco.Web.UI.Client/test/unit/common/filters/umbCmsJoinArray.filter.spec.js
+++ b/src/Umbraco.Web.UI.Client/test/unit/common/filters/umbCmsJoinArray.filter.spec.js
@@ -11,12 +11,9 @@
             {input:[],  separator:', ', prop:'param' ,   expectedResult: ''},
             {input:[{param:'a'},{param:'b'},{param:'c'}],  separator:', ', prop:null ,   expectedResult: ', , '},
             {input:[{param:'a'},{param:'b'},{param:'c'}],  separator:null, prop:'param' ,   expectedResult: 'abc'},
-        ];
-
-        var testCasesWithExpectedError = [
-            {input:'test',  separator:', ', prop:'param'},
-            {input:null,  separator:', ', prop:'param'},
-            {input:undefined,  separator:', ', prop:'param'},
+            {input:'test',  separator:', ', prop:'param', expectedResult: 'test'},
+            {input:null,  separator:', ', prop:'param', expectedResult: ''},
+            {input:undefined,  separator:', ', prop:'param', expectedResult: ''},
         ];
 
         beforeEach(module('umbraco'));
@@ -25,19 +22,11 @@
             $umbCmsJoinArray = $filter('umbCmsJoinArray');
         }));
 
-
         testCases.forEach(function(test){
             it('Blackbox tests with expected result=\''+test.expectedResult+'\'', function() {
                 expect($umbCmsJoinArray(test.input, test.separator, test.prop)).toBe(test.expectedResult);
             });
         });
-
-        testCasesWithExpectedError.forEach(function(test){
-            it('Blackbox tests with expected error.  Input=\''+test.input+'\'', function() {
-                expect(function() { $umbCmsJoinArray(test.input, test.separator, test.prop)}).toThrow();
-            });
-        });
-
     });
 
 }());

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -296,7 +296,7 @@
     <key alias="nodeIsInTrash">This item is in the Recycle Bin</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Vytvořit novou šablonu obsahu z '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Vytvořit novou šablonu obsahu z <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Prázdná</key>
     <key alias="selectBlueprint">Vybrat obsahovou šablonu</key>
     <key alias="createdBlueprintHeading">Šablona obsahu byla vytvořena</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
@@ -316,7 +316,7 @@
         <key alias="nodeIsInTrash">Mae'r eitem yma yn y Bin Ailgylchu</key>
     </area>
     <area alias="blueprints">
-        <key alias="createBlueprintFrom">Creu Templed Cynnwys newydd o '%0%'</key>
+        <key alias="createBlueprintFrom"><![CDATA[Creu Templed Cynnwys newydd o <em>%0%</em>]]></key>
         <key alias="blankBlueprint">Gwag</key>
         <key alias="selectBlueprint">Dewis Templed Cynnwys</key>
         <key alias="createdBlueprintHeading">Templed Cynnwys wedi'i greu</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -317,7 +317,7 @@
     <key alias="nodeIsInTrash">Dette element er i papirkurven</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Opret en ny indholdsskabelon fra '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Opret en ny indholdsskabelon fra <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Blank</key>
     <key alias="selectBlueprint">Vælg en indholdsskabelon</key>
     <key alias="createdBlueprintHeading">Indholdsskabelon oprettet</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/de.xml
@@ -294,8 +294,8 @@
     <key alias="createEmpty">Neues Element anlegen</key>
     <key alias="createFromClipboard">Aus der Zwischenablage einfügen</key>
   </area>
-  <area alias="blueprints">
-    <key alias="createBlueprintFrom">Erzeuge eine neue Inhaltsvorlage von '%0%'</key>
+    <area alias="blueprints">
+    <key alias="createBlueprintFrom"><![CDATA[Erzeuge eine neue Inhaltsvorlage von <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Leer</key>
     <key alias="selectBlueprint">Wählen Sie eine Inhaltsvorlage</key>
     <key alias="createdBlueprintHeading">Inhaltsvorlage erzeugt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -310,7 +310,7 @@
     <key alias="nodeIsInTrash">This item is in the Recycle Bin</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Create a new Content Template from '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Create a new Content Template from <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Blank</key>
     <key alias="selectBlueprint">Select a Content Template</key>
     <key alias="createdBlueprintHeading">Content Template created</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -315,7 +315,7 @@
     <key alias="nodeIsInTrash">This item is in the Recycle Bin</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Create a new Content Template from '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Create a new Content Template from <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Blank</key>
     <key alias="selectBlueprint">Select a Content Template</key>
     <key alias="createdBlueprintHeading">Content Template created</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/es.xml
@@ -196,7 +196,7 @@
         <key alias="contentRoot">Raíz de contenido</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Crear nueva Plantilla de Contenido desde '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Crear nueva Plantilla de Contenido desde <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Vacía</key>
     <key alias="selectBlueprint">Seleccionar Plantilla de Contenido</key>
     <key alias="createdBlueprintHeading">Plantilla de Contenido creada</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -289,7 +289,7 @@
     <key alias="createFromClipboard">Copier du clipboard</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Créer un nouveau Modèle de Contenu à partir de '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Créer un nouveau Modèle de Contenu à partir de <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Vide</key>
     <key alias="selectBlueprint">Sélectionner un Modèle de Contenu</key>
     <key alias="createdBlueprintHeading">Modèle de Contenu créé</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -2342,6 +2342,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
       <key alias="confirmCancelBlockCreationMessage"><![CDATA[Ben je zeker dat je deze wijzigingen wil verwerpen?]]></key>
       <key alias="elementTypeDoesNotExistHeadline">Fout!</key>
       <key alias="elementTypeDoesNotExistDescription">Het Elementtype van dit blok bestaat niet meer</key>
+      <key alias="addBlock">Inhoud toevoegen</key>
       <key alias="propertyEditorNotSupported">Eigenschap '%0%' gebruikt editor '%1%' die niet ondersteund wordt in blokken.</key>
     </area>
   <area alias="contentTemplatesDashboard">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -314,7 +314,7 @@
     <key alias="nodeIsInTrash">Dit item is in de prullenbak</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Nieuw Inhoudssjabloon aanmaken voor '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Nieuw Inhoudssjabloon aanmaken voor <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Leeg</key>
     <key alias="selectBlueprint">Selecteer een Inhoudssjabloon</key>
     <key alias="createdBlueprintHeading">Inhoudssjabloon aangemaakt</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/pl.xml
@@ -193,7 +193,7 @@
     <key alias="contentRoot">Korzeń zawartości</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Stwórz nowy Szablon Zawartości z '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Stwórz nowy Szablon Zawartości z <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Pusty</key>
     <key alias="selectBlueprint">Wybierz Szablon Zawartości</key>
     <key alias="createdBlueprintHeading">Szablon Zawartości został stworzony</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/ru.xml
@@ -96,7 +96,7 @@
     <key alias="atViewingFor">Наблюдать за</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Создать новый шаблон содержимого из '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Создать новый шаблон содержимого из <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Пустой</key>
     <key alias="selectBlueprint">Выбрать шаблон содержимого</key>
     <key alias="createdBlueprintHeading">Шаблон содержимого создан</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/sv.xml
@@ -99,7 +99,7 @@
     <key alias="historyIncludingVariants">Historik (alla varianter)</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">Skapa en ny innehållsmall för '%0%'</key>
+    <key alias="createBlueprintFrom"><![CDATA[Skapa en ny innehållsmall för <em>%0%</em>]]></key>
     <key alias="blankBlueprint">Tom</key>
     <key alias="selectBlueprint">Välj en innehållsmall</key>
     <key alias="createdBlueprintHeading">Innehållsmall skapad</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -309,7 +309,7 @@
     <key alias="nodeIsInTrash">Bu öğe Geri Dönüşüm Kutusu'nda</key>
   </area>
   <area alias="blueprints">
-    <key alias="createBlueprintFrom">'%0%' den yeni bir İçerik Şablonu oluşturun</key>
+    <key alias="createBlueprintFrom"><![CDATA[<em>%0%</em> den yeni bir İçerik Şablonu oluşturun]]></key>
     <key alias="blankBlueprint">Boş</key>
     <key alias="selectBlueprint">Bir İçerik Şablonu Seçin</key>
     <key alias="createdBlueprintHeading">İçerik Şablonu oluşturuldu</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11281

### Description
With the recent changes in `v8/contrib` branch I noticed icon for existing document types always was falling back to `icon-document` even though a new icon was selected.

It seems to be due the changes in https://github.com/umbraco/Umbraco-CMS/pull/11008 where it set icon from route params. However for existing document type this querystring param doesn't exists and the `icon` value was `undefined` (not null) so it updated the icon to the default icon.

If you didn't notice the icon change in header and saved document type, it actual updates the document type with `icon-document` instead of keeping the previous selected icon.