### PR TITLE
Allowed templates list: Change remove icon to text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
@@ -24,8 +24,8 @@
                 <span class="umb-child-selector__child-name">{{selectedChild.name}}</span>
             </div>
             <div class="umb-child-selector__child-actions">
-                <button type="button" class="umb-child-selector__child-remove" ng-click="removeChild(selectedChild, $index)">
-                    <umb-icon icon="icon-trash"></umb-icon>
+                <button type="button" class="umb-node-preview__action umb-node-preview__action--red umb-child-selector__child-remove" ng-click="removeChild(selectedChild, $index)">
+                    <localize key="general_remove">Remove</localize>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have changed the "Remove" icon trashcan to the text "Remove" to align the experience throughout the UI like we have elsewhere.

**Before**
![allowed-templates-before](https://user-images.githubusercontent.com/1932158/137861430-596b9758-6292-4ae7-b9cb-b9738a96db8f.png)


**After**
![allowed-templates-after](https://user-images.githubusercontent.com/1932158/137861454-11b509e2-d623-4577-a0ec-3f07479cd1c2.png)

