### PR TITLE
Attempt to make app local icu setup less problematic.

### DIFF
--- a/build/templates/UmbracoProject/UmbracoProject.csproj
+++ b/build/templates/UmbracoProject/UmbracoProject.csproj
@@ -12,9 +12,18 @@
     </ItemGroup>
 
     <!-- Force windows to use ICU. Otherwise Windows 10 2019H1+ will do it, but older windows 10 and most if not all winodws servers will run NLS -->
-    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-        <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
+    <ItemGroup>
+      <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+
+      <RuntimeHostConfigurationOption 
+        Condition="$(RuntimeIdentifier.StartsWith('win')) Or ($([MSBuild]::IsOSPlatform('windows')) And '$(RuntimeIdentifier)' == '')" 
+        Include="System.Globalization.AppLocalIcu" 
+        Value="68.2.0.9" />
+
+      <RuntimeHostConfigurationOption 
+        Condition="$(RuntimeIdentifier.StartsWith('linux')) Or ($([MSBuild]::IsOSPlatform('linux')) And '$(RuntimeIdentifier)' == '')" 
+        Include="System.Globalization.AppLocalIcu" 
+        Value="68.2.0.9" />
     </ItemGroup>
 
     <Import Project="..\PackageTestSiteName\build\PackageTestSiteName.targets" Condition="'$(PackageTestSiteName)' != ''" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -19,6 +19,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+
+    <RuntimeHostConfigurationOption 
+      Condition="$(RuntimeIdentifier.StartsWith('win')) Or ($([MSBuild]::IsOSPlatform('windows')) And '$(RuntimeIdentifier)' == '')" 
+      Include="System.Globalization.AppLocalIcu" 
+      Value="68.2.0.9" />
+
+    <RuntimeHostConfigurationOption 
+      Condition="$(RuntimeIdentifier.StartsWith('linux')) Or ($([MSBuild]::IsOSPlatform('linux')) And '$(RuntimeIdentifier)' == '')" 
+      Include="System.Globalization.AppLocalIcu" 
+      Value="68.2.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="App_Plugins" />
     <Folder Include="Views" />
   </ItemGroup>


### PR DESCRIPTION
Prevents issues for windows build agent -> linux app server.

On Windows version is split at first '.' e.g. 68.2.0.9 ->  icuuc68.dll
https://github.com/dotnet/runtime/blob/205f70e/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Windows.cs

On Linux we are looking for libicuuc.so.68.2.0.9
https://github.com/dotnet/runtime/blob/205f70e/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs

On macos we don't have a native library in a shiny nuget package so hope
folks are building on their macs or setting the rid until we have a
better solution.

