### PR TITLE
V9: Fix login timeout

### DIFF
--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -132,7 +132,7 @@ namespace Umbraco.Extensions
                 }
             }
 
-            verifiedIdentity =  identity.AuthenticationType == Constants.Security.BackOfficeAuthenticationType ? identity : new ClaimsIdentity(identity.Claims, Constants.Security.BackOfficeAuthenticationType);
+            verifiedIdentity = identity.AuthenticationType == Constants.Security.BackOfficeAuthenticationType ? identity : new ClaimsIdentity(identity.Claims, Constants.Security.BackOfficeAuthenticationType);
             return true;
         }
 

--- a/src/Umbraco.Infrastructure/Security/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Infrastructure/Security/ClaimsIdentityExtensions.cs
@@ -1,17 +1,19 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
+
+using System;
 using System.Linq;
 using System.Security.Claims;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Extensions
 {
     public static class MergeClaimsIdentityExtensions
     {
-        // Ignore these Claims when merging, these claims are dynamically added whenever the ticket
-        // is re-issued and we don't want to merge old values of these.
-        private static readonly string[] s_ignoredClaims = new[] { ClaimTypes.CookiePath, Constants.Security.SessionIdClaimType };
+        // We used to ignore CookiePath and SessionIdClaimType, but these claims are only issued at login
+        // meaning if we don't merge these claims you'll be logged out, after the claims are merged
+        // since your session ID disappears
+        private static readonly string[] s_ignoredClaims = Array.Empty<string>();
 
         public static void MergeAllClaims(this ClaimsIdentity destination, ClaimsIdentity source)
         {

--- a/src/Umbraco.Infrastructure/Security/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Infrastructure/Security/ClaimsIdentityExtensions.cs
@@ -10,9 +10,9 @@ namespace Umbraco.Extensions
 {
     public static class MergeClaimsIdentityExtensions
     {
-        // We used to ignore CookiePath and SessionIdClaimType, but these claims are only issued at login
-        // meaning if we don't merge these claims you'll be logged out, after the claims are merged
-        // since your session ID disappears
+        // Ignore these Claims when merging, these claims are dynamically added whenever the ticket
+        // is re-issued and we don't want to merge old values of these.
+        // We do however want to merge these when the SecurityStampValidator refreshes the principal since it's still the same login session
         private static readonly string[] s_ignoredClaims = { ClaimTypes.CookiePath, Constants.Security.SessionIdClaimType };
 
         public static void MergeAllClaims(this ClaimsIdentity destination, ClaimsIdentity source)

--- a/src/Umbraco.Infrastructure/Security/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Infrastructure/Security/ClaimsIdentityExtensions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
 using System.Linq;
 using System.Security.Claims;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Extensions
@@ -13,7 +13,7 @@ namespace Umbraco.Extensions
         // We used to ignore CookiePath and SessionIdClaimType, but these claims are only issued at login
         // meaning if we don't merge these claims you'll be logged out, after the claims are merged
         // since your session ID disappears
-        private static readonly string[] s_ignoredClaims = Array.Empty<string>();
+        private static readonly string[] s_ignoredClaims = { ClaimTypes.CookiePath, Constants.Security.SessionIdClaimType };
 
         public static void MergeAllClaims(this ClaimsIdentity destination, ClaimsIdentity source)
         {

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
@@ -304,7 +304,7 @@ namespace Umbraco.Cms.Web.BackOffice.Security
             if (routeValues.TryGetValue("controller", out var controllerName) &&
                 routeValues.TryGetValue("action", out var action))
             {
-                if (controllerName?.ToString() == nameof(AuthenticationController).TrimEnd("Controller")
+                if (controllerName?.ToString() == ControllerExtensions.GetControllerName<AuthenticationController>()
                     && action?.ToString() == nameof(AuthenticationController.GetRemainingTimeoutSeconds))
                 {
                     return true;

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
@@ -172,6 +172,9 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                         return;
                     }
 
+                    // This relies on IssuedUtc, so call it before updating it.
+                    await EnsureValidSessionId(ctx);
+
                     // We have to manually specify Issued and Expires,
                     // because the SecurityStampValidator refreshes the principal every 30 minutes,
                     // When the principal is refreshed the Issued is update to time of refresh, however, the Expires remains unchanged
@@ -181,7 +184,6 @@ namespace Umbraco.Cms.Web.BackOffice.Security
                     ctx.Properties.IssuedUtc = _systemClock.UtcNow;
                     ctx.Properties.ExpiresUtc = _systemClock.UtcNow.Add(_globalSettings.TimeOut);
                     ctx.ShouldRenew = true;
-                    await EnsureValidSessionId(ctx);
                 },
                 OnSigningIn = ctx =>
                 {

--- a/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
@@ -30,7 +30,8 @@ namespace Umbraco.Cms.Web.Common.Security
                 ClaimsIdentity newIdentity = refreshingPrincipal.NewPrincipal.Identities.First();
                 ClaimsIdentity currentIdentity = refreshingPrincipal.CurrentPrincipal.Identities.First();
 
-                newIdentity.MergeClaimsFromCookieIdentity(currentIdentity);
+                // Since this is refreshing an existing principal, we want to merge all claims.
+                newIdentity.MergeAllClaims(currentIdentity);
 
                 return Task.CompletedTask;
             };


### PR DESCRIPTION
This PR fixes multiple problems I found with timeout, ensuring that it now works as expected. This fixes #11965

There were two major problems a couple of minor ones

### GetRemainingTimeout

The frontend requests GetRemainingTimeout every 30 seconds to see if it should redirect the user to the login page. The Problem with this is a real chicken or egg scenario without previous implementation. In order to get the remaining time out seconds from the  `TicketExpiresClaimType`, we **must** authenticate the user, but with the old implementation the very act of authenticating the user counts as a "backoffice request", which automatically refreshed the cookie **and** our database login session, meaning that in effect you would never get logged out! 

To fix this I've had to do two things, first of all, I've our auth cookie expiration away from `SlidingExpiration` and we now instead manage this "manually", there is two reasons for this, the first is that we ***don't*** want this token to update when we request `GetRemainingTimeout`, and with `SlidingExpiration` this will always happen regardless, once the half the lifespan of the token has passed. Another subtle side effect of using `SlidingExpiration` is that our `TimeOut` setting won't be honest, for instance, you might set your timeout to be 12 hours, poke around the back office for 5 hours, and step away, now you'd expect to be logged out after 12 hours, however, you won't, you'd be logged out after 7 hours, since you never hit the halfway point of your token, meaning it was never refreshed. 

Secondly, I've added a check `IsRemainingSecondsRequest` where we check if the current request we're trying to authenticate is from the GetRemainingTimeoutSeconds action, if it is, we skip doing `EnsureValidSessionId`, and we don't renew the token. 

The purpose of `EnsureValidSessionId` is to validate that our database login session is not older than our timespan allows, however with the check also updates the `LastValidatedUtc`, meaning that if we call this from the remaining seconds request it'll never expire, and additionally since the `GetRemainingTimeout`, very much serves the same purpose, but using the token expiration instead, it doesn't make sense to also call `EnsureValidSessionId`.

### Refreshing principal

Now you might think, but wait, I do get logged out automatically, and that is correct. But that's caused by a different bug.

By default, the auth principal will be refreshed every 30 minutes, and this is when you'd be logged out. There are two reasons for this.

First off when the principal refreshes we have some custom code that copies our custom claims we've added over to the new identity, but when doing so we explicitly ignored the `CookiePath` and `SessionIdClaimType`, this meant that when your principal refreshed you lost you SessionID, essentially ending your session, `EnsureValidSessionId` would then catch this and log you out, I've changed this so when the principal is refreshed we copy all claims. 

Secondly, there was a bug related to the custom `TicketExpiresClaim`, previously we added the claim after the call to `securityStampValidator.ValidateAsync(ctx);`, this meant that the claim was not added before we merged the claim, and that led to the `GetRemainingTimeout` to log you out because it though the session had expired, I've changed this so we now add the claim before the call, and everything works as intended. 


Lastly I found a weird bug in relation to refreshing the principal, essentially when the principal is refreshed the token gets a new `IssuedUtc`, corresponding to when the principal was refreshed, however the `ExpiresUtc` remains the same. When the token is then renewed the framework then calculates the `ExpireTimeSpan` by doing `ExpiresUtc - IssuedUtc`, resulting in the timespan being reduced by 30 minutes for every principal refresh! To fix this I've updated it so we now explicitly set the `IssuedUtc` and `ExpiresUtc` when renewing the token. 


## Testing

**Note:** There's a gotcha when it comes to the timespan string in the appsettings.json, if you want to specify 24 hours or above you must do so in the format: `d.HH:MM:SS`, for instance if you want 24 hours the string is `"1.00:00:00"`

When testing I checked than you get logged out at the correct interval when 

* Timeout is less than security stamp validation interval
* Greater than security span validation interval

I also tested that the auth token is created correctly when you switch user, and that external login still works as intended, and that `GetRemainingTimeoutSeconds` counts and updates correctly. 

If you don't want to wait for the 30 minutes it takes for the security stamp to be validated you can change the validation interval in `ConfigureSecurityStampOptions` during testing.