### PR TITLE
Remove http-equiv meta tag and update the "enable JS" message a wee bit

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
+++ b/src/Umbraco.Web.UI/Umbraco/Views/Default.cshtml
@@ -34,7 +34,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="robots" content="noindex, nofollow">
     <meta name="pinterest" content="nopin" />
 
@@ -46,8 +45,15 @@
 <body ng-class="{'touch':touchDevice, 'emptySection':emptySection, 'umb-drawer-is-visible':drawer.show, 'umb-tour-is-visible': tour.show, 'tabbing-active':tabbingActive}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">
 
     <noscript>
-        <div style="margin: 10px;">
-            <h3><img src="assets/img/application/logo.png" alt="Umbraco logo" style="vertical-align: text-bottom;" /> Umbraco</h3>
+        <div class="flex flex-wrap flex-column items-center justify-center" style="height: 100%">
+            <h1 class="h3">
+                <span style="width: 30px; height: 30px; vertical-align: text-bottom" class="flex-inline">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 315.89 315.89" fill="#3544b1">
+                        <path d="M0,157.74A157.95,157.95,0,1,1,158,315.89,157.95,157.95,0,0,1,0,157.74Zm154.74,54.09a155.41,155.41,0,0,1-36.5-3.29,27.92,27.92,0,0,1-19.94-16q-5.35-12.34-5.21-38.1a243,243,0,0,1,1.69-26.84q1.55-13,3.09-21.46l1.07-5.59a2,2,0,0,0,0-.49,3.2,3.2,0,0,0-2.65-3.17L75.92,93.67h-.44a3.19,3.19,0,0,0-3.11,2.48c-.35,1.31-.56,2.27-1.17,5.38-1.16,6-2.24,11.85-3.43,20.38a264.17,264.17,0,0,0-2.3,27.94,145.24,145.24,0,0,0,0,19.57q.72,25.94,8.9,41.42t27.72,22.3q19.53,6.81,54.43,6.66h2.91q34.94.15,54.41-6.66t27.71-22.3q8.17-15.53,8.91-41.42a145.24,145.24,0,0,0,0-19.57,266.84,266.84,0,0,0-2.3-27.94c-1.2-8.44-2.27-14.26-3.44-20.38-.61-3.11-.81-4.07-1.16-5.38a3.21,3.21,0,0,0-3.12-2.48h-.52l-20.38,3.18a3.2,3.2,0,0,0-2.68,3.17,4,4,0,0,0,0,.49l1.08,5.59q1.55,8.48,3.12,21.46a245.68,245.68,0,0,1,1.65,26.84q.27,25.69-5.21,38.07a27.9,27.9,0,0,1-19.76,16.07,155.19,155.19,0,0,1-36.48,3.29Z" />
+                    </svg>
+                </span>
+                Umbraco
+            </h1>
             <p>For full functionality of Umbraco CMS it is necessary to enable JavaScript.</p>
             <p>Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener" style="text-decoration: underline;">instructions how to enable JavaScript in your web browser</a>.</p>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
By coincidence I noticed that the `http-equiv` meta tag was still present in the `head` section but since Umbraco does no longer support any version of IE it's no longer needed since the functionality according to Microsoft will not be implemented in Edge anyway, which they state here https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-iedoco/380e2488-f5eb-4457-a07a-0cb1b6e4b4b5

While I did this removal I noticed the "Enable" JavaScript message and tried disabling JavaScript for fun to see what it actually looked like and decided to make the styling a wee bit nicer and switch the .png icon with the .svg icon instead making it easy to change the logo color to match the current brand style (If anyone else ever come across this 😂 ).

Please see the before and after look of the message below.

Hope you like it!

**Before**
![js-disabled-before](https://user-images.githubusercontent.com/1932158/141469442-d564a9bb-4848-42e7-b2b8-8abda62a0ea4.png)


**After**
![js-disabled-after](https://user-images.githubusercontent.com/1932158/141469453-4c00b56a-1951-4905-9310-7ccf42a621c9.png)
