### PR TITLE
Backwards compatible upgrade to ImageSharp 2

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="imagesharp.myget" value="https://www.myget.org/F/sixlabors/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- temporary, until ImageSharp.Web 2.0.0 gets released-->
     <add key="imagesharp.myget" value="https://www.myget.org/F/sixlabors/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
     {
         internal const string StaticBrowserMaxAge = "7.00:00:00";
         internal const string StaticCacheMaxAge = "365.00:00:00";
-        internal const int StaticCachedNameLength = 8;
+        internal const int StaticCacheHashLength = 8;
         internal const string StaticCacheFolder = Constants.SystemDirectories.TempData +  "/MediaCache";
 
         /// <summary>
@@ -32,8 +32,8 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets or sets a value for length of the cached name.
         /// </summary>
-        [DefaultValue(StaticCachedNameLength)]
-        public uint CachedNameLength { get; set; } = StaticCachedNameLength;
+        [DefaultValue(StaticCacheHashLength)]
+        public uint CacheHashLength { get; set; } = StaticCacheHashLength;
 
         /// <summary>
         /// Gets or sets a value for the cache folder.

--- a/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
     {
         internal const string StaticBrowserMaxAge = "7.00:00:00";
         internal const string StaticCacheMaxAge = "365.00:00:00";
-        internal const int StaticCacheHashLength = 8;
+        internal const int StaticCachedNameLength = 8;
         internal const string StaticCacheFolder = Constants.SystemDirectories.TempData +  "/MediaCache";
 
         /// <summary>
@@ -32,14 +32,8 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets or sets a value for length of the cached name.
         /// </summary>
-        [Obsolete("Use CacheHashLength instead")]
-        public uint CachedNameLength { get => CacheHashLength; set { CacheHashLength = value; } }
-
-        /// <summary>
-        /// Gets or sets a value for length of the cached name.
-        /// </summary>
-        [DefaultValue(StaticCacheHashLength)]
-        public uint CacheHashLength { get; set; } = StaticCacheHashLength;
+        [DefaultValue(StaticCachedNameLength)]
+        public uint CachedNameLength { get; set; } = StaticCachedNameLength;
 
         /// <summary>
         /// Gets or sets a value for the cache folder.

--- a/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingCacheSettings.cs
@@ -32,6 +32,12 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets or sets a value for length of the cached name.
         /// </summary>
+        [Obsolete("Use CacheHashLength instead")]
+        public uint CachedNameLength { get => CacheHashLength; set { CacheHashLength = value; } }
+
+        /// <summary>
+        /// Gets or sets a value for length of the cached name.
+        /// </summary>
         [DefaultValue(StaticCacheHashLength)]
         public uint CacheHashLength { get; set; } = StaticCacheHashLength;
 

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -45,7 +45,7 @@
       <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.ImageSharp.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.ImageSharp.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Extensions
                 // options.Configuration is set using ImageSharpConfigurationOptions below
                 options.BrowserMaxAge = imagingSettings.Cache.BrowserMaxAge;
                 options.CacheMaxAge = imagingSettings.Cache.CacheMaxAge;
-                options.CacheHashLength = imagingSettings.Cache.CacheHashLength;
+                options.CacheHashLength = imagingSettings.Cache.CachedNameLength;
 
                 // Use configurable maximum width and height (overwrite ImageSharps default)
                 options.OnParseCommandsAsync = context =>

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.ImageSharp.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.ImageSharp.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Extensions
                 // options.Configuration is set using ImageSharpConfigurationOptions below
                 options.BrowserMaxAge = imagingSettings.Cache.BrowserMaxAge;
                 options.CacheMaxAge = imagingSettings.Cache.CacheMaxAge;
-                options.CachedNameLength = imagingSettings.Cache.CachedNameLength;
+                options.CacheHashLength = imagingSettings.Cache.CacheHashLength;
 
                 // Use configurable maximum width and height (overwrite ImageSharps default)
                 options.OnParseCommandsAsync = context =>

--- a/src/Umbraco.Web.Common/ImageProcessors/CropWebProcessor.cs
+++ b/src/Umbraco.Web.Common/ImageProcessors/CropWebProcessor.cs
@@ -27,6 +27,19 @@ namespace Umbraco.Cms.Web.Common.ImageProcessors
         };
 
         /// <inheritdoc/>
+        [Obsolete("Use the method taking a CommandCollection instead")]
+        public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands, CommandParser parser, CultureInfo culture)
+        {
+            var collection = new CommandCollection();
+            foreach (KeyValuePair<string, string> command in commands)
+            {
+                collection.Add(command.Key, command.Value);
+            }
+
+            return Process(image, logger, collection, parser, culture);
+        }
+
+        /// <inheritdoc/>
         public FormattedImage Process(FormattedImage image, ILogger logger, CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
             RectangleF? coordinates = GetCoordinates(commands, parser, culture);

--- a/src/Umbraco.Web.Common/ImageProcessors/CropWebProcessor.cs
+++ b/src/Umbraco.Web.Common/ImageProcessors/CropWebProcessor.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Web.Common.ImageProcessors
         };
 
         /// <inheritdoc/>
-        public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands, CommandParser parser, CultureInfo culture)
+        public FormattedImage Process(FormattedImage image, ILogger logger, CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
             RectangleF? coordinates = GetCoordinates(commands, parser, culture);
             if (coordinates != null)
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Web.Common.ImageProcessors
             return image;
         }
 
-        private static RectangleF? GetCoordinates(IDictionary<string, string> commands, CommandParser parser, CultureInfo culture)
+        private static RectangleF? GetCoordinates(CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
             float[] coordinates = parser.ParseValue<float[]>(commands.GetValueOrDefault(Coordinates), culture);
 

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -34,7 +34,7 @@
       <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-      <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0-alpha.0.16" />
+      <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0-alpha.0.18" />
       <PackageReference Include="Smidge.Nuglify" Version="4.0.3" />
       <PackageReference Include="Smidge.InMemory" Version="4.0.3" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -34,7 +34,7 @@
       <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-      <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.5" />
+      <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0-alpha.0.10" />
       <PackageReference Include="Smidge.Nuglify" Version="4.0.3" />
       <PackageReference Include="Smidge.InMemory" Version="4.0.3" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -34,7 +34,7 @@
       <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-      <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0-alpha.0.10" />
+      <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0-alpha.0.16" />
       <PackageReference Include="Smidge.Nuglify" Version="4.0.3" />
       <PackageReference Include="Smidge.InMemory" Version="4.0.3" />
       <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ImageProcessors/CropWebProcessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ImageProcessors/CropWebProcessorTests.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ImageProcessors
             var parser = new CommandParser(converters);
             CultureInfo culture = CultureInfo.InvariantCulture;
 
-            var commands = new Dictionary<string, string>
+            var commands = new CommandCollection
             {
                 { CropWebProcessor.Coordinates, "0.1,0.2,0.1,0.4" },  // left, top, right, bottom
             };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11938

### Description
This upgrades ImageSharp and ImageSharp.Web to 2.0.0 without making breaking changes in Umbracos public API.

ImageSharp.Web 2.0.0 is still unreleased, so WIP until that gets released.

To test, check if image generation works, eg. https://localhost:44331/umbraco/assets/img/login.jpg?width=200&format=webp


<!-- Thanks for contributing to Umbraco CMS! -->
