### PR TITLE
Fix DataValueEditor incorrectly serializing JSON value

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -158,10 +158,22 @@ namespace Umbraco.Cms.Core.PropertyEditors
         internal Attempt<object> TryConvertValueToCrlType(object value)
         {
             // Ensure empty string and JSON values are converted to null
-            if (value is string stringValue &&
-                (string.IsNullOrWhiteSpace(stringValue) || (ValueType.InvariantEquals(ValueTypes.Json) && stringValue.DetectIsEmptyJson())))
+            if (value is string stringValue && string.IsNullOrWhiteSpace(stringValue))
             {
                 value = null;
+            }
+            else if (value is not string && ValueType.InvariantEquals(ValueTypes.Json))
+            {
+                // Only serialize value when it's not already a string
+                var jsonValue = _jsonSerializer.Serialize(value);
+                if (jsonValue.DetectIsEmptyJson())
+                {
+                    value = null;
+                }
+                else
+                {
+                    value = jsonValue;
+                }
             }
 
             // Convert the string to a known type

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -158,25 +157,11 @@ namespace Umbraco.Cms.Core.PropertyEditors
         /// <exception cref="System.ArgumentOutOfRangeException">ValueType was out of range.</exception>
         internal Attempt<object> TryConvertValueToCrlType(object value)
         {
-            // Ensure empty string values are converted to null
-            if (value is string s && string.IsNullOrWhiteSpace(s))
+            // Ensure empty string and JSON values are converted to null
+            if (value is string stringValue &&
+                (string.IsNullOrWhiteSpace(stringValue) || (ValueType.InvariantEquals(ValueTypes.Json) && stringValue.DetectIsEmptyJson())))
             {
                 value = null;
-            }
-
-            // Ensure JSON is serialized properly (without indentation or converted to null when empty)
-            if (value is not null && ValueType.InvariantEquals(ValueTypes.Json))
-            {
-                var jsonValue = _jsonSerializer.Serialize(value);
-
-                if (jsonValue.DetectIsEmptyJson())
-                {
-                    value = null;
-                }
-                else
-                {
-                    value = jsonValue;
-                }
             }
 
             // Convert the string to a known type


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/11989.

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/11806 ensured JSON property values weren't serialized with indentation in v8, because the value type could be a Newtonsoft.Json type like `JArray` or `JObject` and calling `ToString()` on them would use  `Formatting.Indented` by default. This was fixed by type checking and using a `ToString()` overload to disable formatting:

https://github.com/umbraco/Umbraco-CMS/blob/f38124839c354f312b1f9653465b1c8bc25bb199/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs#L148-L159

However, in v9 the dependency on Newtonsoft.Json is abstracted to the `IJsonSerializer`, so the checks from this PR couldn't be merged up and required some fixes that were done in PR https://github.com/umbraco/Umbraco-CMS/pull/11904. This code was rewritten as:

https://github.com/umbraco/Umbraco-CMS/blob/dcff0c2f4c2cebbc75545667558fe4d9a6298207/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs#L167-L180

After further inspection, it looks like the property value type is now always a string in v9, so we don't need to serialize the value to a string again (which would result in the serialized JSON string, which contains quotes around the value).