### PR TITLE
Add block thumbnail preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -1,4 +1,4 @@
-.umb-block-card, 
+.umb-block-card,
 umb-block-card {
     position: relative;
     display: inline-block;
@@ -7,12 +7,13 @@ umb-block-card {
     background-color: white;
     border-radius: @doubleBorderRadius;
     box-shadow: 0 1px 2px rgba(0,0,0,.2);
-
     transition: box-shadow 120ms;
 
-    cursor: pointer;
-
     .umb-outline();
+
+    [ng-click] {
+        cursor: pointer;
+    }
 
     &:hover {
         box-shadow: 0 1px 3px rgba(@ui-action-type-hover, .5);
@@ -24,7 +25,7 @@ umb-block-card {
             position: absolute;
             border: 2px solid @ui-active-border;
             border-radius: @doubleBorderRadius;
-            top:0;
+            top: 0;
             bottom: 0;
             left: 0;
             right: 0;
@@ -32,24 +33,31 @@ umb-block-card {
     }
 
     &.--sortable-placeholder {
+        box-shadow: none;
+
         &::after {
             content: "";
             position: absolute;
-            background-color:rgba(@ui-drop-area-color, .05);
+            background-color: rgba(@ui-drop-area-color, .05);
             border: 2px solid rgba(@ui-drop-area-color, .1);
             border-radius: @doubleBorderRadius;
             box-shadow: 0 0 4px rgba(@ui-drop-area-color, 0.05);
-            top:0;
+            top: 0;
             bottom: 0;
             left: 0;
             right: 0;
             animation: umb-block-card--sortable-placeholder 400ms ease-in-out alternate infinite;
+
             @keyframes umb-block-card--sortable-placeholder {
-                0%   { opacity: 1; }
-                100% { opacity: 0.5; }
+                0% {
+                    opacity: 1;
+                }
+
+                100% {
+                    opacity: 0.5;
+                }
             }
         }
-        box-shadow: none;
     }
 
     .__showcase {
@@ -57,11 +65,9 @@ umb-block-card {
         width: 100%;
         padding-bottom: 10/16*100%;
         background-color: @gray-12;
-        
         background-size: cover;
         background-position: 50% 50%;
         background-repeat: no-repeat;
-        
         border-top-left-radius: @doubleBorderRadius;
         border-top-right-radius: @doubleBorderRadius;
 
@@ -72,7 +78,7 @@ umb-block-card {
             border-top-right-radius: 6px;
             box-sizing: border-box;
         }
-        
+
         .__icon {
             position: absolute;
             width: 100%;
@@ -80,20 +86,21 @@ umb-block-card {
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size:42px;
+            font-size: 42px;
         }
     }
-    
+
     .__info {
         width: 100%;
         background-color: #fff;
         padding-top: 10px;
-        padding-bottom: 11px;// 10 + 1 to compentiate for the -1 substraction in margin-bottom.
+        padding-bottom: 11px; // 10 + 1 to compentiate for the -1 substraction in margin-bottom.
         border-bottom-left-radius: @doubleBorderRadius;
         border-bottom-right-radius: @doubleBorderRadius;
 
         &.--error {
             background-color: @errorBackground;
+
             .__name, .__subname {
                 color: @errorText;
             }
@@ -106,6 +113,7 @@ umb-block-card {
             margin-left: 16px;
             margin-bottom: -1px;
         }
+
         .__subname {
             color: @gray-4;
             font-size: 12px;
@@ -130,6 +138,7 @@ umb-block-card {
         right: 0;
         opacity: 0;
         transition: opacity 120ms;
+
         .__action {
             display: inline-block;
             border-radius: 50%;
@@ -137,16 +146,17 @@ umb-block-card {
             height: 28px;
             margin-right: 10px;
             background-color: white;
-            color:@ui-action-type;
+            color: @ui-action-type;
+
             &:hover {
                 color: @ui-action-type-hover;
             }
         }
     }
+
     &:hover, &:focus, &:focus-within {
         .__actions {
             opacity: 1;
         }
     }
-
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.less
@@ -7,22 +7,18 @@
         height: 100%;
         margin-right: 20px;
         margin-bottom: 20px;
-
         color: @ui-action-discreet-type;
         border: 1px dashed @ui-action-discreet-border;
         border-radius: @doubleBorderRadius;
-
         align-items: center;
         justify-content: center;
-
         padding: 5px 15px;
         box-sizing: border-box;
         font-weight: bold;
     }
-    
+
     .__add-button:hover {
         color: @ui-action-discreet-type-hover;
         border-color: @ui-action-discreet-border-hover;
     }
-
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -293,14 +293,10 @@
                 return "none";
             }
 
-            console.log("thumbnail 1", block.thumbnail);
-
             var path = umbRequestHelper.convertVirtualToAbsolutePath(block.thumbnail);
             if (path.toLowerCase().endsWith(".svg") === false) {
                 path += "?upscale=false&width=400";
             }
-
-            console.log("thumbnail 2", `url('${path}')`);
                 
             return `url('${path}')`;
         };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -10,7 +10,7 @@
 (function () {
     "use strict";
 
-    function BlockConfigurationOverlayController($scope, overlayService, localizationService, editorService, elementTypeResource, eventsService, udiService, angularHelper) {
+    function BlockConfigurationOverlayController($scope, overlayService, localizationService, editorService, elementTypeResource, eventsService, udiService, angularHelper, umbRequestHelper) {
 
         var unsubscribe = [];
 
@@ -287,8 +287,26 @@
             });
         };
 
-        vm.removeThumbnailForBlock = function(entry) {
-            entry.thumbnail = null;
+        vm.getBlockBackground = function (block) {
+
+            if (block == null || block.thumbnail == null || block.thumbnail === "") {
+                return "none";
+            }
+
+            console.log("thumbnail 1", block.thumbnail);
+
+            var path = umbRequestHelper.convertVirtualToAbsolutePath(block.thumbnail);
+            if (path.toLowerCase().endsWith(".svg") === false) {
+                path += "?upscale=false&width=400";
+            }
+
+            console.log("thumbnail 2", `url('${path}')`);
+                
+            return `url('${path}')`;
+        };
+
+        vm.removeThumbnailForBlock = function (block) {
+            block.thumbnail = null;
         };
 
         vm.changeIconColor = function (color) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -190,7 +190,10 @@
 
                                         <div class="umb-block-card" ng-if="vm.block.thumbnail !== null">
                                             <div class="__showcase"
-                                                 ng-style="{ 'background-color': vm.block.backgroundColor, 'background-image': vm.getBlockBackground(vm.block) }">
+                                                 ng-style="{
+                                                    'background-color': vm.block.backgroundColor,
+                                                    'background-image': vm.getBlockBackground(vm.block)
+                                                 }">
                                             </div>
                                             <div class="__actions">
                                                 <button type="button" class="btn-reset __action umb-outline" localize="title" title="general_remove" ng-click="vm.removeThumbnailForBlock(vm.block)">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -187,14 +187,19 @@
                                 <div class="umb-el-wrap">
                                     <label class="control-label" for="iconcolor"><localize key="blockEditor_thumbnail">Thumbnail</localize></label>
                                     <div class="controls">
-                                        <div class="__settings-input --hasValue" ng-if="vm.block.thumbnail !== null" >
+                                        <div class="__settings-input --hasValue" ng-if="vm.block.thumbnail !== null">
 
-                                            <umb-node-preview icon="'icon-document'" name="vm.block.thumbnail"></umb-node-preview>
-                                            <div class="__control-actions">
-                                                <button type="button" class="btn-reset __control-actions-btn --remove umb-outline" ng-click="vm.removeThumbnailForBlock(vm.block)">
-                                                    <umb-icon icon="icon-wrong" class="icon"></umb-icon>
-                                                </button>
+                                            <div class="umb-block-card">
+                                                <div class="__showcase"
+                                                     ng-style="{ 'background-color': vm.block.backgroundColor, 'background-image': vm.getBlockBackground(vm.block) }">
+                                                </div>
+                                                <div class="__actions">
+                                                    <button type="button" class="btn-reset __action umb-outline" localize="title" title="general_remove" ng-click="vm.removeThumbnailForBlock(vm.block)">
+                                                        <umb-icon icon="icon-trash" class="icon"></umb-icon>
+                                                    </button>
+                                                </div>
                                             </div>
+
                                         </div>
                                         <button type="button" class="btn-reset __settings-input --noValue umb-outline" ng-if="vm.block.thumbnail === null" ng-click="vm.addThumbnailForBlock(vm.block)">
                                             <localize key="blockEditor_addThumbnail">Add thumbnail</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -187,21 +187,19 @@
                                 <div class="umb-el-wrap">
                                     <label class="control-label" for="iconcolor"><localize key="blockEditor_thumbnail">Thumbnail</localize></label>
                                     <div class="controls">
-                                        <div class="__settings-input --hasValue" ng-if="vm.block.thumbnail !== null">
 
-                                            <div class="umb-block-card">
-                                                <div class="__showcase"
-                                                     ng-style="{ 'background-color': vm.block.backgroundColor, 'background-image': vm.getBlockBackground(vm.block) }">
-                                                </div>
-                                                <div class="__actions">
-                                                    <button type="button" class="btn-reset __action umb-outline" localize="title" title="general_remove" ng-click="vm.removeThumbnailForBlock(vm.block)">
-                                                        <umb-icon icon="icon-trash" class="icon"></umb-icon>
-                                                    </button>
-                                                </div>
+                                        <div class="umb-block-card" ng-if="vm.block.thumbnail !== null">
+                                            <div class="__showcase"
+                                                 ng-style="{ 'background-color': vm.block.backgroundColor, 'background-image': vm.getBlockBackground(vm.block) }">
                                             </div>
-
+                                            <div class="__actions">
+                                                <button type="button" class="btn-reset __action umb-outline" localize="title" title="general_remove" ng-click="vm.removeThumbnailForBlock(vm.block)">
+                                                    <umb-icon icon="icon-trash" class="icon"></umb-icon>
+                                                </button>
+                                            </div>
                                         </div>
-                                        <button type="button" class="btn-reset __settings-input --noValue umb-outline" ng-if="vm.block.thumbnail === null" ng-click="vm.addThumbnailForBlock(vm.block)">
+
+                                        <button type="button" class="btn-reset __add-thumbnail __settings-input --noValue umb-outline" ng-if="vm.block.thumbnail === null" ng-click="vm.addThumbnailForBlock(vm.block)">
                                             <localize key="blockEditor_addThumbnail">Add thumbnail</localize>
                                         </button>
                                     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.less
@@ -98,4 +98,10 @@
             border-color: @ui-action-discreet-border-hover;
         }
     }
+
+    .__add-thumbnail {
+        aspect-ratio: 16 / 9;
+        align-items: center;
+        border-radius: @doubleBorderRadius;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.less
@@ -1,6 +1,5 @@
 .umb-block-list-block-configuration-overlay {
 
-
     .umb-node-preview {
         flex-grow: 1;
     }
@@ -9,13 +8,14 @@
         position: absolute;
         display: flex;
         align-items: center;
-        top:0;
+        top: 0;
         bottom: 0;
         right: 0;
         background-color: rgba(255, 255, 255, 0.8);
         opacity: 0;
         transition: opacity 120ms;
     }
+
     .control-group:hover,
     .control-group:focus,
     .control-group:focus-within {
@@ -23,19 +23,22 @@
             opacity: 1;
         }
     }
+
     .__control-actions-btn {
         position: relative;
         color: @ui-action-discreet-type;
         height: 32px;
         width: 26px;
+
         &:hover {
             color: @ui-action-discreet-type-hover;
         }
+
         &:last-of-type {
             margin-right: 7px;
         }
     }
-    
+
     .umb-node-preview {
         border-bottom: none;
     }
@@ -63,9 +66,8 @@
 
         &.--noValue {
             text-align: center;
-            border-radius: @baseBorderRadius;
-            color: white;
             transition: color 120ms;
+
             &:hover, &:focus {
                 color: @ui-action-discreet-type-hover;
                 border-color: @ui-action-discreet-border-hover;
@@ -79,7 +81,7 @@
     }
 
     .__add-button {
-        width:100%;
+        width: 100%;
         color: @ui-action-discreet-type;
         border: 1px dashed @ui-action-discreet-border;
         border-radius: @baseBorderRadius;
@@ -90,11 +92,10 @@
         box-sizing: border-box;
         margin: 20px 0;
         font-weight: bold;
-    }
-    
-    .__add-button:hover {
-        color: @ui-action-discreet-type-hover;
-        border-color: @ui-action-discreet-border-hover;
-    }
 
+        &:hover {
+            color: @ui-action-discreet-type-hover;
+            border-color: @ui-action-discreet-border-hover;
+        }
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently the block configuration doesn't show a preview of the thumbnail, so you'll first see a preview when the block configuration has been submitted.

I think it is useful to see a preview earlier and it combine it with background color.

https://user-images.githubusercontent.com/2919859/138468464-7d710f00-1671-42a4-93a8-e56bc8867046.mp4

Furthermore I have adjusted the white color labels on the pickers. Although it probably was intended as "placeholders" I think it is confusing and not consistent with the rest of the UI.

It use `aspect-ratio` to set the "add thumbnail" placeholder, which is supported by most modern browsers, but it not supported it will just fallback to the  current "slim" add button style.
https://caniuse.com/mdn-css_properties_aspect-ratio