### PR TITLE
v9: bugfix 11228 Blocklist stylesheet path includes wwwroot

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -109,7 +109,7 @@
                         }
                     ]
                 };
-                
+
                 editorService.contentTypePicker(settingsTypePicker);
 
             });
@@ -179,7 +179,7 @@
                     },
                     close: () => editorService.close()
                 };
-                
+
                 editorService.filePicker(filePicker);
 
             });
@@ -206,26 +206,29 @@
         };
 
         vm.addStylesheetForBlock = function(block) {
-            localizationService.localize("blockEditor_headlineAddCustomStylesheet").then(localizedTitle => {
+          localizationService.localize("blockEditor_headlineAddCustomStylesheet").then(localizedTitle => {
 
-                const filePicker = {
-                    title: localizedTitle,
-                    isDialog: true,
-                    filter: i => {
-                        return !(i.name.indexOf(".css") !== -1);
-                    },
-                    filterCssClass: "not-allowed",
-                    select: node => {
-                        const filepath = decodeURIComponent(node.id.replace(/\+/g, " "));
-                        block.stylesheet = "~/" + filepath;
-                        editorService.close();
-                    },
-                    close: () => editorService.close()
-                };
+            const filePicker = {
+              title: localizedTitle,
+              isDialog: true,
+              section: "settings",
+              treeAlias: "staticFiles",
+              entityType: "file",
+              filter: i => {
+                return !(i.name.indexOf(".css") !== -1);
+              },
+              filterCssClass: "not-allowed",
+              select: node => {
+                const filepath = decodeURIComponent(node.id.replace(/\+/g, " "));
+                block.stylesheet = "~/" + filepath.replace("wwwroot/", "");
+                editorService.close();
+              },
+              close: () => editorService.close()
+            };
 
-                editorService.filePicker(filePicker);
+            editorService.treePicker(filePicker);
 
-            });
+          });
         };
 
         vm.requestRemoveStylesheetForBlock = function(block) {
@@ -251,7 +254,7 @@
         vm.addThumbnailForBlock = function(block) {
 
           localizationService.localize("blockEditor_headlineAddThumbnail").then(localizedTitle => {
-                
+
                 let allowedFileExtensions = ['jpg', 'jpeg', 'png', 'svg', 'webp', 'gif'];
 
                 const thumbnailPicker = {
@@ -269,7 +272,7 @@
                     },
                     close: () => editorService.close()
                 };
-                
+
                 editorService.staticFilePicker(thumbnailPicker);
 
             });


### PR DESCRIPTION
Fixes : https://github.com/umbraco/Umbraco-CMS/issues/11228

# Notes
- Updated blockconfiguration.overlay.controller to use the staticFiles tree picker

# How to test
- Run a clean umbraco install
- Create an element type with a textstring property
- Make a doc type with template and allow as root
- Make an empty stylesheet called "myStylesheet"
- Add a blocklist editor to your root doc type, and pick the stylesheet from the CSS folder
- Go and make some content, and when you type something in the textstring and the CSS pops up, it should now call the right URL "localhost/css/myStylesheet.css