### PR TITLE
Add missing fallback texts in various views

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.html
@@ -138,7 +138,7 @@
                     </div>
 
                     <umb-empty-state ng-if="vm.searchOptions.filter && images.length === 0 && !vm.loading && !activeDrag" position="center">
-                        <localize key="general_searchNoResult"></localize>
+                        <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
                     </umb-empty-state>
 
                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -88,7 +88,7 @@
 
                 <h1 style="margin-bottom: 10px;">Upload a photo</h1>
                 <p style="text-align: center; margin-bottom: 25px; line-height: 1.6em;">
-                    <localize key="user_userinviteAvatarMessage"></localize>
+                    <localize key="user_userinviteAvatarMessage">Uploading a photo of yourself will make it easy for other users to recognize you. Click the circle above to upload your photo.</localize>
                 </p>
                 <div class="flex justify-center items-center">
                     <umb-button type="button"

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -66,7 +66,7 @@
                         <umb-empty-state
                             position="center"
                             size="small">
-                            <localize key="content_noChanges"></localize>
+                            <localize key="content_noChanges">No changes have been made</localize>
                         </umb-empty-state>
                     </div>
 
@@ -168,7 +168,7 @@
                             <option value="">{{chooseLabel}}...</option>
                         </select>
                         <button type="button" ng-show="allowChangeTemplate && node.template !== null" class="umb-node-preview__action" style="margin-left:15px;" ng-click="openTemplate()">
-                            <localize key="general_open">Open</localize><span class="sr-only">&nbsp;{{node.template}} <localize key="template_template"></localize></span>
+                            <localize key="general_open">Open</localize><span class="sr-only">&nbsp;{{node.template}} <localize key="template_template">Template</localize></span>
                         </button>
                     </div>
                 </umb-control-group>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -58,7 +58,7 @@
         <umb-empty-state
             ng-if="content.tabs.length === 0"
             position="center">
-            <localize key="content_noProperties"></localize>
+            <localize key="content_noProperties">No content can be added for this item</localize>
         </umb-empty-state>
 
     </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-variant-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-variant-content.html
@@ -45,7 +45,7 @@
         <umb-empty-state
             ng-if="vm.content.apps.length === 0"
             position="center">
-            <localize key="content_noProperties"></localize>
+            <localize key="content_noProperties">No content can be added for this item</localize>
         </umb-empty-state>
 
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -60,8 +60,8 @@
                                     <span class="umb-variant-switcher__name" ng-bind="entry.variant.displayName"></span>
                                     <span class="umb-variant-switcher__state">
                                         <umb-variant-state variant="entry.variant"></umb-variant-state>
-                                        <span ng-if="entry.variant.language.isMandatory"> - <localize key="general_mandatory"></localize></span>
-                                        <span ng-if="entry.variant.language.isDefault"> - <localize key="general_default"></localize></span>
+                                        <span ng-if="entry.variant.language.isMandatory"> - <localize key="general_mandatory">Mandatory</localize></span>
+                                        <span ng-if="entry.variant.language.isDefault"> - <localize key="general_default">Default</localize></span>
                                     </span>
                                 </span>
                             </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
@@ -60,7 +60,7 @@
         <umb-empty-state
             ng-if="vm.model.tabs.length === 0"
             position="center">
-            <localize key="content_noProperties"></localize>
+            <localize key="content_noProperties">No content can be added for this item</localize>
         </umb-empty-state>
 
     </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -12,7 +12,7 @@
 
                 <umb-empty-state ng-if="!nodeUrl"
                                  size="small">
-                    <localize key="content_noMediaLink"></localize>
+                    <localize key="content_noMediaLink">This media item has no link</localize>
                 </umb-empty-state>
 
                 <ul ng-if="nodeUrl" class="nav nav-stacked mb0">

--- a/src/Umbraco.Web.UI.Client/src/views/components/mediacard/umb-media-card.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/mediacard/umb-media-card.html
@@ -5,12 +5,12 @@
 
         <p ng-if="vm.media.trashed" class="__status --error">
             <umb-icon icon="icon-trash"></umb-icon>
-            <localize key="mediaPicker_trashed"></localize>
+            <localize key="mediaPicker_trashed">Trashed</localize>
         </p>
 
         <p ng-if="vm.notAllowed" class="__status --error">
             <umb-icon icon="icon-block"></umb-icon>
-            <localize key="mediaPicker_notAllowed"></localize>
+            <localize key="mediaPicker_notAllowed">Not allowed</localize>
         </p>
 
         <!-- IMAGE and SVG-->

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -9,7 +9,7 @@
 
                 <div class="control-header" ng-hide="vm.property.hideLabel === true">
                     <small ng-if="vm.showInherit" class="db" style="padding-top: 0; margin-bottom: 5px;">
