### PR TITLE
Add support for readonly properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -182,23 +182,31 @@
                 }
             );
 
-            $scope.propertyEditorDisabled = function (property) {
+            $scope.propertyEditorInherited = function (property) {
                 if (property.unlockInvariantValue) {
-                    return false;
+                  return false;
                 }
 
                 var contentLanguage = $scope.content.language;
 
                 var canEditCulture = !contentLanguage ||
-                    // If the property culture equals the content culture it can be edited
-                    property.culture === contentLanguage.culture ||
-                    // A culture-invariant property can only be edited by the default language variant
-                    (property.culture == null && contentLanguage.isDefault);
+                  // If the property culture equals the content culture it can be edited
+                  property.culture === contentLanguage.culture ||
+                  // A culture-invariant property can only be edited by the default language variant
+                  (property.culture == null && contentLanguage.isDefault);
 
                 var canEditSegment = property.segment === $scope.content.segment;
 
                 return !canEditCulture || !canEditSegment;
-            }
+            };
+
+            $scope.propertyEditorDisabled = function (property) {
+                if (property.readonly) {
+                  return true;
+                }
+
+                return $scope.propertyEditorInherited(property);
+            };
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -11,7 +11,7 @@
                     data-element="property-{{property.alias}}"
                     ng-repeat="property in tab.properties track by property.alias"
                     property="property"
-                    show-inherit="propertyEditorDisabled(property)"
+                    show-inherit="propertyEditorInherited(property)"
                     inherits-from="defaultVariant.displayName">
 
                     <div ng-class="{'o-40 cursor-not-allowed': propertyEditorDisabled(property) }">
@@ -41,7 +41,7 @@
                     data-element="property-{{property.alias}}"
                     ng-repeat="property in group.properties track by property.alias"
                     property="property"
-                    show-inherit="propertyEditorDisabled(property)"
+                    show-inherit="propertyEditorInherited(property)"
                     inherits-from="defaultVariant.displayName">
 
                     <div ng-class="{'o-40 cursor-not-allowed': propertyEditorDisabled(property) }">

--- a/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
@@ -45,10 +45,10 @@
                     show-inherit="vm.model.variants.length > 1 && !property.culture && !activeVariant.language.isDefault"
                     inherits-from="defaultVariant.language.name">
 
-                    <div ng-class="{'o-40 cursor-not-allowed': vm.model.variants.length > 1 && !activeVariant.language.isDefault && !property.culture && !property.unlockInvariantValue}">
+                    <div ng-class="{'o-40 cursor-not-allowed': property.readonly || (vm.model.variants.length > 1 && !activeVariant.language.isDefault && !property.culture && !property.unlockInvariantValue)}">
                         <umb-property-editor
                             model="property"
-                            preview="vm.model.variants.length > 1 && !activeVariant.language.isDefault && !property.culture && !property.unlockInvariantValue">
+                            preview="property.readonly || (vm.model.variants.length > 1 && !activeVariant.language.isDefault && !property.culture && !property.unlockInvariantValue)">
                         </umb-property-editor>
                     </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
It has been possible to mark content properties as read-only from code since at least [Umbraco 7](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Web.Models.ContentEditing.ContentPropertyDisplay.html#Umbraco_Web_Models_ContentEditing_ContentPropertyDisplay_Readonly) (and this is still possible in [v8](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Web.Models.ContentEditing.ContentPropertyDisplay.html#Umbraco_Web_Models_ContentEditing_ContentPropertyDisplay_Readonly) and [v9](https://apidocs.umbraco.com/v9/csharp/api/Umbraco.Cms.Core.Models.ContentEditing.ContentPropertyDisplay.html#Umbraco_Cms_Core_Models_ContentEditing_ContentPropertyDisplay_Readonly)), by using the `EditorModelEventManager` (or `SendingContentNotification` in v9). Setting this to `true` should ensure the property isn't editable from the back-office UI, but this is currently not implemented.

_Note that the model/property is in the `ContentEditing` namespace, so it should only affect back-office editing._

I've encountered this issue while fixing the member `Is Locked Out` property, which should only be editable when a member is locked out (thus not allowing editors to manually lock a member). The previous code used a work-around, because making the property conditionally read-only didn't work, see: https://github.com/umbraco/Umbraco-CMS/pull/11587#issuecomment-963129981. This PR also ensures this property is dynamically updated after saving content, members or media.

To properly fix this issue, every editor should add support for the `readonly` property and e.g. disable the input field, remove 'add' buttons, etc. This is now only the case for the `boolean` (True/False) editor: https://github.com/umbraco/Umbraco-CMS/blob/4bf598d9a4f55a28266e7ae0e3d371cda667c8cb/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.html#L7

This PR implements a quick-fix by disabling cursor input, which is currently also used fro non-variant properties in the non-default culture (on culture-variant document types). Although re-uses existing functionality and is applied to all editors, it's still possible to edit the values, e.g. by clicking the label to focus the input of even toggles checkboxes.

To test this PR, I've created a composer that adds a document type with all possible data editors/types and when the content name equals 'Readonly' will mark all properties read-only: https://gist.github.com/ronaldbarendse/6eda1a0bfee87bdd714409886ecf4219 (I've also included code for v9, as this PR only affects back-office UI).
- Add the code from the above Gist
- Open the back-office and check whether the `Data Editor test` document type is created
- Some data types require some manual setup before these can be properly tested (e.g. adding values to dropdowns, element types to Nested Content or Block List)
- Create 2 content nodes named 'Editable' and 'Readonly'
- With this PR applied, all the properties on the 'Readonly' node should not be editable