### PR TITLE
Crops with CropCoords ensure EXIF rotated images crop correctly

### DIFF
--- a/src/Umbraco.Web.Common/ImageProcessors/CropWebProcessor.cs
+++ b/src/Umbraco.Web.Common/ImageProcessors/CropWebProcessor.cs
@@ -32,6 +32,9 @@ namespace Umbraco.Cms.Web.Common.ImageProcessors
             RectangleF? coordinates = GetCoordinates(commands, parser, culture);
             if (coordinates != null)
             {
+                //allowed for EXIF rotated image (otherwise width and height are transposed and crops the wrong area)
+                image.Image.Mutate(x => x.AutoOrient());
+                
                 // Convert the coordinates to a pixel based rectangle
                 int sourceWidth = image.Image.Width;
                 int sourceHeight = image.Image.Height;


### PR DESCRIPTION
EXIF rotated Images have width/height transposed so crop area is translocated.
Use ImageSharp Image.Mutate(x => x.AutoOrient()); prior to calculation of the crop rectangle.

Add an image with EXIF rotated to the media section with crops, enlarge/move the image in the imagecropper view port, so that we get cropCoordinates (rather than focal point crops).
Rendering front end with `media.GetCropUrl("Crop")` or `@Url.GetCropUrl(media, "Crop")` image crops to wrong area and wrong aspect ratio for the crop as width/height is translocated (even though the browser helps us out for the backoffice media section, and thumbnails use cropMode.Max so browser still respects EXIF rotated)

corrects issue #11329 