### PR TITLE
Ensure crop size in shown for slim thumbnails

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -526,7 +526,9 @@
     position: absolute;
     bottom: -20px;
     height: 20px;
+    min-width: 100px;
     right: 0;
+    text-align: right;
     z-index: @zindexCropperOverlay - 1;
     font-size: 12px;
     opacity: 0.7;

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -568,12 +568,17 @@
     }
 }
 
-.umb-cropper .crop-controls-wrapper__icon-left {
-    margin-right: 10px;
-
-}
+.umb-cropper .crop-controls-wrapper__icon-left,
 .umb-cropper .crop-controls-wrapper__icon-right {
-    margin-left: 10px;
+    color: @gray-3;
+}
+
+.umb-cropper .crop-controls-wrapper__icon-left {
+    margin-right: 15px;
+}
+
+.umb-cropper .crop-controls-wrapper__icon-right {
+    margin-left: 15px;
     font-size: 22px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-crop.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-crop.html
@@ -8,7 +8,7 @@
                 'height': dimensions.image.height
             }"/>
             <div class="__mask" ng-style="maskStyle">
-                <div class="__mask-info">{{width}}px x {{height}}px</div>
+                <div class="__mask-info">{{width}} &times; {{height}} px</div>
             </div>
             <div class="overlay" tabindex="1"></div>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.html
@@ -68,7 +68,7 @@
 
                         <div class="crop-information">
                             <span class="crop-name crop-text">{{value.alias}}</span>
-                            <span class="crop-size crop-text">{{value.width}}px x {{value.height}}px</span>
+                            <span class="crop-size crop-text">{{value.width}} &times; {{value.height}} px</span>
                             <span class="crop-annotation crop-text"><localize key="imagecropper_customCrop" ng-show="isCustomCrop(value)">User defined</localize>&nbsp;</span>
                         </div>
                     </li>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.prevalues.html
@@ -62,7 +62,7 @@
         <div class="control-group umb-prevalues-multivalues__listitem" ng-repeat="item in model.value">
             <umb-icon icon="icon-navigation" class="icon handle"></umb-icon>
             <div class="umb-prevalues-multivalues__left">
-                <p><span>{{item.alias}}</span> <small>({{item.width}}px &times; {{item.height}}px)</small></p>
+                <p><span>{{item.alias}}</span> <small>({{item.width}} &times; {{item.height}}px)</small></p>
             </div>
             <div class="umb-prevalues-multivalues__right">
                 <button type="button" class="umb-node-preview__action" ng-click="edit(item, $event)"><localize key="general_edit">Edit</localize></button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In case you configured a slim thumbnail size (portrait) in image cropper, the label breaks on multiple lines, so you didn't see the full size "width x height" label.

![image](https://user-images.githubusercontent.com/2919859/138600247-c28a5524-f9f0-49e4-a0e5-42be12657db0.png)

Furthermore since it is always configured in pixels, I think we should simplify it from `width px x height px` to just `width x height px`.

https://user-images.githubusercontent.com/2919859/138600166-b4c0c664-faee-47a9-b8c5-e3874738584d.mp4
