### PR TITLE
Change cache level for block list value converter (V8)

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         /// <inheritdoc />
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
-            => PropertyCacheLevel.Element;
+            => PropertyCacheLevel.Elements;
 
         /// <inheritdoc />
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)


### PR DESCRIPTION
## Premise

The value converter for the block list currently has it's cache level set to **Element**, which indicates that values should be cached until the page is published again. 

As the block list may be used for referencing other content within Umbraco, I believe it's essential that the cache level is instead changed to **Elements** - indicating that values should only be cached until *any* page in Umbraco is published.

So for instance **Elements**, if page A has a block element (could be a product picker), with references to page B and C (both products), and a user publishes new changes to page B, the changes will be reflected on page A. If the cache level is left at **Element**, the user will also have to republished page A for the changes to have any effect 😱 

## Performance
While this PR simply changes the cache level, I acknowledge this might at least in some way impact the performance for sites with a lot of content, lots of visitors and frequent changes to content in Umbraco.

A perhaps even better solution would perhaps be to add a config option on the data type about the cache level, but no my knowledge, no other data type / value converter in Umbraco has this. It would also require some changes beyond just the value converter.

## Grid
I can see that the grid value converter also sets the cache level to **Element**, so it suffers from the same problem. For our clients, we always use my own grid package, which instead sets the cache level to [**Snapshot**](https://github.com/skybrud/Skybrud.Umbraco.GridData/blob/v4/main/src/Skybrud.Umbraco.GridData/ValueConverters/GridValueConverter.cs) - although it should probably also be **Elements**

## Umbraco 8
For now I'm making this PR for Umbraco 8 in case there will be another patch release for Umbraco 8. If HQ can agree to this change, I will create a similar PR for Umbraco 9.

