### PR TITLE
We no longer rely on anything in the umbraconightly feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Umbraco Nightly" value="https://www.myget.org/F/umbraconightly/api/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
As noted in https://github.com/umbraco/Umbraco-CMS/pull/11357/files/fc93cd336b34fd26937dfab73625c55fcc2a6ada#r729838683 we no longer need the `NuGet.config` file as we rely on the default NuGet repo by default now..