### PR TITLE
Align tags vertically in content type property component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -458,7 +458,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
 }
 
 .umb-group-builder__group-inherited-label {
-  font-size: 13px;
+  font-size: 0.9rem;
   display: inline-flex;
   align-items: center;
   margin-right: 10px;
@@ -644,7 +644,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
 }
 
 .umb-group-builder__property-preview-label {
-  font-size: 12px;
+  font-size: 0.75rem;
   position: absolute;
   top: 0;
   left: 0;
@@ -740,6 +740,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
     margin-right: 3px;
     display: flex;
     align-items: center;
+    line-height: 1;
 }
 
 /* ---------- SORTABLE ---------- */

--- a/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-property.html
@@ -99,13 +99,13 @@
       <div class="umb-group-builder__property-tags -right">
 
           <div class="umb-group-builder__property-tag" ng-if="vm.property.inherited">
-              <umb-icon icon="icon-merge"></umb-icon>
+              <umb-icon icon="icon-merge" class="umb-group-builder__property-tag-icon"></umb-icon>
               <span style="margin-right: 3px"><localize key="contentTypeEditor_inheritedFrom">Inherited from</localize></span>
               {{vm.property.contentTypeName}}
           </div>
 
           <div class="umb-group-builder__property-tag" ng-if="vm.property.locked">
-              <umb-icon icon="icon-lock"></umb-icon>
+              <umb-icon icon="icon-lock" class="umb-group-builder__property-tag-icon"></umb-icon>
               <localize key="general_locked">Locked</localize>
           </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the tags in properties on a content type wasn't really aligned vertically on a content type, so I have adjusted this a bit.


**Before**

![image](https://user-images.githubusercontent.com/2919859/147886457-43c38b0a-b6ab-423e-8f8a-1c522211a4c6.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/147886413-a23340bf-3466-4d36-87dd-f25b9850d83e.png)
