### PR TITLE
Prune/remove indentation from JSON property values

### DIFF
--- a/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
+++ b/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
@@ -162,7 +162,7 @@ namespace Umbraco.Core.Models
                 case TagsStorageType.Json:
                     try
                     {
-                        return JsonConvert.DeserializeObject<JArray>(value).Select(x => x.ToString(Formatting.None).Trim());
+                        return JsonConvert.DeserializeObject<string[]>(value).Select(x => x.Trim());
                     }
                     catch (JsonException)
                     {

--- a/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
+++ b/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Core.Models
                         break;
 
                     case TagsStorageType.Json:
-                        property.SetValue(JsonConvert.SerializeObject(currentTags.Union(trimmedTags).ToArray()), culture); // json array
+                        property.SetValue(JsonConvert.SerializeObject(currentTags.Union(trimmedTags).ToArray(), Formatting.None), culture); // json array
                         break;
                 }
             }
@@ -85,7 +85,7 @@ namespace Umbraco.Core.Models
                         break;
 
                     case TagsStorageType.Json:
-                        property.SetValue(JsonConvert.SerializeObject(trimmedTags), culture); // json array
+                        property.SetValue(JsonConvert.SerializeObject(trimmedTags, Formatting.None), culture); // json array
                         break;
                 }
             }
@@ -125,7 +125,7 @@ namespace Umbraco.Core.Models
                     break;
 
                 case TagsStorageType.Json:
-                    property.SetValue(JsonConvert.SerializeObject(currentTags.Except(trimmedTags).ToArray()), culture); // json array
+                    property.SetValue(JsonConvert.SerializeObject(currentTags.Except(trimmedTags).ToArray(), Formatting.None), culture); // json array
                     break;
             }
         }
@@ -157,7 +157,7 @@ namespace Umbraco.Core.Models
                 case TagsStorageType.Json:
                     try
                     {
-                        return JsonConvert.DeserializeObject<JArray>(value).Select(x => x.ToString().Trim());
+                        return JsonConvert.DeserializeObject<JArray>(value).Select(x => x.ToString(Formatting.None).Trim());
                     }
                     catch (JsonException)
                     {

--- a/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
+++ b/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
@@ -68,11 +68,13 @@ namespace Umbraco.Core.Models
                 switch (storageType)
                 {
                     case TagsStorageType.Csv:
-                        property.SetValue(string.Join(delimiter.ToString(), currentTags.Union(trimmedTags)), culture); // csv string
+                        property.SetValue(string.Join(delimiter.ToString(), currentTags.Union(trimmedTags)).NullOrWhiteSpaceAsNull(), culture); // csv string
                         break;
 
                     case TagsStorageType.Json:
-                        property.SetValue(JsonConvert.SerializeObject(currentTags.Union(trimmedTags).ToArray(), Formatting.None), culture); // json array
+                        var updatedTags = currentTags.Union(trimmedTags).ToArray();
+                        var updatedValue = updatedTags.Length == 0 ? null : JsonConvert.SerializeObject(updatedTags, Formatting.None);
+                        property.SetValue(updatedValue, culture); // json array
                         break;
                 }
             }
@@ -81,11 +83,12 @@ namespace Umbraco.Core.Models
                 switch (storageType)
                 {
                     case TagsStorageType.Csv:
-                        property.SetValue(string.Join(delimiter.ToString(), trimmedTags), culture); // csv string
+                        property.SetValue(string.Join(delimiter.ToString(), trimmedTags).NullOrWhiteSpaceAsNull(), culture); // csv string
                         break;
 
                     case TagsStorageType.Json:
-                        property.SetValue(JsonConvert.SerializeObject(trimmedTags, Formatting.None), culture); // json array
+                        var updatedValue = trimmedTags.Length == 0 ? null : JsonConvert.SerializeObject(trimmedTags, Formatting.None);
+                        property.SetValue(updatedValue, culture); // json array
                         break;
                 }
             }
@@ -121,11 +124,13 @@ namespace Umbraco.Core.Models
             switch (storageType)
             {
                 case TagsStorageType.Csv:
-                    property.SetValue(string.Join(delimiter.ToString(), currentTags.Except(trimmedTags)), culture); // csv string
+                    property.SetValue(string.Join(delimiter.ToString(), currentTags.Except(trimmedTags)).NullOrWhiteSpaceAsNull(), culture); // csv string
                     break;
 
                 case TagsStorageType.Json:
-                    property.SetValue(JsonConvert.SerializeObject(currentTags.Except(trimmedTags).ToArray(), Formatting.None), culture); // json array
+                    var updatedTags = currentTags.Except(trimmedTags).ToArray();
+                    var updatedValue = updatedTags.Length == 0 ? null : JsonConvert.SerializeObject(updatedTags, Formatting.None);
+                    property.SetValue(updatedValue, culture); // json array
                     break;
             }
         }

