### PR TITLE
Update to .NET6 and ASP.NET Core 6

### DIFF
--- a/build/NuSpecs/UmbracoCms.nuspec
+++ b/build/NuSpecs/UmbracoCms.nuspec
@@ -16,7 +16,7 @@
         <tags>umbraco</tags>
         <repository type="git" url="https://github.com/umbraco/umbraco-cms" />
         <dependencies>
-            <group targetFramework="net5.0">
+            <group targetFramework="net6.0">
                 <dependency id="Umbraco.Cms.Web.Website" version="[$version$]" />
                 <dependency id="Umbraco.Cms.Web.BackOffice" version="[$version$]" />
                 <dependency id="Umbraco.Cms.StaticAssets" version="[$version$]" />

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -49,9 +49,9 @@ stages:
                 vmImage: ubuntu-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: DotNetCoreCLI@2
                   displayName: dotnet build
                   inputs:
@@ -69,9 +69,9 @@ stages:
                 vmImage: macOS-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: DotNetCoreCLI@2
                   displayName: dotnet build
                   inputs:
@@ -89,9 +89,9 @@ stages:
                 vmImage: windows-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: DotNetCoreCLI@2
                   displayName: dotnet build
                   inputs:
@@ -116,9 +116,9 @@ stages:
                 vmImage: ubuntu-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: DotNetCoreCLI@2
                   displayName: dotnet build
                   inputs:
@@ -139,9 +139,9 @@ stages:
                 vmImage: windows-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - powershell: sqllocaldb start mssqllocaldb
                   displayName: Start MSSQL LocalDb
                 - task: DotNetCoreCLI@2
@@ -181,9 +181,9 @@ stages:
                 vmImage: windows-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
 
                 - powershell: sqllocaldb start mssqllocaldb
                   displayName: Start MSSQL LocalDb
@@ -278,9 +278,9 @@ stages:
                 vmImage: ubuntu-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: Bash@3
                   displayName: Create database
                   inputs:
@@ -380,9 +380,9 @@ stages:
                 vmImage: windows-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: NuGetToolInstaller@1
                   displayName: Use NuGet Latest
                 - task: NuGetCommand@2
@@ -533,9 +533,9 @@ stages:
                 vmImage: windows-latest
             steps:
                 - task: UseDotNet@2
-                  displayName: Use .Net 5.x
+                  displayName: Use .Net 6.x
                   inputs:
-                      version: 5.x
+                      version: 6.x
                 - task: PowerShell@2
                   displayName: 'Prep build tool -  C# Docs'
                   inputs:

--- a/build/templates/UmbracoPackage/.template.config/template.json
+++ b/build/templates/UmbracoPackage/.template.config/template.json
@@ -84,16 +84,12 @@
             "datatype": "choice",
             "choices": [
                 {
-                    "choice": "net5.0",
-                    "description": "Target net5.0"
-                },
-                {
                     "choice": "net6.0",
                     "description": "Target net6.0"
                 }
             ],
-            "replaces": "net5.0",
-            "defaultValue": "net5.0"
+            "replaces": "net6.0",
+            "defaultValue": "net6.0"
         }
     }
 }

--- a/build/templates/UmbracoPackage/UmbracoPackage.csproj
+++ b/build/templates/UmbracoPackage/UmbracoPackage.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <ContentTargetFolders>.</ContentTargetFolders>
         <Product>UmbracoPackage</Product>
         <PackageId>UmbracoPackage</PackageId>

--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -80,16 +80,12 @@
             "datatype": "choice",
             "choices": [
                 {
-                    "choice": "net5.0",
-                    "description": "Target net5.0"
-                },
-                {
                     "choice": "net6.0",
                     "description": "Target net6.0"
                 }
             ],
