### PR TITLE
Move member properties to Member Content App (V9 merge regression)

### DIFF
--- a/src/Umbraco.Core/Models/Mapping/MemberTabsAndPropertiesMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/MemberTabsAndPropertiesMapper.cs
@@ -65,14 +65,11 @@ namespace Umbraco.Cms.Core.Models.Mapping
 
             var resolved = base.Map(source, context);
 
-            // This is kind of a hack because a developer is supposed to be allowed to set their property editor - would have been much easier
-            // if we just had all of the membership provider fields on the member table :(
-            // TODO: But is there a way to map the IMember.IsLockedOut to the property ? i dunno.
+            // IMember.IsLockedOut can't be set to true, so make it readonly when that's the case (you can only unlock)
             var isLockedOutProperty = resolved.SelectMany(x => x.Properties).FirstOrDefault(x => x.Alias == Constants.Conventions.Member.IsLockedOut);
             if (isLockedOutProperty?.Value != null && isLockedOutProperty.Value.ToString() != "1")
             {
-                isLockedOutProperty.View = "readonlyvalue";
-                isLockedOutProperty.Value = _localizedTextService.Localize("general", "no");
+                isLockedOutProperty.Readonly = true;
             }
 
             return resolved;
@@ -191,20 +188,6 @@ namespace Umbraco.Cms.Core.Models.Mapping
         {
             var properties = new List<ContentPropertyDisplay>
             {
-                new ContentPropertyDisplay
-                {
-                    Alias = $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}id",
-                    Label = _localizedTextService.Localize("general","id"),
-                    Value = new List<string> {member.Id.ToString(), member.Key.ToString()},
-                    View = "idwithguid"
-                },
-                new ContentPropertyDisplay
-                {
-                    Alias = $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}doctype",
-                    Label = _localizedTextService.Localize("content","membertype"),
-                    Value = _localizedTextService.UmbracoDictionaryTranslate(CultureDictionary, member.ContentType.Name),
-                    View = _propertyEditorCollection[Constants.PropertyEditors.Aliases.Label].GetValueEditor().View
-                },
                 GetLoginProperty(member, _localizedTextService),
                 new ContentPropertyDisplay
                 {
@@ -212,7 +195,7 @@ namespace Umbraco.Cms.Core.Models.Mapping
                     Label = _localizedTextService.Localize("general","email"),
                     Value = member.Email,
                     View = "email",
-                    Validation = {Mandatory = true}
+                    Validation = { Mandatory = true }
                 },
                 new ContentPropertyDisplay
                 {
@@ -221,12 +204,10 @@ namespace Umbraco.Cms.Core.Models.Mapping
                     Value = new Dictionary<string, object>
                     {
                         // TODO: why ignoreCase, what are we doing here?!
-                        {"newPassword", member.GetAdditionalDataValueIgnoreCase("NewPassword", null)},
+                        { "newPassword", member.GetAdditionalDataValueIgnoreCase("NewPassword", null) }
                     },
-                    // TODO: Hard coding this because the changepassword doesn't necessarily need to be a resolvable (real) property editor
                     View = "changepassword",
-                    // Initialize the dictionary with the configuration from the default membership provider
-                    Config = GetPasswordConfig(member)
+                    Config = GetPasswordConfig(member) // Initialize the dictionary with the configuration from the default membership provider
                 },
                 new ContentPropertyDisplay
                 {
@@ -234,7 +215,10 @@ namespace Umbraco.Cms.Core.Models.Mapping
                     Label = _localizedTextService.Localize("content","membergroup"),
                     Value = GetMemberGroupValue(member.Username),
                     View = "membergroups",
-                    Config = new Dictionary<string, object> {{"IsRequired", true}}
+                    Config = new Dictionary<string, object>
+                    {
+                        { "IsRequired", true }
+                    }
                 }
             };
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
@@ -620,20 +620,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
                         {
                             new ContentPropertyDisplay()
                             {
-                                Alias = "_umb_id",
-                                View = "idwithguid",
-                                Value = new []
-                                {
-                                    "123",
-                                    "guid"
-                                }
-                            },
-                            new ContentPropertyDisplay()
-                            {
-                                Alias = "_umb_doctype"
-                            },
-                            new ContentPropertyDisplay()
-                            {
                                 Alias = "_umb_login"
                             },
                             new ContentPropertyDisplay()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This fixes a regression after merging https://github.com/umbraco/Umbraco-CMS/pull/11587 to v9, which caused some very minor issues with the new Member Content App change:
- The 'Is Locked Out' property wasn't using the checkbox/toggle and readonly-state
- The Member Content App also displayed the 'Id' and 'Member Type' (which were removed, as this is already visible in the Info Content App)


---
_This item has been added to our backlog [AB#15619](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/15619)_