### PR TITLE
change LogDto Comment and Parameters to nvarcharmax

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/UmbracoPlan.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Migrations.Upgrade.V_8_9_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_10_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_15_0;
 using Umbraco.Core.Migrations.Upgrade.V_8_17_0;
+using Umbraco.Core.Migrations.Upgrade.V_8_18_0;
 
 namespace Umbraco.Core.Migrations.Upgrade
 {
@@ -209,6 +210,9 @@ namespace Umbraco.Core.Migrations.Upgrade
 
             // to 8.17.0
             To<AddPropertyTypeGroupColumns>("{153865E9-7332-4C2A-9F9D-F20AEE078EC7}");
+
+            // to 8.18.0
+            To<UpdateUmbracoLogParameters>("{6978CF68-1716-484E-B900-C0CF2293A8C8}");
 
             //FINAL
         }

--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_18_0/UpdateUmbracoLogParameters.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_18_0/UpdateUmbracoLogParameters.cs
@@ -1,0 +1,18 @@
+﻿
+using Umbraco.Core.Persistence.Dtos;
+
+namespace Umbraco.Core.Migrations.Upgrade.V_8_18_0
+{
+    public class UpdateUmbracoLogParameters : MigrationBase
+    {
+        public UpdateUmbracoLogParameters(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            AlterColumn<LogDto>(Constants.DatabaseSchema.Tables.Log, "logComment");
+            AlterColumn<LogDto>(Constants.DatabaseSchema.Tables.Log, "parameters");
+        }
+    }
+}

--- a/src/Umbraco.Core/Persistence/Dtos/LogDto.cs
+++ b/src/Umbraco.Core/Persistence/Dtos/LogDto.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Core.Persistence.Dtos
 
         [Column("logComment")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [Length(4000)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         public string Comment { get; set; }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Umbraco.Core.Persistence.Dtos
         /// </summary>
         [Column("parameters")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [Length(500)]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         public string Parameters { get; set; }
     }
 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Migrations\Upgrade\V_8_15_0\UpgradedIncludeIndexes.cs" />
     <Compile Include="Migrations\Upgrade\V_8_10_0\AddPropertyTypeLabelOnTopColumn.cs" />
     <Compile Include="Migrations\Upgrade\V_8_17_0\AddPropertyTypeGroupColumns.cs" />
+    <Compile Include="Migrations\Upgrade\V_8_18_0\UpdateUmbracoLogParameters.cs" />
     <Compile Include="Migrations\Upgrade\V_8_9_0\ExternalLoginTableUserData.cs" />
     <Compile Include="Models\Blocks\BlockEditorDataConverter.cs" />
     <Compile Include="Models\Blocks\BlockEditorData.cs" />


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This fixes issue https://github.com/umbraco/Umbraco-CMS/issues/9458

### Description

This pull request is a result of a Discord Hack session earlier today with Seb, Warren and some other community folk.

To replicate the issue you would need to have say 40+ languages configured in your back office, and then try to save or publish all variants *in one go*.  This causes a SQL error, which therefore prevents the node being saved/published.  This is because Umbraco is trying to write a record to the `UmbracoLogs` table with a comma delimited list of the affected variants in the `parameters` column, and that column has a max length of only 500 chars.

We checked where the 'parameters' column is used. Turns out it's displayed on the 'info' tab as indicated in this screenshot:

![image](https://user-images.githubusercontent.com/4716542/140396247-32d16908-3232-49ec-9733-4d0d80f527c2.png)

We discussed truncating the string to 500 characters before saving but this would mean that there was missing information on the info tab, and it is important to know who published which variant.

We discussed that having such a long list of language names isn't ideal, especially as the language list is hard-coded to the English name. But those enhancements would need proper discussion, so we agreed to keep the scope of this PR to be just fixing the issue that is preventing people from saving content (which does actually happen when you use a tool such as uSync or Translation Manager to create this many variants in one go!).

People who have hit this problem already may have increased the size of the column on the database themselves, so we set the string to be `nvarchar(max)` as this wouldn't cause those people any truncation issues during an upgrade.  

We also thought it was a good idea to change the `logComment` column at the same time to be nvarchar(max) as its existing length of 4000 felt rather arbitrary.

Once the database column has been increased in size you are then able to save/publish 40+ variants in one go. This was shown on the Discord session earlier today.

As this commit contains database schema changes, this PR has been tested on:

- A fresh install using SQL db
- An upgrade of existing instance using SQL db
- A fresh install using SQL CE db
- An upgrade of existing instance using SQL CE db

In all tests above the database gets created / updated correctly.  

Oh and @nul800sebastiaan said to add the migration to a folder called 'V_8_18_0', so I did 😉