### PR TITLE
UI API docs: Fixed incorrect method name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -224,7 +224,7 @@ When building a custom infinite editor view you can use the same components as a
         }
         /**
          * @ngdoc method
-         * @name umbraco.services.editorService#blur
+         * @name umbraco.services.editorService#focus
          * @methodOf umbraco.services.editorService
          *
          * @description


### PR DESCRIPTION
Replacement PR for #11405

<hr />

I noticed that the documentation for [editorService](https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.services.editorService) had two `blur` methods, but with different descriptions:

![image](https://user-images.githubusercontent.com/3634580/137801536-3d40f55f-e436-41da-97ab-5629f0320aec.png)

Turns out the second method is actually the `focus` method, but the ngdocs wrongly mentions the `blur` method. So with this PR, the method is now shown with the correct name:

![image](https://user-images.githubusercontent.com/3634580/137801669-ce912aaa-2bb5-4879-bf87-1d777126f7c8.png)