### PR TITLE
Vary localization based on content or blueprint

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1053,8 +1053,6 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             wasCancelled = saveResult.Success == false && saveResult.Result == OperationResultType.FailedCancelledByEvent;
             if (saveResult.Success)
             {
-                bool isBlueprint = contentItem.PersistedContent.Blueprint;
-
                 if (variantCount > 1)
                 {
                     var variantErrors = ModelState.GetVariantsWithErrors(cultureForInvariantErrors);

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -820,7 +820,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 contentItem.Variants.Where(x => x.Save).Select(x => x.Culture).ToArray(),
                 defaultCulture);
 
-            bool isBlueprint = contentItem.PersistedContent.Blueprint;
+            //get the updated model
+            var display = mapToDisplay(contentItem.PersistedContent);
+            bool isBlueprint = display.IsBlueprint;
 
             var contentSavedHeader = isBlueprint ? "editBlueprintSavedHeader" : "editContentSavedHeader";
             var contentSavedText = isBlueprint ? "editBlueprintSavedText" : "editContentSavedText";
@@ -919,9 +921,6 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
-            //get the updated model
-            var display = mapToDisplay(contentItem.PersistedContent);
 
             //merge the tracked success messages with the outgoing model
             display.Notifications.AddRange(globalNotifications.Notifications);

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -820,11 +820,16 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 contentItem.Variants.Where(x => x.Save).Select(x => x.Culture).ToArray(),
                 defaultCulture);
 
+            bool isBlueprint = contentItem.PersistedContent.Blueprint;
+
+            var contentSavedHeader = isBlueprint ? "editBlueprintSavedHeader" : "editContentSavedHeader";
+            var contentSavedText = isBlueprint ? "editBlueprintSavedText" : "editContentSavedText";
+
             switch (contentItem.Action)
             {
                 case ContentSaveAction.Save:
                 case ContentSaveAction.SaveNew:
-                    SaveAndNotify(contentItem, saveMethod, variantCount, notifications, globalNotifications, "editContentSavedText", "editVariantSavedText", cultureForInvariantErrors, out wasCancelled);
+                    SaveAndNotify(contentItem, saveMethod, variantCount, notifications, globalNotifications, contentSavedHeader, contentSavedText, "editVariantSavedText", cultureForInvariantErrors, out wasCancelled);
                     break;
                 case ContentSaveAction.Schedule:
                 case ContentSaveAction.ScheduleNew:
@@ -834,7 +839,8 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         wasCancelled = false;
                         break;
                     }
-                    SaveAndNotify(contentItem, saveMethod, variantCount, notifications, globalNotifications, "editContentScheduledSavedText", "editVariantSavedText", cultureForInvariantErrors, out wasCancelled);
+
+                    SaveAndNotify(contentItem, saveMethod, variantCount, notifications, globalNotifications, "editContentSavedHeader", "editContentScheduledSavedText", "editVariantSavedText", cultureForInvariantErrors, out wasCancelled);
                     break;
 
                 case ContentSaveAction.SendPublish:
