### PR TITLE
Fix Empty Recycle Bin view not found on Linux

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
@@ -470,7 +470,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 // only add empty recycle bin if the current user is allowed to delete by default
                 if (deleteAllowed)
                 {
-                    menu.Items.Add(new MenuItem("emptyRecycleBin", LocalizedTextService)
+                    menu.Items.Add(new MenuItem("emptyrecyclebin", LocalizedTextService)
                     {
                         Icon = "trash",
                         OpensDialog = true

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cs.xml
@@ -16,7 +16,7 @@
     <key alias="createGroup">Vytvořit skupinu</key>
     <key alias="delete">Odstranit</key>
     <key alias="disable">Deaktivovat</key>
-    <key alias="emptyRecycleBin">Vyprázdnit koš</key>
+    <key alias="emptyrecyclebin">Vyprázdnit koš</key>
     <key alias="enable">Aktivovat</key>
     <key alias="exportDocumentType">Exportovat typ dokumentu</key>
     <key alias="importdocumenttype">Importovat typ dokumentu</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/cy.xml
@@ -18,7 +18,7 @@
     <key alias="delete">Dileu</key>
     <key alias="disable">Analluogi</key>
     <key alias="editSettings">Golygu gosodiadau</key>
-    <key alias="emptyRecycleBin">Gwagu bin ailgylchu</key>
+    <key alias="emptyrecyclebin">Gwagu bin ailgylchu</key>
     <key alias="enable">Galluogi</key>
     <key alias="exportDocumentType">Allforio Math o Ddogfen</key>
     <key alias="importdocumenttype">Mewnforio Math o Ddogfen</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/da.xml
@@ -18,7 +18,7 @@
     <key alias="delete">Slet</key>
     <key alias="disable">Deaktivér</key>
     <key alias="editSettings">Edit settings</key>
-    <key alias="emptyRecycleBin">Tøm papirkurv</key>
+    <key alias="emptyrecyclebin">Tøm papirkurv</key>
     <key alias="enable">Aktivér</key>
     <key alias="exportDocumentType">Eksportér dokumenttype</key>
     <key alias="importdocumenttype">Importér dokumenttype</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/de.xml
@@ -16,7 +16,7 @@
     <key alias="createGroup">Neue Gruppe</key>
     <key alias="delete">Entfernen</key>
     <key alias="disable">Deaktivieren</key>
-    <key alias="emptyRecycleBin">Papierkorb leeren</key>
+    <key alias="emptyrecyclebin">Papierkorb leeren</key>
     <key alias="enable">Aktivieren</key>
     <key alias="exportDocumentType">Dokumenttyp exportieren</key>
     <key alias="importdocumenttype">Dokumenttyp importieren</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -17,7 +17,7 @@
     <key alias="delete">Delete</key>
     <key alias="disable">Disable</key>
     <key alias="editSettings">Edit settings</key>
-    <key alias="emptyRecycleBin">Empty recycle bin</key>
+    <key alias="emptyrecyclebin">Empty recycle bin</key>
     <key alias="enable">Enable</key>
     <key alias="exportDocumentType">Export Document Type</key>
     <key alias="importdocumenttype">Import Document Type</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -18,7 +18,7 @@
     <key alias="delete">Delete</key>
     <key alias="disable">Disable</key>
     <key alias="editSettings">Edit settings</key>
-    <key alias="emptyRecycleBin">Empty recycle bin</key>
+    <key alias="emptyrecyclebin">Empty recycle bin</key>
     <key alias="enable">Enable</key>
     <key alias="exportDocumentType">Export Document Type</key>
     <key alias="importdocumenttype">Import Document Type</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/es.xml
@@ -15,7 +15,7 @@
     <key alias="createGroup">Crear grupo</key>
     <key alias="delete">Borrar</key>
     <key alias="disable">Deshabilitar</key>
-    <key alias="emptyRecycleBin">Vaciar Papelera</key>
+    <key alias="emptyrecyclebin">Vaciar Papelera</key>
     <key alias="enable">Activar</key>
     <key alias="exportDocumentType">Exportar Documento (tipo)</key>
     <key alias="importdocumenttype">Importar Documento (tipo)</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/fr.xml
@@ -16,7 +16,7 @@
     <key alias="createGroup">Créer un groupe</key>
     <key alias="delete">Supprimer</key>
     <key alias="disable">Désactiver</key>
-    <key alias="emptyRecycleBin">Vider la corbeille</key>
+    <key alias="emptyrecyclebin">Vider la corbeille</key>
     <key alias="enable">Activer</key>
     <key alias="exportDocumentType">Exporter le type de document</key>
     <key alias="importdocumenttype">Importer un type de document</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/he.xml
@@ -13,7 +13,7 @@
     <key alias="createPackage">צור חבילה</key>
     <key alias="delete">מחק</key>
     <key alias="disable">נטרל</key>
-    <key alias="emptyRecycleBin">רוקן סל מיחזור</key>
+    <key alias="emptyrecyclebin">רוקן סל מיחזור</key>
     <key alias="exportDocumentType">ייצא סוג קובץ</key>
     <key alias="importdocumenttype">ייבא סוג מסמך</key>
     <key alias="importPackage">ייבא חבילה</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/it.xml
@@ -18,7 +18,7 @@
     <key alias="delete">Cancella</key>
     <key alias="disable">Disabilita</key>
     <key alias="editSettings">Modifica impostazioni</key>
-    <key alias="emptyRecycleBin">Svuota il cestino</key>
+    <key alias="emptyrecyclebin">Svuota il cestino</key>
     <key alias="enable">Abilita</key>
     <key alias="exportDocumentType">Esporta il tipo di documento</key>
     <key alias="importdocumenttype">Importa il tipo di documento</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ja.xml
@@ -14,7 +14,7 @@
     <key alias="createPackage">パッケージの作成</key>
     <key alias="delete">削除</key>
     <key alias="disable">無効</key>
-    <key alias="emptyRecycleBin">ごみ箱を空にする</key>
+    <key alias="emptyrecyclebin">ごみ箱を空にする</key>
     <key alias="exportDocumentType">ドキュメントタイプの書出</key>
     <key alias="importdocumenttype">ドキュメントタイプの読込</key>
     <key alias="importPackage">パッケージの読み込み</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ko.xml
@@ -13,7 +13,7 @@
     <key alias="createPackage">패키지 새로 만들기</key>
     <key alias="delete">삭제</key>
     <key alias="disable">비활성</key>
-    <key alias="emptyRecycleBin">휴지통 비우기</key>
+    <key alias="emptyrecyclebin">휴지통 비우기</key>
     <key alias="exportDocumentType">추출 문서 유형</key>
     <key alias="importdocumenttype">등록 문서 유형</key>
     <key alias="importPackage">패키지 등록</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nb.xml
@@ -14,7 +14,7 @@
     <key alias="createPackage">Opprett pakke</key>
     <key alias="delete">Slett</key>
     <key alias="disable">Deaktiver</key>
-    <key alias="emptyRecycleBin">Tøm papirkurv</key>
+    <key alias="emptyrecyclebin">Tøm papirkurv</key>
     <key alias="exportDocumentType">Eksporter dokumenttype</key>
     <key alias="importdocumenttype">Importer dokumenttype</key>
     <key alias="importPackage">Importer pakke</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/nl.xml
@@ -18,7 +18,7 @@
     <key alias="delete">Verwijderen</key>
     <key alias="disable">Uitschakelen</key>
     <key alias="editSettings">Instellingen wijzigen</key>
-    <key alias="emptyRecycleBin">Prullenbak leegmaken</key>
+    <key alias="emptyrecyclebin">Prullenbak leegmaken</key>
     <key alias="enable">Inschakelen</key>
     <key alias="exportDocumentType">Documenttype exporteren</key>
     <key alias="importdocumenttype">Documenttype importeren</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pl.xml
@@ -15,7 +15,7 @@
     <key alias="createGroup">Stwórz grupę</key>
     <key alias="delete">Usuń</key>
     <key alias="disable">Deaktywuj</key>
-    <key alias="emptyRecycleBin">Opróżnij kosz</key>
+    <key alias="emptyrecyclebin">Opróżnij kosz</key>
     <key alias="enable">Aktywuj</key>
     <key alias="exportDocumentType">Eksportuj typ dokumentu</key>
     <key alias="importdocumenttype">Importuj typ dokumentu</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/pt.xml
@@ -13,7 +13,7 @@
     <key alias="createPackage">Criar Pacote</key>
     <key alias="delete">Remover</key>
     <key alias="disable">Desabilitar</key>
-    <key alias="emptyRecycleBin">Esvaziar Lixeira</key>
+    <key alias="emptyrecyclebin">Esvaziar Lixeira</key>
     <key alias="exportDocumentType">Exportar Tipo de Documento</key>
     <key alias="importdocumenttype">Importar Tipo de Documento</key>
     <key alias="importPackage">Importar Pacote</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/ru.xml
@@ -17,7 +17,7 @@
     <key alias="defaultValue">Значение по умолчанию</key>
     <key alias="delete">Удалить</key>
     <key alias="disable">Отключить</key>
-    <key alias="emptyRecycleBin">Очистить корзину</key>
+    <key alias="emptyrecyclebin">Очистить корзину</key>
     <key alias="enable">Включить</key>
     <key alias="export">Экспорт</key>
     <key alias="exportDocumentType">Экспортировать</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/sv.xml
@@ -20,7 +20,7 @@
     <key alias="defaultValue">Standardvärde</key>
     <key alias="delete">Ta bort</key>
     <key alias="disable">Avaktivera</key>
-    <key alias="emptyRecycleBin">Töm papperskorgen</key>
+    <key alias="emptyrecyclebin">Töm papperskorgen</key>
     <key alias="exportDocumentType">Exportera dokumenttyp</key>
     <key alias="importdocumenttype">Importera dokumenttyp</key>
     <key alias="importPackage">Importera paket</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/tr.xml
@@ -17,7 +17,7 @@
     <key alias="delete">Sil</key>
     <key alias="disable">Devre Dışı Bırak</key>
     <key alias="editSettings">Ayarları düzenle</key>
-    <key alias="emptyRecycleBin">Geri dönüşüm kutusunu boşalt</key>
+    <key alias="emptyrecyclebin">Geri dönüşüm kutusunu boşalt</key>
     <key alias="enable">Etkinleştir</key>
     <key alias="exportDocumentType">Belge Türünü Dışa Aktar</key>
     <key alias="importdocumenttype">Belge Türünü İçe Aktar</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh.xml
@@ -14,7 +14,7 @@
     <key alias="createPackage">创建扩展包</key>
     <key alias="delete">删除</key>
     <key alias="disable">禁用</key>
-    <key alias="emptyRecycleBin">清空回收站</key>
+    <key alias="emptyrecyclebin">清空回收站</key>
     <key alias="exportDocumentType">导出文档类型</key>
     <key alias="importdocumenttype">导入文档类型</key>
     <key alias="importPackage">导入扩展包</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/zh_tw.xml
@@ -14,7 +14,7 @@
     <key alias="createPackage">創建擴展包</key>
     <key alias="delete">刪除</key>
     <key alias="disable">禁用</key>
-    <key alias="emptyRecycleBin">清空回收站</key>
+    <key alias="emptyrecyclebin">清空回收站</key>
     <key alias="exportDocumentType">匯出文檔類型</key>
     <key alias="importdocumenttype">導入文檔類型</key>
     <key alias="importPackage">導入擴展包</key>


### PR DESCRIPTION
Fixes #11868. See bug description and how to reproduce over there.

This PR fixes the casing difference between the request (`emptyRecycleBin`) and the file on disk (`emptyrecyclebin`) so now it works on Linux as well.

Below is a screenshot running on Linux with the PR code. Without the PR code you will not see this dialog as the request will return a 404. 

![image](https://user-images.githubusercontent.com/2269742/154142712-5e72cbd1-ee08-4a0e-ad16-82addd7a08c7.png)
