### PR TITLE
V9: Changed 'bevestig nieuw password' to 'bevestig nieuw wachtwoord'

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1834,7 +1834,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="newPassword">Wijzig je wachtwoord</key>
     <key alias="noLockouts">is niet gedeblokkeerd</key>
     <key alias="noPasswordChange">Het wachtwoord is niet gewijzigd</key>
-    <key alias="confirmNewPassword">Bevestig nieuw password</key>
+    <key alias="confirmNewPassword">Bevestig nieuw wachtwoord</key>
     <key alias="changePasswordDescription">Je kunt je wachtwoord veranderen door onderstaand formulier in te vullen en
       op de knop 'Verander wachtwoord' te klikken
     </key>


### PR DESCRIPTION
### Prerequisites

- [V ] I have added steps to test this contribution in the description below

### Description
When changing your password after forgetting it, the Dutch version said 'bevestig nieuw password' and we've had a complaint from a customer, saying this is not consistent. This should be 'bevestig nieuw wachtwoord'.
This can be tested by requesting a resetlink.

<!-- Thanks for contributing to Umbraco CMS! -->
