### PR TITLE
Adds notifications to RecurringHostedServiceBase

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -18,6 +19,7 @@ using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
@@ -36,6 +38,24 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IScopeProvider _scopeProvider;
         private readonly ILogger<HealthCheckNotifier> _logger;
         private readonly IProfilingLogger _profilingLogger;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public HealthCheckNotifier(
+            IOptions<HealthChecksSettings> healthChecksSettings,
+            HealthCheckCollection healthChecks,
+            HealthCheckNotificationMethodCollection notifications,
+            IRuntimeState runtimeState,
+            IServerRoleAccessor serverRegistrar,
+            IMainDom mainDom,
+            IScopeProvider scopeProvider,
+            ILogger<HealthCheckNotifier> logger,
+            IProfilingLogger profilingLogger,
+            ICronTabParser cronTabParser)
+            : base(
+                healthChecksSettings.Value.Notification.Period,
+                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay),
+                StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckNotifier"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/HealthCheckNotifier.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 using Umbraco.Cms.Core.Logging;
@@ -59,10 +60,12 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IScopeProvider scopeProvider,
             ILogger<HealthCheckNotifier> logger,
             IProfilingLogger profilingLogger,
-            ICronTabParser cronTabParser)
+            ICronTabParser cronTabParser,
+            IEventAggregator eventAggregator)
             : base(
                 healthChecksSettings.Value.Notification.Period,
-                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay))
+                healthChecksSettings.Value.GetNotificationDelay(cronTabParser, DateTime.Now, DefaultDelay),
+                eventAggregator)
         {
             _healthChecksSettings = healthChecksSettings.Value;
             _healthChecks = healthChecks;

--- a/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Routing;
@@ -47,8 +48,9 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             ILogger<KeepAlive> logger,
             IProfilingLogger profilingLogger,
             IServerRoleAccessor serverRegistrar,
-            IHttpClientFactory httpClientFactory)
-            : base(TimeSpan.FromMinutes(5), DefaultDelay)
+            IHttpClientFactory httpClientFactory,
+            IEventAggregator eventAggregator)
+            : base(TimeSpan.FromMinutes(5), DefaultDelay, eventAggregator)
         {
             _hostingEnvironment = hostingEnvironment;
             _mainDom = mainDom;

--- a/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/KeepAlive.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -14,6 +15,7 @@ using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
@@ -30,6 +32,18 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IProfilingLogger _profilingLogger;
         private readonly IServerRoleAccessor _serverRegistrar;
         private readonly IHttpClientFactory _httpClientFactory;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public KeepAlive(
+            IHostingEnvironment hostingEnvironment,
+            IMainDom mainDom,
+            IOptions<KeepAliveSettings> keepAliveSettings,
+            ILogger<KeepAlive> logger,
+            IProfilingLogger profilingLogger,
+            IServerRoleAccessor serverRegistrar,
+            IHttpClientFactory httpClientFactory)
+            : base(TimeSpan.FromMinutes(5), DefaultDelay, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KeepAlive"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -12,6 +13,7 @@ using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -30,6 +32,18 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IProfilingLogger _profilingLogger;
         private readonly ILogger<LogScrubber> _logger;
         private readonly IScopeProvider _scopeProvider;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public LogScrubber(
+            IMainDom mainDom,
+            IServerRoleAccessor serverRegistrar,
+            IAuditService auditService,
+            IOptions<LoggingSettings> settings,
+            IScopeProvider scopeProvider,
+            ILogger<LogScrubber> logger,
+            IProfilingLogger profilingLogger)
+            : base(TimeSpan.FromHours(4), DefaultDelay, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogScrubber"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/LogScrubber.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Scoping;
@@ -47,8 +48,9 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IOptions<LoggingSettings> settings,
             IScopeProvider scopeProvider,
             ILogger<LogScrubber> logger,
-            IProfilingLogger profilingLogger)
-            : base(TimeSpan.FromHours(4), DefaultDelay)
+            IProfilingLogger profilingLogger,
+            IEventAggregator eventAggregator)
+            : base(TimeSpan.FromHours(4), DefaultDelay, eventAggregator)
         {
             _mainDom = mainDom;
             _serverRegistrar = serverRegistrar;

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -3,12 +3,14 @@ using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
@@ -19,6 +21,14 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IUmbracoVersion _umbracoVersion;
         private readonly IOptions<GlobalSettings> _globalSettings;
         private static HttpClient s_httpClient;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public ReportSiteTask(
+            ILogger<ReportSiteTask> logger,
+            IUmbracoVersion umbracoVersion,
+            IOptions<GlobalSettings> globalSettings)
+            : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1), StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         public ReportSiteTask(
             ILogger<ReportSiteTask> logger,

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
@@ -22,8 +23,9 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         public ReportSiteTask(
             ILogger<ReportSiteTask> logger,
             IUmbracoVersion umbracoVersion,
-            IOptions<GlobalSettings> globalSettings)
-            : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1))
+            IOptions<GlobalSettings> globalSettings,
+            IEventAggregator eventAggregator)
+            : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1), eventAggregator)
         {
             _logger = logger;
             _umbracoVersion = umbracoVersion;

--- a/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
@@ -13,6 +14,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -30,6 +32,18 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IServerMessenger _serverMessenger;
         private readonly IServerRoleAccessor _serverRegistrar;
         private readonly IUmbracoContextFactory _umbracoContextFactory;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public ScheduledPublishing(
+            IRuntimeState runtimeState,
+            IMainDom mainDom,
+            IServerRoleAccessor serverRegistrar,
+            IContentService contentService,
+            IUmbracoContextFactory umbracoContextFactory,
+            ILogger<ScheduledPublishing> logger,
+            IServerMessenger serverMessenger)
+            : base(TimeSpan.FromMinutes(1), DefaultDelay, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScheduledPublishing"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -48,8 +49,9 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IContentService contentService,
             IUmbracoContextFactory umbracoContextFactory,
             ILogger<ScheduledPublishing> logger,
-            IServerMessenger serverMessenger)
-            : base(TimeSpan.FromMinutes(1), DefaultDelay)
+            IServerMessenger serverMessenger,
+            IEventAggregator eventAggregator)
+            : base(TimeSpan.FromMinutes(1), DefaultDelay, eventAggregator)
         {
             _runtimeState = runtimeState;
             _mainDom = mainDom;

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 
@@ -28,8 +29,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         /// <param name="messenger">Service broadcasting cache notifications to registered servers.</param>
         /// <param name="logger">The typed logger.</param>
         /// <param name="globalSettings">The configuration for global settings.</param>
-        public InstructionProcessTask(IRuntimeState runtimeState, IServerMessenger messenger, ILogger<InstructionProcessTask> logger, IOptions<GlobalSettings> globalSettings)
-            : base(globalSettings.Value.DatabaseServerMessenger.TimeBetweenSyncOperations, TimeSpan.FromMinutes(1))
+        public InstructionProcessTask(IRuntimeState runtimeState, IServerMessenger messenger, ILogger<InstructionProcessTask> logger, IOptions<GlobalSettings> globalSettings, IEventAggregator eventAggregator)
+            : base(globalSettings.Value.DatabaseServerMessenger.TimeBetweenSyncOperations, TimeSpan.FromMinutes(1), eventAggregator)
         {
             _runtimeState = runtimeState;
             _messenger = messenger;

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTask.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
 {
@@ -21,6 +23,11 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         private readonly IRuntimeState _runtimeState;
         private readonly IServerMessenger _messenger;
         private readonly ILogger<InstructionProcessTask> _logger;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public InstructionProcessTask(IRuntimeState runtimeState, IServerMessenger messenger, ILogger<InstructionProcessTask> logger, IOptions<GlobalSettings> globalSettings)
+            : base(globalSettings.Value.DatabaseServerMessenger.TimeBetweenSyncOperations, TimeSpan.FromMinutes(1), StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstructionProcessTask"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
@@ -24,6 +26,16 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILogger<TouchServerTask> _logger;
         private readonly GlobalSettings _globalSettings;
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public TouchServerTask(
+            IRuntimeState runtimeState,
+            IServerRegistrationService serverRegistrationService,
+            IHostingEnvironment hostingEnvironment,
+            ILogger<TouchServerTask> logger,
+            IOptions<GlobalSettings> globalSettings)
+            : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15), StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchServerTask"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
@@ -37,8 +38,9 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             IServerRegistrationService serverRegistrationService,
             IHostingEnvironment hostingEnvironment,
             ILogger<TouchServerTask> logger,
-            IOptions<GlobalSettings> globalSettings)
-            : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
+            IOptions<GlobalSettings> globalSettings,
+            IEventAggregator eventAggregator)
+            : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15), eventAggregator)
         {
             _runtimeState = runtimeState;
             _serverRegistrationService = serverRegistrationService ?? throw new ArgumentNullException(nameof(serverRegistrationService));

--- a/src/Umbraco.Infrastructure/HostedServices/TempFileCleanup.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/TempFileCleanup.cs
@@ -4,10 +4,12 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Runtime;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -26,6 +28,10 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
 
         private readonly DirectoryInfo[] _tempFolders;
         private readonly TimeSpan _age = TimeSpan.FromDays(1);
+
+        [Obsolete("Use the ctor that inject parameters")]
+        public TempFileCleanup(IIOHelper ioHelper, IMainDom mainDom, ILogger<TempFileCleanup> logger) : base(TimeSpan.FromMinutes(60), DefaultDelay, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TempFileCleanup"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/TempFileCleanup.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/TempFileCleanup.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Runtime;
 
@@ -32,8 +33,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// <param name="ioHelper">Helper service for IO operations.</param>
         /// <param name="mainDom">Representation of the main application domain.</param>
         /// <param name="logger">The typed logger.</param>
-        public TempFileCleanup(IIOHelper ioHelper, IMainDom mainDom, ILogger<TempFileCleanup> logger)
-            : base(TimeSpan.FromMinutes(60), DefaultDelay)
+        public TempFileCleanup(IIOHelper ioHelper, IMainDom mainDom, ILogger<TempFileCleanup> logger, IEventAggregator eventAggregator)
+            : base(TimeSpan.FromMinutes(60), DefaultDelay, eventAggregator)
         {
             _ioHelper = ioHelper;
             _mainDom = mainDom;

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceExecutedNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceExecutedNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceExecutedNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceExecutedNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceExecutingNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceExecutingNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceExecutingNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceExecutingNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceFailedNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceFailedNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceFailedNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceFailedNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public class RecurringHostedServiceNotification : ObjectNotification<RecurringHostedServiceBase>
+    {
+        public RecurringHostedServiceBase Service { get; }
+        public RecurringHostedServiceNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages) => Service = target;
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceRescheduledNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceRescheduledNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceRescheduledNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceRescheduledNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceReschedulingNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceReschedulingNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceReschedulingNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceReschedulingNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceScheduledNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceScheduledNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceScheduledNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceScheduledNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceSchedulingNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceSchedulingNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceSchedulingNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceSchedulingNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceStoppedNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceStoppedNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceStoppedNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceStoppedNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceStoppingNotification.cs
+++ b/src/Umbraco.Infrastructure/Notifications/RecurringHostedServiceStoppingNotification.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Infrastructure.Notifications
+{
+    public sealed class RecurringHostedServiceStoppingNotification : RecurringHostedServiceNotification
+    {
+        public RecurringHostedServiceStoppingNotification(RecurringHostedServiceBase target, EventMessages messages) : base(target, messages)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/HealthCheckNotifierTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 using Umbraco.Cms.Core.Logging;
@@ -147,6 +148,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockScopeProvider = new Mock<IScopeProvider>();
             var mockLogger = new Mock<ILogger<HealthCheckNotifier>>();
             var mockProfilingLogger = new Mock<IProfilingLogger>();
+            var mockEventAggregator = new Mock<IEventAggregator>();
 
             return new HealthCheckNotifier(
                 Options.Create(settings),
@@ -158,7 +160,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                 mockScopeProvider.Object,
                 mockLogger.Object,
                 mockProfilingLogger.Object,
-                Mock.Of<ICronTabParser>());
+                Mock.Of<ICronTabParser>(),
+                mockEventAggregator.Object);
         }
 
         private void VerifyNotificationsNotSent() => VerifyNotificationsSentTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/KeepAliveTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/KeepAliveTests.cs
@@ -12,6 +12,7 @@ using Moq;
 using Moq.Protected;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Runtime;
@@ -104,6 +105,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
             mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
+            var mockEventAggregator = new Mock<IEventAggregator>();
+
             return new KeepAlive(
                 mockHostingEnvironment.Object,
                 mockMainDom.Object,
@@ -111,7 +114,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                 mockLogger.Object,
                 mockProfilingLogger.Object,
                 mockServerRegistrar.Object,
-                mockHttpClientFactory.Object);
+                mockHttpClientFactory.Object,
+                mockEventAggregator.Object);
         }
 
         private void VerifyKeepAliveRequestNotSent() => VerifyKeepAliveRequestSentTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/LogScrubberTests.cs
@@ -82,6 +82,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             var mockProfilingLogger = new Mock<IProfilingLogger>();
 
             _mockAuditService = new Mock<IAuditService>();
+            var mockEventAggregator = new Mock<IEventAggregator>();
 
             return new LogScrubber(
                 mockMainDom.Object,
@@ -90,7 +91,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                 Options.Create(settings),
                 mockScopeProvider.Object,
                 mockLogger.Object,
-                mockProfilingLogger.Object);
+                mockProfilingLogger.Object,
+                mockEventAggregator.Object);
         }
 
         private void VerifyLogsNotScrubbed() => VerifyLogsScrubbed(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ScheduledPublishingTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ScheduledPublishingTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -107,6 +108,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
             _mockLogger = new Mock<ILogger<ScheduledPublishing>>();
 
             var mockServerMessenger = new Mock<IServerMessenger>();
+            var mockEventAggregator = new Mock<IEventAggregator>();
 
             return new ScheduledPublishing(
                 mockRunTimeState.Object,
@@ -115,7 +117,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                 _mockContentService.Object,
                 mockUmbracoContextFactory.Object,
                 _mockLogger.Object,
-                mockServerMessenger.Object);
+                mockServerMessenger.Object,
+                mockEventAggregator.Object);
         }
 
         private void VerifyScheduledPublishingNotPerformed() => VerifyScheduledPublishingPerformed(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTaskTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/InstructionProcessTaskTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration;
@@ -49,8 +50,9 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
             _mockDatabaseServerMessenger = new Mock<IServerMessenger>();
 
             var settings = new GlobalSettings();
+            var mockEventAggregator = new Mock<IEventAggregator>();
 
-            return new InstructionProcessTask(mockRunTimeState.Object, _mockDatabaseServerMessenger.Object, mockLogger.Object, Options.Create(settings));
+            return new InstructionProcessTask(mockRunTimeState.Object, _mockDatabaseServerMessenger.Object, mockLogger.Object, Options.Create(settings), mockEventAggregator.Object);
         }
 
         private void VerifyMessengerNotSynced() => VerifyMessengerSyncedTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration;
