### PR TITLE
Only select ItemIdFieldName in PublishedContentQuery.Search to improve performance

### DIFF
--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Xml.XPath;
 using Examine.Search;
@@ -8,31 +8,46 @@ using Umbraco.Cms.Core.Xml;
 namespace Umbraco.Cms.Core
 {
     /// <summary>
-    /// Query methods used for accessing strongly typed content in templates
+    /// Query methods used for accessing strongly typed content in templates.
     /// </summary>
     public interface IPublishedContentQuery
     {
         IPublishedContent Content(int id);
+
         IPublishedContent Content(Guid id);
+
         IPublishedContent Content(Udi id);
+
         IPublishedContent Content(object id);
+
         IPublishedContent ContentSingleAtXPath(string xpath, params XPathVariable[] vars);
+
         IEnumerable<IPublishedContent> Content(IEnumerable<int> ids);
+
         IEnumerable<IPublishedContent> Content(IEnumerable<Guid> ids);
 
         IEnumerable<IPublishedContent> Content(IEnumerable<object> ids);
+
         IEnumerable<IPublishedContent> ContentAtXPath(string xpath, params XPathVariable[] vars);
+
         IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars);
+
         IEnumerable<IPublishedContent> ContentAtRoot();
 
         IPublishedContent Media(int id);
+
         IPublishedContent Media(Guid id);
+
         IPublishedContent Media(Udi id);
 
         IPublishedContent Media(object id);
+
         IEnumerable<IPublishedContent> Media(IEnumerable<int> ids);
+
         IEnumerable<IPublishedContent> Media(IEnumerable<object> ids);
+
         IEnumerable<IPublishedContent> Media(IEnumerable<Guid> ids);
+
         IEnumerable<IPublishedContent> MediaAtRoot();
 
         /// <summary>
@@ -44,7 +59,7 @@ namespace Umbraco.Cms.Core
         /// <param name="totalRecords">The total amount of records.</param>
         /// <param name="culture">The culture (defaults to a culture insensitive search).</param>
         /// <param name="indexName">The name of the index to search (defaults to <see cref="Constants.UmbracoIndexes.ExternalIndexName" />).</param>
-        /// <param name="loadedFields">The fields to load in the results of the search (defaults to all fields loaded).</param>
+        /// <param name="loadedFields">This parameter is no longer used, because the results are loaded from the published snapshot using the single item ID field.</param>
         /// <returns>
         /// The search results.
         /// </returns>

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -17,8 +17,9 @@ using Constants = Umbraco.Cms.Core.Constants;
 namespace Umbraco.Cms.Infrastructure
 {
     /// <summary>
-    ///     A class used to query for published content, media items
+    /// A class used to query for published content, media items
     /// </summary>
+    /// <seealso cref="Umbraco.Cms.Core.IPublishedContentQuery" />
     public class PublishedContentQuery : IPublishedContentQuery
     {
         private readonly IExamineManager _examineManager;
@@ -26,14 +27,12 @@ namespace Umbraco.Cms.Infrastructure
         private readonly IVariationContextAccessor _variationContextAccessor;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="PublishedContentQuery" /> class.
+        /// Initializes a new instance of the <see cref="PublishedContentQuery" /> class.
         /// </summary>
-        public PublishedContentQuery(IPublishedSnapshot publishedSnapshot,
-            IVariationContextAccessor variationContextAccessor, IExamineManager examineManager)
+        public PublishedContentQuery(IPublishedSnapshot publishedSnapshot, IVariationContextAccessor variationContextAccessor, IExamineManager examineManager)
         {
             _publishedSnapshot = publishedSnapshot ?? throw new ArgumentNullException(nameof(publishedSnapshot));
-            _variationContextAccessor = variationContextAccessor ??
-                                        throw new ArgumentNullException(nameof(variationContextAccessor));
+            _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
             _examineManager = examineManager ?? throw new ArgumentNullException(nameof(examineManager));
         }
 
@@ -72,6 +71,7 @@ namespace Umbraco.Cms.Infrastructure
                     return false;
             }
         }
+
         private static bool ConvertIdObjectToUdi(object id, out Udi guidId)
         {
             switch (id)
@@ -93,160 +93,148 @@ namespace Umbraco.Cms.Infrastructure
 
         #region Content
 
-        public IPublishedContent Content(int id) => ItemById(id, _publishedSnapshot.Content);
+        public IPublishedContent Content(int id)
+            => ItemById(id, _publishedSnapshot.Content);
 
-        public IPublishedContent Content(Guid id) => ItemById(id, _publishedSnapshot.Content);
+        public IPublishedContent Content(Guid id)
+            => ItemById(id, _publishedSnapshot.Content);
 
         public IPublishedContent Content(Udi id)
-        {
-            if (!(id is GuidUdi udi)) return null;
-            return ItemById(udi.Guid, _publishedSnapshot.Content);
-        }
+            => id is GuidUdi udi ? ItemById(udi.Guid, _publishedSnapshot.Content) : null;
 
         public IPublishedContent Content(object id)
         {
             if (ConvertIdObjectToInt(id, out var intId))
+            {
                 return Content(intId);
+            }
+
             if (ConvertIdObjectToGuid(id, out var guidId))
+            {
                 return Content(guidId);
+            }
+
             if (ConvertIdObjectToUdi(id, out var udiId))
+            {
                 return Content(udiId);
+            }
+
             return null;
         }
 
-        public IPublishedContent ContentSingleAtXPath(string xpath, params XPathVariable[] vars) =>
-            ItemByXPath(xpath, vars, _publishedSnapshot.Content);
+        public IPublishedContent ContentSingleAtXPath(string xpath, params XPathVariable[] vars)
+            => ItemByXPath(xpath, vars, _publishedSnapshot.Content);
 
-        public IEnumerable<IPublishedContent> Content(IEnumerable<int> ids) =>
-            ItemsByIds(_publishedSnapshot.Content, ids);
+        public IEnumerable<IPublishedContent> Content(IEnumerable<int> ids)
+            => ItemsByIds(_publishedSnapshot.Content, ids);
 
-        public IEnumerable<IPublishedContent> Content(IEnumerable<Guid> ids) =>
-            ItemsByIds(_publishedSnapshot.Content, ids);
+        public IEnumerable<IPublishedContent> Content(IEnumerable<Guid> ids)
+            => ItemsByIds(_publishedSnapshot.Content, ids);
 
         public IEnumerable<IPublishedContent> Content(IEnumerable<object> ids)
-        {
-            return ids.Select(Content).WhereNotNull();
-        }
-        public IEnumerable<IPublishedContent> ContentAtXPath(string xpath, params XPathVariable[] vars) =>
-            ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
+            => ids.Select(Content).WhereNotNull();
 
-        public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars) =>
-            ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
+        public IEnumerable<IPublishedContent> ContentAtXPath(string xpath, params XPathVariable[] vars)
+            => ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
 
-        public IEnumerable<IPublishedContent> ContentAtRoot() => ItemsAtRoot(_publishedSnapshot.Content);
+        public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars)
+            => ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
+
+        public IEnumerable<IPublishedContent> ContentAtRoot()
+            => ItemsAtRoot(_publishedSnapshot.Content);
 
         #endregion
 
         #region Media
 
