### PR TITLE
Add "MainDom" to log messages, when acquiring MainDom at startup

### DIFF
--- a/src/Umbraco.Core/Runtime/MainDom.cs
+++ b/src/Umbraco.Core/Runtime/MainDom.cs
@@ -154,11 +154,11 @@ namespace Umbraco.Cms.Core.Runtime
             // the handler is not installed so that would be the hosting environment
             if (_signaled)
             {
-                _logger.LogInformation("Cannot acquire (signaled).");
+                _logger.LogInformation("Cannot acquire MainDom (signaled).");
                 return false;
             }
 
-            _logger.LogInformation("Acquiring.");
+            _logger.LogInformation("Acquiring MainDom.");
 
             // Get the lock
             var acquired = false;
@@ -168,12 +168,12 @@ namespace Umbraco.Cms.Core.Runtime
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error while acquiring");
+                _logger.LogError(ex, "Error while acquiring MainDom");
             }
 
             if (!acquired)
             {
-                _logger.LogInformation("Cannot acquire (timeout).");
+                _logger.LogInformation("Cannot acquire MainDom (timeout).");
 
                 // In previous versions we'd let a TimeoutException be thrown
                 // and the appdomain would not start. We have the opportunity to allow it to
@@ -209,7 +209,7 @@ namespace Umbraco.Cms.Core.Runtime
                 _logger.LogWarning(ex, ex.Message);
             }
 
-            _logger.LogInformation("Acquired.");
+            _logger.LogInformation("Acquired MainDom.");
             return true;
         }
 


### PR DESCRIPTION
Following a [question in the Discord](https://discord.com/channels/869656431308189746/882984410432012360/928278060015448145), which I also had wondered about, I feel it could be good to further inform the user/developer about what the "Acquiring" part of the startup does.

So I added MainDom here and there in the log messages, to make it more obvious what that step does.