### PR TITLE
contentpicker: Don't validate minNumber/maxNumber if 0

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -45,14 +45,14 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
         if ($scope.contentPickerForm) {
             //Validate!
             var hasItemsOrMandatory = $scope.renderModel.length !== 0 || ($scope.model.validation && $scope.model.validation.mandatory);
-            if (hasItemsOrMandatory && $scope.minNumberOfItems > $scope.renderModel.length) {
+            if (hasItemsOrMandatory && $scope.minNumberOfItems && $scope.minNumberOfItems > $scope.renderModel.length) {
                 $scope.contentPickerForm.minCount.$setValidity("minCount", false);
             }
             else {
                 $scope.contentPickerForm.minCount.$setValidity("minCount", true);
             }
 
-            if ($scope.maxNumberOfItems < $scope.renderModel.length) {
+            if ($scope.maxNumberOfItems && $scope.maxNumberOfItems < $scope.renderModel.length) {
                 $scope.contentPickerForm.maxCount.$setValidity("maxCount", false);
             }
             else {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -32,7 +32,7 @@
         <div class="umb-contentpicker__min-max-help" ng-if="model.config.multiPicker === true && (maxNumberOfItems > 1 || minNumberOfItems > 0) && (renderModel.length !== 0 || (model.validation && model.validation.mandatory))">
 
             <!-- Both min and max items -->
-            <span ng-if="minNumberOfItems !== maxNumberOfItems">
+            <span ng-if="minNumberOfItems && maxNumberOfItems && minNumberOfItems !== maxNumberOfItems">
                 <span ng-if="renderModel.length < maxNumberOfItems">Add between {{minNumberOfItems}} and {{maxNumberOfItems}} items</span>
                 <span ng-if="renderModel.length > maxNumberOfItems">
                     <localize key="validation_maxCount">You can only have</localize> {{maxNumberOfItems}} <localize key="validation_itemsSelected"> items selected</localize>
@@ -40,7 +40,7 @@
             </span>
 
             <!-- Equal min and max -->
-            <span ng-if="minNumberOfItems === maxNumberOfItems">
+            <span ng-if="minNumberOfItems && maxNumberOfItems && minNumberOfItems === maxNumberOfItems">
                 <span ng-if="renderModel.length < maxNumberOfItems">Add {{minNumberOfItems - renderModel.length}} item(s)</span>
                 <span ng-if="renderModel.length > maxNumberOfItems">
                     <localize key="validation_maxCount">You can only have</localize> {{maxNumberOfItems}} <localize key="validation_itemsSelected"> items selected</localize>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11633 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Fixes the following issues:
- When both `minNumber` and `maxNumber` is `0`, adding 1 or more items fails validation with `You can only have 0 items selected`.
- When `minNumber` is `0` and `maxNumber` is N, contentpicker displays both `Add between 0 and N items` and `Add up to N items`. If more than N items are added, error message `You can only have N items selected` is displayed twice.
- When `minNumber` is N and `maxNumber` is `0`, contentpicker displays `Add between N and 0 items`.

<!-- Thanks for contributing to Umbraco CMS! -->
