### PR TITLE
refactor setTitle in MediaPicker.Controller.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -428,9 +428,9 @@ angular.module("umbraco")
             };
 
             function onNavigationChanged(tab) {
-              $scope.model.activeTab.active = false;
-              $scope.model.activeTab = tab;
-              $scope.model.activeTab.active = true;
+              vm.activeTab.active = false;
+              vm.activeTab = tab;
+              vm.activeTab.active = true;
             };
 
             function clickClearClipboard() {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -103,40 +103,43 @@ angular.module("umbraco")
                 $scope.target = dialogOptions.currentTarget;
             }
 
-            function setTitle() {
-                if (!$scope.model.title) {
-                    localizationService.localizeMany(["defaultdialogs_selectMedia", "mediaPicker_tabClipboard"])
-                        .then(function (data) {
-                            $scope.model.title = data[0];
+          function setTitle(data) {
+            if (!$scope.model.title)
+              $scope.model.title = data[0];        
+          }
 
-
-                            vm.navigation = [{
-                                "alias": "empty",
-                                "name": data[0],
-                                "icon": "icon-umb-media",
-                                "active": true,
-                                "view": ""
-                            }];
-
-                            if(vm.clipboardItems) {
-                                vm.navigation.push({
-                                    "alias": "clipboard",
-                                    "name": data[1],
-                                    "icon": "icon-paste-in",
-                                    "view": "",
-                                    "disabled": vm.clipboardItems.length === 0
-                                });
-                            }
-
-                            vm.activeTab = vm.navigation[0];
-                        });
-
-                }
+          function setNavigation(data) {
+            if (!vm.navigation.length) { 
+            vm.navigation = [{
+              "alias": "empty",
+              "name": data[0],
+              "icon": "icon-umb-media",
+              "active": true,
+              "view": ""
+            }];
+            if (vm.clipboardItems) {
+              vm.navigation.push({
+                "alias": "clipboard",
+                "name": data[1],
+                "icon": "icon-paste-in",
+                "view": "",
+                "disabled": vm.clipboardItems.length === 0
+              });
             }
+              vm.activeTab = vm.navigation[0];
+            }       
+          }
 
-            function onInit() {
 
-                setTitle();
+          function onInit() {
+
+
+              localizationService.localizeMany(["defaultdialogs_selectMedia", "mediaPicker_tabClipboard"])
+                .then(function (localizationResult) {
+                  setTitle(localizationResult);
+                  setNavigation(localizationResult);
+                });
+               
 
                 userService.getCurrentUser().then(function (userData) {
                     userStartNodes = userData.startMediaIds;
@@ -425,9 +428,9 @@ angular.module("umbraco")
             };
 
             function onNavigationChanged(tab) {
-                vm.activeTab.active = false;
-                vm.activeTab = tab;
-                vm.activeTab.active = true;
+              $scope.model.activeTab.active = false;
+              $scope.model.activeTab = tab;
+              $scope.model.activeTab.active = true;
             };
 
             function clickClearClipboard() {


### PR DESCRIPTION
The Issue This Pull request fixed : 
**THE FIX IS ON UMBRACO V9**
 #https://github.com/umbraco/Umbraco-CMS/issues/11424

**Issue brief :** 
Media Multinodepicker not working after opening second time , (open then close then open)

**debugging result :** 
In `mediapicker.controller.js` there is a function called `setTitle();` its called from `onInit();`
this function has two responsibilities 
1-set the title of the picker.
2-set the active tab.

this function has an` If `statement `inside of it :
![image](https://user-images.githubusercontent.com/28313687/138070394-fb010f75-85b4-4421-8a3d-37aaa022d243.png)

**root cause:** 
the if statement mentioned above 
has the value of `$scope.model.title` undefined because its a first loading of the controller.so in the second call of `onInit();`
the object attached to $scope with persist the data until the page is reloaded. 

for the `navigation ` its not attached to $scope so the data is not persisted.  
so the evaluation of the if statement will be true for the first time only, and since the `vm.navigation` is not persisting any data the bug appear. 


The Fix : 
as there are many ways to fix this issue : 
-like attaching the navigation to the $scope object. 
-remove the if statement 

but I as I the best fix for this issue : is to follow the Single responsibility principle because at first glimpse i was lost 
because of the function name. 

so I had to refactor it to 2 functions :

every function do his thing 

```
        setTitle(localizationResult);
         setNavigation(localizationResult); 
```


![MediaPicker](https://user-images.githubusercontent.com/28313687/138072608-e60c99a4-a7fa-4505-91c5-9c77462a8104.gif)



<!-- Thanks for contributing to Umbraco CMS! -->
