### PR TITLE
v9: Remove install endpoint as valid endpoint 

### DIFF
--- a/src/Umbraco.Web.BackOffice/Install/InstallController.cs
+++ b/src/Umbraco.Web.BackOffice/Install/InstallController.cs
@@ -105,10 +105,6 @@ namespace Umbraco.Cms.Web.BackOffice.Install
         [IgnoreFromNotFoundSelectorPolicy]
         public ActionResult Redirect()
         {
-            if (!_runtime.EnableInstaller())
-            {
-                return NotFound();
-            }
             var uri = HttpContext.Request.GetEncodedUrl();
 
             // redirect to install

--- a/src/Umbraco.Web.BackOffice/Install/InstallController.cs
+++ b/src/Umbraco.Web.BackOffice/Install/InstallController.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.WebAssets;
 using Umbraco.Cms.Infrastructure.Install;
+using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Extensions;
 
@@ -101,8 +102,13 @@ namespace Umbraco.Cms.Web.BackOffice.Install
         /// </summary>
         /// <returns></returns>
         [HttpGet]
+        [IgnoreFromNotFoundSelectorPolicy]
         public ActionResult Redirect()
         {
+            if (!_runtime.EnableInstaller())
+            {
+                return NotFound();
+            }
             var uri = HttpContext.Request.GetEncodedUrl();
 
             // redirect to install

--- a/src/Umbraco.Web.Common/Attributes/IgnoreFromNotFoundSelectorPolicyAttribute.cs
+++ b/src/Umbraco.Web.Common/Attributes/IgnoreFromNotFoundSelectorPolicyAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Umbraco.Cms.Web.Common.Attributes
+{
+    /// <summary>
+    /// When applied to an api controller it will be routed to the /Umbraco/BackOffice prefix route so we can determine if it
+    /// is a back office route or not.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class IgnoreFromNotFoundSelectorPolicyAttribute : Attribute
+    {
+    }
+}

--- a/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.Routing;
 
@@ -35,7 +36,7 @@ namespace Umbraco.Cms.Web.Website.Routing
                 // return the endpoint for the RenderController.Index action.
                 ControllerActionDescriptor descriptor = x.Metadata?.GetMetadata<ControllerActionDescriptor>();
                 return descriptor?.ControllerTypeInfo == typeof(RenderController)
-                    && descriptor?.ActionName == nameof(RenderController.Index);
+                       && descriptor?.ActionName == nameof(RenderController.Index);
             });
             return e;
         }
@@ -45,7 +46,7 @@ namespace Umbraco.Cms.Web.Website.Routing
         public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
         {
             // Don't apply this filter to any endpoint group that is a controller route
-            // i.e. only dynamic routes.            
+            // i.e. only dynamic routes.
             foreach (Endpoint endpoint in endpoints)
             {
                 ControllerAttribute controller = endpoint.Metadata?.GetMetadata<ControllerAttribute>();
@@ -80,11 +81,15 @@ namespace Umbraco.Cms.Web.Website.Routing
         {
             for (int i = 0; i < candidates.Count; i++)
             {
-                if (candidates.IsValidCandidate(i))
+                // We have to check if candidates needs to be ignored here
+                // So we dont return false when all endpoints are invalid
+                if (candidates.IsValidCandidate(i) &&
+                    candidates[i].Endpoint.Metadata.GetMetadata<IgnoreFromNotFoundSelectorPolicyAttribute>() is null)
                 {
                     return false;
                 }
             }
+
             return true;
         }
     }


### PR DESCRIPTION
fixes: https://github.com/umbraco/Umbraco-CMS/issues/11589

# Notes 
- Added IgnoreFromNotFoundPolicyAttribute
- Added new Attribute to installer redirect so we actually ignore that endpoint when 404'ing

# How to test
- Install umbraco (run a dummy migration if you already have it installed)
- Try to navigate to a URL that doesn't exist, example: https://localhost:44331/abcdefg
- Assert that you get the new pretty 404 page

Heres the migration class I used to run the installer:
```
namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_2_0
{
    public class NikolajsMig : MigrationBase
    {
        public NikolajsMig(IMigrationContext context) : base(context)
        {
        }

        protected override void Migrate()
        {
        }
    }
}
```
