### PR TITLE
V8: Add allowlist for HelpPage

### DIFF
--- a/src/Umbraco.Core/ConfigsExtensions.cs
+++ b/src/Umbraco.Core/ConfigsExtensions.cs
@@ -5,6 +5,7 @@ using Umbraco.Core.Configuration.Grid;
 using Umbraco.Core.Configuration.HealthChecks;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Dashboards;
+using Umbraco.Core.Help;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Manifest;
@@ -50,6 +51,8 @@ namespace Umbraco.Core
                 factory.GetInstance<IRuntimeState>().Debug));
 
             configs.Add<IContentDashboardSettings>(() => new ContentDashboardSettings());
+
+            configs.Add<IHelpPageSettings>(() => new HelpPageSettings());
         }
     }
 }

--- a/src/Umbraco.Core/Constants-AppSettings.cs
+++ b/src/Umbraco.Core/Constants-AppSettings.cs
@@ -126,6 +126,11 @@ namespace Umbraco.Core
             public const string ContentDashboardUrlAllowlist = "Umbraco.Core.ContentDashboardUrl-Allowlist";
 
             /// <summary>
+            /// A list of allowed addresses to fetch content for the help page.
+            /// </summary>
+            public const string HelpPageUrlAllowList = "Umbraco.Core.HelpPage-Allowlist";
+
+            /// <summary>
             /// TODO: FILL ME IN
             /// </summary>
             public const string DisableElectionForSingleServer = "Umbraco.Core.DisableElectionForSingleServer";

--- a/src/Umbraco.Core/Help/HelpPageSettings.cs
+++ b/src/Umbraco.Core/Help/HelpPageSettings.cs
@@ -1,0 +1,12 @@
+using System.Configuration;
+
+namespace Umbraco.Core.Help
+{
+    public class HelpPageSettings : IHelpPageSettings
+    {
+        public string HelpPageUrlAllowList =>
+            ConfigurationManager.AppSettings.ContainsKey(Constants.AppSettings.HelpPageUrlAllowList)
+                ? ConfigurationManager.AppSettings[Constants.AppSettings.HelpPageUrlAllowList]
+                : null;
+    }
+}

--- a/src/Umbraco.Core/Help/IHelpPageSettings.cs
+++ b/src/Umbraco.Core/Help/IHelpPageSettings.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Core.Help
+{
+    public interface IHelpPageSettings
+    {
+        /// <summary>
+        /// Gets the allowed addresses to retrieve data for the help page.
+        /// </summary>
+        string HelpPageUrlAllowList { get; }
+    }
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -137,6 +137,8 @@
     <Compile Include="Constants-Sql.cs" />
     <Compile Include="Constants-SqlTemplates.cs" />
     <Compile Include="Events\UnattendedInstallEventArgs.cs" />
+    <Compile Include="Help\HelpPageSettings.cs" />
+    <Compile Include="Help\IHelpPageSettings.cs" />
     <Compile Include="Logging\ILogger2.cs" />
     <Compile Include="Logging\Logger2Extensions.cs" />
     <Compile Include="Dashboards\ContentDashboardSettings.cs" />

--- a/src/Umbraco.Web.UI/web.Template.config
+++ b/src/Umbraco.Web.UI/web.Template.config
@@ -39,6 +39,7 @@
         <add key="Umbraco.Core.UseHttps" value="false" />
         <add key="Umbraco.Core.AllowContentDashboardAccessToAllUsers" value="true"/>
         <add key="Umbraco.Core.ContentDashboardUrl-Allowlist" value=""/>
+        <add key="Umbraco.Core.HelpPage-Allowlist" value=""/>
 
         <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
         <add key="webpages:Enabled" value="false" />

--- a/src/Umbraco.Web/Editors/HelpController.cs
+++ b/src/Umbraco.Web/Editors/HelpController.cs
@@ -1,16 +1,33 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using System.Web.Http;
+using Umbraco.Core.Help;
+using Umbraco.Core.Logging;
 
 namespace Umbraco.Web.Editors
 {
     public class HelpController : UmbracoAuthorizedJsonController
     {
+        private readonly IHelpPageSettings _helpPageSettings;
+
+        public HelpController(IHelpPageSettings helpPageSettings)
+        {
+            _helpPageSettings = helpPageSettings;
+        }
+
         private static HttpClient _httpClient;
         public async Task<List<HelpPage>> GetContextHelpForPage(string section, string tree, string baseUrl = "https://our.umbraco.com")
         {
+            if (IsAllowedUrl(baseUrl) is false)
+            {
+                Logger.Error<HelpController>($"The following URL is not listed in the allowlist for HelpPage in web.config: {baseUrl}");
+                throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, "HelpPage source not permitted"));
+            }
+
             var url = string.Format(baseUrl + "/Umbraco/Documentation/Lessons/GetContextHelpDocs?sectionAlias={0}&treeAlias={1}", section, tree);
 
             try
@@ -32,6 +49,17 @@ namespace Umbraco.Web.Editors
             }
 
             return new List<HelpPage>();
+        }
+
+        private bool IsAllowedUrl(string url)
+        {
+            if (string.IsNullOrEmpty(_helpPageSettings.HelpPageUrlAllowList) ||
+                _helpPageSettings.HelpPageUrlAllowList.Contains(url))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
Adds and allowlist for the help page.

I had to update the constructor for the `HelpController`, I'm not sure about the rules for breaking changes in V8, but I guess we can resolve the new settings object with `Current.Factory.GetInstance<IHelpPageSettings>();` in the constructor if this is considered a breaking change.


### Testing
* Ensure everything still works as normal (easiest way is to enter the media section and open the help panel, you should see additional help information for media)
* Add `<add key="Umbraco.Core.HelpPage-Allowlist" value="https://our.umbraco.com,https://www.google.com/"/>` to the appsettings in `Web.config`, and ensure everything still works
* Remove the `https://our.umbraco.com` from the allow list, now the addtitonal help information should fail to load with an error 400.