### PR TITLE
Prune Image Cropper and Media Picker (v3) values

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Web;
 using Newtonsoft.Json;
 using Umbraco.Core.Composing;
@@ -41,9 +39,7 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
 
         /// <inheritdoc />
         public override string ToString()
-        {
-            return Crops != null ? (Crops.Any() ? JsonConvert.SerializeObject(this) : Src) : string.Empty;
-        }
+            => HasCrops() || HasFocalPoint() ? JsonConvert.SerializeObject(this, Formatting.None) : Src;
 
         /// <inheritdoc />
         public string ToHtmlString() => Src;
@@ -134,13 +130,19 @@ namespace Umbraco.Core.PropertyEditors.ValueConverters
         /// </summary>
         /// <returns></returns>
         public bool HasFocalPoint()
-            => FocalPoint != null && (FocalPoint.Left != 0.5m || FocalPoint.Top != 0.5m);
+            => FocalPoint is ImageCropperFocalPoint focalPoint && (focalPoint.Left != 0.5m || focalPoint.Top != 0.5m);
+
+        /// <summary>
+        /// Determines whether the value has crops.
+        /// </summary>
+        public bool HasCrops()
+            => Crops is IEnumerable<ImageCropperCrop> crops && crops.Any();
 
         /// <summary>
         /// Determines whether the value has a specified crop.
         /// </summary>
         public bool HasCrop(string alias)
-            => Crops != null && Crops.Any(x => x.Alias == alias);
+            => Crops is IEnumerable<ImageCropperCrop> crops && crops.Any(x => x.Alias == alias);
 
         /// <summary>
         /// Determines whether the value has a source image.

