### PR TITLE
v9: Downgrade cypress to 8.4.1

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -178,9 +178,9 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -367,6 +367,12 @@
         "string-width": "^4.2.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -454,9 +460,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
-      "integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.4.1.tgz",
+      "integrity": "sha512-itJXq0Vx3sXCUrDyBi2IUrkxVu/gTTp1VhjB5tzGgkeCR8Ae+/T8WV63rsZ7fS8Tpq7LPPXiyoM/sEdOX7cR6A==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.6",
@@ -493,7 +499,6 @@
         "minimist": "^1.2.5",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
-        "proxy-from-env": "1.0.0",
         "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
@@ -1057,16 +1062,17 @@
       "dev": true
     },
     "listr2": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.1.tgz",
-      "integrity": "sha512-pk4YBDA2cxtpM8iLHbz6oEsfZieJKHf6Pt19NlKaHZZVpqHyVs/Wqr7RfBBCeAFCJchGO7WQHVkUPZTvJMHk8w==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.3.tgz",
+      "integrity": "sha512-VqAgN+XVfyaEjSaFewGPcDs5/3hBbWVaX1VgWv2f52MF7US45JuARlArULctiB44IIcEk3JF7GtoFCLqEdeuPA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
+        "clone": "^2.1.2",
         "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
-        "rxjs": "^6.6.7",
+        "rxjs": "^7.4.0",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       }
@@ -1322,12 +1328,6 @@
         }
       }
     },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
-      "dev": true
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -1433,12 +1433,12 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
       }
     },
     "safe-buffer": {
@@ -1590,9 +1590,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
       "dev": true
     },
     "tunnel-agent": {
@@ -1622,9 +1622,9 @@
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
     },
     "umbraco-cypress-testhelpers": {
-      "version": "1.0.0-beta-61",
-      "resolved": "https://registry.npmjs.org/umbraco-cypress-testhelpers/-/umbraco-cypress-testhelpers-1.0.0-beta-61.tgz",
-      "integrity": "sha512-WhOQ5foSWUdO3Vb3vGu6VAEWhncY13QGL323hPTMeVR3dqQd2uUExp7ppOBKYYgWHwjCvJbo0OMGGZMJyfoAPA==",
+      "version": "1.0.0-beta-62",
+      "resolved": "https://registry.npmjs.org/umbraco-cypress-testhelpers/-/umbraco-cypress-testhelpers-1.0.0-beta-62.tgz",
+      "integrity": "sha512-fVjXBdotb2TZrhaWq/HtD1cy+7scHcldJL+HRHeyYtwvUp368lUiAMrx0y4TOZTwBOJ898yyl8yTEPASfAX2pQ==",
       "dev": true,
       "requires": {
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -9,11 +9,11 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.2",
-    "cypress": "^8.7.0",
+    "cypress": "8.4.1",
     "del": "^6.0.0",
     "ncp": "^2.0.0",
     "prompt": "^1.2.0",
-    "umbraco-cypress-testhelpers": "^1.0.0-beta-61"
+    "umbraco-cypress-testhelpers": "^1.0.0-beta-62"
   },
   "dependencies": {
     "typescript": "^3.9.2"


### PR DESCRIPTION
Fixes the build pipeline issues where tests run forever, this is a quirk with cypress 8.7.0

# Notes
- Downgraded cypress to 8.4.1

# How to test
- The acceptance test pipeline should actually run this time and not be timed out after 60 minutes