### PR TITLE
Don't hold static UmbracoContext reference

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyUrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyUrlHelperExtensions.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Extensions
     public static class FriendlyUrlHelperExtensions
     {
 
-        private static IUmbracoContext UmbracoContext { get; } =
+        private static IUmbracoContext UmbracoContext =>
             StaticServiceProvider.Instance.GetRequiredService<IUmbracoContextAccessor>().GetRequiredUmbracoContext();
 
         private static IDataProtectionProvider DataProtectionProvider { get; } =


### PR DESCRIPTION
Fixes #11951 by changing `UmbracoContext` to be an expression rather than being a static setter thus ensuring the current umbraco context is always returned, rather than a cached version from initial execution

See issue for replication / testing steps