### PR TITLE
Set current master template in template tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/.babelrc
+++ b/src/Umbraco.Web.UI.Client/.babelrc
@@ -8,6 +8,7 @@
         ]
     ],
     "plugins": [
+        [ "@babel/plugin-proposal-optional-chaining" ],
         [
             "@babel/plugin-proposal-object-rest-spread",
             {

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -18,123 +18,93 @@
             "dev": true
         },
         "@babel/core": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
-            "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+            "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.6.4",
-                "@babel/helpers": "^7.6.2",
-                "@babel/parser": "^7.6.4",
-                "@babel/template": "^7.6.0",
-                "@babel/traverse": "^7.6.3",
-                "@babel/types": "^7.6.3",
-                "convert-source-map": "^1.1.0",
+                "@babel/code-frame": "^7.15.8",
+                "@babel/generator": "^7.15.8",
+                "@babel/helper-compilation-targets": "^7.15.4",
+                "@babel/helper-module-transforms": "^7.15.8",
+                "@babel/helpers": "^7.15.4",
+                "@babel/parser": "^7.15.8",
+                "@babel/template": "^7.15.4",
+                "@babel/traverse": "^7.15.4",
+                "@babel/types": "^7.15.6",
+                "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
-                "json5": "^2.1.0",
-                "lodash": "^4.17.13",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0",
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "@babel/generator": {
-                    "version": "7.6.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-                    "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+                "@babel/code-frame": {
+                    "version": "7.15.8",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.6.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
+                        "@babel/highlight": "^7.14.5"
                     }
                 },
-                "@babel/parser": {
-                    "version": "7.6.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-                    "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "convert-source-map": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+                    "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
-                },
-                "@babel/traverse": {
-                    "version": "7.6.3",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-                    "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.3",
-                        "@babel/helper-function-name": "^7.1.0",
-                        "@babel/helper-split-export-declaration": "^7.4.4",
-                        "@babel/parser": "^7.6.3",
-                        "@babel/types": "^7.6.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.6.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-                    "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
                 }
             }
         },
         "@babel/generator": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
-            "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+            "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.6.0",
+                "@babel/types": "^7.15.6",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-annotate-as-pure": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-            "integrity": "sha1-Mj053QtQ4Qx8Bsp9djjmhk2MXDI=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+            "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-            "integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.15.4.tgz",
+            "integrity": "sha512-P8o7JP2Mzi0SdC6eWr1zF+AEYvrsZa7GSY1lTayjF5XJhVH0kjLYUZPvTMflP7tBgZoe9gIhTa60QwFpqh/E0Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "@babel/helper-call-delegate": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-            "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-hoist-variables": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/helper-explode-assignable-expression": "^7.15.4",
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-compilation-targets": {
@@ -150,34 +120,34 @@
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.17.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-                    "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
+                    "integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "^1.0.30001254",
-                        "colorette": "^1.3.0",
-                        "electron-to-chromium": "^1.3.830",
+                        "caniuse-lite": "^1.0.30001271",
+                        "electron-to-chromium": "^1.3.878",
                         "escalade": "^3.1.1",
-                        "node-releases": "^1.1.75"
+                        "node-releases": "^2.0.1",
+                        "picocolors": "^1.0.0"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001257",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-                    "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+                    "version": "1.0.30001271",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+                    "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
                     "dev": true
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.836",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz",
-                    "integrity": "sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==",
+                    "version": "1.3.878",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.878.tgz",
+                    "integrity": "sha512-O6yxWCN9ph2AdspAIszBnd9v8s11hQx8ub9w4UGApzmNRnoKhbulOWqbO8THEQec/aEHtvy+donHZMlh6l1rbA==",
                     "dev": true
                 },
                 "node-releases": {
-                    "version": "1.1.75",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-                    "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+                    "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
                     "dev": true
                 },
                 "semver": {
@@ -188,155 +158,206 @@
                 }
             }
         },
