### PR TITLE
Datatype info view: Add missing fallback text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/datatypes/views/datatype.info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/datatypes/views/datatype.info.html
@@ -54,7 +54,7 @@
                 <div ng-if="vm.references.mediaTypes.length > 0" class="mb4">
 
                     <h5 class="mt0" style="margin-bottom: 20px;">
-                        <localize key="references_labelUsedByMediaTypes"></localize>
+                        <localize key="references_labelUsedByMediaTypes">Used in Media Types</localize>
                     </h5>
 
                     <div class="umb-table">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Adding fallback text for "labelUsedByMediaTypes".