### PR TITLE
Prevent Umbraco.Cms package ref adding files to other projects transitively

### DIFF
--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+        <PackageReference Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" PrivateAssets="all" />
         <PackageReference Include="Umbraco.Cms.SqlCe" Version="UMBRACO_VERSION_FROM_TEMPLATE" Condition="'$(UseSqlCe)' == 'true'" />
         <PackageReference Include="Umbraco.SqlServerCE" Version="4.0.0.1" Condition="'$(UseSqlCe)' == 'true'" />
     </ItemGroup>

--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" PrivateAssets="all" />
+        <PackageReference Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" PrivateAssets="contentFiles;analyzers;build;buildTransitive" />
         <PackageReference Include="Umbraco.Cms.SqlCe" Version="UMBRACO_VERSION_FROM_TEMPLATE" Condition="'$(UseSqlCe)' == 'true'" />
         <PackageReference Include="Umbraco.SqlServerCE" Version="4.0.0.1" Condition="'$(UseSqlCe)' == 'true'" />
     </ItemGroup>


### PR DESCRIPTION
Prevents test projects pointing at this from getting generated umbraco files added on build.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
I believe this is the correct fix, certainly worked locally, but I'm no expert on how you guys are writing the umbraco files on build via the `Umbraco.Cms` package.

To test:
1. Generate a project using the template.
2. Add it to a sln
3. Add a unit test project to the sln
4. Add a reference to the cms project (from the unit test project)
5. Build the test project

Expected: Unit test project builds with no side-effects.
Actual: Project builds, but a of files are added (during the build) to the test project (like wwwroot, etc.)

![image](https://user-images.githubusercontent.com/157336/149810748-5f9d7f08-5b28-4da3-afa2-702e000c7e66.png)


It would seem the Umbraco nuget package has `build` assets included, specifically probably a .target file, that copies some Umbraco static files into the project. The problem is that behavior shouldn't be "inherited" as a transitive dependency (i.e. in the unit project).