### PR TITLE
Package telemetry

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -29,6 +29,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         internal const string StaticNoNodesViewPath = "~/umbraco/UmbracoWebsite/NoNodes.cshtml";
         internal const string StaticSqlWriteLockTimeOut = "00:00:05";
         internal const bool StaticSanitizeTinyMce = false;
+        internal const bool StaticRestrictPackageTelemetry = false;
 
         /// <summary>
         /// Gets or sets a value for the reserved URLs.
@@ -130,7 +131,14 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// Gets or sets a value for the main dom lock.
         /// </summary>
         public string MainDomLock { get; set; } = string.Empty;
+
         public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating if the package telemetry information should be restricted.
+        /// </summary>
+        [DefaultValue(StaticRestrictPackageTelemetry)]
+        public bool RestrictPackageTelemetry { get; set; } = StaticRestrictPackageTelemetry;
 
         /// <summary>
         /// Gets or sets a value for the path to the no content view.

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -29,7 +29,6 @@ namespace Umbraco.Cms.Core.Configuration.Models
         internal const string StaticNoNodesViewPath = "~/umbraco/UmbracoWebsite/NoNodes.cshtml";
         internal const string StaticSqlWriteLockTimeOut = "00:00:05";
         internal const bool StaticSanitizeTinyMce = false;
-        internal const bool StaticRestrictPackageTelemetry = false;
 
         /// <summary>
         /// Gets or sets a value for the reserved URLs.
@@ -133,12 +132,6 @@ namespace Umbraco.Cms.Core.Configuration.Models
         public string MainDomLock { get; set; } = string.Empty;
 
         public string Id { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets a value indicating if the package telemetry information should be restricted.
-        /// </summary>
-        [DefaultValue(StaticRestrictPackageTelemetry)]
-        public bool RestrictPackageTelemetry { get; set; } = StaticRestrictPackageTelemetry;
 
         /// <summary>
         /// Gets or sets a value for the path to the no content view.

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -262,7 +262,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddSingleton<IValueEditorCache, ValueEditorCache>();
 
             // Register telemetry service used to gather data about installed packages
-            Services.AddSingleton<TelemetryService>();
+            Services.AddUnique<ITelemetryService, TelemetryService>();
         }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -36,6 +36,7 @@ using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Core.Telemetry;
 using Umbraco.Cms.Core.Templates;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.DependencyInjection;
@@ -259,6 +260,9 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             // Register ValueEditorCache used for validation
             Services.AddSingleton<IValueEditorCache, ValueEditorCache>();
+
+            // Register telemetry service used to gather data about installed packages
+            Services.AddSingleton<TelemetryService>();
         }
     }
 }

--- a/src/Umbraco.Core/Manifest/PackageManifest.cs
+++ b/src/Umbraco.Core/Manifest/PackageManifest.cs
@@ -55,6 +55,12 @@ namespace Umbraco.Cms.Core.Manifest
         [DataMember(Name = "version")]
         public string Version { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether telemetry is allowed
+        /// </summary>
+        [DataMember(Name = "allowPackageTelemetry")]
+        public bool AllowPackageTelemetry { get; set; } = true;
+
         [DataMember(Name = "bundleOptions")]
         public BundleOptions BundleOptions { get; set; }
 

--- a/src/Umbraco.Core/Manifest/PackageManifest.cs
+++ b/src/Umbraco.Core/Manifest/PackageManifest.cs
@@ -48,6 +48,13 @@ namespace Umbraco.Cms.Core.Manifest
         /// </remarks>
         [IgnoreDataMember]
         public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the package
+        /// </summary>
+        [DataMember(Name = "version")]
+        public string Version { get; set; } = string.Empty;
+
         [DataMember(Name = "bundleOptions")]
         public BundleOptions BundleOptions { get; set; }
 

--- a/src/Umbraco.Core/Telemetry/ITelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/ITelemetryService.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Telemetry.Models;
+
+namespace Umbraco.Cms.Core.Telemetry
+{
+    /// <summary>
+    /// Service which gathers the data for telemetry reporting
+    /// </summary>
+    public interface ITelemetryService
+    {
+        /// <summary>
+        /// Try and get the <see cref="TelemetryReportData"/>
+        /// </summary>
+        public bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData);
+    }
+}

--- a/src/Umbraco.Core/Telemetry/ITelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/ITelemetryService.cs
@@ -10,6 +10,6 @@ namespace Umbraco.Cms.Core.Telemetry
         /// <summary>
         /// Try and get the <see cref="TelemetryReportData"/>
         /// </summary>
-        public bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData);
+        bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData);
     }
 }

--- a/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
+++ b/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
@@ -22,5 +22,8 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// </remarks>
         [DataMember(Name = "version")]
         public string Version { get; set; }
+
+        [DataMember(Name = "restrictPackageTelemetry")]
+        public bool RestrictPackageTelemetry { get; set; }
     }
 }

