### PR TITLE
Removes annoying wait text, which causes layout jank

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/nucache.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/nucache.html
@@ -1,11 +1,8 @@
 ﻿<div id="nuCache" style="position: relative;" ng-controller="Umbraco.Dashboard.NuCacheController as vm">
 
-    <div ng-show="vm.loading || vm.working" style="background: rgba(255, 255, 255, 0.60); position: absolute; left: 0; right: 0; top: 0; bottom: 0;">
+    <div ng-show="vm.loading || vm.working" style="background: rgba(255, 255, 255, 0.60); position: absolute; left: 0; right: 0; top: 0; bottom: 0; z-index: 1;">
         <umb-load-indicator></umb-load-indicator>
     </div>
-    <p>
-        <span ng-show="vm.working">(<localize key="nuCache_wait">wait</localize>)</span>
-    </p>
 
     <div class="umb-panel-group__details-group">
         <div class="umb-panel-group__details-group-title">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cs.xml
@@ -337,7 +337,7 @@
     <key alias="noDocumentTypesAllowedAtRoot"><![CDATA[Nejsou zde k dispozici žádné povolené typy dokumentů pro vytváření obsahu. Musíte je povolit v sekci <strong>Typy dokumentů</strong> v části <strong>Nastavení</strong> změnou možnosti <strong>Povolit jako root</strong> v části <strong>Oprávnění</strong>.]]></key>
     <key alias="noMediaTypes" version="7.0"><![CDATA[Nejsou dostupné žádné povolené typy medií. Tyto musíte povolit v sekci nastavení pod <strong>"typy medií"</strong>.]]></key>
     <key alias="noMediaTypesWithNoSettingsAccess">Vybraná média ve stromu neumožňuje vytváření pod nimi žádná další média.</key>
-    <key alias="noMediaTypesEditPermissions">Upravit oprávnění pro tento typ média</key>    
+    <key alias="noMediaTypesEditPermissions">Upravit oprávnění pro tento typ média</key>
     <key alias="documentTypeWithoutTemplate">Typ dokumentu bez šablony</key>
     <key alias="newFolder">Nová složka</key>
     <key alias="newDataType">Nový datový typ</key>
@@ -2232,7 +2232,6 @@
     <key alias="tooltipForPropertyActionsMenu">Otevřít akce vlastností</key>
   </area>
   <area alias="nuCache">
-    <key alias="wait">Čekejte</key>
     <key alias="refreshStatus">Stav obnovení</key>
     <key alias="memoryCache">Cache paměť</key>
     <key alias="memoryCacheDescription">
@@ -2328,7 +2327,7 @@
   <area alias="startupDashboard">
     <key alias="fallbackHeadline">Vítejte v přátelském CMS</key>
     <key alias="fallbackDescription">Děkujeme, že jste si vybrali Umbraco - myslíme si, že by to mohl být začátek něčeho krásného. I když se to může zpočátku zdát ohromující, udělali jsme hodně pro to, aby byla křivka učení co nejhladší a nejrychlejší.</key>
-  </area>  
+  </area>
   <area alias="formsDashboard">
     <key alias="formsHeadline">Umbraco formuláře</key>
     <key alias="formsDescription">Vytvářejte formuláře pomocí intuitivního rozhraní drag and drop. Od jednoduchých kontaktních formulářů, které odesílají e-maily, až po pokročilé dotazníky, které se integrují do systémů CRM. Vaši klienti to budou milovat!</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/cy.xml
@@ -103,7 +103,7 @@
         <key alias="domainUpdated">Parth '%0%' wedi diweddaru</key>
         <key alias="orEdit">Golygu Parthau Presennol</key>
         <key alias="domainHelpWithVariants">
