### PR TITLE
Make debugging work better in VS Code / Codespaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/src/Umbraco.Web.UI",
             "stopAtEntry": false,
+            "requireExactSource": false,
             // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
             "serverReadyAction": {
                 "action": "openExternally",


### PR DESCRIPTION
`requireExactSource` needs to be disabled in order to properly attach to process and debug Umbraco source in VS Code / Codespaces.

Found during my Hacktoberfest stream that Codespaces wouldn't allow me to attach a breakpoint in a library other than the executing library unless this flag was set to false.

Hopefully this makes the contribution experience a little easier!