### PR TITLE
Updates Forms and adds Deploy JSON schema.

### DIFF
--- a/src/JsonSchema/AppSettings.cs
+++ b/src/JsonSchema/AppSettings.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Deploy.Core.Configuration.DeployConfiguration;
+using Umbraco.Deploy.Core.Configuration.DeployProjectConfiguration;
 using Umbraco.Forms.Core.Configuration;
 using SecuritySettings = Umbraco.Cms.Core.Configuration.Models.SecuritySettings;
 
@@ -82,6 +84,7 @@ namespace JsonSchema
                 public BasicAuthSettings BasicAuth { get; set; }
 
                 public PackageMigrationSettings PackageMigration { get; set; }
+
                 public LegacyPasswordMigrationSettings LegacyPasswordMigration { get; set; }
             }
 
@@ -116,6 +119,9 @@ namespace JsonSchema
             /// </summary>
             public class DeployDefinition
             {
+                public DeploySettings Settings { get; set; }
+
+                public DeployProjectConfig Project { get; set; }
             }
         }
     }

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -10,7 +10,8 @@
       <PackageReference Include="CommandLineParser" Version="2.8.0" />
       <PackageReference Include="NJsonSchema" Version="10.5.2" />
       <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-      <PackageReference Include="Umbraco.Forms.Core" Version="9.0.1" />
+      <PackageReference Include="Umbraco.Deploy.Core" Version="9.2.0" />
+      <PackageReference Include="Umbraco.Forms.Core" Version="9.2.0-rc001" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="NJsonSchema" Version="10.5.2" />
       <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
       <PackageReference Include="Umbraco.Deploy.Core" Version="9.2.0" />
-      <PackageReference Include="Umbraco.Forms.Core" Version="9.2.0-rc001" />
+      <PackageReference Include="Umbraco.Forms.Core" Version="9.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This updates the Forms reference and introduces the Deploy package references to the JSON schema project and adds the new properties.  I've tested this by generating the schema file and copying into a V9 project, where I see the updates.

If there's a concern with a dependency on an RC we can hold this and I'll update when the full release of Forms 9.2. is out.