### PR TITLE
Making UmbracoTreeSearcherFields virtual for easier overriding

### DIFF
--- a/src/Umbraco.Web/Search/UmbracoTreeSearcherFields.cs
+++ b/src/Umbraco.Web/Search/UmbracoTreeSearcherFields.cs
@@ -24,28 +24,28 @@ namespace Umbraco.Web.Search
         }
 
         /// <inheritdoc />
-        public IEnumerable<string> GetBackOfficeFields() => _backOfficeFields;
+        public virtual IEnumerable<string> GetBackOfficeFields() => _backOfficeFields;
 
         /// <inheritdoc />
-        public IEnumerable<string> GetBackOfficeMembersFields() => _backOfficeMembersFields;
+        public virtual IEnumerable<string> GetBackOfficeMembersFields() => _backOfficeMembersFields;
 
         /// <inheritdoc />
-        public IEnumerable<string> GetBackOfficeMediaFields() => _backOfficeMediaFields;
+        public virtual IEnumerable<string> GetBackOfficeMediaFields() => _backOfficeMediaFields;
 
         /// <inheritdoc />
-        public IEnumerable<string> GetBackOfficeDocumentFields() => Enumerable.Empty<string>();
+        public virtual IEnumerable<string> GetBackOfficeDocumentFields() => Enumerable.Empty<string>();
 
         /// <inheritdoc />
-        public ISet<string> GetBackOfficeFieldsToLoad() => _backOfficeFieldsToLoad;
+        public virtual ISet<string> GetBackOfficeFieldsToLoad() => _backOfficeFieldsToLoad;
 
         /// <inheritdoc />
-        public ISet<string> GetBackOfficeMembersFieldsToLoad() => _backOfficeMembersFieldsToLoad;
+        public virtual ISet<string> GetBackOfficeMembersFieldsToLoad() => _backOfficeMembersFieldsToLoad;
 
         /// <inheritdoc />
-        public ISet<string> GetBackOfficeMediaFieldsToLoad() => _backOfficeMediaFieldsToLoad;
+        public virtual ISet<string> GetBackOfficeMediaFieldsToLoad() => _backOfficeMediaFieldsToLoad;
 
         /// <inheritdoc />
-        public ISet<string> GetBackOfficeDocumentFieldsToLoad()
+        public virtual ISet<string> GetBackOfficeDocumentFieldsToLoad()
         {
             var fields = _backOfficeDocumentFieldsToLoad;
 


### PR DESCRIPTION
Following the [docs](https://our.umbraco.com/documentation/extending/Backoffice-Search/) for extending backoffice search, it recommends extending the defaults in the `UmbracoTreeSearcherFields` class.

As this class isn't abstract, and the methods aren't virtual, you have to extend with the `new` keyword (this is missing from the docs). Without the `new` keyword you get a warning in Visual Studio.

I have made the methods virtual, this way people can override it to get rid of the warnings and intelisense will suggest these methods too.

This also applies to V9, so hopefully this can be merged up there too!