### PR TITLE
V9: Fix backoffice javascript loading slowly

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -275,6 +275,8 @@ namespace Umbraco.Extensions
             });
 
             builder.Services.AddSmidge(builder.Config.GetSection(Constants.Configuration.ConfigRuntimeMinification));
+            // Replace the Smidge request helper, in order to discourage the use of brotli since it's super slow
+            builder.Services.AddUnique<IRequestHelper, SmidgeRequestHelper>();
             builder.Services.AddSmidgeNuglify();
             builder.Services.AddSmidgeInMemory(false); // it will be enabled based on config/cachebuster
 

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRequestHelper.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRequestHelper.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using Smidge;
+using Smidge.Models;
+
+namespace Umbraco.Cms.Web.Common.RuntimeMinification
+{
+    public class SmidgeRequestHelper : IRequestHelper
+    {
+        private RequestHelper _wrappedRequestHelper;
+
+        public SmidgeRequestHelper(IWebsiteInfo siteInfo)
+        {
+            _wrappedRequestHelper = new RequestHelper(siteInfo);
+        }
+
+        /// <inheritdoc/>
+        public string Content(string path) => _wrappedRequestHelper.Content(path);
+
+        /// <inheritdoc/>
+        public string Content(IWebFile file) => _wrappedRequestHelper.Content(file);
+
+        /// <inheritdoc/>
+        public bool IsExternalRequestPath(string path) => _wrappedRequestHelper.IsExternalRequestPath(path);
+
+        /// <summary>
+        /// Overrides the default order of compression from Smidge, since Brotli is super slow (~10 seconds for backoffice.js)
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <returns></returns>
+        public new CompressionType GetClientCompression(IDictionary<string, StringValues> headers)
+        {
+            var type = CompressionType.None;
+
+            if (headers is not IHeaderDictionary headerDictionary)
+            {
+                headerDictionary = new HeaderDictionary(headers.Count);
+                foreach ((var key, StringValues stringValues) in headers)
+                {
+                    headerDictionary[key] = stringValues;
+                }
+            }
+
+            var acceptEncoding = headerDictionary.GetCommaSeparatedValues(HeaderNames.AcceptEncoding);
+            if (acceptEncoding.Length > 0)
+            {
+                // Prefer in order: GZip, Deflate, Brotli.
+                for (var i = 0; i < acceptEncoding.Length; i++)
+                {
+                    var encoding = acceptEncoding[i].Trim();
+
+                    CompressionType parsed = CompressionType.Parse(encoding);
+
+                    // Not pack200-gzip.
+                    if (parsed == CompressionType.GZip)
+                    {
+                        return CompressionType.GZip;
+                    }
+
+                    if (parsed == CompressionType.Deflate)
+                    {
+                        type = CompressionType.Deflate;
+                    }
+
+                    // Brotli is typically last in the accept encoding header.
+                    if (type != CompressionType.Deflate && parsed == CompressionType.Brotli)
+                    {
+                        type = CompressionType.Brotli;
+                    }
+                }
+            }
+
+            return type;
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRequestHelper.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRequestHelper.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Web.Common.RuntimeMinification
         /// </summary>
         /// <param name="headers"></param>
         /// <returns></returns>
-        public new CompressionType GetClientCompression(IDictionary<string, StringValues> headers)
+        public CompressionType GetClientCompression(IDictionary<string, StringValues> headers)
         {
             var type = CompressionType.None;
 

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -35,8 +35,8 @@
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
       <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.4" />
-      <PackageReference Include="Smidge.Nuglify" Version="4.0.2" />
-      <PackageReference Include="Smidge.InMemory" Version="4.0.2" />
+      <PackageReference Include="Smidge.Nuglify" Version="4.0.3" />
+      <PackageReference Include="Smidge.InMemory" Version="4.0.3" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
       <PackageReference Include="Umbraco.Code" Version="1.2.0">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Details

This fixes #10252 and #11393

The problem was that, `umbraco-backoffice-js.js` and `umbraco-backoffice-extensions-js.js` loaded extremely slowly (~10 seconds for each), when the debug was set to false in the appsettings.

Turns out this was actually two separate issues, but this PR fixes both, the `umbraco-backoffice-extensions-js.js` problem was actually a bug in Smidge, see [this](https://github.com/Shazwazza/Smidge/pull/133) for more information.

The `umbraco-backoffice-js.js` was simply because the Brotli compression for some reason is extremely slow, and smidge will always prefer this. This fix this issue I've replaced the `RequestHelper` that comes with Smidge with our own `SmidgeRequestHelper` which then wraps the smidge `RequestHelper`, but changes the default, so Smidge will now default to gzip, and only use Brotli if there is no other option.

## Testing
⚠️ This only shows up if you have some App_Plugin javascript AND Debug is set to false, remember to do it in the `appsettings.Development.json` file ⚠️ 

* Checkout V9/dev
* Set Debug to false in `appsettings.Development.json`
* Install the umbraco starter kit `Umbraco.TheStarterKit`
* Launch the site and open the backoffice and notice that the backoffice js files loads extremely slow (~10 seconds)
* Checkout this branch 
* Restore nuget dependencies
* Rerun the site and open the backoffice, the js files now loads much much faster (1-2 seconds in my testing)