### PR TITLE
Add datepicker prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/datepicker.controller.js
@@ -1,0 +1,206 @@
+function dateTimePickerController($scope, angularHelper, dateHelper, validationMessageService) {
+
+    let flatPickr = null;
+
+    function onInit() {
+
+        $scope.hasDatetimePickerValue = $scope.model.value ? true : false;
+        $scope.model.datetimePickerValue = null;
+        $scope.serverTime = null;
+        $scope.serverTimeNeedsOffsetting = false;
+
+        // setup the default config
+        var config = {
+            pickDate: true,
+            pickTime: true,
+            useSeconds: true,
+            format: "YYYY-MM-DD HH:mm:ss",
+            icons: {
+                time: "icon-time",
+                date: "icon-calendar",
+                up: "icon-chevron-up",
+                down: "icon-chevron-down"
+            }
+        };
+
+        // map the user config
+        $scope.model.config = Utilities.extend(config, $scope.model.config);;
+        
+        // ensure the format doesn't get overwritten with an empty string
+        if ($scope.model.config.format === "" || $scope.model.config.format === undefined || $scope.model.config.format === null) {
+            $scope.model.config.format = $scope.model.config.pickTime ? "YYYY-MM-DD HH:mm:ss" : "YYYY-MM-DD";
+        }
+
+        // check whether a server time offset is needed
+        if (Umbraco.Sys.ServerVariables.application.serverTimeOffset !== undefined) {
+            // Will return something like 120
+            var serverOffset = Umbraco.Sys.ServerVariables.application.serverTimeOffset;
+    
+            // Will return something like -120
+            var localOffset = new Date().getTimezoneOffset();
+    
+            // If these aren't equal then offsetting is needed
+            // note the minus in front of serverOffset needed 
+            // because C# and javascript return the inverse offset
+            $scope.serverTimeNeedsOffsetting = (-serverOffset !== localOffset);
+        }
+
+        const dateFormat = $scope.model.config.pickTime ? "Y-m-d H:i:S" : "Y-m-d";
+
+        // date picker config
+        $scope.datePickerConfig = {
+            enableTime: $scope.model.config.pickTime,
+            dateFormat: dateFormat,
+            time_24hr: true
+        };
+
+        // Don't show calendar if date format has been set to only time
+        const timeFormat = $scope.model.config.format.toLowerCase();
+        const timeFormatPattern = /^h{1,2}:m{1,2}:s{1,2}\s?a?$/gmi;
+        if (timeFormat.match(timeFormatPattern)) {            
+            $scope.datePickerConfig.enableTime = true;
+            $scope.datePickerConfig.noCalendar = true;
+        }
+            
+        setDatePickerVal();
+
+        // Set the message to use for when a mandatory field isn't completed.
+        // Will either use the one provided on the property type or a localised default.
+        validationMessageService.getMandatoryMessage($scope.model.validation).then(function (value) {
+            $scope.mandatoryMessage = value;
+        });
+    }
+
+    $scope.clearDate = function() {
+        $scope.hasDatetimePickerValue = false;
+        if($scope.model) {
+            $scope.model.datetimePickerValue = null;
+            $scope.model.value = null;
+        }
+        if($scope.datePickerForm && $scope.datePickerForm.datepicker) {
+            $scope.datePickerForm.datepicker.$setValidity("pickerError", true);
+        }
+    }
+
+    $scope.datePickerSetup = function(instance) {
+        flatPickr = instance;
+    };
+
+    $scope.datePickerChange = function(date) {
+        const momentDate = moment(date);
+        setDate(momentDate);
+        setDatePickerVal();
+    };
+
+    $scope.inputChanged = function () {        
+        if ($scope.model.datetimePickerValue === "" && $scope.hasDatetimePickerValue) {
+            // $scope.hasDatetimePickerValue indicates that we had a value before the input was changed,
+            // but now the input is empty.
+            $scope.clearDate();
+        } else if ($scope.model.datetimePickerValue) {
+            var momentDate = moment($scope.model.datetimePickerValue, $scope.model.config.format, true);
+            if (!momentDate || !momentDate.isValid()) {
+                momentDate = moment(new Date($scope.model.datetimePickerValue));
+            }
+            if (momentDate && momentDate.isValid()) {
+                setDate(momentDate);
+            }
+            setDatePickerVal();
+            flatPickr.setDate($scope.model.value, false);
+        }
+    }
+    
+    //here we declare a special method which will be called whenever the value has changed from the server
+    //this is instead of doing a watch on the model.value = faster
+    $scope.model.onValueChanged = function (newVal, oldVal) {
+        if (newVal != oldVal) {
+            //check for c# System.DateTime.MinValue being passed as the clear indicator
+            var minDate = moment('0001-01-01');
+            var newDate = moment(newVal);
+
+            if (newDate.isAfter(minDate)) {
+                setDate(newDate);
+            } else {
+                $scope.clearDate();
+            }
+        }
+    };
+
+    function setDate(momentDate) {        
+        angularHelper.safeApply($scope, function() {
+            // when a date is changed, update the model
+            if (momentDate && momentDate.isValid()) {
+                $scope.datePickerForm.datepicker.$setValidity("pickerError", true);
+                $scope.hasDatetimePickerValue = true;
+                $scope.model.datetimePickerValue = momentDate.format($scope.model.config.format);
+            }
+            else {
+                $scope.hasDatetimePickerValue = false;
+                $scope.model.datetimePickerValue = null;
+            }
+            updateModelValue(momentDate);
+        });
+    }
+
+    function updateModelValue(momentDate) {
+        if ($scope.hasDatetimePickerValue) {
+            if ($scope.model.config.pickTime) {
+                //check if we are supposed to offset the time
+                if ($scope.model.value && Object.toBoolean($scope.model.config.offsetTime) && Umbraco.Sys.ServerVariables.application.serverTimeOffset !== undefined) {
+                    $scope.model.value = dateHelper.convertToServerStringTime(momentDate, Umbraco.Sys.ServerVariables.application.serverTimeOffset);
+                    $scope.serverTime = dateHelper.convertToServerStringTime(momentDate, Umbraco.Sys.ServerVariables.application.serverTimeOffset, "YYYY-MM-DD HH:mm:ss Z");
+                }
+                else {
+                    $scope.model.value = momentDate.format("YYYY-MM-DD HH:mm:ss");
+                }
+            }
+            else {
+                $scope.model.value = momentDate.format("YYYY-MM-DD");
+            }
+        }
+        else {
+            $scope.model.value = null;
+        }
+
+        setDirty();
+    }
+
+    function setDirty() {
+        if ($scope.datePickerForm) {
+            $scope.datePickerForm.datepicker.$setDirty();
+        }
+    }
+
+    /** Sets the value of the date picker control adn associated viewModel objects based on the model value */
+    function setDatePickerVal() {
+        if ($scope.model.value) {
+            var dateVal;
+            //check if we are supposed to offset the time
+            if ($scope.model.value && Object.toBoolean($scope.model.config.offsetTime) && $scope.serverTimeNeedsOffsetting) {
+                //get the local time offset from the server
+                dateVal = dateHelper.convertToLocalMomentTime($scope.model.value, Umbraco.Sys.ServerVariables.application.serverTimeOffset);
+                $scope.serverTime = dateHelper.convertToServerStringTime(dateVal, Umbraco.Sys.ServerVariables.application.serverTimeOffset, "YYYY-MM-DD HH:mm:ss Z");
+            }
+            else {
+                //create a normal moment , no offset required
+                var dateVal = $scope.model.value ? moment($scope.model.value, "YYYY-MM-DD HH:mm:ss") : moment();
+            }
+            $scope.model.datetimePickerValue = dateVal.format($scope.model.config.format);
+        }
+        else {
+            $scope.clearDate();
+        }
+    }
+
+    $scope.$watch("model.value", function(newVal, oldVal) {
+        if (newVal !== oldVal) {
+            $scope.hasDatetimePickerValue = newVal ? true : false;
+            setDatePickerVal();
+        }
+    });
+
+    onInit();
+    
+}
+
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.DatePickerController", dateTimePickerController);

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/datepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/datepicker.html
@@ -1,0 +1,35 @@
+<div class="umb-datepicker" ng-controller="Umbraco.PrevalueEditors.DatePickerController">
+
+    <ng-form name="datePickerForm">
+        <div>
+
+            <umb-date-time-picker
+                ng-model="model.value"
+                options="datePickerConfig"
+                on-setup="datePickerSetup(fpItem)"
+                on-change="datePickerChange(dateStr)">
+
+                <div class="input-append">
+                    <input type="text"
+                           name="datepicker"
+                           id="{{model.alias}}"
+                           ng-model="model.datetimePickerValue"
+                           ng-blur="inputChanged()"
+                           ng-required="model.validation.mandatory"
+                           val-server="value"
+                           class="datepickerinput" />
+                    <button type="button" class="btn-clear" ng-click="clearDate()" ng-show="hasDatetimePickerValue === true || datePickerForm.datepicker.$error.pickerError === true">
+                        <umb-icon icon="icon-delete"></umb-icon>
+                        <span class="sr-only"><localize key="content_removeDate">Clear date</localize></span>
+                    </button>
+                    <span class="add-on">
+                        <umb-icon icon="icon-{{ datePickerConfig.noCalendar ? 'time' : 'calendar' }}"></umb-icon>
+                    </span>
+                </div>
+
+            </umb-date-time-picker>
+
+        </div>
+    </ng-form>
+
+</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently there is no datepicker prevalue editor, but I think this could be useful to many incl. package developers. At the moment we would have the build our own based on `<umb-date-time-picker>` component.

