### PR TITLE
11315: Don't unbind unbinding keys

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -214,13 +214,14 @@ When building a custom infinite editor view you can use the same components as a
          * Method to tell editors that they are begin blurred.
          */
         function blur() {
-
-            /* keyboard shortcuts will be overwritten by the new infinite editor
+            if (isEnabled === true) {
+                /* keyboard shortcuts will be overwritten by the new infinite editor
                 so we need to store the shortcuts for the current editor so they can be rebound
                 when the infinite editor closes
             */
-            unbindKeyboardShortcuts();
-            isEnabled = false;
+                unbindKeyboardShortcuts();
+                isEnabled = false;
+            }
         }
         /**
          * @ngdoc method


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11315

Steps to reproduce can be found in the issue.

Whenever you would trigger the "appState.backdrop" event (on every menu click), it would unbind the previous keys. If you click outside the menu, it would rebind those keys again.
The issue lied in that it would always unbind the previous keys on every menu click. So eventually it would just forget the keys that it had to rebind. This fix makes it so it only unbinds once.