### PR TITLE
v9: Health Check still references web.config instead of appsettings.json

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2262,11 +2262,11 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="httpsCheckExpiringCertificate">Your website's SSL certificate is expiring in %0% days.</key>
     <key alias="healthCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
     <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
-    <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'Umbraco.Core.UseHttps' is set to 'false' in
-      your web.config file. Once you access this site using the HTTPS scheme, that should be set to 'true'.
+    <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'Umbraco:CMS:Global:UseHttps' is set to 'false' in
+      your appSettings.json file. Once you access this site using the HTTPS scheme, that should be set to 'true'.
     </key>
-    <key alias="httpsCheckConfigurationCheckResult">The appSetting 'Umbraco.Core.UseHttps' is set to '%0%' in your
-      web.config file, your cookies are %1% marked as secure.
+    <key alias="httpsCheckConfigurationCheckResult">The appSetting 'Umbraco:CMS:Global:UseHttps' is set to '%0%' in your
+      appSettings.json file, your cookies are %1% marked as secure.
     </key>
     <!-- The following keys don't get tokens passed in -->
     <key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2339,12 +2339,11 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="httpsCheckExpiringCertificate">Your website's SSL certificate is expiring in %0% days.</key>
     <key alias="healthCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
     <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
-    <key alias="httpsCheckConfigurationRectifyNotPossible">The configuration value 'Umbraco:CMS:Global:UseHttps' is set
-      to 'false' in your web.config file. Once you access this site using the HTTPS scheme, that should be set to
-      'true'.
+    <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'Umbraco:CMS:Global:UseHttps' is set to 'false' in
+      your appSettings.json file. Once you access this site using the HTTPS scheme, that should be set to 'true'.
     </key>
-    <key alias="httpsCheckConfigurationCheckResult">The configuration value 'Umbraco:CMS:Global:UseHttps' is set to
-      '%0%' in your web.config file, your cookies are %1% marked as secure.
+    <key alias="httpsCheckConfigurationCheckResult">The appSetting 'Umbraco:CMS:Global:UseHttps' is set to '%0%' in your
+      appSettings.json file, your cookies are %1% marked as secure.
     </key>
     <!-- The following keys don't get tokens passed in -->
     <key alias="compilationDebugCheckSuccessMessage">Debug compilation mode is disabled.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -1962,7 +1962,14 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="httpsCheckExpiringCertificate">Le certificat SSL de votre site web va expirer dans %0% jours.</key>
     <key alias="healthCheckInvalidUrl">Erreur en essayant de contacter l'URL %0% - '%1%'</key>
     <key alias="httpsCheckIsCurrentSchemeHttps">Vous êtes actuellement %0% à voir le site via le schéma HTTPS.</key>
-    <!-- The following keys don't get tokens passed in -->
+    <key alias="httpsCheckConfigurationRectifyNotPossible">
+      L'appSetting 'Umbraco:CMS:Global:UseHttps' se trouve à 'false' dans votre fichier appSettings.json.
+      Une fois que vous aurez accès à ce site via le schema HTTPS, il faudra la mettre à 'true'.
+    </key>
+    <key alias="httpsCheckConfigurationCheckResult">
+      L'appSetting 'Umbraco:CMS:Global:UseHttps' se trouve à '%0%' dans votre fichier
+      appSettings.json, vos cookies sont %1% marqués comme 'secured'.
+    </key>   <!-- The following keys don't get tokens passed in -->
     <key alias="compilationDebugCheckSuccessMessage">Le mode de compilation Debug est désactivé.</key>
     <key alias="compilationDebugCheckErrorMessage">Le mode de compilation Debug est actuellement activé. Il est recommandé de désactiver ce paramètre avant la mise en ligne.</key>
     <!-- The following keys get these tokens passed in:


### PR DESCRIPTION
### Prerequisites
- [x] I have added steps to test this contribution in the description below

### Description
Currently the back office Health Check tab references the old way of turning HTTPS on in the web.config rather than appsettings.json

Old:
![image](https://user-images.githubusercontent.com/200450/140947984-d5684e2c-0ed2-4d5c-8725-d2006accf342.png)

New:
![image](https://user-images.githubusercontent.com/200450/140948225-4194d781-bd48-483b-960b-498876df7a29.png)
