### PR TITLE
Add package tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/Packages/packages.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/Packages/packages.ts
@@ -1,0 +1,161 @@
+/// <reference types="Cypress" />
+import {
+    ContentBuilder,
+    DocumentTypeBuilder
+  } from 'umbraco-cypress-testhelpers';
+
+context('Packages', () => {
+    const packageName = "TestPackage";
+    const rootDocTypeName = "Test document type";
+    const nodeName = "1) Home";
+
+    beforeEach(() => {
+        cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'), false);
+      });
+
+    function CreatePackage(contentId){
+        const newPackage = {
+            id: 0,
+            packageGuid: "00000000-0000-0000-0000-000000000000",
+            name: "TestPackage",
+            packagePath: "",
+            contentLoadChildNodes: false,
+            contentNodeId: contentId,
+            macros: [],
+            languages: [],
+            dictionaryItems: [],
+            templates: [],
+            partialViews: [],
+            documentTypes: [],
+            mediaTypes: [],
+            stylesheets: [],
+            scripts: [],
+            dataTypes: [],
+            mediaUdis: [],
+            mediaLoadChildNodes: false
+        }
+        const url = "https://localhost:44331/umbraco/backoffice/umbracoapi/package/PostSavePackage";
+        cy.umbracoApiRequest(url, 'POST', newPackage);
+    }
+
+    function CreateSimplePackage(){
+
+        const rootDocType = new DocumentTypeBuilder()
+            .withName(rootDocTypeName)
+            .withAllowAsRoot(true)
+            .build();
+        
+        cy.saveDocumentType(rootDocType).then((generatedRootDocType) => {
+            const rootDocTypeAlias = generatedRootDocType["alias"];
+
+            const rootContentNode = new ContentBuilder()
+                .withContentTypeAlias(rootDocTypeAlias)
+                .withAction("saveNew")
+                .addVariant()
+                    .withName(nodeName)
+                    .withSave(true)
+                .done()
+                .build();
+            cy.saveContent(rootContentNode).then((generatedContent) => {
+                CreatePackage(generatedContent.Id);
+            });
+        });
+    }
+
+      it('Creates a simple package', () => {
+
+        cy.umbracoEnsurePackageNameNotExists(packageName);
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+
+        const rootDocType = new DocumentTypeBuilder()
+            .withName(rootDocTypeName)
+            .withAllowAsRoot(true)
+            .build();
+        
+        cy.saveDocumentType(rootDocType).then((generatedRootDocType) => {
+            const rootDocTypeAlias = generatedRootDocType["alias"];
+
+            const rootContentNode = new ContentBuilder()
+                .withContentTypeAlias(rootDocTypeAlias)
+                .withAction("saveNew")
+                .addVariant()
+                    .withName(nodeName)
+                    .withSave(true)
+                .done()
+                .build();
+            cy.saveContent(rootContentNode);
+        });
+        
+        // Navigate to create package section
+        cy.umbracoSection('packages');
+        cy.contains('Created').click();
+        cy.contains('Create package').click();
+
+        // Fill out package creation form
+        cy.get('#headerName').should('be.visible');
+        cy.wait(1000);
+        cy.get('#headerName').type(packageName);
+        cy.get('.controls > .umb-node-preview-add').click();
+        cy.get('.umb-tree-item__label').first().click();
+        cy.contains('Create').click();
+
+        // Navigate pack to packages and Assert the file is created
+        cy.umbracoSection('packages');
+        cy.contains('Created').click();
+        cy.contains(packageName).should('be.visible');
+
+        // Cleanup
+        cy.umbracoEnsurePackageNameNotExists(packageName);
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+      });
+
+      it('Delete package', () => {
+
+        // Ensure cleanup before test
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+        cy.umbracoEnsurePackageNameNotExists(packageName);
+    
+        CreateSimplePackage();
+
+        // Navigate to create package section
+        cy.umbracoSection('packages');
+        cy.contains('Created').click();
+        cy.contains('Delete').click();
+        cy.contains('Yes, delete').click();
+
+        // Assert
+        cy.contains('TestPackage').should('not.exist');
+
+        // Cleanup
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+        cy.umbracoEnsurePackageNameNotExists(packageName);
+      });
+
+      it('Download package', () => {
+
+        // Ensure cleanup before test
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+        cy.umbracoEnsurePackageNameNotExists(packageName);
+        
+        CreateSimplePackage();
+
+        // Navigate to package and download
+        cy.umbracoSection('packages');
+        cy.contains('Created').click();
+        cy.contains('TestPackage').click();
+        cy.contains('Download').click();
+
+        // Assert
+        cy.verifyDownload('package.xml');
+
+        // Cleanup
+        cy.deleteAllContent();
+        cy.umbracoEnsureDocumentTypeNameNotExists(rootDocTypeName);
+        cy.umbracoEnsurePackageNameNotExists(packageName);
+      });
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/cypress/plugins/index.js
+++ b/tests/Umbraco.Tests.AcceptanceTest/cypress/plugins/index.js
@@ -12,6 +12,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 const del = require('del')
+const { isFileExist } = require('cy-verify-downloads');
 
 /**
  * @type {Cypress.PluginConfig}
@@ -25,6 +26,7 @@ module.exports = (on, config) => {
     config.baseUrl = baseUrl;
   }
 
+  on('task', { isFileExist })
   on('after:spec', (spec, results) => {
     if(results.stats.failures === 0 && results.video) {
       // `del()` returns a promise, so it's important to return it to ensure
@@ -32,6 +34,12 @@ module.exports = (on, config) => {
       return del(results.video)
     }
   })
+
+  
+on('task', {
+  isFileExist
+});
+
 
   return config;
 }

--- a/tests/Umbraco.Tests.AcceptanceTest/cypress/support/commands.js
+++ b/tests/Umbraco.Tests.AcceptanceTest/cypress/support/commands.js
@@ -27,6 +27,7 @@
 import {Command} from 'umbraco-cypress-testhelpers';
 import {Chainable} from './chainable';
 import { JsonHelper } from 'umbraco-cypress-testhelpers';
+require('cy-verify-downloads').addCustomCommand();
 new Chainable();
 new Command().registerCypressCommands();
 

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -453,6 +453,12 @@
         "which": "^2.0.1"
       }
     },
+    "cy-verify-downloads": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/cy-verify-downloads/-/cy-verify-downloads-0.0.5.tgz",
+      "integrity": "sha512-aRK7VvKG5rmDJK4hjZ27KM2oOOz0cMO7z/j4zX8qCc4ffXZS1XRJkofUY0w5u6MCB/wUsNMs03VuvkeR2tNPoQ==",
+      "dev": true
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -1622,9 +1628,9 @@
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
     },
     "umbraco-cypress-testhelpers": {
-      "version": "1.0.0-beta-62",
-      "resolved": "https://registry.npmjs.org/umbraco-cypress-testhelpers/-/umbraco-cypress-testhelpers-1.0.0-beta-62.tgz",
-      "integrity": "sha512-fVjXBdotb2TZrhaWq/HtD1cy+7scHcldJL+HRHeyYtwvUp368lUiAMrx0y4TOZTwBOJ898yyl8yTEPASfAX2pQ==",
+      "version": "1.0.0-beta-63",
+      "resolved": "https://registry.npmjs.org/umbraco-cypress-testhelpers/-/umbraco-cypress-testhelpers-1.0.0-beta-63.tgz",
+      "integrity": "sha512-X+DHWktfB+WBb7YrxvpneVfS1PATx2zPYMdkeZTmtoQEeyGxXA9fW6P712/AUbyGAhRhH+46t4cAINdWJxItug==",
       "dev": true,
       "requires": {
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -10,10 +10,11 @@
   "devDependencies": {
     "cross-env": "^7.0.2",
     "cypress": "8.4.1",
+    "cy-verify-downloads": "0.0.5",
     "del": "^6.0.0",
     "ncp": "^2.0.0",
     "prompt": "^1.2.0",
-    "umbraco-cypress-testhelpers": "^1.0.0-beta-62"
+    "umbraco-cypress-testhelpers": "^1.0.0-beta-63"
   },
   "dependencies": {
     "typescript": "^3.9.2"

--- a/tests/Umbraco.Tests.AcceptanceTest/tsconfig.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/tsconfig.json
@@ -14,7 +14,8 @@
         "target": "es5",
 
         "types": [
-            "cypress"
+            "cypress",
+            "cy-verify-downloads"
         ],
         "lib": [
             "es5",


### PR DESCRIPTION
# Notes 
- Added create package test
- Added delete package test
- Added download package test
- Updated cypress-helper package
- Added cy-verify-downloads package

# How to test
- Run umbraco & install
- navigate to the` tests/Umbraco.Tests.AcceptanceTest` folder and run `npm ci & npm run ui`
- Run the package.ts tests