### PR TITLE
V9: Add a health check for umbraco application url

### DIFF
--- a/src/Umbraco.Core/Constants-HealthChecks.cs
+++ b/src/Umbraco.Core/Constants-HealthChecks.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core
+namespace Umbraco.Cms.Core
 {
     /// <summary>
     /// Defines constants.
@@ -20,15 +20,16 @@
 
                     public const string CompilationDebugCheck = "https://umbra.co/healthchecks-compilation-debug";
                 }
+
                 public static class Configuration
                 {
                     public const string MacroErrorsCheck = "https://umbra.co/healthchecks-macro-errors";
                     public const string TrySkipIisCustomErrorsCheck = "https://umbra.co/healthchecks-skip-iis-custom-errors";
                     public const string NotificationEmailCheck = "https://umbra.co/healthchecks-notification-email";
                 }
+
                 public static class FolderAndFilePermissionsCheck
                 {
-
                     public const string FileWriting = "https://umbra.co/healthchecks-file-writing";
                     public const string FolderCreation = "https://umbra.co/healthchecks-folder-creation";
                     public const string FileWritingForPackages = "https://umbra.co/healthchecks-file-writing-for-packages";
@@ -37,7 +38,7 @@
 
                 public static class Security
                 {
-
+                    public const string UmbracoApplicationUrlCheck = "https://umbra.co/healthchecks-umbraco-application-url";
                     public const string ClickJackingCheck = "https://umbra.co/healthchecks-click-jacking";
                     public const string HstsCheck = "https://umbra.co/healthchecks-hsts";
                     public const string NoSniffCheck = "https://umbra.co/healthchecks-no-sniff";
@@ -46,7 +47,6 @@
 
                     public static class HttpsCheck
                     {
-
                         public const string CheckIfCurrentSchemeIsHttps = "https://umbra.co/healthchecks-https-request";
                         public const string CheckHttpsConfigurationSetting = "https://umbra.co/healthchecks-https-config";
                         public const string CheckForValidCertificate = "https://umbra.co/healthchecks-valid-certificate";

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/UmbracoApplicationUrlCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/UmbracoApplicationUrlCheck.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.HealthChecks.Checks.Security
+{
+    [HealthCheck(
+        "6708CA45-E96E-40B8-A40A-0607C1CA7F28",
+        "Application URL Configuration",
+        Description = "Checks if the Umbraco application URL is configured for your site.",
+        Group = "Security")]
+    public class UmbracoApplicationUrlCheck : HealthCheck
+    {
+        private readonly ILocalizedTextService _textService;
+        private readonly IOptionsMonitor<WebRoutingSettings> _webRoutingSettings;
+
+        public UmbracoApplicationUrlCheck(ILocalizedTextService textService, IOptionsMonitor<WebRoutingSettings> webRoutingSettings)
+        {
+            _textService = textService;
+            _webRoutingSettings = webRoutingSettings;
+        }
+
+        /// <summary>
+        /// Executes the action and returns its status
+        /// </summary>
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action) => throw new InvalidOperationException("UmbracoApplicationUrlCheck has no executable actions");
+
+        /// <summary>
+        /// Get the status for this health check
+        /// </summary>
+        public override Task<IEnumerable<HealthCheckStatus>> GetStatus() =>
+            Task.FromResult(CheckUmbracoApplicationUrl().Yield());
+
+        private HealthCheckStatus CheckUmbracoApplicationUrl()
+        {
+            var url = _webRoutingSettings.CurrentValue.UmbracoApplicationUrl;
+
+            string resultMessage;
+            StatusResultType resultType;
+            var success = false;
+
+            if (url.IsNullOrWhiteSpace())
+            {
+                resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultFalse");
+                resultType = StatusResultType.Warning;
+            }
+            else
+            {
+                resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultTrue", new[] { url });
+                resultType = StatusResultType.Success;
+                success = true;
+            }
+
+            return new HealthCheckStatus(resultMessage)
+            {
+                ResultType = resultType,
+                ReadMoreLink = success ? null : Constants.HealthChecks.DocumentationLinks.Security.UmbracoApplicationUrlCheck
+            };
+        }
+    }
+}

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2290,6 +2290,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->
+    <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is set to <strong>%0%</strong>.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultFalse">The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set.</key>
     <key alias="clickJackingCheckHeaderFound">
       <![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>
     <key alias="clickJackingCheckHeaderNotFound">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2372,6 +2372,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->
+    <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is set to <strong>%0%</strong>.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultFalse">The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set.</key>
     <key alias="clickJackingCheckHeaderFound">
       <![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>
     <key alias="clickJackingCheckHeaderNotFound">


### PR DESCRIPTION
## Details 
- V9 implementation for #11776; 
- Adding a new health check which checks if the value of `UmbracoApplicationUrl` appSetting is set;
  - If it isn't set, we will direct to a "Read more" documentation link _**that has to be made**_. ❗ 
 (_Since it isn't possible to change the value in v9 programmatically, we link to a page with all the configurations instead_)

---  
**NB** ❗ Something like https://umbra.co/healthchecks-umbraco-application-url  

---

## Test
- Navigate to the **Settings** section > Health Check > Security 
- Use the _Check group_ button
- Verify that the information displayed in **Application URL Configuration** part is correct
  - Ex: If the appSetting `Umbraco:CMS:WebRouting:UmbracoApplicationUrl` is not set, you will see a warning (⚠️) 
- You can set it to, for example:
```json
"Umbraco": {
  "CMS": {
    . . .
    "WebRouting": {
        "UmbracoApplicationUrl": "https://localhost:44331/"
    }
  }
}
```
- and verify that it results in success (✔️)