### PR TITLE
v9: Throw error on duplicate routes

### DIFF
--- a/src/Umbraco.Core/Services/IConflictingRouteService.cs
+++ b/src/Umbraco.Core/Services/IConflictingRouteService.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Cms.Core.Services
+{
+    public interface IConflictingRouteService
+    {
+        public bool HasConflictingRoutes();
+    }
+}

--- a/src/Umbraco.Core/Services/IConflictingRouteService.cs
+++ b/src/Umbraco.Core/Services/IConflictingRouteService.cs
@@ -2,6 +2,6 @@ namespace Umbraco.Cms.Core.Services
 {
     public interface IConflictingRouteService
     {
-        public bool HasConflictingRoutes();
+        public bool HasConflictingRoutes(out string controllerName);
     }
 }

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
@@ -124,11 +124,11 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             }
 
             // Check if we have multiple controllers with the same name.
-            if (_conflictingRouteService.HasConflictingRoutes())
+            if (_conflictingRouteService.HasConflictingRoutes(out string controllerName))
             {
                 Level = RuntimeLevel.BootFailed;
                 Reason = RuntimeLevelReason.BootFailedOnException;
-                BootFailedException = new BootFailedException("Conflicting routes, you cannot have multiple controllers with the same name");
+                BootFailedException = new BootFailedException($"Conflicting routes, you cannot have multiple controllers with the same name: {controllerName}");
 
                 return;
             }

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -12,6 +13,7 @@ using Umbraco.Cms.Core.Semver;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Runtime
@@ -30,6 +32,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
         private readonly ILogger<RuntimeState> _logger;
         private readonly PendingPackageMigrations _packageMigrationState;
         private readonly Dictionary<string, object> _startupState = new Dictionary<string, object>();
+        private readonly IConflictingRouteService _conflictingRouteService;
 
         /// <summary>
         /// The initial <see cref="RuntimeState"/>
@@ -51,6 +54,25 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             IUmbracoDatabaseFactory databaseFactory,
             ILogger<RuntimeState> logger,
             PendingPackageMigrations packageMigrationState)
+            : this(
+                globalSettings,
+                unattendedSettings,
+                umbracoVersion,
+                databaseFactory,
+                logger,
+                packageMigrationState,
+                StaticServiceProvider.Instance.GetRequiredService<IConflictingRouteService>())
+        {
+        }
+
+        public RuntimeState(
+            IOptions<GlobalSettings> globalSettings,
+            IOptions<UnattendedSettings> unattendedSettings,
+            IUmbracoVersion umbracoVersion,
+            IUmbracoDatabaseFactory databaseFactory,
+            ILogger<RuntimeState> logger,
+            PendingPackageMigrations packageMigrationState,
+            IConflictingRouteService conflictingRouteService)
         {
             _globalSettings = globalSettings;
             _unattendedSettings = unattendedSettings;
@@ -58,7 +80,10 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             _databaseFactory = databaseFactory;
             _logger = logger;
             _packageMigrationState = packageMigrationState;
+            _conflictingRouteService = conflictingRouteService;
         }
+
+
 
 
         /// <inheritdoc />
@@ -98,6 +123,16 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                 _logger.LogDebug("Database is not configured, need to install Umbraco.");
                 Level = RuntimeLevel.Install;
                 Reason = RuntimeLevelReason.InstallNoDatabase;
+                return;
+            }
+
+            // Check if we have multiple controllers with the same name.
+            if (_conflictingRouteService.HasConflictingRoutes())
+            {
+                Level = RuntimeLevel.BootFailed;
+                Reason = RuntimeLevelReason.BootFailedOnException;
+                BootFailedException = new BootFailedException("Conflicting routes, you cannot have multiple controllers with the same name");
+
                 return;
             }
 

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
@@ -83,9 +83,6 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             _conflictingRouteService = conflictingRouteService;
         }
 
-
-
-
         /// <inheritdoc />
         public Version Version => _umbracoVersion.Version;
 

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -114,6 +114,7 @@ namespace Umbraco.Extensions
             });
 
             builder.Services.AddUnique<IIconService, IconService>();
+            builder.Services.AddUnique<IConflictingRouteService, ConflictingRouteService>();
             builder.Services.AddUnique<UnhandledExceptionLoggerMiddleware>();
 
             return builder;

