### PR TITLE
Fix incorrect camelcasing for import document type

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
@@ -118,7 +118,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
 
                 // root actions
                 menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true);
-                menu.Items.Add(new MenuItem("importDocumentType", LocalizedTextService)
+                menu.Items.Add(new MenuItem("importdocumenttype", LocalizedTextService)
                 {
                     Icon = "page-up",
                     SeparatorBefore = true,

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
@@ -19,7 +19,7 @@
     <key alias="emptyRecycleBin">Vyprázdnit koš</key>
     <key alias="enable">Aktivovat</key>
     <key alias="exportDocumentType">Exportovat typ dokumentu</key>
-    <key alias="importDocumentType">Importovat typ dokumentu</key>
+    <key alias="importdocumenttype">Importovat typ dokumentu</key>
     <key alias="importPackage">Importovat balíček</key>
     <key alias="liveEdit">Editovat na stránce</key>
     <key alias="logout">Odhlásit</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
@@ -21,7 +21,7 @@
     <key alias="emptyRecycleBin">Gwagu bin ailgylchu</key>
     <key alias="enable">Galluogi</key>
     <key alias="exportDocumentType">Allforio Math o Ddogfen</key>
-    <key alias="importDocumentType">Mewnforio Math o Ddogfen</key>
+    <key alias="importdocumenttype">Mewnforio Math o Ddogfen</key>
     <key alias="importPackage">Mewnforio Pecyn</key>
     <key alias="liveEdit">Golygu mewn Cynfas</key>
     <key alias="logout">Gadael</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -21,7 +21,7 @@
     <key alias="emptyRecycleBin">Tøm papirkurv</key>
     <key alias="enable">Aktivér</key>
     <key alias="exportDocumentType">Eksportér dokumenttype</key>
-    <key alias="importDocumentType">Importér dokumenttype</key>
+    <key alias="importdocumenttype">Importér dokumenttype</key>
     <key alias="importPackage">Importér pakke</key>
     <key alias="liveEdit">Redigér i Canvas</key>
     <key alias="logout">Log af</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -19,7 +19,7 @@
     <key alias="emptyRecycleBin">Papierkorb leeren</key>
     <key alias="enable">Aktivieren</key>
     <key alias="exportDocumentType">Dokumenttyp exportieren</key>
-    <key alias="importDocumentType">Dokumenttyp importieren</key>
+    <key alias="importdocumenttype">Dokumenttyp importieren</key>
     <key alias="importPackage">Paket importieren</key>
     <key alias="liveEdit">'Canvas'-Modus starten</key>
     <key alias="logout">Abmelden</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -20,7 +20,7 @@
     <key alias="emptyRecycleBin">Empty recycle bin</key>
     <key alias="enable">Enable</key>
     <key alias="exportDocumentType">Export Document Type</key>
-    <key alias="importDocumentType">Import Document Type</key>
+    <key alias="importdocumenttype">Import Document Type</key>
     <key alias="importPackage">Import Package</key>
     <key alias="liveEdit">Edit in Canvas</key>
     <key alias="logout">Exit</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -21,7 +21,7 @@
     <key alias="emptyRecycleBin">Empty recycle bin</key>
     <key alias="enable">Enable</key>
     <key alias="exportDocumentType">Export Document Type</key>
-    <key alias="importDocumentType">Import Document Type</key>
+    <key alias="importdocumenttype">Import Document Type</key>
     <key alias="importPackage">Import Package</key>
     <key alias="liveEdit">Edit in Canvas</key>
     <key alias="logout">Exit</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -18,7 +18,7 @@
     <key alias="emptyRecycleBin">Vaciar Papelera</key>
     <key alias="enable">Activar</key>
     <key alias="exportDocumentType">Exportar Documento (tipo)</key>
-    <key alias="importDocumentType">Importar Documento (tipo)</key>
+    <key alias="importdocumenttype">Importar Documento (tipo)</key>
     <key alias="importPackage">Importar Paquete</key>
     <key alias="liveEdit">Editar en vivo</key>
     <key alias="logout">Cerrar sesión</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -19,7 +19,7 @@
     <key alias="emptyRecycleBin">Vider la corbeille</key>
     <key alias="enable">Activer</key>
     <key alias="exportDocumentType">Exporter le type de document</key>
-    <key alias="importDocumentType">Importer un type de document</key>
+    <key alias="importdocumenttype">Importer un type de document</key>
     <key alias="importPackage">Importer un package</key>
     <key alias="liveEdit">Editer dans Canvas</key>
     <key alias="logout">Déconnexion</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -15,7 +15,7 @@
     <key alias="disable">נטרל</key>
     <key alias="emptyRecycleBin">רוקן סל מיחזור</key>
     <key alias="exportDocumentType">ייצא סוג קובץ</key>
-    <key alias="importDocumentType">ייבא סוג מסמך</key>
+    <key alias="importdocumenttype">ייבא סוג מסמך</key>
     <key alias="importPackage">ייבא חבילה</key>
     <key alias="liveEdit">ערוך במצב "קנבס"</key>
     <key alias="logout">יציאה</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -21,7 +21,7 @@
     <key alias="emptyRecycleBin">Svuota il cestino</key>
     <key alias="enable">Abilita</key>
     <key alias="exportDocumentType">Esporta il tipo di documento</key>
-    <key alias="importDocumentType">Importa il tipo di documento</key>
+    <key alias="importdocumenttype">Importa il tipo di documento</key>
     <key alias="importPackage">Importa il pacchetto</key>
     <key alias="liveEdit">Modifica in Area di Lavoro</key>
     <key alias="logout">Uscita</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -16,7 +16,7 @@
     <key alias="disable">無効</key>
     <key alias="emptyRecycleBin">ごみ箱を空にする</key>
     <key alias="exportDocumentType">ドキュメントタイプの書出</key>
-    <key alias="importDocumentType">ドキュメントタイプの読込</key>
+    <key alias="importdocumenttype">ドキュメントタイプの読込</key>
     <key alias="importPackage">パッケージの読み込み</key>
     <key alias="liveEdit">ライブ編集</key>
     <key alias="logout">ログアウト</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -15,7 +15,7 @@
     <key alias="disable">비활성</key>
     <key alias="emptyRecycleBin">휴지통 비우기</key>
     <key alias="exportDocumentType">추출 문서 유형</key>
-    <key alias="importDocumentType">등록 문서 유형</key>
+    <key alias="importdocumenttype">등록 문서 유형</key>
     <key alias="importPackage">패키지 등록</key>
     <key alias="liveEdit">캔버스 내용 편집</key>
     <key alias="logout">종료</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
@@ -16,7 +16,7 @@
     <key alias="disable">Deaktiver</key>
     <key alias="emptyRecycleBin">Tøm papirkurv</key>
     <key alias="exportDocumentType">Eksporter dokumenttype</key>
-    <key alias="importDocumentType">Importer dokumenttype</key>
+    <key alias="importdocumenttype">Importer dokumenttype</key>
     <key alias="importPackage">Importer pakke</key>
     <key alias="liveEdit">Rediger i Canvas</key>
     <key alias="logout">Logg av</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -21,7 +21,7 @@
     <key alias="emptyRecycleBin">Prullenbak leegmaken</key>
     <key alias="enable">Inschakelen</key>
     <key alias="exportDocumentType">Documenttype exporteren</key>
-    <key alias="importDocumentType">Documenttype importeren</key>
+    <key alias="importdocumenttype">Documenttype importeren</key>
     <key alias="importPackage">Package importeren</key>
     <key alias="liveEdit">Aanpassen in Canvas</key>
     <key alias="logout">Afsluiten</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -18,7 +18,7 @@
     <key alias="emptyRecycleBin">Opróżnij kosz</key>
     <key alias="enable">Aktywuj</key>
     <key alias="exportDocumentType">Eksportuj typ dokumentu</key>
-    <key alias="importDocumentType">Importuj typ dokumentu</key>
+    <key alias="importdocumenttype">Importuj typ dokumentu</key>
     <key alias="importPackage">Importuj zbiór</key>
     <key alias="liveEdit">Edytuj na stronie</key>
     <key alias="logout">Wyjście</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -15,7 +15,7 @@
     <key alias="disable">Desabilitar</key>
     <key alias="emptyRecycleBin">Esvaziar Lixeira</key>
     <key alias="exportDocumentType">Exportar Tipo de Documento</key>
-    <key alias="importDocumentType">Importar Tipo de Documento</key>
+    <key alias="importdocumenttype">Importar Tipo de Documento</key>
     <key alias="importPackage">Importar Pacote</key>
     <key alias="liveEdit">Editar na Tela</key>
     <key alias="logout">Sair</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -21,7 +21,7 @@
     <key alias="enable">Включить</key>
     <key alias="export">Экспорт</key>
     <key alias="exportDocumentType">Экспортировать</key>
-    <key alias="importDocumentType">Импортировать</key>
+    <key alias="importdocumenttype">Импортировать</key>
     <key alias="importPackage">Импортировать пакет</key>
     <key alias="liveEdit">Править на месте</key>
     <key alias="logout">Выйти</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -22,7 +22,7 @@
     <key alias="disable">Avaktivera</key>
     <key alias="emptyRecycleBin">Töm papperskorgen</key>
     <key alias="exportDocumentType">Exportera dokumenttyp</key>
-    <key alias="importDocumentType">Importera dokumenttyp</key>
+    <key alias="importdocumenttype">Importera dokumenttyp</key>
     <key alias="importPackage">Importera paket</key>
     <key alias="liveEdit">Redigera i Canvas</key>
     <key alias="logout">Logga ut</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
@@ -20,7 +20,7 @@
     <key alias="emptyRecycleBin">Geri dönüşüm kutusunu boşalt</key>
     <key alias="enable">Etkinleştir</key>
     <key alias="exportDocumentType">Belge Türünü Dışa Aktar</key>
-    <key alias="importDocumentType">Belge Türünü İçe Aktar</key>
+    <key alias="importdocumenttype">Belge Türünü İçe Aktar</key>
     <key alias="importPackage">Paketi İçe Aktar</key>
     <key alias="liveEdit">Kanvas'ta Düzenle</key>
     <key alias="logout">Çıkış</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -16,7 +16,7 @@
     <key alias="disable">禁用</key>
     <key alias="emptyRecycleBin">清空回收站</key>
     <key alias="exportDocumentType">导出文档类型</key>
-    <key alias="importDocumentType">导入文档类型</key>
+    <key alias="importdocumenttype">导入文档类型</key>
     <key alias="importPackage">导入扩展包</key>
     <key alias="liveEdit">实时编辑模式</key>
     <key alias="logout">退出</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
@@ -16,7 +16,7 @@
     <key alias="disable">禁用</key>
     <key alias="emptyRecycleBin">清空回收站</key>
     <key alias="exportDocumentType">匯出文檔類型</key>
-    <key alias="importDocumentType">導入文檔類型</key>
+    <key alias="importdocumenttype">導入文檔類型</key>
     <key alias="importPackage">導入擴展包</key>
     <key alias="liveEdit">即時編輯模式</key>
     <key alias="logout">退出</key>


### PR DESCRIPTION
### Prerequisites

1. Run a default umbraco installation on a linux container.
2. login to backend
3. go to settings
4. Right click Document types
5. Click Import Document Type

closes  #11752

### Description

Update camelcasing in for the import document link.


<!-- Thanks for contributing to Umbraco CMS! -->
