### PR TITLE
Persist childless groups/tabs

### DIFF
--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -453,11 +453,6 @@ namespace Umbraco.Web.Models.Mapping
                     .Select(x => MapSaveProperty(x, destOrigProperties, context))
                     .ToArray();
 
-                // if the group has no local properties and is not used as parent, skip it, ie sort-of garbage-collect
-                // local groups which would not have local properties anymore
-                if (destProperties.Length == 0 && !sourceGroupParentAliases.Contains(sourceGroup.Alias))
-                    continue;
-
                 // ensure no duplicate alias, then assign the group properties collection
                 EnsureUniqueAliases(destProperties);
                 destGroup.PropertyTypes = new PropertyTypeCollection(isPublishing, destProperties);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11069

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
A check in the `ContentTypeMapDefinition` was removing childless groups and tabs, given tabs are a type of group, before saving. this check has been removed so that childless groups and tabs will be persisted.

#### Tests
As illustrated below,
- Create a new group/tab with no children
- Save the content type
- Switch to another page and return to the content type
- The group/tab should persist with no children

![Da6bEW7Wy3](https://user-images.githubusercontent.com/1710296/136080148-b54faa02-8dc8-4a85-8935-b53c8393f843.gif)

![je7xYSllvn](https://user-images.githubusercontent.com/1710296/136080089-c4951e14-7ff8-43de-9875-5b773858868f.gif)
<!-- Thanks for contributing to Umbraco CMS! -->