@@ -70,13 +71,15 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
                     StaleServerTimeout = _staleServerTimeout,
                 }
             };
+            var mockEventAggregator = new Mock<IEventAggregator>();
 
             return new TouchServerTask(
                 mockRunTimeState.Object,
                 _mockServerRegistrationService.Object,
                 mockRequestAccessor.Object,
                 mockLogger.Object,
-                Options.Create(settings));
+                Options.Create(settings),
+                mockEventAggregator.Object);
         }
 
         private void VerifyServerNotTouched() => VerifyServerTouchedTimes(Times.Never());

--- a/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/TempFileCleanupTests.cs
+++ b/src/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/TempFileCleanupTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Runtime;
@@ -49,8 +50,9 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 
             var mockLogger = new Mock<ILogger<TempFileCleanup>>();
             var mockProfilingLogger = new Mock<IProfilingLogger>();
+            var mockEventAggregator = new Mock<IEventAggregator>();
 
-            return new TempFileCleanup(_mockIOHelper.Object, mockMainDom.Object, mockLogger.Object);
+            return new TempFileCleanup(_mockIOHelper.Object, mockMainDom.Object, mockLogger.Object, mockEventAggregator.Object);
         }
 
         private void VerifyFilesNotCleaned() => VerifyFilesCleaned(Times.Never());


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11272

### Description
This adds notifications for the different states of a `RecurringHostedServiceBase`. I was a bit unsure where to put the notification classes, as I wanted them to include the hosted service itself, so I put them in Umbraco.Infrastructure.

To test, you can add these [notificationhandlers (gist)](https://gist.github.com/skttl/ce011f1ca793c20cb280d2773ea6d536) to your site, and register them in Startup.cs with the following
```
.AddNotificationHandler<RecurringHostedServiceSchedulingNotification, SchedulingNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceScheduledNotification, ScheduledNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceReschedulingNotification, ReschedulingNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceRescheduledNotification, RescheduledNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceExecutingNotification, ExecutingNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceExecutedNotification, ExecutedNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceStoppingNotification, StoppingNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceStoppedNotification, StoppedNotificationHandler>()
.AddNotificationHandler<RecurringHostedServiceFailedNotification, FailedNotificationHandler>()
```

Once the site starts, you should start seeing a lot of info-logs coming from the notificationhandlers.

<!-- Thanks for contributing to Umbraco CMS! -->
