### PR TITLE
Lookup backoffice section name in route locationTitle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -68,13 +68,9 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
 
         var currentRouteParams = null;
 
-        var originalTitle = "";
-
         $rootScope.$on('$changeTitle', function (event, titlePrefix) {
             if (titlePrefix) {
-                $rootScope.locationTitle = titlePrefix + " - " + originalTitle;
-            } else {
-                $rootScope.locationTitle = originalTitle;
+                $rootScope.locationTitle = titlePrefix + " - " + $rootScope.locationTitle;
             }
         });
 
@@ -114,8 +110,6 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
                 }
                 $rootScope.locationTitle = "Umbraco - " + $location.$$host;
             }
-
-            originalTitle = $rootScope.locationTitle;
         });
 
         /** When the route change is rejected - based on checkAuth - we'll prevent the rejected route from executing including

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -1,6 +1,6 @@
 /** Executed when the application starts, binds to events and set global state */
-app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 'appState', 'assetsService', 'eventsService', '$cookies', 'tourService', 'localStorageService',
-    function ($rootScope, $route, $location, urlHelper, navigationService, appState, assetsService, eventsService, $cookies, tourService, localStorageService) {
+app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState', 'assetsService', 'eventsService', 'tourService', 'localStorageService', 'navigationService', 'localizationService',
+    function ($rootScope, $route, $location, $cookies, urlHelper, appState, assetsService, eventsService, tourService, localStorageService, navigationService, localizationService) {
 
         //This sets the default jquery ajax headers to include our csrf token, we
         // need to user the beforeSend method because our token changes per user/login so
@@ -33,9 +33,7 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
                         if (introTour && introTour.disabled !== true && introTour.completed !== true) {
                             tourService.startTour(introTour);
                             localStorageService.set("introTourShown", true);
-                        }
-                        else {
-
+                        } else {
                             const introTourShown = localStorageService.get("introTourShown");
                             if (!introTourShown) {
                                 // Go & show email marketing tour (ONLY when intro tour is completed or been dismissed)
@@ -44,7 +42,6 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
                                     // Unless invoked from tourService JS Client code explicitly.
                                     // Accepted mails = Completed and Declicned mails = Disabled
                                     if (emailMarketingTour && emailMarketingTour.disabled !== true && emailMarketingTour.completed !== true) {
-
                                         // Only show the email tour once per logged in session
                                         // The localstorage key is removed on logout or user session timeout
                                         const emailMarketingTourShown = localStorageService.get("emailMarketingTourShown");
@@ -83,18 +80,15 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
 
         /** execute code on each successful route */
         $rootScope.$on('$routeChangeSuccess', function (event, current, previous) {
-
             var toRetain = currentRouteParams ? navigationService.retainQueryStrings(currentRouteParams, current.params) : null;
 
             //if toRetain is not null it means that there are missing query strings and we need to update the current params
             if (toRetain) {
                 $route.updateParams(toRetain);
                 currentRouteParams = toRetain;
-            }
-            else {
+            } else {
                 currentRouteParams = Utilities.copy(current.params);
             }
-
 
             var deployConfig = Umbraco.Sys.ServerVariables.deploy;
             var deployEnv, deployEnvTitle;
@@ -104,51 +98,41 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
             }
 
             if (current.params.section) {
-
-                //Uppercase the current section, content, media, settings, developer, forms
-                var currentSection = current.params.section.charAt(0).toUpperCase() + current.params.section.slice(1);
-
-                var baseTitle = currentSection + " - " + $location.$$host;
-
-                //Check deploy for Global Umbraco.Sys obj workspace
-                if (deployEnv) {
-                    $rootScope.locationTitle = deployEnvTitle + baseTitle;
-                }
-                else {
-                    $rootScope.locationTitle = baseTitle;
-                }
-
-            }
-            else {
-
+                localizationService.localize("sections_" + current.params.section)
+                    .then(function (currentSection) {
+                        var baseTitle = currentSection + " - " + $location.$$host;
+                        //Check deploy for Global Umbraco.Sys obj workspace
+                        if (deployEnv) {
+                            $rootScope.locationTitle = deployEnvTitle + baseTitle;
+                        } else {
+                            $rootScope.locationTitle = baseTitle;
+                        }
+                    });
+            } else {
                 if (deployEnv) {
                     $rootScope.locationTitle = deployEnvTitle + "Umbraco - " + $location.$$host;
                 }
-
                 $rootScope.locationTitle = "Umbraco - " + $location.$$host;
             }
+
             originalTitle = $rootScope.locationTitle;
         });
 
         /** When the route change is rejected - based on checkAuth - we'll prevent the rejected route from executing including
             wiring up it's controller, etc... and then redirect to the rejected URL.   */
         $rootScope.$on('$routeChangeError', function (event, current, previous, rejection) {
-
             if (rejection.path) {
                 event.preventDefault();
-
                 var returnPath = null;
                 if (rejection.path == "/login" || rejection.path.startsWith("/login/")) {
                     //Set the current path before redirecting so we know where to redirect back to
                     returnPath = encodeURIComponent($location.url());
                 }
-
                 $location.path(rejection.path)
                 if (returnPath) {
                     $location.search("returnPath", returnPath);
                 }
             }
-
         });
 
         //Bind to $routeUpdate which will execute anytime a location changes but the route is not triggered.
@@ -156,45 +140,32 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
         //global state query strings without force re-loading views.
         //We can then detect if it's a location change that should force a route or not programatically.
         $rootScope.$on('$routeUpdate', function (event, next) {
-
             if (!currentRouteParams) {
                 //if there is no current route then always route which is done with reload
                 $route.reload();
-            }
-            else {
-
+            } else {
                 var toRetain = navigationService.retainQueryStrings(currentRouteParams, next.params);
-
                 //if toRetain is not null it means that there are missing query strings and we need to update the current params.
                 if (toRetain) {
                     $route.updateParams(toRetain);
                 }
-
                 //check if the location being changed is only due to global/state query strings which means the location change
                 //isn't actually going to cause a route change.
                 if (navigationService.isRouteChangingNavigation(currentRouteParams, next.params)) {
-
                     //The location change will cause a route change, continue the route if the query strings haven't been updated.
                     $route.reload();
-
-                }
-                else {
-
+                } else {
                     //navigation is not changing but we should update the currentRouteParams to include all current parameters
-
                     if (toRetain) {
                         currentRouteParams = toRetain;
-                    }
-                    else {
+                    } else {
                         currentRouteParams = Utilities.copy(next.params);
                     }
-
                     //always clear the 'sr' query string (soft redirect) if it exists
                     if (currentRouteParams.sr) {
                         currentRouteParams.sr = null;
                         $route.updateParams(currentRouteParams);
                     }
-
                 }
             }
         });
@@ -202,6 +173,7 @@ app.run(['$rootScope', '$route', '$location', 'urlHelper', 'navigationService', 
         //check for touch device, add to global appState
         //var touchDevice = ("ontouchstart" in window || window.touch || window.navigator.msMaxTouchPoints === 5 || window.DocumentTouch && document instanceof DocumentTouch);
         var touchDevice = /android|webos|iphone|ipad|ipod|blackberry|iemobile|touch/i.test(navigator.userAgent.toLowerCase());
+
         appState.setGlobalState("touchDevice", touchDevice);
 
     }]);


### PR DESCRIPTION
The backoffice shows the current section name in the page title (shown in the browser tab).

The current logic is to take the current section alias and uppercase the first character. Sure, kind of smart, but has some limitations:

- If your section name is multiple words these aren't super friendly to read (e.g. "Demo Section" displays as "DemoSection")
- It's not possible to translate these section names

This PR utilises the `localizationService` to lookup the correct name for the section if it exists.

Umbraco already has the convention of looking for section names under `sections_` so I've made it check there for a value. If no value is found the alias is displayed in square brackets (as it does elsewhere): `[sections_demoSection]`.

This issue is present in both V8 and V9, so it would be great if this change could be back-ported to V8 also :-)