### PR TITLE
Adding support for generating thumbnails for tiff images

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -185,6 +185,10 @@ Use this directive to generate a thumbnail grid of media items.
                             item.extension = extensionProp.value;
                         }
 
+                        if(item.extension == 'tiff'){
+                          item.thumbnail += '&format=jpg';
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION
### Prerequisites
Upload a TIFF image and you should see a thumbnail :)

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
When uploading tiff images to backend no thumbnail is visible.
This PR will add `&format=jpg` if `item.extension` is `tiff`

<!-- Thanks for contributing to Umbraco CMS! -->
