### PR TITLE
Fix URL with culture

### DIFF
--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -134,8 +134,13 @@ namespace Umbraco.Cms.Core.Routing
             return GetUrlFromRoute(route, umbracoContext, content.Id, current, mode, culture);
         }
 
-        internal UrlInfo GetUrlFromRoute(string route, IUmbracoContext umbracoContext, int id, Uri current,
-            UrlMode mode, string culture)
+        internal UrlInfo GetUrlFromRoute(
+            string route,
+            IUmbracoContext umbracoContext,
+            int id,
+            Uri current,
+            UrlMode mode,
+            string culture)
         {
             if (string.IsNullOrWhiteSpace(route))
             {
@@ -149,12 +154,12 @@ namespace Umbraco.Cms.Core.Routing
             // route is /<path> or <domainRootId>/<path>
             var pos = route.IndexOf('/');
             var path = pos == 0 ? route : route.Substring(pos);
-            var domainUri = pos == 0
+            DomainAndUri domainUri = pos == 0
                 ? null
                 : DomainUtilities.DomainForNode(umbracoContext.PublishedSnapshot.Domains, _siteDomainMapper, int.Parse(route.Substring(0, pos), CultureInfo.InvariantCulture), current, culture);
 
             var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();
-            if (domainUri is not null || culture == defaultCulture || culture is null)
+            if (domainUri is not null || culture is null || culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
             {
                 var url = AssembleUrl(domainUri, path, current, mode).ToString();
                 return UrlInfo.Url(url, culture);

--- a/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Umbraco.Cms.Core.PublishedCache;
 
@@ -9,7 +10,8 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
         {
             var assigned = domainCache.GetAssigned(documentId, includeWildcards);
 
-            return culture is null ? assigned.Any() : assigned.Any(x => x.Culture == culture);
+            // It's super important that we always compare cultures with ignore case, since we can't be sure of the casing!
+            return culture is null ? assigned.Any() : assigned.Any(x => x.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
Fixes #11687

The issue is that in multilingual setups `Model.Url(culture)` might return nothing (#), depending on the casing of the culture.

The issue was that when we initially create the route for the cache in `ContentCache.GetRouteByIdInternal`, we have a check:

```
var hasDomains = _domainCache.GetAssignedWithCulture(culture, n.Id);
```

this method `GetAssignedWithCulture`, tries to find a domain with the culture in all the domains in the cache, however this check was done without ignoring casing, leading to the route being unable to be created, this PR fixes this by ignoring the casing in the check.

Additionally I've added a minor fix where we tried to match the culture to the default culture, again without ignoring casing. 


## Testing 

Same as the original issue: 

1. Set up a basic 2 language multi-lingual site, be aware that the culture should have a hypen, since it'll be all lowercase regardless, I used Canadian French like the original issue 
2. Create a very basic document type for a home page that varies by culture
3. Setup domains for each culture
4. Save and publish each culture
5. Create add the code below to a template
6. Ensure that all urls are rendered.

### Template snippet
```
<div>
    Cultures Loop:<br>
    @foreach (var (culture, infos) in Model.Cultures)
    {
<ul>
    <li>Culture: @culture.ToString()</li>
    <li>Model.Url(culture): @Model.Url(culture)</li>
    <li>Model.Url(culture): @Model.UrlSegment(culture)</li>
</ul>
    }
</div>
```