### PR TITLE
Media Crops Details view: Add missing fallback texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/overlays/mediacropdetails.html
@@ -12,21 +12,21 @@
 
             <div class="umb-control-group" ng-if="vm.shouldShowUrl">
                 <h5>
-                    <localize key="@general_url"></localize>
+                    <localize key="@general_url">URL</localize>
                 </h5>
                 <input type="text" localize="placeholder" placeholder="@general_url" class="umb-property-editor umb-textstring" ng-model="model.target.url" />
             </div>
 
             <div class="umb-control-group" ng-if="model.target">
                 <h5>
-                    <localize key="@content_altTextOptional"></localize>
+                    <localize key="@content_altTextOptional">Alternative text (optional)</localize>
                 </h5>
                 <input type="text" class="umb-property-editor umb-textstring" ng-model="model.target.altText" umb-auto-focus />
             </div>
 
             <div class="umb-control-group" ng-if="model.target">
                 <h5>
-                    <localize key="@content_captionTextOptional"></localize>
+                    <localize key="@content_captionTextOptional">Caption (optional)</localize>
                 </h5>
                 <input type="text" class="umb-property-editor umb-textstring" ng-model="model.target.caption" />
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Ensuring English fallback texts will be displayed in case they keys are missing in translation files.