### PR TITLE
Fix issue with migration from 8 and added support for 8.18 migration

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -242,6 +242,9 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade
             // to 8.17.0
             To<AddPropertyTypeGroupColumns>("{153865E9-7332-4C2A-9F9D-F20AEE078EC7}");
 
+            // Hack to support migration from 8.18
+            To<NoopMigration>("{03482BB0-CF13-475C-845E-ECB8319DBE3C}");
+
             // This should be safe to execute again. We need it with a new name to ensure updates from all the following has executed this step.
             // - 8.15.0 RC    - Current state: {4695D0C9-0729-4976-985B-048D503665D8}
             // - 8.15.0 Final - Current state: {5C424554-A32D-4852-8ED1-A13508187901}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTableIndexes.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTableIndexes.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using NPoco;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
@@ -20,14 +24,14 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
         {
             // Before adding these indexes we need to remove duplicate data.
             // Get all logins by latest
-            var logins = Database.Fetch<ExternalLoginDto>()
+            var logins = Database.Fetch<ExternalLoginTokenTable.LegacyExternalLoginDto>()
                 .OrderByDescending(x => x.CreateDate)
                 .ToList();
 
             var toDelete = new List<int>();
             // used to track duplicates so they can be removed
             var keys = new HashSet<(string, string)>();
-            foreach(ExternalLoginDto login in logins)
+            foreach(ExternalLoginTokenTable.LegacyExternalLoginDto login in logins)
             {
                 if (!keys.Add((login.ProviderKey, login.LoginProvider)))
                 {
@@ -37,16 +41,16 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
             }
             if (toDelete.Count > 0)
             {
-                Database.DeleteMany<ExternalLoginDto>().Where(x => toDelete.Contains(x.Id)).Execute();
-            }   
+                Database.DeleteMany<ExternalLoginTokenTable.LegacyExternalLoginDto>().Where(x => toDelete.Contains(x.Id)).Execute();
+            }
 
-            var indexName1 = "IX_" + ExternalLoginDto.TableName + "_LoginProvider";
+            var indexName1 = "IX_" + ExternalLoginTokenTable.LegacyExternalLoginDto.TableName + "_LoginProvider";
 
             if (!IndexExists(indexName1))
             {
                 Create
                      .Index(indexName1)
-                     .OnTable(ExternalLoginDto.TableName)
+                     .OnTable(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName)
                      .OnColumn("loginProvider")
                      .Ascending()
                      .WithOptions()
@@ -56,13 +60,13 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
                      .Do();
             }
 
-            var indexName2 = "IX_" + ExternalLoginDto.TableName + "_ProviderKey";
+            var indexName2 = "IX_" + ExternalLoginTokenTable.LegacyExternalLoginDto.TableName + "_ProviderKey";
 
             if (!IndexExists(indexName2))
             {
                 Create
                      .Index(indexName2)
-                     .OnTable(ExternalLoginDto.TableName)
+                     .OnTable(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName)
                      .OnColumn("loginProvider").Ascending()
                      .OnColumn("providerKey").Ascending()
                      .WithOptions()
@@ -70,5 +74,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
                      .Do();
             }
         }