--- a/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+++ b/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
@@ -29,13 +29,13 @@ namespace Umbraco.Tests.PropertyEditors
     {
         private const string CropperJson1 = "{\"focalPoint\": {\"left\": 0.96,\"top\": 0.80827067669172936},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\":\"thumb\",\"width\": 100,\"height\": 100,\"coordinates\": {\"x1\": 0.58729977382575338,\"y1\": 0.055768992440203169,\"x2\": 0,\"y2\": 0.32457553600198386}}]}";
         private const string CropperJson2 = "{\"focalPoint\": {\"left\": 0.98,\"top\": 0.80827067669172936},\"src\": \"/media/1005/img_0672.jpg\",\"crops\": [{\"alias\":\"thumb\",\"width\": 100,\"height\": 100,\"coordinates\": {\"x1\": 0.58729977382575338,\"y1\": 0.055768992440203169,\"x2\": 0,\"y2\": 0.32457553600198386}}]}";
-        private const string CropperJson3 = "{\"focalPoint\": {\"left\": 0.98,\"top\": 0.80827067669172936},\"src\": \"/media/1005/img_0672.jpg\",\"crops\": []}";
+        private const string CropperJson3 = "{\"focalPoint\": {\"left\": 0.5,\"top\": 0.5},\"src\": \"/media/1005/img_0672.jpg\",\"crops\": []}";
         private const string MediaPath = "/media/1005/img_0671.jpg";
 
         [Test]
         public void CanConvertImageCropperDataSetSrcToString()
         {
-            //cropperJson3 - has not crops
+            //cropperJson3 - has no crops
             var cropperValue = CropperJson3.DeserializeImageCropperValue();
             var serialized = cropperValue.TryConvertTo<string>();
             Assert.IsTrue(serialized.Success);
@@ -45,7 +45,7 @@ namespace Umbraco.Tests.PropertyEditors
         [Test]
         public void CanConvertImageCropperDataSetJObject()
         {
-            //cropperJson3 - has not crops
+            //cropperJson3 - has no crops
             var cropperValue = CropperJson3.DeserializeImageCropperValue();
             var serialized = cropperValue.TryConvertTo<JObject>();
             Assert.IsTrue(serialized.Success);

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -1,6 +1,7 @@
-﻿using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
+using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
@@ -66,31 +67,70 @@ namespace Umbraco.Web.PropertyEditors
         /// </remarks>
         public override object FromEditor(ContentPropertyData editorValue, object currentValue)
         {
-            // get the current path
+            // Get the current path
             var currentPath = string.Empty;
             try
             {
                 var svalue = currentValue as string;
                 var currentJson = string.IsNullOrWhiteSpace(svalue) ? null : JObject.Parse(svalue);
-                if (currentJson != null && currentJson["src"] != null)
-                    currentPath = currentJson["src"].Value<string>();
+                if (currentJson != null && currentJson.TryGetValue("src", out var src))
+                {
+                    currentPath = src.Value<string>();
+                }
             }
             catch (Exception ex)
             {
-                // for some reason the value is invalid so continue as if there was no value there
+                // For some reason the value is invalid, so continue as if there was no value there
                 _logger.Warn<ImageCropperPropertyValueEditor>(ex, "Could not parse current db value to a JObject.");
             }
+
             if (string.IsNullOrWhiteSpace(currentPath) == false)
                 currentPath = _mediaFileSystem.GetRelativePath(currentPath);
 
-            // get the new json and path
-            JObject editorJson = null;
+            // Get the new JSON and file path
             var editorFile = string.Empty;
-            if (editorValue.Value != null)
+            if (editorValue.Value is JObject editorJson)
             {
-                editorJson = editorValue.Value as JObject;
-                if (editorJson != null && editorJson["src"] != null)
+                // Populate current file
+                if (editorJson["src"] != null)
+                {
                     editorFile = editorJson["src"].Value<string>();
+                }
+
+                // Clean up redundant/default data
+                if (editorJson.TryGetValue("crops", out var crops))
+                {
+                    foreach (var crop in crops.Values<JObject>().ToList())
+                    {
+                        if (crop.TryGetValue("coordinates", out var coordinates) == false || coordinates.HasValues == false)
+                        {
+                            // Remove crop without coordinates
+                            crop.Remove();
+                            continue;
+                        }
+
+                        // Width/height are already stored in the crop configuration
+                        crop.Remove("width");
+                        crop.Remove("height");
+                    }
+
+                    if (crops.HasValues == false)
+                    {
+                        // Remove empty crops
+                        editorJson.Remove("crops");
+                    }
+                }
+
+                if (editorJson.TryGetValue("focalPoint", out var focalPoint) &&
+                    (focalPoint.HasValues == false || (focalPoint.Value<decimal>("top") == 0.5m && focalPoint.Value<decimal>("left") == 0.5m)))
+                {
+                    // Remove empty/default focal point
+                    editorJson.Remove("focalPoint");
+                }
+            }
+            else
+            {
+                editorJson = null;
             }
 
             // ensure we have the required guids
@@ -118,7 +158,7 @@ namespace Umbraco.Web.PropertyEditors
                     return null; // clear
                 }
 
-                return editorJson?.ToString(); // unchanged
+                return editorJson?.ToString(Formatting.None); // unchanged
             }
 
             // process the file
@@ -135,7 +175,8 @@ namespace Umbraco.Web.PropertyEditors
             // update json and return
             if (editorJson == null) return null;
             editorJson["src"] = filepath == null ? string.Empty : _mediaFileSystem.GetUrl(filepath);
-            return editorJson.ToString();
+
+            return editorJson.ToString(Formatting.None);
         }
 
         private string ProcessFile(ContentPropertyData editorValue, ContentPropertyFile file, string currentPath, Guid cuid, Guid puid)
@@ -159,7 +200,6 @@ namespace Umbraco.Web.PropertyEditors
 
             return filepath;
         }
-
 
         public override string ConvertDbToString(PropertyType propertyType, object value, IDataTypeService dataTypeService)
         {

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
@@ -98,35 +97,7 @@ namespace Umbraco.Web.PropertyEditors
                 }
 
                 // Clean up redundant/default data
-                if (editorJson.TryGetValue("crops", out var crops))
-                {
-                    foreach (var crop in crops.Values<JObject>().ToList())
-                    {
-                        if (crop.TryGetValue("coordinates", out var coordinates) == false || coordinates.HasValues == false)
-                        {
-                            // Remove crop without coordinates
-                            crop.Remove();
-                            continue;
-                        }
-
-                        // Width/height are already stored in the crop configuration
-                        crop.Remove("width");
-                        crop.Remove("height");
-                    }
-
-                    if (crops.HasValues == false)
-                    {
-                        // Remove empty crops
-                        editorJson.Remove("crops");
-                    }
-                }
-
-                if (editorJson.TryGetValue("focalPoint", out var focalPoint) &&
-                    (focalPoint.HasValues == false || (focalPoint.Value<decimal>("top") == 0.5m && focalPoint.Value<decimal>("left") == 0.5m)))
-                {
-                    // Remove empty/default focal point
-                    editorJson.Remove("focalPoint");
-                }
+                ImageCropperValue.Prune(editorJson);
             }
             else
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
By default, Umbraco stores indented JSON values with redundant crop/default focal point values to the database for all Image Cropper and Media Picker (v3, with local crops) property data. You can view the existing data for both editors by doing the following database queries:

