### PR TITLE
Use pointer cursor pointer for keyboard shortcuts overview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-keyboard-shortcuts-overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-keyboard-shortcuts-overview.html
@@ -1,6 +1,8 @@
-<div class="umb-keyboard-shortcuts-overview flex items-center" data-hotkey="alt+shift+k" ng-click="toggleShortcutsOverlay()">
+<div class="umb-keyboard-shortcuts-overview flex items-center cursor-pointer" data-hotkey="alt+shift+k" ng-click="toggleShortcutsOverlay()">
         
-    <div class="umb-keyboard-shortcuts-overview__description"><localize key="shortcuts_showShortcuts">show shortcuts</localize></div>
+    <div class="umb-keyboard-shortcuts-overview__description">
+        <localize key="shortcuts_showShortcuts">show shortcuts</localize>
+    </div>
     
     <div class="umb-keyboard-keys">
         <div class="umb-keyboard-key-wrapper">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed when hover the keyboard shortcuts overview element it no longer use pointer cursor.
It is probably caused by either the element was changed or the previous removed styling which added `cursor: pointer` style to elements with `ng-click` attribute.

We have now a `cursor-pointer` class, which we can use here.

![image](https://user-images.githubusercontent.com/2919859/147978378-6823d074-6c7e-4f32-b1b5-a69804bd835e.png)
