### PR TITLE
11331: Check property on instance if id is not set yet

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -933,12 +933,12 @@
                 }
             };
 
-            scope.deleteProperty = (properties, { id, label }) => {
-                const propertyName = label || "";
+            scope.deleteProperty = (properties, property) => {
+                const propertyName = property.label || "";
 
                 const localizeMany = localizationService.localizeMany(['general_delete']);
-                const localize =  localizationService.localize('contentTypeEditor_confirmDeletePropertyMessage',  [propertyName]);
-                
+                const localize = localizationService.localize('contentTypeEditor_confirmDeletePropertyMessage', [propertyName]);
+
                 $q.all([localizeMany, localize]).then(values => {
                     const translations = values[0];
                     const message = values[1];
@@ -948,7 +948,7 @@
                         content: message,
                         submitButtonLabelKey: 'actions_delete',
                         submit: () => {
-                            const index = properties.findIndex(property => property.id === id);
+                            const index = properties.findIndex(p => property.id ? p.id === property.id : p === property);
                             properties.splice(index, 1);
                             notifyChanged();
 


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11331

Steps to reproduce can be found in the issue. The issue was due to only checking on ids to remove the correct property. However, all unsaved properties all have the same id, so the first one would be deleted.
The video shows what the ids of the items are and the fix in action:
![BugDeletingWrongProperty](https://user-images.githubusercontent.com/11466511/136597705-06d22fd9-039c-4dc3-b2f1-ee63c6aca920.gif)

