### PR TITLE
Obsoletes events added for local database initialization for Umbraco Cloud that are no longer required.

### DIFF
--- a/src/Umbraco.Core/Notifications/UmbracoApplicationComponentsInstallingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationComponentsInstallingNotification.cs
@@ -1,15 +1,22 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System;
+
 namespace Umbraco.Cms.Core.Notifications
 {
+    // TODO (V10): Remove this class.
+
     /// <summary>
     /// Notification that occurs during the Umbraco boot process, before instances of <see cref="IComponent"/> initialize.
     /// </summary>
+    [Obsolete("This notification was added to the core runtime start-up as a hook for Umbraco Cloud local connection string and database setup. " +
+        "Following re-work they are no longer used (from Deploy 9.2.0)." +
+        "Given they are non-documented and no other use is expected, they can be removed in the next major release")]
     public class UmbracoApplicationComponentsInstallingNotification : INotification
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification"/> class.
+        /// Initializes a new instance of the <see cref="UmbracoApplicationComponentsInstallingNotification"/> class.
         /// </summary>
         /// <param name="runtimeLevel">The runtime level</param>
         public UmbracoApplicationComponentsInstallingNotification(RuntimeLevel runtimeLevel) => RuntimeLevel = runtimeLevel;

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationMainDomAcquiredNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationMainDomAcquiredNotification.cs
@@ -1,11 +1,18 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System;
+
 namespace Umbraco.Cms.Core.Notifications
 {
+    // TODO (V10): Remove this class.
+
     /// <summary>
     /// Notification that occurs during Umbraco boot after the MainDom has been acquired.
     /// </summary>
+    [Obsolete("This notification was added to the core runtime start-up as a hook for Umbraco Cloud local connection string and database setup. " +
+        "Following re-work they are no longer used (from Deploy 9.2.0)." +
+        "Given they are non-documented and no other use is expected, they can be removed in the next major release")]
     public class UmbracoApplicationMainDomAcquiredNotification : INotification
     {
         /// <summary>

--- a/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
@@ -133,6 +133,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             // acquire the main domain - if this fails then anything that should be registered with MainDom will not operate
             AcquireMainDom();
 
+            // TODO (V10): Remove this obsoleted notification publish.
             await _eventAggregator.PublishAsync(new UmbracoApplicationMainDomAcquiredNotification(), cancellationToken);
 
             // notify for unattended install
@@ -171,6 +172,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                     break;
             }
 
+            // TODO (V10): Remove this obsoleted notification publish.
             await _eventAggregator.PublishAsync(new UmbracoApplicationComponentsInstallingNotification(State.Level), cancellationToken);
 
             // create & initialize the components


### PR DESCRIPTION
Given they are non-documented and have no use, have obsoleted the notification classes and added comments for their removal in V10.