### PR TITLE
Redirect Dashboard: Wrap Texts in <umb-box> directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.html
@@ -95,18 +95,31 @@
 
     </div>
 
-    <umb-empty-state
-        ng-if="vm.redirectUrls.length === 0 && vm.dashboard.searchTerm.length === 0 && !vm.dashboard.loading"
-        position="center">
-        <div><localize key="redirectUrls_noRedirects">No redirects have been made</localize></div>
-        <small class="faded"><localize key="redirectUrls_noRedirectsDescription">When a published page gets renamed or moved a redirect will automatically be made to the new page</localize></small>
-    </umb-empty-state>
+    <umb-box ng-if="vm.redirectUrls.length === 0 && vm.dashboard.searchTerm.length === 0 && !vm.dashboard.loading">
+        <umb-box-content class="block-form">
 
-    <umb-empty-state
-        ng-if="vm.redirectUrls.length === 0 && vm.dashboard.searchTerm.length > 0 && !vm.dashboard.loading"
-        position="center">
-        <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
-    </umb-empty-state>
+            <umb-empty-state size="small">
+                <div>
+                    <localize key="redirectUrls_noRedirects">No redirects have been made</localize>
+                </div>
+                <small class="faded">
+                    <localize key="redirectUrls_noRedirectsDescription">When a published page gets renamed or moved a redirect will
+                        automatically be made to the new page</localize>
+                </small>
+            </umb-empty-state>
+
+        </umb-box-content>
+    </umb-box>
+
+    <umb-box ng-if="vm.redirectUrls.length === 0 && vm.dashboard.searchTerm.length > 0 && !vm.dashboard.loading">
+        <umb-box-content class="block-form">
+
+            <umb-empty-state size="small">
+                <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
+            </umb-empty-state>
+
+        </umb-box-content>
+    </umb-box>
 
     <div class="flex justify-center items-center">
         <umb-pagination


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I noticed that in most other sections whenever there is some text, it's wrapped in the `<umb-box>` directive. Under "Translation" if there has not been added any the "There are no dictionary items." text is wrapped in this directive and therefore I was thinking it would make sense to do the same in the Redirect Dashboard where the texts for "empty" and "no search results" are wrapped this way as well. See the before and after below.

**Before**
![no-redirects-before](https://user-images.githubusercontent.com/1932158/141771174-353db778-1e23-4d3d-b6f0-316d556cd992.png)

![no-redirects-before-empty-search](https://user-images.githubusercontent.com/1932158/141771194-4265b9cd-0d68-494c-b891-bc64127c8b73.png)


**After**
![no-redirects-after](https://user-images.githubusercontent.com/1932158/141771210-c96382a6-1af4-414f-a9d0-4c83a1cd8413.png)

![no-redirects-after-empty-search](https://user-images.githubusercontent.com/1932158/141771218-d8f9fb0b-fee2-4582-bbbf-8df6509b566b.png)
