### PR TITLE
V8: Fix missing site identifier

### DIFF
--- a/src/Umbraco.Core/Telemetry/ISiteIdentifierService.cs
+++ b/src/Umbraco.Core/Telemetry/ISiteIdentifierService.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Umbraco.Core.Telemetry
+{
+    /// <summary>
+    /// Used to get and create the site identifier
+    /// </summary>
+    public interface ISiteIdentifierService
+    {
+
+        /// <summary>
+        /// Tries to get the site identifier
+        /// </summary>
+        /// <returns></returns>
+        bool TryGetSiteIdentifier(out Guid siteIdentifier);
+
+        /// <summary>
+        /// Creates the site identifier and writes it to config.
+        /// </summary>
+        bool TryCreateSiteIdentifier(out Guid createdGuid);
+    }
+}

--- a/src/Umbraco.Core/Telemetry/ISiteIdentifierService.cs
+++ b/src/Umbraco.Core/Telemetry/ISiteIdentifierService.cs
@@ -15,6 +15,13 @@ namespace Umbraco.Core.Telemetry
         bool TryGetSiteIdentifier(out Guid siteIdentifier);
 
         /// <summary>
+        /// Tries to get the site identifier or otherwise create it if it doesn't exist.
+        /// </summary>
+        /// <param name="siteIdentifier"></param>
+        /// <returns></returns>
+        bool TryGetOrCreateSiteIdentifier(out Guid siteIdentifier);
+
+        /// <summary>
         /// Creates the site identifier and writes it to config.
         /// </summary>
         bool TryCreateSiteIdentifier(out Guid createdGuid);

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Core.Telemetry
         /// <inheritdoc/>
         public bool TryGetTelemetryReportData(out TelemetryReportData telemetryReportData)
         {
-            if (TryGetTelemetryId(out Guid telemetryId) is false)
+            if (_siteIdentifierService.TryGetOrCreateSiteIdentifier(out Guid telemetryId) is false)
             {
                 telemetryReportData = null;
                 return false;
@@ -39,24 +39,6 @@ namespace Umbraco.Core.Telemetry
                 Packages = GetPackageTelemetry()
             };
             return true;
-        }
-
-        private bool TryGetTelemetryId(out Guid telemetryId)
-        {
-            if (_siteIdentifierService.TryGetSiteIdentifier(out var existingId))
-            {
-                telemetryId = existingId;
-                return true;
-            }
-
-            if (_siteIdentifierService.TryCreateSiteIdentifier(out var createdId))
-            {
-                telemetryId = createdId;
-                return true;
-            }
-
-            telemetryId = Guid.Empty;
-            return false;
         }
 
         private IEnumerable<PackageTelemetry> GetPackageTelemetry()

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Services\DateTypeServiceExtensions.cs" />
     <Compile Include="Services\PropertyValidationService.cs" />
     <Compile Include="Composing\TypeCollectionBuilderBase.cs" />
+    <Compile Include="Telemetry\ISiteIdentifierService.cs" />
     <Compile Include="Telemetry\ITelemetryService.cs" />
     <Compile Include="Telemetry\Models\PackageTelemetry.cs" />
     <Compile Include="Telemetry\Models\TelemetryReportData.cs" />

--- a/src/Umbraco.Web/Runtime/WebInitialComposer.cs
+++ b/src/Umbraco.Web/Runtime/WebInitialComposer.cs
@@ -39,7 +39,9 @@ using Umbraco.Web.WebApi;
 using Current = Umbraco.Web.Composing.Current;
 using Umbraco.Web.PropertyEditors;
 using Umbraco.Core.Models;
+using Umbraco.Core.Telemetry;
 using Umbraco.Web.Models;
