### PR TITLE
Null check in Examine backoffice search

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
         public ActionResult<SearchResults> GetSearchResults(string searcherName, string query, int pageIndex = 0, int pageSize = 20)
         {
-            query = query.Trim();
+            query = query?.Trim();
 
             if (query.IsNullOrWhiteSpace())
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed when searching in Examine dashboard using an empty term the search throw and exception, because if use `Trim()` on null.

It seems it has been there since it was added with the Examine 2.0 implementation here:
https://github.com/umbraco/Umbraco-CMS/pull/10241/files#diff-1dc528437321649518d3c1dd7fb92a81ac141b066b68200aaba2605061a754c0R67


**Before**

https://user-images.githubusercontent.com/2919859/147887086-032e0b10-11e1-4de2-be71-fd8f357c0ef1.mp4


**After**

https://user-images.githubusercontent.com/2919859/147887034-93d68395-7962-43f9-b255-0c46f1b227d8.mp4
