### PR TITLE
Published Content Query has "skip" applied twice

### DIFF
--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -145,9 +145,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
 
             totalFound = result.TotalItemCount;
 
-            var pagedResult = result.Skip(Convert.ToInt32(pageIndex));
-
-            return pagedResult;
+            return result;
         }
 
         private bool BuildQuery(StringBuilder sb, string query, string searchFrom, List<string> fields, string type)

--- a/src/Umbraco.Infrastructure/Examine/ExamineUmbracoIndexingHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineUmbracoIndexingHandler.cs
@@ -194,9 +194,8 @@ namespace Umbraco.Cms.Infrastructure.Examine
                             .Field("nodeType", id.ToInvariantString())
                             .Execute(QueryOptions.SkipTake(page * pageSize, pageSize));
                         total = results.TotalItemCount;
-                        var paged = results.Skip(page * pageSize);
-
-                        foreach (ISearchResult item in paged)
+                        
+                        foreach (ISearchResult item in results)
                         {
                             if (int.TryParse(item.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out int contentId))
                             {

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -295,7 +295,7 @@ namespace Umbraco.Cms.Infrastructure
             totalRecords = results.TotalItemCount;
 
             return new CultureContextualSearchResults(
-                results.Skip(skip).ToPublishedSearchResults(_publishedSnapshot.Content), _variationContextAccessor,
+                results.ToPublishedSearchResults(_publishedSnapshot.Content), _variationContextAccessor,
                 culture);
         }
 
@@ -324,7 +324,7 @@ namespace Umbraco.Cms.Infrastructure
 
             totalRecords = results.TotalItemCount;
 
-            return results.Skip(skip).ToPublishedSearchResults(_publishedSnapshot);
+            return results.ToPublishedSearchResults(_publishedSnapshot);
         }
 
         /// <summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
@@ -91,12 +91,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 return SearchResults.Empty();
             }
 
-            var pagedResults = results.Skip(pageIndex * pageSize);
-
             return new SearchResults
             {
                 TotalRecords = results.TotalItemCount,
-                Results = pagedResults.Select(x => new SearchResult
+                Results = results.Select(x => new SearchResult
                 {
                     Id = x.Id,
                     Score = x.Score,


### PR DESCRIPTION
Skipping is done as part of the query now, causing `skip` to be applied twice

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Related to #11377

Whilst investigating the problem with `skip` and `take` returning inconsistent results, I found that more items were skipped than intended. 

`QueryOptions.SkipTake(skip, take)` handles the skipping now, so the later `skip` is not required