-        public IPublishedContent Media(int id) => ItemById(id, _publishedSnapshot.Media);
+        public IPublishedContent Media(int id)
+            => ItemById(id, _publishedSnapshot.Media);
 
-        public IPublishedContent Media(Guid id) => ItemById(id, _publishedSnapshot.Media);
+        public IPublishedContent Media(Guid id)
+            => ItemById(id, _publishedSnapshot.Media);
 
         public IPublishedContent Media(Udi id)
-        {
-            if (!(id is GuidUdi udi)) return null;
-            return ItemById(udi.Guid, _publishedSnapshot.Media);
-        }
+            => id is GuidUdi udi ? ItemById(udi.Guid, _publishedSnapshot.Media) : null;
 
         public IPublishedContent Media(object id)
         {
             if (ConvertIdObjectToInt(id, out var intId))
+            {
                 return Media(intId);
+            }
+
             if (ConvertIdObjectToGuid(id, out var guidId))
+            {
                 return Media(guidId);
+            }
+
             if (ConvertIdObjectToUdi(id, out var udiId))
+            {
                 return Media(udiId);
+            }
+
             return null;
         }
 
-        public IEnumerable<IPublishedContent> Media(IEnumerable<int> ids) => ItemsByIds(_publishedSnapshot.Media, ids);
+        public IEnumerable<IPublishedContent> Media(IEnumerable<int> ids)
+            => ItemsByIds(_publishedSnapshot.Media, ids);
+
         public IEnumerable<IPublishedContent> Media(IEnumerable<object> ids)
-        {
-            return ids.Select(Media).WhereNotNull();
-        }
+            => ids.Select(Media).WhereNotNull();
 
-        public IEnumerable<IPublishedContent> Media(IEnumerable<Guid> ids) => ItemsByIds(_publishedSnapshot.Media, ids);
+        public IEnumerable<IPublishedContent> Media(IEnumerable<Guid> ids)
+            => ItemsByIds(_publishedSnapshot.Media, ids);
 
