### PR TITLE
V8: Add ability to implement your own HtmlSanitizer

### DIFF
--- a/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
+++ b/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
@@ -6,6 +6,7 @@ using Umbraco.Core.Events;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Packaging;
+using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
 using Umbraco.Core.Telemetry;
@@ -81,6 +82,7 @@ namespace Umbraco.Core.Composing.CompositionExtensions
                     new DirectoryInfo(IOHelper.GetRootDirectorySafe())));
 
             composition.RegisterUnique<ITelemetryService, TelemetryService>();
+            composition.RegisterUnique<IHtmlSanitizer, NoOpHtmlSanitizer>();
 
             return composition;
         }

--- a/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
+++ b/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Core.Composing.CompositionExtensions
                     new DirectoryInfo(IOHelper.GetRootDirectorySafe())));
 
             composition.RegisterUnique<ITelemetryService, TelemetryService>();
-            composition.RegisterUnique<IHtmlSanitizer, NoOpHtmlSanitizer>();
+            composition.RegisterUnique<IHtmlSanitizer, NoopHtmlSanitizer>();
 
             return composition;
         }

--- a/src/Umbraco.Core/Security/IHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/IHtmlSanitizer.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Core.Security
+{
+    public interface IHtmlSanitizer
+    {
+        string Sanitize(string html);
+    }
+}

--- a/src/Umbraco.Core/Security/IHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/IHtmlSanitizer.cs
@@ -2,6 +2,11 @@ namespace Umbraco.Core.Security
 {
     public interface IHtmlSanitizer
     {
+        /// <summary>
+        /// Sanitizes HTML
+        /// </summary>
+        /// <param name="html">HTML to be sanitized</param>
+        /// <returns>Sanitized HTML</returns>
         string Sanitize(string html);
     }
 }

--- a/src/Umbraco.Core/Security/NoOpHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/NoOpHtmlSanitizer.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Core.Security
+{
+    public class NoOpHtmlSanitizer : IHtmlSanitizer
+    {
+        public string Sanitize(string html)
+        {
+            return html;
+        }
+    }
+}

