### PR TITLE
Makes the width of .login-overlay__logo dynamic

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -30,9 +30,12 @@
     position: absolute;
     top: 22px;
     left: 25px;
-    width: 30px;
     height: 30px;
     z-index: 1;
+}
+
+.login-overlay__logo > img {
+    max-height:100%;
 }
 
 .login-overlay .umb-modalcolumn {


### PR DESCRIPTION
When adding logos that are not square - especially if they are wide, they turn out really small.

This PR removes the width constraint on the logo, and makes its max-height the original 30px, allowing wider logos to take up the necessary width, while keeping the vertical size of the original logo.

Before
![msedge_iMyyUXC2pA](https://user-images.githubusercontent.com/3726467/146933333-d78043b4-0285-4ebb-9108-c259a7f078e7.png)

After
![msedge_6XwGp0kJwV](https://user-images.githubusercontent.com/3726467/146933348-7f105d38-1c71-4586-9a88-1e362e2c8a90.png)

The logo used: [Buy_n_Large.zip](https://github.com/umbraco/Umbraco-CMS/files/7755387/Buy_n_Large.zip)

