### PR TITLE
Add the ability to configure a backoffice logo

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -219,6 +219,10 @@ namespace Umbraco.Cms.Core.Configuration.Models
         [DefaultValue(StaticLoginLogoImage)]
         public string LoginLogoImage { get; set; } = StaticLoginLogoImage;
 
+        /// <summary>
+        /// Gets or sets a value for the path to the backoffice logo image.
+        /// </summary>
+        public string BackOfficeLogoImage { get; set; } = string.Empty;
 
     }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -407,6 +407,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         {"cssPath", _hostingEnvironment.ToAbsolute(globalSettings.UmbracoCssPath).TrimEnd(Constants.CharArrays.ForwardSlash)},
                         {"allowPasswordReset", _securitySettings.AllowPasswordReset},
                         {"loginBackgroundImage", _contentSettings.LoginBackgroundImage},
+                        {"backOfficeLogoImage", _contentSettings.BackOfficeLogoImage},
                         {"loginLogoImage", _contentSettings.LoginLogoImage },
                         {"showUserInvite", _emailSender.CanSendRequiredEmail()},
                         {"canSendRequiredEmail", _emailSender.CanSendRequiredEmail()},

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
@@ -38,6 +38,8 @@
                     }
                 }
 
+                scope.backOfficeLogoImage = Umbraco.Sys.ServerVariables.umbracoSettings.backOfficeLogoImage;
+
             }));
 
             evts.push(eventsService.on("app.userRefresh", function (evt) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbsections.directive.js
@@ -40,8 +40,12 @@ function sectionsDirective($timeout, $window, navigationService, treeService, se
 
             function calculateWidth() {
                 $timeout(function () {
-                    //total width minus room for avatar, search, and help icon
+                    //total width minus room for avatar, search, help icon and logo
                     var containerWidth = $(".umb-app-header").outerWidth() - $(".umb-app-header__actions").outerWidth();
+                    var logo = $(".umb-app-header__logo");
+                    if (logo.length !== 0) {
+                      containerWidth -= logo.outerWidth();
+                    }
                     var trayToggleWidth = $("#applications .sections li.expand").outerWidth();
                     var sectionsWidth = 0;
                     

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -2,10 +2,18 @@
     background: @blueExtraDark;
     display: flex;
     align-items: center;
-    justify-content: space-between;
     max-width: 100%;
     height: @appHeaderHeight;
     padding: 0 20px;
+}
+
+.umb-app-header__logo {
+    padding-right: 30px;
+    flex-shrink: 0;
+
+    img {
+        height: 30px;
+    }
 }
 
 .umb-app-header__actions {
@@ -14,6 +22,7 @@
     align-items: center;
     margin: 0;
     margin-right: -10px;
+    padding-left: 10px;
 }
 
 .umb-app-header__button {

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -2,8 +2,14 @@
 <div>
 
     <div class="umb-app-header">
+
+        <a class="umb-app-header__logo" href="/" target="_blank" ng-if="backOfficeLogoImage">
+          <img ng-src="{{backOfficeLogoImage}}" alt="" height="30" />
+        </a>
+
         <umb-sections
             ng-if="authenticated"
+            class="flex flex-auto"
             sections="sections">
         </umb-sections>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Inspired by a [screenshot tweet by uMarketingSuite](https://twitter.com/uMarketingSuite/status/1450445642728419331) and a number of clients over the years asking about functionality like this, I have added a setting to allow developers to add a logo to the header in the backoffice, which links to the front end of the site in a new tab.

By adding `BackOfficeImageLogo` pointing at a relative or absolute image URL, the logo will be displayed.

```
{
  "Umbraco": {
    "CMS": {
      "Content": {
        "BackOfficeLogoImage": "assets/img/application/umbraco_logo_white.svg"
      }
    }
  }
}
```

![image](https://user-images.githubusercontent.com/200450/138108358-76dc5105-3d6f-492e-aaad-2eba69c04c5b.png)

Example with a larger logo
![image](https://user-images.githubusercontent.com/200450/138109030-e758c5e7-b5ab-4c78-a913-0e622c0a4ded.png)

Mobile responsive with the larger logo
![image](https://user-images.githubusercontent.com/200450/138109111-f047ebbe-a80b-4156-9f88-a0ef59063b0c.png)

Developers will then be able to white label the CMS for their clients