+using Umbraco.Web.Telemetry;
 
 namespace Umbraco.Web.Runtime
 {
@@ -57,6 +59,8 @@ namespace Umbraco.Web.Runtime
             composition.RegisterUnique<IHttpContextAccessor, AspNetHttpContextAccessor>(); // required for hybrid accessors
 
             composition.ComposeWebMappingProfiles();
+
+            composition.RegisterUnique<ISiteIdentifierService, SiteIdentifierService>();
 
             //register the install components
             //NOTE: i tried to not have these registered if we weren't installing or upgrading but post install when the site restarts

--- a/src/Umbraco.Web/Telemetry/ReportSiteTask.cs
+++ b/src/Umbraco.Web/Telemetry/ReportSiteTask.cs
@@ -62,9 +62,6 @@ namespace Umbraco.Web.Telemetry
                 {
                     request.Content = new StringContent(JsonConvert.SerializeObject(telemetryReportData), Encoding.UTF8, "application/json"); //CONTENT-TYPE header
 
-                    // Set a low timeout - no need to use a larger default timeout for this POST request
-                    _httpClient.Timeout = new TimeSpan(0, 0, 1);
-
                     // Make a HTTP Post to telemetry service
                     // https://telemetry.umbraco.com/installs/
                     // Fire & Forget, do not need to know if its a 200, 500 etc

--- a/src/Umbraco.Web/Telemetry/SiteIdentifierService.cs
+++ b/src/Umbraco.Web/Telemetry/SiteIdentifierService.cs
@@ -34,6 +34,24 @@ namespace Umbraco.Web.Telemetry
             return true;
         }
 
+        public bool TryGetOrCreateSiteIdentifier(out Guid siteIdentifier)
+        {
+            if (TryGetSiteIdentifier(out var existingId))
+            {
+                siteIdentifier = existingId;
+                return true;
+            }
+
+            if (TryCreateSiteIdentifier(out var createdId))
+            {
+                siteIdentifier = createdId;
+                return true;
+            }
+
+            siteIdentifier = Guid.Empty;
+            return false;
+        }
+
         public bool TryCreateSiteIdentifier(out Guid createdGuid)
         {
             createdGuid = Guid.NewGuid();

--- a/src/Umbraco.Web/Telemetry/SiteIdentifierService.cs
+++ b/src/Umbraco.Web/Telemetry/SiteIdentifierService.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Xml.Linq;
+using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.IO;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Telemetry;
+using Umbraco.Web.Install;
+
+namespace Umbraco.Web.Telemetry
+{
+    internal class SiteIdentifierService : ISiteIdentifierService
+    {
+        private readonly IUmbracoSettingsSection _settings;
+        private readonly ILogger _logger;
+
+        public SiteIdentifierService(IUmbracoSettingsSection settings, ILogger logger)
+        {
+            _settings = settings;
+            _logger = logger;
+        }
+
+        public bool TryGetSiteIdentifier(out Guid siteIdentifier)
+        {
+            // Parse telemetry string as a GUID & verify its a GUID and not some random string
+            // since users may have messed with or decided to empty the app setting or put in something random
+            if (Guid.TryParse(_settings.BackOffice.Id, out var parsedTelemetryId) is false)
+            {
+                siteIdentifier = Guid.Empty;
+                return false;
+            }
+
+            siteIdentifier = parsedTelemetryId;
+            return true;
+        }
+
+        public bool TryCreateSiteIdentifier(out Guid createdGuid)
+        {
+            createdGuid = Guid.NewGuid();
+
+            // Modify the XML to add a new GUID site identifier
+            // hack: ensure this does not trigger a restart
+            using (ChangesMonitor.Suspended())
+            {
+                var umbracoSettingsPath = IOHelper.MapPath(SystemFiles.UmbracoSettings);
+
+                if (File.Exists(umbracoSettingsPath) is false)
+                {
+                    _logger.Error<SiteIdentifierService>("Unable to find umbracoSettings.config file to add telemetry site identifier");
+                    return false;
+                }
+
+                try
+                {
+                    var umbracoConfigXml = XDocument.Load(umbracoSettingsPath, LoadOptions.PreserveWhitespace);
+                    if (umbracoConfigXml.Root != null)
+                    {
+                        var backofficeElement = umbracoConfigXml.Root.Element("backOffice");
+                        if (backofficeElement is null)
+                        {
+                            return false;
+                        }
+
+                        // Will add ID attribute if it does not exist
+                        backofficeElement.SetAttributeValue("id", createdGuid.ToString());
+
+                        // Save file back down
+                        umbracoConfigXml.Save(umbracoSettingsPath, SaveOptions.DisableFormatting);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error<SiteIdentifierService>(ex, "Couldn't update umbracoSettings.config with a backoffice with a telemetry site identifier");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Umbraco.Web/Telemetry/SiteIdentifierService.cs
+++ b/src/Umbraco.Web/Telemetry/SiteIdentifierService.cs
@@ -24,7 +24,8 @@ namespace Umbraco.Web.Telemetry
         {
             // Parse telemetry string as a GUID & verify its a GUID and not some random string
             // since users may have messed with or decided to empty the app setting or put in something random
-            if (Guid.TryParse(_settings.BackOffice.Id, out var parsedTelemetryId) is false)
+            if (Guid.TryParse(_settings.BackOffice.Id, out var parsedTelemetryId) is false
+                || parsedTelemetryId == Guid.Empty)
             {
                 siteIdentifier = Guid.Empty;
                 return false;

--- a/src/Umbraco.Web/Telemetry/TelemetryComponent.cs
+++ b/src/Umbraco.Web/Telemetry/TelemetryComponent.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Web.Telemetry
         private readonly ITelemetryService _telemetryService;
         private BackgroundTaskRunner<IBackgroundTask> _telemetryReporterRunner;
 
-        public TelemetryComponent(IProfilingLogger logger, IUmbracoSettingsSection settings, ITelemetryService telemetryService)
+        public TelemetryComponent(IProfilingLogger logger, ITelemetryService telemetryService)
         {
             _logger = logger;
             _telemetryService = telemetryService;

--- a/src/Umbraco.Web/Umbraco.Web.csproj
+++ b/src/Umbraco.Web/Umbraco.Web.csproj
@@ -347,6 +347,7 @@
     <Compile Include="Models\LinkType.cs" />
     <Compile Include="Models\TemplateQuery\OperatorFactory.cs" />
     <Compile Include="Telemetry\ReportSiteTask.cs" />
+    <Compile Include="Telemetry\SiteIdentifierService.cs" />
     <Compile Include="Telemetry\TelemetryComponent.cs" />
     <Compile Include="Telemetry\TelemetryComposer.cs" />
     <Compile Include="Templates\HtmlLocalLinkParser.cs" />


### PR DESCRIPTION
Fixes an issue where the site ID might not exist, for instance if unattended install is used or the site has been updated. This also removes the one second timeout from `ReportSiteTask`, since it's a background task, there's no reason why we demand an answer so fast, and it might cause issues where the telemetry is not sent because it times out. We'll also include the site identifier when requesting the dashboard now.

Adds a new `SiteIdentifierService` for creating/getting the site Id, which is then used in `TelemetryIdentifierStep`, and `TelemetryService`. Now if the site identifier does not exists or is invalid when `ReportSiteTask` a new valid GUID will be generated and stored in `umbracoSettings.config`

## Testing

The site identifier is located in `umbracoSettings.config` under the `backOffice` element.

* Do a fresh install and ensure the site ID is still populated
* Run a site that has an ID and ensure the existing ID is used when `ReportSiteTask` fires
* Remove the ID and re-run the site, ensure that a new ID is generated and saved in the config (you might hav e to re-open the file in your editor to see the change)
* Invalidate the ID by entering something that's not a GUID, ensure the value is replaced with a valid GUID.