### PR TITLE
v9: Fix for OAuth ExternalLogin

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -517,6 +517,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 // Failed only occurs when the user does not exist
                 errors.Add("The requested provider (" + loginInfo.LoginProvider + ") has not been linked to an account, the provider must be linked from the back office.");
             }
+            else if (result == ExternalLoginSignInResult.NotAllowed)
+            {
+                // This occurs when the external provider has approved the login but custom logic in OnExternalLogin has denined it.
+                errors.Add($"The user {loginInfo.Principal.Identity.Name} for the external provider {loginInfo.ProviderDisplayName} has not been accepted and cannot sign in.");
+            }
             else if (result == AutoLinkSignInResult.FailedNotLinked)
             {
                 errors.Add("The requested provider (" + loginInfo.LoginProvider + ") has not been linked to an account, the provider must be linked from the back office.");

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -193,6 +193,17 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                         return AutoLinkSignInResult.FailedException(ex.Message);
                     }
 
+                    var shouldSignIn = autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
+                    if (shouldSignIn == false)
+                    {
+                        Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, autoLinkUser.Id);
+                        return SignInResult.NotAllowed;
+                    }
+                    else
+                    {
+                        return await LinkUser(autoLinkUser, loginInfo);
+                    }
+
                     return await LinkUser(autoLinkUser, loginInfo);
                 }
                 else
@@ -226,7 +237,16 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     }
                     else
                     {
-                        return await LinkUser(autoLinkUser, loginInfo);
+                        var shouldSignIn = autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
+                        if (shouldSignIn == false)
+                        {
+                            Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, autoLinkUser.Id);
+                            return SignInResult.NotAllowed;
+                        }
+                        else
+                        {
+                            return await LinkUser(autoLinkUser, loginInfo);
+                        }
                     }
                 }
             }

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -78,6 +78,7 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                 if (shouldSignIn == false)
                 {
                     Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, user.Id);
+                    return SignInResult.NotAllowed;
                 }
             }
 

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -77,8 +77,8 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                 var shouldSignIn = autoLinkOptions.OnExternalLogin(user, loginInfo);
                 if (shouldSignIn == false)
                 {
-                    Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, user.Id);
-                    return SignInResult.NotAllowed;
+                    LogFailedExternalLogin(loginInfo, user);
+                    return ExternalLoginSignInResult.NotAllowed;
                 }
             }
 
@@ -196,8 +196,8 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     var shouldSignIn = autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
                     if (shouldSignIn == false)
                     {
-                        Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, autoLinkUser.Id);
-                        return SignInResult.NotAllowed;
+                        LogFailedExternalLogin(loginInfo, autoLinkUser);
+                        return ExternalLoginSignInResult.NotAllowed;
                     }
                     else
                     {
@@ -238,8 +238,8 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                         var shouldSignIn = autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
                         if (shouldSignIn == false)
                         {
-                            Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, autoLinkUser.Id);
-                            return SignInResult.NotAllowed;
+                            LogFailedExternalLogin(loginInfo, autoLinkUser);
+                            return ExternalLoginSignInResult.NotAllowed;
                         }
                         else
                         {
@@ -283,5 +283,8 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                 return AutoLinkSignInResult.FailedLinkingUser(errors);
             }
         }
+
+        private void LogFailedExternalLogin(ExternalLoginInfo loginInfo, BackOfficeIdentityUser user) =>
+            Logger.LogWarning("The AutoLinkOptions of the external authentication provider '{LoginProvider}' have refused the login based on the OnExternalLogin method. Affected user id: '{UserId}'", loginInfo.LoginProvider, user.Id);
     }
 }

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -193,8 +193,8 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                         return AutoLinkSignInResult.FailedException(ex.Message);
                     }
 
-                    var shouldSignIn = autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
-                    if (shouldSignIn == false)
+                    var shouldLinkUser = autoLinkOptions.OnExternalLogin == null || autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
+                    if (shouldLinkUser == false)
                     {
                         LogFailedExternalLogin(loginInfo, autoLinkUser);
                         return ExternalLoginSignInResult.NotAllowed;
@@ -235,8 +235,8 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     }
                     else
                     {
-                        var shouldSignIn = autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
-                        if (shouldSignIn == false)
+                        var shouldLinkUser = autoLinkOptions.OnExternalLogin == null || autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
+                        if (shouldLinkUser == false)
                         {
                             LogFailedExternalLogin(loginInfo, autoLinkUser);
                             return ExternalLoginSignInResult.NotAllowed;

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -203,8 +203,6 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     {
                         return await LinkUser(autoLinkUser, loginInfo);
                     }
-
-                    return await LinkUser(autoLinkUser, loginInfo);
                 }
                 else
                 {

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -194,14 +194,14 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     }
 
                     var shouldLinkUser = autoLinkOptions.OnExternalLogin == null || autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
-                    if (shouldLinkUser == false)
+                    if (shouldLinkUser)
                     {
-                        LogFailedExternalLogin(loginInfo, autoLinkUser);
-                        return ExternalLoginSignInResult.NotAllowed;
+                        return await LinkUser(autoLinkUser, loginInfo);
                     }
                     else
                     {
-                        return await LinkUser(autoLinkUser, loginInfo);
+                        LogFailedExternalLogin(loginInfo, autoLinkUser);
+                        return ExternalLoginSignInResult.NotAllowed;
                     }
                 }
                 else
@@ -236,14 +236,14 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     else
                     {
                         var shouldLinkUser = autoLinkOptions.OnExternalLogin == null || autoLinkOptions.OnExternalLogin(autoLinkUser, loginInfo);
-                        if (shouldLinkUser == false)
+                        if (shouldLinkUser)
                         {
-                            LogFailedExternalLogin(loginInfo, autoLinkUser);
-                            return ExternalLoginSignInResult.NotAllowed;
+                            return await LinkUser(autoLinkUser, loginInfo);
                         }
                         else
                         {
-                            return await LinkUser(autoLinkUser, loginInfo);
+                            LogFailedExternalLogin(loginInfo, autoLinkUser);
+                            return ExternalLoginSignInResult.NotAllowed;
                         }
                     }
                 }

--- a/src/Umbraco.Web.BackOffice/Security/ExternalLoginSignInResult.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ExternalLoginSignInResult.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Umbraco.Cms.Web.BackOffice.Security
+{
+    /// <summary>
+    /// Result returned from signing in when external logins are used.
+    /// </summary>
+    public class ExternalLoginSignInResult : SignInResult
+    {
+        public static ExternalLoginSignInResult NotAllowed { get; } = new ExternalLoginSignInResult()
+        {
+            Succeeded = false
+        };
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11591 

### Description
This change fixes an issue where returning `false` in `OnExternalLogin` in a custom `BackOfficeExternalLoginProviderOptions` would still create the user and log them in.

Testing:
- Create a custom `BackOfficeExternalLoginProviderOptions`
- Set `OnExternalLogin` to return false

```csharp
public void Configure(BackOfficeExternalLoginProviderOptions options)
{
  options.AutoLinkOptions = new ExternalSignInAutoLinkOptions(
    autoLinkExternalAccount: true,
    defaultUserGroups: new[] { global::Umbraco.Cms.Core.Constants.Security.EditorGroupAlias },
    defaultCulture: null,
    allowManualLinking: false
  )
  {
    // Optional callback
    OnAutoLinking = (autoLinkUser, loginInfo) => { ... },
    OnExternalLogin = (user, loginInfo) =>
    {
      // There's code here to check what Google Workspace groups the user is in
      // My test user is not in any groups so always returns false
      if (...) { return true; }
      return false;
    }
  };
}
```