### PR TITLE
Exclude the Umbraco Log files from UmbracoProject template gitignore

### DIFF
--- a/build/templates/UmbracoProject/.gitignore
+++ b/build/templates/UmbracoProject/.gitignore
@@ -461,6 +461,9 @@ $RECYCLE.BIN/
 # Dont commit Umbraco TEMP folder containing Examine Indexes, NuCache etc
 **/umbraco/Data/TEMP/
 
+# Umbraco log files
+**/umbraco/Logs/
+
 # Dont commit files that are generated and cached from the default ImageSharp location
 **/umbraco/mediacache/
 


### PR DESCRIPTION
Exclude the Umbraco Log files from UmbracoProject template gitignore. 
I think the current gitignore was possibly created when the log files were inside the TEMP folder