### PR TITLE
[9.3.0] Fixed failure during MovePackageXMLToDB migration

### DIFF
--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -751,7 +751,7 @@ namespace Umbraco.Cms.Core.Packaging
             var packagesFile = _hostingEnvironment.MapPathContentRoot(CreatedPackagesFile);
             File.Delete(packagesFile);
             var packagesFolder = _hostingEnvironment.MapPathContentRoot(_packagesFolderPath);
-            Directory.Delete(packagesFolder);
+            Directory.Delete(packagesFolder, true);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The packages folder deletion would fail if the folder contained any file.
In my specific case it still contained an installedPackages.config XML file.

In this case I assumed we were sure we want to remove the packages folder, but an alternative solution would be to check if the folder still contained any files and skip it's deletion.

### Steps to reproduce:

- Install Umbraco 9.2.0
- Create any file under `umbraco\Data\packages` (e.g `installedPackages.config`)
- Try to upgrade to Umbraco 9.3.0
