### PR TITLE
Allowlisting remote URLs for displaying content on the content dashboard

### DIFF
--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -121,6 +121,11 @@ namespace Umbraco.Core
             public const string ContentDashboardPath = "Umbraco.Core.ContentDashboardPath";
 
             /// <summary>
+            /// A list of allowed addresses to fetch content for the content dashboard.
+            /// </summary>
+            public const string ContentDashboardUrlAllowlist = "Umbraco.Core.ContentDashboardUrl-Allowlist";
+
+            /// <summary>
             /// TODO: FILL ME IN
             /// </summary>
             public const string DisableElectionForSingleServer = "Umbraco.Core.DisableElectionForSingleServer";

--- a/src/Umbraco.Core/Dashboards/ContentDashboardSettings.cs
+++ b/src/Umbraco.Core/Dashboards/ContentDashboardSettings.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Core.Dashboards
 {
-    public class ContentDashboardSettings: IContentDashboardSettings
+    public class ContentDashboardSettings : IContentDashboardSettings
     {
         private const string DefaultContentDashboardPath = "cms";
 
@@ -30,5 +30,14 @@ namespace Umbraco.Core.Dashboards
             ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.ContentDashboardPath)
                 ? ConfigurationManager.AppSettings[Constants.AppSettings.ContentDashboardPath]
                 : DefaultContentDashboardPath;
+
+        /// <summary>
+        /// Gets the allowed addresses to retrieve data for the content dashboard.
+        /// </summary>
+        /// <value>The URLs.</value>
+        public string ContentDashboardUrlAllowlist =>
+            ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.ContentDashboardUrlAllowlist)
+                ? ConfigurationManager.AppSettings[Constants.AppSettings.ContentDashboardUrlAllowlist]
+                : null;
     }
 }

--- a/src/Umbraco.Core/Dashboards/IContentDashboardSettings.cs
+++ b/src/Umbraco.Core/Dashboards/IContentDashboardSettings.cs
@@ -16,5 +16,11 @@
         /// </summary>
         /// <value>The URL path.</value>
         string ContentDashboardPath { get; }
+
+        /// <summary>
+        /// Gets the allowed addresses to retrieve data for the content dashboard.
+        /// </summary>
+        /// <value>The URLs.</value>
+        string ContentDashboardUrlAllowlist { get; }
     }
 }

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -38,7 +38,7 @@
         <add key="Umbraco.Core.DefaultUILanguage" value="en-US" />
         <add key="Umbraco.Core.UseHttps" value="false" />
         <add key="Umbraco.Core.AllowContentDashboardAccessToAllUsers" value="true"/>
-        <add key="Umbraco.Core.ContentDashboardBaseUrl" value=""/>
+        <add key="Umbraco.Core.ContentDashboardUrl-Allowlist" value=""/>
 
         <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
         <add key="webpages:Enabled" value="false" />

--- a/src/Umbraco.Web/Editors/DashboardController.cs
+++ b/src/Umbraco.Web/Editors/DashboardController.cs
@@ -252,6 +252,7 @@ namespace Umbraco.Web.Editors
 
         private bool IsAllowedUrl(string url)
         {
+            // No addresses specified indicates that any URL is allowed
             if (string.IsNullOrEmpty(_dashboardSettings.ContentDashboardUrlAllowlist) || _dashboardSettings.ContentDashboardUrlAllowlist.Contains(url))
             {
                 return true;

--- a/src/Umbraco.Web/Editors/DashboardController.cs
+++ b/src/Umbraco.Web/Editors/DashboardController.cs
@@ -61,12 +61,7 @@ namespace Umbraco.Web.Editors
             var version = UmbracoVersion.SemanticVersion.ToSemanticString();
             var isAdmin = user.IsAdmin();
 
-            if(!IsAllowedUrl(baseUrl))
-            {
-                var errorMsg = $"The following URL is not listed in the allowlist for ContentDashboardUrl in the Web.config: {baseUrl}";
-                Logger.Error<DashboardController>(errorMsg);
-                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, errorMsg));
-            }
+            VerifyDashboardSource(baseUrl);
 
             var url = string.Format("{0}{1}?section={2}&allowed={3}&lang={4}&version={5}&admin={6}",
                 baseUrl,
@@ -110,12 +105,7 @@ namespace Umbraco.Web.Editors
 
         public async Task<HttpResponseMessage> GetRemoteDashboardCss(string section, string baseUrl = "https://dashboard.umbraco.org/")
         {
-            if(!IsAllowedUrl(baseUrl))
-            {
-                var errorMsg = $"The following URL is not listed in the allowlist for ContentDashboardUrl in the Web.config: {baseUrl}";
-                Logger.Error<DashboardController>(errorMsg);
-                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, errorMsg));
-            }
+            VerifyDashboardSource(baseUrl);
 
             var url = string.Format(baseUrl + "css/dashboard.css?section={0}", section);
             var key = "umbraco-dynamic-dashboard-css-" + section;
@@ -158,12 +148,7 @@ namespace Umbraco.Web.Editors
 
         public async Task<HttpResponseMessage> GetRemoteXml(string site, string url)
         {
-            if(!IsAllowedUrl(url))
-            {
-                var errorMsg = $"The following URL is not listed in the allowlist for ContentDashboardUrl in the Web.config: {url}";
-                Logger.Error<DashboardController>(errorMsg);
-                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, errorMsg));
-            }
+            VerifyDashboardSource(url);
 
             // This is used in place of the old feedproxy.config
             // Which was used to grab data from our.umbraco.com, umbraco.com or umbraco.tv
@@ -261,6 +246,15 @@ namespace Umbraco.Web.Editors
             else
             {
                 return false;
+            }
+        }
+
+        private void VerifyDashboardSource(string url)
+        {
+            if(!IsAllowedUrl(url))
+            {
+                Logger.Error<DashboardController>($"The following URL is not listed in the allowlist for ContentDashboardUrl in the Web.config: {url}");
+                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, "Dashboard source not permitted"));
             }
         }
     }

--- a/src/Umbraco.Web/Editors/DashboardController.cs
+++ b/src/Umbraco.Web/Editors/DashboardController.cs
@@ -250,6 +250,7 @@ namespace Umbraco.Web.Editors
             }).ToList();
         }
 
+        // Checks if the passed URL is part of the configured allowlist of addresses
         private bool IsAllowedUrl(string url)
         {
             // No addresses specified indicates that any URL is allowed


### PR DESCRIPTION
## Details
- Removed a non-existent setting from the Web.config (`ContentDashboardBaseUrl`), left out after the renaming done in commit c6bf78e6728caf15afa186597ee105d6de121937;
- Added the ability to allowlist the remote URLs for the "Getting Started" dashboard in config.
- If no addresses are specified, any address is allowed.

## Test
- Without specifying any addresses, the "Getting Started" dashboard should display the content as before.
- Add the following line in Web.config and verify that the behaviour persists:
```
    <appSettings>
        ...
        <add key="Umbraco.Core.ContentDashboardUrl-Allowlist" value="https://dashboard.umbraco.org/,https://dashboard.umbraco.com/,https://www.google.com/"/>
        ...
    </appSettings>
```
- Remove either https://dashboard.umbraco.com/ (and observe that the content is not fetched) or https://dashboard.umbraco.org/ (and observe that the CSS is not fetched) 
  - Check that the corresponding calls to the **GetRemoteDashboardContent** or **GetRemoteDashboardCss** endpoints returns 400 and that the errors are also in the log (Settings > Log Viewer)