### PR TITLE
Makes group name wider to fit long group names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-group.html
@@ -1,14 +1,14 @@
 <div data-element="group-{{vm.group.name}}" class="umb-group-builder__group" ng-class="{'-inherited': vm.group.inherited, 'umb-group-builder__group-handle -sortable': vm.sorting && !vm.group.inherited}" tabindex="0" ng-focus="vm.whenFocus()">
     <div class="umb-group-builder__group-title-wrapper" ng-if="vm.allowName" data-element="{{vm.valTabAlias}}">
 
-        <ng-form name="groupNameForm" data-element="group-name">
+        <ng-form name="groupNameForm" data-element="group-name" class="flx-g1">
             <div class="umb-group-builder__group-title control-group -no-margin" ng-class="{'-inherited': vm.group.inherited}">
                 <umb-icon icon="icon-navigation"
                           class="umb-group-builder__group-title-icon"
                           ng-if="vm.sorting && !vm.group.inherited">
                 </umb-icon>
                 <input data-element="group-name-field"
-                        class="umb-group-builder__group-title-input"
+                        class="umb-group-builder__group-title-input w-100"
                         type="text"
                         localize="placeholder"
                         placeholder="@placeholders_entername"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When adding groups to a content type you only have ~200px width in the field for the name, and then a lot of unused whitespace.

When making somewhat long group names, this is quite annoying, so I fixed it.

Before:
![image](https://user-images.githubusercontent.com/3726467/141643323-f33387b4-1ffb-42c3-8f04-e204faf39603.png)

After 
![image](https://user-images.githubusercontent.com/3726467/141643348-480f5076-bc36-4920-910b-4abcde94d813.png)

