### PR TITLE
Row config confirm overlay: Add fallback text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/overlays/rowdeleteconfirm.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/overlays/rowdeleteconfirm.html
@@ -11,6 +11,6 @@
         </localize>
     </p>
 
-    <localize key="defaultdialogs_confirmdelete"></localize>?
+    <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>?
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I added the English fallback text in case the translation does not exist for a certain language, which would result in an empty text.