### PR TITLE
Implement IUserSessionStore<BackOfficeIdentityUser> to fix timeout bug #11350

### DIFF
--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Core.Security
     /// <summary>
     /// The user store for back office users
     /// </summary>
-    public class BackOfficeUserStore : UmbracoUserStore<BackOfficeIdentityUser, IdentityRole<string>>
+    public class BackOfficeUserStore : UmbracoUserStore<BackOfficeIdentityUser, IdentityRole<string>>, IUserSessionStore<BackOfficeIdentityUser>
     {
         private readonly IScopeProvider _scopeProvider;
         private readonly IUserService _userService;


### PR DESCRIPTION
A quick chat with @bergmania and the solution was to implement `IUserSessionStore<BackOfficeIdentityUser>` to fix timeout bug #11350

## Test
* Try before and after the PR applied to verify
* Update appsettings.json key `Umbraco:CMS:Global:TimeOut`
* Set value to one minute as a string timespan `"00:01:00"`

Before the fix applied nothing would happen after one minute and now with the PR applied the user is logged out after one minute.