--- a/src/Umbraco.Core/PropertyEditors/ComplexPropertyEditorContentEventHandler.cs
+++ b/src/Umbraco.Core/PropertyEditors/ComplexPropertyEditorContentEventHandler.cs
@@ -62,12 +62,12 @@ namespace Umbraco.Core.PropertyEditors
                 {
                     // Remove keys from published value & any nested properties
                     var publishedValue = cultureVal.PublishedValue is JToken jsonPublishedValue ? jsonPublishedValue.ToString(Formatting.None) : cultureVal.PublishedValue?.ToString();
-                    var updatedPublishedVal = _formatPropertyValue(publishedValue, onlyMissingKeys);
+                    var updatedPublishedVal = _formatPropertyValue(publishedValue, onlyMissingKeys).NullOrWhiteSpaceAsNull();
                     cultureVal.PublishedValue = updatedPublishedVal;
 
                     // Remove keys from edited/draft value & any nested properties
                     var editedValue = cultureVal.EditedValue is JToken jsonEditedValue ? jsonEditedValue.ToString(Formatting.None) : cultureVal.EditedValue?.ToString();
-                    var updatedEditedVal = _formatPropertyValue(editedValue, onlyMissingKeys);
+                    var updatedEditedVal = _formatPropertyValue(editedValue, onlyMissingKeys).NullOrWhiteSpaceAsNull();
                     cultureVal.EditedValue = updatedEditedVal;
                 }
             }

--- a/src/Umbraco.Core/PropertyEditors/ComplexPropertyEditorContentEventHandler.cs
+++ b/src/Umbraco.Core/PropertyEditors/ComplexPropertyEditorContentEventHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
@@ -59,11 +61,13 @@ namespace Umbraco.Core.PropertyEditors
                 foreach (var cultureVal in propVals)
                 {
                     // Remove keys from published value & any nested properties
-                    var updatedPublishedVal = _formatPropertyValue(cultureVal.PublishedValue?.ToString(), onlyMissingKeys);
+                    var publishedValue = cultureVal.PublishedValue is JToken jsonPublishedValue ? jsonPublishedValue.ToString(Formatting.None) : cultureVal.PublishedValue?.ToString();
+                    var updatedPublishedVal = _formatPropertyValue(publishedValue, onlyMissingKeys);
                     cultureVal.PublishedValue = updatedPublishedVal;
 
                     // Remove keys from edited/draft value & any nested properties
-                    var updatedEditedVal = _formatPropertyValue(cultureVal.EditedValue?.ToString(), onlyMissingKeys);
+                    var editedValue = cultureVal.EditedValue is JToken jsonEditedValue ? jsonEditedValue.ToString(Formatting.None) : cultureVal.EditedValue?.ToString();
+                    var updatedEditedVal = _formatPropertyValue(editedValue, onlyMissingKeys);
                     cultureVal.EditedValue = updatedEditedVal;
                 }
             }

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
@@ -126,6 +126,8 @@ namespace Umbraco.Core.PropertyEditors
         /// </summary>
         public static JsonSerializerSettings ConfigurationJsonSettings { get; } = new JsonSerializerSettings
         {
+            Formatting = Formatting.None,
+            NullValueHandling = NullValueHandling.Ignore,
             ContractResolver = new ConfigurationCustomContractResolver(),
             Converters = new List<JsonConverter>(new[]{new FuzzyBooleanConverter()})
         };

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -145,8 +145,18 @@ namespace Umbraco.Core.PropertyEditors
         /// <returns></returns>
         internal Attempt<object> TryConvertValueToCrlType(object value)
         {
-            if (value is JValue)
-                value = value.ToString();
+            if (value is JToken jsonValue)
+            {
+                if (jsonValue is JContainer && jsonValue.HasValues == false)
+                {
+                    // Empty JSON array/object
+                    value = null;
+                }
+                else
+                {
+                    value = jsonValue.ToString(Formatting.None);
+                }
+            }
 
             //this is a custom check to avoid any errors, if it's a string and it's empty just make it null
             if (value is string s && string.IsNullOrWhiteSpace(s))
@@ -187,6 +197,7 @@ namespace Umbraco.Core.PropertyEditors
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+
             return value.TryConvertTo(valueType);
         }
 