-            "replaces": "net5.0",
-            "defaultValue": "net5.0"
+            "replaces": "net6.0",
+            "defaultValue": "net6.0"
         },
         "SkipRestore": {
             "type": "parameter",

--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Umbraco.Cms.Web.UI</RootNamespace>
         <DefaultItemExcludes>$(DefaultItemExcludes);App_Plugins/**;</DefaultItemExcludes>
         <DefaultItemExcludes>$(DefaultItemExcludes);umbraco/**;</DefaultItemExcludes>

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
@@ -10,7 +10,7 @@
       <PackageReference Include="CommandLineParser" Version="2.8.0" />
       <PackageReference Include="NJsonSchema" Version="10.5.2" />
       <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-      <PackageReference Include="Umbraco.Forms.Core" Version="9.0.0-preview20210624.66481" />
+      <PackageReference Include="Umbraco.Forms.Core" Version="9.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -75,13 +75,13 @@ namespace Umbraco.Extensions
                     yield return result;
         }
 
-        /// <summary>The distinct by.</summary>
+        /// <summary>The legacy distinct by.</summary>
         /// <param name="source">The source.</param>
         /// <param name="keySelector">The key selector.</param>
         /// <typeparam name="TSource">Source type</typeparam>
         /// <typeparam name="TKey">Key type</typeparam>
         /// <returns>the unique list</returns>
-        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        public static IEnumerable<TSource> LegacyDistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
             where TKey : IEquatable<TKey>
         {
             return source.Distinct(DelegateEqualityComparer<TSource>.CompareMember(keySelector));

--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -578,7 +578,7 @@ namespace Umbraco.Cms.Core.Packaging
 
                         ////Now, we have all property Ids/Aliases and their referenced document Ids and tags
                         //var allExportedTaggedEntities = allTaggedEntities.Where(x => allExportedIds.Contains(x.EntityId))
-                        //    .DistinctBy(x => x.EntityId)
+                        //    .LegacyDistinctBy(x => x.EntityId)
                         //    .OrderBy(x => x.EntityId);
 
                         //foreach (var taggedEntity in allExportedTaggedEntities)

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Extensions
                 // in some cases there will be the same URL for multiple cultures:
                 // * The entire branch is invariant
                 // * If there are less domain/cultures assigned to the branch than the number of cultures/languages installed
-                foreach (UrlInfo dUrl in urlGroup.DistinctBy(x => x.Text.ToUpperInvariant()).OrderBy(x => x.Text).ThenBy(x => x.Culture))
+                foreach (UrlInfo dUrl in urlGroup.LegacyDistinctBy(x => x.Text.ToUpperInvariant()).OrderBy(x => x.Text).ThenBy(x => x.Culture))
                 {
                     result.Add(dUrl);
                 }

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -15,21 +15,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="5.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-        <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
-        <PackageReference Include="Umbraco.Code" Version="1.2.0">
+        <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
+        <PackageReference Include="Umbraco.Code" Version="2.0.0">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -21,12 +21,12 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="2.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Examine" Version="2.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Umbraco.Code" Version="1.2.0">
+    <PackageReference Include="Umbraco.Code" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
+++ b/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
@@ -169,7 +169,7 @@ namespace Umbraco.Cms.Core.Manifest
                 if (manifest.GridEditors != null) gridEditors.AddRange(manifest.GridEditors);
                 if (manifest.ContentApps != null) contentApps.AddRange(manifest.ContentApps);
                 if (manifest.Dashboards != null) dashboards.AddRange(manifest.Dashboards);
-                if (manifest.Sections != null) sections.AddRange(manifest.Sections.DistinctBy(x => x.Alias.ToLowerInvariant()));
+                if (manifest.Sections != null) sections.AddRange(manifest.Sections.LegacyDistinctBy(x => x.Alias.ToLowerInvariant()));
             }
 
             return new CompositePackageManifest(

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/KeysAndIndexes/DeleteKeysAndIndexesBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/KeysAndIndexes/DeleteKeysAndIndexesBuilder.cs
@@ -29,10 +29,10 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.KeysAndIndexe
             _context.BuildingExpression = false;
 
             //get a list of all constraints - this will include all PK, FK and unique constraints
-            var tableConstraints = _context.SqlContext.SqlSyntax.GetConstraintsPerTable(_context.Database).DistinctBy(x => x.Item2).ToList();
+            var tableConstraints = _context.SqlContext.SqlSyntax.GetConstraintsPerTable(_context.Database).LegacyDistinctBy(x => x.Item2).ToList();
 
             //get a list of defined indexes - this will include all indexes, unique indexes and unique constraint indexes
-            var indexes = _context.SqlContext.SqlSyntax.GetDefinedIndexesDefinitions(_context.Database).DistinctBy(x => x.IndexName).ToList();
+            var indexes = _context.SqlContext.SqlSyntax.GetDefinedIndexesDefinitions(_context.Database).LegacyDistinctBy(x => x.IndexName).ToList();
 
             var uniqueConstraintNames = tableConstraints.Where(x => !x.Item2.InvariantStartsWith("PK_") && !x.Item2.InvariantStartsWith("FK_")).Select(x => x.Item2);
             var indexNames = indexes.Select(x => x.IndexName).ToList();

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -189,7 +189,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         private void ValidateDbConstraints(DatabaseSchemaResult result)
         {
             //Check constraints in configured database against constraints in schema
-            var constraintsInDatabase = SqlSyntax.GetConstraintsPerColumn(_database).DistinctBy(x => x.Item3).ToList();
+            var constraintsInDatabase = SqlSyntax.GetConstraintsPerColumn(_database).LegacyDistinctBy(x => x.Item3).ToList();
             var foreignKeysInDatabase = constraintsInDatabase.Where(x => x.Item3.InvariantStartsWith("FK_")).Select(x => x.Item3).ToList();
             var primaryKeysInDatabase = constraintsInDatabase.Where(x => x.Item3.InvariantStartsWith("PK_")).Select(x => x.Item3).ToList();
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .ForUpdate();
 
             // deduplicate the logins
-            logins = logins.DistinctBy(x => x.ProviderKey + x.LoginProvider).ToList();
+            logins = logins.LegacyDistinctBy(x => x.ProviderKey + x.LoginProvider).ToList();
 
             var toUpdate = new Dictionary<int, IExternalLogin>();
             var toDelete = new List<int>();
@@ -225,7 +225,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .ToDictionary(x => x.LoginProvider, x => x.Id);
 
             // deduplicate the tokens
-            tokens = tokens.DistinctBy(x => x.LoginProvider + x.Name).ToList();
+            tokens = tokens.LegacyDistinctBy(x => x.LoginProvider + x.Name).ToList();
 
             var providers = tokens.Select(x => x.LoginProvider).Distinct().ToList();
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -182,7 +182,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .Where<Member2MemberGroupDto>(x => x.Member == memberId);
 
             return Database.Fetch<NodeDto>(sql)
-                .DistinctBy(dto => dto.NodeId)
+                .LegacyDistinctBy(dto => dto.NodeId)
                 .Select(x => MemberGroupFactory.BuildEntity(x));
         }
 
@@ -199,7 +199,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .Where("cmsMember.LoginName=@loginName", new { loginName = username });
 
             return Database.Fetch<NodeDto>(sql)
-                .DistinctBy(dto => dto.NodeId)
+                .LegacyDistinctBy(dto => dto.NodeId)
                 .Select(x => MemberGroupFactory.BuildEntity(x));
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -284,7 +284,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         protected override IEnumerable<IUser> PerformGetByQuery(IQuery<IUser> query)
         {
             var dtos = GetDtosWith(sql => new SqlTranslator<IUser>(sql, query).Translate(), true)
-                .DistinctBy(x => x.Id)
+                .LegacyDistinctBy(x => x.Id)
                 .ToList();
 
             var users = new IUser[dtos.Count];

--- a/src/Umbraco.Infrastructure/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -598,7 +598,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
                 scope.Notifications.Publish(GetContentTypeChangedNotification(changes, eventMessages));
 
-                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.DistinctBy(x => x.Id), eventMessages);
+                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.LegacyDistinctBy(x => x.Id), eventMessages);
                 deletedNotification.WithStateFrom(deletingNotification);
                 scope.Notifications.Publish(deletedNotification);
 
@@ -625,7 +625,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
                 // all descendants are going to be deleted
                 TItem[] allDescendantsAndSelf = itemsA.SelectMany(xx => GetDescendants(xx.Id, true))
-                    .DistinctBy(x => x.Id)
+                    .LegacyDistinctBy(x => x.Id)
                     .ToArray();
                 TItem[] deleted = allDescendantsAndSelf;
 
@@ -656,7 +656,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
                 scope.Notifications.Publish(GetContentTypeChangedNotification(changes, eventMessages));
 
-                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.DistinctBy(x => x.Id), eventMessages);
+                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.LegacyDistinctBy(x => x.Id), eventMessages);
                 deletedNotification.WithStateFrom(deletingNotification);
                 scope.Notifications.Publish(deletedNotification);
 

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
@@ -18,18 +18,21 @@
 
 
     <ItemGroup>
-      <PackageReference Include="HtmlAgilityPack" Version="1.11.36" />
+      <PackageReference Include="HtmlAgilityPack" Version="1.11.38" />
       <PackageReference Include="MailKit" Version="2.15.0" />
-      <PackageReference Include="IPNetwork2" Version="2.5.353" />
+      <PackageReference Include="IPNetwork2" Version="2.5.366" />
       <PackageReference Include="Markdown" Version="2.2.1" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
       <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.10" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.0" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
       <PackageReference Include="MiniProfiler.Shared" Version="4.2.22" />
       <PackageReference Include="ncrontab" Version="3.3.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -37,21 +40,21 @@
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
       <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-      <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
+      <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
       <PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
       <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
       <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.5" />
-      <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
+      <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
       <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-      <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->
-      <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
-      <PackageReference Include="Examine.Core" Version="2.0.0" />
-      <PackageReference Include="Umbraco.Code" Version="1.2.0">
+      <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->
+      <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
+      <PackageReference Include="Examine.Core" Version="2.0.1" />
+      <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
     </ItemGroup>

--- a/src/Umbraco.Persistence.SqlCe/Umbraco.Persistence.SqlCe.csproj
+++ b/src/Umbraco.Persistence.SqlCe/Umbraco.Persistence.SqlCe.csproj
@@ -14,12 +14,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Umbraco.SqlServerCE" Version="4.0.0.1" />
-      <PackageReference Include="Umbraco.Code" Version="1.2.0">
+      <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
     </ItemGroup>

--- a/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
+++ b/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
@@ -15,14 +15,14 @@
 
   <ItemGroup>
     <PackageReference Include="CSharpTest.Net.Collections-NetStd2" Version="14.906.1403.1084" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MessagePack" Version="2.3.75" />
-    <PackageReference Include="K4os.Compression.LZ4" Version="1.2.12" />
+    <PackageReference Include="MessagePack" Version="2.3.85" />
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.2.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Umbraco.Code" Version="1.2.0">
+    <PackageReference Include="Umbraco.Code" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Umbraco.Web.BackOffice/Umbraco.Web.BackOffice.csproj
+++ b/src/Umbraco.Web.BackOffice/Umbraco.Web.BackOffice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>Umbraco.Cms.Web.BackOffice</RootNamespace>
         <PackageId>Umbraco.Cms.Web.BackOffice</PackageId>
@@ -19,13 +19,13 @@
 
     <ItemGroup>
 
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-      <PackageReference Include="Umbraco.Code" Version="1.2.0">
+      <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
     </ItemGroup>

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>Umbraco.Cms.Web.Common</RootNamespace>
         <PackageId>Umbraco.Cms.Web.Common</PackageId>
@@ -25,20 +25,20 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.10" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.10" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-      <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.3" />
-      <PackageReference Include="Smidge.Nuglify" Version="4.0.0" />
-      <PackageReference Include="Smidge.InMemory" Version="4.0.0" />
+      <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.4" />
+      <PackageReference Include="Smidge.Nuglify" Version="4.0.2" />
+      <PackageReference Include="Smidge.InMemory" Version="4.0.2" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-      <PackageReference Include="Umbraco.Code" Version="1.2.0">
+      <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
     </ItemGroup>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Umbraco.Cms.Web.UI</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -66,12 +66,12 @@
   <!-- We don't want to include the generated files, they will throw a lot of errors -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.10" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Umbraco.Code" Version="1.2.0">
+    <PackageReference Include="Umbraco.Code" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -79,6 +79,7 @@
   <PropertyGroup>
     <RazorCompileOnBuild>false</RazorCompileOnBuild>
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator> <!-- Disabling the Razor source generators in .NET 6 -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Umbraco.Web.Website/Umbraco.Web.Website.csproj
+++ b/src/Umbraco.Web.Website/Umbraco.Web.Website.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>Umbraco.Cms.Web.Website</RootNamespace>
         <PackageId>Umbraco.Cms.Web.Website</PackageId>
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Umbraco.Code" Version="1.2.0">
+      <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
     </ItemGroup>

--- a/tests/Umbraco.TestData/Umbraco.TestData.csproj
+++ b/tests/Umbraco.TestData/Umbraco.TestData.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>Umbraco.TestData</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
+++ b/tests/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType> 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -20,7 +20,7 @@
       <Version>0.13.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.16.1</Version>

--- a/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
+++ b/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net5.0</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <RootNamespace>Umbraco.Cms.Tests.Common</RootNamespace>
       <PackageId>Umbraco.Cms.Tests</PackageId>
       <Title>Umbraco CMS Test Tools</Title>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
+++ b/tests/Umbraco.Tests.Integration.SqlCe/Umbraco.Tests.Integration.SqlCe.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Umbraco.Cms.Tests.Integration</RootNamespace>
     <PackageId>Umbraco.Cms.Tests.Integration</PackageId>
     <Title>Umbraco CMS Integration Tests</Title>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.6" />
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
   </ItemGroup>
 
@@ -79,13 +79,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.0" />
+    <PackageReference Include="Examine.Lucene" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/ModelTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/ModelTypeTests.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Published
             Assert.AreEqual("System.Int32[]", type.MakeArrayType().FullName);
 
             // Note the inner assembly qualified name
-            Assert.AreEqual("System.Collections.Generic.IEnumerable`1[[System.Int32[], System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]", typeof(IEnumerable<>).MakeGenericType(type.MakeArrayType()).FullName);
+            Assert.AreEqual("System.Collections.Generic.IEnumerable`1[[System.Int32[], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]", typeof(IEnumerable<>).MakeGenericType(type.MakeArrayType()).FullName);
         }
 
         [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Umbraco.Cms.Tests.UnitTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.6" />
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
   </ItemGroup>
   
@@ -20,12 +20,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.16.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="AngleSharp" Version="0.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="System.Data.Odbc" Version="5.0.0" />
-    <PackageReference Include="System.Data.OleDb" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="System.Data.Odbc" Version="6.0.0" />
+    <PackageReference Include="System.Data.OleDb" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/TestRouteBuilder.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/TestRouteBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -21,6 +22,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Routing
         public TestRouteBuilder()
         {
             var services = new ServiceCollection();
+
+            var diagnosticListener = new DiagnosticListener("UnitTests");
+            services.AddSingleton<DiagnosticSource>(diagnosticListener);
+            services.AddSingleton<DiagnosticListener>(diagnosticListener);
+
             services.AddLogging();
             services.AddMvc();
             services.AddSingleton<IHostApplicationLifetime>(x => new ApplicationLifetime(x.GetRequiredService<ILogger<ApplicationLifetime>>()));


### PR DESCRIPTION
# Details
- Changed targetFramework in nuspec file & project files 
- Updated .net version in pipelines and templates
- Updated NuGet dependencies
- Fixed ambiguous calls
- Disabled the Razor source generators in .NET 6 ([resource](https://andrewlock.net/using-source-generators-with-blazor-in-dotnet-6/))

❗  Note: Download .NET 6 from https://dotnet.microsoft.com/download/dotnet/6.0