### PR TITLE
Allow setting the site name from appsettings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/HostingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/HostingSettings.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets or sets a value for the location of temporary files.
         /// </summary>
-        [DefaultValue(StaticLocalTempStorageLocation)] 
+        [DefaultValue(StaticLocalTempStorageLocation)]
         public LocalTempStorage LocalTempStorageLocation { get; set; } = Enum<LocalTempStorage>.Parse(StaticLocalTempStorageLocation);
 
         /// <summary>
@@ -31,5 +31,10 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <value><c>true</c> if [debug mode]; otherwise, <c>false</c>.</value>
         [DefaultValue(StaticDebug)]
         public bool Debug { get; set; } = StaticDebug;
+
+        /// <summary>
+        /// Gets or sets a value specifying the name of the site.
+        /// </summary>
+        public string SiteName { get; set; }
     }
 }


### PR DESCRIPTION
In ASP.Netcore the `IWebHostEnvironment.ApplicationName` will always be the assembly name. This may cause confusion and issues when load balancing a site, since all the instances will have the same site name. 

* Added a `SiteName` to `HostingSettings`
* Using the new `SiteName` proberty to set the `IHostingEnvironment.SiteName`
* Registered event handler for when SiteName changes 

I had to work around an existing hack with the `IOptionsMonitor`. We currently have an `OptionsMonitorAdapter` that's used for `HostingSettings` when the site is initially launched, which doesn't implement monitoring, this is used to build a `TypeLoader` berfore the actual ServiceProvider is built. To get around this I've added a check that ensures the `IOptionsMonitor` is an actual `OptionsMonitor` and only then do we register the `OnChange` event, this happens when the actual service provider is built.

Not that the `SiteName` is used for the `LocalTempPath`, this however won't update when changing the site name, since this is "cached" in a private backing variable, I've opted not to change this, since we register a `TypeLoader` using that path, so I think it's best if it remains the same untill a server restart. But it's still nice to be able to change the site name when testing load balancing with running sites.

## Testing

* Run this branch without changing the appsettings and ensure that everything still runs and that the site name is the assembly name (Umbraco.Web.UI)
* Change the site name by setting `Umbraco:CMS:Hosting:SiteName` and ensure that everything works and that the site name is changed
* Try changing the site name while the site is running and ensure the changes take effect

And easy way to check the site name is to render it in a view with the following code:

```html
@inject IHostingEnvironment hostingEnvironment

<h1>SiteName: @hostingEnvironment.SiteName</h1>
```