### PR TITLE
v9: Fix build warnings round 1

### DIFF
--- a/src/Umbraco.Core/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Core/Actions/ActionAssignDomain.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'I';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "assignDomain";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
+
+        /// <inheritdoc/>
         public string Icon => "home";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => false;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionBrowse.cs
+++ b/src/Umbraco.Core/Actions/ActionBrowse.cs
@@ -13,11 +13,22 @@
     {
         public const char ActionLetter = 'F';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => false;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
+
+        /// <inheritdoc/>
         public string Icon => "";
+
+        /// <inheritdoc/>
         public string Alias => "browse";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionCopy.cs
+++ b/src/Umbraco.Core/Actions/ActionCopy.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'O';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "copy";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.StructureCategory;
+
+        /// <inheritdoc/>
         public string Icon => "documents";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
+++ b/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
@@ -2,11 +2,22 @@
 {
     public class ActionCreateBlueprintFromContent : IAction
     {
+        /// <inheritdoc/>
         public char Letter => 'ï';
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => false;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
+
+        /// <inheritdoc/>
         public string Icon => "blueprint";
+
+        /// <inheritdoc/>
         public string Alias => "createblueprint";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionDelete.cs
@@ -8,11 +8,22 @@
         public const string ActionAlias = "delete";
         public const char ActionLetter = 'D';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => ActionAlias;
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
+
+        /// <inheritdoc/>
         public string Icon => "delete";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionMove.cs
+++ b/src/Umbraco.Core/Actions/ActionMove.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'M';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "move";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.StructureCategory;
+
+        /// <inheritdoc/>
         public string Icon => "enter";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionNew.cs
+++ b/src/Umbraco.Core/Actions/ActionNew.cs
@@ -8,11 +8,22 @@
         public const string ActionAlias = "create";
         public const char ActionLetter = 'C';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => ActionAlias;
+
+        /// <inheritdoc/>
         public string Icon => "add";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionProtect.cs
+++ b/src/Umbraco.Core/Actions/ActionProtect.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'P';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "protect";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
+
+        /// <inheritdoc/>
         public string Icon => "lock";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionPublish.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'U';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "publish";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
+
+        /// <inheritdoc/>
         public string Icon => string.Empty;
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionRestore.cs
+++ b/src/Umbraco.Core/Actions/ActionRestore.cs
@@ -9,11 +9,22 @@ namespace Umbraco.Cms.Core.Actions
     {
         public const string ActionAlias = "restore";
 
+        /// <inheritdoc/>
         public char Letter => 'V';
+
+        /// <inheritdoc/>
         public string Alias => ActionAlias;
+
+        /// <inheritdoc/>
         public string Category => null;
+
+        /// <inheritdoc/>
         public string Icon => "undo";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => false;
 
     }

--- a/src/Umbraco.Core/Actions/ActionRights.cs
+++ b/src/Umbraco.Core/Actions/ActionRights.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'R';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "rights";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
+
+        /// <inheritdoc/>
         public string Icon => "vcard";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionRollback.cs
+++ b/src/Umbraco.Core/Actions/ActionRollback.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'K';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "rollback";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
+
+        /// <inheritdoc/>
         public string Icon => "undo";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionSort.cs
+++ b/src/Umbraco.Core/Actions/ActionSort.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'S';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "sort";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.StructureCategory;
+
+        /// <inheritdoc/>
         public string Icon => "navigation-vertical";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionToPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionToPublish.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'H';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "sendtopublish";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
+
+        /// <inheritdoc/>
         public string Icon => "outbox";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/ActionUnpublish.cs
+++ b/src/Umbraco.Core/Actions/ActionUnpublish.cs
@@ -8,11 +8,22 @@
     {
         public const char ActionLetter = 'Z';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "unpublish";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
+
+        /// <inheritdoc/>
         public string Icon => "circle-dotted";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => false;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 

--- a/src/Umbraco.Core/Actions/ActionUpdate.cs
+++ b/src/Umbraco.Core/Actions/ActionUpdate.cs
@@ -7,11 +7,22 @@
     {
         public const char ActionLetter = 'A';
 
+        /// <inheritdoc/>
         public char Letter => ActionLetter;
+
+        /// <inheritdoc/>
         public string Alias => "update";
+
+        /// <inheritdoc/>
         public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
+
+        /// <inheritdoc/>
         public string Icon => "save";
+
+        /// <inheritdoc/>
         public bool ShowInNotifier => true;
+
+        /// <inheritdoc/>
         public bool CanBePermissionAssigned => true;
     }
 }

--- a/src/Umbraco.Core/Actions/IAction.cs
+++ b/src/Umbraco.Core/Actions/IAction.cs
@@ -11,32 +11,32 @@ namespace Umbraco.Cms.Core.Actions
     public interface IAction : IDiscoverable
     {
         /// <summary>
-        /// The letter used to assign a permission (must be unique)
+        /// Gets the letter used to assign a permission (must be unique)
         /// </summary>
         char Letter { get; }
 
         /// <summary>
-        /// Whether to allow subscribing to notifications for this action
+        /// Gets a value indicating whether whether to allow subscribing to notifications for this action
         /// </summary>
         bool ShowInNotifier { get; }
 
         /// <summary>
-        /// Whether to allow assigning permissions based on this action
+        /// Gets a value indicating whether whether to allow assigning permissions based on this action
         /// </summary>
         bool CanBePermissionAssigned { get; }
 
         /// <summary>
-        /// The icon to display for this action
+        /// Gets the icon to display for this action
         /// </summary>
         string Icon { get; }
 
         /// <summary>
-        /// The alias for this action (must be unique)
+        /// Gets the alias for this action (must be unique)
         /// </summary>
         string Alias { get; }
 
         /// <summary>
-        /// The category used for this action
+        /// Gets the category used for this action
         /// </summary>
         /// <remarks>
         /// Used in the UI when assigning permissions

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Extensions
             {
                 return default(T);
             }
+
             return result.TryConvertTo<T>().Result;
         }
 
@@ -60,6 +61,7 @@ namespace Umbraco.Extensions
             {
                 return default(T);
             }
+
             return result.TryConvertTo<T>().Result;
         }
     }

--- a/src/Umbraco.Core/Cache/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/ContentCacheRefresher.cs
@@ -13,12 +13,25 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Cache
 {
-    public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCacheRefresherNotification, ContentCacheRefresher.JsonPayload>
+    /// <inheritdoc />
+    public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCacheRefresherNotification,
+        ContentCacheRefresher.JsonPayload>
     {
         private readonly IPublishedSnapshotService _publishedSnapshotService;
         private readonly IIdKeyMap _idKeyMap;
         private readonly IDomainService _domainService;
+        public static readonly Guid UniqueId = Guid.Parse("900A4FBE-DF3C-41E6-BB77-BE896CD158EA");
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContentCacheRefresher"/> class.
+        /// </summary>
+        /// <param name="appCaches">The <see cref="AppCaches"/> to use</param>
+        /// <param name="serializer">The <see cref="IJsonSerializer"/> to use</param>
+        /// <param name="publishedSnapshotService">The <see cref="IPublishedSnapshotService"/> to use</param>
+        /// <param name="idKeyMap">The <see cref="IIdKeyMap"/> to use</param>
+        /// <param name="domainService">The <see cref="IDomainService"/> to use</param>
+        /// <param name="eventAggregator">The <see cref="IEventAggregator"/> to use</param>
+        /// <param name="factory">The <see cref="ICacheRefresherNotificationFactory"/> to use</param>
         public ContentCacheRefresher(
             AppCaches appCaches,
             IJsonSerializer serializer,
@@ -36,29 +49,31 @@ namespace Umbraco.Cms.Core.Cache
 
         #region Define
 
-        public static readonly Guid UniqueId = Guid.Parse("900A4FBE-DF3C-41E6-BB77-BE896CD158EA");
-
+        /// <inheritdoc/>
         public override Guid RefresherUniqueId => UniqueId;
 
+        /// <inheritdoc/>
         public override string Name => "ContentCacheRefresher";
 
         #endregion
 
         #region Refresher
 
+        /// <inheritdoc/>
         public override void Refresh(JsonPayload[] payloads)
         {
             AppCaches.RuntimeCache.ClearOfType<PublicAccessEntry>();
             AppCaches.RuntimeCache.ClearByKey(CacheKeys.ContentRecycleBinCacheKey);
 
             var idsRemoved = new HashSet<int>();
-            var isolatedCache = AppCaches.IsolatedCaches.GetOrCreate<IContent>();
+            IAppPolicyCache isolatedCache = AppCaches.IsolatedCaches.GetOrCreate<IContent>();
 
             foreach (var payload in payloads.Where(x => x.Id != default))
             {
-                //By INT Id
+                // By INT Id
                 isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, int>(payload.Id));
-                //By GUID Key
+
+                // By GUID Key
                 isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, Guid?>(payload.Key));
 
                 _idKeyMap.ClearCache(payload.Id);
@@ -70,7 +85,7 @@ namespace Umbraco.Cms.Core.Cache
                     isolatedCache.ClearOfType<IContent>((k, v) => v.Path.Contains(pathid));
                 }
 
-                //if the item is being completely removed, we need to refresh the domains cache if any domain was assigned to the content
+                // if the item is being completely removed, we need to refresh the domains cache if any domain was assigned to the content
                 if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.Remove))
                 {
                     idsRemoved.Add(payload.Id);
@@ -79,20 +94,22 @@ namespace Umbraco.Cms.Core.Cache
 
             if (idsRemoved.Count > 0)
             {
-                var assignedDomains = _domainService.GetAll(true).Where(x => x.RootContentId.HasValue && idsRemoved.Contains(x.RootContentId.Value)).ToList();
+                var assignedDomains = _domainService.GetAll(true)
+                    .Where(x => x.RootContentId.HasValue && idsRemoved.Contains(x.RootContentId.Value)).ToList();
 
                 if (assignedDomains.Count > 0)
                 {
                     // TODO: this is duplicating the logic in DomainCacheRefresher BUT we cannot inject that into this because it it not registered explicitly in the container,
                     // and we cannot inject the CacheRefresherCollection since that would be a circular reference, so what is the best way to call directly in to the
                     // DomainCacheRefresher?
-
                     ClearAllIsolatedCacheByEntityType<IDomain>();
+
                     // note: must do what's above FIRST else the repositories still have the old cached
                     // content and when the PublishedCachesService is notified of changes it does not see
                     // the new content...
                     // notify
-                    _publishedSnapshotService.Notify(assignedDomains.Select(x => new DomainCacheRefresher.JsonPayload(x.Id, DomainChangeTypes.Remove)).ToArray());
+                    _publishedSnapshotService.Notify(assignedDomains
+                        .Select(x => new DomainCacheRefresher.JsonPayload(x.Id, DomainChangeTypes.Remove)).ToArray());
                 }
             }
 
@@ -102,9 +119,8 @@ namespace Umbraco.Cms.Core.Cache
 
             // TODO: what about this?
             // should rename it, and then, this is only for Deploy, and then, ???
-            //if (Suspendable.PageCacheRefresher.CanUpdateDocumentCache)
+            // if (Suspendable.PageCacheRefresher.CanUpdateDocumentCache)
             //  ...
-
             NotifyPublishedSnapshotService(_publishedSnapshotService, AppCaches, payloads);
 
             base.Refresh(payloads);
@@ -113,12 +129,16 @@ namespace Umbraco.Cms.Core.Cache
         // these events should never trigger
         // everything should be PAYLOAD/JSON
 
+        /// <inheritdoc/>
         public override void RefreshAll() => throw new NotSupportedException();
 
+        /// <inheritdoc/>
         public override void Refresh(int id) => throw new NotSupportedException();
 
+        /// <inheritdoc/>
         public override void Refresh(Guid id) => throw new NotSupportedException();
 
+        /// <inheritdoc/>
         public override void Remove(int id) => throw new NotSupportedException();
 
         #endregion
@@ -128,10 +148,11 @@ namespace Umbraco.Cms.Core.Cache
         /// <summary>
         /// Refreshes the publish snapshot service and if there are published changes ensures that partial view caches are refreshed too
         /// </summary>
-        /// <param name="service"></param>
-        /// <param name="appCaches"></param>
-        /// <param name="payloads"></param>
-        internal static void NotifyPublishedSnapshotService(IPublishedSnapshotService service, AppCaches appCaches, JsonPayload[] payloads)
+        /// <param name="service">The <see cref="IPublishedSnapshotService"/> to notify</param>
+        /// <param name="appCaches">The <see cref="AppCaches"/> to refresh</param>
+        /// <param name="payloads">The <see cref="JsonPayload"/>array</param>
+        internal static void NotifyPublishedSnapshotService(IPublishedSnapshotService service, AppCaches appCaches,
+            JsonPayload[] payloads)
         {
             service.Notify(payloads, out _, out var publishedChanged);
 
@@ -142,8 +163,32 @@ namespace Umbraco.Cms.Core.Cache
             }
         }
 
+        #region Indirect
+
+        /// <summary>
+        /// Refreshes the Content Types in the Cache
+        /// </summary>
+        /// <param name="appCaches">The <see cref="AppCaches"/> to refresh</param>
+        public static void RefreshContentTypes(AppCaches appCaches)
+        {
+            // we could try to have a mechanism to notify the PublishedCachesService
+            // and figure out whether published items were modified or not... keep it
+            // simple for now, just clear the whole thing
+            appCaches.ClearPartialViewCache();
+
+            appCaches.IsolatedCaches.ClearCache<PublicAccessEntry>();
+            appCaches.IsolatedCaches.ClearCache<IContent>();
+        }
+
+        #endregion
         public class JsonPayload
         {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="JsonPayload"/> class.
+            /// </summary>
+            /// <param name="id">The id</param>
+            /// <param name="key">The GUID key</param>
+            /// <param name="changeTypes">The <see cref="TreeChangeTypes"/> that have changed</param>
             public JsonPayload(int id, Guid? key, TreeChangeTypes changeTypes)
             {
                 Id = id;
@@ -151,25 +196,20 @@ namespace Umbraco.Cms.Core.Cache
                 ChangeTypes = changeTypes;
             }
 
+            /// <summary>
+            /// Gets the Id of the Payload
+            /// </summary>
             public int Id { get; }
+
+            /// <summary>
+            /// Gets the Key of the Payload
+            /// </summary>
             public Guid? Key { get; }
+
+            /// <summary>
+            /// Gets the <see cref="TreeChangeTypes"/> of the Payload/>
+            /// </summary>
             public TreeChangeTypes ChangeTypes { get; }
-        }
-
-        #endregion
-
-        #region Indirect
-
-        public static void RefreshContentTypes(AppCaches appCaches)
-        {
-            // we could try to have a mechanism to notify the PublishedCachesService
-            // and figure out whether published items were modified or not... keep it
-            // simple for now, just clear the whole thing
-
-            appCaches.ClearPartialViewCache();
-
-            appCaches.IsolatedCaches.ClearCache<PublicAccessEntry>();
-            appCaches.IsolatedCaches.ClearCache<IContent>();
         }
 
         #endregion

--- a/src/Umbraco.Core/Cache/ContentTypeCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/ContentTypeCacheRefresher.cs
@@ -13,13 +13,26 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Cache
 {
+    /// <inheritdoc />
     public sealed class ContentTypeCacheRefresher : PayloadCacheRefresherBase<ContentTypeCacheRefresherNotification, ContentTypeCacheRefresher.JsonPayload>
     {
         private readonly IPublishedSnapshotService _publishedSnapshotService;
         private readonly IPublishedModelFactory _publishedModelFactory;
         private readonly IContentTypeCommonRepository _contentTypeCommonRepository;
         private readonly IIdKeyMap _idKeyMap;
+        public static readonly Guid UniqueId = Guid.Parse("6902E22C-9C10-483C-91F3-66B7CAE9E2F5");
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContentTypeCacheRefresher"/> class.
+        /// </summary>
+        /// <param name="appCaches">The <see cref="AppCaches"/> to use</param>
+        /// <param name="serializer">The <see cref="IJsonSerializer"/> to use</param>
+        /// <param name="publishedSnapshotService">The <see cref="IPublishedSnapshotService"/> to use</param>
+        /// <param name="publishedModelFactory">The <see cref="IPublishedModelFactory"/> to use</param>
+        /// <param name="idKeyMap">The <see cref="IIdKeyMap"/> to use</param>
+        /// <param name="contentTypeCommonRepository">The <see cref="IContentTypeCommonRepository"/> to use</param>
+        /// <param name="eventAggregator">The <see cref="IEventAggregator"/> to use</param>
+        /// <param name="factory">The <see cref="ICacheRefresherNotificationFactory"/> to use</param>
         public ContentTypeCacheRefresher(
             AppCaches appCaches,
             IJsonSerializer serializer,
@@ -39,22 +52,22 @@ namespace Umbraco.Cms.Core.Cache
 
         #region Define
 
-        public static readonly Guid UniqueId = Guid.Parse("6902E22C-9C10-483C-91F3-66B7CAE9E2F5");
-
+        /// <inheritdoc/>
         public override Guid RefresherUniqueId => UniqueId;
 
+        /// <inheritdoc/>
         public override string Name => "Content Type Cache Refresher";
 
         #endregion
 
         #region Refresher
 
+        /// <inheritdoc/>
         public override void Refresh(JsonPayload[] payloads)
         {
             // TODO: refactor
             // we should NOT directly clear caches here, but instead ask whatever class
             // is managing the cache to please clear that cache properly
-
             _contentTypeCommonRepository.ClearCache(); // always
 
             if (payloads.Any(x => x.ItemType == typeof(IContentType).Name))
@@ -81,16 +94,22 @@ namespace Umbraco.Cms.Core.Cache
             }
 
             if (payloads.Any(x => x.ItemType == typeof(IContentType).Name))
+            {
                 // don't try to be clever - refresh all
                 ContentCacheRefresher.RefreshContentTypes(AppCaches);
+            }
 
             if (payloads.Any(x => x.ItemType == typeof(IMediaType).Name))
+            {
                 // don't try to be clever - refresh all
                 MediaCacheRefresher.RefreshMediaTypes(AppCaches);
+            }
 
             if (payloads.Any(x => x.ItemType == typeof(IMemberType).Name))
+            {
                 // don't try to be clever - refresh all
                 MemberCacheRefresher.RefreshMemberTypes(AppCaches);
+            }
 
             // refresh the models and cache
             _publishedModelFactory.WithSafeLiveFactoryReset(() =>
@@ -101,21 +120,25 @@ namespace Umbraco.Cms.Core.Cache
         }
 
 
+        /// <inheritdoc/>
         public override void RefreshAll()
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc/>
         public override void Refresh(int id)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc/>
         public override void Refresh(Guid id)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc/>
         public override void Remove(int id)
         {
             throw new NotSupportedException();
@@ -127,6 +150,12 @@ namespace Umbraco.Cms.Core.Cache
 
         public class JsonPayload
         {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="JsonPayload"/> class.
+            /// </summary>
+            /// <param name="itemType">The itemType string</param>
+            /// <param name="id">The id</param>
+            /// <param name="changeTypes">The <see cref="ContentTypeChangeTypes"/> to use</param>
             public JsonPayload(string itemType, int id, ContentTypeChangeTypes changeTypes)
             {
                 ItemType = itemType;
@@ -134,10 +163,19 @@ namespace Umbraco.Cms.Core.Cache
                 ChangeTypes = changeTypes;
             }
 
+            /// <summary>
+            /// Gets the Id of the Payload
+            /// </summary>
             public string ItemType { get; }
 
+            /// <summary>
+            /// Gets the Key of the Payload
+            /// </summary>
             public int Id { get; }
 
+            /// <summary>
+            /// Gets the <see cref="ContentTypeChangeTypes"/> of the Payload/>
+            /// </summary>
             public ContentTypeChangeTypes ChangeTypes { get; }
         }
 

--- a/src/Umbraco.Core/Cache/LanguageCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/LanguageCacheRefresher.cs
@@ -9,43 +9,56 @@ using static Umbraco.Cms.Core.Cache.LanguageCacheRefresher.JsonPayload;
 
 namespace Umbraco.Cms.Core.Cache
 {
+    /// <inheritdoc />
     public sealed class LanguageCacheRefresher : PayloadCacheRefresherBase<LanguageCacheRefresherNotification, LanguageCacheRefresher.JsonPayload>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LanguageCacheRefresher"/> class.
+        /// </summary>
+        /// <param name="appCaches">The <see cref="AppCaches"/> to use</param>
+        /// <param name="serializer">The <see cref="IJsonSerializer"/> to use</param>
+        /// <param name="publishedSnapshotService">The <see cref="IPublishedSnapshotService"/> to use</param>
+        /// <param name="eventAggregator">The <see cref="IEventAggregator"/> to use</param>
+        /// <param name="factory">The <see cref="ICacheRefresherNotificationFactory"/> to use</param>
         public LanguageCacheRefresher(
             AppCaches appCaches,
             IJsonSerializer serializer,
             IPublishedSnapshotService publishedSnapshotService,
             IEventAggregator eventAggregator,
             ICacheRefresherNotificationFactory factory)
-            : base(appCaches, serializer, eventAggregator, factory)
-        {
+            : base(appCaches, serializer, eventAggregator, factory) =>
             _publishedSnapshotService = publishedSnapshotService;
-        }
 
         #region Define
 
         public static readonly Guid UniqueId = Guid.Parse("3E0F95D8-0BE5-44B8-8394-2B8750B62654");
         private readonly IPublishedSnapshotService _publishedSnapshotService;
 
+        /// <inheritdoc/>
         public override Guid RefresherUniqueId => UniqueId;
 
+        /// <inheritdoc/>
         public override string Name => "Language Cache Refresher";
 
         #endregion
 
         #region Refresher
 
+        /// <inheritdoc/>
         public override void Refresh(JsonPayload[] payloads)
         {
-            if (payloads.Length == 0) return;
+            if (payloads.Length == 0)
+            {
+                return;
+            }
 
             var clearDictionary = false;
             var clearContent = false;
 
-            //clear all no matter what type of payload
+            // clear all no matter what type of payload
             ClearAllIsolatedCacheByEntityType<ILanguage>();
 
-            foreach (var payload in payloads)
+            foreach (JsonPayload payload in payloads)
             {
                 switch (payload.ChangeType)
                 {
@@ -65,14 +78,15 @@ namespace Umbraco.Cms.Core.Cache
                 ClearAllIsolatedCacheByEntityType<IDictionaryItem>();
             }
 
-            //if this flag is set, we will tell the published snapshot service to refresh ALL content and evict ALL IContent items
+            // if this flag is set, we will tell the published snapshot service to refresh ALL content and evict ALL IContent items
             if (clearContent)
             {
-                //clear all domain caches
+                // clear all domain caches
                 RefreshDomains();
                 ContentCacheRefresher.RefreshContentTypes(AppCaches); // we need to evict all IContent items
-                //now refresh all nucache
-                var clearContentPayload = new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) };
+
+                // now refresh all nucache
+                ContentCacheRefresher.JsonPayload[] clearContentPayload = new[] { new ContentCacheRefresher.JsonPayload(0, null, TreeChangeTypes.RefreshAll) };
                 ContentCacheRefresher.NotifyPublishedSnapshotService(_publishedSnapshotService, AppCaches, clearContentPayload);
             }
 
@@ -83,12 +97,16 @@ namespace Umbraco.Cms.Core.Cache
         // these events should never trigger
         // everything should be PAYLOAD/JSON
 
+        /// <inheritdoc/>
         public override void RefreshAll() => throw new NotSupportedException();
 
+        /// <inheritdoc/>
         public override void Refresh(int id) => throw new NotSupportedException();
 
+        /// <inheritdoc/>
         public override void Refresh(Guid id) => throw new NotSupportedException();
 
+        /// <inheritdoc/>
         public override void Remove(int id) => throw new NotSupportedException();
 
         #endregion
@@ -104,7 +122,7 @@ namespace Umbraco.Cms.Core.Cache
             // content and when the PublishedCachesService is notified of changes it does not see
             // the new content...
 
-            var payloads = new[] { new DomainCacheRefresher.JsonPayload(0, DomainChangeTypes.RefreshAll) };
+            DomainCacheRefresher.JsonPayload[] payloads = new[] { new DomainCacheRefresher.JsonPayload(0, DomainChangeTypes.RefreshAll) };
             _publishedSnapshotService.Notify(payloads);
         }
 
@@ -112,6 +130,12 @@ namespace Umbraco.Cms.Core.Cache
 
         public class JsonPayload
         {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="JsonPayload"/> class.
+            /// </summary>
+            /// <param name="id">The int id to use</param>
+            /// <param name="isoCode">The isoCode to use, you can get this from the CultureInfo</param>
+            /// <param name="changeType">The <see cref="LanguageChangeType"/> to use</param>
             public JsonPayload(int id, string isoCode, LanguageChangeType changeType)
             {
                 Id = id;

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -37,6 +37,9 @@ namespace Umbraco.Cms.Core.Services
         /// </summary>
         TItem Get(string alias);
 
+        /// <summary>
+        /// Gets the count
+        /// </summary>
         int Count();
 
         /// <summary>
@@ -44,53 +47,144 @@ namespace Umbraco.Cms.Core.Services
         /// </summary>
         bool HasContentNodes(int id);
 
+        /// <summary>
+        /// Gets all content types by int Id.
+        /// </summary>
         IEnumerable<TItem> GetAll(params int[] ids);
+
+        /// <summary>
+        /// Gets all content types by Guid Id
+        /// </summary>
         IEnumerable<TItem> GetAll(IEnumerable<Guid> ids);
 
+        /// <summary>
+        /// Gets all descendants for a content type, with bool to specify if you want it to return the parent
+        /// </summary>
         IEnumerable<TItem> GetDescendants(int id, bool andSelf); // parent-child axis
+
+        /// <summary>
+        /// Gets all the content types its composed of
+        /// </summary>
         IEnumerable<TItem> GetComposedOf(int id); // composition axis
 
+        /// <summary>
+        /// Gets all of the children of a content type by int Id
+        /// </summary>
         IEnumerable<TItem> GetChildren(int id);
+
+        /// <summary>
+        /// Gets all of the children of a content type by Guid id
+        /// </summary>
         IEnumerable<TItem> GetChildren(Guid id);
 
+        /// <summary>
+        /// Returns true, false depending if a content has children or not by int Id
+        /// </summary>
         bool HasChildren(int id);
+
+        /// <summary>
+        /// Returns true, false depending if a content has children or not by Guid Id
+        /// </summary>
         bool HasChildren(Guid id);
 
+        /// <summary>
+        /// Saves a content type
+        /// </summary>
         void Save(TItem item, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Saves multiple content types
+        /// </summary>
         void Save(IEnumerable<TItem> items, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Deletes a content type
+        /// </summary>
         void Delete(TItem item, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Deletes multiple content types
+        /// </summary>
         void Delete(IEnumerable<TItem> item, int userId = Constants.Security.SuperUserId);
 
-
+        /// <summary>
+        /// Attempt to validate the document type composition
+        /// </summary>
         Attempt<string[]> ValidateComposition(TItem compo);
 
         /// <summary>
         /// Given the path of a content item, this will return true if the content item exists underneath a list view content item
         /// </summary>
-        /// <param name="contentPath"></param>
-        /// <returns></returns>
         bool HasContainerInPath(string contentPath);
 
         /// <summary>
         /// Gets a value indicating whether there is a list view content item in the path.
         /// </summary>
-        /// <param name="ids"></param>
-        /// <returns></returns>
         bool HasContainerInPath(params int[] ids);
 
+        /// <summary>
+        /// Attempts to create a container
+        /// </summary>
         Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentContainerId, Guid key, string name, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Attempts to save a container
+        /// </summary>
         Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Gets the container by int Id
+        /// </summary>
         EntityContainer GetContainer(int containerId);
+
+        /// <summary>
+        /// Gets the containter by Guid id
+        /// </summary>
         EntityContainer GetContainer(Guid containerId);
+
+        /// <summary>
+        /// Gets multiple containers by int id
+        /// </summary>
         IEnumerable<EntityContainer> GetContainers(int[] containerIds);
+
+        /// <summary>
+        /// Gets multiple containers for a contentType
+        /// </summary>
         IEnumerable<EntityContainer> GetContainers(TItem contentType);
+
+        /// <summary>
+        /// Gets multiple containers by folderName and level
+        /// </summary>
         IEnumerable<EntityContainer> GetContainers(string folderName, int level);
+
+        /// <summary>
+        /// Attempts to delete a container
+        /// </summary>
         Attempt<OperationResult> DeleteContainer(int containerId, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Attempts to rename a container
+        /// </summary>
         Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = Constants.Security.SuperUserId);
 
+        /// <summary>
+        /// Attempts to move a content type
+        /// </summary>
         Attempt<OperationResult<MoveOperationStatusType>> Move(TItem moving, int containerId);
+
+        /// <summary>
+        /// Attempts to copy a content type
+        /// </summary>
         Attempt<OperationResult<MoveOperationStatusType, TItem>> Copy(TItem copying, int containerId);
+
+        /// <summary>
+        /// Copies a root content type
+        /// </summary>
         TItem Copy(TItem original, string alias, string name, int parentId = -1);
+
+        /// <summary>
+        /// Copies a child content type
+        /// </summary>
         TItem Copy(TItem original, string alias, string name, TItem parent);
     }
 }

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -13,18 +13,68 @@ namespace Umbraco.Cms.Core.Services
         /// <summary>
         /// Returns a dictionary of content type <see cref="Udi"/>s and the property type aliases that use a <see cref="IDataType"/>
         /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
         IReadOnlyDictionary<Udi, IEnumerable<string>> GetReferences(int id);
 
+        /// <summary>
+        /// Attempts to create container
+        /// </summary>
         Attempt<OperationResult<OperationResultType, EntityContainer>> CreateContainer(int parentId, Guid key, string name, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Attempts to save a container
+        /// </summary>
         Attempt<OperationResult> SaveContainer(EntityContainer container, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Gets a <see cref="EntityContainer"/> by its Id
+        /// </summary>
+        /// <param name="containerId">Id of the <see cref="EntityContainer"/></param>
+        /// <returns><see cref="EntityContainer"/></returns>
         EntityContainer GetContainer(int containerId);
+
+        /// <summary>
+        /// Gets a <see cref="EntityContainer"/> by its Id
+        /// </summary>
+        /// <param name="containerId">Id of the <see cref="EntityContainer"/></param>
+        /// <returns><see cref="EntityContainer"/></returns>
         EntityContainer GetContainer(Guid containerId);
+
+        /// <summary>
+        /// Gets multiple <see cref="EntityContainer"/> by their ids
+        /// </summary>
+        /// <param name="folderName">folderName the <see cref="EntityContainer"/> lives in</param>
+        /// <param name="level">level of the folder</param>
+        /// /// <returns>An enumerable list of <see cref="EntityContainer"/> objects</returns>
         IEnumerable<EntityContainer> GetContainers(string folderName, int level);
+
+        /// <summary>
+        /// Gets multiple <see cref="EntityContainer"/> by their dataTypes
+        /// </summary>
+        /// <param name="dataType"> The datatype in the<see cref="EntityContainer"/></param>
+        /// /// <returns>An enumerable list of <see cref="EntityContainer"/> objects</returns>
         IEnumerable<EntityContainer> GetContainers(IDataType dataType);
+
+        /// <summary>
+        /// Gets multiple <see cref="EntityContainer"/> by their ids
+        /// </summary>
+        /// <param name="containerIds">Id of the <see cref="EntityContainer"/></param>
+        /// <returns>An enumerable list of <see cref="EntityContainer"/> objects</returns>
         IEnumerable<EntityContainer> GetContainers(int[] containerIds);
+
+        /// <summary>
+        /// Deletes a <see cref="EntityContainer"/> by id
+        /// </summary>
+        /// <param name="containerId">Id of the <see cref="EntityContainer"/></param>
+        /// <param name="userId">Id of the user deleting the container</param>
+        /// <returns><see cref="OperationResult"/></returns>
         Attempt<OperationResult> DeleteContainer(int containerId, int userId = Constants.Security.SuperUserId);
+
+        /// <summary>
+        /// Attempts to rename a <see cref="EntityContainer"/> by id
+        /// </summary>
+        /// <param name="id">Id of the <see cref="EntityContainer"/></param>
+        /// <param name="name">New name of the <see cref="EntityContainer"/></param>
+        /// <returns><see cref="Attempt"/></returns>
         Attempt<OperationResult<OperationResultType, EntityContainer>> RenameContainer(int id, string name, int userId = Constants.Security.SuperUserId);
 
         /// <summary>
@@ -87,6 +137,12 @@ namespace Umbraco.Cms.Core.Services
         /// <returns>Collection of <see cref="IDataType"/> objects with a matching control id</returns>
         IEnumerable<IDataType> GetByEditorAlias(string propertyEditorAlias);
 
+        /// <summary>
+        /// Attempts to move a<see cref="IDataType"/>
+        /// </summary>
+        /// <param name="toMove"><see cref="IDataType"/> to move</param>
+        /// <param name="parentId">id of the <see cref="IDataType"/> parent</param>
+        /// <returns><see cref="Attempt"/></returns>
         Attempt<OperationResult<MoveOperationStatusType>> Move(IDataType toMove, int parentId);
     }
 }

--- a/src/Umbraco.Core/Services/IService.cs
+++ b/src/Umbraco.Core/Services/IService.cs
@@ -5,6 +5,5 @@
     /// </summary>
     public interface IService
     {
-
     }
 }


### PR DESCRIPTION
Fixes alot of build warnings

# Notes
- Added a lot of missing XML documentation
- Renamed some variable and used explicit Types instead of `var`

# How to test
- Not really a lot to test here, just that fixing variable names didn't break anything?
- Review that the comments are correctly displayed