### PR TITLE
added vm. in front of the enterSubmitFolder method call on ng-keydown

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -90,7 +90,7 @@
                                         class="umb-breadcrumbs__add-ancestor"
                                         ng-show="model.showFolderInput"
                                         ng-model="model.newFolderName"
-                                        ng-keydown="enterSubmitFolder($event)"
+                                        ng-keydown="vm.enterSubmitFolder($event)"
                                         ng-blur="vm.submitFolder()"
                                         focus-when="{{model.showFolderInput}}" />
                             </li>


### PR DESCRIPTION
When using the media picker and you want to add a new folder by clicking the plus and entering the folder name. It should submit when you press enter. Currently it only works when you lose focus. 

During today's Discord hacktoberfest conversation, I brought this up and we worked out that the mediapicker.html file had a bug. There was `vm.` missing in from of the method enterSubmitFolder($event) which runs on key down.

When you add `vm.` in it works as expected.

This was tested out live on a call with Umbraco HQ members @nul800sebastiaan, @emmaburstow and @warrenbuckley present.