It can be used for grid settings or as configuration of property editor. We could actually use this to configurate datetime datatype using FlatPickr 😅 or build our own more complex datetime property editor using Flatpickr, but re-use the core datetime prevalue editor.

https://user-images.githubusercontent.com/2919859/138594620-19d03e35-282b-48f3-9982-3f799010d1e5.mp4

The example property editor from the video is attached here: 
[CoffeeEditor.zip](https://github.com/umbraco/Umbraco-CMS/files/7404656/CoffeeEditor.zip)

```
{
    "propertyEditors": [
        {
            "name": "Coffee Editor",
            "alias": "coffee",
            "icon": "coffee-cup",
            "editor": {
                "view": "~/App_Plugins/CoffeeEditor/editor.html",
                "valueType": "JSON"
            },
            "prevalues": {
                "fields": [
                    {
                        "label": "Start Date",
                        "description": "Select a start date",
                        "key": "startDate",
                        "view": "datepicker"
                    },
                    {
                        "label": "End Date",
                        "description": "Select a end date",
                        "key": "endDate",
                        "view": "datepicker"
                    }
                ]
            }
        }
    ],
    "css": [
    ],
    "javascript": [
        "~/App_Plugins/CoffeeEditor/editor.controller.js"
    ]
}
```

We can easily configure it as a date picker, without time:

```
"prevalues": {
    "fields": [
        {
            "label": "Start Date",
            "description": "Select a start date",
            "key": "startDate",
            "view": "datepicker",
            "config": {
                "pickDate": true,
                "pickTime": false,
                "format": "YYYY-MM-DD"
            }
        },
        {
            "label": "End Date",
            "description": "Select a end date",
            "key": "endDate",
            "view": "datepicker",
            "config": {
                "pickDate": true,
                "pickTime": false,
                "format": "YYYY-MM-DD"
            }
        }
    ]
}
```

https://user-images.githubusercontent.com/2919859/138594897-aae580de-7119-41cd-9f9f-6e02d8041c56.mp4


At the moment it is more or less of the property editor. In the future I would like it was easier to share many editors as property editors, macro parameter editors and prevalue editors. https://github.com/umbraco/Umbraco-CMS/discussions/11141