### PR TITLE
Localization: Translate history cleanup labels/descriptions to Dutch

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1674,6 +1674,12 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
       weggooien?
     </key>
     <key alias="addTab">Tabblad toevoegen</key>
+    <key alias="historyCleanupHeading">Geschiedenis opschonen</key>
+    <key alias="historyCleanupDescription">Overschrijf de standaard geschiedenis opschonen instellingen.</key>
+    <key alias="historyCleanupKeepAllVersionsNewerThanDays">Bewaar alle versies nieuwer dan dagen</key>
+    <key alias="historyCleanupKeepLatestVersionPerDayForDays">Bewaar de laatste versie per dag voor dagen</key>
+    <key alias="historyCleanupPreventCleanup">Voorkom opschonen</key>
+    <key alias="historyCleanupGloballyDisabled">Geschiedenis opschonen is globaal uitgeschakeld. Deze instellingen worden pas van kracht nadat ze zijn ingeschakeld.</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Taal toevoegen</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1251,6 +1251,10 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="rollbackTo">Terugzetten naar</key>
     <key alias="selectVersion">Selecteer versie</key>
     <key alias="view">Bekijk</key>
+    <key alias="pagination"><![CDATA[Toont versie %0% tot %1% van %2% versies]]></key>
+    <key alias="versions">Versies</key>
+    <key alias="currentDraftVersion">Conceptversie</key>
+    <key alias="currentPublishedVersion">Gepubliceerde versie</key>
   </area>
   <area alias="scripts">
     <key alias="editscript">Bewerk script-bestand</key>


### PR DESCRIPTION
Translate History Cleanup labels and descriptions to Dutch.

- [x] Update labels and descriptions in info content app (content section)
- [x] Update labels and descriptions in permissions app (settings section) 