### PR TITLE
Exposes the entity containers (folders) created during a package installation in the summary available from the ImportedPackageNotification.

### DIFF
--- a/src/Umbraco.Core/Packaging/InstallationSummary.cs
+++ b/src/Umbraco.Core/Packaging/InstallationSummary.cs
@@ -32,6 +32,7 @@ namespace Umbraco.Cms.Core.Packaging
         public IEnumerable<IPartialView> PartialViewsInstalled { get; set; } = Enumerable.Empty<IPartialView>();
         public IEnumerable<IContent> ContentInstalled { get; set; } = Enumerable.Empty<IContent>();
         public IEnumerable<IMedia> MediaInstalled { get; set; } = Enumerable.Empty<IMedia>();
+        public IEnumerable<EntityContainer> EntityContainersInstalled { get; set; } = Enumerable.Empty<EntityContainer>();
 
         public override string ToString()
         {
@@ -77,6 +78,7 @@ namespace Umbraco.Cms.Core.Packaging
             WriteCount("Stylesheets installed: ", StylesheetsInstalled);
             WriteCount("Scripts installed: ", ScriptsInstalled);
             WriteCount("Partial views installed: ", PartialViewsInstalled);
+            WriteCount("Entity containers installed: ", EntityContainersInstalled);
             WriteCount("Content items installed: ", ContentInstalled);
             WriteCount("Media items installed: ", MediaInstalled, false);
 

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -118,6 +118,16 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 return installationSummary;
             }
         }
+
+        /// <summary>
+        /// Imports and saves package xml as <see cref="IContentType"/>
+        /// </summary>
+        /// <param name="docTypeElements">Xml to import</param>
+        /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
+        /// <returns>An enumerable list of generated ContentTypes</returns>
+        public IReadOnlyList<IMediaType> ImportMediaTypes(IEnumerable<XElement> docTypeElements, int userId)
+            => ImportMediaTypes(docTypeElements, userId, new List<EntityContainer>());
+
         /// <summary>
         /// Imports and saves package xml as <see cref="IContentType"/>
         /// </summary>
@@ -418,10 +428,30 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         /// </summary>
         /// <param name="docTypeElements">Xml to import</param>
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
+        /// <returns>An enumerable list of generated ContentTypes</returns>
+        public IReadOnlyList<IContentType> ImportDocumentTypes(IEnumerable<XElement> docTypeElements, int userId)
+            => ImportDocumentTypes(docTypeElements.ToList(), true, userId, new List<EntityContainer>(), _contentTypeService);
+
+        /// <summary>
+        /// Imports and saves package xml as <see cref="IContentType"/>
+        /// </summary>
+        /// <param name="docTypeElements">Xml to import</param>
+        /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
         /// <param name="entityContainersInstalled">List of entity containers installed by the package to be populated with those created in installing data types.</param>
         /// <returns>An enumerable list of generated ContentTypes</returns>
         public IReadOnlyList<IContentType> ImportDocumentTypes(IEnumerable<XElement> docTypeElements, int userId, List<EntityContainer> entityContainersInstalled)
             => ImportDocumentTypes(docTypeElements.ToList(), true, userId, entityContainersInstalled, _contentTypeService);
+
+        /// <summary>
+        /// Imports and saves package xml as <see cref="IContentType"/>
+        /// </summary>
+        /// <param name="unsortedDocumentTypes">Xml to import</param>
+        /// <param name="importStructure">Boolean indicating whether or not to import the </param>
+        /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
+        /// <returns>An enumerable list of generated ContentTypes</returns>
+        public IReadOnlyList<T> ImportDocumentTypes<T>(IReadOnlyCollection<XElement> unsortedDocumentTypes, bool importStructure, int userId, IContentTypeBaseService<T> service)
+            where T : class, IContentTypeComposition
+            => ImportDocumentTypes(unsortedDocumentTypes, importStructure, userId, new List<EntityContainer>(), service);
 
         /// <summary>
         /// Imports and saves package xml as <see cref="IContentType"/>