@@ -222,6 +233,7 @@ namespace Umbraco.Core.PropertyEditors
                 Current.Logger.Warn<DataValueEditor,object,ValueStorageType>("The value {EditorValue} cannot be converted to the type {StorageTypeValue}", editorValue.Value, ValueTypes.ToStorageType(ValueType));
                 return null;
             }
+
             return result.Result;
         }
 

--- a/src/Umbraco.Core/Serialization/JsonToStringConverter.cs
+++ b/src/Umbraco.Core/Serialization/JsonToStringConverter.cs
@@ -20,9 +20,10 @@ namespace Umbraco.Core.Serialization
             {
                 return reader.Value;
             }
+
             // Load JObject from stream
             JObject jObject = JObject.Load(reader);
-            return jObject.ToString();
+            return jObject.ToString(Formatting.None);
         }
 
         public override bool CanConvert(Type objectType)

--- a/src/Umbraco.Tests/PropertyEditors/BlockEditorComponentTests.cs
+++ b/src/Umbraco.Tests/PropertyEditors/BlockEditorComponentTests.cs
@@ -14,8 +14,7 @@ namespace Umbraco.Tests.PropertyEditors
         private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
         {
             Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Ignore,
-            
+            NullValueHandling = NullValueHandling.Ignore
         };
 
         private const string _contentGuid1 = "036ce82586a64dfba2d523a99ed80f58";

--- a/src/Umbraco.Web/Compose/BlockEditorComponent.cs
+++ b/src/Umbraco.Web/Compose/BlockEditorComponent.cs
@@ -63,7 +63,7 @@ namespace Umbraco.Web.Compose
 
             UpdateBlockListRecursively(blockListValue, createGuid);
 
-            return JsonConvert.SerializeObject(blockListValue.BlockValue);
+            return JsonConvert.SerializeObject(blockListValue.BlockValue, Formatting.None);
         }
 
         private void UpdateBlockListRecursively(BlockEditorData blockListData, Func<Guid> createGuid)

--- a/src/Umbraco.Web/Compose/NestedContentPropertyComponent.cs
+++ b/src/Umbraco.Web/Compose/NestedContentPropertyComponent.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
-using Umbraco.Core.Events;
-using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.Services;
-using Umbraco.Core.Services.Implement;
 using Umbraco.Web.PropertyEditors;
 
 namespace Umbraco.Web.Compose
@@ -47,7 +43,7 @@ namespace Umbraco.Web.Compose
 
             UpdateNestedContentKeysRecursively(complexEditorValue, onlyMissingKeys, createGuid);
 
-            return complexEditorValue.ToString();
+            return complexEditorValue.ToString(Formatting.None);
         }
 
         private void UpdateNestedContentKeysRecursively(JToken json, bool onlyMissingKeys, Func<Guid> createGuid)
@@ -80,7 +76,7 @@ namespace Umbraco.Web.Compose
                         var parsed = JToken.Parse(propVal);
                         UpdateNestedContentKeysRecursively(parsed, onlyMissingKeys, createGuid);
                         // set the value to the updated one
-                        prop.Value = parsed.ToString();
+                        prop.Value = parsed.ToString(Formatting.None);
                     }
                 }
             }

--- a/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/BlockEditorPropertyEditor.cs
@@ -234,7 +234,7 @@ namespace Umbraco.Web.PropertyEditors
                 MapBlockItemData(blockEditorData.BlockValue.SettingsData);
 
                 // return json
-                return JsonConvert.SerializeObject(blockEditorData.BlockValue);
+                return JsonConvert.SerializeObject(blockEditorData.BlockValue, Formatting.None);
             }
 
             #endregion

--- a/src/Umbraco.Web/PropertyEditors/ColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ColorPickerConfigurationEditor.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Web.PropertyEditors
                 if (id >= nextId) nextId = id + 1;
 
                 var label = item.Property("label")?.Value?.Value<string>();
-                value = JsonConvert.SerializeObject(new { value, label });
+                value = JsonConvert.SerializeObject(new { value, label }, Formatting.None);
 
                 output.Items.Add(new ValueListConfiguration.ValueListItem { Id = id, Value = value });
             }

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Web.PropertyEditors
                 }
 
                 // Convert back to raw JSON for persisting
-                return JsonConvert.SerializeObject(grid);
+                return JsonConvert.SerializeObject(grid, Formatting.None);
             }
 
             /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -251,7 +251,7 @@ namespace Umbraco.Web.PropertyEditors
                                 crops = config == null ? Array.Empty<ImageCropperConfiguration.Crop>() : config.Crops
                             };
 
