### PR TITLE
API Documentation: Added extra selector for styling <code> elements in the content

### DIFF
--- a/src/Umbraco.Web.UI.Docs/umb-docs.css
+++ b/src/Umbraco.Web.UI.Docs/umb-docs.css
@@ -34,7 +34,8 @@ a:hover {
     color: rgba(0, 0, 0, .8);
 }
 
-.content p code {
+.content p code,
+.content li code {
     font-size: 85%;
     font-family: inherit;
     background-color: #f7f7f9;


### PR DESCRIPTION
Tiny, tiny PR 😎 

For another PR I'm working on for the API documentation, I noticed that only `<code>` elements inside normal `<p>` text blocks has any styling, but not when inside a `<li>`. This PR fixes that.

The styling and use of class names is a bit weird for the API documentation in general, so I'm not sure the CSS selector can be made less specific. For instance, there is also `<code>` elements within the `<h1>` elements of the different pages 😱 

### Before

![image](https://user-images.githubusercontent.com/3634580/139531450-9a4522de-92bf-467c-b8ec-854a627c1b7e.png)

### After

![image](https://user-images.githubusercontent.com/3634580/139531438-5fcc1703-cc83-4d52-ad7b-7a4481bf9202.png)
