### PR TITLE
fixes umbraco logo appearance on backoffice login page, issue #11830

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -30,6 +30,7 @@
     position: absolute;
     top: 22px;
     left: 25px;
+    width: 30px;
     height: 30px;
     z-index: 1;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -30,7 +30,7 @@
     position: absolute;
     top: 22px;
     left: 25px;
-    width: 30px;
+    min-width: 30px;
     height: 30px;
     z-index: 1;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes #11830 

### Description

The Umbraco Logo could not be seen because it's containing element had no intrinsic width. By adding a width value, the logo will render correctly.
