### PR TITLE
Update styling of imagepicker prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.controller.js
@@ -1,13 +1,18 @@
 function imageFilePickerController($scope, editorService) {
+    var vm = this;
+    vm.model = $scope.model;
 
-    $scope.add = function() {
+    vm.add = add;
+    vm.remove = remove;
+
+    function add() {
         var mediaPickerOptions = {
             view: "mediapicker",
             multiPicker: false,
             disableFolderSelect: true,
             onlyImages: true,
             submit: function (model) {
-                $scope.model.value = model.selection[0].image;
+                vm.model.value = model.selection[0].image;
 
                 editorService.close();
             },
@@ -18,8 +23,8 @@ function imageFilePickerController($scope, editorService) {
         editorService.mediaPicker(mediaPickerOptions);
     };
 
-    $scope.remove = function () {
-        $scope.model.value = null;
+    function remove() {
+        vm.model.value = null;
     };
 
 }

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/imagepicker.html
@@ -1,23 +1,21 @@
-<div ng-controller="Umbraco.PrevalueEditors.ImageFilePickerController" class="umb-property-editor umb-mediapicker">
+<div ng-controller="Umbraco.PrevalueEditors.ImageFilePickerController as vm" class="umb-property-editor umb-mediapicker umb-mediapicker-single">
+    <div class="flex flex-wrap error">
+        <ul class="umb-sortable-thumbnails">
+            <li ng-if="vm.model.value" class="umb-sortable-thumbnails__wrapper">
+                <img ng-src="{{vm.model.value}}" alt="">
 
-    <ul class="umb-sortable-thumbnails" ng-if="model.value">
-        <li class="umb-sortable-thumbnails__wrapper">
-            <img ng-src="{{model.value}}" alt="">
+                <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
+                    <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" ng-click="vm.remove()">
+                        <umb-icon icon="icon-delete" class="icon"></umb-icon>
+                    </button>
+                </div>
+            </li>
 
-            <div class="umb-sortable-thumbnails__actions">
-                <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" ng-click="remove()">
-                    <umb-icon icon="icon-delete" class="icon"></umb-icon>
+            <li style="border: none;" class="add-wrapper unsortable" ng-hide="vm.model.value">
+                <button type="button" aria-label="Open media picker" class="add-link add-link-square btn-reset umb-outline umb-outline--surrounding" ng-click="vm.add()">
+                    <umb-icon icon="icon-add" class="icon large"></umb-icon>
                 </button>
-            </div>
-        </li>
-    </ul>
-
-    <button type="button"
-            class="add-link umb-outline umb-outline--surrounding"
-            ng-class="{'add-link-square': !model.value }"
-            ng-click="add()"
-            ng-hide="model.value">
-        <umb-icon icon="icon-add" class="icon large"></umb-icon>
-    </button>
-
+            </li>
+        </ul>
+    </div>
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I'm currently working on a property editor where I use the image picker prevalue editor and I discovered the styling was a tad outdated hence I made this PR to update the visuals and the code style.

**Before**
![imagepicker prevalue editor-before](https://user-images.githubusercontent.com/1932158/137726047-743d83a8-2ca0-42cb-a03a-8a56338d51bc.png)


**After**
![imagepicker prevalue editor-after](https://user-images.githubusercontent.com/1932158/137726076-35bc065a-b0ff-48e4-8f15-94596953edef.png)

Ideally I would like to use MediaPicker v3 if possible but I'm not sure if it's currently build for being reused like this?

I tried adding the component in the view just dropping it in like `<div ng-controller="Umbraco.PrevalueEditors.ImageFilePickerController" class="umb-property-editor umb-mediapicker"><umb-media-picker3-property-editor model="model"></umb-media-picker3-property-editor></div>` and in the controller I had

`
    vm.model = {};
    vm.model.config = {};
    vm.model.config.multiple = false;
    vm.model.config.filter = "";
`

But I was left with a validation error probably due to the config not taking minimum values into account currently - But would it make sense to tweak it for being reused like that or would my current PR be sufficient for now? 😄 /cc @madsrasmussen 