### PR TITLE
Get multiple with keys function for dictionary items

### DIFF
--- a/src/Umbraco.Core/Cache/RepositoryCachePolicyOptions.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCachePolicyOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Umbraco.Cms.Core.Cache
 {

--- a/src/Umbraco.Core/Persistence/Repositories/IDictionaryRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDictionaryRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Models;
 
@@ -8,6 +8,7 @@ namespace Umbraco.Cms.Core.Persistence.Repositories
     {
         IDictionaryItem Get(Guid uniqueId);
         IDictionaryItem Get(string key);
+        IEnumerable<IDictionaryItem> Get(string[] keys);
         IEnumerable<IDictionaryItem> GetDictionaryItemDescendants(Guid? parentId);
         Dictionary<string, Guid> GetDictionaryItemKeyMap();
     }

--- a/src/Umbraco.Core/Services/ILocalizationService.cs
+++ b/src/Umbraco.Core/Services/ILocalizationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Models;
 
@@ -53,6 +53,8 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="key">Key of the <see cref="IDictionaryItem"/></param>
         /// <returns><see cref="IDictionaryItem"/></returns>
         IDictionaryItem GetDictionaryItemByKey(string key);
+
+        IDictionaryItem[] GetDictionaryItemsByKeys(string[] keys);
 
         /// <summary>
         /// Gets a list of children for a <see cref="IDictionaryItem"/>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -407,8 +407,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                     //allow zero to be cached
                     GetAllCacheAllowZeroCount = true
                 };
-
-                return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, string>(GlobalIsolatedCache, ScopeAccessor, options);
+                return new DefaultRepositoryCachePolicy<IDictionaryItem, string>(GlobalIsolatedCache, ScopeAccessor,
+                    options, (entity) => $"uRepo_{nameof(IDictionaryItem)}_{entity.ItemKey}");
             }
         }
     }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -408,7 +408,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                     GetAllCacheAllowZeroCount = true
                 };
 
-                return new FullDataSetRepositoryCachePolicy<IDictionaryItem, string>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, false);
                 return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, string>(GlobalIsolatedCache, ScopeAccessor, options);
             }
         }

--- a/src/Umbraco.Infrastructure/Services/Implement/LocalizationService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/LocalizationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -161,6 +161,17 @@ namespace Umbraco.Cms.Core.Services.Implement
                 //ensure the lazy Language callback is assigned
                 EnsureDictionaryItemLanguageCallback(item);
                 return item;
+            }
+        }
+
+        public IDictionaryItem[] GetDictionaryItemsByKeys(string[] keys)
+        {
+            using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+            {
+                var items = _dictionaryRepository.Get(keys).ToArray();
+                foreach(var item in items)
+                    EnsureDictionaryItemLanguageCallback(item);
+                return items;
             }
         }
 


### PR DESCRIPTION
This is something that I've wanted for some time now. Within Umbraco we have the GetDictionaryValue function. However, you can only pass one key through it. This is annoying as each GetDictionaryValue call is a call to the database if that key hasn't been put into the cache yet. Meaning that on first load of a page with 20 dictionary values, it'll do 20 calls to the server.

By being able to ask for multiple dictionary values, we'll be able to combine the SQL and reduce it down to 1 call which will save a lot of time for the initial startup of a page. 

I tested it with the following code:
```
@{
    var translations = new string[] { "Test", "Test2", "Test3", "Test4", "Test5" };
}

<html>
<body>
<h1>Old</h1>
@foreach (var translation in translations)
{
    @Umbraco.GetDictionaryValue(translation)
}

<h1>New</h1>
@foreach (var test in _localizationService.GetDictionaryItemsByKeys(translations))
{
    @test.Translations.FirstOrDefault().Value
}
</body>
</html>
```

