### PR TITLE
11343: Remove blocklist block on cancel

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -65,6 +65,9 @@
         vm.layout = []; // The layout object specific to this Block Editor, will be a direct reference from Property Model.
         vm.availableBlockTypes = []; // Available block entries of this property editor.
         vm.labels = {};
+        vm.options = {
+            createFlow: false
+        };
 
         localizationService.localizeMany(["grid_addElement", "content_createEmpty"]).then(function (data) {
             vm.labels.grid_addElement = data[0];
@@ -380,7 +383,7 @@
 
         function editBlock(blockObject, openSettings, blockIndex, parentForm, options) {
 
-            options = options || {};
+            options = options || vm.options;
 
             // this must be set
             if (blockIndex === undefined) {
@@ -560,7 +563,9 @@
                 if (inlineEditing === true) {
                     blockObject.activate();
                 } else if (inlineEditing === false && blockObject.hideContentInOverlay !== true) {
+                    vm.options.createFlow = true;
                     blockObject.edit();
+                    vm.options.createFlow = false;
                 }
             }
         }


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes #11343 

It seems like the logic for this was already in place, but not fully connected yet. Now, I don't know if the way that I did this is the best way. Another idea was to pass the arguments through the edit function, but I don't know if that messes up anything for package developers that are using that function. Let me know if this solution is good enough or if another way is preferred!

![BlockListCancel](https://user-images.githubusercontent.com/11466511/136846064-f357eba7-3044-495d-b26b-f2e86de343dc.gif)