-        public IEnumerable<IPublishedContent> MediaAtRoot() => ItemsAtRoot(_publishedSnapshot.Media);
+        public IEnumerable<IPublishedContent> MediaAtRoot()
+            => ItemsAtRoot(_publishedSnapshot.Media);
 
         #endregion
 
         #region Used by Content/Media
 
         private static IPublishedContent ItemById(int id, IPublishedCache cache)
-        {
-            var doc = cache.GetById(id);
-            return doc;
-        }
+            => cache.GetById(id);
 
         private static IPublishedContent ItemById(Guid id, IPublishedCache cache)
-        {
-            var doc = cache.GetById(id);
-            return doc;
-        }
+            => cache.GetById(id);
 
         private static IPublishedContent ItemByXPath(string xpath, XPathVariable[] vars, IPublishedCache cache)
-        {
-            var doc = cache.GetSingleByXPath(xpath, vars);
-            return doc;
-        }
-
-        //NOTE: Not used?
-        //private IPublishedContent ItemByXPath(XPathExpression xpath, XPathVariable[] vars, IPublishedCache cache)
-        //{
-        //    var doc = cache.GetSingleByXPath(xpath, vars);
-        //    return doc;
-        //}
+            => cache.GetSingleByXPath(xpath, vars);
 
         private static IEnumerable<IPublishedContent> ItemsByIds(IPublishedCache cache, IEnumerable<int> ids)
-        {
-            return ids.Select(eachId => ItemById(eachId, cache)).WhereNotNull();
-        }
+            => ids.Select(eachId => ItemById(eachId, cache)).WhereNotNull();
 
         private IEnumerable<IPublishedContent> ItemsByIds(IPublishedCache cache, IEnumerable<Guid> ids)
-        {
-            return ids.Select(eachId => ItemById(eachId, cache)).WhereNotNull();
-        }
+            => ids.Select(eachId => ItemById(eachId, cache)).WhereNotNull();
 
-        private static IEnumerable<IPublishedContent> ItemsByXPath(string xpath, XPathVariable[] vars,
-            IPublishedCache cache)
-        {
-            var doc = cache.GetByXPath(xpath, vars);
-            return doc;
-        }
+        private static IEnumerable<IPublishedContent> ItemsByXPath(string xpath, XPathVariable[] vars, IPublishedCache cache)
+            => cache.GetByXPath(xpath, vars);
 
-        private static IEnumerable<IPublishedContent> ItemsByXPath(XPathExpression xpath, XPathVariable[] vars,
-            IPublishedCache cache)
-        {
-            var doc = cache.GetByXPath(xpath, vars);
-            return doc;
-        }
+        private static IEnumerable<IPublishedContent> ItemsByXPath(XPathExpression xpath, XPathVariable[] vars, IPublishedCache cache)
+            => cache.GetByXPath(xpath, vars);
 
-        private static IEnumerable<IPublishedContent> ItemsAtRoot(IPublishedCache cache) => cache.GetAtRoot();
+        private static IEnumerable<IPublishedContent> ItemsAtRoot(IPublishedCache cache)
+            => cache.GetAtRoot();
 
         #endregion
 
         #region Search
 
         /// <inheritdoc />
-        public IEnumerable<PublishedSearchResult> Search(string term, string culture = "*",
-            string indexName = Constants.UmbracoIndexes.ExternalIndexName) =>
-            Search(term, 0, 0, out _, culture, indexName);
+        public IEnumerable<PublishedSearchResult> Search(string term, string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName)
+            => Search(term, 0, 0, out _, culture, indexName);
 
         /// <inheritdoc />
         public IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords, string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName, ISet<string> loadedFields = null)
         {
             if (skip < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(skip), skip,
-                    "The value must be greater than or equal to zero.");
+                throw new ArgumentOutOfRangeException(nameof(skip), skip, "The value must be greater than or equal to zero.");
             }
 
             if (take < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(take), take,
-                    "The value must be greater than or equal to zero.");
+                throw new ArgumentOutOfRangeException(nameof(take), take, "The value must be greater than or equal to zero.");
             }
 
             if (string.IsNullOrEmpty(indexName))
@@ -254,10 +242,9 @@ namespace Umbraco.Cms.Infrastructure
                 indexName = Constants.UmbracoIndexes.ExternalIndexName;
             }
 
