### PR TITLE
Add a health check for umbraco application url

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2182,6 +2182,11 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->
+    <key alias="umbracoApplicationUrlCheckResult">The 'umbracoApplicationUrl' option is %0% set in your umbracoSettings.config file.</key>
+    <key alias="umbracoApplicationUrlConfigureButton">Set Umbraco application URL in Config</key>
+    <key alias="umbracoApplicationUrlConfigureDescription">Adds a value to the 'umbracoApplicationUrl' option of umbracoSettings.config to prevent configuring insecure endpoint as the hostname of your Umbraco application.</key>
+    <key alias="umbracoApplicationUrlConfigureSuccess"><![CDATA[The value of 'umbracoApplicationUrl' is now set to <strong>%0%</strong> in your umbracoSettings.config file.]]></key>
+    <key alias="umbracoApplicationUrlConfigureError">Could not update the value of 'umbracoApplicationUrl' option in your umbracoSettings.config file. Error: %0%</key>
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
     <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -2182,7 +2182,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->
-    <key alias="umbracoApplicationUrlCheckResult">The 'umbracoApplicationUrl' option is %0% set in your umbracoSettings.config file.</key>
+    <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[The 'umbracoApplicationUrl' option is set to <strong>%0%</strong> in your umbracoSettings.config file.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultFalse">The 'umbracoApplicationUrl' option is not set in your umbracoSettings.config file.</key>
     <key alias="umbracoApplicationUrlConfigureButton">Set Umbraco application URL in Config</key>
     <key alias="umbracoApplicationUrlConfigureDescription">Adds a value to the 'umbracoApplicationUrl' option of umbracoSettings.config to prevent configuring insecure endpoint as the hostname of your Umbraco application.</key>
     <key alias="umbracoApplicationUrlConfigureSuccess"><![CDATA[The value of 'umbracoApplicationUrl' is now set to <strong>%0%</strong> in your umbracoSettings.config file.]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2219,6 +2219,11 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->
+    <key alias="umbracoApplicationUrlCheckResult">The 'umbracoApplicationUrl' option is %0% set in your umbracoSettings.config file.</key>
+    <key alias="umbracoApplicationUrlConfigureButton">Set Umbraco application URL in Config</key>
+    <key alias="umbracoApplicationUrlConfigureDescription">Adds a value to the 'umbracoApplicationUrl' option of umbracoSettings.config to prevent configuring insecure endpoint as the hostname of your Umbraco application.</key>
+    <key alias="umbracoApplicationUrlConfigureSuccess"><![CDATA[The value of 'umbracoApplicationUrl' is now set to <strong>%0%</strong> in your umbracoSettings.config file.]]></key>
+    <key alias="umbracoApplicationUrlConfigureError">Could not update the value of 'umbracoApplicationUrl' option in your umbracoSettings.config file. Error: %0%</key>
     <key alias="requiredFilePermissionFailed"><![CDATA[The following files must be set up with write permissions but could not be acccessed: <strong>%0%</strong>.]]></key>
     <key alias="optionalFilePermissionFailed"><![CDATA[The following files must be set up with write permissions for certain Umbraco operations to function but could not be acccessed: <strong>%0%</strong>. If they aren't being written to no action need be taken.]]></key>
     <key alias="clickJackingCheckHeaderFound"><![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -2219,7 +2219,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->
-    <key alias="umbracoApplicationUrlCheckResult">The 'umbracoApplicationUrl' option is %0% set in your umbracoSettings.config file.</key>
+    <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[The 'umbracoApplicationUrl' option is set to <strong>%0%</strong> in your umbracoSettings.config file.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultFalse">The 'umbracoApplicationUrl' option is not set in your umbracoSettings.config file.</key>
     <key alias="umbracoApplicationUrlConfigureButton">Set Umbraco application URL in Config</key>
     <key alias="umbracoApplicationUrlConfigureDescription">Adds a value to the 'umbracoApplicationUrl' option of umbracoSettings.config to prevent configuring insecure endpoint as the hostname of your Umbraco application.</key>
     <key alias="umbracoApplicationUrlConfigureSuccess"><![CDATA[The value of 'umbracoApplicationUrl' is now set to <strong>%0%</strong> in your umbracoSettings.config file.]]></key>

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/UmbracoApplicationUrlCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/UmbracoApplicationUrlCheck.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.IO;
+using Umbraco.Core.Services;
+using Umbraco.Web.HealthCheck.Checks.Config;
+
+namespace Umbraco.Web.HealthCheck.Checks.Security
+{
+    [HealthCheck(
+        "6708CA45-E96E-40B8-A40A-0607C1CA7F28",
+        "Application URL Configuration",
+        Description = "Checks if the Umbraco application URL is configured for your site.",
+        Group = "Security")]
+    public class UmbracoApplicationUrlCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+        private readonly IRuntimeState _runtime;
+        private readonly IUmbracoSettingsSection _settings;
+
+        private const string SetApplicationUrlAction = "setApplicationUrl";
+
+        public UmbracoApplicationUrlCheck(ILocalizedTextService textService, IRuntimeState runtime, IUmbracoSettingsSection settings)
+        {
+            _textService = textService;
+            _runtime = runtime;
+            _settings = settings;
+        }
+
+        /// <summary>
+        /// Executes the action and returns its status
+        /// </summary>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            switch (action.Alias)
+            {
+                case SetApplicationUrlAction:
+                    return SetUmbracoApplicationUrl();
+                default:
+                    throw new InvalidOperationException("UmbracoApplicationUrlCheck action requested is either not executable or does not exist");
+            }
+        }
+
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            //return the statuses
+            return new[] { CheckUmbracoApplicationUrl() };
+        }
+
+        private HealthCheckStatus CheckUmbracoApplicationUrl()
+        {
+            var urlConfigured = !_settings.WebRouting.UmbracoApplicationUrl.IsNullOrWhiteSpace();
+            var actions = new List<HealthCheckAction>();
+
+            string resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResult", new[] { urlConfigured ? string.Empty : "not" });
+            StatusResultType resultType = urlConfigured ? StatusResultType.Success : StatusResultType.Warning;
+
+            if (urlConfigured == false)
+            {
+                actions.Add(new HealthCheckAction(SetApplicationUrlAction, Id)
+                {
+                    Name = _textService.Localize("healthcheck", "umbracoApplicationUrlConfigureButton"),
+                    Description = _textService.Localize("healthcheck", "umbracoApplicationUrlConfigureDescription")
+                });
+            }
+
+            return new HealthCheckStatus(resultMessage)
+            {
+                ResultType = resultType,
+                Actions = actions
+            };
+        }
+
+        private HealthCheckStatus SetUmbracoApplicationUrl()
+        {
+            var configFilePath = IOHelper.MapPath("~/config/umbracoSettings.config");
+            const string xPath = "/settings/web.routing/@umbracoApplicationUrl";
+            var configurationService = new ConfigurationService(configFilePath, xPath, _textService);
+            var urlValue = _runtime.ApplicationUrl.ToString();
+            var updateConfigFile = configurationService.UpdateConfigFile(urlValue);
+
+            if (updateConfigFile.Success)
+            {
+                return
+                    new HealthCheckStatus(_textService.Localize("healthcheck", "umbracoApplicationUrlConfigureSuccess", new[] { urlValue }))
+                    {
+                        ResultType = StatusResultType.Success
+                    };
+            }
+
+            return
+               new HealthCheckStatus(_textService.Localize("healthcheck", "umbracoApplicationUrlConfigureError", new[] { updateConfigFile.Result }))
+               {
+                   ResultType = StatusResultType.Error
+               };
+        }
+    }
+}

--- a/src/Umbraco.Web/HealthCheck/Checks/Security/UmbracoApplicationUrlCheck.cs
+++ b/src/Umbraco.Web/HealthCheck/Checks/Security/UmbracoApplicationUrlCheck.cs
@@ -52,19 +52,27 @@ namespace Umbraco.Web.HealthCheck.Checks.Security
 
         private HealthCheckStatus CheckUmbracoApplicationUrl()
         {
-            var urlConfigured = !_settings.WebRouting.UmbracoApplicationUrl.IsNullOrWhiteSpace();
+            var url = _settings.WebRouting.UmbracoApplicationUrl;
+
+            string resultMessage;
+            StatusResultType resultType;
             var actions = new List<HealthCheckAction>();
 
-            string resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResult", new[] { urlConfigured ? string.Empty : "not" });
-            StatusResultType resultType = urlConfigured ? StatusResultType.Success : StatusResultType.Warning;
-
-            if (urlConfigured == false)
+            if (url.IsNullOrWhiteSpace())
             {
+                resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultFalse");
+                resultType = StatusResultType.Warning;
+
                 actions.Add(new HealthCheckAction(SetApplicationUrlAction, Id)
                 {
                     Name = _textService.Localize("healthcheck", "umbracoApplicationUrlConfigureButton"),
                     Description = _textService.Localize("healthcheck", "umbracoApplicationUrlConfigureDescription")
                 });
+            }
+            else
+            {
+                resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultTrue", new[] { url });
+                resultType = StatusResultType.Success;
             }
 
             return new HealthCheckStatus(resultMessage)

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -190,6 +190,7 @@
     <Compile Include="HealthCheck\Checks\Config\ProvidedValueValidation.cs" />
     <Compile Include="Editors\TinyMceController.cs" />
     <Compile Include="HealthCheck\Checks\Data\DatabaseIntegrityCheck.cs" />
+    <Compile Include="HealthCheck\Checks\Security\UmbracoApplicationUrlCheck.cs" />
     <Compile Include="ImageCropperTemplateCoreExtensions.cs" />
     <Compile Include="Install\InstallSteps\TelemetryIdentifierStep.cs" />
     <Compile Include="IUmbracoContextFactory.cs" />


### PR DESCRIPTION
## Details 
- Adding a new health check which checks if the value of `umbracoApplicationUrl` is set in the [umbracoSettings.config](https://our.umbraco.com/documentation/reference/config/umbracosettings/#umbracoapplicationurl) file;
- There is also the option to set it according to the site URL that you are currently using.

## Test
- Navigate to the **Settings** section > Health Check > Security 
- Use the _Check group_ button
- Verify that the information displayed in **Application URL Configuration** part is correct
  - Ex: If `umbracoApplicationUrl=""` in your **umbracoSettings.config** file, you will see a warning (⚠️)  and you will be able to set its value through the newly added button (_Set Umbraco application URL in Config_)
- After clicking the button it should result in success (✔️) and the value in the config should be updated with the application's URL 