-            <![CDATA[Parthau dilys yw: "enghraifft.com", "www.enghraifft.com", "enghraifft.com:8080" neu "https://www.enghraifft.com/". 
+            <![CDATA[Parthau dilys yw: "enghraifft.com", "www.enghraifft.com", "enghraifft.com:8080" neu "https://www.enghraifft.com/".
             Mae llwybrau un-lefel mewn parthau wedi'u cefnogi, e.e. "enghraifft.com/cy" neu "/cy".]]>
         </key>
         <key alias="inherit">Etifeddu</key>
@@ -1000,7 +1000,7 @@
             <![CDATA[
       <p>
         Mae "Runway" yn wefan syml sy'n darparu mathau o ddogfennau a thempledi syml. Gall y gosodwr osod Runway i chi yn awtomatig,
-        ond gallwch olygu, estyn neu ei ddileu yn hawdd. Nid yw'n angenrheidiol a gallwch ddefnyddio Umbraco yn berffaith heb. Ond, 
+        ond gallwch olygu, estyn neu ei ddileu yn hawdd. Nid yw'n angenrheidiol a gallwch ddefnyddio Umbraco yn berffaith heb. Ond,
         mae Runwayyn cynnig sylfaen hawdd wedi'i seilio ar arferion gorau er mwyn i chi gychwyn yn gyflymach nag erioed.
         Os rydych chi'n dewis gosod Runway, gallwch ddewis blociau adeiliadu syml o'r enw Modylau Runway er mwyn mwyhau eich tudalennau Runway.
         </p>
@@ -1187,15 +1187,15 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
         <key alias="mailBody">
             <![CDATA[
         Helo %0%
-        
+
         Mae hyn yn ebost awtomatig i'ch hysbysu fod y dasg '%1%'
         wedi'i berfformio ar y dudalen '%2%'
         gan y defnyddiwr '%3%'
-        
+
         Ewch at http://%4%/#/content/content/edit/%5% i olygu.
 
         Mwynhewch eich diwrnod!
-        
+
         Hwyl fawr oddi wrth y robot Umbraco
         ]]>
         </key>
@@ -2586,14 +2586,13 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
         <key alias="tooltipForPropertyActionsMenuClose">Cau Gweithredoedd Priodweddau</key>
     </area>
     <area alias="nuCache">
-        <key alias="wait">Aros</key>
         <key alias="refreshStatus">Adnewyddu statws</key>
         <key alias="memoryCache">Cuddstôr Cof</key>
         <key alias="memoryCacheDescription">
             <![CDATA[
-                Mae'r botwm hwn yn caniatáu ichi ail-lwytho'r cuddstôr mewn-cof, gan ail-lwytho fo o'r stôr cronfa ddata 
+                Mae'r botwm hwn yn caniatáu ichi ail-lwytho'r cuddstôr mewn-cof, gan ail-lwytho fo o'r stôr cronfa ddata
                 (ond nid yw'n ailadeiladu stôr cronfa ddata hwnna). Mae hyn yn gymharol o gyflym.
-                Defnyddio fo pan ti'n feddwl nad yw'r stôr gof wedi'i hadnewyddu'n iawn, ar ôl i rai digwyddiad 
+                Defnyddio fo pan ti'n feddwl nad yw'r stôr gof wedi'i hadnewyddu'n iawn, ar ôl i rai digwyddiad
                 digwydd&mdash;a fyddai'n arwydd o broblem fach efo Umbraco.
                 (nodyn: mae hyn yn achosi ail-lwytho ar pob gweinydd mewn amgylchedd LB).
         ]]>
@@ -2604,7 +2603,7 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
             <![CDATA[
             Mae'r botwm hwn yn caniatáu ichi ailadeiladu'r cuddstôr cronfa ddata, h.y. y cynnwys o'r tabl cmsContentNu.
             <strong>Gall ailadeiladu fod yn ddrud.</strong>
-            Defnyddio fo pan mae ail-lwytho ddim yn ddigon, a ti'n feddwl mai'r stôr cronfa ddata heb gael ei 
+            Defnyddio fo pan mae ail-lwytho ddim yn ddigon, a ti'n feddwl mai'r stôr cronfa ddata heb gael ei
             chynhyrchu'n iawn&mdash;a fyddai'n arwydd o broblem gritigol efo Umbraco.
         ]]>
         </key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2384,7 +2384,6 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="tooltipForPropertyActionsMenuClose">Close Property Actions</key>
   </area>
   <area alias="nuCache">
-    <key alias="wait">Wait</key>
     <key alias="refreshStatus">Refresh status</key>
     <key alias="memoryCache">Memory Cache</key>
     <key alias="memoryCacheDescription">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2414,7 +2414,6 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="tooltipForPropertyActionsMenuClose">Close Property Actions</key>
   </area>
   <area alias="nuCache">
-    <key alias="wait">Wait</key>
     <key alias="refreshStatus">Refresh status</key>
     <key alias="memoryCache">Memory Cache</key>
     <key alias="memoryCacheDescription">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/fr.xml
@@ -138,7 +138,7 @@
     <key alias="saveListView">Sauver la mise en page de la liste</key>
     <key alias="schedulePublish">Planifier</key>
     <key alias="saveAndPreview">Prévisualiser</key>
-    <key alias="showPage">Prévisualiser</key>    
+    <key alias="showPage">Prévisualiser</key>
     <key alias="showPageDisabled">La prévisualisation est désactivée car aucun modèle n'a été assigné.</key>
     <key alias="styleChoose">Choisir un style</key>
     <key alias="styleShow">Afficher les styles</key>
@@ -2245,7 +2245,6 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="tooltipForPropertyActionsMenu">Ouvrir les Property Actions</key>
   </area>
   <area alias="nuCache">
-    <key alias="wait">Attendez</key>
     <key alias="refreshStatus">Rafraîchir le Statut</key>
     <key alias="memoryCache">Cache Mémoire</key>
     <key alias="memoryCacheDescription">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -2184,7 +2184,6 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="tooltipForPropertyActionsMenuClose">Eigenschapsacties sluiten</key>
   </area>
   <area alias="nuCache">
-      <key alias="wait">Wachten</key>
       <key alias="refreshStatus">Status vernieuwen</key>
       <key alias="memoryCache">Geheugencache</key>
       <key alias="memoryCacheDescription">

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/tr.xml
@@ -108,7 +108,7 @@
     <key alias="inherit">Devral</key>
     <key alias="setLanguage">Kültür</key>
     <key alias="setLanguageHelp">
-      <![CDATA[Geçerli düğümün altındaki düğümler için kültürü ayarlayın, <br /> veya kültürü üst düğümlerden devralın. Ayrıca <br /> 
+      <![CDATA[Geçerli düğümün altındaki düğümler için kültürü ayarlayın, <br /> veya kültürü üst düğümlerden devralın. Ayrıca <br />
         aşağıdaki alan da geçerli değilse geçerli düğüme.]]>
     </key>
     <key alias="setDomains">Alanlar</key>
@@ -1079,7 +1079,7 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
 					</tr>
 				</table>
 			</body>
-		</html>              
+		</html>
   ]]>
     </key>
   </area>
@@ -1108,17 +1108,17 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="mailBody">
       <![CDATA[
       Merhaba %0%
- 
+
       Bu, '%1%' görevinin size bildirilmesi için otomatik bir postadır.
       '%2%' sayfasında gerçekleştirildi
       '%3%' kullanıcısı tarafından
- 
+
       Düzenlemek için http://%4%/#/content/content/edit/%5% adresine gidin.
- 
+
       %6%
- 
+
       İyi günler!
- 
+
       Umbraco robotundan teşekkürler
     ]]>
     </key>
@@ -1198,7 +1198,7 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
 					</tr>
 				</table>
 			</body>
-		</html>  
+		</html>
 	]]>
     </key>
     <key alias="mailBodyVariantHtmlSummary">
@@ -1825,18 +1825,18 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="mailBody">
       <![CDATA[
       Merhaba %0%
- 
+
       Bu, '%1%' belgesinin size bildirilmesi için otomatik bir postadır.
       %2% tarafından '%5%' e çevrilmesi istendi.
- 
+
       Düzenlemek için http://%3%/translation/details.aspx?id=%4% adresine gidin.
- 
+
       Veya çeviri görevlerinize genel bir bakış için Umbraco'da oturum açın
       http://%3%
- 
-      İyi günler!       
-      
-      Umbraco robotdan teşekkürler    
+
+      İyi günler!
+
+      Umbraco robotdan teşekkürler
       ]]>
     </key>
     <key alias="noTranslators">Çevirmen kullanıcısı bulunamadı. Lütfen çeviriye içerik göndermeye başlamadan önce bir çevirmen kullanıcısı oluşturun</key>
@@ -2077,7 +2077,7 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
                 <td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
             </tr>
         </table>
-    </body>                           
+    </body>
 </html>]]>
     </key>
     <key alias="invite">Davet Et</key>
@@ -2399,7 +2399,6 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="tooltipForPropertyActionsMenuClose">Özellik Eylemlerini Kapat</key>
   </area>
   <area alias="nuCache">
-    <key alias="wait">Bekle</key>
     <key alias="refreshStatus">Durumu yenile</key>
     <key alias="memoryCache">Bellek Önbelleği</key>
     <key alias="memoryCacheDescription">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
On the Published Status dashboard, when loading or working, there is an incredibly annoying (Wait) text, that causes the layout to shift.

See this gif, where I've throttled my connection to emphasize the effect.
![RUTbeTmiSC](https://user-images.githubusercontent.com/3726467/136099798-d528adab-50b7-40ac-b8d2-c383667efa1c.gif)

I have removed the text, and the dictionary keys, as they aren't used anywhere else. I also added a z-index value to the overlay, to make it lay above the buttons of the dashboard.

Now it looks like this:
![tmwFuzZdjV](https://user-images.githubusercontent.com/3726467/136099902-d1bb1228-a712-4045-b141-208c59f7b59f.gif)

To test:
Go to the Published Status dashboard, and verify that no (Wait) text is flashing while loading or working.