### PR TITLE
WIP - Extension methods to easily remove items from CollectionBuilders

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -107,5 +107,17 @@ namespace Umbraco.Cms.Core.DependencyInjection
             builder.UrlProviders().Append<T>();
             return builder;
         }
+
+        /// <summary>
+        /// Remove a section.
+        /// </summary>
+        /// <typeparam name="T">The type of the section.</typeparam>
+        /// <param name="builder">The builder.</param>
+        public static IUmbracoBuilder RemoveSection<T>(this IUmbracoBuilder builder)
+            where T : class, ISection
+        {
+            builder.Sections().Remove<T>();
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
As an extension to this [PR ](https://github.com/umbraco/Umbraco-CMS/pull/11691)I think it would be nice to also be able to remove items from collection builders using extension methods. 

The methods can be used as follows:
```csharp
public void ConfigureServices(IServiceCollection services)
{

    services.AddUmbraco(_env, _config)
        .AddBackOffice()
        .AddWebsite()
        .AddComposers()
        .RemoveSection<FormsSection>()
        .Build();

}
```

Any chance this will be merged? 😄 