--- a/src/Umbraco.Core/Security/NoopHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/NoopHtmlSanitizer.cs
@@ -1,6 +1,6 @@
 namespace Umbraco.Core.Security
 {
-    public class NoOpHtmlSanitizer : IHtmlSanitizer
+    public class NoopHtmlSanitizer : IHtmlSanitizer
     {
         public string Sanitize(string html)
         {

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -195,7 +195,7 @@
     <Compile Include="PropertyEditors\IPropertyCacheCompression.cs" />
     <Compile Include="PropertyEditors\UnPublishedContentPropertyCacheCompressionOptions.cs" />
     <Compile Include="Security\IHtmlSanitizer.cs" />
-    <Compile Include="Security\NoOpHtmlSanitizer.cs" />
+    <Compile Include="Security\NoopHtmlSanitizer.cs" />
     <Compile Include="Serialization\AutoInterningStringConverter.cs" />
     <Compile Include="Serialization\AutoInterningStringKeyCaseInsensitiveDictionaryConverter.cs" />
     <Compile Include="PropertyEditors\EyeDropperColorPickerConfiguration.cs" />

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -194,6 +194,8 @@
     <Compile Include="PropertyEditors\PropertyCacheCompression.cs" />
     <Compile Include="PropertyEditors\IPropertyCacheCompression.cs" />
     <Compile Include="PropertyEditors\UnPublishedContentPropertyCacheCompressionOptions.cs" />
+    <Compile Include="Security\IHtmlSanitizer.cs" />
+    <Compile Include="Security\NoOpHtmlSanitizer.cs" />
     <Compile Include="Serialization\AutoInterningStringConverter.cs" />
     <Compile Include="Serialization\AutoInterningStringKeyCaseInsensitiveDictionaryConverter.cs" />
     <Compile Include="PropertyEditors\EyeDropperColorPickerConfiguration.cs" />

--- a/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
+++ b/src/Umbraco.Tests/PublishedContent/PublishedContentTests.cs
@@ -16,6 +16,7 @@ using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
+using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Tests.TestHelpers;
 using Umbraco.Tests.Testing;
@@ -54,7 +55,7 @@ namespace Umbraco.Tests.PublishedContent
             var dataTypeService = new TestObjects.TestDataTypeService(
                 new DataType(new VoidEditor(logger)) { Id = 1 },
                 new DataType(new TrueFalsePropertyEditor(logger)) { Id = 1001 },
-                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, linkParser, pastedImages, Mock.Of<IImageUrlGenerator>())) { Id = 1002 },
+                new DataType(new RichTextPropertyEditor(logger, umbracoContextAccessor, imageSourceParser, linkParser, pastedImages, Mock.Of<IImageUrlGenerator>(), Mock.Of<IHtmlSanitizer>())) { Id = 1002 },
                 new DataType(new IntegerPropertyEditor(logger)) { Id = 1003 },
                 new DataType(new TextboxPropertyEditor(logger)) { Id = 1004 },
                 new DataType(new MediaPickerPropertyEditor(logger)) { Id = 1005 });

--- a/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs
@@ -8,6 +8,7 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Editors;
 using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Security;
 using Umbraco.Core.Services;
 using Umbraco.Web.Templates;
 
@@ -32,8 +33,9 @@ namespace Umbraco.Web.PropertyEditors
         private readonly RichTextEditorPastedImages _pastedImages;
         private readonly HtmlLocalLinkParser _localLinkParser;
         private readonly IImageUrlGenerator _imageUrlGenerator;
+        private readonly IHtmlSanitizer _htmlSanitizer;
 
-        [Obsolete("Use the constructor which takes an IImageUrlGenerator")]
+        [Obsolete("Use the constructor which takes an IHtmlSanitizer")]
         public GridPropertyEditor(ILogger logger,
             IUmbracoContextAccessor umbracoContextAccessor,
             HtmlImageSourceParser imageSourceParser,
@@ -43,12 +45,24 @@ namespace Umbraco.Web.PropertyEditors
         {
         }
 
+        [Obsolete("Use the constructor which takes an IHtmlSanitizer")]
         public GridPropertyEditor(ILogger logger,
             IUmbracoContextAccessor umbracoContextAccessor,
             HtmlImageSourceParser imageSourceParser,
             RichTextEditorPastedImages pastedImages,
             HtmlLocalLinkParser localLinkParser,
             IImageUrlGenerator imageUrlGenerator)
+            : this(logger, umbracoContextAccessor, imageSourceParser, pastedImages, localLinkParser, imageUrlGenerator, Current.Factory.GetInstance<IHtmlSanitizer>())
+        {
+        }
+
+        public GridPropertyEditor(ILogger logger,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            HtmlImageSourceParser imageSourceParser,
+            RichTextEditorPastedImages pastedImages,
+            HtmlLocalLinkParser localLinkParser,
+            IImageUrlGenerator imageUrlGenerator,
+            IHtmlSanitizer htmlSanitizer)
             : base(logger)
         {
             _umbracoContextAccessor = umbracoContextAccessor;
@@ -56,6 +70,7 @@ namespace Umbraco.Web.PropertyEditors
             _pastedImages = pastedImages;
             _localLinkParser = localLinkParser;
             _imageUrlGenerator = imageUrlGenerator;
+            _htmlSanitizer = htmlSanitizer;
         }
 
         public override IPropertyIndexValueFactory PropertyIndexValueFactory => new GridPropertyIndexValueFactory();
@@ -64,7 +79,7 @@ namespace Umbraco.Web.PropertyEditors
         /// Overridden to ensure that the value is validated
         /// </summary>
         /// <returns></returns>
-        protected override IDataValueEditor CreateValueEditor() => new GridPropertyValueEditor(Attribute, _umbracoContextAccessor, _imageSourceParser, _pastedImages, _localLinkParser, _imageUrlGenerator);
+        protected override IDataValueEditor CreateValueEditor() => new GridPropertyValueEditor(Attribute, _umbracoContextAccessor, _imageSourceParser, _pastedImages, _localLinkParser, _imageUrlGenerator, _htmlSanitizer);
 
         protected override IConfigurationEditor CreateConfigurationEditor() => new GridConfigurationEditor();
 
@@ -77,7 +92,7 @@ namespace Umbraco.Web.PropertyEditors
             private readonly MediaPickerPropertyEditor.MediaPickerPropertyValueEditor _mediaPickerPropertyValueEditor;
             private readonly IImageUrlGenerator _imageUrlGenerator;
 
-            [Obsolete("Use the constructor which takes an IImageUrlGenerator")]
+            [Obsolete("Use the constructor which takes an IHtmlSanitizer")]
             public GridPropertyValueEditor(DataEditorAttribute attribute,
                 IUmbracoContextAccessor umbracoContextAccessor,
                 HtmlImageSourceParser imageSourceParser,
@@ -87,20 +102,32 @@ namespace Umbraco.Web.PropertyEditors
             {
             }
 
+            [Obsolete("Use the constructor which takes an IHtmlSanitizer")]
             public GridPropertyValueEditor(DataEditorAttribute attribute,
                 IUmbracoContextAccessor umbracoContextAccessor,
                 HtmlImageSourceParser imageSourceParser,
                 RichTextEditorPastedImages pastedImages,
                 HtmlLocalLinkParser localLinkParser,
                 IImageUrlGenerator imageUrlGenerator)
+                : this(attribute, umbracoContextAccessor, imageSourceParser, pastedImages, localLinkParser, imageUrlGenerator, Current.Factory.GetInstance<IHtmlSanitizer>())
+            {
+            }
+
+            public GridPropertyValueEditor(DataEditorAttribute attribute,
+                IUmbracoContextAccessor umbracoContextAccessor,
+                HtmlImageSourceParser imageSourceParser,
+                RichTextEditorPastedImages pastedImages,
+                HtmlLocalLinkParser localLinkParser,
+                IImageUrlGenerator imageUrlGenerator,
+                IHtmlSanitizer htmlSanitizer)
                 : base(attribute)
             {
                 _umbracoContextAccessor = umbracoContextAccessor;
                 _imageSourceParser = imageSourceParser;
                 _pastedImages = pastedImages;
-                _richTextPropertyValueEditor = new RichTextPropertyEditor.RichTextPropertyValueEditor(attribute, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, _imageUrlGenerator);
-                _mediaPickerPropertyValueEditor = new MediaPickerPropertyEditor.MediaPickerPropertyValueEditor(attribute);
                 _imageUrlGenerator = imageUrlGenerator;
+                _richTextPropertyValueEditor = new RichTextPropertyEditor.RichTextPropertyValueEditor(attribute, umbracoContextAccessor, imageSourceParser, localLinkParser, pastedImages, _imageUrlGenerator, htmlSanitizer);
+                _mediaPickerPropertyValueEditor = new MediaPickerPropertyEditor.MediaPickerPropertyValueEditor(attribute);
             }
 
             /// <summary>


### PR DESCRIPTION
* Adds IHtmlSanitizer interface to be replaced in DI
* Adds NoOpHtmlSanitizer as a default placeholder
* Use IHtmlSanitizer in RTE when persisted to DB

This PR allows people to implement their own HTML sanitizer which will be used server side when storing the output of the RTE in the database.

## Testing

* Implement a custom test `IHtmlSanitizer` and register it in DI with a composer
* Ensure the output of the sanitizer is what's stored in the database, and therefore displayed on the frontend

## Appendix

I used this code to test with:

```c#
using Umbraco.Core;
using Umbraco.Core.Composing;
using Umbraco.Core.Security;

namespace Umbraco.Web.UI
{
    public class CustomSanitizer : IHtmlSanitizer
    {
        public string Sanitize(string html)
        {
            return "<h1>Custom value</h1>";
        }
    }

    public class MyComposer : IComposer
    {
        public void Compose(Composition composition)
        {
            composition.RegisterUnique<IHtmlSanitizer, CustomSanitizer>();
        }
    }
}
```


