### PR TITLE
v8: Fix childless tab persistence

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -455,7 +455,8 @@ namespace Umbraco.Web.Models.Mapping
 
                 // if the group has no local properties and is not used as parent, skip it, ie sort-of garbage-collect
                 // local groups which would not have local properties anymore
-                if (destProperties.Length == 0 && !sourceGroupParentAliases.Contains(sourceGroup.Alias))
+                // only applies to groups; not tabs
+                if (sourceGroup.Type == PropertyGroupType.Group && destProperties.Length == 0 && !sourceGroupParentAliases.Contains(sourceGroup.Alias))
                     continue;
 
                 // ensure no duplicate alias, then assign the group properties collection


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11069

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
A check which removes empty groups was also removing empty tabs. which is not the expected behaviour as per the issue above.

I have added a condition where only groups should undergo this check; that is, tabs should not.

#### Tests
As illustrated below,
- Create a new tab with no children
- Save the content type
- Switch to another page and return to the content type
- The tab should persist with no children
![Da6bEW7Wy3](https://user-images.githubusercontent.com/1710296/136070135-578bac4f-1b88-4915-861f-92de02e6ad81.gif)

<!-- Thanks for contributing to Umbraco CMS! -->
