### PR TITLE
Allow .map files as default browsable file extensions from the App_Pl…

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
@@ -11,8 +11,6 @@ namespace Umbraco.Cms.Core.Configuration.Models
     [UmbracoOptions(Constants.Configuration.ConfigPlugins)]
     public class UmbracoPluginSettings
     {
-        
-
         /// <summary>
         /// Gets or sets the allowed file extensions (including the period ".") that should be accessible from the browser.
         /// </summary>
@@ -25,7 +23,8 @@ namespace Umbraco.Cms.Core.Configuration.Models
             ".jpg", ".jpeg", ".gif", ".png", ".svg", // images
             ".eot", ".ttf", ".woff", // fonts
             ".xml", ".json", ".config", // configurations
-            ".lic" // license
+            ".lic", // license
+            ".map" // js map files
         });
     }
 }


### PR DESCRIPTION
Allow `.map` files as default browsable file extensions from the App_Plugins static file handler.

This will prevent errors like this:
![image](https://user-images.githubusercontent.com/1561480/140411247-8be62ae7-289a-4fdb-89d6-c0141e18440a.png)