-                        <localize key="contentTypeEditor_inheritedFrom"></localize> {{vm.inheritsFrom}}
+                        <localize key="contentTypeEditor_inheritedFrom">Inherited from</localize> {{vm.inheritsFrom}}
                     </small>
 
                     <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-child-selector.html
@@ -9,7 +9,7 @@
                 <strong>{{parentName}}</strong>
             </span>
             <small>
-                (<localize key="general_current"></localize>)
+                (<localize key="general_current">current</localize>)
             </small>
         </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -64,7 +64,7 @@
                         </div>
 
                         <em ng-show="column.isSensitive" class="muted">
-                            <localize key="content_isSensitiveValue_short"></localize>
+                            <localize key="content_isSensitiveValue_short">This value is hidden.</localize>
                         </em>
 
                     </span>

--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -82,8 +82,8 @@
                    <strong>{{file.name}}</strong>
 
                    <span class="file-error" ng-if="file.$error">
-                      <span ng-if="file.$error === 'pattern'" class="errorMessage color-red"><localize key="media_disallowedFileType"></localize></span>
-                      <span ng-if="file.$error === 'maxSize'" class="errorMessage color-red"><localize key="media_maxFileSize"></localize> "{{maxFileSize}}"</span>
+                      <span ng-if="file.$error === 'pattern'" class="errorMessage color-red"><localize key="media_disallowedFileType">Cannot upload this file, it does not have an approved file type</localize></span>
+                      <span ng-if="file.$error === 'maxSize'" class="errorMessage color-red"><localize key="media_maxFileSize">Max file size is</localize> "{{maxFileSize}}"</span>
                    </span>
 
                    <span class="file-error" ng-if="file.serverErrorMessage">

--- a/src/Umbraco.Web.UI.Client/src/views/content/notify.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/notify.html
@@ -13,7 +13,7 @@
                 </div>
                 <div ng-show="vm.saveSuccces" ng-cloak>
                     <div class="alert alert-success">
-                        <localize key="notifications_notificationsSavedFor"></localize> <strong>{{currentNode.name}}</strong>
+                        <localize key="notifications_notificationsSavedFor">Notification settings saved for</localize> <strong>{{currentNode.name}}</strong>
                     </div>
                     <button class="btn btn-primary" ng-click="vm.cancel()"><localize key="general_ok">Ok</localize></button>
                 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/rights.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/rights.html
@@ -19,12 +19,12 @@
 
                     <div ng-show="vm.saveSuccces">
                         <div class="alert alert-success">
-                            <localize key="speechBubbles_permissionsSavedFor"></localize><strong> {{currentNode.name}}</strong>
+                            <localize key="speechBubbles_permissionsSavedFor">Permissions saved for</localize><strong> {{currentNode.name}}</strong>
                         </div>
                     </div>
 
                     <h5 id="content_rights_title"><localize key="defaultdialogs_permissionsSet">Set permissions for</localize> {{ currentNode.name }}</h5>
-                    <p id="content_rights_description" class="abstract" style="margin-bottom: 20px;"><localize key="defaultdialogs_permissionsHelp"></localize></p>
+                    <p id="content_rights_description" class="abstract" style="margin-bottom: 20px;"><localize key="defaultdialogs_permissionsHelp">Select the users groups you want to set permissions for</localize></p>
 
                     <div style="position: relative; display: inline-block; margin-bottom: 20px;">
                         <umb-button

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -105,7 +105,7 @@
     <umb-empty-state
         ng-if="vm.redirectUrls.length === 0 && vm.dashboard.searchTerm.length > 0 && !vm.dashboard.loading"
         position="center">
-        <localize key="general_searchNoResult"></localize>
+        <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
     </umb-empty-state>
 
     <div class="flex justify-center items-center">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/templates/templates.html
@@ -4,8 +4,8 @@
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_allowedTemplatesHeading"></localize></h5>
-                    <small><localize key="contentTypeEditor_allowedTemplatesDescription"></localize></small>
+                    <h5><localize key="contentTypeEditor_allowedTemplatesHeading">Allowed Templates</localize></h5>
+                    <small><localize key="contentTypeEditor_allowedTemplatesDescription">Choose which templates editors are allowed to use on content of this type</localize></small>
                 </div>
                 
                 <div class="sub-view-column-right">

--- a/src/Umbraco.Web.UI.Client/src/views/languages/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/edit.html
@@ -60,7 +60,7 @@
                             </div>
 
                             <div class="umb-alert umb-alert--info" style="margin-top: 20px;" ng-if="vm.showDefaultLanguageInfo">
-                                <localize key="languages_changingDefaultLanguageWarning"></localize>
+                                <localize key="languages_changingDefaultLanguageWarning">Switching default language may result in default content missing.</localize>
                             </div>
 
                         </umb-control-group>

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
@@ -4,6 +4,6 @@
         <localize key="defaultdialogs_languagedeletewarning">This will delete the language</localize> <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
     </div>
 
