### PR TITLE
contentpicker: Don't validate minNumber if empty and not mandatory

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -44,14 +44,15 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
     function validate() {
         if ($scope.contentPickerForm) {
             //Validate!
-            if (($scope.renderModel.length !== 0 || ($scope.model.validation && $scope.model.validation.mandatory)) && $scope.model.config && $scope.model.config.minNumber && parseInt($scope.model.config.minNumber) > $scope.renderModel.length) {
+            var hasItemsOrMandatory = $scope.renderModel.length !== 0 || ($scope.model.validation && $scope.model.validation.mandatory);
+            if (hasItemsOrMandatory && $scope.minNumberOfItems > $scope.renderModel.length) {
                 $scope.contentPickerForm.minCount.$setValidity("minCount", false);
             }
             else {
                 $scope.contentPickerForm.minCount.$setValidity("minCount", true);
             }
 
-            if ($scope.model.config && $scope.model.config.maxNumber && parseInt($scope.model.config.maxNumber) < $scope.renderModel.length) {
+            if ($scope.maxNumberOfItems < $scope.renderModel.length) {
                 $scope.contentPickerForm.maxCount.$setValidity("maxCount", false);
             }
             else {
@@ -145,6 +146,10 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
 
             $scope.umbProperty.setPropertyActions(propertyActions);
         }
+
+        // use these to avoid the nested property lookups/null-checks
+        $scope.minNumberOfItems = $scope.model.config.minNumber ? parseInt($scope.model.config.minNumber) : 0;
+        $scope.maxNumberOfItems = $scope.model.config.maxNumber ? parseInt($scope.model.config.maxNumber) : 0;
     }
 
     //Umbraco persists boolean for prevalues as "0" or "1" so we need to convert that!
@@ -194,7 +199,7 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
     dialogOptions.dataTypeKey = $scope.model.dataTypeKey;
 
     // if we can't pick more than one item, explicitly disable multiPicker in the dialog options
-    if ($scope.model.config.maxNumber && parseInt($scope.model.config.maxNumber) === 1) {
+    if ($scope.maxNumberOfItems === 1) {
         dialogOptions.multiPicker = false;
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -19,7 +19,7 @@
             </umb-node-preview>
         </div>
 
-        <button ng-show="model.config.multiPicker === true && renderModel.length < model.config.maxNumber || renderModel.length === 0 || !model.config.maxNumber"
+        <button ng-show="model.config.multiPicker === true && renderModel.length < maxNumberOfItems || renderModel.length === 0 || !maxNumberOfItems"
                 type="button"
                 class="umb-node-preview-add"
                 ng-click="openCurrentPicker()"
@@ -29,35 +29,35 @@
             <span class="sr-only">...</span>
         </button>
 
-        <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true && (model.config.maxNumber > 1 || model.config.minNumber > 0) && (renderModel.length !== 0 || (model.validation && model.validation.mandatory))">
+        <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true && (maxNumberOfItems > 1 || minNumberOfItems > 0) && (renderModel.length !== 0 || (model.validation && model.validation.mandatory))">
 
             <!-- Both min and max items -->
-            <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber !== model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber">Add between {{model.config.minNumber}} and {{model.config.maxNumber}} items</span>
-                <span ng-if="renderModel.length > model.config.maxNumber">
-                    <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_itemsSelected"> items selected</localize>
+            <span ng-if="minNumberOfItems !== maxNumberOfItems">
+                <span ng-if="renderModel.length < maxNumberOfItems">Add between {{minNumberOfItems}} and {{maxNumberOfItems}} items</span>
+                <span ng-if="renderModel.length > maxNumberOfItems">
+                    <localize key="validation_maxCount">You can only have</localize> {{maxNumberOfItems}} <localize key="validation_itemsSelected"> items selected</localize>
                 </span>
             </span>
 
             <!-- Equal min and max -->
-            <span ng-if="model.config.minNumber && model.config.maxNumber && model.config.minNumber === model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber">Add {{model.config.minNumber - renderModel.length}} item(s)</span>
-                <span ng-if="renderModel.length > model.config.maxNumber">
-                    <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_itemsSelected"> items selected</localize>
+            <span ng-if="minNumberOfItems === maxNumberOfItems">
+                <span ng-if="renderModel.length < maxNumberOfItems">Add {{minNumberOfItems - renderModel.length}} item(s)</span>
+                <span ng-if="renderModel.length > maxNumberOfItems">
+                    <localize key="validation_maxCount">You can only have</localize> {{maxNumberOfItems}} <localize key="validation_itemsSelected"> items selected</localize>
                 </span>
             </span>
 
             <!-- Only max -->
-            <span ng-if="!model.config.minNumber && model.config.maxNumber">
-                <span ng-if="renderModel.length < model.config.maxNumber">Add up to {{model.config.maxNumber}} items</span>
-                <span ng-if="renderModel.length > model.config.maxNumber">
-                    <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_itemsSelected">items selected</localize>
+            <span ng-if="!minNumberOfItems && maxNumberOfItems">
+                <span ng-if="renderModel.length < maxNumberOfItems">Add up to {{maxNumberOfItems}} items</span>
+                <span ng-if="renderModel.length > maxNumberOfItems">
+                    <localize key="validation_maxCount">You can only have</localize> {{maxNumberOfItems}} <localize key="validation_itemsSelected">items selected</localize>
                 </span>
             </span>
 
             <!-- Only min -->
-            <span ng-if="model.config.minNumber && !model.config.maxNumber && renderModel.length < model.config.minNumber">
-                Add at least {{model.config.minNumber}} item(s)
+            <span ng-if="minNumberOfItems && !maxNumberOfItems && renderModel.length < minNumberOfItems">
+                Add at least {{minNumberOfItems}} item(s)
             </span>
 
         </div>
@@ -70,12 +70,12 @@
 
         <div ng-messages="contentPickerForm.minCount.$error" show-validation-on-submit>
             <div class="help-inline" ng-message="minCount">
-                <localize key="validation_minCount">You need to add at least</localize> {{model.config.minNumber}} <localize key="validation_items">items</localize>
+                <localize key="validation_minCount">You need to add at least</localize> {{minNumberOfItems}} <localize key="validation_items">items</localize>
             </div>
         </div>
         <div ng-messages="contentPickerForm.maxCount.$error" show-validation-on-submit>
             <div class="help-inline" ng-message="maxCount">
-                <localize key="validation_maxCount">You can only have</localize> {{model.config.maxNumber}} <localize key="validation_itemsSelected">items selected</localize>
+                <localize key="validation_maxCount">You can only have</localize> {{maxNumberOfItems}} <localize key="validation_itemsSelected">items selected</localize>
             </div>
         </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11025

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
When `Minimum number of items` is > 0, even if it is not mandatory, the validation will fail with `You need at least N items`. This skips the minNumber validation if number of items is 0 and if it is not mandatory.

<!-- Thanks for contributing to Umbraco CMS! -->
