### PR TITLE
WIP: Added ContentApp and Dashboard template

### DIFF
--- a/build/templates/ContentApp/.template.config/template.json
+++ b/build/templates/ContentApp/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "UmbracoPackageTeam",
+    "classifications": [
+        "Web",
+        "Umbraco",
+        "v9"
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+
+    "identity": "Umbraco.Templates.Items.ContentApp",
+    "groupIdentity": "Umbraco.Templates.Items.ContentApp",
+
+    "name": "Umbraco Content App",
+    "shortName": "umbraco-contentapp",
+    "description": "Files to add a content app to an Umbraco v8 project",
+    
+    "sourceName": "UmbracoPackage.1"
+}

--- a/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
+++ b/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="UmbracoPackage.1">
+		<key alias="contentAppHeader">UmbracoPackage.1 super content app</key>
+		<key alias="contentAppDesc">My super awesome content app</key>
+	</area>
+</language>

--- a/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
+++ b/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
@@ -1,0 +1,32 @@
+/**
+ * @ngdoc
+ * 
+ * @name: contentAppController
+ * @description: code for a content app in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function contentAppController() {
+
+        var vm = this;
+        vm.loading = true;
+        vm.message = "";
+
+        function init() {
+            getInfo();
+        }
+
+        function getInfo() {
+            vm.message = "Content App init() has run";
+            vm.loading = false;
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1ContentAppController', contentAppController);
+})();

--- a/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
+++ b/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
@@ -1,0 +1,17 @@
+<div ng-controller="umbracopackage__1ContentAppController as vm">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-if="!vm.loading">
+        <umb-box>
+            <umb-box-header title-key="UmbracoPackage.1_contentAppHeader"
+                            description-key="UmbracoPackage.1_contentAppDesc">
+            </umb-box-header>
+            <umb-box-content>
+                <h4>{{vm.message}}</h4>
+            </umb-box-content>
+
+        </umb-box>
+    </div>
+
+</div>

--- a/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
+++ b/build/templates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
@@ -1,0 +1,14 @@
+{
+    "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js"
+  ],
+  "contentApps": [
+    {
+        "name": "My App", // required - the name that appears under the icon
+        "alias": "umbracopackage._1-contentapp", // required - unique alias for your app
+        "weight": 0, // optional, default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps
+        "icon": "icon-cupcake", // required - the icon to use
+        "view": "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html" // required - the location of the view file
+    }
+  ]
+}

--- a/build/templates/Dashboard/.template.config/template.json
+++ b/build/templates/Dashboard/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "UmbracoPackageTeam",
+    "classifications": [
+        "Web",
+        "Umbraco",
+        "v9"
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+
+    "identity": "Umbraco.Templates.Items.Dashboard",
+    "groupIdentity": "Umbraco.Templates.Items.Dashboard",
+
+    "name": "Umbraco Dashboard Item",
+    "shortName": "umbraco-dashboard",
+    "description": "Umbraco dashboard files",
+    
+    "sourceName": "UmbracoPackage.1"
+}

--- a/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/Lang/en.xml
+++ b/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/Lang/en.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="UmbracoPackage.1">
+		<key alias="dashboardHeader">UmbracoPackage.1 super dashboard</key>
+		<key alias="dashboardDesc">My super awesome dashboard</key>
+	</area>
+	<area alias="dashboardTabs"> 
+		<key alias="umbracopackage._1-dashboard">UmbracoPackage.1</key>
+	</area>
+
+</language>

--- a/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.controller.js
+++ b/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.controller.js
@@ -1,0 +1,41 @@
+/**
+ * @ngdoc
+ * 
+ * @name: dashboardController
+ * @description: code for a dashboard in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function dashboardController($scope,
+        notificationsService,
+        umbracopackage__1DashboardService) {
+
+        var vm = this;
+        vm.loading = true;
+        vm.info = {};
+
+        function init() {
+            getServerInfo();
+        }
+
+        // ask the server what version it is and what time it things it is.
+        function getServerInfo() {
+            umbracopackage__1DashboardService.getServerInfo()
+                .then(function (result) {
+                    vm.info = result.data;
+                    vm.loading = false; 
+                }, function (error) {
+                    console.warn(error);
+                    notificationsService.error('Error', 'Unable to get the server info');
+                });
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1DashboardController', dashboardController);
+})();

--- a/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.html
+++ b/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.html
@@ -1,0 +1,18 @@
+<div ng-controller="umbracopackage__1DashboardController as vm">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-if="!vm.loading">
+        <umb-box>
+            <umb-box-header title-key="UmbracoPackage.1_dashboardHeader"
+                            description-key="UmbracoPackage.1_dashboardDesc">
+            </umb-box-header>
+            <umb-box-content>
+                <h4>Umbraco Version: {{vm.info.status}}</h4>
+                <h4>Server Time : {{vm.info.time | date:'medium'}}</h4>
+            </umb-box-content>
+
+        </umb-box>
+    </div>
+
+</div>

--- a/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.service.js
+++ b/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.service.js
@@ -1,0 +1,28 @@
+/**
+ * @ngdoc
+ * 
+ * @name: dashboardService
+ * @description: provides an interface between the javascript dashboard and our 
+ *               backoffice api.
+ */
+(function () {
+    'use strict';
+
+    function dashboardService($http) {
+
+        var serviceRoot = Umbraco.Sys.ServerVariables.umbracopackage__1.dashboardController;
+
+        return {
+            getServerInfo: getServerInfo
+        }
+
+        /////
+
+        function getServerInfo() {
+            return $http.get(serviceRoot + "GetServerInfo");
+        }
+    };
+
+    angular.module('umbraco')
+        .factory('umbracopackage__1DashboardService', dashboardService);
+})();

