### PR TITLE
V9: Get all servers, including inactive

### DIFF
--- a/src/Umbraco.Core/Services/IServerRegistrationService.cs
+++ b/src/Umbraco.Core/Services/IServerRegistrationService.cs
@@ -38,6 +38,17 @@ namespace Umbraco.Cms.Core.Services
         IEnumerable<IServerRegistration> GetActiveServers(bool refresh = false);
 
         /// <summary>
+        /// Return all servers
+        /// </summary>
+        /// <param name="refresh">A value indicating whether to force-refresh the cache.</param>
+        /// <returns>All servers.</returns>
+        /// <remarks>By default this method will rely on the repository's cache, which is updated each
+        /// time the current server is touched, and the period depends on the configuration. Use the
+        /// <paramref name="refresh"/> parameter to force a cache refresh and reload active servers
+        /// from the database.</remarks>
+        IEnumerable<IServerRegistration> GetServers(bool refresh = false);
+
+        /// <summary>
         /// Gets the role of the current server.
         /// </summary>
         /// <returns>The role of the current server.</returns>

--- a/src/Umbraco.Infrastructure/Services/Implement/ServerRegistrationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ServerRegistrationService.cs
@@ -144,6 +144,26 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <summary>
+        ///  Return active servers
+        /// </summary>
+        /// <param name="refresh">A value indicating whether to force-refresh the cache.</param>
+        /// <returns>All active servers</returns>
+        /// <remarks>By default this method will rely on the repository's cache, which is updated each
+        /// time the current server is touched, and the period depends on the configuration. Use the
+        /// <paramref name="refresh"/> parameter to force a cache refresh and reload active servers
+        /// from the database.</remarks>
+        public IEnumerable<IServerRegistration> GetServers(bool refresh = false)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                scope.ReadLock(Cms.Core.Constants.Locks.Servers);
+                if (refresh)
+                    ((ServerRegistrationRepository)_serverRegistrationRepository).ClearCache();
+                return _serverRegistrationRepository.GetMany().ToArray(); // fast, cached // fast, cached
+            }
+        }
+
+        /// <summary>
         /// Gets the role of the current server.
         /// </summary>
         /// <returns>The role of the current server.</returns>


### PR DESCRIPTION
Don't know if this is a desired addition, but I would like to be able to see all server registrations, including the inactive ones. 😄 

Functionality: 
Expand `IServerRegistrationService.cs` and it's implementation with a `GetServers()` method to return all servers and not only active servers.



