### PR TITLE
Don't write to server table if not using ElectedServerRoleAccessor

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// </summary>
         protected static readonly TimeSpan DefaultDelay = TimeSpan.FromMinutes(3);
 
-        private readonly TimeSpan _period;
+        private TimeSpan _period;
         private readonly TimeSpan _delay;
         private Timer _timer;
 
@@ -73,6 +73,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         /// <inheritdoc/>
         public Task StopAsync(CancellationToken cancellationToken)
         {
+            _period = Timeout.InfiniteTimeSpan;
             _timer?.Change(Timeout.Infinite, 0);
             return Task.CompletedTask;
         }

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -78,8 +78,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
                 return Task.CompletedTask;
             }
 
-            // If we're the IServerRoleAccessor has been changed away from ElectedServerRoleAccessor
-            // this task no longer makes sense, since all it's used for is to allow the ElectedServerRoleAccessor
+            // If the IServerRoleAccessor has been changed away from ElectedServerRoleAccessor this task no longer makes sense,
+            // since all it's used for is to allow the ElectedServerRoleAccessor
             // to figure out what role a given server has, so we just stop this task.
             if (_serverRoleAccessor is not ElectedServerRoleAccessor)
             {

--- a/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTask.cs
@@ -2,13 +2,17 @@
 // See LICENSE for more details.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
@@ -22,6 +26,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
         private readonly IServerRegistrationService _serverRegistrationService;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILogger<TouchServerTask> _logger;
+        private readonly IServerRoleAccessor _serverRoleAccessor;
         private readonly GlobalSettings _globalSettings;
 
         /// <summary>
@@ -37,7 +42,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             IServerRegistrationService serverRegistrationService,
             IHostingEnvironment hostingEnvironment,
             ILogger<TouchServerTask> logger,
-            IOptions<GlobalSettings> globalSettings)
+            IOptions<GlobalSettings> globalSettings,
+            IServerRoleAccessor serverRoleAccessor)
             : base(globalSettings.Value.DatabaseServerRegistrar.WaitTimeBetweenCalls, TimeSpan.FromSeconds(15))
         {
             _runtimeState = runtimeState;
@@ -45,6 +51,24 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
             _globalSettings = globalSettings.Value;
+            _serverRoleAccessor = serverRoleAccessor;
+        }
+
+        [Obsolete("Use constructor that takes an IServerRoleAccessor")]
+        public TouchServerTask(
+            IRuntimeState runtimeState,
+            IServerRegistrationService serverRegistrationService,
+            IHostingEnvironment hostingEnvironment,
+            ILogger<TouchServerTask> logger,
+            IOptions<GlobalSettings> globalSettings)
+            : this(
+                runtimeState,
+                serverRegistrationService,
+                hostingEnvironment,
+                logger,
+                globalSettings,
+                StaticServiceProvider.Instance.GetRequiredService<IServerRoleAccessor>())
+        {
         }
 
         public override Task PerformExecuteAsync(object state)
@@ -52,6 +76,14 @@ namespace Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration
             if (_runtimeState.Level != RuntimeLevel.Run)
             {
                 return Task.CompletedTask;
+            }
+
+            // If we're the IServerRoleAccessor has been changed away from ElectedServerRoleAccessor
+            // this task no longer makes sense, since all it's used for is to allow the ElectedServerRoleAccessor
+            // to figure out what role a given server has, so we just stop this task.
+            if (_serverRoleAccessor is not ElectedServerRoleAccessor)
+            {
+                return StopAsync(CancellationToken.None);
             }
 
             var serverAddress = _hostingEnvironment.ApplicationMainUrl?.ToString();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ServerRegistration/TouchServerTaskTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices.ServerRegistration;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.ServerRegistration
@@ -51,7 +52,15 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
             VerifyServerTouched();
         }
 
-        private TouchServerTask CreateTouchServerTask(RuntimeLevel runtimeLevel = RuntimeLevel.Run, string applicationUrl = ApplicationUrl)
+        [Test]
+        public async Task Does_Not_Execute_When_Role_Accessor_Is_Not_Elected()
+        {
+            TouchServerTask sut = CreateTouchServerTask(useElection: false);
+            await sut.PerformExecuteAsync(null);
+            VerifyServerNotTouched();
+        }
+
+        private TouchServerTask CreateTouchServerTask(RuntimeLevel runtimeLevel = RuntimeLevel.Run, string applicationUrl = ApplicationUrl, bool useElection = true)
         {
             var mockRequestAccessor = new Mock<IHostingEnvironment>();
             mockRequestAccessor.SetupGet(x => x.ApplicationMainUrl).Returns(!string.IsNullOrEmpty(applicationUrl) ? new Uri(ApplicationUrl) : null);
@@ -71,12 +80,17 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices.Serv
                 }
             };
 
+            IServerRoleAccessor roleAccessor = useElection
+                ? new ElectedServerRoleAccessor(_mockServerRegistrationService.Object)
+                : new SingleServerRoleAccessor();
+
             return new TouchServerTask(
                 mockRunTimeState.Object,
                 _mockServerRegistrationService.Object,
                 mockRequestAccessor.Object,
                 mockLogger.Object,
-                Options.Create(settings));
+                Options.Create(settings),
+                roleAccessor);
         }
 
         private void VerifyServerNotTouched() => VerifyServerTouchedTimes(Times.Never());


### PR DESCRIPTION
Fixes #11928 

When the implementation of `IServerRoleAccessor` was switched we would still write to the `umbracoServer` table, which is not desired if load balancing. 

I added a check to the `TouchServerTask` and stop the task if we're not using `ElectedServerRoleAccessor`, this mimicks the behaviour of [V8](https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/src/Umbraco.Web/Compose/DatabaseServerRegistrarAndMessengerComponent.cs#L40).

In order to be able to stop the task, I had to make minor changes to `RecurringHostedServiceBase`. I had to make the period not read only, in order to be able to set it to an infinite timespan in the stop method, otherwise the task would still continue to execute, since we update the timer in a finally block in `ExecuteAsync`.

Lastly I added an additional test that verifies this behaviour.


## Testing
* Clear the `umbracoServer` table
* Run the site with `ElectedServerRoleAccessor` (default), and ensure a row is entered after 15 seconds (after the touch server task runs)
* Replace the `IServerRoleAccessor` with a different implementation, for instance `SingleServerRoleAccessor`
* Clear the table and run the site again, the table should remain empty this time. 