### PR TITLE
Fix build required before initial publish for packages

### DIFF
--- a/templates/UmbracoPackage/buildTransitive/UmbracoPackage.targets
+++ b/templates/UmbracoPackage/buildTransitive/UmbracoPackage.targets
@@ -3,7 +3,7 @@
     <UmbracoPackageMsBuildContentFilesPath>$(MSBuildThisFileDirectory)..\App_Plugins\UmbracoPackage\**\*.*</UmbracoPackageMsBuildContentFilesPath>
   </PropertyGroup>
 
-  <Target Name="CopyUmbracoPackageMsBuildAssets" BeforeTargets="Build">
+  <Target Name="CopyUmbracoPackageMsBuildAssets" BeforeTargets="BeforeBuild">
     <ItemGroup>
       <UmbracoPackageMsBuildContentFiles Include="$(UmbracoPackageMsBuildContentFilesPath)" />
     </ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Similarly to what was already fixed with #11211 package assets also require currently the project to be built and only then published in order to ensure the package assets are correctly copied to the output folder.
This happens because while the aforementioned PR ensures files are published, the current target only seems to run after the build is already finished.
The change ensures the files are copied earlier in the build process, in line with the `CopyUmbracoAssets` target.

### Steps to reproduce

- Install a package with assets (e.g uSync 9.1.0)
- Make sure the project is in a clean state and the assets aren't present in App_Plugins yet (`dotnet clean`)
- Run `dotnet publish` 
- The output should now be missing the package assets
