### PR TITLE
Move member properties to Member Content App

### DIFF
--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -242,9 +242,14 @@ namespace Umbraco.Core
                 public const string FailedPasswordAttemptsLabel = "Failed Password Attempts";
 
                 /// <summary>
-                /// Group name to put the membership properties on
+                /// The standard properties group alias for membership properties.
                 /// </summary>
-                internal const string StandardPropertiesGroupName = "Membership";
+                public const string StandardPropertiesGroupAlias = "membership";
+
+                /// <summary>
+                /// The standard properties group name for membership properties.
+                /// </summary>
+                public const string StandardPropertiesGroupName = "Membership";
 
                 public static Dictionary<string, PropertyType> GetStandardPropertyTypeStubs()
                 {

--- a/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Core/Migrations/Install/DatabaseDataCreator.cs
@@ -230,7 +230,7 @@ namespace Umbraco.Core.Migrations.Install
             _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false, new PropertyTypeGroupDto { Id = 54, UniqueId = new Guid(Constants.PropertyTypeGroups.Article), ContentTypeNodeId = 1036, Text = "Article", Alias = "article", SortOrder = 1 });
             _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false, new PropertyTypeGroupDto { Id = 55, UniqueId = new Guid(Constants.PropertyTypeGroups.VectorGraphics), ContentTypeNodeId = 1037, Text = "Vector Graphics", Alias = "vectorGraphics", SortOrder = 1 });
             //membership property group
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false, new PropertyTypeGroupDto { Id = 11, UniqueId = new Guid(Constants.PropertyTypeGroups.Membership), ContentTypeNodeId = 1044, Text = "Membership", Alias = "membership", SortOrder = 1 });
+            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false, new PropertyTypeGroupDto { Id = 11, UniqueId = new Guid(Constants.PropertyTypeGroups.Membership), ContentTypeNodeId = 1044, Text = Constants.Conventions.Member.StandardPropertiesGroupName, Alias = Constants.Conventions.Member.StandardPropertiesGroupAlias, SortOrder = 1 });
         }
 
         private void CreatePropertyTypeData()

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -250,12 +250,12 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 if (contentType is MemberType memberType)
                 {
                     // ensure that the group exists (ok if it already exists)
-                    memberType.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupName);
+                    memberType.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
 
                     // ensure that property types exist (ok if they already exist)
                     foreach (var (alias, propertyType) in builtinProperties)
                     {
-                        var added = memberType.AddPropertyType(propertyType, Constants.Conventions.Member.StandardPropertiesGroupName);
+                        var added = memberType.AddPropertyType(propertyType, Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
 
                         if (added)
                         {

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -249,14 +249,10 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
                 // ensure builtin properties
                 if (contentType is MemberType memberType)
                 {
-                    // ensure that the group exists (ok if it already exists)
-                    memberType.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
-
                     // ensure that property types exist (ok if they already exist)
                     foreach (var (alias, propertyType) in builtinProperties)
                     {
                         var added = memberType.AddPropertyType(propertyType, Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
-
                         if (added)
                         {
                             var access = new MemberTypePropertyProfileAccess(false, false, false);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -142,11 +142,11 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
 
             //By Convention we add 9 standard PropertyTypes to an Umbraco MemberType
-            entity.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupName);
+            entity.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
             var standardPropertyTypes = Constants.Conventions.Member.GetStandardPropertyTypeStubs();
             foreach (var standardPropertyType in standardPropertyTypes)
             {
-                entity.AddPropertyType(standardPropertyType.Value, Constants.Conventions.Member.StandardPropertiesGroupName);
+                entity.AddPropertyType(standardPropertyType.Value, Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
             }
 
             EnsureExplicitDataTypeForBuiltInProperties(entity);

--- a/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -142,7 +142,6 @@ namespace Umbraco.Core.Persistence.Repositories.Implement
             }
 
             //By Convention we add 9 standard PropertyTypes to an Umbraco MemberType
-            entity.AddPropertyGroup(Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
             var standardPropertyTypes = Constants.Conventions.Member.GetStandardPropertyTypeStubs();
             foreach (var standardPropertyType in standardPropertyTypes)
             {

--- a/src/Umbraco.Core/Services/Implement/MemberService.cs
+++ b/src/Umbraco.Core/Services/Implement/MemberService.cs
@@ -1201,8 +1201,10 @@ namespace Umbraco.Core.Services.Implement
             var memType = new MemberType(-1);
             var propGroup = new PropertyGroup(MemberType.SupportsPublishingConst)
             {
-                Name = "Membership",
-                Id = --identity
+                Alias = Constants.Conventions.Member.StandardPropertiesGroupAlias,
+                Name = Constants.Conventions.Member.StandardPropertiesGroupName,
+                Id = --identity,
+                Key = identity.ToGuid()
             };
             propGroup.PropertyTypes.Add(new PropertyType(Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext, Constants.Conventions.Member.Comments)
             {

--- a/src/Umbraco.Tests/Persistence/Repositories/MemberTypeRepositoryTest.cs
+++ b/src/Umbraco.Tests/Persistence/Repositories/MemberTypeRepositoryTest.cs
@@ -326,7 +326,7 @@ namespace Umbraco.Tests.Persistence.Repositories
                 Assert.AreEqual(3, memberType.PropertyTypes.Count());
 
                 // add one stub property, others are still missing
-                memberType.AddPropertyType(stubs.First().Value, Constants.Conventions.Member.StandardPropertiesGroupName);
+                memberType.AddPropertyType(stubs.First().Value, Constants.Conventions.Member.StandardPropertiesGroupAlias, Constants.Conventions.Member.StandardPropertiesGroupName);
 
                 // saving *new* member type adds the (missing) stub properties
                 repository.Save(memberType);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -582,7 +582,7 @@
             };
 
             scope.canRemoveTab = (tab) => {
-                return tab.inherited !== true;
+                return scope.canRemoveGroup(tab) && _.every(scope.model.groups.filter(group => group.parentAlias === tab.alias), group => scope.canRemoveGroup(group));
             };
 
             scope.setTabOverflowState = (overflowLeft, overflowRight) => {

--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -624,24 +624,29 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                     var origProp = allOrigProps[k];
                     var alias = origProp.alias;
                     var newProp = getNewProp(alias, allNewProps);
-                    if (newProp && !_.isEqual(origProp.value, newProp.value)) {
+                    if (newProp) {
+                        // Always update readonly state
+                        origProp.readonly = newProp.readonly;
 
-                        //they have changed so set the origContent prop to the new one
-                        var origVal = origProp.value;
+                        // Check whether the value has changed and update accordingly
+                        if (!_.isEqual(origProp.value, newProp.value)) {
 
-                        origProp.value = newProp.value;
+                            //they have changed so set the origContent prop to the new one
+                            var origVal = origProp.value;
 
-                        //instead of having a property editor $watch their expression to check if it has
-                        // been updated, instead we'll check for the existence of a special method on their model
-                        // and just call it.
-                        if (Utilities.isFunction(origProp.onValueChanged)) {
-                            //send the newVal + oldVal
-                            origProp.onValueChanged(origProp.value, origVal);
+                            origProp.value = newProp.value;
+
+                            //instead of having a property editor $watch their expression to check if it has
+                            // been updated, instead we'll check for the existence of a special method on their model
+                            // and just call it.
+                            if (Utilities.isFunction(origProp.onValueChanged)) {
+                                //send the newVal + oldVal
+                                origProp.onValueChanged(origProp.value, origVal);
+                            }
+
+                            changed.push(origProp);
                         }
-
-                        changed.push(origProp);
                     }
-
                 }
             }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -269,51 +269,37 @@
 
             /** formats the display model used to display the member to the model used to save the member */
             formatMemberPostData: function (displayModel, action) {
-                //this is basically the same as for media but we need to explicitly add the username,email, password to the save model
+                //this is basically the same as for media but we need to explicitly add the username, email, password to the save model
 
                 var saveModel = this.formatMediaPostData(displayModel, action);
 
                 saveModel.key = displayModel.key;
 
-                var genericTab = _.find(displayModel.tabs, function (item) {
-                    return item.id === 0;
-                });
-
-                //map the member login, email, password and groups
-                var propLogin = _.find(genericTab.properties, function (item) {
-                    return item.alias === "_umb_login";
-                });
-                var propEmail = _.find(genericTab.properties, function (item) {
-                    return item.alias === "_umb_email";
-                });
-                var propPass = _.find(genericTab.properties, function (item) {
-                    return item.alias === "_umb_password";
-                });
-                var propGroups = _.find(genericTab.properties, function (item) {
-                    return item.alias === "_umb_membergroup";
-                });
-                saveModel.email = propEmail.value.trim();
-                saveModel.username = propLogin.value.trim();
-
-                saveModel.password = this.formatChangePasswordModel(propPass.value);
-
-                var selectedGroups = [];
-                for (var n in propGroups.value) {
-                    if (propGroups.value[n] === true) {
-                        selectedGroups.push(n);
+                // Map membership properties
+                _.each(displayModel.membershipProperties, prop => {
+                    switch (prop.alias) {
+                        case '_umb_login':
+                            saveModel.username = prop.value.trim();
+                            break;
+                        case '_umb_email':
+                            saveModel.email = prop.value.trim();
+                            break;
+                        case '_umb_password':
+                            saveModel.password = this.formatChangePasswordModel(prop.value);
+                            break;
+                        case '_umb_membergroup':
+                            saveModel.memberGroups = _.keys(_.pick(prop.value, value => value === true));
+                            break;
                     }
-                }
-                saveModel.memberGroups = selectedGroups;
+                });
 
-                //turn the dictionary into an array of pairs
+                // Map custom member provider properties
                 var memberProviderPropAliases = _.pairs(displayModel.fieldConfig);
-                _.each(displayModel.tabs, function (tab) {
-                    _.each(tab.properties, function (prop) {
-                        var foundAlias = _.find(memberProviderPropAliases, function (item) {
-                            return prop.alias === item[1];
-                        });
+                _.each(displayModel.tabs, tab => {
+                    _.each(tab.properties, prop => {
+                        var foundAlias = _.find(memberProviderPropAliases, item => prop.alias === item[1]);
                         if (foundAlias) {
-                            //we know the current property matches an alias, now we need to determine which membership provider property it was for
+                            // we know the current property matches an alias, now we need to determine which membership provider property it was for
                             // by looking at the key
                             switch (foundAlias[0]) {
                                 case "umbracoMemberLockedOut":
@@ -329,8 +315,6 @@
                         }
                     });
                 });
-
-
 
                 return saveModel;
             },

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-member-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-member-node-info.html
@@ -1,18 +1,6 @@
 <div class="umb-package-details">
     <div class="umb-package-details__main-content">
 
-        <umb-box data-element="node-info-membership" ng-repeat="group in node.tabs| filter: {properties:{view:'readonlyvalue'}} track by group.id">
-
-            <div class="umb-group-panel__header">
-                <div>{{ group.label }}</div>
-            </div>
-            <div class="umb-group-panel__content">
-                <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties | filter: {view:'readonlyvalue'} track by property.alias" property="property">
-                    <umb-property-editor model="property"></umb-property-editor>
-                </umb-property>
-            </div>
-        </umb-box>
-
     </div>
 
     <div class="umb-package-details__sidebar">

--- a/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/member/umb-membergroup-node-info.html
@@ -1,5 +1,6 @@
 <div class="umb-package-details">
     <div class="umb-package-details__main-content">
+
         <umb-box>
             <umb-box-header title-key="content_membergroup"></umb-box-header>
             <umb-box-content class="block-form">

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.controller.js
@@ -9,7 +9,6 @@
         vm.activeTabAlias = null;
 
         vm.setActiveTab = setActiveTab;
-        vm.hideSystemProperties = hideSystemProperties;
 
         $scope.$watchCollection('content.tabs', (newValue) => {
 
@@ -32,15 +31,6 @@
             vm.activeTabAlias = tab.alias;
             vm.tabs.forEach(tab => tab.active = false);
             tab.active = true;
-        }
-
-        function hideSystemProperties (property) {
-            // hide some specific, known properties by alias
-            if (property.alias === "_umb_id" || property.alias === "_umb_doctype") {
-                return false;
-            }
-            // hide all label properties with the alias prefix "umbracoMember" (e.g. "umbracoMemberFailedPasswordAttempts")
-            return property.view !== "readonlyvalue" || property.alias.startsWith('umbracoMember') === false;
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
@@ -6,38 +6,21 @@
 
     <umb-box ng-repeat="tab in vm.tabs track by tab.key" ng-show="tab.alias === vm.activeTabAlias && tab.properties.length > 0">
         <umb-box-content data-element="tab-content-{{tab.alias}}">
-            <umb-property
-                data-element="property-{{property.alias}}"
-                ng-repeat="property in tab.properties track by property.alias"
-                property="property">
-
-                    <umb-property-editor model="property"></umb-property-editor>
-
+            <umb-property data-element="property-{{property.alias}}" ng-repeat="property in tab.properties track by property.alias" property="property">
+                <umb-property-editor model="property"></umb-property-editor>
             </umb-property>
         </umb-box-content>
     </umb-box>
 
-    <div 
-    class="umb-group-panel"
-    data-element="group-{{group.alias}}"
-    ng-repeat="group in content.tabs"
-    ng-if="group.type === 0"
-    ng-show="group.parentAlias === vm.activeTabAlias || vm.tabs.length === 0">
-
+    <div class="umb-group-panel" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs" ng-if="group.type === 0" ng-show="group.parentAlias === vm.activeTabAlias || vm.tabs.length === 0">
         <div class="umb-group-panel__header">
             <div>{{ group.label }}</div>
         </div>
-
         <div class="umb-group-panel__content" data-element="tab-content-{{group.type === 0 ? group.parentAlias : group.alias}}">
-            <umb-property 
-                data-element="property-{{group.alias}}" 
-                ng-repeat="property in group.properties | filter:vm.hideSystemProperties track by property.alias" 
-                property="property">
-
+            <umb-property data-element="property-{{group.alias}}" ng-repeat="property in group.properties track by property.alias"  property="property">
                 <umb-property-editor model="property"></umb-property-editor>
             </umb-property>
         </div>
-
     </div>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/membership/membership.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/membership/membership.html
@@ -1,0 +1,7 @@
+<umb-box data-element="node-membership" class="form-horizontal">
+    <umb-box-content>
+        <umb-property ng-repeat="property in content.membershipProperties track by property.alias" property="property">
+            <umb-property-editor model="property"></umb-property-editor>
+        </umb-property>
+    </umb-box-content>
+</umb-box>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html
@@ -4,6 +4,7 @@
 
         <umb-toggle input-id="{{model.alias}}"
                     checked="renderModel.value"
+                    disabled="model.readonly"
                     on-click="toggle()"
                     show-labels="{{model.config.showLabels}}"
                     label-position="right"

--- a/src/Umbraco.Web/ContentApps/MemberEditorContentAppFactory.cs
+++ b/src/Umbraco.Web/ContentApps/MemberEditorContentAppFactory.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Web.ContentApps
+{
+    internal class MemberEditorContentAppFactory : IContentAppFactory
+    {
+        // see note on ContentApp
+        internal const int Weight = +50;
+
+        private ContentApp _memberApp;
+
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+            switch (source)
+            {
+                case IMember _:
+                    return _memberApp ?? (_memberApp = new ContentApp
+                    {
+                        Alias = "umbMembership",
+                        Name = "Member",
+                        Icon = "icon-user",
+                        View = "views/member/apps/membership/membership.html",
+                        Weight = Weight
+                    });
+
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web/Models/ContentEditing/MemberDisplay.cs
+++ b/src/Umbraco.Web/Models/ContentEditing/MemberDisplay.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Umbraco.Core.Models;
 using Umbraco.Core.Models.ContentEditing;
 using Umbraco.Core.Models.Membership;
 
@@ -41,5 +40,8 @@ namespace Umbraco.Web.Models.ContentEditing
 
         [DataMember(Name = "apps")]
         public IEnumerable<ContentApp> ContentApps { get; set; }
+
+        [DataMember(Name = "membershipProperties")]
+        public IEnumerable<ContentPropertyDisplay> MembershipProperties { get; set; }
     }
 }

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -163,12 +163,6 @@ namespace Umbraco.Web.Models.Mapping
         {
             MapTypeToDisplayBase<MemberTypeDisplay, MemberPropertyTypeDisplay>(source, target);
 
-            var standardGroup = target.Groups.FirstOrDefault(x => x.Alias == Constants.Conventions.Member.StandardPropertiesGroupAlias);
-            if (standardGroup != null)
-            {
-                standardGroup.Inherited = true;
-            }
-
             //map the MemberCanEditProperty,MemberCanViewProperty,IsSensitiveData
             foreach (var propertyType in source.PropertyTypes)
             {

--- a/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/ContentTypeMapDefinition.cs
@@ -163,6 +163,12 @@ namespace Umbraco.Web.Models.Mapping
         {
             MapTypeToDisplayBase<MemberTypeDisplay, MemberPropertyTypeDisplay>(source, target);
 
+            var standardGroup = target.Groups.FirstOrDefault(x => x.Alias == Constants.Conventions.Member.StandardPropertiesGroupAlias);
+            if (standardGroup != null)
+            {
+                standardGroup.Inherited = true;
+            }
+
             //map the MemberCanEditProperty,MemberCanViewProperty,IsSensitiveData
             foreach (var propertyType in source.PropertyTypes)
             {

--- a/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberMapDefinition.cs
@@ -82,12 +82,9 @@ namespace Umbraco.Web.Models.Mapping
             target.ContentTypeAlias = source.ContentType.Alias;
             target.ContentTypeName = source.ContentType.Name;
             target.CreateDate = source.CreateDate;
-            target.Email = source.Email;
             target.Icon = source.ContentType.Icon;
             target.Id = source.Id;
             target.Key = source.Key;
-            target.MemberProviderFieldMapping = GetMemberProviderFieldMapping();
-            target.MembershipScenario = GetMembershipScenario();
             target.Name = source.Name;
             target.Owner = _commonMapper.GetOwner(source, context);
             target.ParentId = source.ParentId;
@@ -98,7 +95,13 @@ namespace Umbraco.Web.Models.Mapping
             target.TreeNodeUrl = _commonMapper.GetMemberTreeNodeUrl(source);
             target.Udi = Udi.Create(Constants.UdiEntityType.Member, source.Key);
             target.UpdateDate = source.UpdateDate;
+
+            // Membership
+            target.MembershipScenario = GetMembershipScenario();
+            target.MemberProviderFieldMapping = GetMemberProviderFieldMapping();
             target.Username = source.Username;
+            target.Email = source.Email;
+            target.MembershipProperties = _tabsAndPropertiesMapper.MapMembershipProperties(source, context);
         }
 
         // Umbraco.Code.MapAll -Trashed -Edited -Updater -Alias -VariesByCulture

--- a/src/Umbraco.Web/Models/Mapping/MemberTabsAndPropertiesMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/MemberTabsAndPropertiesMapper.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Web.Security;
 using Umbraco.Core;
 using Umbraco.Core.Mapping;
-using Umbraco.Core.Composing;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Membership;
 using Umbraco.Core.Security;
@@ -79,53 +78,15 @@ namespace Umbraco.Web.Models.Mapping
                 }
             }
 
-            var umbracoContext = _umbracoContextAccessor.UmbracoContext;
-            if (umbracoContext != null
-                && umbracoContext.Security.CurrentUser != null
-                && umbracoContext.Security.CurrentUser.AllowedSections.Any(x => x.Equals(Constants.Applications.Settings)))
-            {
-                var memberTypeLink = string.Format("#/member/memberTypes/edit/{0}", source.ContentTypeId);
-
-                // Replace the doctype property
-                var docTypeProperty = resolved.SelectMany(x => x.Properties)
-                    .First(x => x.Alias == string.Format("{0}doctype", Constants.PropertyEditors.InternalGenericPropertiesPrefix));
-                docTypeProperty.Value = new List<object>
-                {
-                    new
-                    {
-                        linkText = source.ContentType.Name,
-                        url = memberTypeLink,
-                        target = "_self",
-                        icon = Constants.Icons.ContentType
-                    }
-                };
-                docTypeProperty.View = "urllist";
-            }
-
             return resolved;
         }
 
-        protected override IEnumerable<ContentPropertyDisplay> GetCustomGenericProperties(IContentBase content)
+        public IEnumerable<ContentPropertyDisplay> MapMembershipProperties(IMember member, MapperContext context)
         {
-            var member = (IMember)content;
             var membersProvider = Core.Security.MembershipProviderExtensions.GetMembersMembershipProvider();
 
-            var genericProperties = new List<ContentPropertyDisplay>
+            var properties = new List<ContentPropertyDisplay>
             {
-                new ContentPropertyDisplay
-                {
-                    Alias = $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}id",
-                    Label = _localizedTextService.Localize("general","id"),
-                    Value = new List<string> {member.Id.ToString(), member.Key.ToString()},
-                    View = "idwithguid"
-                },
-                new ContentPropertyDisplay
-                {
-                    Alias = $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}doctype",
-                    Label = _localizedTextService.Localize("content","membertype"),
-                    Value = _localizedTextService.UmbracoDictionaryTranslate(member.ContentType.Name),
-                    View = Current.PropertyEditors[Constants.PropertyEditors.Aliases.Label].GetValueEditor().View
-                },
                 GetLoginProperty(_memberService, member, _localizedTextService),
                 new ContentPropertyDisplay
                 {
@@ -139,21 +100,20 @@ namespace Umbraco.Web.Models.Mapping
                 {
                     Alias = $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}password",
                     Label = _localizedTextService.Localize(null,"password"),
-                    // NOTE: The value here is a json value - but the only property we care about is the generatedPassword one if it exists, the newPassword exists
+                    // NOTE: The value here is a JSON value - but the only property we care about is the generatedPassword one if it exists, the newPassword exists
                     // only when creating a new member and we want to have a generated password pre-filled.
                     Value = new Dictionary<string, object>
                     {
                         // TODO: why ignoreCase, what are we doing here?!
-                        {"generatedPassword", member.GetAdditionalDataValueIgnoreCase("GeneratedPassword", null)},
-                        {"newPassword", member.GetAdditionalDataValueIgnoreCase("NewPassword", null)},
+                        { "generatedPassword", member.GetAdditionalDataValueIgnoreCase("GeneratedPassword", null) },
+                        { "newPassword", member.GetAdditionalDataValueIgnoreCase("NewPassword", null) },
                     },
-                    // TODO: Hard coding this because the changepassword doesn't necessarily need to be a resolvable (real) property editor
                     View = "changepassword",
-                    // initialize the dictionary with the configuration from the default membership provider
+                    // Initialize the dictionary with the configuration from the default membership provider
                     Config = new Dictionary<string, object>(membersProvider.GetConfiguration(_userService))
                     {
-                        // the password change toggle will only be displayed if there is already a password assigned.
-                        {"hasPassword", member.RawPasswordValue.IsNullOrWhiteSpace() == false}
+                        // The password change toggle will only be displayed if there is already a password assigned.
+                        { "hasPassword", member.RawPasswordValue.IsNullOrWhiteSpace() == false }
                     }
                 },
                 new ContentPropertyDisplay
@@ -166,7 +126,7 @@ namespace Umbraco.Web.Models.Mapping
                 }
             };
 
-            return genericProperties;
+            return properties;
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesMapper.cs
+++ b/src/Umbraco.Web/Models/Mapping/TabsAndPropertiesMapper.cs
@@ -52,46 +52,23 @@ namespace Umbraco.Web.Models.Mapping
             var noGroupProperties = content.GetNonGroupedProperties()
                 .Where(x => IgnoreProperties.Contains(x.Alias) == false) // skip ignored
                 .ToList();
-            var genericproperties = MapProperties(content, noGroupProperties, context);
-
-            tabs.Add(new Tab<ContentPropertyDisplay>
-            {
-                Id = 0,
-                Label = LocalizedTextService.Localize("general", "properties"),
-                Alias = "Generic properties",
-                Properties = genericproperties
-            });
-
-            var genericProps = tabs.Single(x => x.Id == 0);
-
-            //store the current props to append to the newly inserted ones
-            var currProps = genericProps.Properties.ToArray();
-
-            var contentProps = new List<ContentPropertyDisplay>();
+            var genericProperties = MapProperties(content, noGroupProperties, context);
 
             var customProperties = GetCustomGenericProperties(content);
             if (customProperties != null)
             {
-                //add the custom ones
-                contentProps.AddRange(customProperties);
+                genericProperties.AddRange(customProperties);
             }
 
-            //now add the user props
-            contentProps.AddRange(currProps);
-
-            //re-assign
-            genericProps.Properties = contentProps;
-
-            //Show or hide properties tab based on whether it has or not any properties
-            if (genericProps.Properties.Any() == false)
+            if (genericProperties.Count > 0)
             {
-                //loop through the tabs, remove the one with the id of zero and exit the loop
-                for (var i = 0; i < tabs.Count; i++)
+                tabs.Add(new Tab<ContentPropertyDisplay>
                 {
-                    if (tabs[i].Id != 0) continue;
-                    tabs.RemoveAt(i);
-                    break;
-                }
+                    Id = 0,
+                    Label = LocalizedTextService.Localize("general", "properties"),
+                    Alias = "Generic properties",
+                    Properties = genericProperties
+                });
             }
         }
 

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -242,7 +242,8 @@ namespace Umbraco.Web.Runtime
                 .Append<ContentTypeDesignContentAppFactory>()
                 .Append<ContentTypeListViewContentAppFactory>()
                 .Append<ContentTypePermissionsContentAppFactory>()
-                .Append<ContentTypeTemplatesContentAppFactory>();
+                .Append<ContentTypeTemplatesContentAppFactory>()
+                .Append<MemberEditorContentAppFactory>();
 
             // register back office sections in the order we want them rendered
             composition.Sections()

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -162,6 +162,7 @@
     <Compile Include="ContentApps\ContentTypeListViewContentAppFactory.cs" />
     <Compile Include="ContentApps\ContentTypeDesignContentAppFactory.cs" />
     <Compile Include="ContentApps\ListViewContentAppFactory.cs" />
+    <Compile Include="ContentApps\MemberEditorContentAppFactory.cs" />
     <Compile Include="Dashboards\ContentDashboard.cs" />
     <Compile Include="Dashboards\DashboardCollection.cs" />
     <Compile Include="Dashboards\DashboardCollectionBuilder.cs" />
@@ -1184,7 +1185,9 @@
     <Compile Include="PublishedCache\IPublishedMediaCache.cs" />
     <Compile Include="PublishedContentExtensions.cs" />
     <Compile Include="ExamineExtensions.cs" />
-    <Compile Include="FormlessPage.cs" />
+    <Compile Include="FormlessPage.cs">
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
     <Compile Include="HtmlHelperRenderExtensions.cs" />
     <Compile Include="Scheduling\SchedulerComponent.cs" />
     <Compile Include="ModelStateExtensions.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11255 and resolves https://github.com/umbraco/Umbraco-CMS/issues/11132.

### Description
Members in Umbraco require the following default properties:
- `umbracoMemberPasswordRetrievalQuestion`
- `umbracoMemberPasswordRetrievalAnswer`
- `umbracoMemberComments`
- `umbracoMemberApproved`
- `umbracoMemberLockedOut`
- `umbracoMemberLastLogin`
- `umbracoMemberLastPasswordChangeDate`
- `umbracoMemberLastLockoutDate`
- `umbracoMemberFailedPasswordAttempts`

These are added to the `Membership` group by default, but Umbraco created this group even when these properties are already present in another group (or since Umbraco 8.17 in another tab). This PR makes sure the group is only created when one of the properties is missing.

The next issue was that some of these properties were 'moved' into the Info Content App, which was done by filtering them from Content and rendering them in Info. Because the filtering logic wasn't the same between these two places and also not properly applied when using tabs, you might end up with properties that weren't rendered at all! Besides that, it's just weird that the Member Type designer and actual Member editor weren't showing the same structure/properties.

Lastly, the membership properties (username, email, password and member groups) were added as generic properties when rendering a member, which causes the Generic tab to show up when you're using tabs.

To fix this, the above default properties aren't moved anymore (and will therefore now show up in the same place as you see in the Member Type desinger) and created a new Member(ship) Content App that allow you to edit the username, email, password and member groups:

![Content](https://user-images.githubusercontent.com/1051287/140501822-451547c2-3022-4413-8b60-a6e76858b5bf.png)

![Member](https://user-images.githubusercontent.com/1051287/140501852-37b139cc-594e-4184-bd4b-223df9e34cd4.png)

![Info](https://user-images.githubusercontent.com/1051287/140501905-6ed649d8-af49-4ea8-905b-7ec72fdeaa66.png)

The following should at least be tested:
- Creating new members (from scratch) still works and after the first save, the default properties are automatically added
- Adding tabs and/or converting the default group into a tab doesn't break the designer and editor views
- Splitting the default properties to different groups/tabs works and it doesn't add the Membership group when all of the properties already exist
- Validation works on both the Content and new Member app
- Resetting the password shows the new password once (and make sure to validate whether this password is also updated correctly)