### PR TITLE
UI API docs: Added reset rules for .close class

### DIFF
--- a/src/Umbraco.Web.UI.Docs/umb-docs.css
+++ b/src/Umbraco.Web.UI.Docs/umb-docs.css
@@ -107,3 +107,23 @@ a:hover {
 .form-search > ul.nav > li.module > a:hover{
     color: #fff;
 }
+
+.close {
+    float: initial;
+    font-size: 14px;
+    font-weight: initial;
+    line-height: 20px;
+    color: #333333;
+    text-shadow: initial;
+    opacity: initial;
+    filter: initial;
+}
+
+.close:hover,
+.close:focus {
+    color: #333333;
+    text-decoration: initial;
+    cursor: initial;
+    opacity: initial;
+    filter: initial;
+}


### PR DESCRIPTION
Replaces #11404 as I messed up the branches 🙃 

<hr />

Functions in the *Backoffice UI API Documentation* gets a class after their name, so a `close` function gets a corresponding `<div class="close"></div>` in the generated HTML.

Unfortunately `bootstrap.min.css` comes with a default styling for `.close`, causing the generated to look a bit weird for all `close` functions - eg. as shown in the screenshot below:

![image](https://user-images.githubusercontent.com/3634580/137798486-af6369ec-534e-4ebf-aae6-367b68e041e7.png)

I can't see any other elements with a `close` class, so it's probably a part of `bootstrap.min.css` that the UI docs are not using. So this PR adds reset rules for `.close` as well as `.close:hover` and `.close:focus`, leading the same `close` method to be styled like this instead:

![image](https://user-images.githubusercontent.com/3634580/137799307-264c18c6-a483-4c51-a060-6a1781740552.png)

This PR targets `v8/contrib` so changes can be merged into both V8 and V9.