### PR TITLE
add update language test

### DIFF
--- a/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Languages/languages.ts
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/integration/Languages/languages.ts
@@ -1,0 +1,31 @@
+/// <reference types="Cypress" />
+context('Languages', () => {
+
+    beforeEach(() => {
+        cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'), false);
+      });
+
+    it('Updates language', () => {
+        // Setup
+        const language = 'Danish';
+        cy.umbracoEnsureLanguageNotExists(language);
+        cy.umbracoCreateLanguage('da', true, '1');
+        cy.umbracoSection('settings');
+
+        // Enter language tree and select the language we just created
+        cy.umbracoTreeItem('settings', ['Languages']).click();
+        cy.get('tr').contains('Danish').click();
+
+        // Edit the language
+        cy.get('div[ng-click="vm.toggleMandatory()"]').children('button').click(); // the mandatory language toggle
+        cy.get('select[name="fallbackLanguage"]').select('No fall back language')       
+
+        // Save and assert success
+        cy.umbracoButtonByLabelKey('buttons_save').click();
+        cy.umbracoSuccessNotification().should('be.visible');
+
+        // Cleanup
+        cy.umbracoEnsureLanguageNotExists(language);
+    });
+
+});

--- a/src/Umbraco.Tests.AcceptanceTest/cypress/support/commands.js
+++ b/src/Umbraco.Tests.AcceptanceTest/cypress/support/commands.js
@@ -26,5 +26,73 @@
 
 import {Command} from 'umbraco-cypress-testhelpers';
 import {Chainable} from './chainable';
+import { JsonHelper } from 'umbraco-cypress-testhelpers';
+
 new Chainable();
 new Command().registerCypressCommands();
+
+Cypress.Commands.add('umbracoCreateLanguage', (culture, isMandatory = false, fallbackLanguageId = 1) => {
+
+    var langData =
+    {
+        "culture": culture,
+        "isMandatory": isMandatory,
+        "fallbackLanguageId": fallbackLanguageId        
+    };
+  
+    // Create language through API
+    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
+      cy.request({
+        method: 'POST',
+        url: '/umbraco/backoffice/umbracoapi/language/SaveLanguage',
+        followRedirect: true,
+        headers: {
+          Accept: 'application/json',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+        body: langData,
+        log: false,
+      }).then((response) => {        
+        return;
+      });
+    });   
+}); 
+
+Cypress.Commands.add('umbracoEnsureLanguageNotExists', (name) => {
+    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
+        cy.request({
+          method: 'GET',
+          url: '/umbraco/backoffice/umbracoapi/language/GetAllLanguages',
+          followRedirect: true,
+          headers: {
+            Accept: 'application/json',
+            'X-UMB-XSRF-TOKEN': token.value,
+          },
+          log: false,
+        }).then((response) => {
+          const searchBody = JsonHelper.getBody(response);
+          if (searchBody.length > 0) {
+            let languageId = null;
+            for (const sb of searchBody) {
+              if (sb.name === name) {
+                languageId = sb.id;
+              }
+            }
+
+            if (languageId !== null) {
+              cy.request({
+                method: 'POST',
+                url: '/umbraco/backoffice/umbracoapi/language/DeleteLanguage?id=' + languageId,
+                followRedirect: false,
+                headers: {
+                  ContentType: 'application/json',
+                  'X-UMB-XSRF-TOKEN': token.value,
+                },
+              }).then((resp) => {
+                return;
+              });
+            }
+          }
+        });
+      });
+}); 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I have the same question as I wrote in https://github.com/umbraco/Umbraco-CMS/pull/11307, what am I supposed to do if I need new cypress commands that aren't in the package? It makes sense to me to just add them to the commands file and you can then transfer the ones in the into the package whenever you want to make a new release of it?

I also wrote some ts definitions of the 2 methods, but the chainable.ts file seems to be gitignored so not sure of the procedure there?

Leaving them here to remember:

```js
/**
 * Checks to see if the language with specified name does not exist
 * If it does it will automatically delete it
 * @param  {string} name Name of language to delete
 * @example cy.umbracoEnsureLanguageNotExists('Danish');
 */
umbracoEnsureLanguageNotExists: (name: string) => Chainable<void>;
/**
 * Creates a language from a culture
 * @param {string} culture Culture of the language - fx "da_DK"
 * @param {boolean} isMandatory Set whether the language is mandatory or not. Defaults to false
 * @param {string} fallbackLanguageId of the language to fallback to. Defaults to 1 which is en_US
 * @example cy.umbracoCreateLanguage('da', true, '1');
 */
umbracoCreateLanguage: (culture: string, isMandatory: boolean, fallbackLanguageId: string) => Chainable<void>;
```

Anyways, this test does the following:
- Creates a new language through the backoffice api - culture: da, mandatory with fallback to english
- Navigates to that language through the ui
- Untoggles mandatory through ui
- Unselects a fallback language through ui
- Saves and verifies it saves
- Deletes the language again

<!-- Thanks for contributing to Umbraco CMS! -->