-        "@babel/helper-define-map": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-            "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+            "integrity": "sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.5.5",
-                "lodash": "^4.17.13"
+                "@babel/helper-annotate-as-pure": "^7.15.4",
+                "@babel/helper-function-name": "^7.15.4",
+                "@babel/helper-member-expression-to-functions": "^7.15.4",
+                "@babel/helper-optimise-call-expression": "^7.15.4",
+                "@babel/helper-replace-supers": "^7.15.4",
+                "@babel/helper-split-export-declaration": "^7.15.4"
+            }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+            "integrity": "sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.14.5",
+                "regexpu-core": "^4.7.1"
+            }
+        },
+        "@babel/helper-define-polyfill-provider": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+            "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-compilation-targets": "^7.13.0",
+                "@babel/helper-module-imports": "^7.12.13",
+                "@babel/helper-plugin-utils": "^7.13.0",
+                "@babel/traverse": "^7.13.0",
+                "debug": "^4.1.1",
+                "lodash.debounce": "^4.0.8",
+                "resolve": "^1.14.2",
+                "semver": "^6.1.2"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+                    "dev": true,
+                    "requires": {
+                        "is-core-module": "^2.2.0",
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-            "integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.15.4.tgz",
+            "integrity": "sha512-J14f/vq8+hdC2KoWLIQSsGrC9EFBKE4NFts8pfMpymfApds+fPqR30AOUWc4tyr56h9l/GA1Sxv2q3dLZWbQ/g==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-            "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+            "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "^7.15.4",
+                "@babel/template": "^7.15.4",
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-            "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+            "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-            "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+            "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-            "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+            "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.5.5"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-            "integrity": "sha1-lggbcRHkhtpNLNlxrRpP4hbMLj0=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+            "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-            "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+            "integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/template": "^7.4.4",
-                "@babel/types": "^7.5.5",
-                "lodash": "^4.17.13"
+                "@babel/helper-module-imports": "^7.15.4",
+                "@babel/helper-replace-supers": "^7.15.4",
+                "@babel/helper-simple-access": "^7.15.4",
+                "@babel/helper-split-export-declaration": "^7.15.4",
+                "@babel/helper-validator-identifier": "^7.15.7",
+                "@babel/template": "^7.15.4",
+                "@babel/traverse": "^7.15.4",
+                "@babel/types": "^7.15.6"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-            "integrity": "sha1-opIMVwKwc8Fd5REGIAqoytIEl9U=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+            "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-            "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+            "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
             "dev": true
         },
-        "@babel/helper-regex": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-            "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.17.13"
-            }
-        },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-            "integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.15.4.tgz",
+            "integrity": "sha512-v53MxgvMK/HCwckJ1bZrq6dNKlmwlyRNYM6ypaRTdXWGOE2c1/SCa6dL/HimhPulGhZKw9W0QhREM583F/t0vQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-wrap-function": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "^7.15.4",
+                "@babel/helper-wrap-function": "^7.15.4",
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-            "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+            "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.5.5",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.5.5",
-                "@babel/types": "^7.5.5"
+                "@babel/helper-member-expression-to-functions": "^7.15.4",
+                "@babel/helper-optimise-call-expression": "^7.15.4",
+                "@babel/traverse": "^7.15.4",
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-            "integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+            "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.15.4"
+            }
+        },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+            "integrity": "sha512-BMRLsdh+D1/aap19TycS4eD1qELGrCBJwzaY9IE8LrpJtJb+H7rQkPIdsfgnMtLBA6DJls7X9z93Z4U8h7xw0A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+            "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4"
+                "@babel/types": "^7.15.4"
             }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.15.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+            "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+            "dev": true
         },
         "@babel/helper-validator-option": {
             "version": "7.14.5",
@@ -345,26 +366,26 @@
             "dev": true
         },
         "@babel/helper-wrap-function": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-            "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.15.4.tgz",
+            "integrity": "sha512-Y2o+H/hRV5W8QhIfTpRIBwl57y8PrZt6JM3V8FOo5qarjshHItyH5lXlpMfBfmBefOqSCpKZs/6Dxqp0E/U+uw==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.2.0"
+                "@babel/helper-function-name": "^7.15.4",
+                "@babel/template": "^7.15.4",
+                "@babel/traverse": "^7.15.4",
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/helpers": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
-            "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+            "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.6.0",
-                "@babel/traverse": "^7.6.2",
-                "@babel/types": "^7.6.0"
+                "@babel/template": "^7.15.4",
+                "@babel/traverse": "^7.15.4",
+                "@babel/types": "^7.15.4"
             }
         },
         "@babel/highlight": {
@@ -379,579 +400,809 @@
             }
         },
         "@babel/parser": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
-            "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+            "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
             "dev": true
         },
-        "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-            "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.15.4.tgz",
+            "integrity": "sha512-eBnpsl9tlhPhpI10kU06JHnrYXwg3+V6CaP2idsCXNef0aeslpqyITXQ74Vfk5uHgY7IG7XP0yIH8b42KSzHog==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0",
-                "@babel/plugin-syntax-async-generators": "^7.2.0"
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
+                "@babel/plugin-proposal-optional-chaining": "^7.14.5"
+            }
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+            "integrity": "sha512-2Z5F2R2ibINTc63mY7FLqGfEbmofrHU9FitJW1Q7aPaKFhiPvSq6QEt/BoWN5oME3GVyjcRuNNSRbb9LC0CSWA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-remap-async-to-generator": "^7.15.4",
+                "@babel/plugin-syntax-async-generators": "^7.8.4"
+            }
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+            "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-proposal-class-static-block": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.15.4.tgz",
+            "integrity": "sha512-M682XWrrLNk3chXCjoPUQWOyYsB93B9z3mRyjtqqYJWDf2mfCdIYgDrA11cgNVhAQieaq6F2fn2f3wI0U4aTjA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-class-static-block": "^7.14.5"
             }
         },
         "@babel/plugin-proposal-dynamic-import": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
-            "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz",
+            "integrity": "sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-export-namespace-from": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
+            "integrity": "sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
             }
         },
         "@babel/plugin-proposal-json-strings": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
