### PR TITLE
Fix "Empty Recycle Bin" functionality  for case sensitive file systems

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
@@ -470,7 +470,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 // only add empty recycle bin if the current user is allowed to delete by default
                 if (deleteAllowed)
                 {
-                    menu.Items.Add(new MenuItem("emptyRecycleBin", LocalizedTextService)
+                    menu.Items.Add(new MenuItem("emptyrecyclebin", LocalizedTextService)
                     {
                         Icon = "trash",
                         OpensDialog = true


### PR DESCRIPTION
The Empty Recycle Bin functionality does not work on case sensitive file systems.

Error:
![image](https://user-images.githubusercontent.com/7831614/153390030-c57f8b85-5fb3-469d-b671-fb9d316f0a2d.png)

System information:

<html>
<body>
<!--StartFragment-->

Category | Data
-- | --
Server OS | Linux 5.4.0-1056-azure #58~18.04.1-Ubuntu SMP Wed Jul 28 23:14:18 UTC 2021
Server Framework | .NET 5.0.14
Default Language | nl-NL
Umbraco Version | 9.3.0
Current Culture | en-GB
Current UI Culture | en-GB
Current Webserver | Kestrel
Browser | Chrome 97.0.4692.99
Browser OS | Win32

<!--EndFragment-->
</body>
</html>

In this PR I've changed the alias of the MenuItem so that it is equal to the view name `emptyrecyclebin.html`

Belongs to: https://github.com/umbraco/Umbraco-CMS/issues/11868