### PR TITLE
Add config to hide backoffice logo

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -46,8 +46,8 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         [ConfigurationProperty("loginLogoImage")]
         internal InnerTextConfigurationElement<string> LoginLogoImage => GetOptionalTextElement("loginLogoImage", "assets/img/application/umbraco_logo_white.svg");
 
-        [ConfigurationProperty("hideBackOfficeLogo")]
-        internal InnerTextConfigurationElement<bool> HideBackOfficeLogo => GetOptionalTextElement("hideBackOfficeLogo", false);
+        [ConfigurationProperty("hideBackofficeLogo")]
+        internal InnerTextConfigurationElement<bool> HideBackofficeLogo => GetOptionalTextElement("hideBackofficeLogo", false);
 
         string IContentSection.NotificationEmailAddress => Notifications.NotificationEmailAddress;
 
@@ -74,6 +74,6 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string IContentSection.LoginBackgroundImage => LoginBackgroundImage;
 
         string IContentSection.LoginLogoImage => LoginLogoImage;
-        bool IContentSection.HideBackOfficeLogo => HideBackOfficeLogo;
+        bool IContentSection.HideBackofficeLogo => HideBackofficeLogo;
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -46,6 +46,9 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         [ConfigurationProperty("loginLogoImage")]
         internal InnerTextConfigurationElement<string> LoginLogoImage => GetOptionalTextElement("loginLogoImage", "assets/img/application/umbraco_logo_white.svg");
 
+        [ConfigurationProperty("hideBackOfficeLogo")]
+        internal InnerTextConfigurationElement<bool> HideBackOfficeLogo => GetOptionalTextElement("hideBackOfficeLogo", false);
+
         string IContentSection.NotificationEmailAddress => Notifications.NotificationEmailAddress;
 
         bool IContentSection.DisableHtmlEmail => Notifications.DisableHtmlEmail;
@@ -71,5 +74,6 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string IContentSection.LoginBackgroundImage => LoginBackgroundImage;
 
         string IContentSection.LoginLogoImage => LoginLogoImage;
+        bool IContentSection.HideBackOfficeLogo => HideBackOfficeLogo;
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         internal InnerTextConfigurationElement<string> LoginLogoImage => GetOptionalTextElement("loginLogoImage", "assets/img/application/umbraco_logo_white.svg");
 
         [ConfigurationProperty("hideBackofficeLogo")]
-        internal InnerTextConfigurationElement<bool> HideBackofficeLogo => GetOptionalTextElement("hideBackofficeLogo", false);
+        internal InnerTextConfigurationElement<bool> HideBackOfficeLogo => GetOptionalTextElement("hideBackofficeLogo", false);
 
         string IContentSection.NotificationEmailAddress => Notifications.NotificationEmailAddress;
 
@@ -74,6 +74,6 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string IContentSection.LoginBackgroundImage => LoginBackgroundImage;
 
         string IContentSection.LoginLogoImage => LoginLogoImage;
-        bool IContentSection.HideBackofficeLogo => HideBackofficeLogo;
+        bool IContentSection.HideBackOfficeLogo => HideBackOfficeLogo;
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
@@ -36,6 +36,6 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string LoginBackgroundImage { get; }
 
         string LoginLogoImage { get; }
-        bool HideBackofficeLogo { get; }
+        bool HideBackOfficeLogo { get; }
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
@@ -12,11 +12,11 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         IEnumerable<string> ImageFileTypes { get; }
 
         IEnumerable<IImagingAutoFillUploadField> ImageAutoFillProperties { get; }
-        
+
         bool ResolveUrlsFromTextString { get; }
 
         IEnumerable<IContentErrorPage> Error404Collection { get; }
-        
+
         string PreviewBadge { get; }
 
         MacroErrorBehaviour MacroErrorBehaviour { get; }
@@ -36,5 +36,6 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string LoginBackgroundImage { get; }
 
         string LoginLogoImage { get; }
+        bool HideBackOfficeLogo { get; }
     }
 }

--- a/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/IContentSection.cs
@@ -36,6 +36,6 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         string LoginBackgroundImage { get; }
 
         string LoginLogoImage { get; }
-        bool HideBackOfficeLogo { get; }
+        bool HideBackofficeLogo { get; }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
@@ -16,6 +16,7 @@
                 { value: "assets/img/application/logo@2x.png" },
                 { value: "assets/img/application/logo@3x.png" }
             ];
