### PR TITLE
Add IsRestarting property to Umbraco application notifications

### DIFF
--- a/src/Umbraco.Core/Notifications/IUmbracoApplicationLifetimeNotification.cs
+++ b/src/Umbraco.Core/Notifications/IUmbracoApplicationLifetimeNotification.cs
@@ -1,0 +1,17 @@
+namespace Umbraco.Cms.Core.Notifications
+{
+    /// <summary>
+    /// Represents an Umbraco application lifetime (starting, started, stopping, stopped) notification.
+    /// </summary>
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
+    public interface IUmbracoApplicationLifetimeNotification : INotification
+    {
+        /// <summary>
+        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRestarting { get; }
+    }
+}

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartedNotification.cs
@@ -3,28 +3,16 @@ namespace Umbraco.Cms.Core.Notifications
     /// <summary>
     /// Notification that occurs when Umbraco has completely booted up and the request processing pipeline is configured.
     /// </summary>
-    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
-    public class UmbracoApplicationStartedNotification : INotification
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.IUmbracoApplicationLifetimeNotification" />
+    public class UmbracoApplicationStartedNotification : IUmbracoApplicationLifetimeNotification
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoApplicationStartedNotification" /> class.
-        /// </summary>
-        public UmbracoApplicationStartedNotification()
-            : this(false)
-        { }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApplicationStartedNotification" /> class.
         /// </summary>
         /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
         public UmbracoApplicationStartedNotification(bool isRestarting) => IsRestarting = isRestarting;
 
-        /// <summary>
-        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
-        /// </value>
+        /// <inheritdoc />
         public bool IsRestarting { get; }
     }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartedNotification.cs
@@ -5,5 +5,26 @@ namespace Umbraco.Cms.Core.Notifications
     /// </summary>
     /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
     public class UmbracoApplicationStartedNotification : INotification
-    { }
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStartedNotification" /> class.
+        /// </summary>
+        public UmbracoApplicationStartedNotification()
+            : this(false)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStartedNotification" /> class.
+        /// </summary>
+        /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
+        public UmbracoApplicationStartedNotification(bool isRestarting) => IsRestarting = isRestarting;
+
+        /// <summary>
+        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRestarting { get; }
+    }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
@@ -10,7 +10,20 @@ namespace Umbraco.Cms.Core.Notifications
         /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
         /// </summary>
         /// <param name="runtimeLevel">The runtime level</param>
-        public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel) => RuntimeLevel = runtimeLevel;
+        public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel)
+            : this(runtimeLevel, false)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
+        /// </summary>
+        /// <param name="runtimeLevel">The runtime level</param>
+        /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
+        public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel, bool isRestarting)
+        {
+            RuntimeLevel = runtimeLevel;
+            IsRestarting = isRestarting;
+        }
 
         /// <summary>
         /// Gets the runtime level.
@@ -19,5 +32,13 @@ namespace Umbraco.Cms.Core.Notifications
         /// The runtime level.
         /// </value>
         public RuntimeLevel RuntimeLevel { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRestarting { get; }
     }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
@@ -1,18 +1,23 @@
+using System;
+
 namespace Umbraco.Cms.Core.Notifications
 {
     /// <summary>
     /// Notification that occurs at the very end of the Umbraco boot process (after all <see cref="IComponent" />s are initialized).
     /// </summary>
-    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
-    public class UmbracoApplicationStartingNotification : INotification
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.IUmbracoApplicationLifetimeNotification" />
+    public class UmbracoApplicationStartingNotification : IUmbracoApplicationLifetimeNotification
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
         /// </summary>
         /// <param name="runtimeLevel">The runtime level</param>
+        [Obsolete("Use ctor with all params")]
         public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel)
             : this(runtimeLevel, false)
