### PR TITLE
Fix issue with missing URLs shown in redirect management

### DIFF
--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -154,7 +154,7 @@ namespace Umbraco.Cms.Core.Routing
                 : DomainUtilities.DomainForNode(umbracoContext.PublishedSnapshot.Domains, _siteDomainMapper, int.Parse(route.Substring(0, pos), CultureInfo.InvariantCulture), current, culture);
 
             var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();
-            if (domainUri is not null || culture == defaultCulture || culture is null)
+            if (domainUri is not null || culture == defaultCulture || string.IsNullOrEmpty(culture))
             {
                 var url = AssembleUrl(domainUri, path, current, mode).ToString();
                 return UrlInfo.Url(url, culture);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11695

### Description
Redirects was no longer shown redirected URLs in redirect management dashboard.

**Before**

![chrome_mZDDJkJ6Pl](https://user-images.githubusercontent.com/2919859/147573176-c8614d1c-2ea0-459c-ae5d-cc649a41eb2a.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/147573166-bebc74bd-45d9-4ed3-9a49-70414a7ef9c0.png)
