### PR TITLE
Media Folder Picker View: Fix localizations

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/mediafolderpicker.html
@@ -5,7 +5,7 @@
             <li ng-if="model.value" class="umb-sortable-thumbnails__wrapper">
 
                 <p class="label label__trashed" ng-if="media.trashed">
-                    <localize key="mediaPicker_trashed"></localize>
+                    <localize key="mediaPicker_trashed">Trashed</localize>
                     <umb-icon icon="icon-trash"></umb-icon>
                 </p>
 
@@ -18,15 +18,21 @@
                 </umb-file-icon>
 
                 <div class="umb-sortable-thumbnails__actions" data-element="sortable-thumbnail-actions">
-                    <button type="button" aria-label="Remove" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="remove()">
+                    <button type="button" class="umb-sortable-thumbnails__action -red btn-reset" data-element="action-remove" ng-click="remove()">
                         <umb-icon icon="icon-delete" class="icon"></umb-icon>
+                        <span class="sr-only">
+                            <localize key="general_remove">Remove</localize>
+                        </span>
                     </button>
                 </div>
             </li>
 
             <li style="border: none;" class="add-wrapper unsortable" ng-hide="model.value">
-                <button type="button" aria-label="Open media picker" data-element="sortable-thumbnails-add" class="add-link add-link-square btn-reset umb-outline umb-outline--surrounding" ng-click="add()">
+                <button type="button" data-element="sortable-thumbnails-add" class="add-link add-link-square btn-reset umb-outline umb-outline--surrounding" ng-click="add()">
                     <umb-icon icon="icon-add" class="icon large"></umb-icon>
+                    <span class="sr-only">
+                        <localize key="mediaPicker_openMediaPicker">Open media picker</localize>
+                    </span>
                 </button>
             </li>
         </ul>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1349,6 +1349,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="confirmRemoveAllMediaEntryMessage">Remove all medias?</key>
     <key alias="tabClipboard">Clipboard</key>
     <key alias="notAllowed">Not allowed</key>
+    <key alias="openMediaPicker">Open media picker</key>
   </area>
   <area alias="relatedlinks">
     <key alias="enterExternal">enter external link</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1361,6 +1361,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="confirmRemoveAllMediaEntryMessage">Remove all medias?</key>
     <key alias="tabClipboard">Clipboard</key>
     <key alias="notAllowed">Not allowed</key>
+    <key alias="openMediaPicker">Open media picker</key>
   </area>
   <area alias="relatedlinks">
     <key alias="enterExternal">enter external link</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I have added changed the two `aria-label` texts to use the `<localization>` directive wrapped in a `<span>` with the `sr-only` class instead ensuring that the values are possible to localize to different languages. I also added a new localization value for the "Open media picker" text, which was apparently not present in the translation files.

Finally I added a missing mapping of the "Trashed" text as well 👍🏻 