### PR TITLE
Fix sql builder OrderByDescending extension

### DIFF
--- a/src/Umbraco.Core/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Core/Persistence/NPocoSqlExtensions.cs
@@ -315,7 +315,7 @@ namespace Umbraco.Core.Persistence
             var columns = fields.Length == 0
                 ? sql.GetColumns<TDto>(withAlias: false)
                 : fields.Select(x => sqlSyntax.GetFieldName(x)).ToArray();
-            return sql.OrderBy(columns.Select(x => x + " DESC"));
+            return sql.OrderBy(columns.Select(x => (x + " DESC")).ToArray());
         }
 
         /// <summary>

--- a/src/Umbraco.Tests/Persistence/NPocoTests/NPocoSqlExtensionsTests.cs
+++ b/src/Umbraco.Tests/Persistence/NPocoTests/NPocoSqlExtensionsTests.cs
@@ -194,6 +194,16 @@ INNER JOIN [dto2] ON [dto1].[id] = [dto2].[dto1id]".NoCrLf(), sql.SQL.NoCrLf());
                 .Where<DataTypeDto>(x => x.EditorAlias == "Umbraco.ColorPickerAlias");
         }
 
+        [Test]
+        public void OrderByDescendingTests()
+        {
+            var sql = Sql()
+                .Select("*")
+                .From<Dto1>()
+                .OrderByDescending<Dto1>(x => x.Value, x => x.Name);
+            Assert.AreEqual("SELECT * FROM [dto1] ORDER BY [dto1].[value] DESC, [dto1].[name] DESC".NoCrLf(), sql.SQL.NoCrLf());
+        }
+
         [TableName("dto1")]
         [PrimaryKey("id", AutoIncrement = false)]
         [ExplicitColumns]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11638

### Description

Fixes the output of the sql builder when using the OrderByDescending extension from NPocoSqlExtensions.
I made this change, because this method wasn't creating valid SQL before.
It relates to this issue that I created earlier: #11638 

Use following steps to reproduce the issue and test the fix (same instructions as the linked issue):

### Steps to reproduce

1. Create a c# database model like this:
```csharp
[TableName("demoTable")]
[PrimaryKey("Id", AutoIncrement = true)]
public class DemoModel
{
    [Column("Id")]
    [PrimaryKeyColumn(AutoIncrement = true, IdentitySeed = 1)]
    public int Id { get; set; }
            
    [Column("Date")]
    public DateTime Date { get; set; }

    [Column("SomeSortableField")]
    public int SomeSortableField { get; set; }
}
```
2. Create some code that builds a query with OrderByDescending like this in a controller or unit test:
```csharp
using(var scope = ScopeProvider.CreateScope(autoComplete: true))
{
    var query = scope.SqlContext.Sql()
        .Select<DemoModel>()
        .From<DemoModel>()
        .OrderByDescending<DemoModel>(e => e.SomeSortableField, e => e.Date);

    var entries = await scope.Database.FetchAsync<DemoModel>(query).ConfigureAwait(false);
}
```
3. notice when this code is run, the code throws an exception that the sql syntax is invalid.
