### PR TITLE
Fixes Umbraco including content files twice

### DIFF
--- a/build/NuSpecs/buildTransitive/Umbraco.Cms.StaticAssets.targets
+++ b/build/NuSpecs/buildTransitive/Umbraco.Cms.StaticAssets.targets
@@ -39,6 +39,7 @@
 
             <ContentWithTargetPath
                 Include="@(_AppPluginsFiles)"
+                Exclude="@(ContentWithTargetPath)"
                 TargetPath="%(Identity)"
                 CopyToOutputDirectory="PreserveNewest"
                 CopyToPublishDirectory="PreserveNewest"/>
@@ -65,6 +66,7 @@
 
             <ContentWithTargetPath
                 Include="@(_UmbracoFolderFiles)"
+                Exclude="@(ContentWithTargetPath)"
                 TargetPath="%(Identity)"
                 CopyToOutputDirectory="PreserveNewest"
                 CopyToPublishDirectory="PreserveNewest"/>
@@ -92,7 +94,7 @@
 
     <Target Name="IncludeUmbracoRazorFiles" BeforeTargets="ResolveRazorGenerateInputs">
         <ItemGroup>
-            <Content Include="$(MSBuildProjectDirectory)\umbraco\**\*.cshtml" />
+            <Content Include="$(MSBuildProjectDirectory)\umbraco\**\*.cshtml" Exclude="@(Content)" />
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION


### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Umbraco content files are being included early in the build process to ensure that if the files didn't exist before, then are taken into account during the build process.
The issue is that, if the files already existed (e.g. incremental builds) they are now being included twice.
In .Net 5 I don't think this caused any observable issue, but in .Net 6 it causes Razer View Compilation to fail for incremental builds.

### Steps to reproduce:
- Activate Razor View Compilation
- Upgrade to .Net 6 (Although this is necessary to easily observe the issue, the incorrect behavior was present nonetheless)
- Compile the code
- Perform any code change and recompile the code without cleaning first.
- The following warning/error will be thrown:
```
CS8785	Generator 'RazorSourceGenerator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'ArgumentException' with message 'The hintName 'umbraco_PartialViewMacros_Templates_Breadcrumb_cshtml.g.cs' of the added source file must be unique within a generator.
```