-        { }
+        {
+            // TODO: Remove this constructor in V10
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
@@ -33,12 +38,7 @@ namespace Umbraco.Cms.Core.Notifications
         /// </value>
         public RuntimeLevel RuntimeLevel { get; }
 
-        /// <summary>
-        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
-        /// </value>
+        /// <inheritdoc />
         public bool IsRestarting { get; }
     }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppedNotification.cs
@@ -3,28 +3,16 @@ namespace Umbraco.Cms.Core.Notifications
     /// <summary>
     /// Notification that occurs when Umbraco has completely shutdown.
     /// </summary>
-    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
-    public class UmbracoApplicationStoppedNotification : INotification
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.IUmbracoApplicationLifetimeNotification" />
+    public class UmbracoApplicationStoppedNotification : IUmbracoApplicationLifetimeNotification
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoApplicationStoppedNotification" /> class.
-        /// </summary>
-        public UmbracoApplicationStoppedNotification()
-            : this(false)
-        { }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApplicationStoppedNotification" /> class.
         /// </summary>
         /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
         public UmbracoApplicationStoppedNotification(bool isRestarting) => IsRestarting = isRestarting;
 
-        /// <summary>
-        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
-        /// </value>
+        /// <inheritdoc />
         public bool IsRestarting { get; }
     }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppedNotification.cs
@@ -5,5 +5,26 @@ namespace Umbraco.Cms.Core.Notifications
     /// </summary>
     /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
     public class UmbracoApplicationStoppedNotification : INotification
-    { }
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStoppedNotification" /> class.
+        /// </summary>
+        public UmbracoApplicationStoppedNotification()
+            : this(false)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStoppedNotification" /> class.
+        /// </summary>
+        /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
+        public UmbracoApplicationStoppedNotification(bool isRestarting) => IsRestarting = isRestarting;
+
+        /// <summary>
+        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRestarting { get; }
+    }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
@@ -5,5 +5,26 @@ namespace Umbraco.Cms.Core.Notifications
     /// </summary>
     /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
     public class UmbracoApplicationStoppingNotification : INotification
-    { }
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStoppingNotification" /> class.
+        /// </summary>
+        public UmbracoApplicationStoppingNotification()
+            : this(false)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoApplicationStoppingNotification" /> class.
+        /// </summary>
+        /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
+        public UmbracoApplicationStoppingNotification(bool isRestarting) => IsRestarting = isRestarting;
+
+        /// <summary>
+        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRestarting { get; }
+    }
 }

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
@@ -1,17 +1,22 @@
+using System;
+
 namespace Umbraco.Cms.Core.Notifications
 {
     /// <summary>
     /// Notification that occurs when Umbraco is shutting down (after all <see cref="IComponent" />s are terminated).
     /// </summary>
-    /// <seealso cref="Umbraco.Cms.Core.Notifications.INotification" />
-    public class UmbracoApplicationStoppingNotification : INotification
+    /// <seealso cref="Umbraco.Cms.Core.Notifications.IUmbracoApplicationLifetimeNotification" />
+    public class UmbracoApplicationStoppingNotification : IUmbracoApplicationLifetimeNotification
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApplicationStoppingNotification" /> class.
         /// </summary>
+        [Obsolete("Use ctor with all params")]
         public UmbracoApplicationStoppingNotification()
             : this(false)
-        { }
+        {
+            // TODO: Remove this constructor in V10
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoApplicationStoppingNotification" /> class.
@@ -19,12 +24,7 @@ namespace Umbraco.Cms.Core.Notifications
         /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
         public UmbracoApplicationStoppingNotification(bool isRestarting) => IsRestarting = isRestarting;
 
-        /// <summary>
-        /// Gets a value indicating whether Umbraco is restarting (e.g. after an install or upgrade).
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if Umbraco is restarting; otherwise, <c>false</c>.
-        /// </value>
+        /// <inheritdoc />
         public bool IsRestarting { get; }
     }
 }

--- a/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
@@ -153,11 +153,11 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             // Store token, so we can re-use this during restart
             _cancellationToken = cancellationToken;
 
