### PR TITLE
Removing explicit namespaces for UmbracoViewPage in templates

### DIFF
--- a/src/Umbraco.Core/IO/ViewHelper.cs
+++ b/src/Umbraco.Core/IO/ViewHelper.cs
@@ -13,7 +13,11 @@ namespace Umbraco.Cms.Core.IO
 
         public ViewHelper(IFileSystem viewFileSystem)
         {
-            if (viewFileSystem == null) throw new ArgumentNullException(nameof(viewFileSystem));
+            if (viewFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(viewFileSystem));
+            }
+
             _viewFileSystem = viewFileSystem;
         }
 
@@ -65,13 +69,15 @@ namespace Umbraco.Cms.Core.IO
             var content = new StringBuilder();
 
             if (string.IsNullOrWhiteSpace(modelNamespaceAlias))
+            {
                 modelNamespaceAlias = "ContentModels";
+            }
 
             // either
-            // @inherits Umbraco.Web.Mvc.UmbracoViewPage
-            // @inherits Umbraco.Web.Mvc.UmbracoViewPage<ModelClass>
-            content.AppendLine("@using Umbraco.Cms.Web.Common.PublishedModels;");
-            content.Append("@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage");
+            // @inherits UmbracoViewPage
+            // @inherits UmbracoViewPage<ModelClass>
+            content.Append("@inherits UmbracoViewPage");
+
             if (modelClassName.IsNullOrWhiteSpace() == false)
             {
                 content.Append("<");
@@ -100,6 +106,7 @@ namespace Umbraco.Cms.Core.IO
             // Layout = null;
             // Layout = "layoutPage.cshtml";
             content.Append("@{\r\n\tLayout = ");
+
             if (layoutPageAlias.IsNullOrWhiteSpace())
             {
                 content.Append("null");
@@ -111,6 +118,7 @@ namespace Umbraco.Cms.Core.IO
                 content.Append(".cshtml\"");
             }
             content.Append(";\r\n}");
+
             return content.ToString();
         }
 
@@ -138,8 +146,11 @@ namespace Umbraco.Cms.Core.IO
             {
                 //then kill the old file..
                 var oldFile = ViewPath(currentAlias);
+
                 if (_viewFileSystem.FileExists(oldFile))
+                {
                     _viewFileSystem.DeleteFile(oldFile);
+                }
             }
 
             var data = Encoding.UTF8.GetBytes(t.Content);
@@ -162,7 +173,9 @@ namespace Umbraco.Cms.Core.IO
             var design = template.Content;
 
             if (string.IsNullOrEmpty(design))
+            {
                 design = GetDefaultFileContent(template.MasterTemplateAlias);
+            }
 
             return design;
         }

--- a/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -327,7 +327,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Packaging
                 Assert.Multiple(() =>
                 {
                     Assert.AreEqual("umbPackage", xml.Root.Name.ToString());
-                    Assert.AreEqual($"<Templates><Template><Name>Text page</Name><Key>{template.Key}</Key><Alias>textPage</Alias><Design><![CDATA[@using Umbraco.Cms.Web.Common.PublishedModels;{Environment.NewLine}@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage{Environment.NewLine}@{{{Environment.NewLine}\tLayout = null;{Environment.NewLine}}}]]></Design></Template></Templates>", xml.Element("umbPackage").Element("Templates").ToString(SaveOptions.DisableFormatting));
+                    Assert.AreEqual($"<Templates><Template><Name>Text page</Name><Key>{template.Key}</Key><Alias>textPage</Alias><Design><![CDATA[@inherits UmbracoViewPage{Environment.NewLine}@{{{Environment.NewLine}\tLayout = null;{Environment.NewLine}}}]]></Design></Template></Templates>", xml.Element("umbPackage").Element("Templates").ToString(SaveOptions.DisableFormatting));
                     Assert.IsNull(xml.DocumentType);
                     Assert.IsNull(xml.Parent);
                     Assert.IsNull(xml.NextNode);

--- a/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/src/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
                 Assert.That(repository.Get("test"), Is.Not.Null);
                 Assert.That(FileSystems.MvcViewsFileSystem.FileExists("test.cshtml"), Is.True);
                 Assert.AreEqual(
-                    @"@usingUmbraco.Cms.Web.Common.PublishedModels;@inheritsUmbraco.Cms.Web.Common.Views.UmbracoViewPage@{Layout=null;}".StripWhitespace(),
+                    @"@inherits UmbracoViewPage @{ Layout = null; }".StripWhitespace(),
                     template.Content.StripWhitespace());
             }
         }
