### PR TITLE
Fixes 11057: Mandatory Image not validating after first time failure

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html
@@ -69,4 +69,8 @@
         <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.maxCount.errorMsg"></span>
     </div>
 
+    <ng-form name="vm.modelValueForm">
+        <input type="hidden" name="modelValue" ng-model="vm.model.value.length" ng-required="vm.model.validation.mandatory && vm.model.value.length === 0" />
+    </ng-form>
+
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -137,6 +137,10 @@
             if (vm.propertyForm) {
                 vm.propertyForm.$setDirty();
             }
+
+            if (vm.modelValueForm) {
+                vm.modelValueForm.modelValue.$setDirty();
+            }
         }
 
         function addMediaAt(createIndex, $event) {


### PR DESCRIPTION
The PR adds the same validation mechanism as the legacy Media Picker to allow the server to correctly update the validation message after failed publish.

See #11057 for testing instruction.