--- a/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/package.manifest
+++ b/build/templates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/package.manifest
@@ -1,0 +1,15 @@
+{
+  "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/dashboard/dashboard.service.js",
+    "~/App_Plugins/UmbracoPackage.1/dashboard/dashboard.controller.js"
+  ],
+  "dashboards": [
+    {
+      "alias": "umbracopackage._1-dashboard",
+      "sections": [
+        "content"
+      ],
+      "view": "~/App_Plugins/UmbracoPackage.1/dashboard/dashboard.html"
+    }
+  ]
+}

--- a/build/templates/Dashboard/Controllers/DashboardComponent.cs
+++ b/build/templates/Dashboard/Controllers/DashboardComponent.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Routing;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+namespace UmbracoPackage._1.Controllers
+{
+    public class DashboardComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.AddNotificationHandler<ServerVariablesParsingNotification, ServerVariablesParsingNotificationHandler>();
+        }
+    }
+
+    internal class ServerVariablesParsingNotificationHandler : INotificationHandler<ServerVariablesParsingNotification>
+    {
+        private readonly LinkGenerator linkGenerator;
+
+        public ServerVariablesParsingNotificationHandler(LinkGenerator linkGenerator)
+        {
+            this.linkGenerator = linkGenerator;
+        }
+
+        public void Handle(ServerVariablesParsingNotification notification)
+        {
+            notification.ServerVariables.Add("umbracopackage__1", new Dictionary<string, object>()
+            {
+                { "dashboardController", linkGenerator.GetUmbracoApiServiceBaseUrl<DashboardApiController>(controller => controller.GetApi()) }
+            });
+        }
+    }
+}

--- a/build/templates/Dashboard/Controllers/DashboardController.cs
+++ b/build/templates/Dashboard/Controllers/DashboardController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Umbraco.Cms.Web.BackOffice.Controllers;
+
+namespace UmbracoPackage._1.Controllers
+{
+    public class DashboardApiController : UmbracoAuthorizedApiController
+    {
+        /// <summary>
+        ///  GetApi - Called in our ServerVariablesParser.Parsing event handler
+        ///  this gets the URL of this API, so we don't have to hardwire it anywhere
+        /// </summary>
+        [HttpGet]
+        public bool GetApi() => true;
+
+
+        /// <summary>
+        ///  Simple call return the time,
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        public Object GetServerInfo()
+        {
+            return new
+            {
+                time = DateTime.UtcNow
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below


### Description
The Community Packages Team thought about moving some/all of the item templates we have under the https://github.com/umbraco/Package.Templates repo to v9. As Umbraco is providing the current templates as of the move to NET5 we think that it makes sense to have all templates governed under one location.

This PR is WIP to add and discuss which ItemTemplates we should add and what the correct way is to provide them.

This initial PR has the template files for ContentApp and Dashboard added. They are not yet created by the build script.
