### PR TITLE
Adjust z-index of notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
@@ -1,5 +1,5 @@
 .umb-notifications {
-    z-index: 999999;
+    z-index: @zindexNotification;
     position: absolute;
     bottom: @editorFooterHeight;
     left: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -362,6 +362,8 @@
 @zindexUmbOverlay:        7500;
 @zindexOverlayBackdrop:   2000;
 
+@zindexNotification:      8000;
+
 // these are used for the tour which should be on top of everything else
 @zindexTourBackdrop:      9999;
 @zindexTourModal:        10000;

--- a/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/notifications/umb-notifications.html
@@ -1,5 +1,5 @@
 <div class="umb-notifications" id="umb-notifications-wrapper" ng-cloak>
-    <ul class="umb-notifications__notifications" aria-live="assertive" aria-relevant="additions">
+    <ul ng-if="notifications" class="umb-notifications__notifications" aria-live="assertive" aria-relevant="additions">
         <li ng-repeat="notification in notifications"
             class="alert alert-block alert-{{notification.type}} umb-notifications__notification animated -half-second fadeIn"
             ng-class="{'-no-border -extra-padding': notification.type === 'form'}">

--- a/src/Umbraco.Web.UI/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Web.UI/umbraco/UmbracoBackOffice/Default.cshtml
@@ -72,8 +72,6 @@
 
             </div>
 
-            <umb-notifications></umb-notifications>
-
         </div>
 
         <umb-tour ng-if="tour.show"
@@ -86,6 +84,8 @@
         <umb-search ng-if="search.show" on-close="closeSearch()"></umb-search>
 
     </div>
+
+    <umb-notifications></umb-notifications>
 
     <umb-backdrop ng-if="backdrop.show || infiniteMode"
                   backdrop-opacity="backdrop.opacity"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/11701

### Description
This PR adjust the changes made in https://github.com/umbraco/Umbraco-CMS/pull/10518

- Store the z-index in a variable
- Decrease the z-index (I don't see the reason to use z-index 999999 unless we needed to overwrite some third party overlays etc.). We can't guard us against e.g. package developer doing stuff with an even higher z-index e.g. 1000000 or using `!important`, but we know the z-indexes used in core CSS. Not sure there is a specific use-case where notifications should be above tour overlay?
- Only show `<ul>` when any notifications are appended to list.

If saving a content node and open a block list item, the notification is since https://github.com/umbraco/Umbraco-CMS/pull/10518 above block overlay, but the notification can't be closed.
It seems to because notifications exists inside `mainwrapper` in DOM, while overlays are outside this.

I noticed there is this static view https://github.com/umbraco/Umbraco-CMS/blob/v9/contrib/src/Umbraco.Web.UI.Client/src/index.html (not sure what it used for though), but here `<umb-notifications>` component is not placed inside `mainwrapper`. I don't recall if is originally was or has been moved later.


**Before**

https://user-images.githubusercontent.com/2919859/144763993-51f786e3-695b-4591-8a0c-90fae67f108a.mp4


**After**

https://user-images.githubusercontent.com/2919859/144763904-a25a56e8-7277-4247-8fa4-6bda1a1a3574.mp4
