### PR TITLE
Set default tree group for core trees

### DIFF
--- a/src/Umbraco.Core/Extensions/TypeExtensions.cs
+++ b/src/Umbraco.Core/Extensions/TypeExtensions.cs
@@ -430,10 +430,16 @@ namespace Umbraco.Extensions
             where T : Attribute
         {
             if (type == null) return Enumerable.Empty<T>();
-            return type.GetCustomAttributes(typeof (T), inherited).OfType<T>();
+            return type.GetCustomAttributes(typeof(T), inherited).OfType<T>();
         }
 
-          /// <summary>
+        public static bool HasCustomAttribute<T>(this Type type, bool inherit)
+            where T : Attribute
+        {
+            return type.GetCustomAttribute<T>(inherit) != null;
+        }
+
+        /// <summary>
         /// Tries to return a value based on a property name for an object but ignores case sensitivity
         /// </summary>
         /// <param name="type"></param>

--- a/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TreeCollectionBuilder.cs
@@ -48,6 +48,12 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
 
             var attribute = controllerType.GetCustomAttribute<TreeAttribute>(false);
             if (attribute == null) return;
+
+            bool isCoreTree = controllerType.HasCustomAttribute<CoreTreeAttribute>(false);
+
+            // Use section as tree group if core tree, so it isn't grouped by empty key and thus end up in "Third Party" tree group if adding custom tree nodes in other groups, e.g. "Settings" tree group.
+            attribute.TreeGroup = attribute.TreeGroup ?? (isCoreTree ? attribute.SectionAlias : attribute.TreeGroup);
+
             var tree = new Tree(attribute.SortOrder, attribute.SectionAlias, attribute.TreeGroup, attribute.TreeAlias, attribute.TreeTitle, attribute.TreeUse, controllerType, attribute.IsSingleNodeTree);
             _trees.Add(tree);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11793

### Description
This PR fixes issues when adding custom trees to e.g. content section to a different tree group, because existing content tree (core tree) had null value in `TreeGroup` and thus end up with empty string as group key.

https://github.com/umbraco/Umbraco-CMS/blob/5bfab13dc5a268714aad2426a2b68ab5561a6407/src/Umbraco.Core/Services/TreeService.cs#L37-L43

This mean the existing content tree was shown in "Third Party" tree group, which is confusing:
https://github.com/umbraco/Umbraco-CMS/blob/5bfab13dc5a268714aad2426a2b68ab5561a6407/src/Umbraco.Web.BackOffice/Trees/ApplicationTreeController.cs#L173

We could by default use section as tree group is TreeGroup isn't set, but that would affect existing implementation if developers haven't explicit set TreeGroup (where is currently is placed in a "Third Party" tree group).

Since `TreeGroup` property is a readonly string property, we can't set a default value in `GetBySectionGrouped()` method.
It need to be assigned in either constructor of `Tree` class or assigned a value when instance on Tree class is created in `AddTreeController()` mehtod. I have chosen the latter one.

## Test notes

Add some custom trees to content section. Some without `[CoreTree]` attribute and without `TreeGroup` specified.

```
[Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
[Tree(Constants.Applications.Content, Constants.Trees.ContentBlueprints, SortOrder = 10, TreeGroup = Constants.Trees.Groups.Settings)]
[PluginController(Constants.Web.Mvc.BackOfficeTreeArea)]
[CoreTree]
public class ContentTemplateController : ContentBlueprintTreeController
{
    public ContentTemplateController(
        ILocalizedTextService localizedTextService,
        UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
        IMenuItemCollectionFactory menuItemCollectionFactory,
        IContentService contentService,
        IContentTypeService contentTypeService,
        IEntityService entityService,
        IEventAggregator eventAggregator)
        : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory,
                contentService, contentTypeService, entityService, eventAggregator)
    {

    }

    protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
    {
        var root = base.CreateRootNode(queryStrings);

        if (!string.IsNullOrEmpty(root.Value.RoutePath))
        {
            // Update route to content section
            root.Value.RoutePath = root.Value.RoutePath.Replace(Constants.Applications.Settings, Constants.Applications.Content);
        }

        return root;
    }

    protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings)
    {
        var collection = base.GetMenuForNode(id, queryStrings);

        if (collection.Value.Items.Count > 0)
        {
            foreach (var menuItem in collection.Value.Items)
            {
                if (menuItem.Action is ActionCreateBlueprintFromContent)
                {
                    var route = menuItem.AdditionalData["actionRoute"]?.ToString();

                    if (!string.IsNullOrEmpty(route))
                    {
                        // Update route to content section
                        menuItem.NavigateToRoute(route.Replace($"/{Constants.Applications.Settings}/", $"/{Constants.Applications.Content}/"));
                    }
                }
            }
        }

        return collection;
    }

}
```

```
[Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
[Tree(Constants.Applications.Content, Constants.Trees.Dictionary, SortOrder = 12)]
[PluginController(Constants.Web.Mvc.BackOfficeTreeArea)]
public class CustomDictionaryTreeController : DictionaryTreeController
{
    public CustomDictionaryTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IMenuItemCollectionFactory menuItemCollectionFactory, ILocalizationService localizationService, IEventAggregator eventAggregator)
        : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory, localizationService, eventAggregator)
    {

    }
}

[Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
[Tree(Constants.Applications.Content, Constants.Trees.Scripts, SortOrder = 13, TreeGroup = "Custom")]
[PluginController(Constants.Web.Mvc.BackOfficeTreeArea)]
public class CustomTreeController : TreeController
{
    public CustomTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IEventAggregator eventAggregator)
        : base (localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
    {

    }

    protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, [ModelBinder(typeof(HttpQueryStringModelBinder))] FormCollection queryStrings) => throw new System.NotImplementedException();
    protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, [ModelBinder(typeof(HttpQueryStringModelBinder))] FormCollection queryStrings) => throw new System.NotImplementedException();
}
}
```

**Before**

![image](https://user-images.githubusercontent.com/2919859/147667585-7080c5ed-68a5-49f3-a726-c9abead3414c.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/147667812-8b7c37bf-adf7-4deb-af44-60906a37dc2b.png)
