### PR TITLE
Get correct temp path for Examine indexes

### DIFF
--- a/src/Umbraco.Examine.Lucene/UmbracoApplicationRoot.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoApplicationRoot.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
         public DirectoryInfo ApplicationRoot
             => new DirectoryInfo(
                 Path.Combine(
-                    _hostingEnvironment.MapPathContentRoot(Core.Constants.SystemDirectories.TempData),
+                    _hostingEnvironment.LocalTempPath,
                     "ExamineIndexes"));
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #11678

### Description
Currently the `LocalTempStorageLocation` appsetting is not respected for Examine indexes when set to `EnvironmentTemp`. This PR fixes that and places Examine indexes in the correct folder
