### PR TITLE
new stick top position for rte toolbar if tabs are present, issue #11870

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -38,6 +38,10 @@
 .umb-rte .mce-top-part {
 	position: sticky;
 	top: 0;
+
+  umb-editor-tab-bar ~ div & {
+    top: 50px;
+  }
 }
 
 /* make sure the menu wraps */


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes #11870

### Description

The tab nav bar takes up a height of `50px`. So we need to adjust the sticky top position for the RTE toolbar accordingly.

I updated this:

```
.umb-rte .mce-top-part {
	position: sticky;
	top: 0;
}
```

To this:

```
.umb-rte .mce-top-part {
	position: sticky;
	top: 0;

  umb-editor-tab-bar ~ div & {
    top: 50px;
  }
}
```

I didn't see an easier way to detect whether the RTE is contained inside of a tab. So I used the sibling selector.


### Recordings

The following recordings show two use cases. 

**Left side** shows an RTE on the page under a tab.

**Right side** shows an RTE with no tabs.

**Desktop:**

https://user-images.githubusercontent.com/713355/150907350-731ca8fb-8b00-4389-9785-722d06ba7ca2.mp4

**Mobile:**

https://user-images.githubusercontent.com/713355/150907354-3727b8c6-ad39-4d8e-8a71-58fbd56e4b1e.mp4