-                            property.SetValue(JsonConvert.SerializeObject(json), pvalue.Culture, pvalue.Segment);
+                            property.SetValue(JsonConvert.SerializeObject(json, Formatting.None), pvalue.Culture, pvalue.Segment);
                         }
                         else
                         {

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -1,16 +1,14 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
-using Umbraco.Core.Media;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.PropertyEditors.ValueConverters;
 using Umbraco.Core.Services;
 using Umbraco.Web.Media;
 
@@ -170,7 +168,7 @@ namespace Umbraco.Web.PropertyEditors
                     var sourcePath = _mediaFileSystem.GetRelativePath(src);
                     var copyPath = _mediaFileSystem.CopyFile(args.Copy, property.PropertyType, sourcePath);
                     jo["src"] = _mediaFileSystem.GetUrl(copyPath);
-                    args.Copy.SetValue(property.Alias, jo.ToString(), propertyValue.Culture, propertyValue.Segment);
+                    args.Copy.SetValue(property.Alias, jo.ToString(Formatting.None), propertyValue.Culture, propertyValue.Segment);
                     isUpdated = true;
                 }
             }
@@ -241,17 +239,12 @@ namespace Umbraco.Web.PropertyEditors
                             // it can happen when an image is uploaded via the folder browser, in which case
                             // the property value will be the file source eg '/media/23454/hello.jpg' and we
                             // are fixing that anomaly here - does not make any sense at all but... bah...
-
-                            var dt = _dataTypeService.GetDataType(property.PropertyType.DataTypeId);
-                            var config = dt?.ConfigurationAs<ImageCropperConfiguration>();
                             src = svalue;
-                            var json = new
-                            {
-                                src = svalue,
-                                crops = config == null ? Array.Empty<ImageCropperConfiguration.Crop>() : config.Crops
-                            };
 
-                            property.SetValue(JsonConvert.SerializeObject(json, Formatting.None), pvalue.Culture, pvalue.Segment);
+                            property.SetValue(JsonConvert.SerializeObject(new
+                            {
+                                src = svalue
+                            }, Formatting.None), pvalue.Culture, pvalue.Segment);
                         }
                         else
                         {

--- a/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -179,6 +179,10 @@ namespace Umbraco.Web.PropertyEditors
             {
                 src = val,
                 crops = crops
+            }, new JsonSerializerSettings()
+            {
+                Formatting = Formatting.None,
+                NullValueHandling = NullValueHandling.Ignore
             });
         }
     }

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -130,16 +130,19 @@ namespace Umbraco.Web.PropertyEditors
         public override object FromEditor(ContentPropertyData editorValue, object currentValue)
         {
             var value = editorValue.Value?.ToString();
-
             if (string.IsNullOrEmpty(value))
             {
-                return string.Empty;
+                return null;
             }
 
             try
             {
+                var links = JsonConvert.DeserializeObject<List<LinkDisplay>>(value);
+                if (links.Count == 0)
+                    return null;
+
                 return JsonConvert.SerializeObject(
-                    from link in JsonConvert.DeserializeObject<List<LinkDisplay>>(value)
+                    from link in links
                     select new MultiUrlPickerValueEditor.LinkDto
                     {
                         Name = link.Name,

--- a/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -123,6 +123,7 @@ namespace Umbraco.Web.PropertyEditors
 
         private static readonly JsonSerializerSettings LinkDisplayJsonSerializerSettings = new JsonSerializerSettings
         {
+            Formatting = Formatting.None,
             NullValueHandling = NullValueHandling.Ignore
         };
 
@@ -146,8 +147,8 @@ namespace Umbraco.Web.PropertyEditors
                         Target = link.Target,
                         Udi = link.Udi,
                         Url = link.Udi == null ? link.Url : null, // only save the URL for external links
-                    }, LinkDisplayJsonSerializerSettings
-                    );
+                    },
+                    LinkDisplayJsonSerializerSettings);
             }
             catch (Exception ex)
             {

--- a/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -60,7 +60,7 @@ namespace Umbraco.Web.PropertyEditors
             public override object FromEditor(ContentPropertyData editorValue, object currentValue)
             {
                 var asArray = editorValue.Value as JArray;
-                if (asArray == null)
+                if (asArray == null || asArray.HasValues == false)
                 {
                     return null;
                 }

--- a/src/Umbraco.Web/PropertyEditors/MultipleValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleValueEditor.cs
@@ -49,12 +49,16 @@ namespace Umbraco.Web.PropertyEditors
         public override object FromEditor(Core.Models.Editors.ContentPropertyData editorValue, object currentValue)
         {
             var json = editorValue.Value as JArray;
-            if (json == null)
+            if (json == null || json.HasValues == false)
             {
                 return null;
             }
 
             var values = json.Select(item => item.Value<string>()).ToArray();
+            if (values.Length == 0)
+            {
+                return null;
+            }
 
             return JsonConvert.SerializeObject(values, Formatting.None);
         }

--- a/src/Umbraco.Web/PropertyEditors/MultipleValueEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/MultipleValueEditor.cs
@@ -56,7 +56,7 @@ namespace Umbraco.Web.PropertyEditors
 
             var values = json.Select(item => item.Value<string>()).ToArray();
 
-            return JsonConvert.SerializeObject(values);
+            return JsonConvert.SerializeObject(values, Formatting.None);
         }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -134,7 +134,7 @@ namespace Umbraco.Web.PropertyEditors
                     }
                 }
 
