### PR TITLE
V9:  Prevent delete or unpublish of items that have references

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -157,6 +157,8 @@ namespace Umbraco.Cms.Core.Configuration.Models
         internal const string StaticLoginBackgroundImage = "assets/img/login.jpg";
         internal const string StaticLoginLogoImage = "assets/img/application/umbraco_logo_white.svg";
         internal const bool StaticHideBackOfficeLogo = false;
+        internal const bool StaticDisableDeleteWhenReferenced = false;
+        internal const bool StaticDisableUnpublishWhenReferenced = false;
 
         /// <summary>
         /// Gets or sets a value for the content notification settings.
@@ -225,6 +227,18 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// </summary>
         [DefaultValue(StaticHideBackOfficeLogo)]
         public bool HideBackOfficeLogo { get; set; } = StaticHideBackOfficeLogo;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable the deletion of items referenced by other items.
+        /// </summary>
+        [DefaultValue(StaticDisableDeleteWhenReferenced)]
+        public bool DisableDeleteWhenReferenced { get; set; } = StaticDisableDeleteWhenReferenced;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable the unpublishing of items referenced by other items.
+        /// </summary>
+        [DefaultValue(StaticDisableUnpublishWhenReferenced)]
+        public bool DisableUnpublishWhenReferenced { get; set; } = StaticDisableUnpublishWhenReferenced;
 
         /// <summary>
         /// Get or sets the model representing the global content version cleanup policy

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -100,7 +100,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl", "previewHubUrl", "iconApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "minimumPasswordLength", "minimumPasswordNonAlphaNum", "hideBackofficeLogo"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "minimumPasswordLength", "minimumPasswordNonAlphaNum", "hideBackofficeLogo", "disableDeleteWhenReferenced", "disableUnpublishWhenReferenced"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}
@@ -413,6 +413,8 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         {"loginBackgroundImage", _contentSettings.LoginBackgroundImage},
                         {"loginLogoImage", _contentSettings.LoginLogoImage },
                         {"hideBackofficeLogo", _contentSettings.HideBackOfficeLogo },
