### PR TITLE
camelCase translations for importDocumentType

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
@@ -68,7 +68,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         /// <param name="id"></param>
         /// <param name="queryStrings"></param>
         /// <returns></returns>
-        public ActionResult<TreeNode> GetTreeNode([FromRoute] string id, [ModelBinder(typeof(HttpQueryStringModelBinder))]FormCollection queryStrings)
+        public ActionResult<TreeNode> GetTreeNode([FromRoute] string id, [ModelBinder(typeof(HttpQueryStringModelBinder))] FormCollection queryStrings)
         {
             int asInt;
             Guid asGuid = Guid.Empty;
@@ -325,7 +325,8 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         /// <returns></returns>
         protected bool HasPathAccess(IUmbracoEntity entity, FormCollection queryStrings)
         {
-            if (entity == null) return false;
+            if (entity == null)
+                return false;
             return RecycleBinId == Constants.System.RecycleBinContent
                 ? _backofficeSecurityAccessor.BackOfficeSecurity.CurrentUser.HasContentPathAccess(entity, _entityService, _appCaches)
                 : _backofficeSecurityAccessor.BackOfficeSecurity.CurrentUser.HasMediaPathAccess(entity, _entityService, _appCaches);
@@ -469,13 +470,13 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 // only add empty recycle bin if the current user is allowed to delete by default
                 if (deleteAllowed)
                 {
-	                menu.Items.Add(new MenuItem("emptyrecyclebin", LocalizedTextService)
-	                {
-	                    Icon = "trash",
-	                    OpensDialog = true
-	                });
-	                menu.Items.Add(new RefreshNode(LocalizedTextService, true));
-				}
+                    menu.Items.Add(new MenuItem("emptyRecycleBin", LocalizedTextService)
+                    {
+                        Icon = "trash",
+                        OpensDialog = true
+                    });
+                    menu.Items.Add(new RefreshNode(LocalizedTextService, true));
+                }
                 return menu;
             }
 
@@ -608,7 +609,8 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         /// <returns></returns>
         internal bool IgnoreUserStartNodes(FormCollection queryStrings)
         {
-            if (_ignoreUserStartNodes.HasValue) return _ignoreUserStartNodes.Value;
+            if (_ignoreUserStartNodes.HasValue)
+                return _ignoreUserStartNodes.Value;
 
             var dataTypeKey = queryStrings.GetValue<Guid?>(TreeQueryStringParameters.DataTypeKey);
             _ignoreUserStartNodes = dataTypeKey.HasValue && _dataTypeService.IsDataTypeIgnoringUserStartNodes(dataTypeKey.Value);

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
@@ -76,7 +76,8 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                     }));
 
             //if the request is for folders only then just return
-            if (queryStrings["foldersonly"].ToString().IsNullOrWhiteSpace() == false && queryStrings["foldersonly"] == "1") return nodes;
+            if (queryStrings["foldersonly"].ToString().IsNullOrWhiteSpace() == false && queryStrings["foldersonly"] == "1")
+                return nodes;
 
             var children = _entityService.GetChildren(intId, UmbracoObjectTypes.DocumentType).ToArray();
             var contentTypes = _contentTypeService.GetAll(children.Select(c => c.Id).ToArray()).ToDictionary(c => c.Id);
@@ -117,7 +118,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
 
                 // root actions
                 menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true);
