### PR TITLE
V8: Fix deleting file on external filesystem

### DIFF
--- a/src/Umbraco.Web/Editors/CodeFileController.cs
+++ b/src/Umbraco.Web/Editors/CodeFileController.cs
@@ -306,7 +306,7 @@ namespace Umbraco.Web.Editors
             switch (type)
             {
                 case Core.Constants.Trees.PartialViews:
-                    if (IsDirectory(virtualPath, SystemDirectories.PartialViews))
+                    if (CanDeleteDirectory(virtualPath, SystemDirectories.PartialViews, Current.FileSystems.PartialViewsFileSystem))
                     {
                         Services.FileService.DeletePartialViewFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -318,7 +318,7 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Partial View or folder found with the specified path");
 
                 case Core.Constants.Trees.PartialViewMacros:
-                    if (IsDirectory(virtualPath, SystemDirectories.MacroPartials))
+                    if (CanDeleteDirectory(virtualPath, SystemDirectories.MacroPartials, Current.FileSystems.MacroPartialsFileSystem))
                     {
                         Services.FileService.DeletePartialViewMacroFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -330,7 +330,7 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Partial View Macro or folder found with the specified path");
 
                 case Core.Constants.Trees.Scripts:
-                    if (IsDirectory(virtualPath, SystemDirectories.Scripts))
+                    if (CanDeleteDirectory(virtualPath, SystemDirectories.Scripts, Current.FileSystems.ScriptsFileSystem))
                     {
                         Services.FileService.DeleteScriptFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -343,7 +343,7 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Script or folder found with the specified path");
 
                 case Core.Constants.Trees.Stylesheets:
-                    if (IsDirectory(virtualPath, SystemDirectories.Css))
+                    if (CanDeleteDirectory(virtualPath, SystemDirectories.Css, Current.FileSystems.StylesheetsFileSystem))
                     {
                         Services.FileService.DeleteStyleSheetFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -634,14 +634,23 @@ namespace Umbraco.Web.Editors
             return value;
         }
 
-        private bool IsDirectory(string virtualPath, string systemDirectory)
+        private bool CanDeleteDirectory(string virtualPath, string systemDirectory, IFileSystem fileSystem)
         {
             var path = IOHelper.MapPath(systemDirectory + "/" + virtualPath);
-            var dirInfo = new DirectoryInfo(path);
 
-            // If you turn off indexing in Windows this will have the attribute:
-            // `FileAttributes.Directory | FileAttributes.NotContentIndexed`
-            return (dirInfo.Attributes & FileAttributes.Directory) != 0;
+            // If it's a physical filesystem check with directory info
+            if (fileSystem.CanAddPhysical)
+            {
+                var dirInfo = new DirectoryInfo(path);
+
+                // If you turn off indexing in Windows this will have the attribute:
+                // `FileAttributes.Directory | FileAttributes.NotContentIndexed`
+                return (dirInfo.Attributes & FileAttributes.Directory) != 0;
+            }
+
+            // Otherwise check the filesystem abstraction to see if the folder exists
+            // Since this is used for delete, it presumably exists if we're trying to delete it
+            return fileSystem.DirectoryExists(path);
         }
 
         // this is an internal class for passing stylesheet data from the client to the controller while editing

--- a/src/Umbraco.Web/Editors/CodeFileController.cs
+++ b/src/Umbraco.Web/Editors/CodeFileController.cs
@@ -306,7 +306,7 @@ namespace Umbraco.Web.Editors
             switch (type)
             {
                 case Core.Constants.Trees.PartialViews:
-                    if (CanDeleteDirectory(virtualPath, SystemDirectories.PartialViews, Current.FileSystems.PartialViewsFileSystem))
+                    if (IsDirectory(virtualPath, SystemDirectories.PartialViews, Current.FileSystems.PartialViewsFileSystem))
                     {
                         Services.FileService.DeletePartialViewFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -318,7 +318,7 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Partial View or folder found with the specified path");
 
                 case Core.Constants.Trees.PartialViewMacros:
-                    if (CanDeleteDirectory(virtualPath, SystemDirectories.MacroPartials, Current.FileSystems.MacroPartialsFileSystem))
+                    if (IsDirectory(virtualPath, SystemDirectories.MacroPartials, Current.FileSystems.MacroPartialsFileSystem))
                     {
                         Services.FileService.DeletePartialViewMacroFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -330,7 +330,7 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Partial View Macro or folder found with the specified path");
 
                 case Core.Constants.Trees.Scripts:
-                    if (CanDeleteDirectory(virtualPath, SystemDirectories.Scripts, Current.FileSystems.ScriptsFileSystem))
+                    if (IsDirectory(virtualPath, SystemDirectories.Scripts, Current.FileSystems.ScriptsFileSystem))
                     {
                         Services.FileService.DeleteScriptFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -343,7 +343,7 @@ namespace Umbraco.Web.Editors
                     return Request.CreateErrorResponse(HttpStatusCode.NotFound, "No Script or folder found with the specified path");
 
                 case Core.Constants.Trees.Stylesheets:
-                    if (CanDeleteDirectory(virtualPath, SystemDirectories.Css, Current.FileSystems.StylesheetsFileSystem))
+                    if (IsDirectory(virtualPath, SystemDirectories.Css, Current.FileSystems.StylesheetsFileSystem))
                     {
                         Services.FileService.DeleteStyleSheetFolder(virtualPath);
                         return Request.CreateResponse(HttpStatusCode.OK);
@@ -634,7 +634,7 @@ namespace Umbraco.Web.Editors
             return value;
         }
 
-        private bool CanDeleteDirectory(string virtualPath, string systemDirectory, IFileSystem fileSystem)
+        private bool IsDirectory(string virtualPath, string systemDirectory, IFileSystem fileSystem)
         {
             var path = IOHelper.MapPath(systemDirectory + "/" + virtualPath);
 


### PR DESCRIPTION
This fixes #11963 

The issue was exactly as @rasmusjp mentioned in the issue that when deleting a codefile, we use the local filesystem to check if we're trying to delete afolder, which of course won't work with external filesystems.

Unfortunately there's no really good way to achieve this with the `IFileSystem` abstraction, so what I've had to do is to first check if the registered `IFileSystem` is a physical file system using `CanAddPhysical`, if it's a physical file system, we rely on the old method, however, if it's not we instead use the `DirectoryExists` method in the `IFileSystem` to see if it's a folder. This method will of course only return true if the folder actually exists, but since this is only used to check if we need to delete a file or a folder, I think it's a fair assumption that the folder you're trying to delete actually exists.

### Testing

This one is a bit tricky to test, since you need to create a custom `IFileSystem` that doesn't use the physical filesystem, and you can't install `Umbraco.Cloud.StorageProviders.AzureBlob` directly into the cms project, so what I had to do was:

* Setup a storage account with a blob storage container
* Create an Umbraco 8.17 (not using the source code, but adding the CMS nuget package to an empty .net framework site)
* Add `Umbraco.Cloud.StorageProviders.AzureBlob` to that site
* Create a custom `IFileSystems` that uses the azure blob filesystem from the package
* Replace the normal `IFileSystems` with your implementation using a composer
* Add the blob connection strings to web config: `<add name="blob" connectionString="<ConnectionStringHere>" />`
* Run and install the site
* Build this branch and copy the dlls to the site while it's running (otherwise the build will overwrite the copied dlls), the site should restart when you copy the dlls
* Ensure that you can create and delete stylesheets

Note: there is a bug with the `Umbraco.Cloud.StorageProviders.AzureBlob` when used in this manner because folders is not really a thing in azure blob, so you can't create folders in the backoffce, so I had to do that on the azure portal itself, and as soon as the folder is empty it disappears, however this is not a problem with the CMS but an effect of how blob storage works 

### Appendix

Custom `IFileSystems` implementation:

```c#
using Umbraco.Cloud.StorageProviders.AzureBlob;
using Umbraco.Core.IO;

namespace EightSeventeen
{
    public class CustomFileSystems : IFileSystems
    {
        private readonly FileSystems _fileSystems;

        public CustomFileSystems(FileSystems fileSystems)
        {
            _fileSystems = fileSystems;
        }

        public IFileSystem MacroPartialsFileSystem => _fileSystems.MacroPartialsFileSystem;
        
        public IFileSystem PartialViewsFileSystem => _fileSystems.PartialViewsFileSystem;

        private IFileSystem _styleSheetFileSystem;
        
        public IFileSystem StylesheetsFileSystem
        {
            get
            {
                if (_styleSheetFileSystem is null)
                {
                    _styleSheetFileSystem = new FileSystem(SystemDirectories.Css, "blob", "styles");
                }

                return _styleSheetFileSystem;
            }
        }
        
        public IFileSystem ScriptsFileSystem => _fileSystems.ScriptsFileSystem;
        
        public IFileSystem MvcViewsFileSystem => _fileSystems.MvcViewsFileSystem;
    }
}
```

Composer:

```c#
using Umbraco.Core;
using Umbraco.Core.Composing;
using Umbraco.Core.IO;

namespace EightSeventeen
{
    public class MyComposer : IComposer
    {
        public void Compose(Composition composition)
        {
            composition.RegisterUnique<IFileSystems, CustomFileSystems>();
        }
    }
}
```