### PR TITLE
Content grid: Add missing fallback value

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
@@ -18,7 +18,7 @@
 
         <ul class="umb-content-grid__details-list" ng-class="{'-light': !item.published && item.updater != null}">
             <li class="umb-content-grid__details-item" ng-if="item.state">
-                <div class="umb-content-grid__details-label"><localize key="general_status"></localize>:</div>
+                <div class="umb-content-grid__details-label"><localize key="general_status">Status</localize>:</div>
                 <div class="umb-content-grid__details-value"><umb-variant-state variant="item"></umb-variant-state></div>
             </li>
             <li class="umb-content-grid__details-item" ng-repeat="property in contentProperties">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
"Oh my god I'm back again...." 🎶 😄 

Turns out I missed a few views where localization fallbacks are still missing - So this PR addresses a single missing fallback value ensuring a text will be displayed in case the value is missing from other language files 👍🏻 
