### PR TITLE
Feature/add missing fallback text user overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.Overlays.UserController">
     <div class="umb-control-group" ng-if="!showPasswordFields">
 
-       <h5><localize key="user_yourProfile"></localize></h5>
+       <h5><localize key="user_yourProfile">Your profile</localize></h5>
 
         <umb-button
             alias="editUser"
@@ -75,7 +75,7 @@
 
 
     <div class="umb-control-group" ng-if="!showPasswordFields && history.length">
-        <h5><localize key="user_yourHistory"></localize></h5>
+        <h5><localize key="user_yourHistory">Your recent history</localize></h5>
         <ul class="umb-tree">
             <li ng-repeat="item in history | orderBy:'time':true">
                 <a ng-href="{{item.link}}" ng-click="gotoHistory(item.link)" prevent-default>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In this PR I'm Ensuring English fallback texts will be displayed in case they keys are missing in translation files. Also I have removed some unused code, which appears to have been commented out since some time in 2019 😃 

