### PR TITLE
UmbEditorHeaders hide-icon on "true"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -14,7 +14,7 @@
             <ng-form data-element="editor-icon" name="iconForm">
                 <button
                     type="button" class="umb-panel-header-icon"
-                    ng-if="!hideIcon"
+                    ng-if="hideIcon !== 'true'"
                     ng-click="openIconPicker()"
                     ng-class="{'-placeholder': $parent.icon === '' || $parent.icon === null}"
                     title="{{$parent.icon}}">


### PR DESCRIPTION
### Prerequisites
-  [X] If there's an existing issue for this PR then this fixes #11659 
- [x] I have added steps to test this contribution in the description below


### Description
Since it looks like the `hideIcon `handles as a string instead of a bool. Changing the ng-if to check if it's a string does the trick.