### PR TITLE
Publish hotkey doesn't work in RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -200,7 +200,7 @@
                 }
             }));
 
-            evts.push(eventsService.on("rte.shortcut.publish", function () {
+            evts.push(eventsService.on("rte.shortcut.saveAndPublish", function () {
                 $scope.saveAndPublish();
             }));
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1223,7 +1223,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
             editor.addShortcut('Ctrl+P', '', function () {
                 angularHelper.safeApply($rootScope, function () {
-                    eventsService.emit("rte.shortcut.publish");
+                    eventsService.emit("rte.shortcut.saveAndPublish");
                 });
             });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #11450

### Description
You previously couldn't press `Ctrl+P` within a TinyMCE editor to publish the page. This PR fixes the issue by emitting an event that is then picked up in the edit controller.

As per @nul800sebastiaan's comment, based against `v8/contrib` so it can then be merged into v9