### PR TITLE
Mediatypes permissions view: Add missing fallback texts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediatypes/views/permissions/permissions.html
@@ -3,8 +3,8 @@
         <umb-box-content>
             <div class="sub-view-columns">
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_allowAsRootHeading"></localize></h5>
-                    <small><localize key="contentTypeEditor_allowAsRootDescription"></localize></small>
+                    <h5><localize key="contentTypeEditor_allowAsRootHeading">Allow as root</localize></h5>
+                    <small><localize key="contentTypeEditor_allowAsRootDescription">Allow editors to create content of this type in the root of the content tree.</localize></small>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-toggle
@@ -16,8 +16,8 @@
             </div>
             <div class="sub-view-columns">
                 <div class="sub-view-column-left">
-                    <h5><localize key="contentTypeEditor_childNodesHeading"></localize></h5>
-                    <small><localize key="contentTypeEditor_childNodesDescription"></localize></small>
+                    <h5><localize key="contentTypeEditor_childNodesHeading">Allowed child node types</localize></h5>
+                    <small><localize key="contentTypeEditor_childNodesDescription">Allow content of the specified types to be created underneath content of this type.</localize></small>
                 </div>
                 <div class="sub-view-column-right">
                     <umb-child-selector
@@ -29,7 +29,7 @@
                         on-add="vm.addChild"
                         on-remove="vm.removeChild"
                         on-sort="vm.sortChildren">
-                    </umb-child-selector>        
+                    </umb-child-selector>
                 </div>
             </div>
         </umb-box-content>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Add missing fallback texts ensruing a text will be rendered in case language files are out of sync.