### PR TITLE
Fix items found in PVS-Studio analysis

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -49,6 +49,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
                 if (!ModelsMode.IsAuto())
                 {
                     _flagOutOfDateModels = false;
+                    return;
                 }
 
                 _flagOutOfDateModels = value;

--- a/src/Umbraco.Core/Extensions/ObjectExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ObjectExtensions.cs
@@ -626,7 +626,6 @@ namespace Umbraco.Extensions
             if (type == typeof(sbyte)) return XmlConvert.ToString((sbyte)value);
             if (type == typeof(short)) return XmlConvert.ToString((short)value);
             if (type == typeof(TimeSpan)) return XmlConvert.ToString((TimeSpan)value);
-            if (type == typeof(bool)) return XmlConvert.ToString((bool)value);
             if (type == typeof(uint)) return XmlConvert.ToString((uint)value);
             if (type == typeof(ulong)) return XmlConvert.ToString((ulong)value);
             if (type == typeof(ushort)) return XmlConvert.ToString((ushort)value);

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -269,16 +269,10 @@ namespace Umbraco.Extensions
 
             if (!pcr.HasPublishedContent())
             {
-                var logMsg = nameof(DetectCollisionAsync) +
+                const string logMsg = nameof(DetectCollisionAsync) +
                              " did not resolve a content item for original url: {Url}, translated to {TranslatedUrl} and culture: {Culture}";
-                if (pcr.IgnorePublishedContentCollisions)
-                {
-                    logger.LogDebug(logMsg, url, uri, culture);
-                }
-                else
-                {
-                    logger.LogDebug(logMsg, url, uri, culture);
-                }
+
+                logger.LogDebug(logMsg, url, uri, culture);
 
                 var urlInfo = UrlInfo.Message(textService.Localize("content", "routeErrorCannotRoute"), culture);
                 return Attempt.Succeed(urlInfo);

--- a/src/Umbraco.Infrastructure/Persistence/Querying/ExpressionVisitorBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Querying/ExpressionVisitorBase.cs
@@ -468,7 +468,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Querying
                 case nameof(StringExtensions.InvariantStartsWith):
                 case nameof(StringExtensions.InvariantEndsWith):
                 case nameof(StringExtensions.InvariantContains):
-                case nameof(StringExtensions.InvariantEquals):                
+                case nameof(StringExtensions.InvariantEquals):
 
                     string compareValue;
 
@@ -629,7 +629,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Querying
                     if (m.Arguments.Count == 2)
                     {
                         var n1 = Visit(m.Arguments[0]);
-                        var f = m.Arguments[2];
+                        var f = m.Arguments[1];
                         if (!(f is Expression<Func<string, string>> fl))
                             throw new NotSupportedException("Expression is not a proper lambda.");
                         var ff = fl.Compile();

--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -760,27 +760,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 if (id == Constants.System.Root && startNodes.Length > 0 &&
                     startNodes.Contains(Constants.System.Root) == false && !ignoreUserStartNodes)
                 {
-                    if (pageNumber > 0)
-                    {
-                        return new PagedResult<EntityBasic>(0, 0, 0);
-                    }
-
-                    IEntitySlim[] nodes = _entityService.GetAll(objectType.Value, startNodes).ToArray();
-                    if (nodes.Length == 0)
-                    {
-                        return new PagedResult<EntityBasic>(0, 0, 0);
-                    }
-
-                    if (pageSize < nodes.Length)
-                    {
-                        pageSize = nodes.Length; // bah
-                    }
-
-                    var pr = new PagedResult<EntityBasic>(nodes.Length, pageNumber, pageSize)
-                    {
-                        Items = nodes.Select(_umbracoMapper.Map<EntityBasic>)
-                    };
-                    return pr;
+                    return new PagedResult<EntityBasic>(0, 0, 0);
                 }
 
                 // else proceed as usual

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -479,7 +479,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         {
             if (userSave == null)
             {
-                throw new ArgumentNullException("userSave");
+                throw new ArgumentNullException(nameof(userSave));
             }
 
             if (userSave.Message.IsNullOrWhiteSpace())
@@ -487,7 +487,6 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 ModelState.AddModelError("Message", "Message cannot be empty");
             }
 
-            IUser user;
             if (_securitySettings.UsernameIsEmail)
             {
                 // ensure it's the same
@@ -496,16 +495,14 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             else
             {
                 // first validate the username if we're showing it
-                var userResult = CheckUniqueUsername(userSave.Username, u => u.LastLoginDate != default || u.EmailConfirmedDate.HasValue);
-                if (!(userResult.Result is null))
+                ActionResult<IUser> userResult = CheckUniqueUsername(userSave.Username, u => u.LastLoginDate != default || u.EmailConfirmedDate.HasValue);
+                if (userResult.Result is not null)
                 {
                     return userResult.Result;
                 }
-
-                user = userResult.Value;
             }
 
-            user = CheckUniqueEmail(userSave.Email, u => u.LastLoginDate != default || u.EmailConfirmedDate.HasValue);
+            IUser user = CheckUniqueEmail(userSave.Email, u => u.LastLoginDate != default || u.EmailConfirmedDate.HasValue);
 
             if (ModelState.IsValid == false)
             {

--- a/src/Umbraco.Web.Common/Routing/RoutableDocumentFilter.cs
+++ b/src/Umbraco.Web.Common/Routing/RoutableDocumentFilter.cs
@@ -195,7 +195,8 @@ namespace Umbraco.Cms.Web.Common.Routing
             var routeValues = new RouteValueDictionary();
 
             // To get the matchedEndpoint of the provide url
-            RouteEndpoint matchedEndpoint = routeEndpoints
+            RouteEndpoint matchedEndpoint = routeEndpoints?
+                .Where(e => e.RoutePattern.RawText != null)
                 .Where(e => new TemplateMatcher(
                         TemplateParser.Parse(e.RoutePattern.RawText),
                         new RouteValueDictionary())

--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -73,8 +73,6 @@ namespace Umbraco.Cms.Web.Common.Security
             }
             else
             {
-                string username;
-
                 MemberIdentityUser currentMember = await GetCurrentMemberAsync();
 
                 // If a member could not be resolved from the provider, we are clearly not authorized and can break right here
@@ -84,7 +82,6 @@ namespace Umbraco.Cms.Web.Common.Security
                 }
 
                 int memberId = int.Parse(currentMember.Id, CultureInfo.InvariantCulture);
-                username = currentMember.UserName;
 
                 // If types defined, check member is of one of those types
                 IList<string> allowTypesList = allowTypes as IList<string> ?? allowTypes.ToList();
@@ -95,10 +92,11 @@ namespace Umbraco.Cms.Web.Common.Security
                 }
 
                 // If specific members defined, check member is of one of those
-                if (allowAction && allowMembers.Any())
+                var allowMembersList = allowMembers.ToList();
+                if (allowAction && allowMembersList.Any())
                 {
                     // Allow only if member's Id is in the list
-                    allowAction = allowMembers.Contains(memberId);
+                    allowAction = allowMembersList.Contains(memberId);
                 }
 
                 // If groups defined, check member is of one of those groups
@@ -118,7 +116,7 @@ namespace Umbraco.Cms.Web.Common.Security
         public bool IsLoggedIn()
         {
             HttpContext httpContext = _httpContextAccessor.HttpContext;
-            return httpContext?.User != null && httpContext.User.Identity.IsAuthenticated;
+            return httpContext?.User.Identity?.IsAuthenticated ?? false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
During yesterday's UmbraCollab Thursday we looked at this report from PVS Studio: https://pvs-studio.com/en/blog/posts/csharp/0898/

We found that most of the problems were valid, in short:

- 01: `ExpressionVisitorBase` - seems like a copy-paste error, indeed the intention would have been to take the second parameter and not the third.
- 02: `ObjectExtensions` - clear and correct, we were doing the exact same thing twice, no need.
- 03: `ModelsBuilderSettings` - a bit more of a puzzle but we all agreed that if the models mode is any of the "auto" ones then it makes no sense to flag the models to be out of date, the "auto" handler will take care of it so no need to flag it and put a button in the backoffice to reload the models. 
- 04: `RoutableDocumentFilter` - indeed a null check was missing and Rider also highlighted another possible null reference error on `e.RoutePattern.RawText` so we fixed that one as well.
- 05: `RelateOnCopyNotificationHandler` - NOT fixed. Indeed the arguments are in the wrong order in the code, but since there's a slight chance that someone is already depending on the wrong name/alias combo we don't want to introduce a breaking change, I'll propose it for v10 instead.
- 06: `UrlProviderExtensions` - the if/else wasn't necessary indeed, deleted a few lines.
- 07: `MemberManager` - indeed, the `username` variable was entirely unused and unnecessary, we found some additional warnings in Rider and fixed those up as well making sure that we don't do multiple enumerations and preventing a null ref error
- 08: `UsersController` - correctly identified as a `user` variable getting assigned and then immediately being overwritten which didn't make any sense, also cleaned up some code a little bit
- 09: `EntityController` - this was a surprising one, indeed we start the method with `if (pageNumber <= 0) return NotFound();` so `pageNumber` is always greater than `0` - so we could remove anything after that `if` check since we immediately return something when `pageNumber > 0` (which is: always!), so we removed the dead code.
-  10: `ConvertersTests` - NOT fixed. We believe this is a false positive, the `contentType1` object is used with different parameters and works fine for this test, also `contentType2` is set up to be used in a later part of this test, the confusion might be coming from the fact that we named `cnt1` and `cnt2` which both use `contentType1`, an automated analyzer can not determine that `cnt1` means "a content item created with the content type `contentType1` and `nodeId` 1003" and `cnt2` means "another content item, of the same content type but with a different id `1004`. 

All in all, some good fixes in there, a few things don't really make a difference but we've managed to fix some real errors here, so a worthwhile scan with a good outcome! 👍 