### PR TITLE
[v9] Fix the basehttpheader health check so that it's checking the root of the domain instead of the /umbraco path

### DIFF
--- a/src/Umbraco.Core/HealthChecks/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/BaseHttpHeaderCheck.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -20,8 +20,8 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
     public abstract class BaseHttpHeaderCheck : HealthCheck
     {
         private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly ILocalizedTextService _textService;
         private readonly string _header;
-        private readonly string _value;
         private readonly string _localizedTextPrefix;
         private readonly bool _metaTagOptionAvailable;
         private static HttpClient s_httpClient;
@@ -33,25 +33,17 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
             IHostingEnvironment hostingEnvironment,
             ILocalizedTextService textService,
             string header,
-            string value,
             string localizedTextPrefix,
             bool metaTagOptionAvailable)
         {
-            LocalizedTextService = textService ?? throw new ArgumentNullException(nameof(textService));
+            _textService = textService ?? throw new ArgumentNullException(nameof(textService));
             _hostingEnvironment = hostingEnvironment;
             _header = header;
-            _value = value;
             _localizedTextPrefix = localizedTextPrefix;
             _metaTagOptionAvailable = metaTagOptionAvailable;
         }
 
         private static HttpClient HttpClient => s_httpClient ??= new HttpClient();
-
-
-        /// <summary>
-        /// Gets the localized text service.
-        /// </summary>
-        protected ILocalizedTextService LocalizedTextService { get; }
 
         /// <summary>
         /// Gets a link to an external read more page.
@@ -95,12 +87,12 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
                 }
 
                 message = success
-                    ? LocalizedTextService.Localize($"healthcheck", $"{_localizedTextPrefix}CheckHeaderFound")
-                    : LocalizedTextService.Localize($"healthcheck", $"{_localizedTextPrefix}CheckHeaderNotFound");
+                    ? _textService.Localize($"healthcheck", $"{_localizedTextPrefix}CheckHeaderFound")
+                    : _textService.Localize($"healthcheck", $"{_localizedTextPrefix}CheckHeaderNotFound");
             }
             catch (Exception ex)
             {
-                message = LocalizedTextService.Localize("healthcheck","healthCheckInvalidUrl", new[] { url.ToString(), ex.Message });
+                message = _textService.Localize("healthcheck","healthCheckInvalidUrl", new[] { url.ToString(), ex.Message });
             }
 
             return

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/ClickJackingCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/ClickJackingCheck.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.Hosting;
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
         /// Initializes a new instance of the <see cref="ClickJackingCheck"/> class.
         /// </summary>
         public ClickJackingCheck(IHostingEnvironment hostingEnvironment, ILocalizedTextService textService)
-            : base(hostingEnvironment, textService, "X-Frame-Options", "sameorigin", "clickJacking", true)
+            : base(hostingEnvironment, textService, "X-Frame-Options", "clickJacking", true)
         {
         }
 

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/ExcessiveHeadersCheck.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -53,7 +53,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
         {
             string message;
             var success = false;
-            var url = _hostingEnvironment.ApplicationMainUrl.GetLeftPart(UriPartial.Authority);;
+            var url = _hostingEnvironment.ApplicationMainUrl.GetLeftPart(UriPartial.Authority);
 
             // Access the site home page and check for the headers
             var request = new HttpRequestMessage(HttpMethod.Head, url);

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/HstsCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/HstsCheck.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.Hosting;
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
         /// but then you should include subdomains and I wouldn't suggest to do that for Umbraco-sites.
         /// </remarks>
         public HstsCheck(IHostingEnvironment hostingEnvironment, ILocalizedTextService textService)
-            : base(hostingEnvironment, textService, "Strict-Transport-Security", "max-age=10886400", "hSTS", true)
+            : base(hostingEnvironment, textService, "Strict-Transport-Security", "hSTS", true)
         {
         }
 

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/NoSniffCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/NoSniffCheck.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.Hosting;
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
         /// Initializes a new instance of the <see cref="NoSniffCheck"/> class.
         /// </summary>
         public NoSniffCheck(IHostingEnvironment hostingEnvironment, ILocalizedTextService textService)
-            : base(hostingEnvironment, textService, "X-Content-Type-Options", "nosniff", "noSniff", false)
+            : base(hostingEnvironment, textService, "X-Content-Type-Options", "noSniff", false)
         {
         }
 

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/XssProtectionCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/XssProtectionCheck.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.Hosting;
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
         /// but then you should include subdomains and I wouldn't suggest to do that for Umbraco-sites.
         /// </remarks>
         public XssProtectionCheck(IHostingEnvironment hostingEnvironment, ILocalizedTextService textService)
-            : base(hostingEnvironment, textService, "X-XSS-Protection", "1; mode=block", "xssProtection", true)
+            : base(hostingEnvironment, textService, "X-XSS-Protection", "xssProtection", true)
         {
         }
 


### PR DESCRIPTION
Fix the basehttpheader health check so that it's checking the root of the domain instead of the /umbraco path.

It should be this way anyway especially if meta tags are being checked instead of headers.

Additionally, on Umbraco Cloud these tests are all passing (even if wrong) as it's actually checking https://identity.umbraco.com for headers

This makes it consistent with the ExcessiveHeadersCheck.cs also

Additionally I have removed the unused "value" from all the security checks as this was used for fixing the checks in v8 but that's not a thing in v9

v8 version of this PR - https://github.com/umbraco/Umbraco-CMS/pull/11534