### PR TITLE
v9: some url paths are not correct on case sensitive filesystems

### DIFF
--- a/src/Umbraco.Core/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Core/Actions/ActionAssignDomain.cs
@@ -8,7 +8,7 @@
         public const char ActionLetter = 'I';
 
         public char Letter => ActionLetter;
-        public string Alias => "assignDomain";
+        public string Alias => "assigndomain";
         public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
         public string Icon => "home";
         public bool ShowInNotifier => false;

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
@@ -60,7 +60,7 @@
     <key alias="other">Ostatní</key>
   </area>
   <area alias="actionDescriptions">
-    <key alias="assignDomain">Povolit přístup k přiřazování kultury a názvů hostitelů</key>
+    <key alias="assigndomain">Povolit přístup k přiřazování kultury a názvů hostitelů</key>
     <key alias="auditTrail">Povolit přístup k zobrazení protokolu historie uzlu</key>
     <key alias="browse">Povolit přístup k zobrazení uzlu</key>
     <key alias="changeDocType">Povolit přístup ke změně typu dokumentu daného uzlu</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
@@ -5,7 +5,7 @@
     <link>https://www.method4.co.uk/</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Diwylliannau ac Enwau Gwesteia</key>
+    <key alias="assigndomain">Diwylliannau ac Enwau Gwesteia</key>
     <key alias="auditTrail">Trywydd Archwilio</key>
     <key alias="browse">Dewis Nod</key>
     <key alias="changeDocType">Newid Math o Ddogfen</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Tilføj domæne</key>
+    <key alias="assigndomain">Tilføj domæne</key>
     <key alias="auditTrail">Revisionsspor</key>
     <key alias="browse">Gennemse elementer</key>
     <key alias="changeDocType">Skift Dokument Type</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Kulturen und Hostnamen</key>
+    <key alias="assigndomain">Kulturen und Hostnamen</key>
     <key alias="auditTrail">Protokoll</key>
     <key alias="browse">Durchsuchen</key>
     <key alias="changeDocType">Dokumenttyp ändern</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Culture and Hostnames</key>
+    <key alias="assigndomain">Culture and Hostnames</key>
     <key alias="auditTrail">Audit Trail</key>
     <key alias="browse">Browse Node</key>
     <key alias="changeDocType">Change Document Type</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Culture and Hostnames</key>
+    <key alias="assigndomain">Culture and Hostnames</key>
     <key alias="auditTrail">Audit Trail</key>
     <key alias="browse">Browse Node</key>
     <key alias="changeDocType">Change Document Type</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Administrar dominios</key>
+    <key alias="assigndomain">Administrar dominios</key>
     <key alias="auditTrail">Historial</key>
     <key alias="browse">Nodo de Exploración</key>
     <key alias="changeDocType">Cambiar tipo de documento</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Culture et noms d'hôte</key>
+    <key alias="assigndomain">Culture et noms d'hôte</key>
     <key alias="auditTrail">Informations d'audit</key>
     <key alias="browse">Parcourir</key>
     <key alias="changeDocType">Changer le type de document</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">נהל שמות מתחם</key>
+    <key alias="assigndomain">נהל שמות מתחם</key>
     <key alias="auditTrail">מעקב ביקורות</key>
     <key alias="browse">צפה בתוכן</key>
     <key alias="copy">העתק</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Gestisci hostnames</key>
+    <key alias="assigndomain">Gestisci hostnames</key>
     <key alias="auditTrail">Audit Trail</key>
     <key alias="browse">Sfoglia</key>
     <key alias="changeDocType">Cambia tipo di documento</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">ドメインの割り当て</key>
+    <key alias="assigndomain">ドメインの割り当て</key>
     <key alias="auditTrail">動作記録</key>
     <key alias="browse">ノードの参照</key>
     <key alias="changeDocType">ドキュメントタイプの変更</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">호스트명 관리</key>
+    <key alias="assigndomain">호스트명 관리</key>
     <key alias="auditTrail">감사 추적</key>
     <key alias="browse">노드 탐색</key>
     <key alias="copy">복사</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Angi domene</key>
+    <key alias="assigndomain">Angi domene</key>
     <key alias="auditTrail">Revisjoner</key>
     <key alias="browse">Bla gjennom</key>
     <key alias="changeDocType">Skift dokumenttype</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Beheer domeinnamen</key>
+    <key alias="assigndomain">Beheer domeinnamen</key>
     <key alias="auditTrail">Documentgeschiedenis</key>
     <key alias="browse">Node bekijken</key>
     <key alias="changeDocType">Documenttype wijzigen</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Zarządzanie hostami</key>
+    <key alias="assigndomain">Zarządzanie hostami</key>
     <key alias="auditTrail">Historia zmian</key>
     <key alias="browse">Przeglądaj węzeł</key>
     <key alias="changeDocType">Zmień typ dokumentu</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Gerenciar hostnames</key>
+    <key alias="assigndomain">Gerenciar hostnames</key>
     <key alias="auditTrail">Caminho de Auditoria</key>
     <key alias="browse">Navegar o Nó</key>
     <key alias="copy">Copiar</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Языки и домены</key>
+    <key alias="assigndomain">Языки и домены</key>
     <key alias="auditTrail">История исправлений</key>
     <key alias="browse">Просмотреть</key>
     <key alias="changeDocType">Изменить тип документа</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -8,7 +8,7 @@
     <key alias="umbContent">Innehåll</key>
   </area>
   <area alias="actions">
-    <key alias="assignDomain">Hantera domännamn</key>
+    <key alias="assigndomain">Hantera domännamn</key>
     <key alias="auditTrail">Hantera versioner</key>
     <key alias="browse">Surfa på sidan</key>
     <key alias="changeDocType">Ändra dokumenttyp</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">Kültür ve Ana Bilgisayar Adları</key>
+    <key alias="assigndomain">Kültür ve Ana Bilgisayar Adları</key>
     <key alias="auditTrail">Denetim Yolu</key>
     <key alias="browse">Düğüme Göz At</key>
     <key alias="changeDocType">Belge Türünü Değiştir</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">管理主机名</key>
+    <key alias="assigndomain">管理主机名</key>
     <key alias="auditTrail">跟踪审计</key>
     <key alias="browse">浏览节点</key>
     <key alias="changeDocType">改变文档类型</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
@@ -5,7 +5,7 @@
     <link>https://our.umbraco.com/documentation/Extending-Umbraco/Language-Files</link>
   </creator>
   <area alias="actions">
-    <key alias="assignDomain">管理主機名稱</key>
+    <key alias="assigndomain">管理主機名稱</key>
     <key alias="auditTrail">跟蹤審計</key>
     <key alias="browse">流覽節點</key>
     <key alias="changeDocType">改變文檔類型</key>


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/11670

# Notes 
- recase assignDomain to assigndomain

# How to test
- If you're on Windows, navigate to your umbraco folder and run the powershell script `(Get-ChildItem -Recurse -Directory).FullName | ForEach-Object {fsutil.exe file setCaseSensitiveInfo $_ enable}`
- Run umbraco
- Create an empty document type and allow as root
- Create a content page for the document type
- Right click the content and click "Culture and Hostnames" this should now give you a menu and not an error