### PR TITLE
Compositions View: Add missing fallback texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -30,21 +30,22 @@
                     </div>
 
                     <div class="umb-control-group">
-                        <localize key="contentTypeEditor_compositionsDescription"></localize>
+                        <localize key="contentTypeEditor_compositionsDescription">Inherit tabs and properties from an existing Document Type. New tabs will be added to the current Document Type or
+                        merged if a tab with an identical name exists.</localize>
                     </div>
 
                     <umb-empty-state ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes <= 1"
                                      position="center">
-                        <localize key="contentTypeEditor_noAvailableCompositions"></localize>
+                        <localize key="contentTypeEditor_noAvailableCompositions">There are no Content Types available to use as a composition.</localize>
                     </umb-empty-state>
 
                     <umb-empty-state ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1">
-                        <localize key="contentTypeEditor_compositionInUse"></localize>
+                        <localize key="contentTypeEditor_compositionInUse">This Content Type is used in a composition, and therefore cannot be composed itself.</localize>
                     </umb-empty-state>
 
                     <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1 && model.whereCompositionUsed.length > 0">
-                        <h5><localize key="contentTypeEditor_compositionUsageHeading"></localize></h5>
-                        <p><localize key="contentTypeEditor_compositionUsageSpecification"></localize></p>
+                        <h5><localize key="contentTypeEditor_compositionUsageHeading">Where is this composition used?</localize></h5>
+                        <p><localize key="contentTypeEditor_compositionUsageSpecification">This composition is currently used in the composition of the following Content Types:</localize></p>
                         <ul class="umb-checkbox-list">
                             <li class="umb-checkbox-list__item"
                                 ng-repeat="contentTypeEntity in model.whereCompositionUsed">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Ensuring English fallback texts will be displayed in case they keys are missing in translation files.