### PR TITLE
Ensure block list thumbnails aren't cropped

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -58,7 +58,7 @@ umb-block-card {
         padding-bottom: 10/16*100%;
         background-color: @gray-12;
         
-        background-size: cover;
+        background-size: contain;
         background-position: 50% 50%;
         background-repeat: no-repeat;
         


### PR DESCRIPTION
Update background size property to `contain` so that the whole image shows

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The block list editor thumbnails aren't fully shown if they aren't the expected aspect ratio.

This PR means that this option becomes relevant, and the background colour is shown if the image doesn't fully fit the area
![image](https://user-images.githubusercontent.com/1469061/136773547-2a77bab8-d835-4440-94ca-3e2584e2f792.png)

Before
![image](https://user-images.githubusercontent.com/1469061/136773393-4771a2a0-204f-4a7a-8040-f5022cf59482.png)

After
![image](https://user-images.githubusercontent.com/1469061/136773464-2765e6d3-4a69-4717-92e6-495e83bba415.png)


