### PR TITLE
Fix importing DocType if parent folder already exists

### DIFF
--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -575,21 +575,22 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         {
             var importedFolders = new Dictionary<string, int>();
             var trackEntityContainersInstalled = new List<EntityContainer>();
-            foreach (var documentType in unsortedDocumentTypes)
+
+            foreach (XElement documentType in unsortedDocumentTypes)
             {
-                var foldersAttribute = documentType.Attribute("Folders");
-                var infoElement = documentType.Element("Info");
+                XAttribute foldersAttribute = documentType.Attribute("Folders");
+                XElement infoElement = documentType.Element("Info");
                 if (foldersAttribute != null && infoElement != null
-                    //don't import any folder if this is a child doc type - the parent doc type will need to
-                    //exist which contains it's folders
+                    // don't import any folder if this is a child doc type - the parent doc type will need to
+                    // exist which contains it's folders
                     && ((string)infoElement.Element("Master")).IsNullOrWhiteSpace())
                 {
                     var alias = documentType.Element("Info").Element("Alias").Value;
                     var folders = foldersAttribute.Value.Split(Constants.CharArrays.ForwardSlash);
 
-                    var folderKeysAttribute = documentType.Attribute("FolderKeys");
+                    XAttribute folderKeysAttribute = documentType.Attribute("FolderKeys");
 
-                    var folderKeys = Array.Empty<Guid>();
+                    Guid[] folderKeys = Array.Empty<Guid>();
                     if (folderKeysAttribute != null)
                     {
                         folderKeys = folderKeysAttribute.Value.Split(Constants.CharArrays.ForwardSlash).Select(x=>Guid.Parse(x)).ToArray();
@@ -597,22 +598,22 @@ namespace Umbraco.Cms.Infrastructure.Packaging
 
                     var rootFolder = WebUtility.UrlDecode(folders[0]);
 
-                    EntityContainer current;
+                    EntityContainer current = null;
                     Guid? rootFolderKey = null;
                     if (folderKeys.Length == folders.Length && folderKeys.Length > 0)
                     {
                         rootFolderKey = folderKeys[0];
                         current = _contentTypeService.GetContainer(rootFolderKey.Value);
                     }
-                    else
-                    {
-                        //level 1 = root level folders, there can only be one with the same name
-                        current = _contentTypeService.GetContainers(rootFolder, 1).FirstOrDefault();
-                    }
+
+                    // The folder might already exists, but with a different key, so check if it exists, even if there is a key.
+                    // Level 1 = root level folders, there can only be one with the same name
+                    current ??= _contentTypeService.GetContainers(rootFolder, 1).FirstOrDefault();
 
                     if (current == null)
                     {
-                        var tryCreateFolder = _contentTypeService.CreateContainer(-1, rootFolderKey ?? Guid.NewGuid(), rootFolder);
+                        Attempt<OperationResult<OperationResultType, EntityContainer>> tryCreateFolder =
+                            _contentTypeService.CreateContainer(-1, rootFolderKey ?? Guid.NewGuid(), rootFolder);
                         if (tryCreateFolder == false)
                         {
                             _logger.LogError(tryCreateFolder.Exception, "Could not create folder: {FolderName}", rootFolder);
@@ -644,7 +645,7 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         private EntityContainer CreateContentTypeChildFolder(string folderName, Guid folderKey, IUmbracoEntity current)
         {
             var children = _entityService.GetChildren(current.Id).ToArray();
-            var found = children.Any(x => x.Name.InvariantEquals(folderName) ||x.Key.Equals(folderKey));
+            var found = children.Any(x => x.Name.InvariantEquals(folderName) || x.Key.Equals(folderKey));
             if (found)
             {
                 var containerId = children.Single(x => x.Name.InvariantEquals(folderName)).Id;


### PR DESCRIPTION
Fixes #11772 

## Description

If you exported a document type within a folder from site A, and tried to import it into site B, where a folder with the same name already exists it would cause an error.

This is because when importing a document type/package, we'd check if a folder with that folder *key* already exists, if it doesn't we'd try to create the folder. 

Problem is that folder keys are not consistent across sites. To fix this I've changed it so we first check if there is a folder with the same *key*, if there isn't, we check if there already exists a folder with the same name, even if a key is provided. If a folder with the same name already exists, we just use that one.

## Testing
* Follow steps to reproduce in linked issue, not that the doc types should be generated from a separate site
* Ensure it also works on different levels, so a doc type within a folder within a folder, where the folders already exists
* Ensure the folders are still created if they don't exist