### PR TITLE
Updates to Media Selection list view to better match Grid View

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -225,6 +225,17 @@
 .umb-media-grid__list-item.selected, .umb-media-grid__list-item.selected:hover, .umb-media-grid__list-item.selected:focus {
     border: 2px solid #f5c1bc !important;
 }
+.umb-media-grid__list-item-name:hover {
+    text-decoration:underline;
+} 
+.umb-media-grid__list-item.-filtered:not(.-folder) {
+  cursor: not-allowed;
+
+  * {
+    pointer-events: none;
+  }
+}
+
 
 .umb-media-grid__list-view .umb-table-cell.umb-table__name {
     flex: 1 1 25%;

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-media-grid.html
@@ -79,19 +79,22 @@
 
                     </div>
                 </div>
-                <div class="umb-table-body">
-                    <div class="umb-table-row umb-media-grid__list-item -selectable" ng-click="clickItem(item, $event, $index)" ng-repeat="item in items | filter:filterBy | orderBy:sortBy:sortReverse" ng-class="{'-selected': item.selected}">
+                <div class="umb-table-body"> 
+                    <div class="umb-table-row umb-media-grid__list-item -selectable"
+                         ng-click="clickItem(item, $event, $index)"
+                         ng-repeat="item in items | filter:filterBy | orderBy:sortBy:sortReverse"
+                         ng-class="{'-selected': item.selected, '-folder': item.isFolder, '-filtered': item.filtered}">
                         <div class="umb-table-cell">
                             <umb-icon icon="icon-check" class="umb-table-body__icon umb-table-body__checkicon" ng-if="item.selected"></umb-icon>
                             <umb-icon icon="{{item.thumbnail ? 'icon-picture' : item.icon}}" class="umb-table-body__icon" ng-if="!item.selected"></umb-icon>
                         </div>
                         <div class="umb-table-cell umb-table__name">
-                            <umb-icon icon="icon-navigation-right"
-                                      ng-show="item.isFolder"
-                                      ng-class="{'-locked': item.selected || !item.file || !item.thumbnail}"
-                                      ng-click="clickItemName(item, $event, $index)">
-                            </umb-icon>
-                            <span data-src="{{item.value.src}}" class="item-name">{{item.name}}</span>
+                            <div class="umb-media-grid__list-item-name"
+                                 ng-class="{'-locked': item.selected || !item.file || !item.thumbnail}"
+                                 ng-click="clickItemName(item, $event, $index)">
+                                <umb-icon icon="icon-navigation-right" ng-show="item.isFolder"></umb-icon>
+                                <span data-src="{{item.value.src}}" class="item-name">{{item.name}}</span>
+                            </div>
                         </div>
                         <div class="umb-table-cell">
                             <span class="muted small" style="font-size:0.8em">{{item.updateDate | date:'medium'}}</span>


### PR DESCRIPTION
in media selection, made folder name clickable to select into a folder.  Added not allowed cursor on not allowed items.

### Prerequisites

- [ X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

Some updates to the media selection list view to better align it to the grid view option: 
*  Update the folders so whole name is selectable to drill into the folder, instead of just the arrow (which is hard to find).  Also made the text underline on hover to signal that it does something different.  

![media-list-selctions](https://user-images.githubusercontent.com/1120701/139591878-256acd4e-3bfa-4f40-b90f-914784a93248.gif)

* Updated the pointer to not allowed on items that are not allowed to be selected, in the same way that the grid view does.  

![media-no-allowed](https://user-images.githubusercontent.com/1120701/139591771-7eaecfd4-f59d-4f0f-9e49-db775a79bac4.gif)

<!-- 

    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
