### PR TITLE
Being able to copy & paste grid controls

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
@@ -18,6 +18,8 @@ function clipboardService($window, notificationsService, eventsService, localSto
     TYPES.BLOCK = "block";
     TYPES.RAW = "raw";
     TYPES.MEDIA = "media";
+    TYPES.GRID_CONTROL = "gridControl";
+    TYPES.GRID_ROW = "gridRow";
 
     var clearPropertyResolvers = {};
     var pastePropertyResolvers = {};

--- a/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
@@ -19,7 +19,6 @@ function clipboardService($window, notificationsService, eventsService, localSto
     TYPES.RAW = "raw";
     TYPES.MEDIA = "media";
     TYPES.GRID_CONTROL = "gridControl";
-    TYPES.GRID_ROW = "gridRow";
 
     var clearPropertyResolvers = {};
     var pastePropertyResolvers = {};

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -88,28 +88,26 @@
                                 </div>
 
                                <!-- Row tool -->
-                               <div class="umb-tools row-tools" ng-show="(row === active || row === currentRowWithActiveChild) && !sortMode">
+                                <div class="umb-tools row-tools" ng-show="(row === active || row === currentRowWithActiveChild) && !sortMode">
 
-                                   <div class="cell-tools-edit row-tool" ng-if="hasSettings">
-                                       <button type="button" class="btn-icon" ng-click="editGridItemSettings(row, 'row')" localize="title" title="@grid_settings">
-                                           <umb-icon icon="icon-settings"></umb-icon>
-                                           <span class="sr-only">
-                                               <localize key="grid_settings">Settings</localize>
-                                           </span>
-                                       </button>
-                                   </div>
+                                    <div class="cell-tools-edit row-tool" ng-if="hasSettings">
+                                        <button type="button" class="btn-icon" ng-click="editGridItemSettings(row, 'row')" localize="title" title="@grid_settings">
+                                            <umb-icon icon="icon-settings"></umb-icon>
+                                            <span class="sr-only">
+                                                <localize key="grid_settings">Settings</localize>
+                                            </span>
+                                        </button>
+                                    </div>
 
                                     <div class="cell-tools-remove row-tool">
                                         <button class="icon-trash btn-reset" ng-click="togglePrompt(row)" type="button"></button>
-                                        <umb-confirm-action
-                                            ng-if="row.deletePrompt"
-                                            direction="left"
-                                            on-confirm="removeRow(section, $index)"
-                                            on-cancel="hidePrompt(row)">
+                                        <umb-confirm-action ng-if="row.deletePrompt"
+                                                            direction="left"
+                                                            on-confirm="removeRow(section, $index)"
+                                                            on-cancel="hidePrompt(row)">
                                         </umb-confirm-action>
                                     </div>
-
-                               </div>
+                                </div>
 
 
                             </div>
@@ -218,6 +216,15 @@
                                                                                                   on-confirm="removeControl(area, $index)"
                                                                                                   on-cancel="hidePrompt(control)">
                                                                               </umb-confirm-action>
+                                                                          </div>
+
+                                                                          <div class="umb-control-tool">
+                                                                              <button type="button" class="umb-control-tool-icon btn-icon" ng-click="copyControl(control)">
+                                                                                  <umb-icon icon="icon-documents"></umb-icon>
+                                                                                  <span class="sr-only">
+                                                                                      <localize key="general_copy">Copy</localize>
+                                                                                  </span>
+                                                                              </button>
                                                                           </div>
 
                                                                       </div>


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/6638

Can be tested by using the copy button and then pasting it for a control or a row.
![GridCopy](https://user-images.githubusercontent.com/11466511/137594314-c3b68c8f-402c-42b0-822f-32c3da0a685d.gif)

