### PR TITLE
New interface for custom backoffice assets in C#

### DIFF
--- a/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollectionBuilder.cs
+++ b/src/Umbraco.Core/WebAssets/CustomBackOfficeAssetsCollectionBuilder.cs
@@ -1,9 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 
 namespace Umbraco.Cms.Core.WebAssets
 {
-    public class CustomBackOfficeAssetsCollectionBuilder : OrderedCollectionBuilderBase<CustomBackOfficeAssetsCollectionBuilder, CustomBackOfficeAssetsCollection, IAssetFile>
+    public class CustomBackOfficeAssetsCollectionBuilder : ICollectionBuilder<CustomBackOfficeAssetsCollection, IAssetFile>
     {
-        protected override CustomBackOfficeAssetsCollectionBuilder This => this;
+        private readonly List<IAssetFile> _files = new List<IAssetFile>();
+
+        public CustomBackOfficeAssetsCollection CreateCollection(IServiceProvider factory) => new CustomBackOfficeAssetsCollection(() => _files);
+
+        public void RegisterWith(IServiceCollection services) => services.Add(new ServiceDescriptor(typeof(CustomBackOfficeAssetsCollection), CreateCollection, ServiceLifetime.Singleton));
+
+        public void AddAssetFile(IAssetFile file)
+        {
+            if (file is null) throw new ArgumentNullException(nameof(file));
+            _files.Add(file);
+        }
     }
 }


### PR DESCRIPTION
I noticed that there was a way to register js and CSS scripts within C#, but I think the current interface for it is not the greatest.
I also didn't even know that this existed, so I'll certainly have to write some documentation for this later (depending on what will happen with this PR of course).

I decided to remove the OrderedCollectionBuilder that was being used here as adding a new type for each file is just undoable.

The interface will then change from:
```
public class CustomPackageComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.BackOfficeAssets().Append<CustomPackageScript>();
        }
    }

    public class CustomPackageScript : JavaScriptFile
    {
        public CustomPackageScript() : base("/App_Plugins/Test/testJavascript.js") { }
    }
```

To
```
public class CustomPackageComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.BackOfficeAssets().AddAssetFile(new JavaScriptFile("/App_Plugins/Test/testJavascript.js"));
        }
    }
```

This is mostly how the TreeCollectionBuilder also handles TreeDefinitions.
However, this will be a breaking change, so I am wondering how to best proceed with this!