### PR TITLE
Handled flushing of cache instruction messages when created from handling events in a background thread

### DIFF
--- a/src/Umbraco.Web/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Web/BatchedDatabaseServerMessenger.cs
@@ -68,9 +68,11 @@ namespace Umbraco.Web
             BatchMessage(refresher, messageType, idsA, arrayType, json);
         }
 
-        public void FlushBatch()
+        public void FlushBatch() => FlushBatch(null);
+
+        internal void FlushBatch(HttpContextBase httpContext)
         {
-            var batch = GetBatch(false);
+            var batch = httpContext != null ? GetBatch(false, httpContext) : GetBatch(false);
             if (batch == null) return;
 
             var instructions = batch.SelectMany(x => x.Instructions).ToArray();
@@ -83,9 +85,9 @@ namespace Umbraco.Web
                 {
                     WriteInstructions(scope, instructionsBatch);
                 }
+
                 scope.Complete();
             }
-
         }
 
         private void WriteInstructions(IScope scope, IEnumerable<RefreshInstruction> instructions)
@@ -111,10 +113,15 @@ namespace Umbraco.Web
                 // the case if the asp.net synchronization context has kicked in
                 ?? (HttpContext.Current == null ? null : new HttpContextWrapper(HttpContext.Current));
 
-            // if no context was found, return null - we cannot not batch
+            // if no context was found, return null - we cannot batch
             if (httpContext == null) return null;
 
-            var key = typeof (BatchedDatabaseServerMessenger).Name;
+            return GetBatch(create, httpContext);
+        }
+
+        protected ICollection<RefreshInstructionEnvelope> GetBatch(bool create, HttpContextBase httpContext)
+        {
+            var key = typeof(BatchedDatabaseServerMessenger).Name;
 
             // no thread-safety here because it'll run in only 1 thread (request) at a time
             var batch = (ICollection<RefreshInstructionEnvelope>)httpContext.Items[key];
@@ -128,9 +135,17 @@ namespace Umbraco.Web
             MessageType messageType,
             IEnumerable<object> ids = null,
             Type idType = null,
+            string json = null) => BatchMessage(refresher, messageType, null, ids, idType, json);
+
+        protected void BatchMessage(
+            ICacheRefresher refresher,
+            MessageType messageType,
+            HttpContextBase httpContext,
+            IEnumerable<object> ids = null,
+            Type idType = null,
             string json = null)
         {
-            var batch = GetBatch(true);
+            var batch = httpContext != null ? GetBatch(true, httpContext) : GetBatch(true);
             var instructions = RefreshInstruction.GetInstructions(refresher, messageType, ids, idType, json);
 
             // batch if we can, else write to DB immediately


### PR DESCRIPTION
This PR relates to [this issue](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/90) raised on the Deploy tracker.  The problem and cause is well described there, and I've replicated with a load balanced setup and found the same behaviour.

It looks like we need to fix this in CMS rather than Deploy though, as Deploy is raising the expected events following a content deployment operation.

What's going wrong though is that when the events are handled in `DistributedCacheBinder`, we ensure an Umbraco context, using the `HttpContext` if available, but creating one if not.  For the events triggered from Deploy, we don't have an `HttpContext` so one is created.  When the events related to cache instructions are handled, the `BatchedDatabaseServerMessenger` is used to create a batch of instructions, stored in `HttpContext.Items` - which is on our created `HttpContext`.

The flushing of the messages though - and the writing of the cache instruction records to the database - happens at the end of an Umbraco request, which will have an `HttpContext`, but a different one to the one we created when handling the events.  And hence it doesn't find any messages in the `HttpContext.Items` to write.

What I've done is to add a dependency to `DistributedCacheBinder` on the `BatchedDatabaseServerMessenger` interface, `IServerMessenger`.  And then called an explicit "flush" operation using the created `HttpContext`.  To do that I had to create some method overloads to allow the passing in of an `HttpContextBase` instance.

This looks to resolve the problem.  The only concern I've got really is this additional dependency, and whether from an architecture/semantic point of view the `DistributedCacheBinder` should really have to "know" about flushing server messages.  But maybe it's OK, and hopefully there's a clear enough comment about why it seems to be necessary and has been added.

To Test (there's a bit of setup needed to prepare this, so not sure if it's necessary to redo or just review what I did):

- Set up a local load balanced Umbraco environment.  I used some steps from the training course to do this, but essentially it needs:
    - A single Umbraco CMS web application to use as a staging environment.
    - Two Umbraco CMS web application to use as live environments
    - Set all these up with IIS and host headers
    - Configure Umbraco Deploy between the staging application and one of the live ones:
        - Install from NuGet `UmbracoDeploy.OnPrem`
        - Make the necessary updates to `web.config` (the custom section, the reference to the Deploy settings, and the API key)
        - Add and configure `config\UmbracoDeploy.config` (referencing one of the live environments from staging)
        - Add and configure `config\UmbracoDeploy.Settings.config` (can be empty)
    - Create a doc type with template and a single property in stage
        - The template should just write out the value of the property
    - Copy the `.cshtml` file created to both live environments
    - Copy the `.uda` files created to one of the live environments and run a Deploy extraction
    - Create a content item and deploy it
        - Make sure the template renders the correct value in all environments
    - Make a change to the content and deploy it
        - Before the change in this PR, you would see only the first live environment displaying the updated value
        - With the change in this PR, you should see both environments updating,
