### PR TITLE
Focus lock improvements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -123,7 +123,14 @@
                     lastKnownElement.focus();
                 }
                 else if(defaultFocusedElement === null ){
-                    firstFocusableElement.focus();
+                    // If the first focusable elements are either items from the umb-sub-views-nav menu or the umb-button-ellipsis we most likely want to start the focus on the second item
+                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action'));
+                    if(avoidStartElm === 0) {
+                        focusableElements[1].focus();
+                    }
+                    else {
+                        firstFocusableElement.focus();
+                    }
                 }
                 else {
                     defaultFocusedElement.focus();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -175,34 +175,27 @@
             }
 
             function onInit(targetElm) {
-
                 $timeout(() => {
+                        // Fetch the DOM nodes we need
+                        getDomNodes();
 
-                    // Fetch the DOM nodes we need
-                    getDomNodes();
+                        cleanupEventHandlers();
 
-                    cleanupEventHandlers();
+                        getFocusableElements(targetElm);
 
-                    getFocusableElements(targetElm);
+                        if(focusableElements.length > 0) {
 
-                    if(focusableElements.length > 0) {
+                            observeDomChanges();
 
-                        observeDomChanges();
+                            setElementFocus();
 
-                        setElementFocus();
-
-                        //  Handle keydown
-                        target.addEventListener('keydown', handleKeydown);
-                    }
-
-                });
+                            //  Handle keydown
+                            target.addEventListener('keydown', handleKeydown);
+                        }
+                }, 500);
             }
 
-            scope.$on('$includeContentLoaded', () => {
-                angularHelper.safeApply(scope, () => {
-                    onInit();
-                });
-            });
+            onInit();
 
             // If more than one editor is still open then re-initialize otherwise remove the event listener
             scope.$on('$destroy', function () {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -124,7 +124,8 @@
                 }
                 else if(defaultFocusedElement === null ){
                     // If the first focusable elements are either items from the umb-sub-views-nav menu or the umb-button-ellipsis we most likely want to start the focus on the second item
-                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action'));
+                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action') || elm.classList.contains('umb-tab-button'));
+
                     if(avoidStartElm === 0) {
                         focusableElements[1].focus();
                     }
@@ -243,6 +244,3 @@
     angular.module('umbraco.directives').directive('umbFocusLock', FocusLock);
 
 })();
-
-
-// TODO: Ensure the domObserver is NOT started when there is only one infinite overlay and it's being destroyed!

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -33,7 +33,7 @@
             $rootScope.lastKnownFocusableElements.push(document.activeElement);
 
             // List of elements that can be focusable within the focus lock
-            var focusableElementsSelector = '[role="button"], a[href]:not([disabled]):not(.ng-hide), button:not([disabled]):not(.ng-hide), textarea:not([disabled]):not(.ng-hide), input:not([disabled]):not(.ng-hide), select:not([disabled]):not(.ng-hide)';
+            var focusableElementsSelector = '[role="button"], a[href]:not([disabled]):not(.ng-hide), button:not([disabled]):not(.ng-hide), textarea:not([disabled]):not(.ng-hide), input:not([disabled]):not(.ng-hide):not([type="hidden"]), select:not([disabled]):not(.ng-hide)';
 
             function getDomNodes(){
                 infiniteEditorsWrapper = document.querySelector('.umb-editors');


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed this issue #11334 and was wondering what the issue could be since the focus lock was thoroughly tested but apparently this scenario was overlooked. The issue boils down to the fact that we used to check for `includeContentLoaded`, which kinda works when the views are transcluded but when they're not the focus lock is not being activated.

I have fixed this by resorting to using a timeout value of 500ms, which is not ideal but it appears to actually work more stable and in all tested scenarios so far, which is why I think we should to down this route instead.

Furthermore I have ensured that input fields with `type="hidden"` will not be selected as some of the focusable elements either and I have also added a check to ensure that when content editors want to edit block content that focus is starting at the content rather than the ellipsis or sub-nav stuff in the upper right corner of the overlay.

The below GIF's only showcase the behavior in the "Content" section since the other scenarios have been tested and still work and the "Content" section is where the improvement makes a difference.

**Before**
![focus-lock-content-before](https://user-images.githubusercontent.com/1932158/138166707-30a6e2cc-1350-493e-a51e-49a13f41b0f2.gif)

_Notice that the focus disappears here since it goes out into the browser, which can't be seen in the GIF_

**After**
![focus-lock-content-after](https://user-images.githubusercontent.com/1932158/138166091-ed138cf8-7f2e-4c1c-abca-17768e992500.gif)