--- a/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
+++ b/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Telemetry.Models
+{
+    /// <summary>
+    /// Serializable class containing information about an installed package.
+    /// </summary>
+    [DataContract(Name = "packageTelemetry")]
+    public class PackageTelemetry
+    {
+        /// <summary>
+        /// Gets or sets the name of the installed package.
+        /// </summary>
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the installed package.
+        /// </summary>
+        /// <remarks>
+        /// This may be an empty string if no version is specified, of if there has been opted out of package tracking.
+        /// </remarks>
+        [DataMember(Name = "version")]
+        public string Version { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
+++ b/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
@@ -22,8 +22,5 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// </remarks>
         [DataMember(Name = "version")]
         public string Version { get; set; }
-
-        [DataMember(Name = "restrictPackageTelemetry")]
-        public bool RestrictPackageTelemetry { get; set; }
     }
 }

--- a/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
+++ b/src/Umbraco.Core/Telemetry/Models/PackageTelemetry.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// Gets or sets the version of the installed package.
         /// </summary>
         /// <remarks>
-        /// This may be an empty string if no version is specified, of if there has been opted out of package tracking.
+        /// This may be an empty string if no version is specified, or if package telemetry has been restricted.
         /// </remarks>
         [DataMember(Name = "version")]
         public string Version { get; set; }

--- a/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
+++ b/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// Gets or sets an enumerable containing information about packages.
         /// </summary>
         /// <remarks>
-        /// Contains only the name and version of the packages, unless no version is specified or the feature has been opted out.
+        /// Contains only the name and version of the packages, unless no version is specified or package telemetry has been restricted.
         /// </remarks>
         [DataMember(Name = "packages")]
         public IEnumerable<PackageTelemetry> Packages { get; set; }

--- a/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
+++ b/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Telemetry.Models
+{
+    /// <summary>
+    /// Serializable class containing telemetry information.
+    /// </summary>
+    [DataContract]
+    public class TelemetryReportData
+    {
+        /// <summary>
+        /// Gets or sets a random GUID to prevent an instance for posting multiple times pr. day.
+        /// </summary>
+        [DataMember(Name = "id")]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Umbraco CMS version.
+        /// </summary>
+        [DataMember(Name = "version")]
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets an enumerable containing information about packages.
+        /// </summary>
+        /// <remarks>
+        /// Contains only the name and version of the packages, unless no version is specified or the feature has been opted out.
+        /// </remarks>
+        [DataMember(Name = "packages")]
+        public IEnumerable<PackageTelemetry> Packages { get; set; }
+    }
+}

--- a/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
+++ b/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
@@ -30,11 +30,5 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// </remarks>
         [DataMember(Name = "packages")]
         public IEnumerable<PackageTelemetry> Packages { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether package telemetry is restricted.
-        /// </summary>
-        [DataMember(Name = "restrictPackageTelemetry")]
-        public bool RestrictPackageTelemetry { get; set; }
     }
 }

--- a/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
+++ b/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.Telemetry.Models
     public class TelemetryReportData
     {
         /// <summary>
-        /// Gets or sets a random GUID to prevent an instance for posting multiple times pr. day.
+        /// Gets or sets a random GUID to prevent an instance posting multiple times pr. day.
         /// </summary>
         [DataMember(Name = "id")]
         public Guid Id { get; set; }
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// Gets or sets an enumerable containing information about packages.
         /// </summary>
         /// <remarks>
-        /// Contains only the name and version of the packages, unless no version is specified or package telemetry has been restricted.
+        /// Contains only the name and version of the packages, unless no version is specified.
         /// </remarks>
         [DataMember(Name = "packages")]
         public IEnumerable<PackageTelemetry> Packages { get; set; }

--- a/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
+++ b/src/Umbraco.Core/Telemetry/Models/TelemetryReportData.cs
@@ -30,5 +30,11 @@ namespace Umbraco.Cms.Core.Telemetry.Models
         /// </remarks>
         [DataMember(Name = "packages")]
         public IEnumerable<PackageTelemetry> Packages { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether package telemetry is restricted.
+        /// </summary>
+        [DataMember(Name = "restrictPackageTelemetry")]
+        public bool RestrictPackageTelemetry { get; set; }
     }
 }

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Manifest;
+
+namespace Umbraco.Cms.Core.Telemetry
+{
+    public class TelemetryService
+    {
+        private readonly IManifestParser _manifestParser;
+
+        public TelemetryService(IManifestParser manifestParser)
+        {
+            _manifestParser = manifestParser;
+        }
+
+        public IEnumerable<string> GetInstalledPackages()
+        {
+            List<string> packages = new ();
+
+            var manifests = _manifestParser.GetManifests();
+            foreach (var manifest in manifests)
+            {
+                packages.Add(manifest.PackageName);
+            }
+
+            return packages;
+        }
+    }
+}

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -77,11 +77,14 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                packages.Add(new PackageTelemetry
+                if (!_globalSettings.RestrictPackageTelemetry || !string.IsNullOrEmpty(manifest.Version))
                 {
-                    Name = manifest.PackageName,
-                    Version = _globalSettings.RestrictPackageTelemetry ? string.Empty : manifest.Version
-                });
+                    packages.Add(new PackageTelemetry
+                    {
+                        Name = manifest.PackageName,
+                        Version = manifest.Version ?? string.Empty
+                    });
+                }
             }
 
             return packages;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -73,12 +73,14 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                if (_globalSettings.CurrentValue.RestrictPackageTelemetry is false || string.IsNullOrEmpty(manifest.Version) is false)