-            "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.5.tgz",
+            "integrity": "sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-json-strings": "^7.2.0"
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-json-strings": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-logical-assignment-operators": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.5.tgz",
+            "integrity": "sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+            "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+            "integrity": "sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
-            "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
+            "version": "7.15.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.15.6.tgz",
+            "integrity": "sha512-qtOHo7A1Vt+O23qEAX+GdBpqaIuD3i9VRrWgCJeq7WO6H2d14EK3q11urj5Te2MAeK97nMiIdRpwd/ST4JFbNg==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.13.8",
-                "@babel/helper-compilation-targets": "^7.13.8",
-                "@babel/helper-plugin-utils": "^7.13.0",
+                "@babel/compat-data": "^7.15.0",
+                "@babel/helper-compilation-targets": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.13.0"
-            },
-            "dependencies": {
-                "@babel/helper-plugin-utils": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-                    "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-                    "dev": true
-                },
-                "@babel/plugin-syntax-object-rest-spread": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-                    "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.8.0"
-                    }
-                },
-                "@babel/plugin-transform-parameters": {
-                    "version": "7.15.4",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
-                    "integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.14.5"
-                    }
-                }
+                "@babel/plugin-transform-parameters": "^7.15.4"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
-            "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.5.tgz",
+            "integrity": "sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+            "integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-private-methods": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.14.5.tgz",
+            "integrity": "sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-proposal-private-property-in-object": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.15.4.tgz",
+            "integrity": "sha512-X0UTixkLf0PCCffxgu5/1RQyGGbgZuKoI+vXP4iSbJSYwPb7hu06omsFGBvQ9lJEvwgrxHdS8B5nbfcd8GyUNA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.15.4",
+                "@babel/helper-create-class-features-plugin": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
-            "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.14.5.tgz",
+            "integrity": "sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-syntax-async-generators": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
-            "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            }
+        },
+        "@babel/plugin-syntax-class-static-block": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-syntax-dynamic-import": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
-            "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-export-namespace-from": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-syntax-json-strings": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
-            "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
-            "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-private-property-in-object": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
-            "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+            "integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-            "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.14.5.tgz",
+            "integrity": "sha512-szkbzQ0mNk0rpu76fzDdqSyPu0MuvpXgC+6rz5rpMb5OIRxdmHfQxrktL8CYolL2d8luMCZTR0DpIMIdL27IjA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0"
+                "@babel/helper-module-imports": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-remap-async-to-generator": "^7.14.5"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-            "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+            "integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
-            "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
+            "version": "7.15.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+            "integrity": "sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "lodash": "^4.17.13"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-            "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+            "integrity": "sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-define-map": "^7.5.5",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5",
-                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/helper-annotate-as-pure": "^7.15.4",
+                "@babel/helper-function-name": "^7.15.4",
+                "@babel/helper-optimise-call-expression": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-replace-supers": "^7.15.4",
+                "@babel/helper-split-export-declaration": "^7.15.4",
                 "globals": "^11.1.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
-            "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+            "integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
-            "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+            "version": "7.14.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+            "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
-            "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.14.5.tgz",
+            "integrity": "sha512-loGlnBdj02MDsFaHhAIJzh7euK89lBrGIdM9EAtHFo6xKygCUGuuWe07o1oZVk287amtW1n0808sQM99aZt3gw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-            "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.14.5.tgz",
+            "integrity": "sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
-            "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.14.5.tgz",
+            "integrity": "sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-for-of": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-            "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+            "integrity": "sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-function-name": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-            "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+            "integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-function-name": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-literals": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
-            "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+            "integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-member-expression-literals": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
-            "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+            "integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-            "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+            "integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-module-transforms": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
-            "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+            "integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.4.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-module-transforms": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-simple-access": "^7.15.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-            "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.15.4.tgz",
+            "integrity": "sha512-fJUnlQrl/mezMneR72CKCgtOoahqGJNVKpompKwzv3BrEXdlPspTcyxrZ1XmDTIr9PpULrgEQo3qNKp6dW7ssw==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.4.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-hoist-variables": "^7.15.4",
+                "@babel/helper-module-transforms": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.14.9",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
             }
         },
         "@babel/plugin-transform-modules-umd": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-            "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.5.tgz",
+            "integrity": "sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
-            "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.9.tgz",
+            "integrity": "sha512-l666wCVYO75mlAtGFfyFwnWmIXQm3kSH0C3IRnJqWcZbWkoihyAdDhFm2ZWaxWTqvBvhVFfJjMRQ0ez4oN1yYA==",
             "dev": true,
             "requires": {
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.14.5"
             }
         },
         "@babel/plugin-transform-new-target": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-            "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.14.5.tgz",
+            "integrity": "sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-object-super": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-            "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+            "integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5"
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-replace-supers": "^7.14.5"
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-            "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+            "integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.4.4",
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-property-literals": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
-            "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+            "integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-regenerator": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-            "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
+            "integrity": "sha512-NVIY1W3ITDP5xQl50NgTKlZ0GrotKtLna08/uGY6ErQt6VEQZXla86x/CTddm5gZdcr+5GSsvMeTmWA5Ii6pkg==",
             "dev": true,
             "requires": {
-                "regenerator-transform": "^0.14.0"
+                "regenerator-transform": "^0.14.2"
             }
         },
         "@babel/plugin-transform-reserved-words": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
