### PR TITLE
Variant state: Add missing fallback texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-variant-state.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-variant-state.html
@@ -1,6 +1,6 @@
 ﻿<span ng-switch="vm.variant.state">
-    <span ng-switch-when="NotCreated"><localize key="content_notCreated"></localize></span>
-    <span ng-switch-when="Draft"><localize key="content_unpublished"></localize></span>
-    <span ng-switch-when="PublishedPendingChanges"><localize key="content_publishedPendingChanges"></localize></span>
-    <span ng-switch-when="Published"><localize key="content_published"></localize></span>
+    <span ng-switch-when="NotCreated"><localize key="content_notCreated">Not created</localize></span>
+    <span ng-switch-when="Draft"><localize key="content_unpublished">Unpublished</localize></span>
+    <span ng-switch-when="PublishedPendingChanges"><localize key="content_publishedPendingChanges">Published (pending changes)</localize></span>
+    <span ng-switch-when="Published"><localize key="content_published">Published</localize></span>
 </span>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -252,6 +252,7 @@
     <key alias="type">Type</key>
     <key alias="unpublish">Unpublish</key>
     <key alias="unpublished">Unpublished</key>
+    <key alias="notCreated">Not created</key>
     <key alias="updateDate">Last edited</key>
     <key alias="updateDateDesc" version="7.0">Date/time this document was edited</key>
     <key alias="uploadClear">Remove file(s)</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -255,7 +255,7 @@
     <key alias="captionTextOptional">Caption (optional)</key>
     <key alias="type">Type</key>
     <key alias="unpublish">Unpublish</key>
-    <key alias="unpublished">Draft</key>
+    <key alias="unpublished">Unpublished</key>
     <key alias="notCreated">Not created</key>
     <key alias="updateDate">Last edited</key>
     <key alias="updateDateDesc" version="7.0">Date/time this document was edited</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have mapped all the missing fallback values in this view as well as adding the "notCreated" key into the en.xml where it was missing. I also noticed that in the en.xml the value of the "unpublished" key was "Unpublished" and in the en-us.xml it was "Draft". I have changed the "Draft" text to be "Unpublished" as well. Please let me know if it should be the other way around - As long as they're aligned I think we're good 👍🏻 😃 