### PR TITLE
Get ApplicationMainUrl from IServerAddressesFeature

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -183,6 +183,13 @@ namespace Umbraco.Cms.Web.Common.AspNetCore
             // Update application main URL
             if (_applicationUrls.TryAdd(currentApplicationUrl))
             {
+                // Do not downgrade existing secure main URL to non-secure protocol
+                if (currentApplicationUrl.Scheme == Uri.UriSchemeHttp &&
+                    ApplicationMainUrl?.Scheme == Uri.UriSchemeHttps)
+                {
+                    return;
+                }
+
                 // Check if application URL is known by the server
                 var serverAddresses = _server?.Features.Get<IServerAddressesFeature>()?.Addresses;
                 if (serverAddresses is not null)

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -207,9 +207,11 @@ namespace Umbraco.Cms.Web.Common.Middleware
             // Especially the DEBUG sent when debugging the application is annoying because it uses http, even when the https is available.
             if (request.Method == "GET" || request.Method == "POST")
             {
-                return new Uri($"{request.Scheme}://{request.Host}{request.PathBase}", UriKind.Absolute);
+                var url = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase);
 
+                return new Uri(url, UriKind.Absolute);
             }
+
             return null;
         }
 

--- a/tests/Umbraco.Tests.Benchmarks/ApplicationMainUrlBenchmark.cs
+++ b/tests/Umbraco.Tests.Benchmarks/ApplicationMainUrlBenchmark.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Umbraco.Tests.Benchmarks.Config;
+
+namespace Umbraco.Tests.Benchmarks
+{
+    [QuickRunWithMemoryDiagnoserConfig]
+    public class ApplicationMainUrlBenchmark
+    {
+        private readonly HttpRequest _request;
+
+        public ApplicationMainUrlBenchmark()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Method = "GET";
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("example.com");
+
+            _request = httpContext.Request;
+        }
+
+        [Benchmark]
+        public Uri GetApplicationUrlFromCurrentRequestString()
+        {
+            if (_request.Method == "GET" || _request.Method == "POST")
+            {
+                return new Uri($"{_request.Scheme}://{_request.Host}{_request.PathBase}", UriKind.Absolute);
+            }
+
+            return null;
+        }
+
+        [Benchmark]
+        public Uri GetApplicationUrlFromCurrentRequestUriHelper()
+        {
+            if (_request.Method == "GET" || _request.Method == "POST")
+            {
+                var url = UriHelper.BuildAbsolute(_request.Scheme, _request.Host, _request.PathBase);
+
+                return new Uri(url, UriKind.Absolute);
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
+++ b/tests/Umbraco.Tests.Benchmarks/Umbraco.Tests.Benchmarks.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Moq">
       <Version>4.16.1</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />    
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>  


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
By default, the latest application URL was automatically set as the main URL if the `UmbracoApplicationUrl` isn't explicitly configured. This PR only sets the main URL if it can find the application URL in the `IServerAddressFeature` that contains all addresses known to the application: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/web-host?view=aspnetcore-5.0#server-urls.

This feature won't include any or the correct URLs if you're running the application out-of-process or using a proxy, in which case you're required to explicitly configure the Umbraco application URL.
