### PR TITLE
Adds migration back for v9 for #10450

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -267,7 +267,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade
 
             // TO 9.2.0
             To<AddUserGroup2NodeTable>("{0571C395-8F0B-44E9-8E3F-47BDD08D817B}");
-
+            To<AddDefaultForNotificationsToggle>("{AD3D3B7F-8E74-45A4-85DB-7FFAD57F9243}");
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_2_0/AddDefaultForNotificationsToggle.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_2_0/AddDefaultForNotificationsToggle.cs
@@ -1,0 +1,17 @@
+﻿using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_2_0
+{
+    public class AddDefaultForNotificationsToggle : MigrationBase
+    {
+        public AddDefaultForNotificationsToggle(IMigrationContext context)
+            : base(context)
+        { }
+
+        protected override void Migrate()
+        {
+            var updateSQL = Sql($"UPDATE {Constants.DatabaseSchema.Tables.UserGroup} SET userGroupDefaultPermissions = userGroupDefaultPermissions + 'N' WHERE userGroupAlias IN ('admin', 'writer', 'editor')");
+            Execute.Sql(updateSQL.SQL).Do();
+        }
+    }
+}


### PR DESCRIPTION
As discussed @bergmania - to test, after upgrading to 9.2, you will see the added "N" in the database

![image](https://user-images.githubusercontent.com/304656/146384061-6beeef04-941a-43b6-8122-116a341e7de5.png)

And if you have SMTP set up properly, you will see the notifications option in the right-click menu

![image](https://user-images.githubusercontent.com/304656/146384140-59652718-f635-4b7f-a027-20cd9956b9a1.png)


---
_This item has been added to our backlog [AB#15615](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/15615)_