-            "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.14.5.tgz",
+            "integrity": "sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
-            "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+            "integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
-            "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+            "integrity": "sha512-/daZ8s2tNaRekl9YJa9X4bzjpeRZLt122cpgFnQPLGUe61PH8zMEBmYqKkW5xF5JUEh5buEGXJoQpqBmIbpmEQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
-            "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.14.5.tgz",
+            "integrity": "sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-            "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+            "integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
-            "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.14.5.tgz",
+            "integrity": "sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-transform-unicode-escapes": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
+            "integrity": "sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
-            "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.14.5.tgz",
+            "integrity": "sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+                "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/preset-env": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
-            "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.8.tgz",
+            "integrity": "sha512-rCC0wH8husJgY4FPbHsiYyiLxSY8oMDJH7Rl6RQMknbN9oDDHhM9RDFvnGM2MgkbUJzSQB4gtuwygY5mCqGSsA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-                "@babel/plugin-proposal-dynamic-import": "^7.5.0",
-                "@babel/plugin-proposal-json-strings": "^7.2.0",
-                "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
-                "@babel/plugin-syntax-async-generators": "^7.2.0",
-                "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-                "@babel/plugin-syntax-json-strings": "^7.2.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-                "@babel/plugin-transform-arrow-functions": "^7.2.0",
-                "@babel/plugin-transform-async-to-generator": "^7.5.0",
-                "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-                "@babel/plugin-transform-block-scoping": "^7.6.3",
-                "@babel/plugin-transform-classes": "^7.5.5",
-                "@babel/plugin-transform-computed-properties": "^7.2.0",
-                "@babel/plugin-transform-destructuring": "^7.6.0",
-                "@babel/plugin-transform-dotall-regex": "^7.6.2",
-                "@babel/plugin-transform-duplicate-keys": "^7.5.0",
-                "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-                "@babel/plugin-transform-for-of": "^7.4.4",
-                "@babel/plugin-transform-function-name": "^7.4.4",
-                "@babel/plugin-transform-literals": "^7.2.0",
-                "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-                "@babel/plugin-transform-modules-amd": "^7.5.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.6.0",
-                "@babel/plugin-transform-modules-systemjs": "^7.5.0",
-                "@babel/plugin-transform-modules-umd": "^7.2.0",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
-                "@babel/plugin-transform-new-target": "^7.4.4",
-                "@babel/plugin-transform-object-super": "^7.5.5",
-                "@babel/plugin-transform-parameters": "^7.4.4",
-                "@babel/plugin-transform-property-literals": "^7.2.0",
-                "@babel/plugin-transform-regenerator": "^7.4.5",
-                "@babel/plugin-transform-reserved-words": "^7.2.0",
-                "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-                "@babel/plugin-transform-spread": "^7.6.2",
-                "@babel/plugin-transform-sticky-regex": "^7.2.0",
-                "@babel/plugin-transform-template-literals": "^7.4.4",
-                "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-                "@babel/plugin-transform-unicode-regex": "^7.6.2",
-                "@babel/types": "^7.6.3",
-                "browserslist": "^4.6.0",
-                "core-js-compat": "^3.1.1",
-                "invariant": "^2.2.2",
-                "js-levenshtein": "^1.1.3",
-                "semver": "^5.5.0"
+                "@babel/compat-data": "^7.15.0",
+                "@babel/helper-compilation-targets": "^7.15.4",
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-validator-option": "^7.14.5",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
+                "@babel/plugin-proposal-async-generator-functions": "^7.15.8",
+                "@babel/plugin-proposal-class-properties": "^7.14.5",
+                "@babel/plugin-proposal-class-static-block": "^7.15.4",
+                "@babel/plugin-proposal-dynamic-import": "^7.14.5",
+                "@babel/plugin-proposal-export-namespace-from": "^7.14.5",
+                "@babel/plugin-proposal-json-strings": "^7.14.5",
+                "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+                "@babel/plugin-proposal-numeric-separator": "^7.14.5",
+                "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
+                "@babel/plugin-proposal-optional-chaining": "^7.14.5",
+                "@babel/plugin-proposal-private-methods": "^7.14.5",
+                "@babel/plugin-proposal-private-property-in-object": "^7.15.4",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-class-properties": "^7.12.13",
+                "@babel/plugin-syntax-class-static-block": "^7.14.5",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+                "@babel/plugin-syntax-top-level-await": "^7.14.5",
+                "@babel/plugin-transform-arrow-functions": "^7.14.5",
+                "@babel/plugin-transform-async-to-generator": "^7.14.5",
+                "@babel/plugin-transform-block-scoped-functions": "^7.14.5",
+                "@babel/plugin-transform-block-scoping": "^7.15.3",
+                "@babel/plugin-transform-classes": "^7.15.4",
+                "@babel/plugin-transform-computed-properties": "^7.14.5",
+                "@babel/plugin-transform-destructuring": "^7.14.7",
+                "@babel/plugin-transform-dotall-regex": "^7.14.5",
+                "@babel/plugin-transform-duplicate-keys": "^7.14.5",
+                "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
+                "@babel/plugin-transform-for-of": "^7.15.4",
+                "@babel/plugin-transform-function-name": "^7.14.5",
+                "@babel/plugin-transform-literals": "^7.14.5",
+                "@babel/plugin-transform-member-expression-literals": "^7.14.5",
+                "@babel/plugin-transform-modules-amd": "^7.14.5",
+                "@babel/plugin-transform-modules-commonjs": "^7.15.4",
+                "@babel/plugin-transform-modules-systemjs": "^7.15.4",
+                "@babel/plugin-transform-modules-umd": "^7.14.5",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
+                "@babel/plugin-transform-new-target": "^7.14.5",
+                "@babel/plugin-transform-object-super": "^7.14.5",
+                "@babel/plugin-transform-parameters": "^7.15.4",
+                "@babel/plugin-transform-property-literals": "^7.14.5",
+                "@babel/plugin-transform-regenerator": "^7.14.5",
+                "@babel/plugin-transform-reserved-words": "^7.14.5",
+                "@babel/plugin-transform-shorthand-properties": "^7.14.5",
+                "@babel/plugin-transform-spread": "^7.15.8",
+                "@babel/plugin-transform-sticky-regex": "^7.14.5",
+                "@babel/plugin-transform-template-literals": "^7.14.5",
+                "@babel/plugin-transform-typeof-symbol": "^7.14.5",
+                "@babel/plugin-transform-unicode-escapes": "^7.14.5",
+                "@babel/plugin-transform-unicode-regex": "^7.14.5",
+                "@babel/preset-modules": "^0.1.4",
+                "@babel/types": "^7.15.6",
+                "babel-plugin-polyfill-corejs2": "^0.2.2",
+                "babel-plugin-polyfill-corejs3": "^0.2.5",
+                "babel-plugin-polyfill-regenerator": "^0.2.2",
+                "core-js-compat": "^3.16.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
-                "@babel/types": {
-                    "version": "7.6.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-                    "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/preset-modules": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+            "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+            "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@babel/template": {
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+            "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.14.5",
+                "@babel/parser": "^7.15.4",
+                "@babel/types": "^7.15.4"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.15.8",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
                     }
                 }
             }
         },
