### PR TITLE
Configuration for url replace characters from app settings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/RequestHandlerSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RequestHandlerSettings.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Umbraco.Cms.Core.Configuration.UmbracoSettings;
 using Umbraco.Extensions;
 
@@ -86,11 +87,58 @@ namespace Umbraco.Cms.Core.Configuration.Models
 
         //// return DefaultCharCollection;
 
+        private IEnumerable<IChar> _charCollection;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use empty list of characters.
+        /// UrlReplaceCharacters is empty during initialization (first time only), it's a trick for unit testing.
+        /// </summary>
+        public bool UseEmpty { get; set; }
         /// <summary>
         /// Gets or sets a value for the default character collection for replacements.
         /// </summary>
         /// WB-TODO
-        public IEnumerable<IChar> CharCollection { get; set; } = DefaultCharCollection;
+        public IEnumerable<IChar> CharCollection
+        {
+            get
+            {
+                if (UseEmpty)
+                {
+                    return Enumerable.Empty<IChar>();
+                }
+
+                return SetCharCollection();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets list of characters that can be overwritten from configuration.
+        /// </summary>
+        public IEnumerable<CharItem> UrlReplaceCharacters { get; set; }
+
+        /// <summary>
+        /// Returns a combination of default characters and from configuration.
+
+        /// </summary>
+        /// <returns></returns>
+        internal IEnumerable<IChar> SetCharCollection()
+        {
+            if (UrlReplaceCharacters?.Any() != true)
+            {
+                return DefaultCharCollection;
+            }
+
+            var charCollection = new List<IChar>();
+            foreach (var defaultChar in DefaultCharCollection)
+            {
+                if (UrlReplaceCharacters.Any(x => x.Char == defaultChar.Char))
+                    continue;
+
+                charCollection.Add(defaultChar);
+            }
+
+            return charCollection;
+        }
 
         /// <summary>
         /// Defines a character replacement.

--- a/src/Umbraco.Web.UI/appsettings.template.json
+++ b/src/Umbraco.Web.UI/appsettings.template.json
@@ -36,7 +36,17 @@
         "KeepAlivePingUrl": "{umbracoApplicationUrl}/api/keepalive/ping"
       },
       "RequestHandler": {
-        "ConvertUrlsToAscii": "try"
+        "ConvertUrlsToAscii": "try",
+        "UrlReplaceCharacters": [
+          {
+            "Char": "ø",
+            "Replacement": "oe"
+          },
+          {
+            "Char": "ö",
+            "Replacement": "o"
+          }
+        ]
       },
       "RuntimeMinification": {
         "dataFolder": "umbraco/Data/TEMP/Smidge",

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/DefaultShortStringHelperTestsWithoutSetup.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/DefaultShortStringHelperTestsWithoutSetup.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         {
             var requestHandlerSettings = new RequestHandlerSettings()
             {
-                CharCollection = Enumerable.Empty<IChar>(),
+                UseEmpty = true,
                 ConvertUrlsToAscii = "false"
             };
 
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         {
             var requestHandlerSettings = new RequestHandlerSettings()
             {
-                CharCollection = Enumerable.Empty<IChar>(),
+                UseEmpty = true,
                 ConvertUrlsToAscii = "false"
             };
 
@@ -339,7 +339,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         {
             var requestHandlerSettings = new RequestHandlerSettings()
             {
-                CharCollection = Enumerable.Empty<IChar>(),
+                UseEmpty = true,
                 ConvertUrlsToAscii = "false"
             };
 


### PR DESCRIPTION
I realized that we cannot configure the replaceable characters in the url.
It's implemented in v8 and can be managed in umbracoSettings.config, but cannot do the same for v9.
Our client wants to replace it and use a configuration similar to v8.

Issue: https://github.com/umbraco/Umbraco-CMS/issues/11727