-            if (!_examineManager.TryGetIndex(indexName, out var index) || !(index is IUmbracoIndex umbIndex))
+            if (!_examineManager.TryGetIndex(indexName, out var index) || index is not IUmbracoIndex umbIndex)
             {
-                throw new InvalidOperationException(
-                    $"No index found by name {indexName} or is not of type {typeof(IUmbracoIndex)}");
+                throw new InvalidOperationException($"No index found by name {indexName} or is not of type {typeof(IUmbracoIndex)}");
             }
 
             var query = umbIndex.Searcher.CreateQuery(IndexTypes.Content);
@@ -294,28 +281,24 @@ namespace Umbraco.Cms.Infrastructure
 
             totalRecords = results.TotalItemCount;
 
-            return new CultureContextualSearchResults(
-                results.ToPublishedSearchResults(_publishedSnapshot.Content), _variationContextAccessor,
-                culture);
+            return new CultureContextualSearchResults(results.ToPublishedSearchResults(_publishedSnapshot.Content), _variationContextAccessor, culture);
         }
 
         /// <inheritdoc />
-        public IEnumerable<PublishedSearchResult> Search(IQueryExecutor query) => Search(query, 0, 0, out _);
+        public IEnumerable<PublishedSearchResult> Search(IQueryExecutor query)
+            => Search(query, 0, 0, out _);
 
         /// <inheritdoc />
-        public IEnumerable<PublishedSearchResult> Search(IQueryExecutor query, int skip, int take,
-            out long totalRecords)
+        public IEnumerable<PublishedSearchResult> Search(IQueryExecutor query, int skip, int take, out long totalRecords)
         {
             if (skip < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(skip), skip,
-                    "The value must be greater than or equal to zero.");
+                throw new ArgumentOutOfRangeException(nameof(skip), skip, "The value must be greater than or equal to zero.");
             }
 
             if (take < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(take), take,
-                    "The value must be greater than or equal to zero.");
+                throw new ArgumentOutOfRangeException(nameof(take), take, "The value must be greater than or equal to zero.");
             }
 
             var results = skip == 0 && take == 0
@@ -328,8 +311,7 @@ namespace Umbraco.Cms.Infrastructure
         }
 
         /// <summary>
