### PR TITLE
Localization: Rename RelatieTypen to RelatieTypes (Dutch)

### DIFF
--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1794,7 +1794,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="memberRoles">Rollen</key>
     <key alias="memberTypes">Ledentypes</key>
     <key alias="documentTypes">Documenttypes</key>
-    <key alias="relationTypes">RelatieTypen</key>
+    <key alias="relationTypes">RelatieTypes</key>
     <key alias="packager">Packages</key>
     <key alias="packages">Packages</key>
     <key alias="partialViews">Partial Views</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -1794,7 +1794,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="memberRoles">Rollen</key>
     <key alias="memberTypes">Ledentypes</key>
     <key alias="documentTypes">Documenttypes</key>
-    <key alias="relationTypes">RelatieTypes</key>
+    <key alias="relationTypes">Relatietypes</key>
     <key alias="packager">Packages</key>
     <key alias="packages">Packages</key>
     <key alias="partialViews">Partial Views</key>


### PR DESCRIPTION
In Dutch, both word 'types' and the word 'typen' can be used, but it is nice to do this consistently.

![image](https://user-images.githubusercontent.com/7831614/149134517-2779943e-e714-4bd3-86c5-a4e479c543cc.png)