-        "@babel/template": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-            "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.6.0",
-                "@babel/types": "^7.6.0"
-            }
-        },
         "@babel/traverse": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
-            "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
+            "version": "7.15.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+            "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.6.2",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/parser": "^7.6.2",
-                "@babel/types": "^7.6.0",
+                "@babel/code-frame": "^7.14.5",
+                "@babel/generator": "^7.15.4",
+                "@babel/helper-function-name": "^7.15.4",
+                "@babel/helper-hoist-variables": "^7.15.4",
+                "@babel/helper-split-export-declaration": "^7.15.4",
+                "@babel/parser": "^7.15.4",
+                "@babel/types": "^7.15.4",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
+                "globals": "^11.1.0"
             },
             "dependencies": {
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
+                "@babel/code-frame": {
+                    "version": "7.15.8",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
                 }
             }
         },
         "@babel/types": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-            "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+            "version": "7.15.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+            "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.14.9",
                 "to-fast-properties": "^2.0.0"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
-                }
             }
         },
         "@gulp-sourcemaps/identity-map": {
@@ -1826,12 +2077,50 @@
             "dev": true
         },
         "babel-plugin-dynamic-import-node": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-            "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
             "dev": true,
             "requires": {
                 "object.assign": "^4.1.0"
+            }
+        },
+        "babel-plugin-polyfill-corejs2": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+            "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.13.11",
+                "@babel/helper-define-polyfill-provider": "^0.2.2",
+                "semver": "^6.1.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "babel-plugin-polyfill-corejs3": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+            "integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-define-polyfill-provider": "^0.2.2",
+                "core-js-compat": "^3.16.2"
+            }
+        },
+        "babel-plugin-polyfill-regenerator": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+            "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-define-polyfill-provider": "^0.2.2"
             }
         },
         "bach": {
@@ -2773,7 +3062,7 @@
         "cli-color": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
-            "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+            "integrity": "sha1-fRBzj0hSaCT4/n2lGFfLD1cv4B8=",
             "dev": true,
             "requires": {
                 "ansi-regex": "^2.1.1",
@@ -2982,12 +3271,6 @@
             "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
             "dev": true
         },
-        "colorette": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-            "dev": true
-        },
         "colornames": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
@@ -3013,7 +3296,7 @@
                 "color": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-                    "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+                    "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
                     "dev": true,
                     "requires": {
                         "color-convert": "^1.9.1",
@@ -3245,45 +3528,50 @@
             }
         },
         "core-js-compat": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