-                return JsonConvert.SerializeObject(rows).ToXmlString<string>();
+                return JsonConvert.SerializeObject(rows, Formatting.None).ToXmlString<string>();
             }
 
             #endregion
@@ -254,8 +254,9 @@ namespace Umbraco.Web.PropertyEditors
                 }
 
                 // return json
-                return JsonConvert.SerializeObject(rows);
+                return JsonConvert.SerializeObject(rows, Formatting.None);
             }
+
             #endregion
 
             public IEnumerable<UmbracoEntityReference> GetReferences(object value)

--- a/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs
@@ -103,7 +103,7 @@ namespace Umbraco.Web.PropertyEditors
                 var rows = _nestedContentValues.GetPropertyValues(propertyValue);
 
                 if (rows.Count == 0)
-                    return string.Empty;
+                    return null;
 
                 foreach (var row in rows.ToList())
                 {
@@ -229,7 +229,7 @@ namespace Umbraco.Web.PropertyEditors
                 var rows = _nestedContentValues.GetPropertyValues(editorValue.Value);
 
                 if (rows.Count == 0)
-                    return string.Empty;
+                    return null;
 
                 foreach (var row in rows.ToList())
                 {

--- a/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/RichTextPropertyEditor.cs
@@ -142,7 +142,7 @@ namespace Umbraco.Web.PropertyEditors
                 var editorValueWithMediaUrlsRemoved = _imageSourceParser.RemoveImageSources(parseAndSavedTempImages);
                 var parsed = MacroTagParser.FormatRichTextContentForPersistence(editorValueWithMediaUrlsRemoved);
 
-                return parsed;
+                return parsed.NullOrWhiteSpaceAsNull();
             }
 
             /// <summary>

--- a/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/TagsPropertyEditor.cs
@@ -52,7 +52,7 @@ namespace Umbraco.Web.PropertyEditors
 
                 if (editorValue.Value is JArray json)
                 {
-                    return json.Select(x => x.Value<string>());
+                    return json.HasValues ? json.Select(x => x.Value<string>()) : null;
                 }
 
                 if (string.IsNullOrWhiteSpace(value) == false)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/2996 (again, but for v8, as the changes from https://github.com/umbraco/Umbraco-CMS/pull/6416 probably weren't correctly merged up).

### Description
While working on PR https://github.com/umbraco/Umbraco-CMS/pull/11805, I noticed we're not only storing verbose property values for the Image Cropper and Media Picker (v3), but a lot of other complex editors also stored redundant data (e.g. empty strings/arrays, whitespace/indented JSON, etc.).

Most issues are caused by converting to/from JSON types and strings over and over again, eventually returning serialized JSON that contains indentation or even converting a `null` value into an empty JSON array again (and storing `[]`).

One very important thing to note regarding property data: whenever the value is `null`, it doesn't insert a row into the `umbracoPropertyData` table. This means not storing empty strings or JSON arrays will save much more database storage then just the few characters of the actual value!

Testing can be done by saving content with different editors from the back-office and inspecting the database values. You can create a document type containing all editors using the code from this Gist: https://gist.github.com/ronaldbarendse/6eda1a0bfee87bdd714409886ecf4219.

The following SQL query returns all property data with the latest versions first:
```sql
SELECT
    cv.nodeId,
    cv.text,
    pt.Alias,
    pd.languageId,
    pd.segment,
    pd.intValue,
    pd.decimalValue,
    pd.dateValue,
    pd.varcharValue,
    pd.textValue
FROM
    umbracoPropertyData pd
    INNER JOIN umbracoContentVersion cv ON cv.id = pd.versionId AND cv.[current] = 1
    INNER JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
ORDER BY
    cv.versionDate DESC
```