### PR TITLE
v9: IsLiveFactoryEnabled always returns true

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedModelFactoryExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedModelFactoryExtensions.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Extensions
     public static class PublishedModelFactoryExtensions
     {
         /// <summary>
-        /// Returns true if the current <see cref="IPublishedModelFactory"/> is an implementation of <see cref="ILivePublishedModelFactory2"/> and is enabled
+        /// Returns true if the current <see cref="IPublishedModelFactory"/> is an implementation of <see cref="IAutoPublishedModelFactory"/> and is enabled
         /// </summary>
         public static bool IsLiveFactoryEnabled(this IPublishedModelFactory factory)
         {
@@ -21,8 +21,8 @@ namespace Umbraco.Extensions
                 return liveFactory.Enabled;
             }
 
-            // if it's not ILivePublishedModelFactory we can't determine if it's enabled or not so return true
-            return true;
+            // if it's not ILivePublishedModelFactory we know we're not using a live factory
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/11409

# Notes
- Changed IsLiveFactory to return false if its not ILivePublishedModelFactory to match v8 behavior

# How to test
- Set a debug point in IsLiveFactoryEnabled
- open appsettings.json and change ModelsMode to something else than InMemoryAuto, the other options are `Nothing`, `SourceCodeManual` & `SourceCodeAuto`
```
"ModelsBuilder": {
        "ModelsMode": "InMemoryAuto", // CHANGE THIS
        "Enable": true
      }
```
- Make sure the behavior matches in v8, so run a v8 project and follow the above steps, ModelsMode in v8 can be found in Web.Config and the options are: `Nothing`, `PureLive(InMemoryAuto for v9)`, `AppData(SourceCodeManual for v9)` & `LiveAppData(SourceCodeAuto for v9)`