### PR TITLE
Adds support for simple markdown in property descriptions, and extended property descriptions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
@@ -75,7 +75,21 @@
                 // inheritance is (i.e.infinite editing)
                 var found = angularHelper.traverseScopeChain($scope, s => s && s.vm && s.vm.constructor.name === "UmbPropertyController");
                 vm.parentUmbProperty = found ? found.vm : null;
+          }
+
+          if (vm.property.description) {
+            // split by lines containing only '--'
+            var descriptionParts = vm.property.description.split(/^--$/gim);
+            if (descriptionParts.length > 1) {
+              // if more than one part, we have an extended description,
+              // combine to one extended description, and remove leading linebreak
+              vm.property.extendedDescription = descriptionParts.splice(1).join("--").substring(1);
+              vm.property.extendedDescriptionVisible = false;
+
+              // set propertydescription to first part, and remove trailing linebreak
+              vm.property.description = descriptionParts[0].slice(0, -1);
             }
+          }
         }
 
     }

--- a/src/Umbraco.Web.UI.Client/src/common/filters/simpleMarkdown.filter.js.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/simpleMarkdown.filter.js.js
@@ -1,0 +1,20 @@
+/**
+* @ngdoc filter
+* @name umbraco.filters.simpleMarkdown
+* @description 
+* Used when rendering a string as Markdown as HTML (i.e. with ng-bind-html). Allows use of **bold**, *italics*, ![images](url) and [links](url)
+**/
+angular.module("umbraco.filters").filter('simpleMarkdown', function () {
+  return function (text) {
+	if (!text) {
+		return '';
+    }
+
+    return text
+      .replace(/\*\*(.*)\*\*/gim, '<b>$1</b>')
+      .replace(/\*(.*)\*/gim, '<i>$1</i>')
+      .replace(/!\[(.*?)\]\((.*?)\)/gim, "<img alt='$1' src='$2' />")
+      .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2' target='_blank' class='underline'>$1</a>")
+      .replace(/\n/g, '<br />').trim();
+  };
+});

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -237,7 +237,6 @@ umb-property:last-of-type .umb-control-group {
     }
 
     .control-description {
-        max-width:480px;// avoiding description becoming too wide when its placed on top of property.
         margin-bottom: 5px;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -24,7 +24,20 @@
 
                     <umb-property-actions ng-if="!vm.showInherit" actions="vm.propertyActions"></umb-property-actions>
 
-                    <small class="control-description" ng-if="vm.property.description" ng-bind-html="vm.property.description | preserveNewLineInHtml"></small>
+                    <small class="control-description" ng-if="vm.property.description" ng-bind-html="vm.property.description | simpleMarkdown"></small>
+
+                    <div ng-if="vm.property.extendedDescription">
+
+                      <div ng-if="vm.property.extendedDescriptionVisible">
+                        <small class="control-description" ng-bind-html="vm.property.extendedDescription | simpleMarkdown"></small>
+                      </div>
+
+                      <button type="button" class="btn btn-mini btn-link btn-link-reverse p0" ng-click="vm.property.extendedDescriptionVisible = !vm.property.extendedDescriptionVisible">
+                          <localize ng-if="!vm.property.extendedDescriptionVisible" key="general_readMore"></localize>
+                          <localize ng-if="vm.property.extendedDescriptionVisible" key="general_close"></localize>
+                      </button>
+
+                    </div>
                 </div>
 
                 <div class="controls" ng-transclude>


### PR DESCRIPTION
This one adds the ability to use simple markdown in property descriptions.

I've added a filter for converting simple markdown like `**bold**` `*italics*` `![images](url)` and `[links](url)`

![image](https://user-images.githubusercontent.com/3726467/141645283-87e1f38a-8f97-4226-a70e-2d0609cabc79.png)

In addition to that, a new convention where if you put a line with `--` in your description, the description will split up in a default description, and an extended description that you can show by clicking Read more.

This makes for a less crowded editor experience, with easy access to more detailed descriptions of each field.

![image](https://user-images.githubusercontent.com/3726467/141645335-3d1b10b6-8d10-48ea-a84d-32045d366ee8.png)

In the above examples the following description is used:
```
Write some text in this field.
**Important!**
This is going to be live on the website
--
If you write something you *don't like*, you have to apologize. 
![Umbraco logo](/umbraco/assets/img/application/logo.png)
[Umbraco HQ](https://www.umbraco.com)
```

Could be especially useful with label type properties, and the "label above" setting
![image](https://user-images.githubusercontent.com/3726467/141645570-bb71e664-ee6f-4c54-bf33-ff9ba3221622.png)