### PR TITLE
Check form and querystring when validating `ufprt` in `ValidateUmbracoFormRouteStringAttribute`

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
@@ -145,12 +145,12 @@ namespace Umbraco.Extensions
         /// <returns>The extracted `ufprt` token.</returns>
         public static string GetUfprt(this HttpRequest request)
         {
-            if (request.HasFormContentType && request.Form.TryGetValue("ufprt", out StringValues formVal))
+            if (request.HasFormContentType && request.Form.TryGetValue("ufprt", out StringValues formVal) && formVal != StringValues.Empty)
             {
                 return formVal.ToString();
             }
 
-            if (request.Query.TryGetValue("ufprt", out StringValues queryVal))
+            if (request.Query.TryGetValue("ufprt", out StringValues queryVal) && queryVal != StringValues.Empty)
             {
                 return queryVal.ToString();
             }

--- a/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
@@ -136,5 +136,25 @@ namespace Umbraco.Extensions
 
             return new Uri(routingSettings.UmbracoApplicationUrl);
         }
+
+        /// <summary>
+        /// Gets the Umbraco `ufprt` encrypted string from the current request
+        /// </summary>
+        /// <param name="request">The current request</param>
+        /// <returns>The extracted `ufprt` token.</returns>
+        public static string GetUfprt(this HttpRequest request)
+        {
+            if (request.HasFormContentType && request.Form.TryGetValue("ufprt", out StringValues formVal))
+            {
+                return formVal.ToString();
+            }
+
+            if (request.Query.TryGetValue("ufprt", out StringValues queryVal))
+            {
+                return queryVal.ToString();
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Routing;
 

--- a/src/Umbraco.Web.Common/Filters/ValidateUmbracoFormRouteStringAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ValidateUmbracoFormRouteStringAttribute.cs
@@ -42,7 +42,9 @@ namespace Umbraco.Cms.Web.Common.Filters
             {
                 if (context == null) throw new ArgumentNullException(nameof(context));
 
-                var ufprt = context.HttpContext.Request.Form["ufprt"];
+                var ufprt = context.HttpContext.Request.HasFormContentType
+                    ? context.HttpContext.Request.Form["ufprt"]
+                    : context.HttpContext.Request.Query["ufprt"];
 
                 if (context.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
                 {

--- a/src/Umbraco.Web.Common/Filters/ValidateUmbracoFormRouteStringAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ValidateUmbracoFormRouteStringAttribute.cs
@@ -42,9 +42,7 @@ namespace Umbraco.Cms.Web.Common.Filters
             {
                 if (context == null) throw new ArgumentNullException(nameof(context));
 
-                var ufprt = context.HttpContext.Request.HasFormContentType
-                    ? context.HttpContext.Request.Form["ufprt"]
-                    : context.HttpContext.Request.Query["ufprt"];
+                var ufprt = context.HttpContext.Request.GetUfprt();
 
                 if (context.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
                 {

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -201,23 +201,23 @@ namespace Umbraco.Cms.Web.Website.Routing
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            // if it is a POST/GET then a value must be in the request
-            if ((!httpContext.Request.HasFormContentType || !httpContext.Request.Form.TryGetValue("ufprt", out StringValues encodedVal))
-                && !httpContext.Request.Query.TryGetValue("ufprt", out encodedVal))
+            // if it is a POST/GET then a `ufprt` value must be in the request
+            var ufprt = httpContext.Request.GetUfprt();
+            if (string.IsNullOrWhiteSpace(ufprt))
             {
                 return null;
             }
 
             if (!EncryptionHelper.DecryptAndValidateEncryptedRouteString(
                 _dataProtectionProvider,
-                encodedVal,
-                out IDictionary<string, string> decodedParts))
+                ufprt,
+                out IDictionary<string, string> decodedUfprt))
             {
                 return null;
             }
 
             // Get all route values that are not the default ones and add them separately so they eventually get to action parameters
-            foreach (KeyValuePair<string, string> item in decodedParts.Where(x => ReservedAdditionalKeys.AllKeys.Contains(x.Key) == false))
+            foreach (KeyValuePair<string, string> item in decodedUfprt.Where(x => ReservedAdditionalKeys.AllKeys.Contains(x.Key) == false))
             {
                 values[item.Key] = item.Value;
             }
@@ -225,9 +225,9 @@ namespace Umbraco.Cms.Web.Website.Routing
             // return the proxy info without the surface id... could be a local controller.
             return new PostedDataProxyInfo
             {
-                ControllerName = WebUtility.UrlDecode(decodedParts.First(x => x.Key == ReservedAdditionalKeys.Controller).Value),
-                ActionName = WebUtility.UrlDecode(decodedParts.First(x => x.Key == ReservedAdditionalKeys.Action).Value),
-                Area = WebUtility.UrlDecode(decodedParts.First(x => x.Key == ReservedAdditionalKeys.Area).Value),
+                ControllerName = WebUtility.UrlDecode(decodedUfprt.First(x => x.Key == ReservedAdditionalKeys.Controller).Value),
+                ActionName = WebUtility.UrlDecode(decodedUfprt.First(x => x.Key == ReservedAdditionalKeys.Action).Value),
+                Area = WebUtility.UrlDecode(decodedUfprt.First(x => x.Key == ReservedAdditionalKeys.Area).Value),
             };
         }
 


### PR DESCRIPTION
Fixes #11956

### Description
Checks to see if the request has form data before validating the `ufprt` parameter in the forms data collection, and if it doesn't assumes it must be on the querystring.

I'm not sure if this then makes this attributes name a little wrong depending on what `Form` refers to in it's name? Another option could be to product a second attribute for validating `QueryString` instead and then people have to explicitly select which approach they are expecting?