### PR TITLE
Add slider prevalue editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/slider.controller.js
@@ -57,6 +57,7 @@
         var stepDecimalPlaces = $scope.model.config.step % 1 == 0
             ? 0
             : _.last($scope.model.config.step.toString().replace(",", ".").split(".")).length;
+
         // setup default
         $scope.sliderOptions = {
             "start": start,

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/slider.controller.js
@@ -1,0 +1,101 @@
+﻿function sliderController($scope) {
+
+    let sliderRef = null;
+
+    /** configure some defaults on init */
+    function configureDefaults() {
+        $scope.model.config.enableRange = $scope.model.config.enableRange ? Object.toBoolean($scope.model.config.enableRange) : false;
+        $scope.model.config.initVal1 = $scope.model.config.initVal1 ? parseFloat($scope.model.config.initVal1) : 0;
+        $scope.model.config.initVal2 = $scope.model.config.initVal2 ? parseFloat($scope.model.config.initVal2) : 0;
+        $scope.model.config.minVal = $scope.model.config.minVal ? parseFloat($scope.model.config.minVal) : 0;
+        $scope.model.config.maxVal = $scope.model.config.maxVal ? parseFloat($scope.model.config.maxVal) : 100;
+        $scope.model.config.step = $scope.model.config.step ? parseFloat($scope.model.config.step) : 1;
+    }
+
+    function setModelValue(values) {
+        $scope.model.value = values ? values.toString() : null;
+        setDirty();
+    }
+
+    function setDirty() {
+        if ($scope.modelValueForm) {
+            $scope.modelValueForm.modelValue.$setDirty();
+        }
+    }
+
+    $scope.setup = function(slider) {
+        sliderRef = slider;
+    };
+
+    $scope.change = function (values) {
+        setModelValue(values);
+    };
+
+    function init() {
+        configureDefaults();
+
+        // format config to fit slider plugin
+        const start = $scope.model.config.enableRange ? [$scope.model.config.initVal1, $scope.model.config.initVal2] : [$scope.model.config.initVal1];
+        const step = $scope.model.config.step;
+        const tooltips = $scope.model.config.enableRange ? [true, true] : [true];
+        const min = $scope.model.config.minVal ? [$scope.model.config.minVal] : [$scope.model.config.minVal];
+        const max = $scope.model.config.maxVal ? [$scope.model.config.maxVal] : [$scope.model.config.maxVal];
+
+        // set model.value to the default value if it's not set (but don't trigger setDirty, just silently update with the default value)
+        if (!$scope.model.value) {
+            $scope.model.value = start.toString();
+        }
+
+        // convert to array - exiting value can be a number if switching from numeric/decimal property editor
+        $scope.sliderValue = $scope.model.value
+            ? Utilities.isString($scope.model.value) || Utilities.isNumber($scope.model.value)
+                    ? $scope.model.value.toString().split(',')
+                    : null
+            : null;
+        
+        // don't render values with decimal places if the step increment in a whole number
+        var stepDecimalPlaces = $scope.model.config.step % 1 == 0
+            ? 0
+            : _.last($scope.model.config.step.toString().replace(",", ".").split(".")).length;
+        // setup default
+        $scope.sliderOptions = {
+            "start": start,
+            "step": step,
+            "tooltips": tooltips,
+            "format": {
+                to: function (value) {
+                    return value.toFixed(stepDecimalPlaces);
+                },
+                from: function (value) {
+                    return Number(value);
+                }
+            },
+            "range": {
+                "min": min,
+                "max": max
+            },
+            "pips": {
+                mode: 'steps',
+                density: 100,
+                filter: filterPips
+            }
+        };
+
+        function filterPips(value) {
+            // show a pip for min and maximum value
+            return value === $scope.model.config.minVal || value === $scope.model.config.maxVal ? 1 : -1;
+        }
+
+    }
+    
+    $scope.$watch('model.value', function(newValue, oldValue){
+        if(newValue && newValue !== oldValue) {
+            $scope.sliderValue = newValue.split(',');
+            sliderRef.noUiSlider.set($scope.sliderValue);
+        }
+    })
+
+    init();
+
+}
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.SliderController", sliderController);

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/slider.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/slider.html
@@ -1,4 +1,4 @@
-﻿<div class="umb-property-editor umb-slider" ng-controller="Umbraco.PropertyEditors.SliderController">
+﻿<div class="umb-property-editor umb-slider" ng-controller="Umbraco.PrevalueEditors.SliderController">
 
     <ng-form name="modelValueForm">
         <div style="padding-top: 50px; padding-bottom: 40px;">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/slider/slider.controller.js
@@ -57,6 +57,7 @@
         var stepDecimalPlaces = $scope.model.config.step % 1 == 0
             ? 0
             : _.last($scope.model.config.step.toString().replace(",", ".").split(".")).length;
+
         // setup default
         $scope.sliderOptions = {
             "start": start,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In some cases I think it would be useful to allow (package) developers to use slider as prevalue editor to configure an property editor or in grid settings.

The prevalue editor could (unlike the property editor) extend the noUiSlider config to extend more features, but I have kept it consistent with the slider property editor, so the config in prevalue editor would be:

```
{
    "propertyEditors": [
        {
            "name": "Coffee Editor",
            "alias": "coffee",
            "icon": "coffee-cup",
            "editor": {
                "view": "~/App_Plugins/CoffeeEditor/editor.html",
                "valueType": "JSON"
            },
            "prevalues": {
                "fields": [
                    {
                        "label": "Coffee Strength",
                        "description": "How strong is this coffee?",
                        "key": "strength",
                        "view": "slider",
                        "config": {
                            "minVal": 1,
                            "maxVal": 10,
                            "initVal1":  5
                        }
                    }
                ]
            }
        }
    ],
    "css": [
    ],
    "javascript": [
        "~/App_Plugins/CoffeeEditor/editor.controller.js"
    ]
}
```

https://user-images.githubusercontent.com/2919859/138596246-01be67e0-edeb-4d23-9d6a-364fdc26acc0.mp4

The property editor shown in the video is attached here: [CoffeeEditor.zip](https://github.com/umbraco/Umbraco-CMS/files/7404704/CoffeeEditor.zip)


It we need more control we could add own own prevalue editor using the `<umb-range-slider>` component.

I think these changes covers most use cases.