### PR TITLE
Added section for promoted packages in the back-office.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/ourpackagerrepository.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/ourpackagerrepository.resource.js
@@ -36,7 +36,21 @@ function ourPackageRepositoryResource($q, $http, umbDataFormatter, umbRequestHel
                $http.get(baseurl + "?pageIndex=0&pageSize=" + maxResults + "&category=" + category + "&order=Popular&version=" + Umbraco.Sys.ServerVariables.application.version),
                'Failed to query packages');
         },
-       
+
+        getPromoted: function (maxResults, category) {
+
+            if (maxResults === undefined) {
+                maxResults = 20;
+            }
+            if (category === undefined) {
+                category = "";
+            }
+
+            return umbRequestHelper.resourcePromise(
+               $http.get(baseurl + "?pageIndex=0&pageSize=" + maxResults + "&category=" + category + "&order=Popular&version=" + Umbraco.Sys.ServerVariables.application.version + "&onlyPromoted=true"),
+               'Failed to query packages');
+        },
+
         search: function (pageIndex, pageSize, orderBy, category, query, canceler) {
 
             var httpConfig = {};

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    function PackagesRepoController($scope, $timeout, ourPackageRepositoryResource, $q, packageResource, localStorageService, localizationService) {
+    function PackagesRepoController($scope, $timeout, ourPackageRepositoryResource, $q, localizationService) {
 
         var vm = this;
 
@@ -24,6 +24,8 @@
         vm.closeLightbox = closeLightbox;
         vm.search = search;
         vm.installCompleted = false;
+        vm.highlightedPackageCollections = [];
+        vm.labels = [];
 
         var defaultSort = "Latest";
         var currSort = defaultSort;
@@ -46,28 +48,37 @@
         function init() {
 
             vm.loading = true;
+            localizationService.localizeMany(["packager_packagesPopular", "packager_packagesPromoted"])
+                .then(function (labels) {
+                    vm.labels = labels;
 
-            $q.all([
-                ourPackageRepositoryResource.getCategories()
-                    .then(function (cats) {
-                        vm.categories = cats.filter(function (cat) {
-                            return cat.name !== "Umbraco Pro";
+                    var popularPackages, promotedPackages;
+                    $q.all([
+                        ourPackageRepositoryResource.getCategories()
+                            .then(function (cats) {
+                                vm.categories = cats.filter(function (cat) {
+                                    return cat.name !== "Umbraco Pro";
+                                });
+                            }),
+                        ourPackageRepositoryResource.getPopular(10)
+                            .then(function (pack) {
+                                 popularPackages = { title: vm.labels[0], packages: pack.packages };
+                            }),
+                        ourPackageRepositoryResource.getPromoted(20)
+                            .then(function (pack) {
+                                promotedPackages = { title: vm.labels[1], packages: pack.packages };
+                            }),
+                        ourPackageRepositoryResource.search(vm.pagination.pageNumber - 1, vm.pagination.pageSize, currSort)
+                            .then(function (pack) {
+                                vm.packages = pack.packages;
+                                vm.pagination.totalPages = Math.ceil(pack.total / vm.pagination.pageSize);
+                            })
+                        ])
+                        .then(function () {
+                            vm.highlightedPackageCollections = [popularPackages, promotedPackages];
+                            vm.loading = false;
                         });
-                    }),
-                ourPackageRepositoryResource.getPopular(8)
-                    .then(function (pack) {
-                        vm.popular = pack.packages;
-                    }),
-                ourPackageRepositoryResource.search(vm.pagination.pageNumber - 1, vm.pagination.pageSize, currSort)
-                    .then(function (pack) {
-                        vm.packages = pack.packages;
-                        vm.pagination.totalPages = Math.ceil(pack.total / vm.pagination.pageSize);
-                    })
-            ])
-                .then(function () {
-                    vm.loading = false;
                 });
-
         }
 
         function selectCategory(selectedCategory, categories) {
@@ -96,10 +107,15 @@
 
             currSort = defaultSort;
 
+            var popularPackages, promotedPackages;
             $q.all([
-                ourPackageRepositoryResource.getPopular(8, searchCategory)
+                ourPackageRepositoryResource.getPopular(10, searchCategory)
                     .then(function (pack) {
-                        vm.popular = pack.packages;
+                        popularPackages = { title: vm.labels[0], packages: pack.packages };
+                    }),
+                ourPackageRepositoryResource.getPromoted(20, searchCategory)
+                    .then(function (pack) {
+                        promotedPackages = { title: vm.labels[1], packages: pack.packages };
                     }),
                 ourPackageRepositoryResource.search(vm.pagination.pageNumber - 1, vm.pagination.pageSize, currSort, searchCategory, vm.searchQuery)
                     .then(function (pack) {
@@ -109,6 +125,7 @@
                     })
                 ])
                 .then(function () {
+                    vm.highlightedPackageCollections = [popularPackages, promotedPackages];
                     vm.loading = false;
                 });
         }

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.controller.js
@@ -25,7 +25,7 @@
         vm.search = search;
         vm.installCompleted = false;
         vm.highlightedPackageCollections = [];
-        vm.labels = [];
+        vm.labels = {};
 
         var defaultSort = "Latest";
         var currSort = defaultSort;
@@ -50,7 +50,8 @@
             vm.loading = true;
             localizationService.localizeMany(["packager_packagesPopular", "packager_packagesPromoted"])
                 .then(function (labels) {
-                    vm.labels = labels;
+                    vm.labels.popularPackages = labels[0];
+                    vm.labels.promotedPackages = labels[1];
 
                     var popularPackages, promotedPackages;
                     $q.all([
@@ -62,11 +63,11 @@
                             }),
                         ourPackageRepositoryResource.getPopular(10)
                             .then(function (pack) {
-                                 popularPackages = { title: vm.labels[0], packages: pack.packages };
+                                popularPackages = { title: vm.labels.popularPackages, packages: pack.packages };
                             }),
                         ourPackageRepositoryResource.getPromoted(20)
                             .then(function (pack) {
-                                promotedPackages = { title: vm.labels[1], packages: pack.packages };
+                                promotedPackages = { title: vm.labels.promotedPackages, packages: pack.packages };
                             }),
                         ourPackageRepositoryResource.search(vm.pagination.pageNumber - 1, vm.pagination.pageSize, currSort)
                             .then(function (pack) {
@@ -111,11 +112,11 @@
             $q.all([
                 ourPackageRepositoryResource.getPopular(10, searchCategory)
                     .then(function (pack) {
-                        popularPackages = { title: vm.labels[0], packages: pack.packages };
+                        popularPackages = { title: vm.labels.popularPackages, packages: pack.packages };
                     }),
                 ourPackageRepositoryResource.getPromoted(20, searchCategory)
                     .then(function (pack) {
-                        promotedPackages = { title: vm.labels[1], packages: pack.packages };
+                        promotedPackages = { title: vm.labels.promotedPackages, packages: pack.packages };
                     }),
                 ourPackageRepositoryResource.search(vm.pagination.pageNumber - 1, vm.pagination.pageSize, currSort, searchCategory, vm.searchQuery)
                     .then(function (pack) {

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -36,46 +36,48 @@
 
         <div ng-show="vm.loading === false">
 
-            <div class="umb-packages-section" ng-if="vm.searchQuery == '' && vm.popular.length > 0">
-                <h4><strong><localize key="packager_packagesPopular">Popular</localize></strong></h4>
-                <div class="umb-packages">
+            <div ng-repeat="highlightedPackageCollection in vm.highlightedPackageCollections">
+                <div class="umb-packages-section" ng-if="vm.searchQuery == '' && highlightedPackageCollection.packages.length > 0">
+                    <h4><strong>{{highlightedPackageCollection.title}}</strong></h4>
+                    <div class="umb-packages">
 
-                    <div class="umb-package" ng-repeat="package in vm.popular">
-                        <button type="button" class="umb-package-link" ng-click="vm.showPackageDetails(package)">
+                        <div class="umb-package" ng-repeat="package in highlightedPackageCollection.packages">
+                            <button type="button" class="umb-package-link" ng-click="vm.showPackageDetails(package)">
 
-                            <div class="flex flex-column">
-                                <div class="umb-package-icon">
-                                    <img ng-src="{{package.icon}}" alt="" />
-                                </div>
-
-                                <div class="umb-package-info">
-                                    <div class="umb-package-name">{{package.name}}</div>
-                                    <div class="umb-package-description">{{package.excerpt | limitTo: 40}}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
-
-                                    <div class="umb-package-numbers">
-                                        <small class="umb-package-downloads">
-                                            <umb-icon icon="icon-download-alt"></umb-icon>
-                                            <strong>{{package.downloads}}</strong>
-                                        </small>
-                                        <small class="umb-package-likes">
-                                            <umb-icon icon="icon-hearts" class="icon-hearts"></umb-icon>
-                                            <strong>{{package.likes}}</strong>
-                                        </small>
+                                <div class="flex flex-column">
+                                    <div class="umb-package-icon">
+                                        <img ng-src="{{package.icon}}" alt="" />
                                     </div>
-                                    <div class="umb-package-cloud">
-                                        <div ng-if="package.certifiedToWorkOnUmbracoCloud">
-                                            <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
-                                            <span><localize key="packager_verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
+
+                                    <div class="umb-package-info">
+                                        <div class="umb-package-name">{{package.name}}</div>
+                                        <div class="umb-package-description">{{package.excerpt | limitTo: 40}}<span ng-if="package.excerpt > (package.excerpt | limitTo: 40)">...</span></div>
+
+                                        <div class="umb-package-numbers">
+                                            <small class="umb-package-downloads">
+                                                <umb-icon icon="icon-download-alt"></umb-icon>
+                                                <strong>{{package.downloads}}</strong>
+                                            </small>
+                                            <small class="umb-package-likes">
+                                                <umb-icon icon="icon-hearts" class="icon-hearts"></umb-icon>
+                                                <strong>{{package.likes}}</strong>
+                                            </small>
                                         </div>
+                                        <div class="umb-package-cloud">
+                                            <div ng-if="package.certifiedToWorkOnUmbracoCloud">
+                                                <umb-icon icon="icon-cloud" class="icon-cloud"></umb-icon>
+                                                <span><localize key="packager_verifiedToWorkOnUmbracoCloud">Verified to work on Umbraco Cloud</localize></span>
+                                            </div>
+                                        </div>
+
                                     </div>
-
                                 </div>
-                            </div>
 
-                        </button>
-                    </div> <!-- end package -->
+                            </button>
+                        </div> <!-- end package -->
 
-                </div> <!-- end packages -->
+                    </div> <!-- end packages -->
+                </div>
             </div>
 
             <div class="umb-packages-section" ng-if="vm.packages.length > 0">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -1292,6 +1292,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="packageNoResultsDescription">Please try searching for another package or browse through the categories
     </key>
     <key alias="packagesPopular">Popular</key>
+    <key alias="packagesPromoted">Promoted</key>
     <key alias="packagesNew">New releases</key>
     <key alias="packageHas">has</key>
     <key alias="packageKarmaPoints">karma points</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -1310,6 +1310,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="packageNoResultsDescription">Please try searching for another package or browse through the categories
     </key>
     <key alias="packagesPopular">Popular</key>
+    <key alias="packagesPromoted">Promoted</key>
     <key alias="packagesNew">New releases</key>
     <key alias="packageHas">has</key>
     <key alias="packageKarmaPoints">karma points</key>


### PR DESCRIPTION
This PR adds an additional panel to the Umbraco back-office Packages section, so between "Popular" and "New releases", we can have a "Promoted" section.  The intention here is to have the option to highlight HQ, technical partner and selected community packages.

To Test:

- Check with the PR in place that the back-office presents a new panel showing the HQ packages.
- Via the our back-office, remove the "Is Promoted?" flag from one, and check the display is updated (given a little time for index updates and cache invalidation).
- Then remove both and ensure the panel and the header is removed.