### PR TITLE
Transition of lazy loaded image

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbimagelazyload.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbimagelazyload.directive.js
@@ -36,19 +36,23 @@ Use this directive to lazy-load an image only when it is scrolled into view.
 
     function ImageLazyLoadDirective() {
 
-        const placeholder = "assets/img/transparent.png";
+      const placeholder = "assets/img/transparent.png";
 
-        function link(scope, element, attrs) {
+      function link(scope, element, attrs) {
 
             const observer = new IntersectionObserver(loadImg);
             const img = element[0];
             img.src = placeholder;
+            img.classList.add("lazy");
             observer.observe(img);
 
-            function loadImg(changes) {
-                changes.forEach(change => {
-                    if (change.intersectionRatio > 0 && change.target.src.indexOf(placeholder) > 0) {
-                        change.target.src = attrs.umbImageLazyLoad;
+            function loadImg(entries) {
+                entries.forEach(entry => {
+                  if (entry.intersectionRatio > 0 && entry.target.src.indexOf(placeholder) > 0) {
+                      let lazyImage = entry.target;
+                      lazyImage.src = attrs.umbImageLazyLoad;
+                      lazyImage.classList.add("loaded");
+                      observer.unobserve(lazyImage);
                     }
                 });
             }

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -14,6 +14,20 @@
 	box-shadow: 3px 0px 7px rgba(0,0,0,0.16);
 }
 
+img:not([src]):not([srcset]) {
+  visibility: hidden;
+}
+
+img.lazy {
+  -webkit-transition: opacity 1.2s cubic-bezier(0.16, 1.08, 0.38, 0.98);
+  transition: opacity 1.2s cubic-bezier(0.16, 1.08, 0.38, 0.98);
+  opacity: 0;
+}
+
+img.lazy.loaded {
+  opacity: 1;
+}
+
 .umb-scrollable, .umb-auto-overflow {
 	overflow: auto;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adjust the `umb-image-lazy-load` directive by adding a `lazy` class and `loaded` class when image has been loaded making a smoother transition from the temporary transparent image to the loaded image.


https://user-images.githubusercontent.com/2919859/146643177-6f992c9e-c375-4927-815e-0850f2614d96.mp4


I have attached the custom listview layout used in a custom listview for "People".
[ListviewLayouts.zip](https://github.com/umbraco/Umbraco-CMS/files/7739314/ListviewLayouts.zip)

I have hardcoded the `imageProp.value` though as each `photo` properties return null in value property.
Not sure if something has changed in 9.2.0-RC because it is working just fine in 9.1.2

I am using this listview layout in a few projects and works with both Media Picker 3 and legacy media picker.

```
$scope.items = $scope.items.map(function (obj) {

          if (obj.contentTypeAlias === "person") {
              console.log("properties", obj.properties);
                
                var imageProp = _.find(obj.properties, function (p) { return (p.alias === "photo"); });
                if (imageProp) {
                   //obj.thumbnail = "https://www.gravatar.com/avatar/?d=mm&s=100&f=y";

                   imageProp.value = '662af6ca-411a-4c93-a6c7-22c4845698e7';
                   
                   if (imageProp.value) {
                      var mediaId = Utilities.isArray(imageProp.value) ? (imageProp.value[0] ? imageProp.value[0].mediaKey : null) : imageProp.value;
                      console.log("media id", mediaId);
                      if (mediaId) {
                         mediaResource.getById(mediaId).then(function (media) {
                             obj.thumbnail = mediaHelper.resolveFile(media) + "?width=100&height=100&mode=crop";
                         });
                      }
                   }
                }
            }

            return obj;
        });
```
