### PR TITLE
Fix for misaligned focalpoint

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -607,6 +607,7 @@
         box-sizing: border-box;
         line-height: 0;
         contain: content;
+        position: relative;
         .checkeredBackground();
 
         &:focus, &:focus-within {


### PR DESCRIPTION
This adds a fallback for browsers that don't support `contain: content`, to make sure the positioning context is correct.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #11339 

### How to test

- Using Safari on macOS, go to the Media section of a clean install of Umbraco 9 (or any v8 version ~~before~~ _after_ the Media Picker v3 was introduced)
- Upload an image

Observe that the focal point is positioned in the center of the image as expected, and that when clicking the image to re-position the focal point, the focal point gets positioned where the click occurred.

<!-- Thanks for contributing to Umbraco CMS! -->
