### PR TITLE
11935 - provide unique ApplicationId for slot to allow consistent MainDom acquisition

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreAzureAppServiceSlotHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreAzureAppServiceSlotHostingEnvironment.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Cms.Web.Common.AspNetCore
+{
+    /// <summary>
+    /// An HostingEnvironment specifically for Azure App Service Slots that
+    /// provides an ApplicationId unique to a slot. This is required for acquiring/maintaining
+    /// the MainDom.
+    /// </summary>
+    public class AspNetCoreAzureAppServiceSlotHostingEnvironment : AspNetCoreHostingEnvironment, IHostingEnvironment
+    {
+        private const string SlotInstanceIdKey = "WEBSITE_INSTANCE_ID";
+        private const string SlotDeploymentIdKey = "WEBSITE_DEPLOYMENT_ID";
+
+        private string _applicationId;
+
+        public AspNetCoreAzureAppServiceSlotHostingEnvironment(
+            IServiceProvider serviceProvider,
+            IOptionsMonitor<HostingSettings> hostingSettings,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
+            IWebHostEnvironment webHostEnvironment)
+            : base(serviceProvider, hostingSettings, webRoutingSettings, webHostEnvironment)
+        {
+        }
+
+        /// <inheritdoc/>
+        string IHostingEnvironment.ApplicationId
+        {
+            get
+            {
+                if (_applicationId != null)
+                {
+                    return _applicationId;
+                }
+
+                var slotInstanceId = Environment.GetEnvironmentVariable(SlotInstanceIdKey);
+                if (string.IsNullOrWhiteSpace(slotInstanceId))
+                {
+                    throw new InvalidOperationException("Could not find a WEBSITE_INSTANCE_ID environment variable which suggests this is not an Azure AppService Slot.");
+                }
+
+                var deploymentId = Environment.GetEnvironmentVariable(SlotDeploymentIdKey);
+                if (string.IsNullOrWhiteSpace(deploymentId))
+                {
+                    throw new InvalidOperationException("Could not find a WEBSITE_DEPLOYMENT_ID environment variable which suggests this is not an Azure AppService Slot.");
+                }
+
+                return _applicationId = $"{slotInstanceId}:{deploymentId}";
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -383,6 +383,16 @@ namespace Umbraco.Extensions
         }
 
         /// <summary>
+        /// Adds support for acquiring MainDom on a AppService slot.
+        /// </summary>
+        public static IUmbracoBuilder AddAzureAppServiceSlotSupport(this IUmbracoBuilder builder)
+        {
+            builder.Services.AddUnique<IHostingEnvironment, AspNetCoreAzureAppServiceSlotHostingEnvironment>();
+
+            return builder;
+        }
+
+        /// <summary>
         /// Adds SqlCe support for Umbraco
         /// </summary>
         private static IUmbracoBuilder AddUmbracoSqlCeSupport(this IUmbracoBuilder builder)


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11935

### Description
With the help of @nzdev we have created a new class called `AspNetCoreAzureAppServiceSlotHostingEnvironment` and this inherits from `AspNetCoreHostingEnvironment`. The purpose of this new class is purely to provide a unique ApplicationId for the slot that the Umbraco instance exists on. Without this, the MainDom of that instance cannot be acquired consistently since the slot swapping process would release the MainDom to the slot that was previously the production slot.

I have also added an extension method called `AddAzureAppServiceSlotSupport()` that can be used during the startup process. This method registers the new class, replacing the `AspNetCoreHostingEnvironment` registration:

``` 
services
    .AddUmbraco()
    .AddBackOffice()
    .AddWebsite()
    .AddAzureAppServiceSlotSupport()
    .AddComposers()
    .Build();
```