### PR TITLE
Changed import button localize key to correct one.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/importdocumenttype.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/importdocumenttype.html
@@ -42,7 +42,7 @@
         <br />
         <br />
         <button class="btn btn-primary" ng-click="import()">
-            <localize key="actions_importDocumentType">Import</localize>
+            <localize key="actions_importdocumenttype">Import</localize>
         </button>
     </div>
     <div ng-if="vm.state === 'done'">


### PR DESCRIPTION
Fixed a typo in the importdocumenttype.html so it gets the correct translation. 

Reproduction on 9.0.1:
When importing a documentType, click import, select a file. In this screen [actions_importDocumentType] appears instead of the translation "Import Document Type".