### PR TITLE
Update RemoveTreeController to use TController 

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -80,5 +80,11 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 _trees.Remove(tree);
             }
         }
+
+        public void RemoveTreeControllers(IEnumerable<Type> controllerTypes)
+        {
+            foreach (var controllerType in controllerTypes)
+                RemoveTreeController(controllerType);
+        }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -72,10 +72,10 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         // TODO: Change parameter name to "controllerType" in a major version to make it consistent with AddTreeController method.
         public void RemoveTreeController(Type type)
         {
-            if (!typeof(TreeControllerBase).IsAssignableFrom(controllerType))
-                throw new ArgumentException($"Type {controllerType} does not inherit from {typeof(TreeControllerBase).FullName}.");
+            if (!typeof(TreeControllerBase).IsAssignableFrom(type))
+                throw new ArgumentException($"Type {type} does not inherit from {typeof(TreeControllerBase).FullName}.");
 
-            var tree = _trees.FirstOrDefault(x => x.TreeControllerType == controllerType);
+            var tree = _trees.FirstOrDefault(x => x.TreeControllerType == type);
             if (tree != null)
             {
                 _trees.Remove(tree);

--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -69,7 +69,8 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             where TController : TreeControllerBase
             => RemoveTreeController(typeof(TController));
 
-        public void RemoveTreeController(Type controllerType)
+        // TODO: Change parameter name to "controllerType" in a major version to make it consistent with AddTreeController method.
+        public void RemoveTreeController(Type type)
         {
             if (!typeof(TreeControllerBase).IsAssignableFrom(controllerType))
                 throw new ArgumentException($"Type {controllerType} does not inherit from {typeof(TreeControllerBase).FullName}.");

--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -58,11 +58,23 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 AddTreeController(controllerType);
         }
 
-        public void RemoveTreeController<T>() => RemoveTreeController(typeof(T));
-
-        public void RemoveTreeController(Type type)
+        public void RemoveTree(Tree treeDefinition)
         {
-            var tree = _trees.FirstOrDefault(it => it.TreeControllerType == type);
+            if (treeDefinition == null)
+                throw new ArgumentNullException(nameof(treeDefinition));
+            _trees.Remove(treeDefinition);
+        }
+
+        public void RemoveTreeController<TController>()
+            where TController : TreeControllerBase
+            => RemoveTreeController(typeof(TController));
+
+        public void RemoveTreeController(Type controllerType)
+        {
+            if (!typeof(TreeControllerBase).IsAssignableFrom(controllerType))
+                throw new ArgumentException($"Type {controllerType} does not inherit from {typeof(TreeControllerBase).FullName}.");
+
+            var tree = _trees.FirstOrDefault(x => x.TreeControllerType == controllerType);
             if (tree != null)
             {
                 _trees.Remove(tree);


### PR DESCRIPTION
… and add method to remove Tree definition

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Previous this PR https://github.com/umbraco/Umbraco-CMS/pull/11250 introduced `RemoveTreeController()` methods. However this didn't require the controller should inherits from `TreeControllerBase` like  `AddTreeController()` methods.

So you could pass in any type:

```
public class TreeComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Trees().RemoveTreeController<string>();
        builder.Trees().RemoveTreeController<int>();
        builder.Trees().RemoveTreeController<DateTime>();
        builder.Trees().RemoveTreeController<ContentBlueprintTreeController>();
    }
}
```

but only the latter one would work. This may be considered as a breaking change, but shouldn't really have worked if any class was specified, which not inherits from `TreeControllerBase`.

Remove multiple tree controllers:

```
public class TreeComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Trees().RemoveTreeController<ContentBlueprintTreeController>();
        builder.Trees().RemoveTreeController<DictionaryTreeController>();
    }
}
```

or

```
public class TreeComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Trees().RemoveTreeControllers(new List<Type>
        { 
            typeof(ContentBlueprintTreeController), 
            typeof(DictionaryTreeController) 
        });
    }
}
```