```sql
-- Get all Umbraco.ImageCropper property data
SELECT * FROM [umbracoPropertyData] WHERE propertyTypeId IN (
  SELECT id FROM cmsPropertyType INNER JOIN umbracoDataType ON cmsPropertyType.dataTypeId = umbracoDataType.nodeId AND umbracoDataType.propertyEditorAlias = 'Umbraco.ImageCropper'
);

-- Get all Umbraco.MediaPicker3 property data
SELECT * FROM [umbracoPropertyData] WHERE propertyTypeId IN (
  SELECT id FROM cmsPropertyType INNER JOIN umbracoDataType ON cmsPropertyType.dataTypeId = umbracoDataType.nodeId AND umbracoDataType.propertyEditorAlias = 'Umbraco.MediaPicker3'
);
```

On a clean Umbraco 8 install (`v8/dev`) with The Starter Kit, the image crop data on media is stored without indenting, but still contains an empty crops value (this is probably directly populated by the package install):
```json
{"src":"/media/bqubxyxr/16403439029_f500be349b_o.jpg","crops":null}
```

After saving this media item in the back-office, it now contains indentation and also the default focal point, which both bloats this value from 67 characters to 138 (more than double):
```json
{    "src": "/media/bqubxyxr/16403439029_f500be349b_o.jpg",    "focalPoint": {      "left": 0.5,      "top": 0.5    },    "crops": null  }
```

This gets even worse when you start configuring crops, as the crops are also stored in the property data, even when you've not changed the crop coordinates. After adding 2 crops to the Image Cropper data type (Avatar 100x100 and Hero 1920x200) and saving the media item again, the value is now 360 characters:
```json
{    "src": "/media/bqubxyxr/16403439029_f500be349b_o.jpg",    "focalPoint": {      "left": 0.5,      "top": 0.5    },    "crops": [      {        "alias": "Avatar",        "width": 100,        "height": 100,        "coordinates": null      },      {        "alias": "Hero",        "width": 1920,        "height": 200,        "coordinates": null      }    ]  }
```

There's already code available to apply any missing configured crops to this value (added in https://github.com/umbraco/Umbraco-CMS/pull/6950), so we don't have to store the crops when it doesn't have coordinates (the width/height is always redundant). The focal point is also optional and the code already deals with a missing value, so there's no need to store the default centered (0.5,0.5) value.

The same happens for the Media Picker (v3), because that also stores redundant values for the local crops and focal point. This PR updates both editors to prune the values in `IDataValueEditor.FromEditor()` and re-add the configured crops in the `IDataValueEditor.ToEditor()` method.

-------------------

Make sure you've observed the above cases and then apply this PR. After saving the media item, the following data should be stored in the database:
```json
{"src":"/media/bqubxyxr/16403439029_f500be349b_o.jpg"}
```

If you change the focal point and save, this should be the only thing that's added:
```json
{"src":"/media/bqubxyxr/16403439029_f500be349b_o.jpg","focalPoint":{"left":0.64347202295552364,"top":0.24395730824424425}}
```

After resetting the focal point (which is added in PR https://github.com/umbraco/Umbraco-CMS/pull/10923) and changing one of the crops, only the crop alias and coordinates are now stored on save:
```json
{"src":"/media/bqubxyxr/16403439029_f500be349b_o.jpg","crops":[{"alias":"Avatar","coordinates":{"x1":0.70518867924528306,"y1":0,"x2":0,"y2":0.55792116850276741}}]}
```

The same can be tested for the Media Picker by enabling the local focal point and adding custom crops to the picker. Also make sure the pruned data is added back when rendering the value on the front-end, e.g. by including the following in the `Home.cshtml` view:
```cshtml
<pre>@Json.Encode(Model.HeroBackgroundImage.Value("umbracoFile"))</pre>
```

This returns a serialized version of the `ImageCropperValue` that's used in the `GetCropUrl()` method and should include all crops with their dimensions, e.g.:
```json
{"Src":"/media/bqubxyxr/16403439029_f500be349b_o.jpg","FocalPoint":null,"Crops":[{"Alias":"Avatar","Width":100,"Height":100,"Coordinates":{"X1":0.70518867924528306,"Y1":0,"X2":0,"Y2":0.55792116850276741}},{"Alias":"Hero","Width":1920,"Height":200,"Coordinates":null}]}
```