@@ -596,6 +626,7 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                         var folderName = WebUtility.UrlDecode(folders[i]);
                         Guid? folderKey = (folderKeys.Length == folders.Length) ? folderKeys[i] : null;
                         current = CreateContentTypeChildFolder(folderName, folderKey ?? Guid.NewGuid(), current);
+                        entityContainersInstalled.Add(current);
                         importedFolders[alias] = current.Id;
                     }
                 }
@@ -1011,6 +1042,15 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         #endregion
 
         #region DataTypes
+
+        /// <summary>
+        /// Imports and saves package xml as <see cref="IDataType"/>
+        /// </summary>
+        /// <param name="dataTypeElements">Xml to import</param>
+        /// <param name="userId">Optional id of the user</param>
+        /// <returns>An enumerable list of generated DataTypeDefinitions</returns>
+        public IReadOnlyList<IDataType> ImportDataTypes(IReadOnlyCollection<XElement> dataTypeElements, int userId)
+             => ImportDataTypes(dataTypeElements, userId, new List<EntityContainer>());
 
         /// <summary>
         /// Imports and saves package xml as <see cref="IDataType"/>

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -469,7 +469,6 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             where T : class, IContentTypeComposition
         {
             var importedContentTypes = new Dictionary<string, T>();
-            entityContainersInstalled = new List<EntityContainer>();
 
             //When you are importing a single doc type we have to assume that the dependencies are already there.
             //Otherwise something like uSync won't work.

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -94,10 +94,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
 
             int numberOfTemplates = (from doc in templateElement.Elements("Template") select doc).Count();
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
@@ -142,10 +141,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
 
             // Assert
             IContentType mRBasePage = contentTypes.First(x => x.Alias == "MRBasePage");
@@ -168,10 +166,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
 
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
@@ -277,10 +274,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert
@@ -313,14 +309,13 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert - Re-Import contenttypes doesn't throw
-            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled));
+            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0));
             Assert.That(contentTypes.Count(), Is.EqualTo(numberOfDocTypes));
             Assert.That(dataTypeDefinitions, Is.Not.Null);
             Assert.That(dataTypeDefinitions.Any(), Is.True);
@@ -338,14 +333,13 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert - Re-Import contenttypes doesn't throw
-            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled));
+            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0));
             Assert.That(contentTypes.Count(), Is.EqualTo(numberOfDocTypes));
             Assert.That(dataTypeDefinitions, Is.Not.Null);
             Assert.That(dataTypeDefinitions.Any(), Is.True);
@@ -364,9 +358,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var packageDocument = CompiledPackageContentBase.Create(element);
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0);
             var importedContentTypes = contentTypes.ToDictionary(x => x.Alias, x => x);
             IReadOnlyList<IContent> contents = PackageDataInstallation.ImportContentBase(packageDocument.Yield(), importedContentTypes, 0, ContentTypeService, ContentService);
             int numberOfDocs = (from doc in element.Descendants()
@@ -392,8 +385,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var packageMedia = CompiledPackageContentBase.Create(element);
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IMediaType> mediaTypes = PackageDataInstallation.ImportMediaTypes(mediaTypesElement.Elements("MediaType"), 0, entityContainersInstalled);
+            IReadOnlyList<IMediaType> mediaTypes = PackageDataInstallation.ImportMediaTypes(mediaTypesElement.Elements("MediaType"), 0);
             var importedMediaTypes = mediaTypes.ToDictionary(x => x.Alias, x => x);
             IReadOnlyList<IMedia> medias = PackageDataInstallation.ImportContentBase(packageMedia.Yield(), importedMediaTypes, 0, MediaTypeService, MediaService);
             int numberOfDocs = (from doc in element.Descendants()
@@ -421,9 +413,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var packageDocument = CompiledPackageContentBase.Create(element);
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0);
             var importedContentTypes = contentTypes.ToDictionary(x => x.Alias, x => x);
             IReadOnlyList<IContent> contents = PackageDataInstallation.ImportContentBase(packageDocument.Yield(), importedContentTypes, 0, ContentTypeService, ContentService);
             int numberOfDocs = (from doc in element.Descendants()
@@ -733,9 +724,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert
@@ -761,8 +751,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            var entityContainersInstalled = new List<EntityContainer>();
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -94,9 +94,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
 
             int numberOfTemplates = (from doc in templateElement.Elements("Template") select doc).Count();
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
@@ -141,9 +142,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
 
             // Assert
             IContentType mRBasePage = contentTypes.First(x => x.Alias == "MRBasePage");
@@ -166,9 +168,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypes = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
 
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
@@ -274,9 +277,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert
@@ -309,13 +313,14 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert - Re-Import contenttypes doesn't throw
-            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0));
+            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled));
             Assert.That(contentTypes.Count(), Is.EqualTo(numberOfDocTypes));
             Assert.That(dataTypeDefinitions, Is.Not.Null);
             Assert.That(dataTypeDefinitions.Any(), Is.True);
