### PR TITLE
Extended check for locally installed LocalDb to include the most recent version 15.

### DIFF
--- a/src/Umbraco.Core/Persistence/LocalDb.cs
+++ b/src/Umbraco.Core/Persistence/LocalDb.cs
@@ -103,8 +103,8 @@ namespace Umbraco.Core.Persistence
 
             if (string.IsNullOrWhiteSpace(programFiles)) return;
 
-            // detect 14, 13, 12, 11
-            for (var i = 14; i > 10; i--)
+            // detect 15, 14, 13, 12, 11
+            for (var i = 15; i > 10; i--)
             {
                 var exe = Path.Combine(programFiles, $@"Microsoft SQL Server\{i}0\Tools\Binn\SqlLocalDB.exe");
                 if (File.Exists(exe) == false) continue;

--- a/src/Umbraco.Core/Persistence/LocalDb.cs
+++ b/src/Umbraco.Core/Persistence/LocalDb.cs
@@ -103,8 +103,8 @@ namespace Umbraco.Core.Persistence
 
             if (string.IsNullOrWhiteSpace(programFiles)) return;
 
-            // detect 15, 14, 13, 12, 11
-            for (var i = 15; i > 10; i--)
+            // detect (17, 16) 15, 14, 13, 12, 11 - future-proofing by a couple of versions
+            for (var i = 17; i > 10; i--)
             {
                 var exe = Path.Combine(programFiles, $@"Microsoft SQL Server\{i}0\Tools\Binn\SqlLocalDB.exe");
                 if (File.Exists(exe) == false) continue;


### PR DESCRIPTION
Raised as an issue in the Cloud tracker [here](https://github.com/umbraco/Umbraco.Cloud.Issues/issues/550) is a situation where LocalDb is available locally, but can't be successfully used.  The fix is needed in Umbraco 8 CMS.

I've extended the check to include the most recent version 15.

Assuming you the latest version locally, this can be tested with a temporarily added unit test, which I've not checked in as it depends on the local file system.  

```
using NUnit.Framework;
using Umbraco.Core.Persistence;

namespace Umbraco.Tests.Persistence
{
    internal class LocalDbTests
    {
        [Test]
        public void DetectsVersion()
        {
            var localDb = new LocalDb();
            Assert.IsTrue(localDb.IsAvailable);
            Assert.AreEqual(15, localDb.Version);
        }
    }
}
```