### PR TITLE
Enables friendly pasting in multipletextbox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.controller.js
@@ -26,6 +26,29 @@
         }
     }
 
+    $scope.paste = function (event, index) {
+        event.preventDefault();
+        var text = (event.clipboardData || window.clipboardData || event.originalEvent.clipboardData).getData('text');
+        var lines = text.split(/\r?\n/).map(line => { return { value: line, hasFocus: false } });
+
+        if (lines.length > 0) {
+            // merge with the current text
+            var currentText = $scope.model.value[index].value;
+            lines[0].value = currentText.substring(0, event.target.selectionStart) + lines[0].value;
+            lines[lines.length - 1].value = lines[lines.length - 1].value + currentText.substring(event.target.selectionEnd);
+
+            // clear selection
+            event.target.selectionEnd = event.target.selectionStart;
+
+            // remove focus from existing values
+            $scope.model.value.forEach(value => value.hasFocus = false);
+
+            // add all the lines to the value
+            lines[lines.length - 1].hasFocus = true;
+            $scope.model.value.splice(index, 1, ...lines);
+        }
+    }
+
     $scope.addRemoveOnKeyDown = function (event, index) {
 
         var txtBoxValue = $scope.model.value[index];

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multipletextbox/multipletextbox.html
@@ -6,6 +6,7 @@
                  class="umb-property-editor umb-textstring textstring flx-i"
                  ng-trim="false"
                  ng-keyup="addRemoveOnKeyDown($event, $index)"
+                 ng-paste="paste($event, $index)"
                  focus-when="{{item.hasFocus}}" />
 
           <div class="icon-wrapper">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The gist of this is, when you paste multiline text in multipletextbox (Repeatable textstrings), the linebreaks gets converted into spaces. Not very friendly...

![msedge_q1cqHJeBLj](https://user-images.githubusercontent.com/3726467/136097915-8ed56147-0c28-483b-8130-97deff4980b1.png)

So I added an eventhandler listening for the paste event, that splits the pasted text by linebreak, and adds it to the array.

It also factors in the caret position in the input field, so existing text in the field you are pasting in to, gets merged with the pasted text.

See example gif:

![OHYsyuSOes](https://user-images.githubusercontent.com/3726467/136098120-f6a85ec6-b7ff-4c44-838f-648c22654dc8.gif)

To test:
- create a property using Repeatable textstrings
- paste some multiline text
- try pasting text (and multiline text) into existing text, to see the merging