### PR TITLE
Documenttypes Permissions view: Add missing fallback texts and fix styling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -96,14 +96,15 @@
             <div class="sub-view-columns">
 
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_historyCleanupHeading"></localize></h5>
-                    <small><localize key="contentTypeEditor_historyCleanupDescription"></localize></small>
+                    <h5><localize key="contentTypeEditor_historyCleanupHeading">History cleanup</localize></h5>
+                    <small><localize key="contentTypeEditor_historyCleanupDescription">Allow override the global settings for when history versions are removed.</localize></small>
                 </div>
 
                 <div class="sub-view-column-right">
                     <umb-box-content>
                         <div class="umb-panel-group__details-status-text" ng-if="!model.historyCleanup.globalEnableCleanup">
-                            <p class="umb-panel-group__details-status-action"><localize key="contentTypeEditor_historyCleanupGloballyDisabled"></localize></p>
+                            <p class="umb-panel-group__details-status-action"><localize key="contentTypeEditor_historyCleanupGloballyDisabled">NOTE! The cleanup of historically content versions are disabled globally. These settings will not take effect before it
+                            is enabled.</localize></p>
                         </div>
 
                         <umb-control-group label="@contentTypeEditor_historyCleanupPreventCleanup">

--- a/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documenttypes/views/permissions/permissions.html
@@ -102,8 +102,8 @@
 
                 <div class="sub-view-column-right">
                     <umb-box-content>
-                        <div class="umb-panel-group__details-status-text" ng-if="!model.historyCleanup.globalEnableCleanup">
-                            <p class="umb-panel-group__details-status-action"><localize key="contentTypeEditor_historyCleanupGloballyDisabled">NOTE! The cleanup of historically content versions are disabled globally. These settings will not take effect before it
+                        <div class="umb-panel-group__details-status-text umb-alert umb-alert--info mb3" ng-if="!model.historyCleanup.globalEnableCleanup">
+                            <p class="mb0"><localize key="contentTypeEditor_historyCleanupGloballyDisabled"><b>NOTE!</b> The cleanup of historically content versions are disabled globally. These settings will not take effect before it
                             is enabled.</localize></p>
                         </div>
 

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -1730,7 +1730,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
-    <key alias="historyCleanupGloballyDisabled">NOTE! The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.</key>
+    <key alias="historyCleanupGloballyDisabled"><![CDATA[<b>NOTE!</b> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -1763,7 +1763,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
-    <key alias="historyCleanupGloballyDisabled">NOTE! The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.</key>
+    <key alias="historyCleanupGloballyDisabled"><![CDATA[<b>NOTE!</b> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Ensuring a fallback text will be displayed in case the language files are missing some of the keys.

Furthermore I noticed the styling of the "history info" could be improved, so I changed it to use the "umb-alert umb-alert--info" classes instead and wrapping the "NOTE!" part in bold.

**Before**
![history-info-before](https://user-images.githubusercontent.com/1932158/141446728-43391d89-1f65-4d8c-88be-8a9f8f73e1e1.png)

**After**
![history-info-after](https://user-images.githubusercontent.com/1932158/141446115-93ee0ae2-80b5-416d-9ef7-614531b031e4.png)