-                menu.Items.Add(new MenuItem("importdocumenttype", LocalizedTextService)
+                menu.Items.Add(new MenuItem("importDocumentType", LocalizedTextService)
                 {
                     Icon = "page-up",
                     SeparatorBefore = true,

--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/tree.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/tree.mocks.js
@@ -28,7 +28,7 @@ angular.module('umbraco.mocks').
 
               { separator: true, name: "Reload", cssclass: "refresh", alias: "users", metaData: {} },
           
-                { separator: true, name: "Empty Recycle Bin", cssclass: "trash", alias: "emptyrecyclebin", metaData: {} }
+                { separator: true, name: "Empty Recycle Bin", cssclass: "trash", alias: "emptyRecycleBin", metaData: {} }
           ];
 
           var result = {

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
@@ -16,10 +16,10 @@
     <key alias="createGroup">Vytvořit skupinu</key>
     <key alias="delete">Odstranit</key>
     <key alias="disable">Deaktivovat</key>
-    <key alias="emptyrecyclebin">Vyprázdnit koš</key>
+    <key alias="emptyRecycleBin">Vyprázdnit koš</key>
     <key alias="enable">Aktivovat</key>
     <key alias="exportDocumentType">Exportovat typ dokumentu</key>
-    <key alias="importdocumenttype">Importovat typ dokumentu</key>
+    <key alias="importDocumentType">Importovat typ dokumentu</key>
     <key alias="importPackage">Importovat balíček</key>
     <key alias="liveEdit">Editovat na stránce</key>
     <key alias="logout">Odhlásit</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
@@ -18,10 +18,10 @@
     <key alias="delete">Dileu</key>
     <key alias="disable">Analluogi</key>
     <key alias="editSettings">Golygu gosodiadau</key>
-    <key alias="emptyrecyclebin">Gwagu bin ailgylchu</key>
+    <key alias="emptyRecycleBin">Gwagu bin ailgylchu</key>
     <key alias="enable">Galluogi</key>
     <key alias="exportDocumentType">Allforio Math o Ddogfen</key>
-    <key alias="importdocumenttype">Mewnforio Math o Ddogfen</key>
+    <key alias="importDocumentType">Mewnforio Math o Ddogfen</key>
     <key alias="importPackage">Mewnforio Pecyn</key>
     <key alias="liveEdit">Golygu mewn Cynfas</key>
     <key alias="logout">Gadael</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -18,10 +18,10 @@
     <key alias="delete">Slet</key>
     <key alias="disable">Deaktivér</key>
     <key alias="editSettings">Edit settings</key>
-    <key alias="emptyrecyclebin">Tøm papirkurv</key>
+    <key alias="emptyRecycleBin">Tøm papirkurv</key>
     <key alias="enable">Aktivér</key>
     <key alias="exportDocumentType">Eksportér dokumenttype</key>
-    <key alias="importdocumenttype">Importér dokumenttype</key>
+    <key alias="importDocumentType">Importér dokumenttype</key>
     <key alias="importPackage">Importér pakke</key>
     <key alias="liveEdit">Redigér i Canvas</key>
     <key alias="logout">Log af</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -16,10 +16,10 @@
     <key alias="createGroup">Neue Gruppe</key>
     <key alias="delete">Entfernen</key>
     <key alias="disable">Deaktivieren</key>
-    <key alias="emptyrecyclebin">Papierkorb leeren</key>
+    <key alias="emptyRecycleBin">Papierkorb leeren</key>
     <key alias="enable">Aktivieren</key>
     <key alias="exportDocumentType">Dokumenttyp exportieren</key>
-    <key alias="importdocumenttype">Dokumenttyp importieren</key>
+    <key alias="importDocumentType">Dokumenttyp importieren</key>
     <key alias="importPackage">Paket importieren</key>
     <key alias="liveEdit">'Canvas'-Modus starten</key>
     <key alias="logout">Abmelden</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -17,10 +17,10 @@
     <key alias="delete">Delete</key>
     <key alias="disable">Disable</key>
     <key alias="editSettings">Edit settings</key>
-    <key alias="emptyrecyclebin">Empty recycle bin</key>
+    <key alias="emptyRecycleBin">Empty recycle bin</key>
     <key alias="enable">Enable</key>
     <key alias="exportDocumentType">Export Document Type</key>
-    <key alias="importdocumenttype">Import Document Type</key>
+    <key alias="importDocumentType">Import Document Type</key>
     <key alias="importPackage">Import Package</key>
     <key alias="liveEdit">Edit in Canvas</key>
     <key alias="logout">Exit</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -18,10 +18,10 @@
     <key alias="delete">Delete</key>
     <key alias="disable">Disable</key>
     <key alias="editSettings">Edit settings</key>
-    <key alias="emptyrecyclebin">Empty recycle bin</key>
+    <key alias="emptyRecycleBin">Empty recycle bin</key>
     <key alias="enable">Enable</key>
     <key alias="exportDocumentType">Export Document Type</key>
-    <key alias="importdocumenttype">Import Document Type</key>
+    <key alias="importDocumentType">Import Document Type</key>
     <key alias="importPackage">Import Package</key>
     <key alias="liveEdit">Edit in Canvas</key>
     <key alias="logout">Exit</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -15,10 +15,10 @@
     <key alias="createGroup">Crear grupo</key>
     <key alias="delete">Borrar</key>
     <key alias="disable">Deshabilitar</key>
-    <key alias="emptyrecyclebin">Vaciar Papelera</key>
+    <key alias="emptyRecycleBin">Vaciar Papelera</key>
     <key alias="enable">Activar</key>
     <key alias="exportDocumentType">Exportar Documento (tipo)</key>
-    <key alias="importdocumenttype">Importar Documento (tipo)</key>
+    <key alias="importDocumentType">Importar Documento (tipo)</key>
     <key alias="importPackage">Importar Paquete</key>
     <key alias="liveEdit">Editar en vivo</key>
     <key alias="logout">Cerrar sesión</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -16,10 +16,10 @@
     <key alias="createGroup">Créer un groupe</key>
     <key alias="delete">Supprimer</key>
     <key alias="disable">Désactiver</key>
-    <key alias="emptyrecyclebin">Vider la corbeille</key>
+    <key alias="emptyRecycleBin">Vider la corbeille</key>
     <key alias="enable">Activer</key>
     <key alias="exportDocumentType">Exporter le type de document</key>
-    <key alias="importdocumenttype">Importer un type de document</key>
+    <key alias="importDocumentType">Importer un type de document</key>
     <key alias="importPackage">Importer un package</key>
     <key alias="liveEdit">Editer dans Canvas</key>
     <key alias="logout">Déconnexion</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -13,9 +13,9 @@
     <key alias="createPackage">צור חבילה</key>
     <key alias="delete">מחק</key>
     <key alias="disable">נטרל</key>
-    <key alias="emptyrecyclebin">רוקן סל מיחזור</key>
+    <key alias="emptyRecycleBin">רוקן סל מיחזור</key>
     <key alias="exportDocumentType">ייצא סוג קובץ</key>
-    <key alias="importdocumenttype">ייבא סוג מסמך</key>
+    <key alias="importDocumentType">ייבא סוג מסמך</key>
     <key alias="importPackage">ייבא חבילה</key>
     <key alias="liveEdit">ערוך במצב "קנבס"</key>
     <key alias="logout">יציאה</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -13,9 +13,9 @@
     <key alias="createPackage">Crea pacchetto</key>
     <key alias="delete">Cancella</key>
     <key alias="disable">Disabilita</key>
-    <key alias="emptyrecyclebin">Svuota il cestino</key>
+    <key alias="emptyRecycleBin">Svuota il cestino</key>
     <key alias="exportDocumentType">Esporta il tipo di documento</key>
-    <key alias="importdocumenttype">Importa il tipo di documento</key>
+    <key alias="importDocumentType">Importa il tipo di documento</key>
     <key alias="importPackage">Importa il pacchetto</key>
     <key alias="liveEdit">Modifica in Area di Lavoro</key>
     <key alias="logout">Uscita</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -14,9 +14,9 @@
     <key alias="createPackage">パッケージの作成</key>
     <key alias="delete">削除</key>
     <key alias="disable">無効</key>
-    <key alias="emptyrecyclebin">ごみ箱を空にする</key>
+    <key alias="emptyRecycleBin">ごみ箱を空にする</key>
     <key alias="exportDocumentType">ドキュメントタイプの書出</key>
-    <key alias="importdocumenttype">ドキュメントタイプの読込</key>
+    <key alias="importDocumentType">ドキュメントタイプの読込</key>
     <key alias="importPackage">パッケージの読み込み</key>
     <key alias="liveEdit">ライブ編集</key>
     <key alias="logout">ログアウト</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -13,9 +13,9 @@
     <key alias="createPackage">패키지 새로 만들기</key>
     <key alias="delete">삭제</key>
     <key alias="disable">비활성</key>
-    <key alias="emptyrecyclebin">휴지통 비우기</key>
+    <key alias="emptyRecycleBin">휴지통 비우기</key>
     <key alias="exportDocumentType">추출 문서 유형</key>
-    <key alias="importdocumenttype">등록 문서 유형</key>
+    <key alias="importDocumentType">등록 문서 유형</key>
     <key alias="importPackage">패키지 등록</key>
     <key alias="liveEdit">캔버스 내용 편집</key>
     <key alias="logout">종료</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
@@ -14,9 +14,9 @@
     <key alias="createPackage">Opprett pakke</key>
     <key alias="delete">Slett</key>
     <key alias="disable">Deaktiver</key>
-    <key alias="emptyrecyclebin">Tøm papirkurv</key>
+    <key alias="emptyRecycleBin">Tøm papirkurv</key>
     <key alias="exportDocumentType">Eksporter dokumenttype</key>
-    <key alias="importdocumenttype">Importer dokumenttype</key>
+    <key alias="importDocumentType">Importer dokumenttype</key>
     <key alias="importPackage">Importer pakke</key>
     <key alias="liveEdit">Rediger i Canvas</key>
     <key alias="logout">Logg av</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -18,10 +18,10 @@
     <key alias="delete">Verwijderen</key>
     <key alias="disable">Uitschakelen</key>
     <key alias="editSettings">Instellingen wijzigen</key>
-    <key alias="emptyrecyclebin">Prullenbak leegmaken</key>
+    <key alias="emptyRecycleBin">Prullenbak leegmaken</key>
     <key alias="enable">Inschakelen</key>
     <key alias="exportDocumentType">Documenttype exporteren</key>
-    <key alias="importdocumenttype">Documenttype importeren</key>
+    <key alias="importDocumentType">Documenttype importeren</key>
     <key alias="importPackage">Package importeren</key>
     <key alias="liveEdit">Aanpassen in Canvas</key>
     <key alias="logout">Afsluiten</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -15,10 +15,10 @@
     <key alias="createGroup">Stwórz grupę</key>
     <key alias="delete">Usuń</key>
     <key alias="disable">Deaktywuj</key>
-    <key alias="emptyrecyclebin">Opróżnij kosz</key>
+    <key alias="emptyRecycleBin">Opróżnij kosz</key>
     <key alias="enable">Aktywuj</key>
     <key alias="exportDocumentType">Eksportuj typ dokumentu</key>
-    <key alias="importdocumenttype">Importuj typ dokumentu</key>
+    <key alias="importDocumentType">Importuj typ dokumentu</key>
     <key alias="importPackage">Importuj zbiór</key>
     <key alias="liveEdit">Edytuj na stronie</key>
     <key alias="logout">Wyjście</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -13,9 +13,9 @@
     <key alias="createPackage">Criar Pacote</key>
     <key alias="delete">Remover</key>
     <key alias="disable">Desabilitar</key>
-    <key alias="emptyrecyclebin">Esvaziar Lixeira</key>
+    <key alias="emptyRecycleBin">Esvaziar Lixeira</key>
     <key alias="exportDocumentType">Exportar Tipo de Documento</key>
-    <key alias="importdocumenttype">Importar Tipo de Documento</key>
+    <key alias="importDocumentType">Importar Tipo de Documento</key>
     <key alias="importPackage">Importar Pacote</key>
     <key alias="liveEdit">Editar na Tela</key>
     <key alias="logout">Sair</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -17,11 +17,11 @@
     <key alias="defaultValue">Значение по умолчанию</key>
     <key alias="delete">Удалить</key>
     <key alias="disable">Отключить</key>
-    <key alias="emptyrecyclebin">Очистить корзину</key>
+    <key alias="emptyRecycleBin">Очистить корзину</key>
     <key alias="enable">Включить</key>
     <key alias="export">Экспорт</key>
     <key alias="exportDocumentType">Экспортировать</key>
-    <key alias="importdocumenttype">Импортировать</key>
+    <key alias="importDocumentType">Импортировать</key>
     <key alias="importPackage">Импортировать пакет</key>
     <key alias="liveEdit">Править на месте</key>
     <key alias="logout">Выйти</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -20,9 +20,9 @@
     <key alias="defaultValue">Standardvärde</key>
     <key alias="delete">Ta bort</key>
     <key alias="disable">Avaktivera</key>
-    <key alias="emptyrecyclebin">Töm papperskorgen</key>
+    <key alias="emptyRecycleBin">Töm papperskorgen</key>
     <key alias="exportDocumentType">Exportera dokumenttyp</key>
-    <key alias="importdocumenttype">Importera dokumenttyp</key>
+    <key alias="importDocumentType">Importera dokumenttyp</key>
     <key alias="importPackage">Importera paket</key>
     <key alias="liveEdit">Redigera i Canvas</key>
     <key alias="logout">Logga ut</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
@@ -17,10 +17,10 @@
     <key alias="delete">Sil</key>
     <key alias="disable">Devre Dışı Bırak</key>
     <key alias="editSettings">Ayarları düzenle</key>
-    <key alias="emptyrecyclebin">Geri dönüşüm kutusunu boşalt</key>
+    <key alias="emptyRecycleBin">Geri dönüşüm kutusunu boşalt</key>
     <key alias="enable">Etkinleştir</key>
     <key alias="exportDocumentType">Belge Türünü Dışa Aktar</key>
-    <key alias="importdocumenttype">Belge Türünü İçe Aktar</key>
+    <key alias="importDocumentType">Belge Türünü İçe Aktar</key>
     <key alias="importPackage">Paketi İçe Aktar</key>
     <key alias="liveEdit">Kanvas'ta Düzenle</key>
     <key alias="logout">Çıkış</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -14,9 +14,9 @@
     <key alias="createPackage">创建扩展包</key>
     <key alias="delete">删除</key>
     <key alias="disable">禁用</key>
-    <key alias="emptyrecyclebin">清空回收站</key>
+    <key alias="emptyRecycleBin">清空回收站</key>
     <key alias="exportDocumentType">导出文档类型</key>
-    <key alias="importdocumenttype">导入文档类型</key>
+    <key alias="importDocumentType">导入文档类型</key>
     <key alias="importPackage">导入扩展包</key>
     <key alias="liveEdit">实时编辑模式</key>
     <key alias="logout">退出</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
@@ -14,9 +14,9 @@
     <key alias="createPackage">創建擴展包</key>
     <key alias="delete">刪除</key>
     <key alias="disable">禁用</key>
-    <key alias="emptyrecyclebin">清空回收站</key>
+    <key alias="emptyRecycleBin">清空回收站</key>
     <key alias="exportDocumentType">匯出文檔類型</key>
-    <key alias="importdocumenttype">導入文檔類型</key>
+    <key alias="importDocumentType">導入文檔類型</key>
     <key alias="importPackage">導入擴展包</key>
     <key alias="liveEdit">即時編輯模式</key>
     <key alias="logout">退出</key>


### PR DESCRIPTION
Rename `importdocumenttype` to `importDocumentType` and `emptyrecyclebin` to `emptyRecycleBin` to match UI and mocks

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

1. Go to Settings
2. Right click Document Types and choose Import Document Type
3. Click Import and choose a .udt file
4. The CTA button should now correctly show the text "Import Document Type"

**Before:**

<img width="317" alt="Screenshot 2021-10-07 at 11 12 26" src="https://user-images.githubusercontent.com/752371/136364084-c62b9feb-e2a5-484f-888b-d1de0ca05e21.png">

**After:**

<img width="403" alt="Screenshot 2021-10-07 at 11 59 05" src="https://user-images.githubusercontent.com/752371/136364119-27ba6696-4ff7-421a-aaba-91effb98bffe.png">

I also changed emptyRecycleBin because it was also affected by the same commit that renamed importDocumentType, even though the UI seemed to work perfectly well, however `tree.mocks.js` did reflect the camelCase version of it from earlier, so found it best to use camelCase on both keys moving forward.