### PR TITLE
Fix sending invite emails

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -525,6 +525,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             var user = await _userManager.FindByIdAsync(((int) userDisplay.Id).ToString());
             var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
+            // Use info from SMTP Settings if configured, otherwise set fromEmail as fallback
+            var senderEmail = !string.IsNullOrEmpty(_globalSettings.Smtp?.From) ? _globalSettings.Smtp.From : fromEmail;
+
             var inviteToken = string.Format("{0}{1}{2}",
                 (int)userDisplay.Id,
                 WebUtility.UrlEncode("|"),
@@ -550,14 +553,14 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             var emailBody = _localizedTextService.Localize("user","inviteEmailCopyFormat",
                 //Ensure the culture of the found user is used for the email!
                 UmbracoUserExtensions.GetUserCulture(to.Language, _localizedTextService, _globalSettings),
-                new[] { userDisplay.Name, from, message, inviteUri.ToString(), fromEmail });
+                new[] { userDisplay.Name, from, message, inviteUri.ToString(), senderEmail });
 
             // This needs to be in the correct mailto format including the name, else
             // the name cannot be captured in the email sending notification.
             // i.e. "Some Person" <hello@example.com>
             var toMailBoxAddress = new MailboxAddress(to.Name, to.Email);
 
-            var mailMessage = new EmailMessage(null /*use info from smtp settings*/, toMailBoxAddress.ToString(), emailSubject, emailBody, true);
+            var mailMessage = new EmailMessage(senderEmail, toMailBoxAddress.ToString(), emailSubject, emailBody, true);
 
             await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.UserInvite, true);
         }


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/11453

The issue occurs only on Umbraco Cloud due to a special "send email flow" which broke because of the change introduced in https://github.com/umbraco/Umbraco-CMS/pull/11266. More specifically, there, the SMTP settings are not in the config files and sending `null` will make the `emailMessage.From` to always be `null`  while the `configuredEmailAddress` won't also be setup:

https://github.com/umbraco/Umbraco-CMS/blob/f5ea5df8f3eef8e84d5495e372ec90dfaaa57873/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs#L82

</br>

This PR makes sure to fall back to the current user's email if the SMTP settings are not configured.
