### PR TITLE
Fix for issue 11987 - Ignores missing package dependencies in sort

### DIFF
--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -514,7 +514,7 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             //Sorting the Document Types based on dependencies - if its not a single doc type import ref. #U4-5921
             List<XElement> documentTypes = isSingleDocTypeImport
                 ? unsortedDocumentTypes.ToList()
-                : graph.GetSortedItems().Select(x => x.Item).ToList();
+                : graph.GetSortedItems(throwOnMissing: false).Select(x => x.Item).ToList();
 
             //Iterate the sorted document types and create them as IContentType objects
             foreach (XElement documentType in documentTypes)


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11987
### Description
See issue for detailed description of problem solved.

The package import process throws a Missing Dependency" error when importing packages with dependencies on compositions defined in other packages.  Sorting the incoming document types by dependency creates an error state because the externally-defined composition does not exist within the graph's scope (the incoming XML document). This changes ignores these missing dependencies so they can be resolved by later code.

Testing guidelines are in the issue

<!-- Thanks for contributing to Umbraco CMS! -->
