### PR TITLE
Added check for IgnoreCurrentState to GetPendingPackageMigrations

### DIFF
--- a/src/Umbraco.Infrastructure/Packaging/PendingPackageMigrations.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PendingPackageMigrations.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Core.Packaging
             {
                 string currentMigrationState = null;
                 var planKeyValueKey = Constants.Conventions.Migrations.KeyValuePrefix + plan.Name;
-                if (keyValues.TryGetValue(planKeyValueKey, out var value))
+                if (!plan.IgnoreCurrentState && keyValues.TryGetValue(planKeyValueKey, out var value))
                 {
                     currentMigrationState = value;
 
@@ -49,7 +49,7 @@ namespace Umbraco.Cms.Core.Packaging
                 }
                 else
                 {
-                    // If there is nothing in the DB then we need to run
+                    // If ignoring state OR there is nothing in the DB then we need to run
                     pendingMigrations.Add(plan.Name);
                 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11960

### Description
This PR implements the suggested change in the issue - adding a check for IgnoreCurrentState to the process generating the list of pending package migrations.

A unit test has been added to PendingPackageMigrationsTest, and the process described in the issue can be used to test the change.
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