+                var restrictPackageTelemetry = _globalSettings.CurrentValue.RestrictPackageTelemetry;
+                if (restrictPackageTelemetry is false || string.IsNullOrEmpty(manifest.Version) is false)
                 {
                     packages.Add(new PackageTelemetry
                     {
                         Name = manifest.PackageName,
-                        Version = manifest.Version ?? string.Empty
+                        Version = manifest.Version ?? string.Empty,
+                        RestrictPackageTelemetry = restrictPackageTelemetry
                     });
                 }
             }

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -68,10 +68,15 @@ namespace Umbraco.Cms.Core.Telemetry
         private IEnumerable<PackageTelemetry> GetPackageTelemetry()
         {
             List<PackageTelemetry> packages = new ();
-
             IEnumerable<PackageManifest> manifests = _manifestParser.GetManifests();
+
             foreach (PackageManifest manifest in manifests)
             {
+                if (manifest.AllowPackageTelemetry is false)
+                {
+                    continue;
+                }
+
                 packages.Add(new PackageTelemetry { Name = manifest.PackageName, Version = manifest.Version });
             }
 

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.Telemetry
     /// <inheritdoc/>
     internal class TelemetryService : ITelemetryService
     {
-        private readonly GlobalSettings _globalSettings;
+        private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
         private readonly IManifestParser _manifestParser;
         private readonly IUmbracoVersion _umbracoVersion;
 
@@ -20,13 +20,13 @@ namespace Umbraco.Cms.Core.Telemetry
         /// Initializes a new instance of the <see cref="TelemetryService"/> class.
         /// </summary>
         public TelemetryService(
-            IOptions<GlobalSettings> globalSettings,
+            IOptionsMonitor<GlobalSettings> globalSettings,
             IManifestParser manifestParser,
             IUmbracoVersion umbracoVersion)
         {
-            _globalSettings = globalSettings.Value;
             _manifestParser = manifestParser;
             _umbracoVersion = umbracoVersion;
+            _globalSettings = globalSettings;
         }
 
         /// <inheritdoc/>
@@ -51,7 +51,7 @@ namespace Umbraco.Cms.Core.Telemetry
         {
             // Parse telemetry string as a GUID & verify its a GUID and not some random string
             // since users may have messed with or decided to empty the app setting or put in something random
-            if (Guid.TryParse(_globalSettings.Id, out var parsedTelemetryId) is false)
+            if (Guid.TryParse(_globalSettings.CurrentValue.Id, out var parsedTelemetryId) is false)
             {
                 telemetryId = Guid.Empty;
                 return false;
@@ -73,7 +73,7 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                if (!_globalSettings.RestrictPackageTelemetry || !string.IsNullOrEmpty(manifest.Version))
+                if (!_globalSettings.CurrentValue.RestrictPackageTelemetry || !string.IsNullOrEmpty(manifest.Version))
                 {
                     packages.Add(new PackageTelemetry
                     {

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -10,7 +10,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Telemetry
 {
     /// <summary>
-    /// Service which provides the required data for telemetry reporting
+    /// Service which gathers the data for telemetry reporting
     /// </summary>
     public sealed class TelemetryService
     {
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Core.Telemetry
         }
 
         /// <summary>
-        /// Try and get the <see cref="TelemetryReportData"/> for this site.
+        /// Try and get the <see cref="TelemetryReportData"/>
         /// </summary>
         public bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData)
         {
@@ -54,7 +54,7 @@ namespace Umbraco.Cms.Core.Telemetry
         private bool TryGetTelemetryId(out Guid telemetryId)
         {
             // Parse telemetry string as a GUID & verify its a GUID and not some random string
-            // In case of users may have messed or decided to empty the file contents or put in something random
+            // since users may have messed with or decided to empty the app setting or put in something random
             if (Guid.TryParse(_globalSettings.Id, out var parsedTelemetryId) is false)
             {
                 telemetryId = Guid.Empty;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -77,7 +77,11 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                packages.Add(new PackageTelemetry { Name = manifest.PackageName, Version = manifest.Version });
+                packages.Add(new PackageTelemetry
+                {
+                    Name = manifest.PackageName,
+                    Version = _globalSettings.RestrictPackageTelemetry ? string.Empty : manifest.Version
+                });
             }
 
             return packages;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -9,10 +9,8 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Telemetry
 {
-    /// <summary>
-    /// Service which gathers the data for telemetry reporting
-    /// </summary>
-    public sealed class TelemetryService
+    /// <inheritdoc/>
+    internal class TelemetryService : ITelemetryService
     {
         private readonly GlobalSettings _globalSettings;
         private readonly IManifestParser _manifestParser;
@@ -31,9 +29,7 @@ namespace Umbraco.Cms.Core.Telemetry
             _umbracoVersion = umbracoVersion;
         }
 
-        /// <summary>
-        /// Try and get the <see cref="TelemetryReportData"/>
-        /// </summary>
+        /// <inheritdoc/>
         public bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData)
         {
             if (TryGetTelemetryId(out Guid telemetryId) is false)

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -42,7 +42,8 @@ namespace Umbraco.Cms.Core.Telemetry
             {
                 Id = telemetryId,
                 Version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild(),
-                Packages = GetPackageTelemetry()
+                Packages = GetPackageTelemetry(),
+                RestrictPackageTelemetry = _globalSettings.CurrentValue.RestrictPackageTelemetry
             };
             return true;
         }
@@ -73,14 +74,12 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                var restrictPackageTelemetry = _globalSettings.CurrentValue.RestrictPackageTelemetry;
-                if (restrictPackageTelemetry is false || string.IsNullOrEmpty(manifest.Version) is false)
+                if (_globalSettings.CurrentValue.RestrictPackageTelemetry is false || string.IsNullOrEmpty(manifest.Version) is false)
                 {
                     packages.Add(new PackageTelemetry
                     {
                         Name = manifest.PackageName,
-                        Version = manifest.Version ?? string.Empty,
-                        RestrictPackageTelemetry = restrictPackageTelemetry
+                        Version = manifest.Version ?? string.Empty
                     });
                 }
             }

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Core.Telemetry.Models;
 
 namespace Umbraco.Cms.Core.Telemetry
 {
@@ -12,14 +13,14 @@ namespace Umbraco.Cms.Core.Telemetry
             _manifestParser = manifestParser;
         }
 
-        public IEnumerable<string> GetInstalledPackages()
+        public IEnumerable<PackageTelemetry> GetInstalledPackages()
         {
-            List<string> packages = new ();
+            List<PackageTelemetry> packages = new ();
 
-            var manifests = _manifestParser.GetManifests();
-            foreach (var manifest in manifests)
+            IEnumerable<PackageManifest> manifests = _manifestParser.GetManifests();
+            foreach (PackageManifest manifest in manifests)
             {
-                packages.Add(manifest.PackageName);
+                packages.Add(new PackageTelemetry { Name = manifest.PackageName, Version = manifest.Version });
             }
 
             return packages;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -42,8 +42,7 @@ namespace Umbraco.Cms.Core.Telemetry
             {
                 Id = telemetryId,
                 Version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild(),
-                Packages = GetPackageTelemetry(),
-                RestrictPackageTelemetry = _globalSettings.CurrentValue.RestrictPackageTelemetry
+                Packages = GetPackageTelemetry()
             };
             return true;
         }
@@ -74,14 +73,11 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                if (_globalSettings.CurrentValue.RestrictPackageTelemetry is false || string.IsNullOrEmpty(manifest.Version) is false)
+                packages.Add(new PackageTelemetry
                 {
-                    packages.Add(new PackageTelemetry
-                    {
-                        Name = manifest.PackageName,
-                        Version = manifest.Version ?? string.Empty
-                    });
-                }
+                    Name = manifest.PackageName,
+                    Version = manifest.Version ?? string.Empty
+                });
             }
 
             return packages;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -1,19 +1,71 @@
+using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Telemetry.Models;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Telemetry
 {
+    /// <summary>
+    /// Service which provides the required data for telemetry reporting
+    /// </summary>
     public class TelemetryService
     {
+        private readonly GlobalSettings _globalSettings;
         private readonly IManifestParser _manifestParser;
+        private readonly IUmbracoVersion _umbracoVersion;
 
-        public TelemetryService(IManifestParser manifestParser)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryService"/> class.
+        /// </summary>
+        public TelemetryService(
+            IOptions<GlobalSettings> globalSettings,
+            IManifestParser manifestParser,
+            IUmbracoVersion umbracoVersion)
         {
+            _globalSettings = globalSettings.Value;
             _manifestParser = manifestParser;
+            _umbracoVersion = umbracoVersion;
         }
 
-        public IEnumerable<PackageTelemetry> GetInstalledPackages()
+        /// <summary>
+        /// Try and get the <see cref="TelemetryReportData"/> for this site.
+        /// </summary>
+        public bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData)
+        {
+            if (TryGetTelemetryId(out Guid telemetryId) is false)
+            {
+                telemetryReportData = null;
+                return false;
+            }
+
+            telemetryReportData = new TelemetryReportData
+            {
+                Id = telemetryId,
+                Version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild(),
+                Packages = GetPackageTelemetry()
+            };
+            return true;
+        }
+
+        private bool TryGetTelemetryId(out Guid telemetryId)
+        {
+            // Parse telemetry string as a GUID & verify its a GUID and not some random string
+            // In case of users may have messed or decided to empty the file contents or put in something random
+            if (Guid.TryParse(_globalSettings.Id, out var parsedTelemetryId) is false)
+            {
+                telemetryId = Guid.Empty;
+                return false;
+            }
+
+            telemetryId = parsedTelemetryId;
+            return true;
+        }
+
+        private IEnumerable<PackageTelemetry> GetPackageTelemetry()
         {
             List<PackageTelemetry> packages = new ();
 

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.Telemetry
     /// <summary>
     /// Service which provides the required data for telemetry reporting
     /// </summary>
-    public class TelemetryService
+    public sealed class TelemetryService
     {
         private readonly GlobalSettings _globalSettings;
         private readonly IManifestParser _manifestParser;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -73,7 +73,7 @@ namespace Umbraco.Cms.Core.Telemetry
                     continue;
                 }
 
-                if (!_globalSettings.CurrentValue.RestrictPackageTelemetry || !string.IsNullOrEmpty(manifest.Version))
+                if (_globalSettings.CurrentValue.RestrictPackageTelemetry is false || string.IsNullOrEmpty(manifest.Version) is false)
                 {
                     packages.Add(new PackageTelemetry
                     {

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         public ReportSiteTask(
             ILogger<ReportSiteTask> logger,
             ITelemetryService telemetryService)
-            : base(TimeSpan.FromDays(1), TimeSpan.FromSeconds(10))
+            : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1))
         {
             _logger = logger;
             _telemetryService = telemetryService;

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net.Http;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -8,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Telemetry.Models;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
@@ -94,16 +94,5 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
                 _logger.LogDebug("There was a problem sending a request to the Umbraco telemetry service");
             }
         }
-        [DataContract]
-        private class TelemetryReportData
-        {
-            [DataMember(Name = "id")]
-            public Guid Id { get; set; }
-
-            [DataMember(Name = "version")]
-            public string Version { get; set; }
-        }
-
-
     }
 }

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -3,31 +3,25 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using Umbraco.Cms.Core.Configuration;
-using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Telemetry;
 using Umbraco.Cms.Core.Telemetry.Models;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
     public class ReportSiteTask : RecurringHostedServiceBase
     {
         private readonly ILogger<ReportSiteTask> _logger;
-        private readonly IUmbracoVersion _umbracoVersion;
-        private readonly IOptions<GlobalSettings> _globalSettings;
+        private readonly TelemetryService _telemetryService;
         private static HttpClient s_httpClient;
 
         public ReportSiteTask(
             ILogger<ReportSiteTask> logger,
-            IUmbracoVersion umbracoVersion,
-            IOptions<GlobalSettings> globalSettings)
+            TelemetryService telemetryService)
             : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1))
         {
             _logger = logger;
-            _umbracoVersion = umbracoVersion;
-            _globalSettings = globalSettings;
+            _telemetryService = telemetryService;
             s_httpClient = new HttpClient();
         }
 
@@ -37,14 +31,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// </summary>
         public override async Task PerformExecuteAsync(object state)
         {
-            // Try & get a value stored in umbracoSettings.config on the backoffice XML element ID attribute
-            var backofficeIdentifierRaw = _globalSettings.Value.Id;
-
-            // Parse as a GUID & verify its a GUID and not some random string
-            // In case of users may have messed or decided to empty the file contents or put in something random
-            if (Guid.TryParse(backofficeIdentifierRaw, out var telemetrySiteIdentifier) == false)
+            if (_telemetryService.TryGetTelemetryReportData(out TelemetryReportData telemetryReportData) is false)
             {
-                // Some users may have decided to mess with the XML attribute and put in something else
                 _logger.LogWarning("No telemetry marker found");
 
                 return;
@@ -72,8 +60,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
 
                 using (var request = new HttpRequestMessage(HttpMethod.Post, "installs/"))
                 {
-                    var postData = new TelemetryReportData { Id = telemetrySiteIdentifier, Version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild() };
-                    request.Content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json"); //CONTENT-TYPE header
+                    request.Content = new StringContent(JsonConvert.SerializeObject(telemetryReportData), Encoding.UTF8, "application/json"); //CONTENT-TYPE header
 
                     // Make a HTTP Post to telemetry service
                     // https://telemetry.umbraco.com/installs/

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -64,9 +64,6 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
 #if DEBUG
                     // Send data to DEBUG telemetry service
                     s_httpClient.BaseAddress = new Uri("https://telemetry.rainbowsrock.net/");
-
-
-
 #endif
                 }
 

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -40,7 +40,6 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
 
             try
             {
-
                 if (s_httpClient.BaseAddress is null)
                 {
                     // Send data to LIVE telemetry

--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -12,13 +12,13 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
     public class ReportSiteTask : RecurringHostedServiceBase
     {
         private readonly ILogger<ReportSiteTask> _logger;
-        private readonly TelemetryService _telemetryService;
+        private readonly ITelemetryService _telemetryService;
         private static HttpClient s_httpClient;
 
         public ReportSiteTask(
             ILogger<ReportSiteTask> logger,
-            TelemetryService telemetryService)
-            : base(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1))
+            ITelemetryService telemetryService)
+            : base(TimeSpan.FromDays(1), TimeSpan.FromSeconds(10))
         {
             _logger = logger;
             _telemetryService = telemetryService;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/ManifestParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/ManifestParserTests.cs
@@ -484,5 +484,27 @@ javascript: ['~/test.js',/*** some note about stuff asd09823-4**09234*/ '~/test2
             Assert.AreEqual("Content", manifest.Sections[0].Name);
             Assert.AreEqual("World", manifest.Sections[1].Name);
         }
+
+        [Test]
+        public void CanParseManifest_Version()
+        {
+            const string json = @"{""name"": ""VersionPackage"", ""version"": ""1.0.0""}";
+            PackageManifest manifest = _parser.ParseManifest(json);
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual("VersionPackage", manifest.PackageName);
+                Assert.AreEqual("1.0.0", manifest.Version);
+            });
+        }
+
+        [Test]
+        public void CanParseManifest_TrackingAllowed()
+        {
+            const string json = @"{""allowPackageTelemetry"": false }";
+            PackageManifest manifest = _parser.ParseManifest(json);
+
+            Assert.IsFalse(manifest.AllowPackageTelemetry);
+        }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -73,6 +73,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             Assert.IsTrue(success);
             Assert.Multiple(() =>
             {
+                Assert.IsFalse(telemetry.RestrictPackageTelemetry);
+
                 Assert.AreEqual(2, telemetry.Packages.Count());
                 var versionPackage = telemetry.Packages.FirstOrDefault(x => x.Name == versionPackageName);
                 Assert.AreEqual(versionPackageName, versionPackage.Name);
@@ -114,7 +116,9 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             var version = CreateUmbracoVersion(9, 1, 1);
             PackageManifest[] manifests =
             {
-                new () { PackageName = "Package1", Version = "1.0.1" }
+                new () { PackageName = "Package1", Version = "1.0.1" },
+                new () { PackageName = "Package2", Version = string.Empty },
+                new () { PackageName = "Package3", Version = "2.0.1", AllowPackageTelemetry = false }
             };
             var manifestParser = CreateManifestParser(manifests);
             var sut = new TelemetryService(globalSettings, manifestParser, version);
@@ -124,9 +128,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             Assert.IsTrue(success);
             Assert.Multiple(() =>
             {
+                Assert.IsTrue(telemetry.RestrictPackageTelemetry);
+
                 Assert.AreEqual(1, telemetry.Packages.Count());
                 var package = telemetry.Packages.First();
-                Assert.AreEqual(string.Empty, package.Version);
+                Assert.AreEqual("1.0.1", package.Version);
                 Assert.AreEqual("Package1", package.Name);
             });
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -73,8 +73,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             Assert.IsTrue(success);
             Assert.Multiple(() =>
             {
-                Assert.IsFalse(telemetry.RestrictPackageTelemetry);
-
                 Assert.AreEqual(2, telemetry.Packages.Count());
                 var versionPackage = telemetry.Packages.FirstOrDefault(x => x.Name == versionPackageName);
                 Assert.AreEqual(versionPackageName, versionPackage.Name);
@@ -109,33 +107,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             });
         }
 
-        [Test]
-        public void RespectsRestrictPackageTelemetry()
-        {
-            var globalSettings = CreateGlobalSettings(restrictPackageTelemetry: true);
-            var version = CreateUmbracoVersion(9, 1, 1);
-            PackageManifest[] manifests =
-            {
-                new () { PackageName = "Package1", Version = "1.0.1" },
-                new () { PackageName = "Package2", Version = string.Empty },
-                new () { PackageName = "Package3", Version = "2.0.1", AllowPackageTelemetry = false }
-            };
-            var manifestParser = CreateManifestParser(manifests);
-            var sut = new TelemetryService(globalSettings, manifestParser, version);
-
-            var success = sut.TryGetTelemetryReportData(out var telemetry);
-
-            Assert.IsTrue(success);
-            Assert.Multiple(() =>
-            {
-                Assert.IsTrue(telemetry.RestrictPackageTelemetry);
-
-                Assert.AreEqual(1, telemetry.Packages.Count());
-                var package = telemetry.Packages.First();
-                Assert.AreEqual("1.0.1", package.Version);
-                Assert.AreEqual("Package1", package.Name);
-            });
-        }
 
         private IManifestParser CreateManifestParser(IEnumerable<PackageManifest> manifests)
         {
@@ -150,14 +121,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             return Mock.Of<IUmbracoVersion>(x => x.SemanticVersion == version);
         }
 
-        private IOptionsMonitor<GlobalSettings> CreateGlobalSettings(string guidString = null, bool restrictPackageTelemetry = false)
+        private IOptionsMonitor<GlobalSettings> CreateGlobalSettings(string guidString = null)
         {
             if (guidString is null)
             {
                 guidString = Guid.NewGuid().ToString();
             }
 
-            var globalSettings = new GlobalSettings { Id = guidString, RestrictPackageTelemetry = restrictPackageTelemetry };
+            var globalSettings = new GlobalSettings { Id = guidString };
             return Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == globalSettings);
         }
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Telemetry;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
+{
+    [TestFixture]
+    public class TelemetryServiceTests
+    {
+        [TestCase("0F1785C5-7BA0-4C52-AB62-863BD2C8F3FE", true)]
+        [TestCase("This is not a guid", false)]
+        [TestCase("", false)]
+        public void OnlyParsesIfValidId(string guidString, bool shouldSucceed)
+        {
+            var globalSettings = CreateGlobalSettings(guidString);
+            var version = CreateUmbracoVersion(9, 1, 1);
+            var sut = new TelemetryService(globalSettings, Mock.Of<IManifestParser>(), version);
+
+            var result = sut.TryGetTelemetryReportData(out var telemetry);
+
+            Assert.AreEqual(shouldSucceed, result);
+            if (shouldSucceed)
+            {
+                // When toString is called on a GUID it will to lower, so do the same to our guidString
+                Assert.AreEqual(guidString.ToLower(), telemetry.Id.ToString());
+            }
+            else
+            {
+                Assert.IsNull(telemetry);
+            }
+        }
+
+        [Test]
+        public void ReturnsSemanticVersionWithoutBuild()
+        {
+            var globalSettings = CreateGlobalSettings();
+            var version = CreateUmbracoVersion(9, 1, 1, "-rc", "-ad2f4k2d");
+
+            var sut = new TelemetryService(globalSettings, Mock.Of<IManifestParser>(), version);
+
+            var result = sut.TryGetTelemetryReportData(out var telemetry);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("9.1.1-rc", telemetry.Version);
+        }
+
+        [Test]
+        public void CanGatherPackageTelemetry()
+        {
+            var globalSettings = CreateGlobalSettings();
+            var version = CreateUmbracoVersion(9, 1, 1);
+            var versionPackageName = "VersionPackage";
+            var packageVersion = "1.0.0";
+            var noVersionPackageName = "NoVersionPackage";
+            PackageManifest[] manifests =
+            {
+                new () { PackageName = versionPackageName, Version = packageVersion },
+                new () { PackageName = noVersionPackageName }
+            };
+            var manifestParser = CreateManifestParser(manifests);
+            var sut = new TelemetryService(globalSettings, manifestParser, version);
+
+            var success = sut.TryGetTelemetryReportData(out var telemetry);
+
+            Assert.IsTrue(success);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(2, telemetry.Packages.Count());
+                var versionPackage = telemetry.Packages.FirstOrDefault(x => x.Name == versionPackageName);
+                Assert.AreEqual(versionPackageName, versionPackage.Name);
+                Assert.AreEqual(packageVersion, versionPackage.Version);
+
+                var noVersionPackage = telemetry.Packages.FirstOrDefault(x => x.Name == noVersionPackageName);
+                Assert.AreEqual(noVersionPackageName, noVersionPackage.Name);
+                Assert.AreEqual(string.Empty, noVersionPackage.Version);
+            });
+        }
+
+        [Test]
+        public void RespectsAllowPackageTelemetry()
+        {
+            var globalSettings = CreateGlobalSettings();
+            var version = CreateUmbracoVersion(9, 1, 1);
+            PackageManifest[] manifests =
+            {
+                new () { PackageName = "DoNotTrack", AllowPackageTelemetry = false },
+                new () { PackageName = "TrackingAllowed", AllowPackageTelemetry = true }
+            };
+            var manifestParser = CreateManifestParser(manifests);
+            var sut = new TelemetryService(globalSettings, manifestParser, version);
+
+            var success = sut.TryGetTelemetryReportData(out var telemetry);
+
+            Assert.IsTrue(success);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(1, telemetry.Packages.Count());
+                Assert.AreEqual("TrackingAllowed", telemetry.Packages.First().Name);
+            });
+        }
+
+        [Test]
+        public void RespectsRestrictPackageTelemetry()
+        {
+            var globalSettings = CreateGlobalSettings(restrictPackageTelemetry: true);
+            var version = CreateUmbracoVersion(9, 1, 1);
+            PackageManifest[] manifests =
+            {
+                new () { PackageName = "Package1", Version = "1.0.1" }
+            };
+            var manifestParser = CreateManifestParser(manifests);
+            var sut = new TelemetryService(globalSettings, manifestParser, version);
+
+            var success = sut.TryGetTelemetryReportData(out var telemetry);
+
+            Assert.IsTrue(success);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(1, telemetry.Packages.Count());
+                var package = telemetry.Packages.First();
+                Assert.AreEqual(string.Empty, package.Version);
+                Assert.AreEqual("Package1", package.Name);
+            });
+        }
+
+        private IManifestParser CreateManifestParser(IEnumerable<PackageManifest> manifests)
+        {
+            var manifestParserMock = new Mock<IManifestParser>();
+            manifestParserMock.Setup(x => x.GetManifests()).Returns(manifests);
+            return manifestParserMock.Object;
+        }
+
+        private IUmbracoVersion CreateUmbracoVersion(int major, int minor, int patch, string prerelease = "", string build = "")
+        {
+            var version = new SemVersion(major, minor, patch, prerelease, build);
+            return Mock.Of<IUmbracoVersion>(x => x.SemanticVersion == version);
+        }
+
+        private IOptions<GlobalSettings> CreateGlobalSettings(string guidString = null, bool restrictPackageTelemetry = false)
+        {
+            if (guidString is null)
+            {
+                guidString = Guid.NewGuid().ToString();
+            }
+
+            var globalSettings = new GlobalSettings { Id = guidString, RestrictPackageTelemetry = restrictPackageTelemetry };
+            return Mock.Of<IOptions<GlobalSettings>>(x => x.Value == globalSettings);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -144,7 +144,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             return Mock.Of<IUmbracoVersion>(x => x.SemanticVersion == version);
         }
 
-        private IOptions<GlobalSettings> CreateGlobalSettings(string guidString = null, bool restrictPackageTelemetry = false)
+        private IOptionsMonitor<GlobalSettings> CreateGlobalSettings(string guidString = null, bool restrictPackageTelemetry = false)
         {
             if (guidString is null)
             {
@@ -152,7 +152,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
             }
 
             var globalSettings = new GlobalSettings { Id = guidString, RestrictPackageTelemetry = restrictPackageTelemetry };
-            return Mock.Of<IOptions<GlobalSettings>>(x => x.Value == globalSettings);
+            return Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == globalSettings);
         }
     }
 }


