### PR TITLE
Set current selected master template in tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -559,11 +559,13 @@
                 }
             });
 
+            const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
+
             localizationService.localize("template_mastertemplate").then(title => {
                 const editor = {
                     title,
                     filterCssClass: 'not-allowed',
-                    filter: item => !availableMasterTemplates.some(template => template.id == item.id),                    
+                    filter: item => !availableMasterTemplates.some(template => template.id == item.id),
                     submit: model => {
                         var template = model.selection[0];
                         if (template && template.alias) {
@@ -576,6 +578,12 @@
                         editorService.close();
                     },
                     close: () => editorService.close()
+                }
+
+                if (currentTemplate) {
+                    editor.currentNode = {
+                        path: currentTemplate.path
+                    };
                 }
 
                 editorService.templatePicker(editor);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is a new PR target target v9 instead of this closed PR for v8 https://github.com/umbraco/Umbraco-CMS/pull/11482

This ensures the current selected master template is selected and highlighted in tree.