### PR TITLE
V8: Delete temp document type file if validation fails

### DIFF
--- a/src/Umbraco.Web/Editors/ContentTypeController.cs
+++ b/src/Umbraco.Web/Editors/ContentTypeController.cs
@@ -284,9 +284,9 @@ namespace Umbraco.Web.Editors
 
         public DocumentTypeDisplay PostSave(DocumentTypeSave contentTypeSave)
         {
-            //Before we send this model into this saving/mapping pipeline, we need to do some cleanup on variations.	
-            //If the doc type does not allow content variations, we need to update all of it's property types to not allow this either	
-            //else we may end up with ysods. I'm unsure if the service level handles this but we'll make sure it is updated here	
+            //Before we send this model into this saving/mapping pipeline, we need to do some cleanup on variations.
+            //If the doc type does not allow content variations, we need to update all of it's property types to not allow this either
+            //else we may end up with ysods. I'm unsure if the service level handles this but we'll make sure it is updated here
             if (!contentTypeSave.AllowCultureVariant)
             {
                 foreach (var prop in contentTypeSave.Groups.SelectMany(x => x.Properties))
@@ -301,16 +301,16 @@ namespace Umbraco.Web.Editors
                 saveContentType: type => Services.ContentTypeService.Save(type),
                 beforeCreateNew: ctSave =>
                 {
-                    //create a default template if it doesn't exist -but only if default template is == to the content type	
+                    //create a default template if it doesn't exist -but only if default template is == to the content type
                     if (ctSave.DefaultTemplate.IsNullOrWhiteSpace() == false && ctSave.DefaultTemplate == ctSave.Alias)
                     {
                         var template = CreateTemplateForContentType(ctSave.Alias, ctSave.Name);
 
-                        // If the alias has been manually updated before the first save,	
-                        // make sure to also update the first allowed template, as the	
-                        // name will come back as a SafeAlias of the document type name,	
-                        // not as the actual document type alias.	
-                        // For more info: http://issues.umbraco.org/issue/U4-11059	
+                        // If the alias has been manually updated before the first save,
+                        // make sure to also update the first allowed template, as the
+                        // name will come back as a SafeAlias of the document type name,
+                        // not as the actual document type alias.
+                        // For more info: http://issues.umbraco.org/issue/U4-11059
                         if (ctSave.DefaultTemplate != template.Alias)
                         {
                             var allowedTemplates = ctSave.AllowedTemplates.ToArray();
@@ -319,7 +319,7 @@ namespace Umbraco.Web.Editors
                             ctSave.AllowedTemplates = allowedTemplates;
                         }
 
-                        //make sure the template alias is set on the default and allowed template so we can map it back	
+                        //make sure the template alias is set on the default and allowed template so we can map it back
                         ctSave.DefaultTemplate = template.Alias;
 
                     }
@@ -611,6 +611,8 @@ namespace Umbraco.Web.Editors
                 }
                 else
                 {
+                    // Cleanup the temp file
+                    System.IO.File.Delete(destFileName);
                     model.Notifications.Add(new Notification(
                         Services.TextService.Localize("speechBubbles", "operationFailedHeader"),
                         Services.TextService.Localize("media", "disallowedFileType"),
@@ -619,6 +621,8 @@ namespace Umbraco.Web.Editors
             }
             else
             {
+                // Cleanup the temp file
+                System.IO.File.Delete(result.FileData[0].LocalFileName);
                 model.Notifications.Add(new Notification(
                                         Services.TextService.Localize("speechBubbles", "operationFailedHeader"),
                                         Services.TextService.Localize("media", "invalidFileName"),


### PR DESCRIPTION
Minor amend to a previous fix, this PR ensures we delete any invalid file uploaded using the "import document type" feature