### PR TITLE
Return explicit Type in Multi Node Tree Picker

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -148,8 +148,17 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase
                     return multiNodeTreePicker;
                 }
 
+<<<<<<< HEAD
                 // return the first nodeId as this is one of the excluded properties that expects a single id
                 return udis.FirstOrDefault();
+=======
+                if (isSingleNodePicker)
+                {
+                    return multiNodeTreePicker.Count > 0 ? multiNodeTreePicker[0] : null;
+                }
+
+                return multiNodeTreePicker;
+>>>>>>> 56b4e5ae4e (Check IList isn't empty)
             }
         }
 

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Globalization;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -5,178 +6,195 @@ using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
-namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+/// <summary>
+///     The multi node tree picker property editor value converter.
+/// </summary>
+[DefaultPropertyValueConverter(typeof(MustBeStringValueConverter))]
+public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase
 {
-
-    /// <summary>
-    /// The multi node tree picker property editor value converter.
-    /// </summary>
-    [DefaultPropertyValueConverter(typeof(MustBeStringValueConverter))]
-    public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase
+    private static readonly List<string> _propertiesToExclude = new()
     {
-        private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
-        private readonly IPublishedModelFactory _publishedModelFactory;
-        private readonly IMemberService _memberService;
+        Constants.Conventions.Content.InternalRedirectId.ToLower(CultureInfo.InvariantCulture),
+        Constants.Conventions.Content.Redirect.ToLower(CultureInfo.InvariantCulture),
+    };
 
-        private static readonly List<string> PropertiesToExclude = new()
+    private readonly IMemberService _memberService;
+    private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
+    private readonly IPublishedModelFactory _publishedModelFactory;
+
+    public MultiNodeTreePickerValueConverter(
+        IPublishedSnapshotAccessor publishedSnapshotAccessor,
+        IPublishedModelFactory publishedModelFactory,
+        IMemberService memberService)
+    {
+        _publishedSnapshotAccessor = publishedSnapshotAccessor ??
+                                     throw new ArgumentNullException(nameof(publishedSnapshotAccessor));
+        _publishedModelFactory = publishedModelFactory;
+        _memberService = memberService;
+    }
+
+    public override bool IsConverter(IPublishedPropertyType propertyType) =>
+        propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
+
+    public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
+        => PropertyCacheLevel.Snapshot;
+
+    public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+    {
+        var contentTypeStrings = propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.Filter;
+        var contentTypes = contentTypeStrings?.Split(',') ?? Array.Empty<string>();
+
+        if (IsSingleNodePicker(propertyType))
         {
-            Constants.Conventions.Content.InternalRedirectId.ToLower(CultureInfo.InvariantCulture),
-            Constants.Conventions.Content.Redirect.ToLower(CultureInfo.InvariantCulture)
-        };
-
-        public MultiNodeTreePickerValueConverter(
-            IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            IPublishedModelFactory publishedModelFactory,
-            IMemberService memberService)
-        {
-            _publishedSnapshotAccessor = publishedSnapshotAccessor ?? throw new ArgumentNullException(nameof(publishedSnapshotAccessor));
-            _publishedModelFactory = publishedModelFactory;
-            _memberService = memberService;
-        }
-
-        public override bool IsConverter(IPublishedPropertyType propertyType) =>
-            propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker);
-
-        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
-            => PropertyCacheLevel.Snapshot;
-
-        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-        {
-            var contentTypeStrings = propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.Filter;
-            var contentTypes = contentTypeStrings?.Split(',') ?? Array.Empty<string>();
-
-            if (IsSingleNodePicker(propertyType))
-            {
-                return contentTypes.Length == 1
-                    ? ModelType.For(contentTypes[0])
-                    : typeof(IPublishedContent);
-            }
-
             return contentTypes.Length == 1
-                ? typeof(IEnumerable<>).MakeGenericType(ModelType.For(contentTypes[0]))
-                : typeof(IEnumerable<IPublishedContent>);
+                ? ModelType.For(contentTypes[0])
+                : typeof(IPublishedContent);
         }
 
-        public override object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
+        return contentTypes.Length == 1
+            ? typeof(IEnumerable<>).MakeGenericType(ModelType.For(contentTypes[0]))
+            : typeof(IEnumerable<IPublishedContent>);
+    }
+
+    public override object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
+    {
+        if (source == null || !propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
         {
-            if (source == null)
-            {
-                return null;
-            }
-
-            if (propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
-            {
-                var nodeIds = source.ToString()?
-                    .Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(UdiParser.Parse)
-                    .ToArray();
-                return nodeIds;
-            }
-
             return null;
         }
 
-        public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object? source, bool preview)
+        Udi[]? nodeIds = source.ToString()?
+            .Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
+            .Select(UdiParser.Parse)
+            .ToArray();
+
+        return nodeIds;
+
+    }
+
+    public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object? source, bool preview)
+    {
+        if (source == null || !propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
         {
-            if (source == null)
-            {
-                return null;
-            }
+            return source;
+        }
 
-            var udis = (Udi[])source;
-            var isSingleNodePicker = IsSingleNodePicker(propertyType);
+        var udis = (Udi[])source;
 
-            var contentTypeStrings = propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.Filter;
-            var contentTypes = contentTypeStrings?.Split(',');
-
-            if (PropertiesToExclude.InvariantContains(propertyType.Alias) == false)
-            {
-                var multiNodeTreePicker = contentTypes?.Length == 1
-                    ? _publishedModelFactory.CreateModelList(contentTypes[0])!
-                    : new List<IPublishedContent>();
-
-                var objectType = UmbracoObjectTypes.Unknown;
-                var publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
-                foreach (var udi in udis)
-                {
-                    if (udi is not GuidUdi guidUdi)
-                    {
-                        continue;
-                    }
-
-                    IPublishedContent? multiNodeTreePickerItem = null;
-                    switch (udi.EntityType)
-                    {
-                        case Constants.UdiEntityType.Document:
-                            multiNodeTreePickerItem = GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Document, id => publishedSnapshot.Content?.GetById(guidUdi.Guid));
-                            break;
-                        case Constants.UdiEntityType.Media:
-                            multiNodeTreePickerItem = GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Media, id => publishedSnapshot.Media?.GetById(guidUdi.Guid));
-                            break;
-                        case Constants.UdiEntityType.Member:
-                            multiNodeTreePickerItem = GetPublishedContent(udi, ref objectType, UmbracoObjectTypes.Member, id =>
-                            {
-                                IMember? m = _memberService.GetByKey(guidUdi.Guid);
-                                if (m == null)
-                                {
-                                    return null;
-                                }
-
-                                IPublishedContent? member = publishedSnapshot.Members?.Get(m);
-                                return member;
-                            });
-                            break;
-                    }
-
-                    if (multiNodeTreePickerItem != null && multiNodeTreePickerItem.ContentType.ItemType != PublishedItemType.Element)
-                    {
-                        multiNodeTreePicker.Add(multiNodeTreePickerItem);
-                        if (isSingleNodePicker)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (isSingleNodePicker)
-                {
-                    return multiNodeTreePicker.Count > 0 ? multiNodeTreePicker[0] : null;
-                }
-
-                return multiNodeTreePicker;
-            }
-
+        if (_propertiesToExclude.InvariantContains(propertyType.Alias))
+        {
             // return the first nodeId as this is one of the excluded properties that expects a single id
             return udis.FirstOrDefault();
         }
 
-        /// <summary>
-        /// Attempt to get an IPublishedContent instance based on ID and content type
-        /// </summary>
-        /// <param name="nodeId">The content node ID</param>
-        /// <param name="actualType">The type of content being requested</param>
-        /// <param name="expectedType">The type of content expected/supported by <paramref name="contentFetcher"/></param>
-        /// <param name="contentFetcher">A function to fetch content of type <paramref name="expectedType"/></param>
-        /// <returns>The requested content, or null if either it does not exist or <paramref name="actualType"/> does not match <paramref name="expectedType"/></returns>
-        private IPublishedContent? GetPublishedContent<T>(T nodeId, ref UmbracoObjectTypes actualType, UmbracoObjectTypes expectedType, Func<T, IPublishedContent?> contentFetcher)
+        var isSingleNodePicker = IsSingleNodePicker(propertyType);
+
+        var contentTypeStrings = propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.Filter;
+        var contentTypes = contentTypeStrings?.Split(',');
+
+        IList multiNodeTreePicker = contentTypes?.Length == 1
+            ? _publishedModelFactory.CreateModelList(contentTypes[0])!
+            : new List<IPublishedContent>();
+
+        UmbracoObjectTypes objectType = UmbracoObjectTypes.Unknown;
+        IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
+
+        foreach (Udi udi in udis)
         {
-            // is the actual type supported by the content fetcher?
-            if (actualType != UmbracoObjectTypes.Unknown && actualType != expectedType)
+            if (udi is not GuidUdi guidUdi)
             {
-                // no, return null
-                return null;
+                continue;
             }
 
-            // attempt to get the content
-            var content = contentFetcher(nodeId);
-            if (content != null)
+            IPublishedContent? multiNodeTreePickerItem = null;
+            switch (udi.EntityType)
             {
-                // if we found the content, assign the expected type to the actual type so we don't have to keep looking for other types of content
-                actualType = expectedType;
+                case Constants.UdiEntityType.Document:
+                    multiNodeTreePickerItem = GetPublishedContent(
+                        udi,
+                        ref objectType,
+                        UmbracoObjectTypes.Document,
+                        id => publishedSnapshot.Content?.GetById(guidUdi.Guid));
+                    break;
+                case Constants.UdiEntityType.Media:
+                    multiNodeTreePickerItem = GetPublishedContent(
+                        udi,
+                        ref objectType,
+                        UmbracoObjectTypes.Media,
+                        id => publishedSnapshot.Media?.GetById(guidUdi.Guid));
+                    break;
+                case Constants.UdiEntityType.Member:
+                    multiNodeTreePickerItem = GetPublishedContent(
+                        udi,
+                        ref objectType,
+                        UmbracoObjectTypes.Member,
+                        id =>
+                        {
+                            IMember? m = _memberService.GetByKey(guidUdi.Guid);
+                            if (m == null)
+                            {
+                                return null;
+                            }
+
+                            IPublishedContent? member = publishedSnapshot?.Members?.Get(m);
+                            return member;
+                        });
+                    break;
             }
-            return content;
+
+            if (multiNodeTreePickerItem == null || multiNodeTreePickerItem.ContentType.ItemType == PublishedItemType.Element)
+            {
+                continue;
+            }
+
+            multiNodeTreePicker.Add(multiNodeTreePickerItem);
+            if (isSingleNodePicker)
+            {
+                break;
+            }
         }
 
-        private static bool IsSingleNodePicker(IPublishedPropertyType propertyType) => propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.MaxNumber == 1;
+        if (isSingleNodePicker)
+        {
+            return multiNodeTreePicker.Count > 0 ? multiNodeTreePicker[0] : null;
+        }
+
+        return multiNodeTreePicker;
+    }
+
+    private static bool IsSingleNodePicker(IPublishedPropertyType propertyType) =>
+        propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.MaxNumber == 1;
+
+    /// <summary>
+    ///     Attempt to get an IPublishedContent instance based on ID and content type
+    /// </summary>
+    /// <param name="nodeId">The content node ID</param>
+    /// <param name="actualType">The type of content being requested</param>
+    /// <param name="expectedType">The type of content expected/supported by <paramref name="contentFetcher" /></param>
+    /// <param name="contentFetcher">A function to fetch content of type <paramref name="expectedType" /></param>
+    /// <returns>
+    ///     The requested content, or null if either it does not exist or <paramref name="actualType" /> does not match
+    ///     <paramref name="expectedType" />
+    /// </returns>
+    private IPublishedContent? GetPublishedContent<T>(T nodeId, ref UmbracoObjectTypes actualType, UmbracoObjectTypes expectedType, Func<T, IPublishedContent?> contentFetcher)
+    {
+        // is the actual type supported by the content fetcher?
+        if (actualType != UmbracoObjectTypes.Unknown && actualType != expectedType)
+        {
+            // no, return null
+            return null;
+        }
+
+        // attempt to get the content
+        IPublishedContent? content = contentFetcher(nodeId);
+        if (content != null)
+        {
+            // if we found the content, assign the expected type to the actual type so we don't have to keep looking for other types of content
+            actualType = expectedType;
+        }
+
+        return content;
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -1,9 +1,9 @@
+using System.Collections;
 using System.Globalization;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 [DefaultPropertyValueConverter(typeof(MustBeStringValueConverter))]
 public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase
 {
-    private static readonly List<string> PropertiesToExclude = new()
+    private static readonly List<string> _propertiesToExclude = new()
     {
         Constants.Conventions.Content.InternalRedirectId.ToLower(CultureInfo.InvariantCulture),
         Constants.Conventions.Content.Redirect.ToLower(CultureInfo.InvariantCulture),
@@ -22,16 +22,16 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase
 
     private readonly IMemberService _memberService;
     private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
-    private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+    private readonly IPublishedModelFactory _publishedModelFactory;
 
     public MultiNodeTreePickerValueConverter(
         IPublishedSnapshotAccessor publishedSnapshotAccessor,
-        IUmbracoContextAccessor umbracoContextAccessor,
+        IPublishedModelFactory publishedModelFactory,
         IMemberService memberService)
     {
         _publishedSnapshotAccessor = publishedSnapshotAccessor ??
                                      throw new ArgumentNullException(nameof(publishedSnapshotAccessor));
-        _umbracoContextAccessor = umbracoContextAccessor;
+        _publishedModelFactory = publishedModelFactory;
         _memberService = memberService;
     }
 
@@ -42,127 +42,126 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase
         => PropertyCacheLevel.Snapshot;
 
     public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-        => IsSingleNodePicker(propertyType)
-            ? typeof(IPublishedContent)
+    {
+        var contentTypeStrings = propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.Filter;
+        var contentTypes = contentTypeStrings?.Split(',') ?? Array.Empty<string>();
+
+        if (IsSingleNodePicker(propertyType))
+        {
+            return contentTypes.Length == 1
+                ? ModelType.For(contentTypes[0])
+                : typeof(IPublishedContent);
+        }
+
+        return contentTypes.Length == 1
+            ? typeof(IEnumerable<>).MakeGenericType(ModelType.For(contentTypes[0]))
             : typeof(IEnumerable<IPublishedContent>);
+    }
 
     public override object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
     {
-        if (source == null)
+        if (source == null || !propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
         {
             return null;
         }
 
-        if (propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
-        {
-            Udi[]? nodeIds = source.ToString()?
-                .Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
-                .Select(UdiParser.Parse)
-                .ToArray();
-            return nodeIds;
-        }
+        Udi[]? nodeIds = source.ToString()?
+            .Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
+            .Select(UdiParser.Parse)
+            .ToArray();
 
-        return null;
+        return nodeIds;
+
     }
 
     public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object? source, bool preview)
     {
-        if (source == null)
+        if (source == null || !propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
         {
-            return null;
+            return source;
         }
 
-        // TODO: Inject an UmbracoHelper and create a GetUmbracoHelper method based on either injected or singleton
-        if (_umbracoContextAccessor.TryGetUmbracoContext(out _))
+        var udis = (Udi[])source;
+
+        if (_propertiesToExclude.InvariantContains(propertyType.Alias))
         {
-            if (propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker))
+            // return the first nodeId as this is one of the excluded properties that expects a single id
+            return udis.FirstOrDefault();
+        }
+
+        var isSingleNodePicker = IsSingleNodePicker(propertyType);
+
+        var contentTypeStrings = propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.Filter;
+        var contentTypes = contentTypeStrings?.Split(',');
+
+        IList multiNodeTreePicker = contentTypes?.Length == 1
+            ? _publishedModelFactory.CreateModelList(contentTypes[0])!
+            : new List<IPublishedContent>();
+
+        UmbracoObjectTypes objectType = UmbracoObjectTypes.Unknown;
+        IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
+
+        foreach (Udi udi in udis)
+        {
+            if (udi is not GuidUdi guidUdi)
             {
-                var udis = (Udi[])source;
-                var isSingleNodePicker = IsSingleNodePicker(propertyType);
+                continue;
+            }
 
-                if ((propertyType.Alias != null && PropertiesToExclude.InvariantContains(propertyType.Alias)) == false)
-                {
-                    var multiNodeTreePicker = new List<IPublishedContent>();
-
-                    UmbracoObjectTypes objectType = UmbracoObjectTypes.Unknown;
-                    IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
-                    foreach (Udi udi in udis)
-                    {
-                        if (udi is not GuidUdi guidUdi)
+            IPublishedContent? multiNodeTreePickerItem = null;
+            switch (udi.EntityType)
+            {
+                case Constants.UdiEntityType.Document:
+                    multiNodeTreePickerItem = GetPublishedContent(
+                        udi,
+                        ref objectType,
+                        UmbracoObjectTypes.Document,
+                        id => publishedSnapshot.Content?.GetById(guidUdi.Guid));
+                    break;
+                case Constants.UdiEntityType.Media:
+                    multiNodeTreePickerItem = GetPublishedContent(
+                        udi,
+                        ref objectType,
+                        UmbracoObjectTypes.Media,
+                        id => publishedSnapshot.Media?.GetById(guidUdi.Guid));
+                    break;
+                case Constants.UdiEntityType.Member:
+                    multiNodeTreePickerItem = GetPublishedContent(
+                        udi,
+                        ref objectType,
+                        UmbracoObjectTypes.Member,
+                        id =>
                         {
-                            continue;
-                        }
-
-                        IPublishedContent? multiNodeTreePickerItem = null;
-                        switch (udi.EntityType)
-                        {
-                            case Constants.UdiEntityType.Document:
-                                multiNodeTreePickerItem = GetPublishedContent(
-                                    udi,
-                                    ref objectType,
-                                    UmbracoObjectTypes.Document,
-                                    id => publishedSnapshot.Content?.GetById(guidUdi.Guid));
-                                break;
-                            case Constants.UdiEntityType.Media:
-                                multiNodeTreePickerItem = GetPublishedContent(
-                                    udi,
-                                    ref objectType,
-                                    UmbracoObjectTypes.Media,
-                                    id => publishedSnapshot.Media?.GetById(guidUdi.Guid));
-                                break;
-                            case Constants.UdiEntityType.Member:
-                                multiNodeTreePickerItem = GetPublishedContent(
-                                    udi,
-                                    ref objectType,
-                                    UmbracoObjectTypes.Member,
-                                    id =>
-                                    {
-                                        IMember? m = _memberService.GetByKey(guidUdi.Guid);
-                                        if (m == null)
-                                        {
-                                            return null;
-                                        }
-
-                                        IPublishedContent? member = publishedSnapshot?.Members?.Get(m);
-                                        return member;
-                                    });
-                                break;
-                        }
-
-                        if (multiNodeTreePickerItem != null &&
-                            multiNodeTreePickerItem.ContentType.ItemType != PublishedItemType.Element)
-                        {
-                            multiNodeTreePicker.Add(multiNodeTreePickerItem);
-                            if (isSingleNodePicker)
+                            IMember? m = _memberService.GetByKey(guidUdi.Guid);
+                            if (m == null)
                             {
-                                break;
+                                return null;
                             }
-                        }
-                    }
 
-                    if (isSingleNodePicker)
-                    {
-                        return multiNodeTreePicker.FirstOrDefault();
-                    }
+                            IPublishedContent? member = publishedSnapshot?.Members?.Get(m);
+                            return member;
+                        });
+                    break;
+            }
 
-                    return multiNodeTreePicker;
-                }
+            if (multiNodeTreePickerItem == null || multiNodeTreePickerItem.ContentType.ItemType == PublishedItemType.Element)
+            {
+                continue;
+            }
 
-<<<<<<< HEAD
-                // return the first nodeId as this is one of the excluded properties that expects a single id
-                return udis.FirstOrDefault();
-=======
-                if (isSingleNodePicker)
-                {
-                    return multiNodeTreePicker.Count > 0 ? multiNodeTreePicker[0] : null;
-                }
-
-                return multiNodeTreePicker;
->>>>>>> 56b4e5ae4e (Check IList isn't empty)
+            multiNodeTreePicker.Add(multiNodeTreePickerItem);
+            if (isSingleNodePicker)
+            {
+                break;
             }
         }
 
-        return source;
+        if (isSingleNodePicker)
+        {
+            return multiNodeTreePicker.Count > 0 ? multiNodeTreePicker[0] : null;
+        }
+
+        return multiNodeTreePicker;
     }
 
     private static bool IsSingleNodePicker(IPublishedPropertyType propertyType) =>


### PR DESCRIPTION
### Summary
Update Multi Node Tree Picker to return an enumerable or single instance of an explicit type when only one item type is selected when creating the data type

### Prerequisites

- [x] I have added steps to test this contribution in the description below

When setting up a Multinode Treepicker, and selecting only a single applicable type, the generated models will reflect that by returning the explicit type.
![image](https://user-images.githubusercontent.com/1469061/137387592-89935be4-260b-467b-a175-b4e776c3e2d3.png)

i.e. If you create a MNTP with a single allowed type of `TheDocumentTypeAlias`, the generated model will generate with a property type of `IEnumerable<TheDocumentTypeAlias>` rather than `IEnumerable<IPublishedContent>` - much like the functionality of Nested Content.

Similarly, if the MNTP has the maximum number of items set to 1, then the generated model will have a property with type `TheDocumentTypeAlias` rather than `IPublishedContent`

To test, create a number of multinode treepickers with variying node types, allowed items of type, and maximum number of items. Add these to a document, and generate models. The generated models should reflect your setup, and in the views you can access the properties with an explicit type.

Maybe a breaking change, but since all models inherit from `IPublishedContent` it might not be?