+
+
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTableIndexesFixup.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTableIndexesFixup.cs
@@ -14,29 +14,29 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
 
         protected override void Migrate()
         {
-            var indexName1 = "IX_" + ExternalLoginDto.TableName + "_LoginProvider";
-            var indexName2 = "IX_" + ExternalLoginDto.TableName + "_ProviderKey";
+            var indexName1 = "IX_" + ExternalLoginTokenTable.LegacyExternalLoginDto.TableName + "_LoginProvider";
+            var indexName2 = "IX_" + ExternalLoginTokenTable.LegacyExternalLoginDto.TableName + "_ProviderKey";
 
             if (IndexExists(indexName1))
             {
                 // drop it since the previous migration index was wrong, and we
                 // need to modify a column that belons to it
-                Delete.Index(indexName1).OnTable(ExternalLoginDto.TableName).Do();
+                Delete.Index(indexName1).OnTable(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName).Do();
             }
 
             if (IndexExists(indexName2))
             {
                 // drop since it's using a column we're about to modify
-                Delete.Index(indexName2).OnTable(ExternalLoginDto.TableName).Do();
+                Delete.Index(indexName2).OnTable(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName).Do();
             }
 
             // then fixup the length of the loginProvider column
-            AlterColumn<ExternalLoginDto>(ExternalLoginDto.TableName, "loginProvider");
+            AlterColumn<ExternalLoginTokenTable.LegacyExternalLoginDto>(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName, "loginProvider");
 
             // create it with the correct definition
             Create
                  .Index(indexName1)
-                 .OnTable(ExternalLoginDto.TableName)
+                 .OnTable(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName)
                  .OnColumn("loginProvider").Ascending()
                  .OnColumn("userId").Ascending()
                  .WithOptions()
@@ -48,9 +48,9 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
             // re-create the original
             Create
                  .Index(indexName2)
-                 .OnTable(ExternalLoginDto.TableName)
+                 .OnTable(ExternalLoginTokenTable.LegacyExternalLoginDto.TableName)
                  .OnColumn("loginProvider").Ascending()
-                 .OnColumn("providerKey").Ascending()                 
+                 .OnColumn("providerKey").Ascending()
                  .WithOptions()
                  .NonClustered()
                  .Do();

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTokenTable.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_0_0/ExternalLoginTokenTable.cs
@@ -1,10 +1,14 @@
+using System;
 using System.Collections.Generic;
+using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
 {
-
     public class ExternalLoginTokenTable : MigrationBase
     {
         public ExternalLoginTokenTable(IMigrationContext context)
@@ -13,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
         }
 
         /// <summary>
-        /// Adds new External Login token table
+        ///     Adds new External Login token table
         /// </summary>
         protected override void Migrate()
         {
@@ -24,6 +28,54 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0
             }
 
             Create.Table<ExternalLoginTokenDto>().Do();
+        }
+
+        [TableName(TableName)]
+        [ExplicitColumns]
+        [PrimaryKey("Id")]
+        internal class LegacyExternalLoginDto
+        {
+            public const string TableName = Constants.DatabaseSchema.Tables.ExternalLogin;
+
+            [Column("id")] [PrimaryKeyColumn] public int Id { get; set; }
+
+            [Obsolete(
+                "This only exists to ensure you can upgrade using external logins from umbraco version where this was used to the new where it is not used")]
+            [Column("userId")]
+            public int? UserId { get; set; }
+
+
+            /// <summary>
+            ///     Used to store the name of the provider (i.e. Facebook, Google)
+            /// </summary>
+            [Column("loginProvider")]
+            [Length(400)]
+            [NullSetting(NullSetting = NullSettings.NotNull)]
+            [Index(IndexTypes.UniqueNonClustered, ForColumns = "loginProvider,userOrMemberKey",
+                Name = "IX_" + TableName + "_LoginProvider")]
+            public string LoginProvider { get; set; }
+
+            /// <summary>
+            ///     Stores the key the provider uses to lookup the login
+            /// </summary>
+            [Column("providerKey")]
+            [Length(4000)]
+            [NullSetting(NullSetting = NullSettings.NotNull)]
+            [Index(IndexTypes.NonClustered, ForColumns = "loginProvider,providerKey",
+                Name = "IX_" + TableName + "_ProviderKey")]
+            public string ProviderKey { get; set; }
+
+            [Column("createDate")]
+            [Constraint(Default = SystemMethods.CurrentDateTime)]
+            public DateTime CreateDate { get; set; }
+
+            /// <summary>
+            ///     Used to store any arbitrary data for the user and external provider - like user tokens returned from the provider
+            /// </summary>
+            [Column("userData")]
+            [NullSetting(NullSetting = NullSettings.Null)]
+            [SpecialDbType(SpecialDbTypes.NTEXT)]
+            public string UserData { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/11976

Fix issue with migration from 8 and added support for 8.18 migration.

The 8.18 have added a new noop migration just to change state, so we can but it into  the right order in v9. Otherwise it would skip directly to 9.1 and continue from there.

The bug was fixed by reintoducting the old model from pre 9.3, and only use it for the old migrations