### PR TITLE
Added simple breadcrumbs to blocklist

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbbreadcrumbs.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbbreadcrumbs.directive.js
@@ -45,6 +45,7 @@ Use this directive to generate a list of breadcrumbs.
 @param {array} ancestors Array of ancestors
 @param {string} entityType The content entity type (member, media, content).
 @param {callback=} onOpen Function callback when an ancestor is clicked. This will override the default link behaviour.
+@param {string} noLinks Determines if the breadcrumbs should only show text instead of showing links
 **/
 
 (function () {
@@ -102,7 +103,8 @@ Use this directive to generate a list of breadcrumbs.
                 ancestors: "=",
                 forNewEntity: "=",
                 entityType: "@",
-                onOpen: "&"
+                onOpen: "&",
+                noLinks: "@"
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
     .controller("Umbraco.Editors.BlockEditorController",
-        function ($scope, localizationService, formHelper, overlayService) {
+        function ($scope, localizationService, formHelper, overlayService, editorService) {
 
             var vm = this;
 
@@ -37,6 +37,12 @@ angular.module("umbraco")
 
                 vm.tabs = apps;
             }
+
+            vm.ancestors = editorService.getEditors().map(item => {
+                return {
+                    name: item.title
+                };
+            });
 
             vm.submitAndClose = function () {
                 if (vm.model && vm.model.submit) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
@@ -25,13 +25,10 @@
 
                 <umb-editor-footer-content-left>
 
-                    <ul class="umb-breadcrumbs">
-                        <li class="umb-breadcrumbs__ancestor" ng-repeat="ancestor in vm.ancestors">
-                            <span ng-if="!$last" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}">{{ancestor.name}}</span>
-                            <span ng-if="!$last" class="umb-breadcrumbs__separator">&#47;</span>
-                            <span class="umb-breadcrumbs__ancestor-text" ng-if="$last" title="{{ancestor.name}}">{{ancestor.name}}</span>
-                        </li>
-                    </ul>
+                    <umb-breadcrumbs ng-if="vm.ancestors && vm.ancestors.length > 0"
+                                     ancestors="vm.ancestors"
+                                     no-links="true">
+                    </umb-breadcrumbs>
 
                 </umb-editor-footer-content-left>
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.html
@@ -23,7 +23,17 @@
 
             <umb-editor-footer>
 
-                <!-- Missing breadcrumbs -->
+                <umb-editor-footer-content-left>
+
+                    <ul class="umb-breadcrumbs">
+                        <li class="umb-breadcrumbs__ancestor" ng-repeat="ancestor in vm.ancestors">
+                            <span ng-if="!$last" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}">{{ancestor.name}}</span>
+                            <span ng-if="!$last" class="umb-breadcrumbs__separator">&#47;</span>
+                            <span class="umb-breadcrumbs__ancestor-text" ng-if="$last" title="{{ancestor.name}}">{{ancestor.name}}</span>
+                        </li>
+                    </ul>
+
+                </umb-editor-footer-content-left>
 
                 <umb-editor-footer-content-right>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-breadcrumbs.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-breadcrumbs.html
@@ -1,11 +1,13 @@
 <ul class="umb-breadcrumbs">
     <li class="umb-breadcrumbs__ancestor" ng-repeat="ancestor in ancestors">
-        
+
+        <span ng-if="(!$last || forNewEntity) && noLinks" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}">{{ancestor.name}}</span>
+
         <!-- go to node on click -->
-        <a ng-if="(!$last || forNewEntity) && !allowOnOpen" ng-href="#{{::pathTo(ancestor)}}" ng-click="openPath(ancestor, $event)" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}">{{ancestor.name}}</a>
+        <a ng-if="(!$last || forNewEntity) && !allowOnOpen && !noLinks" ng-href="#{{::pathTo(ancestor)}}" ng-click="openPath(ancestor, $event)" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}">{{ancestor.name}}</a>
 
         <!-- use callback to handle click -->
-        <a ng-if="(!$last || forNewEntity) && allowOnOpen" href="#" ng-click="open(ancestor)" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}" prevent-default>{{ancestor.name}}</a>
+        <a ng-if="(!$last || forNewEntity) && allowOnOpen && !noLinks" href="#" ng-click="open(ancestor)" class="umb-breadcrumbs__ancestor-link" title="{{ancestor.name}}" prevent-default>{{ancestor.name}}</a>
 
         <span ng-if="(!$last || forNewEntity)" class="umb-breadcrumbs__separator">&#47;</span>
 


### PR DESCRIPTION
When you are using blocklist in a blocklist (and potentially even further) it can get very confusing in what item you were in again. This PR adds some breadcrumbs so that you always know where exactly you are editing something.

The breadcrumbs themselves are non-clickable as I wasn't sure how that logic would work. For example, I am 3 levels deep and want to return to level 1 through the breadcrumbs, but I haven't saved yet. Should I get the "Are you sure" for both screens? Or only one? What if one is newly created and one is just edited? So for now, I've opted to just show the information there and for it to not be clickable.
![BlocklistBreadcrumb](https://user-images.githubusercontent.com/11466511/137203976-6bf31e10-de8e-4cc5-9dd9-f269eb96ba9b.gif)
