### PR TITLE
v9: don't reload page when navigating to edit user

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.controller.js
@@ -182,6 +182,12 @@ angular.module("umbraco")
            $scope.changePasswordModel.value.confirm = "";
         }
 
+        $scope.editUser = function()  {
+          $location
+            .path('/users/users/user/' + $scope.user.id);
+          $scope.model.close();
+        }
+
         dashboardResource.getDashboard("user-dialog").then(function (dashboard) {
             $scope.dashboard = dashboard;
         });

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -11,9 +11,8 @@
 
         <umb-button
             alias="editUser"
-            type="link"
-            href="#/users/users/user/{{user.id}}"
-            action="model.close()"
+            type="button"
+            action="editUser()"
             button-style="action"
             label="Edit"
             label-key="general_edit"
@@ -75,7 +74,7 @@
                     <localize key="defaultdialogs_unLinkYour">Un-link your</localize>&nbsp;{{login.caption}}&nbsp;<localize key="defaultdialogs_account">account</localize>
                 </button>
             </div>
-            
+
         </div>
 
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/user/user.html
@@ -6,14 +6,13 @@
     </h5>
 
     <umb-button
-      action="model.close()"
+      action="editUser()"
       alias="editUser"
       button-style="action"
-      href="#/users/users/user/{{user.id}}"
       label="Edit"
       label-key="general_edit"
       ng-if="canEditProfile"
-      type="link">
+      type="button">
     </umb-button>
 
     <umb-button


### PR DESCRIPTION
Fixes and issue where when you pressed the edit user button:
![image](https://user-images.githubusercontent.com/70372949/139023129-79df3785-3a12-4486-b1f4-ab195fd770c0.png)

This would trigger a full page reload, and thus show tours/email subscription notifications again.

# Notes 
- Changed button to now use editUser function
- implemented editUser function

# How to test
- Run a clean install of umbraco
- When you get the tour notification, just close it (**do not press "don't show this again"**)
- Press the edit user button, it should not give you the tours popup anymore