### PR TITLE
Don't show stack trace in production mode

### DIFF
--- a/src/Umbraco.Web/WebApi/EnableDetailedErrorsAttribute.cs
+++ b/src/Umbraco.Web/WebApi/EnableDetailedErrorsAttribute.cs
@@ -16,8 +16,10 @@ namespace Umbraco.Web.WebApi
             {
                 actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
             }
-
-            actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Default;
+            else
+            {
+                actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Default;
+            }
         }
     }
 }

--- a/src/Umbraco.Web/WebApi/EnableDetailedErrorsAttribute.cs
+++ b/src/Umbraco.Web/WebApi/EnableDetailedErrorsAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http;
+﻿using System.Web;
+using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 
@@ -11,7 +12,7 @@ namespace Umbraco.Web.WebApi
     {
         public override void OnActionExecuting(HttpActionContext actionContext)
         {
-            actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+            actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = HttpContext.Current.IsDebuggingEnabled ? IncludeErrorDetailPolicy.Always : IncludeErrorDetailPolicy.Default;
         }
     }
 }

--- a/src/Umbraco.Web/WebApi/EnableDetailedErrorsAttribute.cs
+++ b/src/Umbraco.Web/WebApi/EnableDetailedErrorsAttribute.cs
@@ -12,7 +12,12 @@ namespace Umbraco.Web.WebApi
     {
         public override void OnActionExecuting(HttpActionContext actionContext)
         {
-            actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = HttpContext.Current.IsDebuggingEnabled ? IncludeErrorDetailPolicy.Always : IncludeErrorDetailPolicy.Default;
+            if (HttpContext.Current?.IsDebuggingEnabled ?? false)
+            {
+                actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+            }
+
+            actionContext.ControllerContext.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Default;
         }
     }
 }


### PR DESCRIPTION
Fixes and issue where you were able to see exception stack traces while you were running Umbraco in production mode.
# Notes
- Added check to see if we're in debug mode
- Set proper Error detail policy if we're in production
# How to test
- In your `web.config` file set your debug attirubute in compilation to false like so: `<compilation debug=false />` to enable production mode, this can be found under the `<system.web>` tag
- Also set the customError mode to on like so: `<customErrors mode="On" />` this can be found under the `<system.web>` tag
- Finally in a API controller, throw an exception
- Assert that you cannot see the stack trace in the browser, or in the dev tools console.
- I tested this with the TourController cause it pops as soon as you log in like this:
```
public IEnumerable<BackOfficeTourFile> GetTours()
{
            throw new Exception("TestException");
}
```