### PR TITLE
Save overlay: Add missing fallback texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
@@ -7,7 +7,7 @@
     <div ng-if="!vm.loading">
         <div class="mb3">
             <p>
-                <localize key="content_variantsToSave"></localize>
+                <localize key="content_variantsToSave">Choose which variants to be saved.</localize>
             </p>
         </div>
 
@@ -39,7 +39,7 @@
                             <span class="umb-variant-selector-entry__description" ng-if="!saveVariantSelectorForm.saveVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
                                 <umb-variant-state variant="variant"></umb-variant-state>
                                 <span ng-if="variant.isMandatory"> - </span>
-                                <span ng-if="variant.isMandatory"><localize key="general_mandatory"></localize></span>
+                                <span ng-if="variant.isMandatory"><localize key="general_mandatory">Mandatory</localize></span>
                             </span>
                             <span class="umb-variant-selector-entry__description" ng-messages="saveVariantSelectorForm.saveVariantSelector.$error" show-validation-on-submit>
                                 <span class="text-warning" ng-message="valServerField">{{saveVariantSelectorForm.saveVariantSelector.errorMsg}}</span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Added 2 missing fallback texts ensuring people will see an English fallback in case the keys have not been translated in other language files.