### PR TITLE
Take `ufprt` from form data if post, fallback to query

### DIFF
--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Cms.Web.Website.Routing
 
             IPublishedRequest publishedRequest = await RouteRequestAsync(umbracoContext);
 
-            umbracoRouteValues = await _routeValuesFactory.CreateAsync(httpContext, publishedRequest);            
+            umbracoRouteValues = await _routeValuesFactory.CreateAsync(httpContext, publishedRequest);
 
             // now we need to do some public access checks
             umbracoRouteValues = await _publicAccessRequestHandler.RewriteForPublishedContentAccessAsync(httpContext, umbracoRouteValues);
@@ -202,8 +202,8 @@ namespace Umbraco.Cms.Web.Website.Routing
             }
 
             // if it is a POST/GET then a value must be in the request
-            if (!httpContext.Request.Query.TryGetValue("ufprt", out StringValues encodedVal)
-                && (!httpContext.Request.HasFormContentType || !httpContext.Request.Form.TryGetValue("ufprt", out encodedVal)))
+            if ((!httpContext.Request.HasFormContentType || !httpContext.Request.Form.TryGetValue("ufprt", out StringValues encodedVal))
+                && !httpContext.Request.Query.TryGetValue("ufprt", out encodedVal))
             {
                 return null;
             }


### PR DESCRIPTION
Fixed issue that exists in 9.x

The `ufprt` value is now taken from the Form data instead of the query data if the request is a post. This aligns with Umbraco 8.

#### Test
- This can be tested by having both a ufprt as query string and formdata.