### PR TITLE
Row config view: Fix fallback texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/rowconfig.html
@@ -18,12 +18,14 @@
 
                     <div class="umb-form-settings form-horizontal">
 
-                        <p><localize key="grid_addRowConfigurationDetail"></localize></p>
+                        <p><localize key="grid_addRowConfigurationDetail">Adjust the row by setting cell widths and adding additional cells</localize></p>
 
                         <div class="alert alert-warn ng-scope" ng-show="nameChanged">
-                            <p>Modifying a row configuration name will result in loss of
-                            data for any existing content that is based on this configuration.</p>
-                            <p><strong>Modifying only the label will not result in data loss.</strong></p>
+                            <localize key="grid_warningText">
+                                <p>Modifying a row configuration name will result in loss of
+                                    data for any existing content that is based on this configuration.</p>
+                                <p><strong>Modifying only the label will not result in data loss.</strong></p>
+                            </localize>
                         </div>
 
                         <umb-control-group label="@general_name">
@@ -70,10 +72,16 @@
                                 <div class="grid-size-scaler">
                                     <button type="button" class="btn-link" ng-click="vm.scaleDown(currentCell)">
                                         <umb-icon icon="icon-remove" class="icon"></umb-icon>
+                                        <span class="sr-only">
+                                            <localize key="general_remove">Remove</localize>
+                                        </span>
                                     </button>
                                     <span>{{currentCell.grid}}</span>
                                     <button type="button" class="btn-link" ng-click="vm.scaleUp(currentCell, availableRowSpace, true)">
                                         <umb-icon icon="icon-add" class="icon"></umb-icon>
+                                        <span class="sr-only">
+                                            <localize key="general_add">Add</localize>
+                                        </span>
                                     </button>
                                 </div>
                             </umb-control-group>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1645,6 +1645,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="chooseDefault">Choose default</key>
     <key alias="areAdded">are added</key>
     <key alias="warning">Warning</key>
+    <key alias="warningText"><![CDATA[<p>Modifying a row configuration name will result in loss of data for any existing content that is based on this configuration.</p> <p><strong>Modifying only the label will not result in data loss.</strong></p>]]></key>
     <key alias="youAreDeleting">You are deleting the row configuration</key>
     <key alias="deletingARow">Deleting a row configuration name will result in loss of data for any existing content that is based on this configuration.</key>
     <key alias="deleteLayout">You are deleting the layout</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1665,6 +1665,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="chooseDefault">Choose default</key>
     <key alias="areAdded">are added</key>
     <key alias="warning">Warning</key>
+    <key alias="warningText"><![CDATA[<p>Modifying a row configuration name will result in loss of data for any existing content that is based on this configuration.</p> <p><strong>Modifying only the label will not result in data loss.</strong></p>]]></key>
     <key alias="youAreDeleting">You are deleting the row configuration</key>
     <key alias="deletingARow">Deleting a row configuration name will result in loss of data for any existing content that is based on this configuration.</key>
     <key alias="deleteLayout">You are deleting the layout</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed a few fallback texts were missing in this view. I also added a new text to the translation files since it was hardcoded into the view.

Furthermore I added some `sr-only` texts for some of the buttons in order to improve accessibility.