### PR TITLE
Added EntityController.GetUrlsByIds support for int & guid + update MNTP

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/mocks/resources/entity.mocks.js
+++ b/src/Umbraco.Web.UI.Client/src/common/mocks/resources/entity.mocks.js
@@ -34,7 +34,7 @@ angular.module('umbraco.mocks').
           return [200, nodes, null];
       }
 
-      function returnUrlsbyUdis(status, data, headers) {
+      function returnUrlsByIds(status, data, headers) {
 
           if (!mocksUtils.checkAuth()) {
               return [401, null, null];
@@ -83,8 +83,8 @@ angular.module('umbraco.mocks').
                   .respond(returnEntitybyIdsPost);
 
               $httpBackend
-                  .whenPOST(mocksUtils.urlRegex('/umbraco/UmbracoApi/Entity/GetUrlsByUdis'))
-                  .respond(returnUrlsbyUdis);
+                  .whenPOST(mocksUtils.urlRegex('/umbraco/UmbracoApi/Entity/GetUrlsByIds'))
+                  .respond(returnUrlsByIds);
 
               $httpBackend
                   .whenGET(mocksUtils.urlRegex('/umbraco/UmbracoApi/Entity/GetAncestors'))

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -127,19 +127,19 @@ function entityResource($q, $http, umbRequestHelper) {
                'Failed to retrieve url for id:' + id);
         },
 
-        getUrlsByUdis: function(udis, culture) {
-          var query = "culture=" + (culture || "");
+        getUrlsByIds: function(ids, type, culture) {
+          var query = `type=${type}&culture=${culture || ""}`;
 
           return umbRequestHelper.resourcePromise(
              $http.post(
                  umbRequestHelper.getApiUrl(
                      "entityApiBaseUrl",
-                     "GetUrlsByUdis",
+                     "GetUrlsByIds",
                      query),
                  {
-                     udis: udis
+                     ids: ids
                  }),
-             'Failed to retrieve url map for udis ' + udis);
+             'Failed to retrieve url map for ids ' + ids);
         },
 
         getUrlByUdi: function (udi, culture) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -421,7 +421,7 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
 
                 var requests = [
                     entityResource.getByIds(missingIds, entityType),
-                    entityResource.getUrlsByUdis(missingIds)
+                    entityResource.getUrlsByIds(missingIds, entityType)
                 ];
 
                 return $q.all(requests).then(function ([data, urlMap]) {


### PR DESCRIPTION
Fixes issue with MNTP (for 8.18) in a partial view macro - GH #11631

Renamed GetUrlsByUdis to match, don't do this in v9 as it would be
breaking there, instead mark it obsolete.

TODO: v9 ensure integration test coverage, more painful here as no 
WebApplicationFactory.
