### PR TITLE
v9 - Allow configuring TinyMCE scripting sanitization

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -174,10 +174,10 @@ namespace Umbraco.Cms.Core.Configuration.Models
         public bool IsPickupDirectoryLocationConfigured => !string.IsNullOrWhiteSpace(Smtp?.PickupDirectoryLocation);
 
         /// <summary>
-        /// Gets a value indicating whether TinyMCE scripting sanitization should be applied.
+        /// Gets or sets a value indicating whether TinyMCE scripting sanitization should be applied.
         /// </summary>
         [DefaultValue(StaticSanitizeTinyMce)]
-        public bool SanitizeTinyMce => StaticSanitizeTinyMce;
+        public bool SanitizeTinyMce { get; set; } = StaticSanitizeTinyMce;
 
         /// <summary>
         /// Gets a value representing the time in milliseconds to lock the database for a write operation.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The `SanitizeTinyMce` wasn't settable, being always false, even though the new project template tried to set it to true.
The option should now be configurable, allowing TinyMCE scripting sanitization to be enabled.