### PR TITLE
v9: fix helppanel tests locally

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/HelpPanel/systemInformation.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/HelpPanel/systemInformation.ts
@@ -32,10 +32,7 @@ context('System Information', () => {
         cy.get('[alias="editUser"]').click();
         cy.get('[name="culture"]').select('string:da-DK', { force: true});
         cy.umbracoButtonByLabelKey('buttons_save').click({force: true});
-        //Refresh site to display new language
-        cy.reload();
-        cy.get('.umb-tour-step', { timeout: 60000 }).should('be.visible'); // We now due to the api calls this will be shown, but slow computers can take a while
-        cy.get('.umb-tour-step__close').click();
+
         openSystemInformation();
         //Assert
         cy.contains('Current Culture').parent().should('contain', 'da-DK');


### PR DESCRIPTION
# Notes
- Removed tour steps closing - this would only pop up of you ran an unattended install

# How to test
- Run a clean umbraco installation
- Click "don't show again" to tours
- Run the cypress tests