### PR TITLE
Adjust styling to make grid config look better

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/gridview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/gridview.less
@@ -621,7 +621,6 @@
 	}
 
 	.preview-rows {
-
 		display: inline-block;
 		position: relative;
 		box-sizing: border-box;
@@ -675,9 +674,9 @@
 	}
 
 	.preview-rows.columns {
-		min-height: 18px;
+		min-height: 16px;
 		line-height: 11px;
-		padding: 1px;
+        padding: 0 1px 1px 1px;
 
         &.prevalues-rows {
             min-height: 30px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that there were som pixels being a bit "off" in the grid datatype's row configuration, which is adressed in this PR.

**Before**
![grid-row-config-after](https://user-images.githubusercontent.com/1932158/137740933-7f38ef1b-3752-42dc-a665-365bacbfc89f.png)

**After**
![grid-row-config-before](https://user-images.githubusercontent.com/1932158/137740916-e3ae1208-cce8-4489-ab55-e66aba44ca4f.png)