@@ -883,7 +889,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         if (!await ValidatePublishBranchPermissionsAsync(contentItem))
                         {
                             globalNotifications.AddErrorNotification(
-                                _localizedTextService.Localize(null,"publish"),
+                                _localizedTextService.Localize(null, "publish"),
                                 _localizedTextService.Localize("publish", "invalidPublishBranchPermissions"));
                             wasCancelled = false;
                             break;
@@ -900,7 +906,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         if (!await ValidatePublishBranchPermissionsAsync(contentItem))
                         {
                             globalNotifications.AddErrorNotification(
-                                _localizedTextService.Localize(null,"publish"),
+                                _localizedTextService.Localize(null, "publish"),
                                 _localizedTextService.Localize("publish", "invalidPublishBranchPermissions"));
                             wasCancelled = false;
                             break;
@@ -1041,13 +1047,15 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// </remarks>
         private void SaveAndNotify(ContentItemSave contentItem, Func<IContent, OperationResult> saveMethod, int variantCount,
             Dictionary<string, SimpleNotificationModel> notifications, SimpleNotificationModel globalNotifications,
-            string invariantSavedLocalizationAlias, string variantSavedLocalizationAlias, string cultureForInvariantErrors,
+            string savedContentHeaderLocalizationAlias, string invariantSavedLocalizationAlias, string variantSavedLocalizationAlias, string cultureForInvariantErrors,
             out bool wasCancelled)
         {
             var saveResult = saveMethod(contentItem.PersistedContent);
             wasCancelled = saveResult.Success == false && saveResult.Result == OperationResultType.FailedCancelledByEvent;
             if (saveResult.Success)
             {
+                bool isBlueprint = contentItem.PersistedContent.Blueprint;
+
                 if (variantCount > 1)
                 {
                     var variantErrors = ModelState.GetVariantsWithErrors(cultureForInvariantErrors);
@@ -1061,15 +1069,15 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         var variantName = GetVariantName(culture, segment);
 
                         AddSuccessNotification(notifications, culture, segment,
-                            _localizedTextService.Localize("speechBubbles", "editContentSavedHeader"),
-                            _localizedTextService.Localize(null,variantSavedLocalizationAlias, new[] { variantName }));
+                            _localizedTextService.Localize("speechBubbles", savedContentHeaderLocalizationAlias),
+                            _localizedTextService.Localize(null, variantSavedLocalizationAlias, new[] { variantName }));
                     }
                 }
                 else if (ModelState.IsValid)
                 {
                     globalNotifications.AddSuccessNotification(
-                        _localizedTextService.Localize("speechBubbles", "editContentSavedHeader"),
-                        _localizedTextService.Localize("speechBubbles",invariantSavedLocalizationAlias));
+                        _localizedTextService.Localize("speechBubbles", savedContentHeaderLocalizationAlias),
+                        _localizedTextService.Localize("speechBubbles", invariantSavedLocalizationAlias));
                 }
             }
         }

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -1322,6 +1322,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="editMultiContentPublishedText">%0% dokumenter udgivet og synlige på hjemmesiden</key>
     <key alias="editVariantPublishedText">%0% udgivet og synligt på hjemmesiden</key>
     <key alias="editMultiVariantPublishedText">%0% dokumenter udgivet for sprogene %1% og synlige på hjemmesiden</key>
+    <key alias="editBlueprintSavedHeader">Indholdsskabelon gemt</key>
+    <key alias="editBlueprintSavedText">Rettelser er blevet gemt</key>
     <key alias="editContentSavedHeader">Indhold gemt</key>
     <key alias="editContentSavedText">Husk at publicere for at gøre det synligt for besøgende</key>
     <key alias="editContentScheduledSavedText">En planlægning for udgivelse er blevet opdateret</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1519,6 +1519,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="editContentPublishedFailedByParent">Publishing failed because the parent page isn't published</key>
     <key alias="editContentPublishedHeader">Content published</key>
     <key alias="editContentPublishedText">and visible on the website</key>
+    <key alias="editBlueprintSavedHeader">Content Template saved</key>
+    <key alias="editBlueprintSavedText">Changes have been successfully saved</key>
     <key alias="editContentSavedHeader">Content saved</key>
     <key alias="editContentSavedText">Remember to publish to make changes visible</key>
     <key alias="editContentSendToPublish">Sent For Approval</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1545,8 +1545,9 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="editContentPublishedText">and is visible on the website</key>
     <key alias="editMultiContentPublishedText">%0% documents published and visible on the website</key>
     <key alias="editVariantPublishedText">%0% published and visible on the website</key>
-    <key alias="editMultiVariantPublishedText">%0% documents published for languages %1% and visible on the website
-    </key>
+    <key alias="editMultiVariantPublishedText">%0% documents published for languages %1% and visible on the website</key>
+    <key alias="editBlueprintSavedHeader">Content Template saved</key>
+    <key alias="editBlueprintSavedText">Changes have been successfully saved</key>
     <key alias="editContentSavedHeader">Content saved</key>
     <key alias="editContentSavedText">Remember to publish to make changes visible</key>
     <key alias="editContentScheduledSavedText">A schedule for publishing has been updated</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [<!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/11792)

### Description
When saving a blueprint / content template it used same localization texts as for regular content, which was confusing.

https://user-images.githubusercontent.com/2919859/147567444-1500771a-f0f0-4bec-b70f-fcc71716470e.mp4
