### PR TITLE
Check for path traversal before uploading file

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -590,32 +590,41 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                 var root = _hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads);
                 var tempPath = Path.Combine(root,fileName);
-
-                using (var stream = System.IO.File.Create(tempPath))
+                if (Path.GetFullPath(tempPath).StartsWith(Path.GetFullPath(root)))
                 {
-                    formFile.CopyToAsync(stream).GetAwaiter().GetResult();
-                }
-
-                if (ext.InvariantEquals("udt"))
-                {
-                    model.TempFileName = Path.Combine(root, fileName);
-
-                    var xd = new XmlDocument
+                    using (var stream = System.IO.File.Create(tempPath))
                     {
-                        XmlResolver = null
-                    };
-                    xd.Load(model.TempFileName);
+                        formFile.CopyToAsync(stream).GetAwaiter().GetResult();
+                    }
 
-                    model.Alias = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Alias")?.FirstChild.Value;
-                    model.Name = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Name")?.FirstChild.Value;
-                }
-                else
+                    if (ext.InvariantEquals("udt"))
+                    {
+                        model.TempFileName = Path.Combine(root, fileName);
+
+                        var xd = new XmlDocument
+                        {
+                            XmlResolver = null
+                        };
+                        xd.Load(model.TempFileName);
+
+                        model.Alias = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Alias")?.FirstChild.Value;
+                        model.Name = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Name")?.FirstChild.Value;
+                    }
+                    else
+                    {
+                        model.Notifications.Add(new BackOfficeNotification(
+                            _localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                            _localizedTextService.Localize("media", "disallowedFileType"),
+                            NotificationStyle.Warning));
+                    }
+                }else
                 {
                     model.Notifications.Add(new BackOfficeNotification(
-                        _localizedTextService.Localize("speechBubbles","operationFailedHeader"),
-                        _localizedTextService.Localize("media","disallowedFileType"),
+                        _localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                        _localizedTextService.Localize("media", "invalidFileName"),
                         NotificationStyle.Warning));
                 }
+
             }
 
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -304,6 +304,7 @@
     <key alias="clickToUpload">Click to upload</key>
     <key alias="orClickHereToUpload">or click here to choose files</key>
     <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
+    <key alias="invalidFileName">Cannot upload this file, it does not have a valid file name</key>
     <key alias="maxFileSize">Max file size is</key>
     <key alias="mediaRoot">Media root</key>
     <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -308,6 +308,7 @@
     <key alias="clickToUpload">Click to upload</key>
     <key alias="orClickHereToUpload">or click here to choose files</key>
     <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
+    <key alias="invalidFileName">Cannot upload this file, it does not have a valid file name</key>
     <key alias="maxFileSize">Max file size is</key>
     <key alias="mediaRoot">Media root</key>
     <key alias="moveToSameFolderFailed">Parent and destination folders cannot be the same</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
The purpose of this PR is to check for path traversal before uploading a file. 
Even though this is not really an issue (it requires the user to be logged in to the backoffice in order to use this in the first place), automated security scans report this as a potential vulnerability.

We prevent this by checking that the Path.combine() returns a path that is within the parent directory

<!-- Thanks for contributing to Umbraco CMS! -->
