### PR TITLE
Cherry-pick: support import/export for doc type history cleanup policy

### DIFF
--- a/src/Umbraco.Core/Models/IContentType.cs
+++ b/src/Umbraco.Core/Models/IContentType.cs
@@ -4,12 +4,16 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 
 namespace Umbraco.Cms.Core.Models
 {
-    [Obsolete("This will be merged into IContentType in Umbraco 10")]
+    /// <summary>
+    /// Defines a content type that contains a history cleanup policy.
+    /// </summary>
+    [Obsolete("This will be merged into IContentType in Umbraco 10.")]
     public interface IContentTypeWithHistoryCleanup : IContentType
     {
         /// <summary>
-        ///     Gets or Sets the history cleanup configuration
+        /// Gets or sets the history cleanup configuration.
         /// </summary>
+        /// <value>The history cleanup configuration.</value>
         HistoryCleanup HistoryCleanup { get; set; }
     }
 

--- a/src/Umbraco.Core/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentTypeMapDefinition.cs
@@ -185,19 +185,14 @@ namespace Umbraco.Cms.Core.Models.Mapping
             {
                 target.HistoryCleanup = new HistoryCleanupViewModel
                 {
-                    PreventCleanup = sourceWithHistoryCleanup.HistoryCleanup.PreventCleanup,
-                    KeepAllVersionsNewerThanDays =
-                        sourceWithHistoryCleanup.HistoryCleanup.KeepAllVersionsNewerThanDays,
-                    KeepLatestVersionPerDayForDays =
-                        sourceWithHistoryCleanup.HistoryCleanup.KeepLatestVersionPerDayForDays,
-                    GlobalKeepAllVersionsNewerThanDays =
-                        _contentSettings.ContentVersionCleanupPolicy.KeepAllVersionsNewerThanDays,
-                    GlobalKeepLatestVersionPerDayForDays =
-                        _contentSettings.ContentVersionCleanupPolicy.KeepLatestVersionPerDayForDays,
+                    PreventCleanup = sourceWithHistoryCleanup.HistoryCleanup?.PreventCleanup ?? false,
+                    KeepAllVersionsNewerThanDays = sourceWithHistoryCleanup.HistoryCleanup?.KeepAllVersionsNewerThanDays,
+                    KeepLatestVersionPerDayForDays = sourceWithHistoryCleanup.HistoryCleanup?.KeepLatestVersionPerDayForDays,
+                    GlobalKeepAllVersionsNewerThanDays = _contentSettings.ContentVersionCleanupPolicy.KeepAllVersionsNewerThanDays,
+                    GlobalKeepLatestVersionPerDayForDays = _contentSettings.ContentVersionCleanupPolicy.KeepLatestVersionPerDayForDays,
                     GlobalEnableCleanup = _contentSettings.ContentVersionCleanupPolicy.EnableCleanup
                 };
             }
-
 
             target.AllowCultureVariant = source.VariesByCulture();
             target.AllowSegmentVariant = source.VariesBySegment();

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -12,7 +12,6 @@ using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Packaging;
 using Umbraco.Cms.Core.Packaging;
@@ -22,8 +21,6 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
-using Language = Umbraco.Cms.Core.Models.Language;
-using Stylesheet = Umbraco.Cms.Core.Models.Stylesheet;
 
 namespace Umbraco.Cms.Infrastructure.Packaging
 {
@@ -832,7 +829,7 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 return;
             }
 
-            withCleanup.HistoryCleanup ??= new HistoryCleanup();
+            withCleanup.HistoryCleanup ??= new Core.Models.ContentEditing.HistoryCleanup();
 
             if (bool.TryParse(element.Attribute("preventCleanup")?.Value, out var preventCleanup))
             {

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Packaging;
 using Umbraco.Cms.Core.Packaging;
@@ -21,6 +22,8 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
+using Language = Umbraco.Cms.Core.Models.Language;
+using Stylesheet = Umbraco.Cms.Core.Models.Stylesheet;
 
 namespace Umbraco.Cms.Infrastructure.Packaging
 {
@@ -814,7 +817,45 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             UpdateContentTypesPropertyGroups(contentType, documentType.Element("Tabs"));
             UpdateContentTypesProperties(contentType, documentType.Element("GenericProperties"));
 
+            if (contentType is IContentTypeWithHistoryCleanup withCleanup)
+            {
+                UpdateHistoryCleanupPolicy(withCleanup, documentType.Element("HistoryCleanupPolicy"));
+            }
+
             return contentType;
+        }
+
+        private void UpdateHistoryCleanupPolicy(IContentTypeWithHistoryCleanup withCleanup, XElement element)
+        {
+            if (element == null)
+            {
+                return;
+            }
+
+            withCleanup.HistoryCleanup ??= new HistoryCleanup();
+
+            if (bool.TryParse(element.Attribute("preventCleanup")?.Value, out var preventCleanup))
+            {
+                withCleanup.HistoryCleanup.PreventCleanup = preventCleanup;
+            }
+
+            if (int.TryParse(element.Attribute("keepAllVersionsNewerThanDays")?.Value, out var keepAll))
+            {
+                withCleanup.HistoryCleanup.KeepAllVersionsNewerThanDays = keepAll;
+            }
+            else
+            {
+                withCleanup.HistoryCleanup.KeepAllVersionsNewerThanDays = null;
+            }
+
+            if (int.TryParse(element.Attribute("keepLatestVersionPerDayForDays")?.Value, out var keepLatest))
+            {
+                withCleanup.HistoryCleanup.KeepLatestVersionPerDayForDays = keepLatest;
+            }
+            else
+            {
+                withCleanup.HistoryCleanup.KeepLatestVersionPerDayForDays = null;
+            }
         }
 
         private void UpdateContentTypesAllowedTemplates(IContentType contentType, XElement allowedTemplatesElement, XElement defaultTemplateElement)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -297,15 +297,17 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         private void PersistHistoryCleanup(IContentType entity)
         {
+            // historyCleanup property is not mandatory for api endpoint, handle the case where it's not present.
+            // DocumentTypeSave doesn't handle this for us like ContentType constructors do.
             if (entity is IContentTypeWithHistoryCleanup entityWithHistoryCleanup)
             {
                 ContentVersionCleanupPolicyDto dto = new ContentVersionCleanupPolicyDto()
                 {
                     ContentTypeId = entity.Id,
                     Updated = DateTime.Now,
-                    PreventCleanup = entityWithHistoryCleanup.HistoryCleanup.PreventCleanup,
-                    KeepAllVersionsNewerThanDays = entityWithHistoryCleanup.HistoryCleanup.KeepAllVersionsNewerThanDays,
-                    KeepLatestVersionPerDayForDays = entityWithHistoryCleanup.HistoryCleanup.KeepLatestVersionPerDayForDays
+                    PreventCleanup = entityWithHistoryCleanup.HistoryCleanup?.PreventCleanup ?? false,
+                    KeepAllVersionsNewerThanDays = entityWithHistoryCleanup.HistoryCleanup?.KeepAllVersionsNewerThanDays,
+                    KeepLatestVersionPerDayForDays = entityWithHistoryCleanup.HistoryCleanup?.KeepLatestVersionPerDayForDays
                 };
                 Database.InsertOrUpdate(dto);
             }

--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/views/permissions/permissions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/views/permissions/permissions.html
@@ -101,23 +101,19 @@
                 </div>
 
                 <div class="sub-view-column-right">
-                    <umb-box-content>
-                        <div class="umb-panel-group__details-status-text" ng-if="!model.historyCleanup.globalEnableCleanup">
-                            <p class="umb-panel-group__details-status-action"><localize key="contentTypeEditor_historyCleanupGloballyDisabled"></localize></p>
-                        </div>
+                    <p ng-if="!model.historyCleanup.globalEnableCleanup" class="umb-alert umb-alert--info"><localize key="contentTypeEditor_historyCleanupGloballyDisabled"></localize></p>
 
-                        <umb-control-group label="@contentTypeEditor_historyCleanupPreventCleanup">
-                            <umb-toggle checked="model.historyCleanup.preventCleanup" on-click="vm.toggleHistoryCleanupPreventCleanup()"></umb-toggle>
-                        </umb-control-group>
+                    <umb-control-group label="@contentTypeEditor_historyCleanupPreventCleanup">
+                        <umb-toggle checked="model.historyCleanup.preventCleanup" on-click="vm.toggleHistoryCleanupPreventCleanup()"></umb-toggle>
+                    </umb-control-group>
 
-                        <umb-control-group label="@contentTypeEditor_historyCleanupKeepAllVersionsNewerThanDays">
-                            <input ng-readonly="model.historyCleanup.preventCleanup" placeholder="{{model.historyCleanup.globalKeepAllVersionsNewerThanDays}}" type="number" min="0" max="2147483647" ng-model="model.historyCleanup.keepAllVersionsNewerThanDays" />
-                        </umb-control-group>
+                    <umb-control-group label="@contentTypeEditor_historyCleanupKeepAllVersionsNewerThanDays">
+                        <input ng-readonly="model.historyCleanup.preventCleanup" placeholder="{{model.historyCleanup.globalKeepAllVersionsNewerThanDays}}" type="number" min="0" max="2147483647" ng-model="model.historyCleanup.keepAllVersionsNewerThanDays" />
+                    </umb-control-group>
 
-                        <umb-control-group label="@contentTypeEditor_historyCleanupKeepLatestVersionPerDayForDays">
-                            <input ng-readonly="model.historyCleanup.preventCleanup" placeholder="{{model.historyCleanup.globalKeepLatestVersionPerDayForDays}}" type="number" min="0" max="2147483647" ng-model="model.historyCleanup.keepLatestVersionPerDayForDays" />
-                        </umb-control-group>
-                    </umb-box-content>
+                    <umb-control-group label="@contentTypeEditor_historyCleanupKeepLatestVersionPerDayForDays">
+                        <input ng-readonly="model.historyCleanup.preventCleanup" placeholder="{{model.historyCleanup.globalKeepLatestVersionPerDayForDays}}" type="number" min="0" max="2147483647" ng-model="model.historyCleanup.keepLatestVersionPerDayForDays" />
+                    </umb-control-group>
                 </div>
 
             </div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1833,11 +1833,11 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     </key>
     <key alias="usingEditor">using this editor will get updated with the new settings.</key>
     <key alias="historyCleanupHeading">History cleanup</key>
-    <key alias="historyCleanupDescription">Allow override the global settings for when history versions are removed.</key>
+    <key alias="historyCleanupDescription">Allow overriding the global history cleanup settings.</key>
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
-    <key alias="historyCleanupGloballyDisabled">NOTE! The content version cleanup feature is disabled globally. These settings will not take effect until it is enabled.</key>
+    <key alias="historyCleanupGloballyDisabled">History cleanup is disabled globally, these settings will not take effect until it is enabled.</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1897,11 +1897,11 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     </key>
     <key alias="usingEditor">using this editor will get updated with the new settings.</key>
     <key alias="historyCleanupHeading">History cleanup</key>
-    <key alias="historyCleanupDescription">Allow override the global settings for when history versions are removed.</key>
+    <key alias="historyCleanupDescription">Allow overriding the global history cleanup settings.</key>
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
-    <key alias="historyCleanupGloballyDisabled">NOTE! The content version cleanup feature is disabled globally. These settings will not take effect until it is enabled.</key>
+    <key alias="historyCleanupGloballyDisabled">History cleanup is disabled globally, these settings will not take effect until it is enabled.</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/ImportResources.Designer.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/ImportResources.Designer.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importin
         ///  &lt;/info&gt;
         ///  &lt;Documents&gt;
         ///    &lt;DocumentSet importMode=&quot;root&quot;&gt;
-        ///      &lt;NewType id=&quot;1148&quot; parentID=&quot;-1&quot; level=&quot;1&quot; creatorID=&quot;0&quot; sortOrder=&quot;9&quot; createDate=&quot;2013-07-23T12:06:07&quot; updateDate=&quot;2013-07-23T15:56:37&quot; nodeName=&quot;DoIt&quot; urlName=&quot;doit&quot; path=&quot;-1,1148&quot; isDoc=&quot;&quot; nodeType=&quot;1134&quot; creatorName=&quot;admin&quot; writerName=&quot;admin&quot; writerID=&quot;0&quot; template=&quot;1133&quot; nodeTy [rest of string was truncated]&quot;;.
+        ///      &lt;NewType key=&quot;9c9b55d0-2fbf-4f12-afea-023bd7b2519d&quot; id=&quot;1148&quot; parentID=&quot;-1&quot; level=&quot;1&quot; creatorID=&quot;0&quot; sortOrder=&quot;9&quot; createDate=&quot;2013-07-23T12:06:07&quot; updateDate=&quot;2013-07-23T15:56:37&quot; nodeName=&quot;DoIt&quot; urlName=&quot;doit&quot; path=&quot;-1,1148&quot; isDoc=&quot;&quot; nodeType=&quot;1134&quot; creatorName=&quot;admin&quot; writerName= [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string CheckboxList_Content_Package {
             get {
@@ -91,7 +91,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importin
         ///  &lt;/info&gt;
         ///  &lt;Documents&gt;
         ///    &lt;DocumentSet importMode=&quot;root&quot;&gt;
-        ///      &lt;umbHomePage id=&quot;1068&quot; parentID=&quot;-1&quot; level=&quot;1&quot; creatorID=&quot;0&quot; sortOrder=&quot;0&quot; createDate=&quot;2014-11-26T12:52:35&quot; updateDate=&quot;2014-11-26T12:52:36&quot; nodeName=&quot;Home&quot; urlName=&quot;home&quot; path=&quot;-1,1068&quot; isDoc=&quot;&quot; nodeType=&quot;1056&quot; creatorName=&quot;Morten Christensen&quot; writerName=&quot;Morten Christensen&quot;  [rest of string was truncated]&quot;;.
+        ///      &lt;umbHomePage key=&quot;9c9b55d0-2fbf-4f12-afea-023bd7b2519d&quot; id=&quot;1068&quot; parentID=&quot;-1&quot; level=&quot;1&quot; creatorID=&quot;0&quot; sortOrder=&quot;0&quot; createDate=&quot;2014-11-26T12:52:35&quot; updateDate=&quot;2014-11-26T12:52:36&quot; nodeName=&quot;Home&quot; urlName=&quot;home&quot; path=&quot;-1,1068&quot; isDoc=&quot;&quot; nodeType=&quot;1056&quot; creatorName=&quot;Morten Ch [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string CompositionsTestPackage {
             get {
@@ -124,15 +124,14 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importin
         ///  &lt;files /&gt;
         ///  &lt;info&gt;
         ///    &lt;package&gt;
-        ///      &lt;name&gt;Dictionary-Package&lt;/name&gt;      
+        ///      &lt;name&gt;Dictionary-Package&lt;/name&gt;
         ///    &lt;/package&gt;
         ///  &lt;/info&gt;
         ///  &lt;DictionaryItems&gt;
-        ///    &lt;DictionaryItem Key=&quot;Parent&quot;&gt;
+        ///    &lt;DictionaryItem Key=&quot;28f2e02a-8c66-4fcd-85e3-8524d551c0d3&quot; Name=&quot;Parent&quot;&gt;
         ///      &lt;Value LanguageId=&quot;2&quot; LanguageCultureAlias=&quot;nb-NO&quot;&gt;&lt;![CDATA[ForelderVerdi]]&gt;&lt;/Value&gt;
         ///      &lt;Value LanguageId=&quot;3&quot; LanguageCultureAlias=&quot;en-GB&quot;&gt;&lt;![CDATA[ParentValue]]&gt;&lt;/Value&gt;
-        ///      &lt;DictionaryItem Key=&quot;Child&quot;&gt;
-        ///        &lt;Value LanguageId=&quot;2&quot; LanguageCultureAlias=&quot;nb-NO&quot;&gt;&lt;![CDATA[BarnV [rest of string was truncated]&quot;;.
+        ///      &lt;DictionaryItem Key=&quot;e7dba0a9-d517-4ba4-8e18-2764d392c611&quot; Name=&quot; [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Dictionary_Package {
             get {
@@ -240,6 +239,33 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importin
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;DocumentType&gt;
+        ///  &lt;Info&gt;
+        ///    &lt;Name&gt;test&lt;/Name&gt;
+        ///    &lt;Key&gt;150ead17-d359-42a2-ac33-6504cc52ced1&lt;/Key&gt;
+        ///    &lt;Alias&gt;test&lt;/Alias&gt;
+        ///    &lt;Icon&gt;folder.gif&lt;/Icon&gt;
+        ///    &lt;Thumbnail&gt;folder.png&lt;/Thumbnail&gt;
+        ///    &lt;Description&gt;
+        ///    &lt;/Description&gt;
+        ///    &lt;AllowAtRoot&gt;False&lt;/AllowAtRoot&gt;
+        ///    &lt;AllowedTemplates&gt;
+        ///      &lt;Template&gt;test&lt;/Template&gt;
+        ///    &lt;/AllowedTemplates&gt;
+        ///    &lt;DefaultTemplate&gt;test&lt;/DefaultTemplate&gt;
+        ///  &lt;/Info&gt;
+        ///  &lt;Structure&gt;
+        ///    &lt;DocumentType&gt;test&lt;/DocumentType&gt;
+        ///  &lt;/Str [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string SingleDocType_WithCleanupPolicy {
+            get {
+                return ResourceManager.GetString("SingleDocType_WithCleanupPolicy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
         ///&lt;umbPackage&gt;
         ///  &lt;info&gt;
@@ -249,8 +275,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importin
         ///  &lt;/info&gt;
         ///  &lt;Documents&gt;
         ///    &lt;DocumentSet importMode=&quot;root&quot;&gt;
-        ///      &lt;Homepage id=&quot;1072&quot; parentID=&quot;-1&quot; level=&quot;1&quot; creatorID=&quot;0&quot; sortOrder=&quot;0&quot; createDate=&quot;2013-02-17T09:04:39&quot; updateDate=&quot;2013-02-17T09:10:47&quot; nodeName=&quot;Home&quot; urlName=&quot;home&quot; path=&quot;-1,1072&quot; isDoc=&quot;&quot; nodeType=&quot;1062&quot; creatorName=&quot;admin&quot; writerName=&quot;admin&quot; writerID=&quot;0&quot; template=&quot;1049&quot;&gt;
-        ///        &lt;slide [rest of string was truncated]&quot;;.
+        ///      &lt;Homepage key=&quot;9c9b55d0-2fbf-4f12-afea-023bd7b2519d&quot; id=&quot;1072&quot; parentID=&quot;-1&quot; level=&quot;1&quot; creatorID=&quot;0&quot; sortOrder=&quot;0&quot; createDate=&quot;2013-02-17T09:04:39&quot; updateDate=&quot;2013-02-17T09:10:47&quot; nodeName=&quot;Home&quot; urlName=&quot;home&quot; path=&quot;-1,1072&quot; isDoc=&quot;&quot; nodeType=&quot;1062&quot; creatorName=&quot;admin&quot; writerName=&quot;admin&quot; wr [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string StandardMvc_Package {
             get {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/ImportResources.resx
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/ImportResources.resx
@@ -1,17 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -156,5 +156,8 @@
   </data>
   <data name="MediaTypesAndMedia_Package.xml" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>MediaTypesAndMedia-Package.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="SingleDocType_WithCleanupPolicy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SingleDocType-WithCleanupPolicy.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
 </root>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/SingleDocType-WithCleanupPolicy.xml
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/SingleDocType-WithCleanupPolicy.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<DocumentType>
+  <Info>
+    <Name>test</Name>
+    <Key>150ead17-d359-42a2-ac33-6504cc52ced1</Key>
+    <Alias>test</Alias>
+    <Icon>folder.gif</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>
+    </Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <AllowedTemplates>
+      <Template>test</Template>
+    </AllowedTemplates>
+    <DefaultTemplate>test</DefaultTemplate>
+  </Info>
+  <Structure>
+    <DocumentType>test</DocumentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Name>test</Name>
+      <Alias>test</Alias>
+      <Type>b4471851-82b6-4c75-afa4-39fa9c6a75e9</Type>
+      <Definition>fbaf13a8-4036-41f2-93a3-974f678c312a</Definition>
+      <Tab>
+      </Tab>
+      <Mandatory>False</Mandatory>
+      <Validation>
+      </Validation>
+      <Description><![CDATA[]]></Description>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs />
+  <HistoryCleanupPolicy preventCleanup="true" keepAllVersionsNewerThanDays="1" keepLatestVersionPerDayForDays="2" />
+</DocumentType>


### PR DESCRIPTION
Support import/export for doc type history cleanup policy (#11660)

* Support import/export for doc type history cleanup policy
* Support unset/null history cleanup value
* Resolve issue when api endpoints called without cleanup policy. noop isn't good enough as map fails for response.
* null conditional vs null coalesce assignment
* Don't overwrite existing policy if omitted in import XML
* Update history cleanup warning and translations
* Change history cleanup alert to infomational styling
* Remove margin around history cleanup config