### PR TITLE
Fix incorrect styling of actions in tags editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-tags-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-tags-editor.less
@@ -1,4 +1,4 @@
-﻿.umb-tags-editor {
+.umb-tags-editor {
     border: @inputBorder solid 1px;
     padding: 5px;
     min-height: 54px;
@@ -14,24 +14,26 @@
         position: relative;
         user-select: all;
 
+        > .btn-icon {
+            color: @white;
+            padding: 0;
+            position: relative;
+            cursor: pointer;
+            padding-left: 2px;
+            font-size: 15px;
+            right: -5px;
+            bottom: -1px;
+            user-select: none;
+        }
+
         .umb_confirm-action {
 
-            > .btn-icon {
-                color: @white;
-                padding: 0;
-                position: relative;
-                cursor: pointer;
-                padding-left: 2px;
-                font-size: 15px;
-                right: -5px;
-                bottom: -1px;
-                user-select: none;
-            }
-
-            .umb_confirm-action__overlay.-left {
-                top: 8px;
-                left: auto;
-                right: 15px;
+            &__overlay {
+                &.-left {
+                  top: 8px;
+                  left: auto;
+                  right: 15px;
+                }
             }
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tags/umb-tags-editor.html
@@ -13,6 +13,7 @@
                 <span ng-bind-html="tag"></span>
 
                 <umb-icon icon="icon-trash"
+                          class="btn-icon"
                           ng-click="vm.showPrompt($index, tag)"
                           localize="title"
                           title="@buttons_deleteTag">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
It seems the styling of tags editor at some point has changed, so the delete button didn't have correct cursor style and not prevented selection of tags text behind, when clicking delete button.

Furthermore the confirm prompt was move too much to left.

**Before**

https://user-images.githubusercontent.com/2919859/147571556-a04ffd25-210f-415a-acce-f8e7fc527cdf.mp4


**After**

https://user-images.githubusercontent.com/2919859/147570816-348821d4-17cb-43db-bf75-b12eb439b28c.mp4
