### PR TITLE
Fix for build warning errors when enabling nullable reference types of the project #11894

### DIFF
--- a/src/Umbraco.Web.Common/Authorization/FeatureAuthorizeHandler.cs
+++ b/src/Umbraco.Web.Common/Authorization/FeatureAuthorizeHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -36,7 +36,9 @@ namespace Umbraco.Cms.Web.Common.Authorization
 
         private bool? IsAllowed(AuthorizationHandlerContext context)
         {
+            #nullable enable
             Endpoint? endpoint = null;
+            #nullable disable
 
             switch (context.Resource)
             {

--- a/src/Umbraco.Web.UI/Views/Partials/grid/bootstrap3-fluid.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/grid/bootstrap3-fluid.cshtml
@@ -7,9 +7,9 @@
     Razor helpers located at the bottom of this file
 *@
 
-@if (Model != null && Model.GetType() == typeof(JObject) && Model.sections != null)
+@if (Model != null && Model!.GetType() == typeof(JObject) && Model!.sections != null)
 {
-    var oneColumn = ((System.Collections.ICollection)Model.sections).Count == 1;
+    var oneColumn = ((System.Collections.ICollection)Model!.sections).Count == 1;
 
     <div class="umb-grid">
         @if (oneColumn)
@@ -55,9 +55,9 @@
                         <div @RenderElementAttributes(area)>
                             @foreach (var control in area.controls)
                             {
-                                if (control != null && control.editor != null && control.editor.view != null)
+                                if (control != null && control!.editor != null && control!.editor.view != null)
                                 {
-                                    <text>@await Html.PartialAsync("grid/editors/base", (object)control)</text>
+                                    <text>@await Html.PartialAsync("grid/editors/base", (object)control!)</text>
                                 }
                             }
                         </div>

--- a/src/Umbraco.Web.UI/Views/Partials/grid/bootstrap3.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/grid/bootstrap3.cshtml
@@ -3,9 +3,9 @@
 @using Newtonsoft.Json.Linq
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<dynamic>
 
-@if (Model != null && Model.GetType() == typeof(JObject) && Model.sections != null)
+@if (Model != null && Model!.GetType() == typeof(JObject) && Model!.sections != null)
 {
-    var oneColumn = ((System.Collections.ICollection)Model.sections).Count == 1;
+    var oneColumn = ((System.Collections.ICollection)Model!.sections).Count == 1;
 
     <div class="umb-grid">
         @if (oneColumn)
@@ -56,9 +56,9 @@
                         <div @RenderElementAttributes(area)>
                             @foreach (var control in area.controls)
                             {
-                                if (control != null && control.editor != null && control.editor.view != null)
+                                if (control != null && control!.editor != null && control!.editor.view != null)
                                 {
-                                    <text>@await Html.PartialAsync("grid/editors/base", (object)control)</text>
+                                    <text>@await Html.PartialAsync("grid/editors/base", (object)control!)</text>
                                 }
                             }
                         </div>

--- a/src/Umbraco.Web.UI/umbraco/PartialViewMacros/Templates/LoginStatus.cshtml
+++ b/src/Umbraco.Web.UI/umbraco/PartialViewMacros/Templates/LoginStatus.cshtml
@@ -15,7 +15,7 @@
 {
     <div class="login-status">
 
-        <p>Welcome back <strong>@Context.User.Identity.Name</strong>!</p>
+        <p>Welcome back <strong>@Context.User!.Identity!.Name</strong>!</p>
 
         @using (Html.BeginUmbracoForm<UmbLoginStatusController>("HandleLogout", new { RedirectUrl = logoutModel.RedirectUrl }))
         {

--- a/src/Umbraco.Web.UI/umbraco/UmbracoWebsite/NotFound.cshtml
+++ b/src/Umbraco.Web.UI/umbraco/UmbracoWebsite/NotFound.cshtml
@@ -42,8 +42,8 @@
                 @if (hostingEnvironment.IsDebugMode)
                 {
 
-                    var reason = (string)Context.Items["reason"];
-                    var message = (string)Context.Items["message"];
+                    var reason = (string?)Context.Items["reason"];
+                    var message = (string?)Context.Items["message"];
 
                     if (!reason.IsNullOrWhiteSpace())
                     {


### PR DESCRIPTION
### Prerequisites

-  [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#11894](https://github.com/umbraco/Umbraco-CMS/issues/11894)

### Description

#### Build warning for the nullable context

When enabling nullable context for project (_On the Build > General tab of the project properties, enable nullable_) will produce nullable warnings. The warnings mentioned below are fixed with this PR.

    * CS8602  - Nullable References warning fix
    * CS8632  - Nullable annotations context warning fix
    * CS8600  - Possible null value to non-nullable type warning fix



<!-- Thanks for contributing to Umbraco CMS! -->