--- a/src/Umbraco.Web.BackOffice/Services/ConflictingRouteService.cs
+++ b/src/Umbraco.Web.BackOffice/Services/ConflictingRouteService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Controllers;
+
+namespace Umbraco.Cms.Web.BackOffice.Services
+{
+    public class ConflictingRouteService : IConflictingRouteService
+    {
+        private readonly TypeLoader _typeLoader;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConflictingRouteService"/> class.
+        /// </summary>
+        public ConflictingRouteService(TypeLoader typeLoader) => _typeLoader = typeLoader;
+
+        /// <inheritdoc/>
+        public bool HasConflictingRoutes()
+        {
+            var controllers = _typeLoader.GetTypes<UmbracoApiControllerBase>().ToList();
+            // var pluginControllers = _typeLoader.GetTypes<PluginController>().ToList();
+            // controllers.AddRange(pluginControllers);
+            foreach (Type controller in controllers)
+            {
+                if (controllers.Count(x => x.Name == controller.Name) > 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Umbraco.Web.BackOffice/Services/ConflictingRouteService.cs
+++ b/src/Umbraco.Web.BackOffice/Services/ConflictingRouteService.cs
@@ -19,8 +19,6 @@ namespace Umbraco.Cms.Web.BackOffice.Services
         public bool HasConflictingRoutes()
         {
             var controllers = _typeLoader.GetTypes<UmbracoApiControllerBase>().ToList();
-            // var pluginControllers = _typeLoader.GetTypes<PluginController>().ToList();
-            // controllers.AddRange(pluginControllers);
             foreach (Type controller in controllers)
             {
                 if (controllers.Count(x => x.Name == controller.Name) > 1)

--- a/src/Umbraco.Web.BackOffice/Services/ConflictingRouteService.cs
+++ b/src/Umbraco.Web.BackOffice/Services/ConflictingRouteService.cs
@@ -16,17 +16,19 @@ namespace Umbraco.Cms.Web.BackOffice.Services
         public ConflictingRouteService(TypeLoader typeLoader) => _typeLoader = typeLoader;
 
         /// <inheritdoc/>
-        public bool HasConflictingRoutes()
+        public bool HasConflictingRoutes(out string controllerName)
         {
             var controllers = _typeLoader.GetTypes<UmbracoApiControllerBase>().ToList();
             foreach (Type controller in controllers)
             {
                 if (controllers.Count(x => x.Name == controller.Name) > 1)
                 {
+                    controllerName = controller.Name;
                     return true;
                 }
             }
 
+            controllerName = string.Empty;
             return false;
         }
     }

--- a/tests/Umbraco.Tests.Integration/Testing/TestConflictingRouteService.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/TestConflictingRouteService.cs
@@ -1,9 +1,14 @@
+using System;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Tests.Integration.Testing
 {
     public class TestConflictingRouteService : IConflictingRouteService
     {
-        public bool HasConflictingRoutes() => false;
+        public bool HasConflictingRoutes(out string controllername)
+        {
+            controllername = string.Empty;
+            return false;
+        }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Testing/TestConflictingRouteService.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/TestConflictingRouteService.cs
@@ -1,0 +1,9 @@
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Testing
+{
+    public class TestConflictingRouteService : IConflictingRouteService
+    {
+        public bool HasConflictingRoutes() => false;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -201,6 +201,9 @@ namespace Umbraco.Cms.Tests.Integration.Testing
             IWebHostEnvironment webHostEnvironment = TestHelper.GetWebHostEnvironment();
             services.AddRequiredNetCoreServices(TestHelper, webHostEnvironment);
 
+            // We register this service because we need it for IRuntimeState, if we don't this breaks 900 tests
+            services.AddSingleton<IConflictingRouteService, TestConflictingRouteService>();
+
             // Add it!
             Core.Hosting.IHostingEnvironment hostingEnvironment = TestHelper.GetHostingEnvironment();
             TypeLoader typeLoader = services.AddTypeLoader(


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco-CMS/issues/11584
# Notes
- Created IConflictingRouteService interface
- Created ConflictingRouteService class

# How to test
- Create 2 controllers that derive from `UmbracoAuthorizedApiController`, remember to use 2 different namespaces
- Run umbraco and assert that you now get an error.
- Please also test this with making a controller with the same name as one of the umbraco API controllers, like TourController