### PR TITLE
V9: Add ability to implement your own HtmlSanitizer

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -263,6 +263,9 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             // Register telemetry service used to gather data about installed packages
             Services.AddUnique<ITelemetryService, TelemetryService>();
+
+            // Register a noop IHtmlSanitizer to be replaced
+            Services.AddUnique<IHtmlSanitizer, NoopHtmlSanitizer>();
         }
     }
 }

--- a/src/Umbraco.Core/Security/IHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/IHtmlSanitizer.cs
@@ -1,4 +1,4 @@
-namespace Umbraco.Core.Security
+namespace Umbraco.Cms.Core.Security
 {
     public interface IHtmlSanitizer
     {

--- a/src/Umbraco.Core/Security/IHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/IHtmlSanitizer.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Core.Security
+{
+    public interface IHtmlSanitizer
+    {
+        string Sanitize(string html);
+    }
+}

--- a/src/Umbraco.Core/Security/IHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/IHtmlSanitizer.cs
@@ -2,6 +2,11 @@ namespace Umbraco.Core.Security
 {
     public interface IHtmlSanitizer
     {
+        /// <summary>
+        /// Sanitizes HTML
+        /// </summary>
+        /// <param name="html">HTML to be sanitized</param>
+        /// <returns>Sanitized HTML</returns>
         string Sanitize(string html);
     }
 }

--- a/src/Umbraco.Core/Security/NoOpHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/NoOpHtmlSanitizer.cs
@@ -1,4 +1,4 @@
-namespace Umbraco.Core.Security
+namespace Umbraco.Cms.Core.Security
 {
     public class NoOpHtmlSanitizer : IHtmlSanitizer
     {

--- a/src/Umbraco.Core/Security/NoOpHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/NoOpHtmlSanitizer.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Core.Security
+{
+    public class NoOpHtmlSanitizer : IHtmlSanitizer
+    {
+        public string Sanitize(string html)
+        {
+            return html;
+        }
+    }
+}

--- a/src/Umbraco.Core/Security/NoopHtmlSanitizer.cs
+++ b/src/Umbraco.Core/Security/NoopHtmlSanitizer.cs
@@ -1,6 +1,6 @@
 namespace Umbraco.Cms.Core.Security
 {
-    public class NoOpHtmlSanitizer : IHtmlSanitizer
+    public class NoopHtmlSanitizer : IHtmlSanitizer
     {
         public string Sanitize(string html)
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -81,6 +81,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             private readonly HtmlLocalLinkParser _localLinkParser;
             private readonly RichTextEditorPastedImages _pastedImages;
             private readonly IImageUrlGenerator _imageUrlGenerator;
+            private readonly IHtmlSanitizer _htmlSanitizer;
 
             public RichTextPropertyValueEditor(
                 DataEditorAttribute attribute,
@@ -92,7 +93,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 RichTextEditorPastedImages pastedImages,
                 IImageUrlGenerator imageUrlGenerator,
                 IJsonSerializer jsonSerializer,
-                IIOHelper ioHelper)
+                IIOHelper ioHelper,
+                IHtmlSanitizer htmlSanitizer)
                 : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
             {
                 _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -100,6 +102,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 _localLinkParser = localLinkParser;
                 _pastedImages = pastedImages;
                 _imageUrlGenerator = imageUrlGenerator;
+                _htmlSanitizer = htmlSanitizer;
             }
 
             /// <inheritdoc />
@@ -156,8 +159,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 var parseAndSavedTempImages = _pastedImages.FindAndPersistPastedTempImages(editorValue.Value.ToString(), mediaParentId, userId, _imageUrlGenerator);
                 var editorValueWithMediaUrlsRemoved = _imageSourceParser.RemoveImageSources(parseAndSavedTempImages);
                 var parsed = MacroTagParser.FormatRichTextContentForPersistence(editorValueWithMediaUrlsRemoved);
+                var sanitized = _htmlSanitizer.Sanitize(parsed);
 
-                return parsed.NullOrWhiteSpaceAsNull();
+                return sanitized.NullOrWhiteSpaceAsNull();
             }
 
             /// <summary>


### PR DESCRIPTION
Migrates #11897 to V9

See original PR for more information, including testing steps.

I've updated the constructor of `RichTextPropertyValueEditor`, however this class is internal, so it shouldn't be a breaking change.

## Test code

```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Security;
using Umbraco.Extensions;

namespace Umbraco.Cms.Web.UI
{
    public class CustomSanitizer : IHtmlSanitizer
    {
        public string Sanitize(string html) => "<h1>Custom value</h1>";
    }

    public class MyComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder) => builder.Services.AddUnique<IHtmlSanitizer, CustomSanitizer>();
    }
}
```