### PR TITLE
Remove z-index

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
@@ -79,7 +79,6 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
 }
 .umb-block-list__block--actions {
     position: absolute;
-    z-index:999999999;// We always want to be on top of custom view, but we need to make sure we still are behind relevant Umbraco CMS UI. ToDo: Needs further testing.
     top: 10px;
     right: 10px;
     font-size: 0;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #10764

### Description
This PR removes the z-index since it's not needed. The natural stacking order achieves the goal since the actions will sit on top of anything inside the "block" since it's last in the source order.

Callum proposed to lower the z-index in this PR https://github.com/umbraco/Umbraco-CMS/pull/9529/commits/0fbe20c8a2e86bdbbb30abd4942d2842cdcdfe0b but I feel removing it is the best option potentially avoiding other z-index headaches.