### PR TITLE
V9/bugfix/fix lucene immense raw fields prevent indexing

### DIFF
--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
@@ -8,8 +8,6 @@ using Examine;
 using Examine.Lucene;
 using Examine.Lucene.Providers;
 using Lucene.Net.Documents;
-using Lucene.Net.Index;
-using Lucene.Net.Store;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -103,10 +101,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
                     //remove the original value so we can store it the correct way
                     d.RemoveField(f.Key);
 
-                    d.Add(new StringField(
-                        f.Key,
-                        f.Value[0].ToString(),
-                        Field.Store.YES));
+                    d.Add(new StoredField(f.Key, f.Value[0].ToString()));
                 }
             }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -80,6 +80,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="33.1.1" />
     <PackageReference Include="Examine.Lucene" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.11" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #11487

### Description

If a very large field was stored for property editors that store __raw_ versions (rich text & grid) indexing would break.
There are steps to reproduce for manual testing in the linked issue.

But can also just run test @ 6ce1e4f vs a8825b6 