### PR TITLE
V8/feature/app header localized titles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -10,7 +10,7 @@
         <div class="flex items-center">
             <ul class="umb-app-header__actions">
                 <li data-element="global-search" class="umb-app-header__action">
-                    <button type="button" class="umb-app-header__button btn-reset" hotkey="ctrl+space" ng-click="searchClick()" ng-mousedown="rememberFocus()">
+                    <button type="button" class="umb-app-header__button btn-reset" hotkey="ctrl+space" ng-click="searchClick()" ng-mousedown="rememberFocus()" localize="title" title="@general_search">
                         <span class="sr-only">
                             <localize key="visuallyHiddenTexts_openBackofficeSearch">Open backoffice search</localize>...
                         </span>
@@ -18,7 +18,7 @@
                     </button>
                 </li>
                 <li data-element="global-help" class="umb-app-header__action">
-                    <button type="button" class="umb-app-header__button btn-reset" hotkey="ctrl+shift+h" ng-click="helpClick()">
+                    <button type="button" class="umb-app-header__button btn-reset" hotkey="ctrl+shift+h" ng-click="helpClick()" localize="title" title="@general_help">
                         <span class="sr-only">
                             <localize key="visuallyHiddenTexts_openCloseBackofficeHelp">Open/Close backoffice help</localize>...
                         </span>


### PR DESCRIPTION
Added localized title attributes to the help and search buttons in the app header (top right of umbraco backoffice).

![image](https://user-images.githubusercontent.com/9142936/138079848-827c78c4-11fe-494f-b0cc-6dc4a69b4545.png)

As it is a backoffice UI improvement, I have submitted it to v8 so it can be cherry picked for v9 too