### PR TITLE
Feature/upload correct media type

### DIFF
--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -730,8 +730,8 @@ namespace Umbraco.Web.Editors
                             {
                                 var fileProperty = mediaTypeItem.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == "umbracoFile");
                             if (fileProperty != null) {
-                                    var dataTypeKey = fileProperty.DataTypeKey;
-                                    var dataType = Services.DataTypeService.GetDataType(dataTypeKey);
+                                var dataTypeKey = fileProperty.DataTypeKey;
+                                var dataType = Services.DataTypeService.GetDataType(dataTypeKey);
 
                                 if (dataType != null && dataType.Configuration is IFileExtensionsConfig fileExtensionsConfig) {
                                         var fileExtensions = fileExtensionsConfig.FileExtensions;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/7735

### Description
Ever since Umbraco version 8.14, the way media gets uploaded has changed. In the past, uploading media directly from a MediaPicker would respect the permissions set on the upload folder when not using the default mediaType of "Image". Ever since version 8.14 this has changed, and even if the folder does not allow the default "Image" item to be uploaded, it still forces the uploaded image to be that media type (and same with File).

With this pullrequest, we not just upload an image with the default 'Image' Media Type, but first try to determine if the folder we are trying to upload the item to has any specific permissions set that have the "umbracoFile" property. If that is the case, we want to use that Media Type instead of the default!

To test this Pullrequest, simply try out any mediapicker that points towards a media folder that has specific permissions set up, upload a new image, and it will upload it to the correct media type! If it does not find any items within it's permitted children with a property of alias umbracoFile, it will continue with the rest of the Umbraco logic and upload to the default type!

Kind regards,
Corné Hoskam (@cornehoskam) & Stefan Besteman (@stefanbesteman-weareyou)