-            StaticApplicationLogging.Initialize(_loggerFactory);
-            StaticServiceProvider.Instance = _serviceProvider;
-
             if (isRestarting == false)
             {
+                StaticApplicationLogging.Initialize(_loggerFactory);
+                StaticServiceProvider.Instance = _serviceProvider;
+
                 AppDomain.CurrentDomain.UnhandledException += (_, args)
                     => _logger.LogError(args.ExceptionObject as Exception, $"Unhandled exception in AppDomain{(args.IsTerminating ? " (terminating)" : null)}.");
             }
@@ -226,7 +226,6 @@ namespace Umbraco.Cms.Infrastructure.Runtime
         {
             _components.Terminate();
             await _eventAggregator.PublishAsync(new UmbracoApplicationStoppingNotification(isRestarting), cancellationToken);
-            StaticApplicationLogging.Initialize(null);
         }
 
         private void AcquireMainDom()

--- a/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
@@ -173,8 +173,8 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             // Add application started and stopped notifications (only on initial startup, not restarts)
             if (_hostApplicationLifetime.ApplicationStarted.IsCancellationRequested == false)
             {
-                _hostApplicationLifetime.ApplicationStarted.Register(() => _eventAggregator.Publish(new UmbracoApplicationStartedNotification()));
-                _hostApplicationLifetime.ApplicationStopped.Register(() => _eventAggregator.Publish(new UmbracoApplicationStoppedNotification()));
+                _hostApplicationLifetime.ApplicationStarted.Register(() => _eventAggregator.Publish(new UmbracoApplicationStartedNotification(false)));
+                _hostApplicationLifetime.ApplicationStopped.Register(() => _eventAggregator.Publish(new UmbracoApplicationStoppedNotification(false)));
             }
 
             // acquire the main domain - if this fails then anything that should be registered with MainDom will not operate


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is a minor addition to PR https://github.com/umbraco/Umbraco-CMS/pull/11857 that adds a very useful `IsRestarting` property to the `UmbracoApplicationStartingNotification`, `UmbracoApplicationStartedNotification`, `UmbracoApplicationStoppingNotification` and `UmbracoApplicationStoppedNotification`.

In 'normal' applications the running process is killed when it's stopped (and the application state is clean when started again), but that's not the case when Umbraco restarts: it's only stopping and starting the runtime, not the whole application.

So if you only want to execute some code on the initial startup of Umbraco, handling the `UmbracoApplicationStartingNotification` could result in running it twice when Umbraco has installed or upgraded (as that's when the Umbraco runtime gets restarted). In hindsight, we should've probably named these `UmbracoRuntime...Notification` instead 🤡

Testing can be done using the same steps as described in the related PR, but you can replace the `UmbracoApplicationNotificationHandler` with the class below to log the value of the new property:

```c#
public class UmbracoApplicationNotificationHandler : INotificationHandler<UmbracoApplicationStartingNotification>, INotificationHandler<UmbracoApplicationStartedNotification>, INotificationHandler<UmbracoApplicationStoppingNotification>, INotificationHandler<UmbracoApplicationStoppedNotification>
{
    private readonly ILogger _logger;

    public UmbracoApplicationNotificationHandler(ILogger<UmbracoApplicationNotificationHandler> logger) => _logger = logger;

    public void Handle(UmbracoApplicationStartingNotification notification) => Log(notification, notification.IsRestarting);

    public void Handle(UmbracoApplicationStartedNotification notification) => Log(notification, notification.IsRestarting);

    public void Handle(UmbracoApplicationStoppingNotification notification) => Log(notification, notification.IsRestarting);

    public void Handle(UmbracoApplicationStoppedNotification notification) => Log(notification, notification.IsRestarting);

    private void Log(INotification notification, bool isRestarting) => _logger.LogInformation("{Type} - {IsRestarting}", notification.GetType().Name, isRestarting);
}
```