### PR TITLE
Fixed issue in umbeditorheader.directive.js example

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -161,12 +161,14 @@ Use this directive to construct a header inside the main editor window.
                 name: "",
                 navigation: [
                     {
+                        "alias": "section1",
                         "name": "Section 1",
                         "icon": "icon-document-dashed-line",
                         "view": "/App_Plugins/path/to/html.html",
                         "active": true
                     },
                     {
+                        "alias": "section2",
                         "name": "Section 2",
                         "icon": "icon-list",
                         "view": "/App_Plugins/path/to/html.html",


### PR DESCRIPTION
When using the `navigation` parameter for the `umbEditorHeader` directive, one must specify an alias for each of the sections - otherwise the Angular repeater will trigger an error as the repeater is tracking the sections by their aliases.

Since the examples didn't include the alias, and because there appears to be no other information about the aliases, I've updated the example to include the aliases.
