### PR TITLE
Map both settings and content data via property editors.

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -123,51 +123,57 @@ namespace Umbraco.Web.PropertyEditors
                 if (blockEditorData == null)
                     return string.Empty;
 
-                foreach (var row in blockEditorData.BlockValue.ContentData)
+                void MapBlockItemData(List<BlockItemData> items)
                 {
-                    foreach (var prop in row.PropertyValues)
+                    foreach (var row in items)
                     {
-                        // create a temp property with the value
-                        // - force it to be culture invariant as the block editor can't handle culture variant element properties
-                        prop.Value.PropertyType.Variations = ContentVariation.Nothing;
-                        var tempProp = new Property(prop.Value.PropertyType);
-                        tempProp.SetValue(prop.Value.Value);
-
-                        var propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
-                        if (propEditor == null)
+                        foreach (var prop in row.PropertyValues)
                         {
-                            // NOTE: This logic was borrowed from Nested Content and I'm unsure why it exists.
-                            // if the property editor doesn't exist I think everything will break anyways?
+                            // create a temp property with the value
+                            // - force it to be culture invariant as the block editor can't handle culture variant element properties
+                            prop.Value.PropertyType.Variations = ContentVariation.Nothing;
+                            var tempProp = new Property(prop.Value.PropertyType);
+                            tempProp.SetValue(prop.Value.Value);
+
+                            var propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+                            if (propEditor == null)
+                            {
+                                // NOTE: This logic was borrowed from Nested Content and I'm unsure why it exists.
+                                // if the property editor doesn't exist I think everything will break anyways?
+                                // update the raw value since this is what will get serialized out
+                                row.RawPropertyValues[prop.Key] = tempProp.GetValue()?.ToString();
+                                continue;
+                            }
+
+                            var dataType = dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId);
+                            if (dataType == null)
+                            {
+                                // deal with weird situations by ignoring them (no comment)
+                                row.PropertyValues.Remove(prop.Key);
+                                _logger.Warn<BlockEditorPropertyValueEditor, string, Guid, string>(
+                                    "ToEditor removed property value {PropertyKey} in row {RowId} for property type {PropertyTypeAlias}",
+                                    prop.Key, row.Key, property.PropertyType.Alias);
+                                continue;
+                            }
+
+                            if (!valEditors.TryGetValue(dataType.Id, out var valEditor))
+                            {
+                                var tempConfig = dataType.Configuration;
+                                valEditor = propEditor.GetValueEditor(tempConfig);
+
+                                valEditors.Add(dataType.Id, valEditor);
+                            }
+
+                            var convValue = valEditor.ToEditor(tempProp, dataTypeService);
+
                             // update the raw value since this is what will get serialized out
-                            row.RawPropertyValues[prop.Key] = tempProp.GetValue()?.ToString();
-                            continue;
+                            row.RawPropertyValues[prop.Key] = convValue;
                         }
-
-                        var dataType = dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId);
-                        if (dataType == null)
-                        {
-                            // deal with weird situations by ignoring them (no comment)
-                            row.PropertyValues.Remove(prop.Key);
-                            _logger.Warn<BlockEditorPropertyValueEditor,string,Guid,string>(
-                                "ToEditor removed property value {PropertyKey} in row {RowId} for property type {PropertyTypeAlias}",
-                                prop.Key, row.Key, property.PropertyType.Alias);
-                            continue;
-                        }
-
-                        if (!valEditors.TryGetValue(dataType.Id, out var valEditor))
-                        {
-                            var tempConfig = dataType.Configuration;
-                            valEditor = propEditor.GetValueEditor(tempConfig);
-
-                            valEditors.Add(dataType.Id, valEditor);
-                        }
-
-                        var convValue = valEditor.ToEditor(tempProp, dataTypeService);
-
-                        // update the raw value since this is what will get serialized out
-                        row.RawPropertyValues[prop.Key] = convValue;
                     }
                 }
+
+                MapBlockItemData(blockEditorData.BlockValue.ContentData);
+                MapBlockItemData(blockEditorData.BlockValue.SettingsData);
 
                 // return json convertable object
                 return blockEditorData.BlockValue;
@@ -198,27 +204,34 @@ namespace Umbraco.Web.PropertyEditors
                 if (blockEditorData == null || blockEditorData.BlockValue.ContentData.Count == 0)
                     return string.Empty;
 
-                foreach (var row in blockEditorData.BlockValue.ContentData)
+                void MapBlockItemData(List<BlockItemData> items)
                 {
-                    foreach (var prop in row.PropertyValues)
+                    foreach (var row in items)
                     {
-                        // Fetch the property types prevalue
-                        var propConfiguration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId).Configuration;
+                        foreach (var prop in row.PropertyValues)
+                        {
+                            // Fetch the property types prevalue
+                            var propConfiguration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId)
+                                .Configuration;
 
-                        // Lookup the property editor
-                        var propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
-                        if (propEditor == null) continue;
+                            // Lookup the property editor
+                            var propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+                            if (propEditor == null) continue;
 
-                        // Create a fake content property data object
-                        var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration);
+                            // Create a fake content property data object
+                            var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration);
 
-                        // Get the property editor to do it's conversion
-                        var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, prop.Value.Value);
+                            // Get the property editor to do it's conversion
+                            var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, prop.Value.Value);
 
-                        // update the raw value since this is what will get serialized out
-                        row.RawPropertyValues[prop.Key] = newValue;
+                            // update the raw value since this is what will get serialized out
+                            row.RawPropertyValues[prop.Key] = newValue;
+                        }
                     }
                 }
+
+                MapBlockItemData(blockEditorData.BlockValue.ContentData);
+                MapBlockItemData(blockEditorData.BlockValue.SettingsData);
 
                 // return json
                 return JsonConvert.SerializeObject(blockEditorData.BlockValue);


### PR DESCRIPTION
Closes #11598

For steps to test follow instructions from issue then apply this patch and re-publish.
This is pretty low effort in terms of code changes but it seems to work just fine.

![image](https://user-images.githubusercontent.com/2056399/144579567-57d98dd8-5ffb-461f-8837-680d76ecbfdd.png)

![image](https://user-images.githubusercontent.com/2056399/144579069-cfe43d02-62a3-47fd-bd94-e0ff799fc0b9.png)

![image](https://user-images.githubusercontent.com/2056399/144579167-acd9586c-acd6-4ac5-ab70-1ed19c795614.png)

Left side json is one I saved and published before patch, right is saved and published after patch.

Backoffice block list editor works for both.