@@ -126,7 +126,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
                 Assert.That(repository.Get("test2"), Is.Not.Null);
                 Assert.That(FileSystems.MvcViewsFileSystem.FileExists("test2.cshtml"), Is.True);
                 Assert.AreEqual(
-                    "@usingUmbraco.Cms.Web.Common.PublishedModels;@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage @{ Layout = \"test.cshtml\";}".StripWhitespace(),
+                    "@inherits UmbracoViewPage @{ Layout = \"test.cshtml\";}".StripWhitespace(),
                     template2.Content.StripWhitespace());
             }
         }

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/ViewHelperTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/ViewHelperTests.cs
@@ -14,8 +14,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         {
             var view = ViewHelper.GetDefaultFileContent();
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+                FixView(@"@inherits UmbracoViewPage
 @{
     Layout = null;
 }"), FixView(view));
@@ -24,12 +23,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         [Test]
         public void Layout()
         {
-            var view = ViewHelper.GetDefaultFileContent(layoutPageAlias: "Dharznoik");
+            var view = ViewHelper.GetDefaultFileContent(layoutPageAlias: "Master");
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+                FixView(@"@using UmbracoViewPage
 @{
-    Layout = ""Dharznoik.cshtml"";
+    Layout = ""Master.cshtml"";
 }"), FixView(view));
         }
 
@@ -38,8 +36,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         {
             var view = ViewHelper.GetDefaultFileContent(modelClassName: "ClassName");
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ClassName>
+                FixView(@"@inherits UmbracoViewPage<ClassName>
 @{
     Layout = null;
 }"), FixView(view));
@@ -50,8 +47,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         {
             var view = ViewHelper.GetDefaultFileContent(modelNamespace: "Models");
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+                FixView(@"@inherits UmbracoViewPage
 @{
     Layout = null;
 }"), FixView(view));
@@ -62,8 +58,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         {
             var view = ViewHelper.GetDefaultFileContent(modelClassName: "ClassName", modelNamespace: "My.Models");
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.ClassName>
+                FixView(@"@inherits UmbracoViewPage<ContentModels.ClassName>
 @using ContentModels = My.Models;
 @{
     Layout = null;
@@ -75,8 +70,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         {
             var view = ViewHelper.GetDefaultFileContent(modelClassName: "ClassName", modelNamespace: "My.Models", modelNamespaceAlias: "MyModels");
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<MyModels.ClassName>
+                FixView(@"@inherits UmbracoViewPage<MyModels.ClassName>
 @using MyModels = My.Models;
 @{
     Layout = null;
@@ -86,13 +80,12 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Templates
         [Test]
         public void Combined()
         {
-            var view = ViewHelper.GetDefaultFileContent(layoutPageAlias: "Dharznoik", modelClassName: "ClassName", modelNamespace: "My.Models", modelNamespaceAlias: "MyModels");
+            var view = ViewHelper.GetDefaultFileContent(layoutPageAlias: "Master", modelClassName: "ClassName", modelNamespace: "My.Models", modelNamespaceAlias: "MyModels");
             Assert.AreEqual(
-                FixView(@"@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<MyModels.ClassName>
+                FixView(@"@inherits UmbracoViewPage<MyModels.ClassName>
 @using MyModels = My.Models;
 @{
-    Layout = ""Dharznoik.cshtml"";
+    Layout = ""Master.cshtml"";
 }"), FixView(view));
         }
 


### PR DESCRIPTION
When creating templates in the backoffice the editor adds a bunch of `@using`'s that ultimately don't appear to be needed.

This might be a legacy thing where IDE's wouldn't pick up references in the `Views/web.config` and so without those lines you'd have no intellisense.

With V9 / netcore these references are included in the `_ViewStart.cshtml`, which most modern IDE's (Visual Studio, VS Code, Rider) do a good job of picking up. I see no reason why these lines should be there, and we can instead encourage devs to keep their views cleaner.

This PR removes the explicit `Umbraco.Cms.Web.Common.PublishedModels` and `Umbraco.Cms.Web.Common.Views` references from templates created via the CMS. The former is not needed, as there's already the `@using ContentModels = ...` alias.

If I've overlooked something here please do tell me!