### PR TITLE
Filter block cards and show empty message

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsBlockCard.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsBlockCard.filter.js
@@ -24,14 +24,12 @@ angular.module("umbraco.filters").filter('umbCmsBlockCard', function () {
 
       // Return the filtered array
       return array.filter((block, i) => {
-        console.log("block", block);
         const props = ['id', 'key', 'udi', 'alias', 'name', 'description'];
 
         let found = false;
 
         for (let i = 0; i < props.length; i++) {
-          console.log("prop", props[i]);
-          console.log("id", block.elementTypeModel["id"]);
+
           if (!block.elementTypeModel.hasOwnProperty(props[i])) {
             continue;
           }

--- a/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsBlockCard.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsBlockCard.filter.js
@@ -25,7 +25,7 @@ angular.module("umbraco.filters").filter('umbCmsBlockCard', function () {
       // Return the filtered array
       return array.filter((block, i) => {
         console.log("block", block);
-        const props = ['id', 'key', 'udi', 'alias', 'name'];
+        const props = ['id', 'key', 'udi', 'alias', 'name', 'description'];
 
         let found = false;
 
@@ -36,7 +36,9 @@ angular.module("umbraco.filters").filter('umbCmsBlockCard', function () {
             continue;
           }
 
-          if (block.elementTypeModel[props[i]].toString().toLowerCase().includes(term)) {
+          if (block.elementTypeModel[props[i]] != null &&
+             block.elementTypeModel[props[i]] !== '' &&
+             block.elementTypeModel[props[i]].toString().toLowerCase().includes(term)) {
              found = true;
           }
         }

--- a/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsBlockCard.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/umbCmsBlockCard.filter.js
@@ -1,0 +1,49 @@
+/**
+ * @ngdoc filter
+ * @name umbraco.filters.filter:umbCmsBlockCard
+ * @namespace umbCmsBlockCard
+ * 
+ * @description
+ * Filter block cards based on specific properties.
+ * 
+ */
+angular.module("umbraco.filters").filter('umbCmsBlockCard', function () {
+  return function (array, searchTerm) {
+    // If no array is given, exit.
+    if (!array) {
+      return;
+    }
+    // If no search term exists, return the array unfiltered.
+    else if (!searchTerm) {
+      return array;
+    }
+    // Otherwise, continue.
+    else {
+      // Convert filter text to lower case.
+      const term = searchTerm.toLowerCase();
+
+      // Return the filtered array
+      return array.filter((block, i) => {
+        console.log("block", block);
+        const props = ['id', 'key', 'udi', 'alias', 'name'];
+
+        let found = false;
+
+        for (let i = 0; i < props.length; i++) {
+          console.log("prop", props[i]);
+          console.log("id", block.elementTypeModel["id"]);
+          if (!block.elementTypeModel.hasOwnProperty(props[i])) {
+            continue;
+          }
+
+          if (block.elementTypeModel[props[i]].toString().toLowerCase().includes(term)) {
+             found = true;
+          }
+        }
+
+        return found;
+
+      })
+    }
+  }
+});

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -27,17 +27,23 @@
                     </umb-search-filter>
                 </div>
 
-                <div class="umb-block-card-grid">
+                <div class="umb-block-card-grid" ng-show="filteredBlocks.length > 0">
 
                     <umb-block-card
                         class="umb-outline"
-                        ng-repeat="block in vm.model.availableItems | filter: vm.filter.searchTerm"
+                        ng-repeat="block in filteredBlocks = (vm.model.availableItems | umbCmsBlockCard: vm.filter.searchTerm)"
                         block-config-model="block.blockConfigModel"
                         element-type-model="block.elementTypeModel"
                         ng-click="vm.selectItem(block, $event)">
                     </umb-block-card>
 
                 </div>
+
+                <umb-empty-state ng-if="filteredBlocks.length === 0"
+                                 position="center">
+                  <localize key="general_searchNoResult">Sorry, we can not find what you are looking for.</localize>
+                </umb-empty-state>
+
             </div>
 
             <div ng-if="vm.activeTab.alias === 'clipboard'">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently filtering block cards also filter by data included it block model, but may not be relevant to content editors, e.g. filtering on the term "image", doesn't really filter any blocks containing "image".

I have modified this to use a custom filter (it could also be a local function, but I guess it could be useful to have a filter if developer made a custom block editor or similar using `<block-card>` component).

It filter on the following properties:
- Id
- Key (Guid)
- Udi
- Alias
- Name
- Description

Including Id, Key and Udi makes it easy to developers to filter to a specific block by an identifier - at least that is what is possible in the current behaviour. It also add an empty message in case no blocks are found via the filtering.

Not sure about the naming convention of the core filter though. It seems the newer ones are prefixes with `umbCms`, but we also have one just prefixed with `umb`. Furthermore not all filters are documented https://apidocs.umbraco.com/v9/ui/#/api/umbraco.filters or incorrect documented, e.g. regarding parameters/arguments.


**Before**

https://user-images.githubusercontent.com/2919859/144763445-3749f1b4-ea4b-4c36-8c84-bde2aa05e500.mp4

**After**

https://user-images.githubusercontent.com/2919859/144763194-87886bb7-8368-43b1-aa24-e240964d25ca.mp4
