### PR TITLE
V9: Fixes issue where PublishedContentQuery executes skip twice. 

### DIFF
--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -295,7 +295,7 @@ namespace Umbraco.Cms.Infrastructure
             totalRecords = results.TotalItemCount;
 
             return new CultureContextualSearchResults(
-                results.Skip(skip).ToPublishedSearchResults(_publishedSnapshot.Content), _variationContextAccessor,
+                results.ToPublishedSearchResults(_publishedSnapshot.Content), _variationContextAccessor,
                 culture);
         }
 
@@ -324,7 +324,7 @@ namespace Umbraco.Cms.Infrastructure
 
             totalRecords = results.TotalItemCount;
 
-            return results.Skip(skip).ToPublishedSearchResults(_publishedSnapshot);
+            return results.ToPublishedSearchResults(_publishedSnapshot);
         }
 
         /// <summary>


### PR DESCRIPTION
 Fixes issue where PublishedContentQuery executes skip twice.
 So if the query returns 4 results, and you have skip =1 take=5, you only had 2 results. This is fixed in this commit.

This is an issue compared to v8, because Examine now handles skiptake directly, in a few lines above these changes.