+            scope.hideBackofficeLogo = Umbraco.Sys.ServerVariables.umbracoSettings.hideBackofficeLogo;
 
             // when a user logs out or timesout
             evts.push(eventsService.on("app.notAuthenticated", function () {
@@ -104,13 +105,24 @@
                 $timeout.cancel(scope.logoModal.timer);
             };
             scope.hideLogoModal = function() {
-                $timeout.cancel(scope.logoModal.timer);
-                scope.logoModal.timer = $timeout(function () {
-                    scope.logoModal.show = false;
-                }, 100);
+                if(scope.logoModal.show === true) {
+                    $timeout.cancel(scope.logoModal.timer);
+                    scope.logoModal.timer = $timeout(function () {
+                        scope.logoModal.show = false;
+                    }, 100);
+                }
             };
             scope.stopClickEvent = function($event) {
                 $event.stopPropagation();
+            };
+
+            scope.toggleLogoModal = function() {
+                if(scope.logoModal.show) {
+                    $timeout.cancel(scope.logoModal.timer);
+                    scope.logoModal.show = false;
+                } else {
+                    scope.showLogoModal();
+                }
             };
 
         }

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -9,10 +9,17 @@
 
 .umb-app-header__logo {
     margin-right: 30px;
+    flex-shrink: 0;
     button {
         img {
             height: 30px;
         }
+    }
+    
+}
+@media (max-width: 1279px) {
+    .umb-app-header__logo {
+        display: none;
     }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -1,7 +1,11 @@
 <div>
     <div class="umb-app-header">
-        <div class="umb-app-header__logo">
-            <button type="button" class="btn-reset" ng-click="showLogoModal()">
+        <div class="umb-app-header__logo" ng-if="hideBackofficeLogo !== true">
+            <button
+                type="button"
+                class="btn-reset"
+                ng-click="toggleLogoModal()"
+            >
                 <img
                     src="assets/img/application/umbraco_logomark_white.svg"
                     alt="Umbraco"

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -356,7 +356,7 @@ namespace Umbraco.Web.Editors
                         {"allowPasswordReset", Current.Configs.Settings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  Current.Configs.Settings().Content.LoginBackgroundImage},
                         {"loginLogoImage", Current.Configs.Settings().Content.LoginLogoImage },
-                        {"hideBackofficeLogo", Current.Configs.Settings().Content.HideBackofficeLogo },
+                        {"hideBackofficeLogo", Current.Configs.Settings().Content.HideBackOfficeLogo },
                         {"showUserInvite", EmailSender.CanSendRequiredEmail},
                         {"canSendRequiredEmail", EmailSender.CanSendRequiredEmail},
                         {"showAllowSegmentationForDocumentTypes", false},

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -356,6 +356,7 @@ namespace Umbraco.Web.Editors
                         {"allowPasswordReset", Current.Configs.Settings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  Current.Configs.Settings().Content.LoginBackgroundImage},
                         {"loginLogoImage", Current.Configs.Settings().Content.LoginLogoImage },
+                        {"hideBackOfficeLogo", Current.Configs.Settings().Content.HideBackOfficeLogo },
                         {"showUserInvite", EmailSender.CanSendRequiredEmail},
                         {"canSendRequiredEmail", EmailSender.CanSendRequiredEmail},
                         {"showAllowSegmentationForDocumentTypes", false},

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -57,7 +57,7 @@ namespace Umbraco.Web.Editors
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl", "iconApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "minimumPasswordLength", "minimumPasswordNonAlphaNum"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "minimumPasswordLength", "minimumPasswordNonAlphaNum", "hideBackofficeLogo"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}

--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -356,7 +356,7 @@ namespace Umbraco.Web.Editors
                         {"allowPasswordReset", Current.Configs.Settings().Security.AllowPasswordReset},
                         {"loginBackgroundImage",  Current.Configs.Settings().Content.LoginBackgroundImage},
                         {"loginLogoImage", Current.Configs.Settings().Content.LoginLogoImage },
-                        {"hideBackOfficeLogo", Current.Configs.Settings().Content.HideBackOfficeLogo },
+                        {"hideBackofficeLogo", Current.Configs.Settings().Content.HideBackofficeLogo },
                         {"showUserInvite", EmailSender.CanSendRequiredEmail},
                         {"canSendRequiredEmail", EmailSender.CanSendRequiredEmail},
                         {"showAllowSegmentationForDocumentTypes", false},


### PR DESCRIPTION
### Summary 
Adding config to hide the logo from backoffice

The following setting can be set in `umbracoSettings.config`:
```xml
<?xml version="1.0" encoding="utf-8"?>
<settings>
  <content>
    <hideBackofficeLogo>true</hideBackofficeLogo>
  </content>
</settings>
```
![image](https://user-images.githubusercontent.com/1561480/153880559-809ed6c4-9a72-434d-8d28-6fdb25f9f9d6.png)
vs
![image](https://user-images.githubusercontent.com/1561480/153880335-db69bd20-35fe-4ee3-aee6-a530fd0aea9c.png)

Related to https://github.com/umbraco/Umbraco-CMS/pull/11949

