### PR TITLE
v10: fix binary breaking change in service collection extensions

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -14,30 +14,27 @@ namespace Umbraco.Extensions
         /// Removes all previous registrations for the type <typeparamref name="TService"/>.
         /// </remarks>
         public static void AddUnique<TService, TImplementing>(
+            this IServiceCollection services)
+            where TService : class
+            where TImplementing : class, TService
+        {
+            AddUnique<TService, TImplementing>(services, ServiceLifetime.Singleton);
+        }
+
+        /// <summary>
+        /// Adds a service of type <typeparamref name="TService"/> with an implementation type of <typeparamref name="TImplementing"/> to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <remarks>
+        /// Removes all previous registrations for the type <typeparamref name="TService"/>.
+        /// </remarks>
+        public static void AddUnique<TService, TImplementing>(
             this IServiceCollection services,
-            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            ServiceLifetime lifetime)
             where TService : class
             where TImplementing : class, TService
         {
             services.RemoveAll<TService>();
             services.Add(ServiceDescriptor.Describe(typeof(TService), typeof(TImplementing), lifetime));
-        }
-
-        /// <summary>
-        /// Adds services of types <typeparamref name="TService1"/> &amp; <typeparamref name="TService2"/> with a shared implementation type of <typeparamref name="TImplementing"/> to the specified <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// Removes all previous registrations for the types <typeparamref name="TService1"/> &amp; <typeparamref name="TService2"/>.
-        /// </remarks>
-        public static void AddMultipleUnique<TService1, TService2, TImplementing>(
-            this IServiceCollection services,
-            ServiceLifetime lifetime = ServiceLifetime.Singleton)
-            where TService1 : class
-            where TService2 : class
-            where TImplementing : class, TService1, TService2
-        {
-            services.AddUnique<TService1, TImplementing>(lifetime);
-            services.AddUnique<TService2>(factory => (TImplementing)factory.GetRequiredService<TService1>(), lifetime);
         }
 
         // TODO(V11): Remove this function.

--- a/src/Umbraco.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -44,8 +44,17 @@ namespace Umbraco.Extensions
         /// Removes all previous registrations for the types <typeparamref name="TService1"/> &amp; <typeparamref name="TService2"/>.
         /// </remarks>
         public static void AddMultipleUnique<TService1, TService2, TImplementing>(
+            this IServiceCollection services)
+            where TService1 : class
+            where TService2 : class
+            where TImplementing : class, TService1, TService2
+        {
+            AddMultipleUnique<TService1, TService2, TImplementing>(services, ServiceLifetime.Singleton);
+        }
+
+        public static void AddMultipleUnique<TService1, TService2, TImplementing>(
             this IServiceCollection services,
-            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            ServiceLifetime lifetime)
             where TService1 : class
             where TService2 : class
             where TImplementing : class, TService1, TService2
@@ -71,8 +80,16 @@ namespace Umbraco.Extensions
         /// </remarks>
         public static void AddUnique<TService>(
             this IServiceCollection services,
+            Func<IServiceProvider, TService> factory)
+            where TService : class
+        {
+            AddUnique<TService>(services, factory, ServiceLifetime.Singleton);
+        }
+
+        public static void AddUnique<TService>(
+            this IServiceCollection services,
             Func<IServiceProvider, TService> factory,
-            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            ServiceLifetime lifetime)
             where TService : class
         {
             services.RemoveAll<TService>();

--- a/src/Umbraco.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -37,6 +37,23 @@ namespace Umbraco.Extensions
             services.Add(ServiceDescriptor.Describe(typeof(TService), typeof(TImplementing), lifetime));
         }
 
+        /// <summary>
+        /// Adds services of types <typeparamref name="TService1"/> &amp; <typeparamref name="TService2"/> with a shared implementation type of <typeparamref name="TImplementing"/> to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <remarks>
+        /// Removes all previous registrations for the types <typeparamref name="TService1"/> &amp; <typeparamref name="TService2"/>.
+        /// </remarks>
+        public static void AddMultipleUnique<TService1, TService2, TImplementing>(
+            this IServiceCollection services,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TService1 : class
+            where TService2 : class
+            where TImplementing : class, TService1, TService2
+        {
+            services.AddUnique<TService1, TImplementing>(lifetime);
+            services.AddUnique<TService2>(factory => (TImplementing)factory.GetRequiredService<TService1>(), lifetime);
+        }
+
         // TODO(V11): Remove this function.
         [Obsolete("This method is functionally equivalent to AddSingleton<TImplementing>() please use that instead.")]
         public static void AddUnique<TImplementing>(this IServiceCollection services)


### PR DESCRIPTION
# Notes
Seems like we refactored a method in 52f5269e011558ceba0ed44ec23f9aed40205b54, this causes binary breaking changes, and therefore breaks some packages, this PR remedies that by putting the original method back.

# How to test
- Install the uSync package
- Run umbraco and navigate to the settings page
- Try exporting settings, that should now work