+                        {"disableDeleteWhenReferenced", _contentSettings.DisableDeleteWhenReferenced },
+                        {"disableUnpublishWhenReferenced", _contentSettings.DisableUnpublishWhenReferenced },
                         {"showUserInvite", _emailSender.CanSendRequiredEmail()},
                         {"canSendRequiredEmail", _emailSender.CanSendRequiredEmail()},
                         {"showAllowSegmentationForDocumentTypes", false},

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.delete.controller.js
@@ -19,6 +19,7 @@ function ContentDeleteController($scope, $timeout, contentResource, treeService,
 
     $scope.checkingReferences = true;
     $scope.warningText = null;
+    $scope.disableDelete = false;
     
     $scope.performDelete = function() {
 
@@ -85,9 +86,20 @@ function ContentDeleteController($scope, $timeout, contentResource, treeService,
     };
 
     $scope.onReferencesWarning = () => {
-        localizationService.localize("references_deleteWarning").then((value) => {
-            $scope.warningText = value;
-        });
+        // check if the deletion of items that have references has been disabled
+        if (Umbraco.Sys.ServerVariables.umbracoSettings.disableDeleteWhenReferenced) {
+            // this will only be set to true if we have a warning, indicating that this item or its descendants have reference
+            $scope.disableDelete = true;
+
+            localizationService.localize("references_deleteDisabledWarning").then((value) => {
+                $scope.warningText = value;
+            });
+        }
+        else {
+            localizationService.localize("references_deleteWarning").then((value) => {
+                $scope.warningText = value;
+            });
+        }
     };
 
     $scope.cancel = function() {

--- a/src/Umbraco.Web.UI.Client/src/views/content/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/delete.html
@@ -10,7 +10,7 @@
         </div>
 
         <div ng-hide="success">
-            <p class="abstract">
+            <p class="abstract" ng-if="!disableDelete">
                 <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
             </p>
 
@@ -28,7 +28,9 @@
                 <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
             </div>
 
-            <umb-confirm on-confirm="performDelete" confirm-button-style="danger" on-cancel="cancel" ng-hide="checkingReferences"></umb-confirm>
+            <umb-confirm ng-if="!disableDelete" on-confirm="performDelete" confirm-button-style="danger" on-cancel="cancel" ng-hide="checkingReferences"></umb-confirm>
+
+            <umb-confirm ng-if="disableDelete" confirm-button-style="danger" on-cancel="cancel"></umb-confirm>
         </div>
 
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/unpublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/unpublish.controller.js
@@ -117,6 +117,13 @@
 
         vm.onReferencesWarning = () => {
             $scope.model.submitButtonStyle = "danger";
+
+            // check if the unpublishing of items that have references has been disabled
+            if (Umbraco.Sys.ServerVariables.umbracoSettings.disableUnpublishWhenReferenced) {
+                // this will only be disabled if we have a warning, indicating that this item or its descendants have reference
+                $scope.model.disableSubmitButton = true;
+            }
+
             localizationService.localize("references_unpublishWarning").then((value) => {
                 vm.warningText = value;
             });

--- a/src/Umbraco.Web.UI.Client/src/views/media/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/media/delete.html
@@ -10,7 +10,7 @@
         </div>
 
         <div ng-hide="success">
-            <p class="abstract">
+            <p class="abstract" ng-if="!disableDelete">
                 <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
             </p>
 
@@ -24,7 +24,9 @@
                 <localize key="defaultdialogs_recycleBinWarning">When items are deleted from the recycle bin, they will be gone forever</localize>.
             </div>
 
-            <umb-confirm on-confirm="performDelete" on-cancel="close" confirm-button-style="danger" ng-hide="checkingReferences"></umb-confirm>
+            <umb-confirm ng-if="!disableDelete" on-confirm="performDelete" confirm-button-style="danger" on-cancel="close" ng-hide="checkingReferences"></umb-confirm>
+
+            <umb-confirm ng-if="disableDelete" confirm-button-style="danger" on-cancel="close"></umb-confirm>
         </div>
 
     </div>

--- a/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/media/media.delete.controller.js
@@ -10,6 +10,7 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
 
     $scope.checkingReferences = true;
     $scope.warningText = null;
+    $scope.disableDelete = false;
 
     $scope.performDelete = function() {
 
@@ -73,9 +74,20 @@ function MediaDeleteController($scope, mediaResource, treeService, navigationSer
     };
 
     $scope.onReferencesWarning = () => {
-        localizationService.localize("references_deleteWarning").then((value) => {
-            $scope.warningText = value;
-        });
+        // check if the deletion of items that have references has been disabled
+        if (Umbraco.Sys.ServerVariables.umbracoSettings.disableDeleteWhenReferenced) {
+            // this will only be set to true if we have a warning, indicating that this item or its descendants have reference
+            $scope.disableDelete = true;
+
+            localizationService.localize("references_deleteDisabledWarning").then((value) => {
+                $scope.warningText = value;
+            });
+        }
+        else {
+            localizationService.localize("references_deleteWarning").then((value) => {
+                $scope.warningText = value;
+            });
+        }
     };
 
     $scope.close = function() {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.controller.js
@@ -5,6 +5,7 @@
 
         var vm = this;
         vm.loading = true;
+        vm.disableDelete = false;
 
         function onInit() {
             $scope.model.hideSubmitButton = true;
@@ -16,6 +17,13 @@
 
         vm.onReferencesWarning = () => {
             $scope.model.submitButtonStyle = "danger";
+
+            // check if the deletion of items that have references has been disabled
+            if (Umbraco.Sys.ServerVariables.umbracoSettings.disableDeleteWhenReferenced) {
+                // this will only be set to true if we have a warning, indicating that this item or its descendants have reference
+                vm.disableDelete = true;
+                $scope.model.disableSubmitButton = true;
+            }
 
             localizationService.localize("general_delete").then(function (action) {
               localizationService.localize("references_listViewDialogWarning", [action.toLowerCase()]).then((value) => {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/delete.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.Overlays.ListViewDeleteController as vm">
 
-    <p class="abstract">
+    <p class="abstract" ng-if="!vm.disableDelete">
         <localize key="defaultdialogs_confirmdeleteNumberOfItems" tokens="[model.numberOfItems, model.totalItems]">Are you sure you want to delete</localize>?
     </p>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/overlays/listviewunpublish.controller.js
@@ -75,6 +75,12 @@
         vm.onReferencesWarning = () => {
             $scope.model.submitButtonStyle = "danger";
           
+            // check if the unpublishing of items that have references has been disabled
+            if (Umbraco.Sys.ServerVariables.umbracoSettings.disableUnpublishWhenReferenced) {
+                // this will only be disabled if we have a warning, indicating that this item or its descendants have reference
+                $scope.model.disableSubmitButton = true;
+            }
+
             localizationService.localize("content_unpublish").then(function (action) {
                 localizationService.localize("references_listViewDialogWarning", [action.toLowerCase()]).then((value) => {
                     vm.warningText = value;

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -2473,6 +2473,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="labelUsedInMemberDescendants">One or more of this item's descendants is being used in a member.</key>
     <key alias="deleteWarning">This item or its descendants is being used. Deletion can lead to broken links on your website.</key>
     <key alias="unpublishWarning">This item or its descendants is being used. Unpublishing can lead to broken links on your website. Please take the appropriate actions.</key>
+    <key alias="deleteDisabledWarning">This item or its descendants is being used. Therefore, deletion has been disabled.</key>
     <key alias="listViewDialogWarning">The following items you are trying to %0% are used by other content.</key>
   </area>
   <area alias="logViewer">

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -2556,6 +2556,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="labelUsedInMemberDescendants">One or more of this item's descendants is being used in a member.</key>
     <key alias="deleteWarning">This item or its descendants is being used. Deletion can lead to broken links on your website.</key>
     <key alias="unpublishWarning">This item or its descendants is being used. Unpublishing can lead to broken links on your website. Please take the appropriate actions.</key>
+    <key alias="deleteDisabledWarning">This item or its descendants is being used. Therefore, deletion has been disabled.</key>
     <key alias="listViewDialogWarning">The following items you are trying to %0% are used by other content.</key>
   </area>
   <area alias="logViewer">


### PR DESCRIPTION
## Details
- By adding the following config options, editors are prevented from deleting Content or Media items (or their descendants) that have references from other items:
```
"Umbraco": {
  "CMS": {
      "Content": {
        . . .
        "DisableDeleteWhenReferenced": true,
        "DisableUnpublishWhenReferenced": true
      },
    . . .
  }
}
```
- When the options are set, if the items (or their descendants) have references, the "_delete_" button will not appear, as well as the confirmation prompt;
  - A new warning is also shown;
- In the bulk delete Content or Media items, the "_delete_" button is disabled, as well as the confirmation prompt;
- In the unpublish case, the "_unpublish_" button is disabled;
- If the items have no references, the delete or unpublish dialogues are unchanged!

## Test
- Add the above options ⬆️ to your config;
- Have the SK installed
  - Try to **delete** Content item with and without reference -> Observe the difference;
  - Try to **delete** Media item with and without reference -> Observe the difference;  
  - Try to **unpublish** Content item with and without reference -> Observe the difference;  
  - Try to **bulk delete** Content items (from the list view) with and without reference -> Observe the difference;  
  - Try to **bulk delete** Media items (from the list view) with and without reference -> Observe the difference;  
  - Try to **bulk unpublish** Content items (from the list view) with and without reference -> Observe the difference;
  - Change the value of the config options and observe the difference;  
  - Removing the config options shouldn't change the existing behaviour.