### PR TITLE
Added name & color description for umbAvatar

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
@@ -45,6 +45,8 @@ Use this directive to render an avatar.
 @param {string} size (<code>attribute</code>): The size of the avatar (xs, s, m, l, xl).
 @param {string} img-src (<code>attribute</code>): The image source to the avatar.
 @param {string} img-srcset (<code>atribute</code>): Reponsive support for the image source.
+@param {string=} name (<code>attribute</code>): Name initials will be used if no image source.
+@param {string=} color (<code>attribute</code>): Color will be used if no image source (primary, secondary, success, warning, danger).
 **/
 
 (function() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
I used the `umbAvatar` directive in a component. And noticed that the default `umbAvatar` (with no images) just became a `?`. After some digging I found out that I could pass in name & color as parameters. And that fixed the default `umbAvatar`. So I just wanted to add them to the description.

I Don't know if my wording is correct for the description though.
