### PR TITLE
Updated border radius of notification to match button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/notifications/umb-notifications.less
@@ -22,7 +22,7 @@
     font-size: 14px;
     border: none;
     position: relative;
-    border-radius: 10px;
+    border-radius: 3px;
     margin: 10px;
 
     .close {


### PR DESCRIPTION
**Description**

This PR changes the border radius of umb-notifications component in backoffice to match the border radius of buttons.

**Before**

![image](https://user-images.githubusercontent.com/5023476/145233952-06ae8d80-cebf-4e22-9e4e-26f575db47f5.png)


**After**

![image](https://user-images.githubusercontent.com/5023476/145234086-074a0ffb-b51c-4e35-83e6-8ee9d21f4100.png)
