### PR TITLE
Add UmbracoApplicationStartedNotification and UmbracoApplicationStoppedNotification

### DIFF
--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartedNotification.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.Notifications
+{
+    /// <summary>
+    /// Notification that occurs when Umbraco has completely booted up and the request processing pipeline is configured.
+    /// </summary>
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
+    public class UmbracoApplicationStartedNotification : INotification
+    { }
+}

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
@@ -1,23 +1,23 @@
-// Copyright (c) Umbraco.
-// See LICENSE for more details.
-
 namespace Umbraco.Cms.Core.Notifications
 {
     /// <summary>
-    /// Notification that occurs at the very end of the Umbraco boot
-    /// process and after all <see cref="IComponent"/> initialize.
+    /// Notification that occurs at the very end of the Umbraco boot process (after all <see cref="IComponent" />s are initialized).
     /// </summary>
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
     public class UmbracoApplicationStartingNotification : INotification
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification"/> class.
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
         /// </summary>
         /// <param name="runtimeLevel">The runtime level</param>
         public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel) => RuntimeLevel = runtimeLevel;
 
         /// <summary>
-        /// Gets the runtime level of execution.
+        /// Gets the runtime level.
         /// </summary>
+        /// <value>
+        /// The runtime level.
+        /// </value>
         public RuntimeLevel RuntimeLevel { get; }
     }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppedNotification.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.Notifications
+{
+    /// <summary>
+    /// Notification that occurs when Umbraco has completely shutdown.
+    /// </summary>
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
+    public class UmbracoApplicationStoppedNotification : INotification
+    { }
+}

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
@@ -1,4 +1,9 @@
 namespace Umbraco.Cms.Core.Notifications
 {
-    public class UmbracoApplicationStoppingNotification : INotification { }
+    /// <summary>
+    /// Notification that occurs when Umbraco is shutting down (after all <see cref="IComponent" />s are terminated).
+    /// </summary>
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
+    public class UmbracoApplicationStoppingNotification : INotification
+    { }
 }

--- a/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
@@ -182,7 +182,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             await _eventAggregator.PublishAsync(new UmbracoApplicationMainDomAcquiredNotification(), cancellationToken);
 
             // notify for unattended install
-            await _eventAggregator.PublishAsync(new RuntimeUnattendedInstallNotification());
+            await _eventAggregator.PublishAsync(new RuntimeUnattendedInstallNotification(), cancellationToken);
             DetermineRuntimeLevel();
 
             if (!State.UmbracoCanBoot())
@@ -198,7 +198,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
 
             // if level is Run and reason is UpgradeMigrations, that means we need to perform an unattended upgrade
             var unattendedUpgradeNotification = new RuntimeUnattendedUpgradeNotification();
