### PR TITLE
Focus Lock: Exclude children elements where parent / grandparent etc. has a .ng-hide class set

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -35,9 +35,6 @@
             // List of elements that can be focusable within the focus lock
             var focusableElementsSelector = '[role="button"], a[href]:not([disabled]):not(.ng-hide), button:not([disabled]):not(.ng-hide), textarea:not([disabled]):not(.ng-hide), input:not([disabled]):not(.ng-hide), select:not([disabled]):not(.ng-hide)';
 
-            // Grab the body element so we can add the tabbing class on it when needed
-            var bodyElement = document.querySelector('body');
-
             function getDomNodes(){
                 infiniteEditorsWrapper = document.querySelector('.umb-editors');
                 if(infiniteEditorsWrapper) {
@@ -47,7 +44,10 @@
 
             function getFocusableElements(targetElm) {
                 var elm = targetElm ? targetElm : target;
-                focusableElements = elm.querySelectorAll(focusableElementsSelector);
+
+                // Filter out elements that are children of parents with the .ng-hide class
+                focusableElements = [...elm.querySelectorAll(focusableElementsSelector)].filter(elm => !elm.closest('.ng-hide'));
+
                 // Set first and last focusable elements
                 firstFocusableElement = focusableElements[0];
                 lastFocusableElement = focusableElements[focusableElements.length - 1];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently the focus lock directive sometimes place focus on elements that are hidden in the view since the querySelector does not take into account that the element might be living inside an area that is hidden using `ng-hide` - The code changes converts the nodelist into an array where we filter out those elements leaving us with the elements that we need and, which are visible.

This also prevents situations where tabbing kinda "Locks" on the last element in the infinite editor - It's something I've seen myself, don't know if others have experienced this issue.