### PR DESCRIPTION
This adds the functionality to send telemetry information about installed packages.

The `TelemetryService` uses the `IManifestParser` to look for `package.manifests` in the App_Plugins folder. By default the names and versions of the installed packages will be sent, provided that the package has specified a version in the new `version` property  in the `package.manifest`. For the name of the package, the name of the folder will be used, unless the package creator has specified a different name with the `name` property in the `package.manifest`

If a package creator does not wish for there to be sent telemetry information about their package at all they can set `allowPackageTelemetry` to false in their `package.manifest` and then the package will be skipped entirely.

If a site developer wishes to restrict the information sent about the installed package they can set the global setting `RestrictPackageTelemetry` to true in their appsettings.json, and then the version of the installed packages will be omitted: 

```json
"CMS": {
  "Global": {
    "RestrictPackageTelemetry": true
  }
}
```

## Testing

1. Test pass 
2. Try and create some packages in the `App_Plugins` folder, there doesn't need to be any content, just a folder, and a package.maniest
3. Ensure that if you add a "name" property it will be used for the package name, otherwise the folder name should be used
4. Ensure that "version" property is used if there is any, otherwise it should just be an empty string
5. Ensure that the package is completely ignored if the "allowPackageTelemetry" is set to false
6. Try and set the `RestrictPackageTelemetry` global setting to true, and ensure that no package versions are sent regardless

When testing this you can either put a breakpoint in `ReportSiteTask` and look at the `TelemetryReportData` that the telemetry service returns when it runs, or if you want to go the full mile you can set up a server to retrieve the request that is sent, and ammend the `s_httpClient.BaseAddress` to instead use a URI of your server, I used a simple Flask server with python for this. You might want to reduce the delay so you don't have to wait a full minute every time.

Example `package.manifest` with the new properties:

```json
{
    "allowPackageTelemetry": false,
    "name": "Do Not Track",
    "version": "2.1.5"
}
```

Flask test server:

```python
import json

from flask import Flask, app
from flask.globals import request

app = Flask("JsonDumpServer")


@app.route("/installs/", methods=['POST'])
def dump_json():
    print("Received request\n\n")
    print(f"{json.dumps(request.get_json(), indent=2)}\n\n")
    return "Request received"


app.config['ENV'] = 'development'
app.config['TESTING'] = True
app.run()

```