-            "integrity": "sha512-GNZkENsx5pMnS7Inwv7ZO/s3B68a9WU5kIjxqrD/tkNR8mtfXJRk8fAKRlbvWZSGPc59/TkiOBDYl5Cb65pTVA==",
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.3.tgz",
+            "integrity": "sha512-4zP6/y0a2RTHN5bRGT7PTq9lVt3WzvffTNjqnTKsXhkAYNDTkdCLOIfAdOLcQ/7TDdyRj3c+NeHe1NmF1eDScw==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.7.1",
-                "semver": "^6.3.0"
+                "browserslist": "^4.17.3",
+                "semver": "7.0.0"
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.7.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.1.tgz",
-                    "integrity": "sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==",
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
+                    "integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "^1.0.30000999",
-                        "electron-to-chromium": "^1.3.284",
-                        "node-releases": "^1.1.36"
+                        "caniuse-lite": "^1.0.30001271",
+                        "electron-to-chromium": "^1.3.878",
+                        "escalade": "^3.1.1",
+                        "node-releases": "^2.0.1",
+                        "picocolors": "^1.0.0"
                     }
                 },
+                "caniuse-lite": {
+                    "version": "1.0.30001271",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+                    "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+                    "dev": true
+                },
                 "electron-to-chromium": {
-                    "version": "1.3.292",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.292.tgz",
-                    "integrity": "sha512-hqkem5ANpt6mxVXmhAmlbdG8iicuyM/jEYgmP1tiHPeOLyZoTyGUzrDmJS/xyrrZy9frkW1uQcubicu7f6DS5g==",
+                    "version": "1.3.878",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.878.tgz",
+                    "integrity": "sha512-O6yxWCN9ph2AdspAIszBnd9v8s11hQx8ub9w4UGApzmNRnoKhbulOWqbO8THEQec/aEHtvy+donHZMlh6l1rbA==",
                     "dev": true
                 },
                 "node-releases": {
-                    "version": "1.1.37",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.37.tgz",
-                    "integrity": "sha512-0EOsAEdn6S2vQdDGBWBpmClm5BCkXVkVOURdnhfg7//rxI2XbleRdKig87WuBrk+0PHZ4OhO58fRm9mzWW4jNw==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^6.3.0"
-                    }
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+                    "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+                    "dev": true
                 },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
                     "dev": true
                 }
             }
@@ -3911,7 +4199,7 @@
         "diagnostics": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
-            "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+            "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
             "dev": true,
             "requires": {
                 "colorspace": "1.1.x",
@@ -4006,7 +4294,7 @@
         "domhandler": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
             "dev": true,
             "requires": {
                 "domelementtype": "1"
@@ -4275,7 +4563,7 @@
                 "debug": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "dev": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -4317,7 +4605,7 @@
         "env-variable": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-            "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
+            "integrity": "sha1-kT3YML7xHpagOcA41BMGBOujf4g=",
             "dev": true
         },
         "errno": {
@@ -4458,7 +4746,7 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
                     "dev": true,
                     "optional": true
                 }
@@ -6097,6 +6385,12 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
+        },
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -7340,7 +7634,7 @@
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -7355,7 +7649,7 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
                     "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -7692,15 +7986,6 @@
                 "p-is-promise": "^1.1.0"
             }
         },
-        "invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
-            "dev": true,
-            "requires": {
-                "loose-envify": "^1.0.0"
-            }
-        },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -7800,6 +8085,15 @@
                 "hsla-regex": "^1.0.0",
                 "rgb-regex": "^1.0.1",
                 "rgba-regex": "^1.0.0"
+            }
+        },
+        "is-core-module": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
             }
         },
         "is-data-descriptor": {
@@ -8199,12 +8493,6 @@
             "resolved": "https://registry.npmjs.org/jquery-ui-touch-punch/-/jquery-ui-touch-punch-0.2.3.tgz",
             "integrity": "sha1-7tgiQnM7okP0az6HwYQbMIGR2mg="
         },
-        "js-levenshtein": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-            "dev": true
-        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8349,7 +8637,7 @@
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
         "json-buffer": {
@@ -8390,12 +8678,20 @@
             "dev": true
         },
         "json5": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-            "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
             "dev": true,
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "^1.2.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                }
             }
         },
         "jsprim": {
@@ -8570,7 +8866,7 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
                     "dev": true
                 },
                 "to-regex-range": {
@@ -8637,7 +8933,7 @@
         "kuler": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
-            "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+            "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
             "dev": true,
             "requires": {
                 "colornames": "^1.1.1"
@@ -8886,6 +9182,12 @@
             "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
             "dev": true
         },
+        "lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+            "dev": true
+        },
         "lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -9049,15 +9351,6 @@
             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
             "dev": true
         },
-        "loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
-            "dev": true,
-            "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            }
-        },
         "loud-rejection": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -9209,7 +9502,7 @@
         "memoizee": {
             "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
-            "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+            "integrity": "sha1-B6APIEaZ+alcLZ53IYJxx81hDVc=",
             "dev": true,
             "requires": {
                 "d": "1",
@@ -9336,7 +9629,7 @@
         "minimize": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/minimize/-/minimize-2.2.0.tgz",
-            "integrity": "sha512-IxR2XMbw9pXCxApkdD9BTcH2U4XlXhbeySUrv71rmMS9XDA8BVXEsIuFu24LtwCfBgfbL7Fuh8/ZzkO5DaTLlQ==",
+            "integrity": "sha1-ixZ28wBR2FmNdDZGvRJpCwdNpMM=",
             "dev": true,
             "requires": {
                 "argh": "^0.1.4",
@@ -9361,7 +9654,7 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
                     "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
@@ -13271,6 +13564,12 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
+        },
         "picomatch": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
@@ -13739,12 +14038,6 @@
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
             "dev": true
         },
-        "private": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
-            "dev": true
-        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -13999,27 +14292,33 @@
             }
         },
         "regenerate": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-            "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+            "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
             "dev": true
         },
         "regenerate-unicode-properties": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-            "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
