### PR TITLE
V9: Visiting a page without a template returns "Page Not Found"

### DIFF
--- a/src/Umbraco.Web.Common/Controllers/RenderController.cs
+++ b/src/Umbraco.Web.Common/Controllers/RenderController.cs
@@ -55,11 +55,13 @@ namespace Umbraco.Cms.Web.Common.Controllers
 
         /// <summary>
         /// Gets an action result based on the template name found in the route values and a model.
-        /// If the template found in the route values doesn't physically exist, Umbraco not found result is returned.
         /// </summary>
         /// <typeparam name="T">The type of the model.</typeparam>
         /// <param name="model">The model.</param>
         /// <returns>The action result.</returns>
+        /// <remarks>
+        /// If the template found in the route values doesn't physically exist, Umbraco not found result is returned.
+        /// </remarks>
         protected override IActionResult CurrentTemplate<T>(T model)
         {
             if (EnsurePhsyicalViewExists(UmbracoRouteValues.TemplateName) == false)

--- a/src/Umbraco.Web.Common/Controllers/RenderController.cs
+++ b/src/Umbraco.Web.Common/Controllers/RenderController.cs
@@ -54,6 +54,24 @@ namespace Umbraco.Cms.Web.Common.Controllers
         public virtual IActionResult Index() => CurrentTemplate(new ContentModel(CurrentPage));
 
         /// <summary>
+        /// Gets an action result based on the template name found in the route values and a model.
+        /// If the template found in the route values doesn't physically exist, Umbraco not found result is returned.
+        /// </summary>
+        /// <typeparam name="T">The type of the model.</typeparam>
+        /// <param name="model">The model.</param>
+        /// <returns>The action result.</returns>
+        protected override IActionResult CurrentTemplate<T>(T model)
+        {
+            if (EnsurePhsyicalViewExists(UmbracoRouteValues.TemplateName) == false)
+            {
+                // no physical template file was found
+                return new PublishedContentNotFoundResult(UmbracoContext);
+            }
+
+            return View(UmbracoRouteValues.TemplateName, model);
+        }
+
+        /// <summary>
         /// Before the controller executes we will handle redirects and not founds
         /// </summary>
         public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -123,6 +141,6 @@ namespace Umbraco.Cms.Web.Common.Controllers
             {
                 return new PublishedContentNotFoundResult(UmbracoContext);
             }
-        }        
+        }
     }
 }

--- a/src/Umbraco.Web.Common/Controllers/UmbracoPageController.cs
+++ b/src/Umbraco.Web.Common/Controllers/UmbracoPageController.cs
@@ -90,7 +90,7 @@ namespace Umbraco.Cms.Web.Common.Controllers
         /// <param name="template">The view name.</param>
         protected bool EnsurePhsyicalViewExists(string template)
         {
-            if (string.IsNullOrEmpty(template))
+            if (string.IsNullOrWhiteSpace(template))
             {
                 string docTypeAlias = UmbracoRouteValues.PublishedRequest.PublishedContent.ContentType.Alias;
                 _logger.LogWarning("No physical template file was found for document type with alias {Alias}", docTypeAlias);

--- a/src/Umbraco.Web.Common/Controllers/UmbracoPageController.cs
+++ b/src/Umbraco.Web.Common/Controllers/UmbracoPageController.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Cms.Web.Common.Controllers
         /// <param name="model">The model.</param>
         /// <returns>The action result.</returns>
         /// <exception cref="InvalidOperationException">If the template found in the route values doesn't physically exist and exception is thrown</exception>
-        protected IActionResult CurrentTemplate<T>(T model)
+        protected virtual IActionResult CurrentTemplate<T>(T model)
         {
             if (EnsurePhsyicalViewExists(UmbracoRouteValues.TemplateName) == false)
             {
@@ -90,6 +90,13 @@ namespace Umbraco.Cms.Web.Common.Controllers
         /// <param name="template">The view name.</param>
         protected bool EnsurePhsyicalViewExists(string template)
         {
+            if (string.IsNullOrEmpty(template))
+            {
+                string docTypeAlias = UmbracoRouteValues.PublishedRequest.PublishedContent.ContentType.Alias;
+                _logger.LogWarning("No physical template file was found for document type with alias {Alias}", docTypeAlias);
+                return false;
+            }
+
             ViewEngineResult result = _compositeViewEngine.FindView(ControllerContext, template, false);
             if (result.View != null)
             {
@@ -99,6 +106,5 @@ namespace Umbraco.Cms.Web.Common.Controllers
             _logger.LogWarning("No physical template file was found for template {Template}", template);
             return false;
         }
-
     }
 }


### PR DESCRIPTION
Fixes: #11846

## Details:
If there is a document type without a template, a "Page Not Found" is returned. (Same as the v8 logic)

## Test
- Follow the "Steps to reproduce" in the original issue;
- Make sure the "Page Not Found" page is returned instead of the error.
- Check that there is an entry in the log with the document type alias (_as the template name will be null_)