### PR TITLE
adding . applying filter

### DIFF
--- a/src/Umbraco.Web.BackOffice/PropertyEditors/TagsDataController.cs
+++ b/src/Umbraco.Web.BackOffice/PropertyEditors/TagsDataController.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.Common.Attributes;
+using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Extensions;
 using Constants = Umbraco.Cms.Core.Constants;
 
@@ -33,6 +34,8 @@ namespace Umbraco.Cms.Web.BackOffice.PropertyEditors
         /// <param name="culture"></param>
         /// <param name="query"></param>
         /// <returns></returns>
+        ///
+        [AllowHttpJsonConfigration]
         public IEnumerable<TagModel> GetTags(string tagGroup, string culture, string query = null)
         {
             if (culture == string.Empty) culture = null;

--- a/src/Umbraco.Web.Common/Filters/AllowHttpJsonConfigrationAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/AllowHttpJsonConfigrationAttribute.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Umbraco.Cms.Web.Common.Formatters;
+
+namespace Umbraco.Cms.Web.Common.Filters
+{
+    public class AllowHttpJsonConfigrationAttribute : TypeFilterAttribute
+    {
+        /// <summary>
+        /// This filter overwrites  AngularJsonOnlyConfigurationAttribute and get the api back to its defualt behavior 
+        /// </summary>
+        public AllowHttpJsonConfigrationAttribute() : base(typeof(AllowJsonXHRConfigrationFilter))
+        {
+            Order = 2; // this value must be more than the AngularJsonOnlyConfigurationAttribute on order to overwrtie it 
+        }
+
+        private class AllowJsonXHRConfigrationFilter : IResultFilter
+        {
+            public void OnResultExecuted(ResultExecutedContext context)
+            {
+            }
+
+            public void OnResultExecuting(ResultExecutingContext context)
+            {
+                if (context.Result is ObjectResult objectResult)
+                {
+                    objectResult.Formatters.RemoveType<AngularJsonMediaTypeFormatter>();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below
1-make a get request from somewhere which has a Backoffice user cookie on this url : 
http://localhost:9000/umbraco/backoffice/umbracoapi/tagsdata/GetTags?tagGroup=default&culture=
2-you'll notice that there is no XsrfPrefix. if you remove the new filter it will appear again.

 existing issue for this PR : https://github.com/umbraco/Umbraco-CMS/issues/11371

**### Issue Description** 
#The Main issue was that the typehead of the tags property is not appearing. 

**###debugging result** 
#after some debugging I found out that the initialization of the bloodhound.js throws an exception.
 (The library was falling duo to the remote API call failure) .
**###Root Cause**
 #that fail was because XsrfPrefix value. which bloodhound.js was not able to parse the response object to a valid json. 
 
 **###the Fix**
 
 I added a new action filter called `[AllowHttpJsonConfigration] ` that can be put on top of any method that we will need to call out side of angular.js 
 
 **Usage :** 
 
![image](https://user-images.githubusercontent.com/28313687/137934586-b913cca4-c83a-4729-8d78-bb16d42796c8.png)


**how it works :** 

its just removes the `AngularJsonMediaTypeFormatter ` formatter 

![image](https://user-images.githubusercontent.com/28313687/137934763-4acfcb23-3294-4f36-bada-0ae062bf303a.png)


final result : 

![image](https://user-images.githubusercontent.com/28313687/137934842-71556f22-4684-4cd9-bda7-d0ea77b53756.png)


finaly , I'm happy to be the first Arabian to be a developer on this awesome CMS 

<3 <3  

 
 
 