+            "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0"
+                "regenerate": "^1.4.2"
             }
         },
+        "regenerator-runtime": {
+            "version": "0.13.9",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+            "dev": true
+        },
         "regenerator-transform": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
-            "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+            "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
             "dev": true,
             "requires": {
-                "private": "^0.1.6"
+                "@babel/runtime": "^7.8.4"
             }
         },
         "regex-cache": {
@@ -14048,29 +14347,29 @@
             "dev": true
         },
         "regexpu-core": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
-            "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
+            "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0",
-                "regenerate-unicode-properties": "^8.1.0",
-                "regjsgen": "^0.5.0",
-                "regjsparser": "^0.6.0",
-                "unicode-match-property-ecmascript": "^1.0.4",
-                "unicode-match-property-value-ecmascript": "^1.1.0"
+                "regenerate": "^1.4.2",
+                "regenerate-unicode-properties": "^9.0.0",
+                "regjsgen": "^0.5.2",
+                "regjsparser": "^0.7.0",
+                "unicode-match-property-ecmascript": "^2.0.0",
+                "unicode-match-property-value-ecmascript": "^2.0.0"
             }
         },
         "regjsgen": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-            "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
             "dev": true
         },
         "regjsparser": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-            "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
+            "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -14868,7 +15167,7 @@
                 "debug": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "dev": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -15460,7 +15759,7 @@
         "text-hex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+            "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
             "dev": true
         },
         "text-table": {
@@ -15552,7 +15851,7 @@
         "timers-ext": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "integrity": "sha1-b1ethXjgej+5+R2Th9ZWR1VeJcY=",
             "dev": true,
             "requires": {
                 "es5-ext": "~0.10.46",
@@ -15887,31 +16186,31 @@
             "dev": true
         },
         "unicode-canonical-property-names-ecmascript": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-            "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
             "dev": true
         },
         "unicode-match-property-ecmascript": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-            "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
             "dev": true,
             "requires": {
-                "unicode-canonical-property-names-ecmascript": "^1.0.4",
-                "unicode-property-aliases-ecmascript": "^1.0.4"
+                "unicode-canonical-property-names-ecmascript": "^2.0.0",
+                "unicode-property-aliases-ecmascript": "^2.0.0"
             }
         },
         "unicode-match-property-value-ecmascript": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
             "dev": true
         },
         "unicode-property-aliases-ecmascript": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-            "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
             "dev": true
         },
         "union-value": {

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -51,9 +51,9 @@
     "wicg-inert": "^3.0.2"
   },
   "devDependencies": {
-    "@babel/core": "7.6.4",
-    "@babel/plugin-proposal-object-rest-spread": "7.13.8",
-    "@babel/preset-env": "7.6.3",
+    "@babel/core": "7.15.8",
+    "@babel/plugin-proposal-object-rest-spread": "7.15.6",
+    "@babel/preset-env": "7.15.8",
     "autoprefixer": "9.6.5",
     "caniuse-lite": "^1.0.30001237",
     "cssnano": "4.1.10",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -52,7 +52,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.15.8",
-    "@babel/plugin-proposal-object-rest-spread": "7.15.6",
     "@babel/preset-env": "7.15.8",
     "autoprefixer": "9.6.5",
     "caniuse-lite": "^1.0.30001237",

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -252,6 +252,7 @@ body.touch .umb-tree {
 // Tree item states
 // -------------------------
 .not-published {
+    > .umb-tree-item__inner > .umb-icon,
     > .umb-tree-item__inner > i.icon,
     > .umb-tree-item__inner > a {
         opacity: 0.6;
@@ -259,6 +260,7 @@ body.touch .umb-tree {
 }
 
 .not-allowed {
+    > .umb-tree-item__inner > .umb-icon,
     > .umb-tree-item__inner > i.icon,
     > .umb-tree-item__inner > a {
         cursor: not-allowed;

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -559,40 +559,14 @@
                 }
             });
 
+            const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
+
             localizationService.localize("template_mastertemplate").then(title => {
+
                 const editor = {
                     title,
                     filterCssClass: 'not-allowed',
-                    filter: item => {
-
-                        const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
-                        const allowed = availableMasterTemplates.some(template => template.id == item.id);
-
-                        // Set selected node.
-                        item.selected = currentTemplate?.id == item.id;
-
-                        if (currentTemplate)
-                        {
-                            const path = currentTemplate.path.split(",");
-                            if (path.length > 2) {
-                                // Sync tree if current template not is a root level.
-                                treeService.syncTree({
-                                    node: item.parent(),
-                                    path: path
-                                })
-                                .then(node => {
-                                    // Update selected node from current selected template.
-                                    node.selected = currentTemplate?.id == node.id;
-
-                                    if (!allowed) {
-                                        node.cssClasses.push("not-allowed");
-                                    }
-                                });
-                            }
-                        }
-
-                        return !allowed;
-                    },
+                    filter: item => !availableMasterTemplates.some(template => template.id == item.id),
                     submit: model => {
                         var template = model.selection[0];
                         if (template && template.alias) {
@@ -605,6 +579,12 @@
                         editorService.close();
                     },
                     close: () => editorService.close()
+                }
+
+                if (currentTemplate) {
+                    editor.currentNode = {
+                        path: currentTemplate.path
+                    };
                 }
 
                 editorService.templatePicker(editor);

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -566,7 +566,9 @@
                     filter: item => {
 
                         const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
+                        const allowed = availableMasterTemplates.some(template => template.id == item.id);
 
+                        // Set selected node.
                         item.selected = currentTemplate?.id == item.id;
 
                         if (currentTemplate)
@@ -581,11 +583,15 @@
                                 .then(node => {
                                     // Update selected node from current selected template.
                                     node.selected = currentTemplate?.id == node.id;
+
+                                    if (!allowed) {
+                                        node.cssClasses.push("not-allowed");
+                                    }
                                 });
                             }
                         }
 
-                        return !availableMasterTemplates.some(template => template.id == item.id);
+                        return !allowed;
                     },
                     submit: model => {
                         var template = model.selection[0];

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -569,6 +569,26 @@
 
                         item.selected = currentTemplate?.id == item.id;
 
+                        if (currentTemplate)
+                        {
+                            const path = currentTemplate.path.split(",");
+                            if (path.length > 2) {
+                                // Sync tree if current template not is a root level.
+                                treeService.syncTree({ node: item, path: path }).then(syncArgs =>
+                                {
+                                    console.log("syncArgs", syncArgs);
+                                });
+                            }
+                        }
+                        
+
+                        console.log("item", item);
+                        
+
+                        console.log("currentTemplate", currentTemplate);
+
+                        
+
                         return !availableMasterTemplates.some(template => template.id == item.id);
                     },
                     submit: model => {

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -574,8 +574,7 @@
                                 // Sync tree if current template not is a root level.
                                 treeService.syncTree({
                                     node: item.parent(),
-                                    path: path,
-                                    forceReload: true
+                                    path: path
                                 })
                                 .then(node => {
                                     // Update selected node from current selected template.

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -567,6 +567,8 @@
 
                         const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
 
+                        item.selected = currentTemplate?.id == node.id;
+
                         if (currentTemplate)
                         {
                             const path = currentTemplate.path.split(",");

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -563,7 +563,14 @@
                 const editor = {
                     title,
                     filterCssClass: 'not-allowed',
-                    filter: item => !availableMasterTemplates.some(template => template.id == item.id),                    
+                    filter: item => {
+
+                        const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
+
+                        item.selected = currentTemplate?.id == item.id;
+
+                        return !availableMasterTemplates.some(template => template.id == item.id);
+                    },
                     submit: model => {
                         var template = model.selection[0];
                         if (template && template.alias) {

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -567,7 +567,7 @@
 
                         const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
 
-                        item.selected = currentTemplate?.id == node.id;
+                        item.selected = currentTemplate?.id == item.id;
 
                         if (currentTemplate)
                         {

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -567,27 +567,22 @@
 
                         const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
 
-                        item.selected = currentTemplate?.id == item.id;
-
                         if (currentTemplate)
                         {
                             const path = currentTemplate.path.split(",");
                             if (path.length > 2) {
                                 // Sync tree if current template not is a root level.
-                                treeService.syncTree({ node: item, path: path }).then(syncArgs =>
-                                {
-                                    console.log("syncArgs", syncArgs);
+                                treeService.syncTree({
+                                    node: item.parent(),
+                                    path: path,
+                                    forceReload: true
+                                })
+                                .then(node => {
+                                    // Update selected node from current selected template.
+                                    node.selected = currentTemplate?.id == node.id;
                                 });
                             }
                         }
-                        
-
-                        console.log("item", item);
-                        
-
-                        console.log("currentTemplate", currentTemplate);
-
-                        
 
                         return !availableMasterTemplates.some(template => template.id == item.id);
                     },


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Recently the template picker has changed to use a tree picker by @patrickdemooij9 in https://github.com/umbraco/Umbraco-CMS/pull/11363

I think it would be great to show the selected template, when opening the template picker.

https://user-images.githubusercontent.com/2919859/138605039-5040132d-c145-456c-bc90-c5555306422c.mp4


Furthermore it seems we currently can't use javascript optional chaining operator without the gulp task is failing.

We could install `@babel/plugin-proposal-optional-chaining` plugin https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining but this is included in a newer version of `@babel/preset-env`, which also includes `@babel/plugin-proposal-object-rest-spread` https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread

Optional chaining has been included in `@babel/preset-env` since v7.8.0: https://github.com/babel/babel/issues/10809