### PR TITLE
Remove comma that makes the JS task throw an error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -575,7 +575,7 @@
                         }
                         editorService.close();
                     },
-                    close: () => editorService.close(),                    
+                    close: () => editorService.close()
                 }
 
                 editorService.templatePicker(editor);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
After syncing my fork this morning I noticed the JS task throwed the error below, which I fixed with this wee PR.

`
[08:28:36] 
C:\Git\Private\UmbContrib\src\Umbraco.Web.UI.Client\src\views\templates\edit.controller.js
  578:55  error  Unexpected trailing comma  comma-dangle

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
`
