### PR TITLE
Minor edits to the XPath query help sheet

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -49,21 +49,21 @@
                         </p>
 
                         <p>
-                            Placeholders finds the nearest published ID and runs its query from there, so for instance:
+                            A placeholder finds the nearest published ID and runs its query from there, so for instance:
                         </p>
                         
                         <pre>$parent/newsArticle</pre>
                         
                         <p>
-                            Will try to get the parent if available, but will then fall back to the nearest ancestor and query for all news articles there.
+                            Will try to get the parent if available, but will then fall back to the nearest ancestor and query for all news article children there.
                         </p>
 
                         <p>
                             Available placeholders: <br/>
-                            <code>$current</code>: current page or closest found ancestor<br/>
-                            <code>$parent</code>: parent page or closest found ancestor<br/>
-                            <code>$root</code>: root of the content tree<br/>
-                            <code>$site</code>: Ancestor node at level 1 <br/>
+                            <code>$current</code>: Current page or closest found ancestor<br/>
+                            <code>$parent</code>: Parent page or closest found ancestor<br/>
+                            <code>$root</code>: Root of the content tree<br/>
+                            <code>$site</code>: Ancestor node at level 1<br/>
                         </p>
                         <p>
                             Note: The placeholder can only be used at the beginning of the query.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This fixes a couple of inconsistencies, spelling-wise on the **Multinode Treepicker**'s XPath query help sheet.

Also adds a note clarifying that the placeholder only works when used at the beginning of the query.

### Testing the changes

Here's a couple of before and after screenshots to show the results of this PR - to test if it has been applied, create a new Datatype using the Multinode Treepicker and click the `Query for root node with XPath` link. Then click the `Show XPath query help` link and compare the screen with the "after" screenshot (or maybe just make sure that XPath is spelled consistently). 

**Before:**

![xpath-before](https://user-images.githubusercontent.com/5463/137562035-a6345b00-733a-4464-9d61-d8ec4349372e.jpg)

**After:**

![xpath-after](https://user-images.githubusercontent.com/5463/137562049-00cae1cb-6f37-409d-b33a-393102cf0f10.jpg)