-            await _eventAggregator.PublishAsync(unattendedUpgradeNotification);
+            await _eventAggregator.PublishAsync(unattendedUpgradeNotification, cancellationToken);
             switch (unattendedUpgradeNotification.UnattendedUpgradeResult)
             {
                 case RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors:
@@ -206,6 +206,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                     {
                         throw new InvalidOperationException($"Unattended upgrade result was {RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors} but no {nameof(BootFailedException)} was registered");
                     }
+
                     // we cannot continue here, the exception will be rethrown by BootFailedMiddelware
                     return;
                 case RuntimeUnattendedUpgradeNotification.UpgradeResult.CoreUpgradeComplete:


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Umbraco currently doesn't have it's own started/stopped notifications and the `UmbracoApplicationStartingNotification` is published before the request processing pipeline is configured (this is the [default behavior](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-5.0&tabs=visual-studio#startasync-1) of `IHostedService`, which `CoreRuntime` implements).

You can already [use the ASP.NET Core `IHostApplicationLifetime` and register a callback](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-5.0#ihostapplicationlifetime-1), but that's linked to the application lifetime and not specifically to Umbraco's runtime. The Umbraco runtime is restarted after completing a new install, which doesn't trigger any of the callbacks registered in the `IHostApplicationLifetime` (as it's not a complete application restart).

Having to use a different way to run your custom code after the application has completely started isn't friendly. Also, having starting/stopping notifications without the accompanying started/stopped ones seems weird.

As discussed in https://github.com/umbraco/Umbraco.Deploy.Issues/issues/91#issuecomment-1012012670, the `UmbracoApplicationStartedNotification` could be used for things like monitoring Deploy trigger files and Examines `RebuildOnStartupHandler` (that currently rebuilds the indexes 1 minute after the first request, but requires the handler to be instantiated on each request).

-------------
Testing can be done by adding the following code to an Umbraco site, starting/stopping the application and checking the logs. I've also added an API controller to manually invoke the Umbraco/application runtime methods:
- `/umbraco/api/runtime/restart` - restarts the Umbraco runtime (same as after install)
- `/umbraco/api/runtime/stop` - stops the Umbraco runtime
- `/umbraco/api/runtime/start` - starts the Umbraco runtime
- `/umbraco/api/runtime/stopapplication` - stops the application

Ensure the messages are logged in the correct order:
```
[15:38:57 INF] Acquiring.
[15:38:57 INF] Acquired.
[15:38:57 INF] ApplicationComponent.Initialize
[15:38:57 INF] UmbracoApplicationStartingNotification
[15:38:58 INF] Now listening on: https://localhost:44331
[15:38:58 INF] Now listening on: http://localhost:9000
[15:38:58 INF] UmbracoApplicationStartedNotification
[15:38:58 INF] Application started. Press Ctrl+C to shut down.
[15:38:58 INF] Hosting environment: Development
[15:38:58 INF] Content root path: ...\src\Umbraco.Web.UI

[15:39:06 INF] Stopping (environment)
[15:39:06 INF] Released (environment)
[15:39:06 INF] Application is shutting down...
[15:39:06 INF] Queued Hosted Service is stopping.
[15:39:06 INF] ApplicationComponent.Terminate
[15:39:06 INF] UmbracoApplicationStoppingNotification
[15:39:06 INF] UmbracoApplicationStoppedNotification
```

```c#
using System.Threading.Tasks;
using Microsoft.Extensions.Hosting;
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Web.Common.Controllers;

public class ApplicationComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddComponent<ApplicationComponent>();
        builder.AddNotificationHandler<UmbracoApplicationStartingNotification, UmbracoApplicationNotificationHandler>();
        builder.AddNotificationHandler<UmbracoApplicationStartedNotification, UmbracoApplicationNotificationHandler>();
        builder.AddNotificationHandler<UmbracoApplicationStoppingNotification, UmbracoApplicationNotificationHandler>();
        builder.AddNotificationHandler<UmbracoApplicationStoppedNotification, UmbracoApplicationNotificationHandler>();
    }
}

public class ApplicationComponent : IComponent
{
    private readonly ILogger _logger;

    public ApplicationComponent(ILogger<ApplicationComponent> logger) => _logger = logger;

    public void Initialize() => _logger.LogInformation(GetType().Name + ".Initialize");

    public void Terminate() => _logger.LogInformation(GetType().Name + ".Terminate");
}

public class UmbracoApplicationNotificationHandler : INotificationHandler<UmbracoApplicationStartingNotification>, INotificationHandler<UmbracoApplicationStartedNotification>, INotificationHandler<UmbracoApplicationStoppingNotification>, INotificationHandler<UmbracoApplicationStoppedNotification>
{
    private readonly ILogger _logger;

    public UmbracoApplicationNotificationHandler(ILogger<UmbracoApplicationNotificationHandler> logger) => _logger = logger;

    public void Handle(UmbracoApplicationStartingNotification notification) => _logger.LogInformation(notification.GetType().Name);

    public void Handle(UmbracoApplicationStartedNotification notification) => _logger.LogInformation(notification.GetType().Name);

    public void Handle(UmbracoApplicationStoppingNotification notification) => _logger.LogInformation(notification.GetType().Name);

    public void Handle(UmbracoApplicationStoppedNotification notification) => _logger.LogInformation(notification.GetType().Name);
}

public class RuntimeController : UmbracoApiController
{
    private readonly IRuntime _runtime;
    private readonly IHostApplicationLifetime _hostApplicationLifetime;

    public RuntimeController(IRuntime runtime, IHostApplicationLifetime hostApplicationLifetime)
    {
        _runtime = runtime;
        _hostApplicationLifetime = hostApplicationLifetime;
    }

    public async Task Start() => await _runtime.StartAsync(_hostApplicationLifetime.ApplicationStopping);

    public async Task Restart() => await _runtime.RestartAsync();

    public async Task Stop() => await _runtime.StopAsync(_hostApplicationLifetime.ApplicationStopping);

    public void StopApplication() => _hostApplicationLifetime.StopApplication();
}
```