### PR TITLE
11777: Remove sorting because we need the correct order

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/membergrouppicker/membergrouppicker.html
@@ -2,7 +2,7 @@
 
 	<div ng-model="renderModel">
 		<umb-node-preview
-			ng-repeat="node in renderModel | orderBy:'name'"
+			ng-repeat="node in renderModel"
 			icon="node.icon"
 			name="node.name"
 			allow-remove="allowRemove"


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes #11777 

The issue here was that there was an ordering on the name in the template, while the angular code relies on the position of the item.

So, if you were to add in the following order: "Test2", "Test3", "Test1". It would show up as "Test1", "Test2", "Test3" because of the ordering on the name while the data object still used the first ordering. So when you would want to remove "Test2", it would remove "Test3" because it is trying to remove the item on index 1.

I think the ordering on the name isn't needed here anyway, so I removed it.

![Issue-11777](https://user-images.githubusercontent.com/11466511/149403155-67a76c25-64a7-4f2c-9321-390f6ed910b8.gif)

