### PR TITLE
Hide localization key while loading

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/localization/localize.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/localization/localize.directive.js
@@ -1,5 +1,4 @@
-angular.module("umbraco.directives")
-
+angular.module('umbraco.directives')
     /**
     * @ngdoc directive
     * @name umbraco.directives.directive:localize
@@ -8,12 +7,12 @@ angular.module("umbraco.directives")
     * @description
     * <div>
     *   <strong>Component</strong><br />
-    *   Localize a specific token to put into the HTML as an item
+    *   Localize a specific token to put into the HTML as an item.
     * </div>
     * <div>
     *   <strong>Attribute</strong><br />
-    *   Add a HTML attribute to an element containing the HTML attribute name you wish to localise
-    *   Using the format of '@section_key' or 'section_key'
+    *   Add an HTML attribute to an element containing the HTML attribute name you wish to localize,
+    *   using the format of '@section_key' or 'section_key'.
     * </div>
     * ##Usage
     * <pre>
@@ -36,12 +35,11 @@ angular.module("umbraco.directives")
                 watchTokens: '@'
             },
             replace: true,
-
             link: function (scope, element, attrs) {
                 var key = scope.key;
-                scope.text = "";
+                scope.text = '';
 
-                // A render function to be able to update tokens as values update.
+                // A render function to be able to update tokens as values update
                 function render() {
                     element.html(localizationService.tokenReplace(scope.text, scope.tokens || null));
                 }
@@ -50,26 +48,28 @@ angular.module("umbraco.directives")
                     scope.text = value;
                     render();
                 });
+
                 if (scope.watchTokens === 'true') {
                     scope.$watch("tokens", render, true);
                 }
             }
         };
     })
-
     .directive('localize', function ($log, localizationService) {
         return {
             restrict: 'A',
             link: function (scope, element, attrs) {
-                //Support one or more attribute properties to update
+                // Support one or more attribute properties to update
                 var keys = attrs.localize.split(',');
 
                 Utilities.forEach(keys, (value, key) => {
                     var attr = element.attr(value);
-
                     if (attr) {
+                        // Localizing is done async, so make sure the key isn't visible
+                        element.removeAttr(value);
+                        
                         if (attr[0] === '@') {
-                            //If the translation key starts with @ then remove it
+                            // If the translation key starts with @ then remove it
                             attr = attr.substring(1);
                         }
 
@@ -82,5 +82,4 @@ angular.module("umbraco.directives")
                 });
             }
         };
-
     });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed that when the `localize` AngularJS directive was used on attributes (e.g. `<input type="text" localize="placeholder" placeholder="@section_key" />`), the localization key was visible while it was still loading the translations. Although this is probably not visible for most users, if you have a slower connection (or change your language), you might see it change from the key to the actual translated value, for example:

![Localize key visible](https://user-images.githubusercontent.com/1051287/139592786-5f58795d-8b14-4f57-aa61-200e118cb4bb.png)

![Localized value](https://user-images.githubusercontent.com/1051287/139592820-e5784b84-f7e1-4ac1-ab05-2128e33f6611.png)

To get rid of it, this PR removes the attribute before loading the translation, so you'll only see the translated value. To test, you can disable the browser cache and throttle the connection speed:

![Disabled cache and throttled connection](https://user-images.githubusercontent.com/1051287/139597925-0d494fb8-88da-48be-b130-506c52629bde.png)