-    <localize key="defaultdialogs_confirmdelete"></localize>?
+    <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>?
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/infiniteeditors/parameter.html
@@ -42,7 +42,7 @@
                         </div>
 
                         <button type="button" class="btn-reset editor-placeholder" data-element="editor-add" ng-if="!model.parameter.editor" hotkey="alt+shift+e" ng-click="vm.openMacroParameterPicker(model.parameter)">
-                            <localize key="shortcuts_addEditor"></localize>
+                            <localize key="shortcuts_addEditor">Add editor</localize>
                         </button>
 
                         <div class="editor clearfix" ng-if="model.parameter.editor">

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/create.html
@@ -19,7 +19,7 @@
                     <li class="umb-action">
                         <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
                             <umb-icon icon="icon-folder" class="icon large"></umb-icon>
-                            <span class="menu-label"><localize key="general_folder"></localize>...</span>
+                            <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
                         </button>
                     </li>
                 </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/listview/listview.html
@@ -2,8 +2,8 @@
     <umb-box-content>
         <div class="sub-view-columns">
             <div class="sub-view-column-left">
-                <h5><localize key="contentTypeEditor_enableListViewHeading"></localize></h5>
-                <small><localize key="contentTypeEditor_enableListViewDescription"></localize></small>
+                <h5><localize key="contentTypeEditor_enableListViewHeading">Enable list view</localize></h5>
+                <small><localize key="contentTypeEditor_enableListViewDescription">Configures the content item to show a sortable and searchable list of its children, the children will not be shown in the tree</localize></small>
             </div>
             <div class="sub-view-column-right">
                 <umb-list-view-settings 

--- a/src/Umbraco.Web.UI.Client/src/views/membertypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/membertypes/create.html
@@ -10,7 +10,7 @@
                     <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
                         <umb-icon icon="icon-folder" class="icon large"></umb-icon>
                         <span class="menu-label">
-                            <localize key="general_folder"></localize>
+                            <localize key="general_folder">Folder</localize>
                         </span>
                     </button>
                 </li>

--- a/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviewmacros/create.html
@@ -31,7 +31,7 @@
                         <li class="umb-action">
                             <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="vm.showCreateFolder()">
                                 <umb-icon icon="icon-folder" class="icon large"></umb-icon>
-                                <span class="menu-label"><localize key="general_folder"></localize>...</span>
+                                <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
                             </button>
                         </li>
                     </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/partialviews/create.html
@@ -25,7 +25,7 @@
                         <li class="umb-action">
                             <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="vm.showCreateFolder()">
                                 <umb-icon icon="icon-folder" class="icon large"></umb-icon>
-                                <span class="menu-label"><localize key="general_folder"></localize>...</span>
+                                <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
                             </button>
                         </li>
                     </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/layouts/list/list.html
@@ -62,13 +62,13 @@
     <umb-empty-state
         ng-if="!items && options.filter.length > 0"
         position="center">
-        <localize key="general_searchNoResult"></localize>
+        <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
     </umb-empty-state>
 
     <umb-empty-state
         ng-if="!items && options.filter.length == 0 && vm.isRecycleBin"
         position="center">
-        <localize key="general_recycleBinEmpty"></localize>
+        <localize key="general_recycleBinEmpty">Your recycle bin is empty</localize>
     </umb-empty-state>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
@@ -1,7 +1,7 @@
 <div>
 
     <p class="abstract">
-        <localize key="defaultdialogs_confirmdelete"></localize>?
+        <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>?
     </p>
 
     <div class="umb-alert umb-alert--warning" ng-show="model.deletesVariants && !model.isTrashed">

--- a/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/relationtypes/create.html
@@ -12,7 +12,7 @@
 
                 <!-- Direction -->
                 <umb-control-group label="@relationType_direction">
-                    <p tabindex="0" class="sr-only"><localize key="relationType_direction"></localize></p>
+                    <p tabindex="0" class="sr-only"><localize key="relationType_direction">Direction</localize></p>
                     <ul class="unstyled">
                         <li>
                             <label class="radio" for="parentToChild">

--- a/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/stylesheets/create.html
@@ -22,7 +22,7 @@
                     <li class="umb-action">
                         <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="vm.showCreateFolder()">
                             <umb-icon icon="icon-folder" class="icon large"></umb-icon>
-                            <span class="menu-label"><localize key="general_folder"></localize>...</span>
+                            <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
                         </button>
                     </li>
                 </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
@@ -113,7 +113,7 @@
 
     <!-- Empty states -->
     <umb-empty-state ng-if="!vm.loading && !vm.filteredUserGroups.length" position="center">
-        <localize key="general_searchNoResult"></localize>
+        <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
     </umb-empty-state>
 
 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have added fallback texts in several views where one key has been missing in order to not spam the PR tracker too much with these kind of PR - It's done to ensure that in case a translation key is missing then we at least show an English fallback text 😃 