@@ -333,13 +338,14 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert - Re-Import contenttypes doesn't throw
-            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0));
+            Assert.DoesNotThrow(() => PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled));
             Assert.That(contentTypes.Count(), Is.EqualTo(numberOfDocTypes));
             Assert.That(dataTypeDefinitions, Is.Not.Null);
             Assert.That(dataTypeDefinitions.Any(), Is.True);
@@ -358,8 +364,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var packageDocument = CompiledPackageContentBase.Create(element);
 
             // Act
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0, entityContainersInstalled);
             var importedContentTypes = contentTypes.ToDictionary(x => x.Alias, x => x);
             IReadOnlyList<IContent> contents = PackageDataInstallation.ImportContentBase(packageDocument.Yield(), importedContentTypes, 0, ContentTypeService, ContentService);
             int numberOfDocs = (from doc in element.Descendants()
@@ -385,7 +392,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var packageMedia = CompiledPackageContentBase.Create(element);
 
             // Act
-            IReadOnlyList<IMediaType> mediaTypes = PackageDataInstallation.ImportMediaTypes(mediaTypesElement.Elements("MediaType"), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IMediaType> mediaTypes = PackageDataInstallation.ImportMediaTypes(mediaTypesElement.Elements("MediaType"), 0, entityContainersInstalled);
             var importedMediaTypes = mediaTypes.ToDictionary(x => x.Alias, x => x);
             IReadOnlyList<IMedia> medias = PackageDataInstallation.ImportContentBase(packageMedia.Yield(), importedMediaTypes, 0, MediaTypeService, MediaService);
             int numberOfDocs = (from doc in element.Descendants()
@@ -413,8 +421,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             var packageDocument = CompiledPackageContentBase.Create(element);
 
             // Act
-            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IDataType> dataTypeDefinitions = PackageDataInstallation.ImportDataTypes(dataTypeElement.Elements("DataType").ToList(), 0, entityContainersInstalled);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypesElement.Elements("DocumentType"), 0, entityContainersInstalled);
             var importedContentTypes = contentTypes.ToDictionary(x => x.Alias, x => x);
             IReadOnlyList<IContent> contents = PackageDataInstallation.ImportContentBase(packageDocument.Yield(), importedContentTypes, 0, ContentTypeService, ContentService);
             int numberOfDocs = (from doc in element.Descendants()
@@ -724,8 +733,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
+            var entityContainersInstalled = new List<EntityContainer>();
             IReadOnlyList<ITemplate> templates = PackageDataInstallation.ImportTemplates(templateElement.Elements("Template").ToList(), 0);
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert
@@ -751,7 +761,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             XElement docTypeElement = xml.Descendants("DocumentTypes").First();
 
             // Act
-            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0);
+            var entityContainersInstalled = new List<EntityContainer>();
+            IReadOnlyList<IContentType> contentTypes = PackageDataInstallation.ImportDocumentTypes(docTypeElement.Elements("DocumentType"), 0, entityContainersInstalled);
             int numberOfDocTypes = (from doc in docTypeElement.Elements("DocumentType") select doc).Count();
 
             // Assert


### PR DESCRIPTION
These are currently not exposed, and hence not handled by Umbraco Deploy to create the `.uda` files after a package installation.  With this information we'll be able to create the schema files on disk for these two and resolve remaining schema mismatch errors following a package installation locally and on Cloud.