### PR TITLE
Allow switching property editor from numeric to slider

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -45,8 +45,13 @@
         if (!$scope.model.value) {
             $scope.model.value = start.toString();
         }
-        // convert to array
-        $scope.sliderValue = $scope.model.value ? $scope.model.value.split(',') : null;
+
+        // convert to array - exiting value can be a number if switching from numeric/decimal property editor
+        $scope.sliderValue = $scope.model.value ?
+                (Utilities.isString($scope.model.value) || Utilities.isNumber($scope.model.value)
+                ? $scope.model.value.toString().split(',')
+                : null)
+            : null;
         
         // don't render values with decimal places if the step increment in a whole number
         var stepDecimalPlaces = $scope.model.config.step % 1 == 0


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11259

### Description
This PR allow switching property editor from numeric/decimal datatype to a slider datatype without breaking editor.
I couldn't reproduce on directly on a content node or as a property on a block, but I can reproduce when it is a block settings property. I guess there a different in how the value is stored.

However it would also allow changing from other datatypes storing a number/decimal value or at least improve it a bit.