### PR TITLE
V9: Fix removing element from BlockList

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -101,11 +101,30 @@
 
         /**
          * Generate label for Block, uses either the labelInterpolator or falls back to the contentTypeName.
-         * @param {Object} blockObject BlockObject to recive data values from.
+         * @param {Object} blockObject BlockObject to receive data values from.
          */
         function getBlockLabel(blockObject) {
             if (blockObject.labelInterpolator !== undefined) {
-                var labelVars = Object.assign({"$contentTypeName": blockObject.content.contentTypeName, "$settings": blockObject.settingsData || {}, "$layout": blockObject.layout || {}, "$index": (blockObject.index || 0)+1 }, blockObject.data);
+                // blockobject.content may be null if the block is no longer allowed,
+                // so try and fall back to the label in the config,
+                // if that too is null, there's not much we can do, so just default to empty string.
+                var contentTypeName;
+                if(blockObject.content != null){
+                  contentTypeName = blockObject.content.contentTypeName;
+                }
+                else if(blockObject.config != null && blockObject.config.label != null){
+                  contentTypeName = blockObject.config.label;
+                }
+                else {
+                  contentTypeName = "";
+                }
+
+                var labelVars = Object.assign({
+                  "$contentTypeName": contentTypeName,
+                  "$settings": blockObject.settingsData || {},
+                  "$layout": blockObject.layout || {},
+                  "$index": (blockObject.index || 0)+1
+                }, blockObject.data);
                 var label = blockObject.labelInterpolator(labelVars);
                 if (label) {
                     return label;
@@ -511,10 +530,10 @@
              * @methodOf umbraco.services.blockEditorModelObject
              * @description Retrieve a Block Object for the given layout entry.
              * The Block Object offers the necessary data to display and edit a block.
-             * The Block Object setups live syncronization of content and settings models back to the data of your Property Editor model.
-             * The returned object, named ´BlockObject´, contains several usefull models to make editing of this block happen.
+             * The Block Object setups live synchronization of content and settings models back to the data of your Property Editor model.
+             * The returned object, named ´BlockObject´, contains several useful models to make editing of this block happen.
              * The ´BlockObject´ contains the following properties:
-             * - key {string}: runtime generated key, usefull for tracking of this object
+             * - key {string}: runtime generated key, useful for tracking of this object
              * - content {Object}: Content model, the content data in a ElementType model.
              * - settings {Object}: Settings model, the settings data in a ElementType model.
              * - config {Object}: A local deep copy of the block configuration model.
@@ -522,12 +541,11 @@
              * - updateLabel {Method}: Method to trigger an update of the label for this block.
              * - data {Object}: A reference to the content data object from your property editor model.
              * - settingsData {Object}: A reference to the settings data object from your property editor model.
-             * - layout {Object}: A refernce to the layout entry from your property editor model.
+             * - layout {Object}: A reference to the layout entry from your property editor model.
              * @param {Object} layoutEntry the layout entry object to build the block model from.
-             * @return {Object | null} The BlockObject for the given layout entry. Or null if data or configuration wasnt found for this block.
+             * @return {Object | null} The BlockObject for the given layout entry. Or null if data or configuration wasn't found for this block.
              */
             getBlockObject: function (layoutEntry) {
-
                 var contentUdi = layoutEntry.contentUdi;
 
                 var dataModel = getDataByUdi(contentUdi, this.value.contentData);


### PR DESCRIPTION
Fixes #11942 

If you removed a block from a block list editor, the editor would fail to load in any content that used that block.

The issue is that a [change was made](https://github.com/umbraco/Umbraco-CMS/commit/405ed44bb18ab6f5de3b2372b511497470198f89#diff-1917457fd201c21b7a9c50c34e6527656a0707186c40df0c7f79293b0245d54f) to try and fall back to `contentTypeName`, in that change we now also pass the content type name in the label vars. However if a block is no longer allowed `blockObject.content` is null, leading to the error. I fixed this by checking the content for null, and if was null try to fall back to the label in the config, if that too is null we give up and fall back to an empty string. After this you now see the expected "Unsupported" block.

![image](https://user-images.githubusercontent.com/16456704/152778173-b4c22c07-9c0c-4cd4-ae24-59cebc1aab8d.png)

## Testing
* Run `npm run build`
* Follow the testing steps in the issue
* Ensure you see the "Unsupported" block