### PR TITLE
Validate that imageUrl param is a relative path

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ImagesController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ImagesController.cs
@@ -88,8 +88,14 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 ImageCropMode = ImageCropMode.Max,
                 CacheBusterValue = rnd
             });
-
-            return new RedirectResult(imageUrl, false);
+            if (Url.IsLocalUrl(imageUrl))
+            {
+                return new LocalRedirectResult(imageUrl, false);
+            }
+            else
+            {
+                return Unauthorized();
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/ImagesController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ImagesController.cs
@@ -54,12 +54,20 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         public IActionResult GetResized(string imagePath, int width)
         {
             var ext = Path.GetExtension(imagePath);
-
+            
+            // check if imagePath is local to prevent open redirect
+            if (!Uri.IsWellFormedUriString(imagePath, UriKind.Relative))
+            {
+                return Unauthorized();
+            }
+            
             // we need to check if it is an image by extension
             if (_imageUrlGenerator.IsSupportedImageFormat(ext) == false)
+            {
                 return NotFound();
-
-            //redirect to ImageProcessor thumbnail with rnd generated from last modified time of original media file
+            }
+            
+            // redirect to ImageProcessor thumbnail with rnd generated from last modified time of original media file
             DateTimeOffset? imageLastModified = null;
             try
             {


### PR DESCRIPTION
To prevent open redirects, the imagePath should point to a relative path (i.e. not point to a different domain).

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR implements a simple control on the imagePath to prevent open redirects. Since there is no reason for the imagePath to point to a different domain (i.e. imagePath="https://..../image.jpg"), we should return an Unauthorized() response when the path is not UriKind.Relative.


<!-- Thanks for contributing to Umbraco CMS! -->
