### PR TITLE
Makes the template column in NC config expandable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.controller.js
@@ -1,4 +1,4 @@
-﻿angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.DocTypePickerController", [
+angular.module("umbraco").controller("Umbraco.PropertyEditors.NestedContent.DocTypePickerController", [
 
     "$scope",
     "Umbraco.PropertyEditors.NestedContent.Resources",
@@ -10,6 +10,7 @@
         var selectElementTypeModalTitle = "";
 
         $scope.elemTypeTabs = [];
+        $scope.expandTemplate = false;
 
 
         init();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.doctypepicker.html
@@ -1,4 +1,4 @@
-﻿<div id="{{model.alias}}" class="umb-nested-content__doctypepicker" ng-controller="Umbraco.PropertyEditors.NestedContent.DocTypePickerController">
+<div id="{{model.alias}}" class="umb-nested-content__doctypepicker" ng-controller="Umbraco.PropertyEditors.NestedContent.DocTypePickerController">
     <div>
         <table class="table table-striped">
             <thead>
@@ -10,7 +10,11 @@
                     <th>
                         <localize key="general_group">Group</localize>
                     </th>
-                    <th>
+                    <th ng-class="{'w-100':expandTemplate}">
+                        <button type="button" class="pull-right p0 btn btn-link" ng-click="expandTemplate = !expandTemplate"
+                                ng-class="{'fa-flip-horizontal': !expandTemplate}">
+                          <umb-icon icon="icon-tab-key"></umb-icon>
+                        </button>
                         <localize key="template_template">Template</localize>
                     </th>
                     <th></th>


### PR DESCRIPTION
When adding name templates to Nested Content data types, it's most of the time incredibly hard to overview what's in the template field.

This one tries to help, by making it possible to expand the column containing the template field, thus making the field wider.

![bQjVFY35nS](https://user-images.githubusercontent.com/3726467/141647598-770a4c00-5c6a-400c-9838-e7b0cbdb65b6.gif)


