### PR TITLE
Added description to entityResource.getSafeAlias

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -36,6 +36,27 @@ function entityResource($q, $http, umbRequestHelper) {
     //the factory object returned
     return {
 
+        /**
+         * @ngdoc method
+         * @name umbraco.resources.entityResource#getSafeAlias
+         * @methodOf umbraco.resources.entityResource
+         *
+         * @description
+         * Converts the given string to a safe alias
+         *
+         * ##usage
+         * <pre>
+         * entityResource.getSafeAlias(value, camelCase)
+         *    .then(function(safeAlias) {
+         *        Do stuff...
+         *    });
+         * </pre>
+         *
+         * @param {string} value the value to convert to a safe alias
+         * @param {boolean} camelCase if camel casing should be used
+         * @returns {Promise} resourcePromise object containing the safe alias.
+         *
+         */
         getSafeAlias: function (value, camelCase) {
 
             if (!value) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I have being going through the Backoffice UI API Documentation. And noticed that a description for `getSafeAlias`. I just wanted to add it since people might miss it otherwise. (I sure did). 