-        ///     This is used to contextualize the values in the search results when enumerating over them so that the correct
-        ///     culture values are used
+        /// This is used to contextualize the values in the search results when enumerating over them, so that the correct culture values are used.
         /// </summary>
         private class CultureContextualSearchResults : IEnumerable<PublishedSearchResult>
         {
@@ -337,8 +319,7 @@ namespace Umbraco.Cms.Infrastructure
             private readonly IVariationContextAccessor _variationContextAccessor;
             private readonly IEnumerable<PublishedSearchResult> _wrapped;
 
-            public CultureContextualSearchResults(IEnumerable<PublishedSearchResult> wrapped,
-                IVariationContextAccessor variationContextAccessor, string culture)
+            public CultureContextualSearchResults(IEnumerable<PublishedSearchResult> wrapped, IVariationContextAccessor variationContextAccessor, string culture)
             {
                 _wrapped = wrapped;
                 _variationContextAccessor = variationContextAccessor;
@@ -347,20 +328,19 @@ namespace Umbraco.Cms.Infrastructure
 
             public IEnumerator<PublishedSearchResult> GetEnumerator()
             {
-                //We need to change the current culture to what is requested and then change it back
+                // We need to change the current culture to what is requested and then change it back
                 var originalContext = _variationContextAccessor.VariationContext;
                 if (!_culture.IsNullOrWhiteSpace() && !_culture.InvariantEquals(originalContext.Culture))
                     _variationContextAccessor.VariationContext = new VariationContext(_culture);
 
-                //now the IPublishedContent returned will be contextualized to the culture specified and will be reset when the enumerator is disposed
-                return new CultureContextualSearchResultsEnumerator(_wrapped.GetEnumerator(), _variationContextAccessor,
-                    originalContext);
+                // Now the IPublishedContent returned will be contextualized to the culture specified and will be reset when the enumerator is disposed
+                return new CultureContextualSearchResultsEnumerator(_wrapped.GetEnumerator(), _variationContextAccessor, originalContext);
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
             /// <summary>
-            ///     Resets the variation context when this is disposed
+            /// Resets the variation context when this is disposed.
             /// </summary>
             private class CultureContextualSearchResultsEnumerator : IEnumerator<PublishedSearchResult>
             {
@@ -368,30 +348,28 @@ namespace Umbraco.Cms.Infrastructure
                 private readonly IVariationContextAccessor _variationContextAccessor;
                 private readonly IEnumerator<PublishedSearchResult> _wrapped;
 
-                public CultureContextualSearchResultsEnumerator(IEnumerator<PublishedSearchResult> wrapped,
-                    IVariationContextAccessor variationContextAccessor, VariationContext originalContext)
+                public CultureContextualSearchResultsEnumerator(IEnumerator<PublishedSearchResult> wrapped, IVariationContextAccessor variationContextAccessor, VariationContext originalContext)
                 {
                     _wrapped = wrapped;
                     _variationContextAccessor = variationContextAccessor;
                     _originalContext = originalContext;
                 }
 
+                public PublishedSearchResult Current => _wrapped.Current;
+
+                object IEnumerator.Current => Current;
+
                 public void Dispose()
                 {
                     _wrapped.Dispose();
-                    //reset
+
+                    // Reset to original variation context
                     _variationContextAccessor.VariationContext = _originalContext;
                 }
 
                 public bool MoveNext() => _wrapped.MoveNext();
 
-                public void Reset()
-                {
-                    _wrapped.Reset();
-                }
-
-                public PublishedSearchResult Current => _wrapped.Current;
-                object IEnumerator.Current => Current;
+                public void Reset() => _wrapped.Reset();
             }
         }
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -26,6 +26,9 @@ namespace Umbraco.Cms.Infrastructure
         private readonly IPublishedSnapshot _publishedSnapshot;
         private readonly IVariationContextAccessor _variationContextAccessor;
 
+        private static readonly HashSet<string> s_itemIdFieldNameHashSet =
+            new HashSet<string>() { ExamineFieldNames.ItemIdFieldName };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PublishedContentQuery" /> class.
         /// </summary>
@@ -270,7 +273,8 @@ namespace Umbraco.Cms.Infrastructure
             }
 
             // Only select item ID field, because results are loaded from the published snapshot based on this single value
-            var queryExecutor = ordering.SelectField(ExamineFieldNames.ItemIdFieldName);
+            var queryExecutor = ordering.SelectFields(s_itemIdFieldNameHashSet);
+
 
             var results = skip == 0 && take == 0
                 ? queryExecutor.Execute()
@@ -301,7 +305,7 @@ namespace Umbraco.Cms.Infrastructure
             if (query is IOrdering ordering)
             {
                 // Only select item ID field, because results are loaded from the published snapshot based on this single value
-                query = ordering.SelectField(ExamineFieldNames.ItemIdFieldName);
+                query = ordering.SelectFields(s_itemIdFieldNameHashSet);
             }
 
             var results = skip == 0 && take == 0


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/9823 introduced a new `loadedFields` parameter to one of the  `IPublishedContentQuery.Search()` overloads, which should be used to limit the amount of fields to load in the Examine search results. However, this method doesn't expose the actual search results, but maps them to a `PublishedSearchResult` by fetching the content from the published snapshot by only using the results item ID.

Long story short: we only ever need to select the item ID field, so the `loadedFields` parameter should currently always be set to `new HashSet<string>() { ExamineFieldNames.ItemIdFieldName }` for optimal performance. This PR ensures that's always the case and ignores this parameter (which should be cleaned up in the v10 branch).

I've also added an additional null-check in case the `VariationContext` is not set and fixed up some code styling. To review the actual changes, only use commit https://github.com/umbraco/Umbraco-CMS/commit/d04981bc22823e85df37548c40425eea24e4565c.

I've tested this by checking if the same results are logged both before and after applying this PR (using content from The Starter Kit):
```c#
using System;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Web;

public class ApplicationComposer : ComponentComposer<ApplicationComponent>
{ }

public class ApplicationComponent : IComponent
{
    private readonly ILogger<ApplicationComponent> _logger;
    private readonly IUmbracoContextFactory _umbracoContextFactory;
    private readonly IServiceProvider _serviceProvider;

    public ApplicationComponent(ILogger<ApplicationComponent> logger, IUmbracoContextFactory umbracoContextFactory, IServiceProvider serviceProvider)
    {
        _logger = logger;
        _umbracoContextFactory = umbracoContextFactory;
        _serviceProvider = serviceProvider;
    }

    public void Initialize()
    {
        using UmbracoContextReference _ = _umbracoContextFactory.EnsureUmbracoContext();
        using IServiceScope serviceScope = _serviceProvider.CreateScope();
        IPublishedContentQuery publishedContentQuery = serviceScope.ServiceProvider.GetRequiredService<IPublishedContentQuery>();

        foreach (var result in publishedContentQuery.Search("Umbraco"))
        {
            _logger.LogInformation("Found content {ContentName} with score {Score}", result.Content.Name, result.Score);
        }
    }

    public void Terminate()
    { }
}
```

You can also add a breakpoint on the return statement of the `Search` method and inspect the results to determine only a single field is loaded and the result ID is still set to the node ID.