### PR TITLE
Add security policy to repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,9 @@ The people [listed here](https://umbraco.com/about-us/trust-center/security-and-
 
 | Major Version | Bugs and Regression Fixes  | Security Patches  |
 | ------------- | -------------------------- |------------------ |
-| 9             | :white_check_mark:         |:white_check_mark:|
-| 8             | :white_check_mark:         |:white_check_mark:|
-| 7 (>7.15)     | :x:                        |:white_check_mark:|
-| 7 (< 7.15)    | :x:                        |:x:|
+|9              | :white_check_mark:         |:white_check_mark:|
+|8              | :white_check_mark:         |:white_check_mark:|
+|7              | :x:                        |:white_check_mark:|
+|< 7            | :x:                        |:x:|
 
 Detailed information regarding supported versions can be found [here](https://umbraco.com/products/knowledge-center/long-term-support-and-end-of-life/). 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+For responsible disclosure of a possible security vulnerability in Umbraco CMS, Umbraco Cloud, Umbraco Forms or Courier, we'd like you to follow these guidelines.
+
+This way we get all the information we need in order to take appropriate and timely action. Thus, we ask you to report it directly to us thus, not to report the vulnerability in any public forums (like GitHub) etc. to ensure that it does not get exploited in the wild. 
+
+## Reporting a Vulnerability
+
+- Reach out to us directly at security@umbraco.com 
+- Make sure to provide us with as much and thorough information as you can
+- If necessary, you may PGP encrypt your email. Our public key is 0x772416F630362CA2 (also to be found on https://keyserver.pgp.com/ and https://keybase.io/umbraco) 
+
+
+## What we expect from you
+In order for us to fix and handle the vulnerability appropriately, we need your help. We need you to:
+
+- Not tell anyone about the problem until we have fixed it. You will also not submit it as a CVE during this time.
+
+- Make sure to verify your claim of a security vulnerability by sharing a proof of concept
+- Reporting the results of an automated scan is usually not helpful. Please send us proof on how you think an attacker could exploit each of the scan results. 
+
+## What'll happen next?
+We will acknowledge receipt of your vulnerability report ASAP, usually within 1 business day. If we take the security issue further, we'll send you regular updates about our progress. As an acknowledgement of your contribution, we offer to publicly acknowledge your disclosure. 
+
+If your security vulnerability gets merged, we'll communicate about it along with a fix in a public security advisory on the [Umbraco blog](https://umbraco.com/blog/).
+
+## List of security contributors
+We'd like to thank the contributors for their amazing efforts in making Umbraco safer, and we've therefore gathered a dedicated list of Umbraco security contributors.
+
+The people [listed here](https://umbraco.com/about-us/trust-center/security-and-umbraco/how-to-report-a-vulnerability-in-umbraco/list-of-security-contributors/), are all the first who provided us with actionable security information which helped us fix a particular vulnerability. 
+
+## Supported Versions
+
+| Major Version | Bugs and Regression Fixes  | Security Patches  |
+| ------------- | -------------------------- |------------------ |
+| 9             | :white_check_mark:         |:white_check_mark:|
+| 8             | :white_check_mark:         |:white_check_mark:|
+| 7 (>7.15)     | :x:                        |:white_check_mark:|
+| 7 (< 7.15)    | :x:                        |:x:|
+
+Detailed information regarding supported versions can be found [here](https://umbraco.com/products/knowledge-center/long-term-support-and-end-of-life/). 

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -590,32 +590,41 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                 var root = _hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads);
                 var tempPath = Path.Combine(root,fileName);
-
-                using (var stream = System.IO.File.Create(tempPath))
+                if (Path.GetFullPath(tempPath).StartsWith(Path.GetFullPath(root)))
                 {
-                    formFile.CopyToAsync(stream).GetAwaiter().GetResult();
-                }
-
-                if (ext.InvariantEquals("udt"))
-                {
-                    model.TempFileName = Path.Combine(root, fileName);
-
-                    var xd = new XmlDocument
+                    using (var stream = System.IO.File.Create(tempPath))
                     {
-                        XmlResolver = null
-                    };
-                    xd.Load(model.TempFileName);
+                        formFile.CopyToAsync(stream).GetAwaiter().GetResult();
+                    }
 
-                    model.Alias = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Alias")?.FirstChild.Value;
-                    model.Name = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Name")?.FirstChild.Value;
-                }
-                else
+                    if (ext.InvariantEquals("udt"))
+                    {
+                        model.TempFileName = Path.Combine(root, fileName);
+
+                        var xd = new XmlDocument
+                        {
+                            XmlResolver = null
+                        };
+                        xd.Load(model.TempFileName);
+
+                        model.Alias = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Alias")?.FirstChild.Value;
+                        model.Name = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Name")?.FirstChild.Value;
+                    }
+                    else
+                    {
+                        model.Notifications.Add(new BackOfficeNotification(
+                            _localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                            _localizedTextService.Localize("media", "disallowedFileType"),
+                            NotificationStyle.Warning));
+                    }
+                }else
                 {
                     model.Notifications.Add(new BackOfficeNotification(
-                        _localizedTextService.Localize("speechBubbles","operationFailedHeader"),
-                        _localizedTextService.Localize("media","disallowedFileType"),
+                        _localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                        _localizedTextService.Localize("media", "invalidFileName"),
                         NotificationStyle.Warning));
                 }
+
             }
 
 

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -304,6 +304,7 @@
     <key alias="clickToUpload">Click to upload</key>
     <key alias="orClickHereToUpload">or click here to choose files</key>
     <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
+    <key alias="invalidFileName">Cannot upload this file, it does not have a valid file name</key>
     <key alias="maxFileSize">Max file size is</key>
     <key alias="mediaRoot">Media root</key>
     <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -308,6 +308,7 @@
     <key alias="clickToUpload">Click to upload</key>
     <key alias="orClickHereToUpload">or click here to choose files</key>
     <key alias="disallowedFileType">Cannot upload this file, it does not have an approved file type</key>
+    <key alias="invalidFileName">Cannot upload this file, it does not have a valid file name</key>
     <key alias="maxFileSize">Max file size is</key>
     <key alias="mediaRoot">Media root</key>
     <key alias="moveToSameFolderFailed">Parent and destination folders cannot be the same</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Adding a security policy file to the repository based on the guidelines described in the [Umbraco Trust Center](https://umbraco.com/about-us/trust-center/security-and-umbraco/how-to-report-a-vulnerability-in-umbraco/). 

The goal of adding this file is to make our guidelines more easily accessible and read by people before reporting a vulnerability via the wrong channels (e.g. GitHub issues or Our).


<!-- Thanks for contributing to Umbraco CMS! -->
