### PR TITLE
V10/feature/filesystem maindomlock

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -29,6 +29,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         internal const string StaticNoNodesViewPath = "~/umbraco/UmbracoWebsite/NoNodes.cshtml";
         internal const string StaticSqlWriteLockTimeOut = "00:00:05";
         internal const bool StaticSanitizeTinyMce = false;
+        internal const int StaticMainDomReleaseSignalPollingInterval = 2000;
 
         /// <summary>
         /// Gets or sets a value for the reserved URLs (must end with a comma).
@@ -144,6 +145,18 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// </para>
         /// </summary>
         public string MainDomKeyDiscriminator { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the duration (in milliseconds) for which the MainDomLock release signal polling task should sleep.
+        /// </summary>
+        /// <remarks>
+        /// Doesn't apply to MainDomSemaphoreLock.
+        /// <para>
+        ///  The default value is 2000ms.
+        /// </para>
+        /// </remarks>
+        [DefaultValue(StaticMainDomReleaseSignalPollingInterval)]
+        public int MainDomReleaseSignalPollingInterval { get; set; } = StaticMainDomReleaseSignalPollingInterval;
 
         /// <summary>
         /// Gets or sets the telemetry ID.

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -138,6 +138,14 @@ namespace Umbraco.Cms.Core.Configuration.Models
         public string MainDomLock { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets a value to discriminate MainDom boundaries.
+        /// <para>
+        /// Generally the default should suffice but useful for advanced scenarios e.g. azure deployment slot based zero downtime deployments.
+        /// </para>
+        /// </summary>
+        public string MainDomKeyDiscriminator { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the telemetry ID.
         /// </summary>
         public string Id { get; set; } = string.Empty;

--- a/src/Umbraco.Core/Persistence/Constants-Locks.cs
+++ b/src/Umbraco.Core/Persistence/Constants-Locks.cs
@@ -65,6 +65,11 @@ namespace Umbraco.Cms.Core
             /// All languages.
             /// </summary>
             public const int Languages = -340;
+
+            /// <summary>
+            /// ScheduledPublishing job.
+            /// </summary>
+            public const int ScheduledPublishing = -341;
         }
     }
 }

--- a/src/Umbraco.Core/Runtime/IMainDomKeyGenerator.cs
+++ b/src/Umbraco.Core/Runtime/IMainDomKeyGenerator.cs
@@ -1,0 +1,13 @@
+namespace Umbraco.Cms.Core.Runtime
+{
+    /// <summary>
+    /// Defines a class which can generate a distinct key for a MainDom boundary.
+    /// </summary>
+    public interface IMainDomKeyGenerator
+    {
+        /// <summary>
+        /// Returns a key that signifies a MainDom boundary.
+        /// </summary>
+        string GenerateKey();
+    }
+}

--- a/src/Umbraco.Core/Runtime/MainDom.cs
+++ b/src/Umbraco.Core/Runtime/MainDom.cs
@@ -87,7 +87,7 @@ namespace Umbraco.Cms.Core.Runtime
 
                 if (_isMainDom.HasValue == false)
                 {
-                    throw new InvalidOperationException("Register called when MainDom has not been acquired");
+                    throw new InvalidOperationException("Register called before IsMainDom has been established");
                 }
                 else if (_isMainDom == false)
                 {
@@ -225,7 +225,7 @@ namespace Umbraco.Cms.Core.Runtime
             {
                 if (!_isMainDom.HasValue)
                 {
-                    throw new InvalidOperationException("MainDom has not been acquired yet");
+                    throw new InvalidOperationException("IsMainDom has not been established yet");
                 }
                 return _isMainDom.Value;
             }

--- a/src/Umbraco.Core/Runtime/MainDomSemaphoreLock.cs
+++ b/src/Umbraco.Core/Runtime/MainDomSemaphoreLock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -22,6 +23,11 @@ namespace Umbraco.Cms.Core.Runtime
 
         public MainDomSemaphoreLock(ILogger<MainDomSemaphoreLock> logger, IHostingEnvironment hostingEnvironment)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException("MainDomSemaphoreLock is only supported on Windows.");
+            }
+
             var mainDomId = MainDom.GetMainDomId(hostingEnvironment);
             var lockName = "UMBRACO-" + mainDomId + "-MAINDOM-LCK";
             _systemLock = new SystemLock(lockName);

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -250,7 +250,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
 
                     case "FileSystemMainDomLock":
                     default:
-                        return new FileSystemMainDomLock(loggerFactory.CreateLogger<FileSystemMainDomLock>(), mainDomKeyGenerator, hostingEnvironment);
+                        return new FileSystemMainDomLock(loggerFactory.CreateLogger<FileSystemMainDomLock>(), mainDomKeyGenerator, hostingEnvironment, factory.GetRequiredService<IOptionsMonitor<GlobalSettings>>());
                 }
             });
 

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -220,6 +220,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
 
         private static IUmbracoBuilder AddMainDom(this IUmbracoBuilder builder)
         {
+            builder.Services.AddSingleton<IMainDomKeyGenerator, DefaultMainDomKeyGenerator>();
             builder.Services.AddSingleton<IMainDomLock>(factory =>
             {
                 var globalSettings = factory.GetRequiredService<IOptions<GlobalSettings>>();
@@ -231,15 +232,20 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
                 var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
                 var loggerFactory = factory.GetRequiredService<ILoggerFactory>();
                 var npocoMappers = factory.GetRequiredService<NPocoMapperCollection>();
+                var mainDomKeyGenerator = factory.GetRequiredService<IMainDomKeyGenerator>();
+
+                if (globalSettings.Value.MainDomLock == "FileSystemMainDomLock")
+                {
+                    return new FileSystemMainDomLock(loggerFactory.CreateLogger<FileSystemMainDomLock>(), mainDomKeyGenerator, hostingEnvironment);
+                }
 
                 return globalSettings.Value.MainDomLock.Equals("SqlMainDomLock") || isWindows == false
                     ? (IMainDomLock)new SqlMainDomLock(
-                            loggerFactory.CreateLogger<SqlMainDomLock>(),
                             loggerFactory,
                             globalSettings,
                             connectionStrings,
                             dbCreator,
-                            hostingEnvironment,
+                            mainDomKeyGenerator,
                             databaseSchemaCreatorFactory,
                             npocoMappers)
                     : new MainDomSemaphoreLock(loggerFactory.CreateLogger<MainDomSemaphoreLock>(), hostingEnvironment);

--- a/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Runtime;
@@ -13,7 +12,6 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
-using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -32,32 +30,6 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IScopeProvider _scopeProvider;
         private readonly IServerRoleAccessor _serverRegistrar;
         private readonly IUmbracoContextFactory _umbracoContextFactory;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ScheduledPublishing"/> class.
-        /// </summary>
-        // Note: Ignoring the two version notice rule as this class should probably be internal.
-        // We don't expect anyone downstream to be instantiating a HostedService
-        [Obsolete("This constructor will be removed in version 10, please use an alternative constructor.")]
-        public ScheduledPublishing(
-            IRuntimeState runtimeState,
-            IMainDom mainDom,
-            IServerRoleAccessor serverRegistrar,
-            IContentService contentService,
-            IUmbracoContextFactory umbracoContextFactory,
-            ILogger<ScheduledPublishing> logger,
-            IServerMessenger serverMessenger)
-            : this(
-                runtimeState,
-                mainDom,
-                serverRegistrar,
-                contentService,
-                umbracoContextFactory,
-                logger,
-                serverMessenger,
-                StaticServiceProvider.Instance.GetRequiredService<IScopeProvider>())
-        {
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScheduledPublishing"/> class.

--- a/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ScheduledPublishing.cs
@@ -5,13 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Runtime;
-using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -27,20 +29,16 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         private readonly IMainDom _mainDom;
         private readonly IRuntimeState _runtimeState;
         private readonly IServerMessenger _serverMessenger;
+        private readonly IScopeProvider _scopeProvider;
         private readonly IServerRoleAccessor _serverRegistrar;
         private readonly IUmbracoContextFactory _umbracoContextFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScheduledPublishing"/> class.
         /// </summary>
-        /// <param name="runtimeState">Representation of the state of the Umbraco runtime.</param>
-        /// <param name="mainDom">Representation of the main application domain.</param>
-        /// <param name="serverRegistrar">Provider of server registrations to the distributed cache.</param>
-        /// <param name="contentService">Service for handling content operations.</param>
-        /// <param name="umbracoContextFactory">Service for creating and managing Umbraco context.</param>
-        /// <param name="logger">The typed logger.</param>
-        /// <param name="serverMessenger">Service broadcasting cache notifications to registered servers.</param>
-        /// <param name="backofficeSecurityFactory">Creates and manages <see cref="IBackOfficeSecurity"/> instances.</param>
+        // Note: Ignoring the two version notice rule as this class should probably be internal.
+        // We don't expect anyone downstream to be instantiating a HostedService
+        [Obsolete("This constructor will be removed in version 10, please use an alternative constructor.")]
         public ScheduledPublishing(
             IRuntimeState runtimeState,
             IMainDom mainDom,
@@ -49,6 +47,30 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             IUmbracoContextFactory umbracoContextFactory,
             ILogger<ScheduledPublishing> logger,
             IServerMessenger serverMessenger)
+            : this(
+                runtimeState,
+                mainDom,
+                serverRegistrar,
+                contentService,
+                umbracoContextFactory,
+                logger,
+                serverMessenger,
+                StaticServiceProvider.Instance.GetRequiredService<IScopeProvider>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScheduledPublishing"/> class.
+        /// </summary>
+        public ScheduledPublishing(
+            IRuntimeState runtimeState,
+            IMainDom mainDom,
+            IServerRoleAccessor serverRegistrar,
+            IContentService contentService,
+            IUmbracoContextFactory umbracoContextFactory,
+            ILogger<ScheduledPublishing> logger,
+            IServerMessenger serverMessenger,
+            IScopeProvider scopeProvider)
             : base(TimeSpan.FromMinutes(1), DefaultDelay)
         {
             _runtimeState = runtimeState;
@@ -58,6 +80,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             _umbracoContextFactory = umbracoContextFactory;
             _logger = logger;
             _serverMessenger = serverMessenger;
+            _scopeProvider = scopeProvider;
         }
 
         public override Task PerformExecuteAsync(object state)
@@ -93,8 +116,6 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
 
             try
             {
-                // We don't need an explicit scope here because PerformScheduledPublish creates it's own scope
-                // so it's safe as it will create it's own ambient scope.
                 // Ensure we run with an UmbracoContext, because this will run in a background task,
                 // and developers may be using the UmbracoContext in the event handlers.
 
@@ -105,6 +126,14 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
                 // - and we should definitively *not* have to flush it here (should be auto)
 
                 using UmbracoContextReference contextReference = _umbracoContextFactory.EnsureUmbracoContext();
+                using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
+
+                /* We used to assume that there will never be two instances running concurrently where (IsMainDom && ServerRole == SchedulingPublisher)
+                 * However this is possible during an azure deployment slot swap for the SchedulingPublisher instance when trying to achieve zero downtime deployments.
+                 * If we take a distributed write lock, we are certain that the multiple instances of the job will not run in parallel.
+                 * It's possible that during the swapping process we may run this job more frequently than intended but this is not of great concern and it's
+                 * only until the old SchedulingPublisher shuts down. */
+                scope.EagerWriteLock(Constants.Locks.ScheduledPublishing);
                 try
                 {
                     // Run

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -175,6 +175,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             _database.Insert(Cms.Core.Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Cms.Core.Constants.Locks.Domains, Name = "Domains" });
             _database.Insert(Cms.Core.Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Cms.Core.Constants.Locks.KeyValues, Name = "KeyValues" });
             _database.Insert(Cms.Core.Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Cms.Core.Constants.Locks.Languages, Name = "Languages" });
+            _database.Insert(Cms.Core.Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Cms.Core.Constants.Locks.ScheduledPublishing, Name = "ScheduledPublishing" });
 
             _database.Insert(Cms.Core.Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Cms.Core.Constants.Locks.MainDom, Name = "MainDom" });
         }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_0_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_1_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_2_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_3_0;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_4_0;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade
@@ -277,6 +278,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade
             To<UpdateExternalLoginToUseKeyInsteadOfId>("{CA7A1D9D-C9D4-4914-BC0A-459E7B9C3C8C}");
             To<AddTwoFactorLoginTable>("{0828F206-DCF7-4F73-ABBB-6792275532EB}");
 
+            // TO 9.4.0
+            To<AddScheduledPublishingLock>("{DBBA1EA0-25A1-4863-90FB-5D306FB6F1E1}");
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_4_0/AddScheduledPublishingLock.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_9_4_0/AddScheduledPublishingLock.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_9_4_0
+{
+    internal class AddScheduledPublishingLock : MigrationBase
+    {
+        public AddScheduledPublishingLock(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override void Migrate() =>
+            Database.Insert(Cms.Core.Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Cms.Core.Constants.Locks.ScheduledPublishing, Name = "ScheduledPublishing" });
+    }
+}

--- a/src/Umbraco.Infrastructure/Runtime/DefaultMainDomKeyGenerator.cs
+++ b/src/Umbraco.Infrastructure/Runtime/DefaultMainDomKeyGenerator.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Runtime;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Runtime
+{
+
+    internal class DefaultMainDomKeyGenerator : IMainDomKeyGenerator
+    {
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
+
+        public DefaultMainDomKeyGenerator(IHostingEnvironment hostingEnvironment, IOptionsMonitor<GlobalSettings> globalSettings)
+        {
+            _hostingEnvironment = hostingEnvironment;
+            _globalSettings = globalSettings;
+        }
+
+        public string GenerateKey()
+        {
+            var machineName = Environment.MachineName;
+            var mainDomId = MainDom.GetMainDomId(_hostingEnvironment);
+            var discriminator = _globalSettings.CurrentValue.MainDomKeyDiscriminator;
+
+            var rawKey = $"{machineName}{mainDomId}{discriminator}";
+
+            return rawKey.GenerateHash<SHA1>();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -1,10 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Runtime;
 
@@ -13,6 +14,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
     internal class FileSystemMainDomLock : IMainDomLock
     {
         private readonly ILogger<FileSystemMainDomLock> _logger;
+        private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
         private readonly CancellationTokenSource _cancellationTokenSource = new();
         private readonly string _lockFilePath;
         private readonly string _releaseSignalFilePath;
@@ -20,14 +22,14 @@ namespace Umbraco.Cms.Infrastructure.Runtime
         private FileStream _lockFileStream;
         private Task _listenForReleaseSignalFileTask;
 
-        private const int s_maxTriesRemovingLockReleaseSignalFile = 3;
-
         public FileSystemMainDomLock(
             ILogger<FileSystemMainDomLock> logger,
             IMainDomKeyGenerator mainDomKeyGenerator,
-            IHostingEnvironment hostingEnvironment)
+            IHostingEnvironment hostingEnvironment,
+            IOptionsMonitor<GlobalSettings> globalSettings)
         {
             _logger = logger;
+            _globalSettings = globalSettings;
 
             var lockFileName = $"MainDom_{mainDomKeyGenerator.GenerateKey()}.lock";
             _lockFilePath = Path.Combine(hostingEnvironment.LocalTempPath, lockFileName);
@@ -45,18 +47,18 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                 {
                     _logger.LogDebug("Attempting to obtain MainDom lock file handle {lockFilePath}", _lockFilePath);
                     _lockFileStream = File.Open(_lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-                    DeleteLockReleaseFile();
+                    DeleteLockReleaseSignalFile();
                     return Task.FromResult(true);
                 }
                 catch (IOException)
                 {
                     _logger.LogDebug("Couldn't obtain MainDom lock file handle, signalling for release of {lockFilePath}", _lockFilePath);
-                    CreateLockReleaseFile();
-                    Thread.Sleep(500);
+                    CreateLockReleaseSignalFile();
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Unexpected exception attempting to obtain MainDom lock file handle {lockFilePath}, giving up", _lockFilePath);
+                    _lockFileStream?.Close();
                     return Task.FromResult(false);
                 }
             }
@@ -64,6 +66,12 @@ namespace Umbraco.Cms.Infrastructure.Runtime
 
             return Task.FromResult(false);
         }
+
+        public void CreateLockReleaseSignalFile() =>
+            _ = File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
+
+        public void DeleteLockReleaseSignalFile() =>
+            File.Delete(_releaseSignalFilePath);
 
         // Create a long running task to poll to check if anyone has created a lock release file.
         public Task ListenAsync()
@@ -80,46 +88,6 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                 TaskScheduler.Default);
 
             return _listenForReleaseSignalFileTask;
-        }
-
-        public void Dispose()
-        {
-            _lockFileStream?.Close();
-            _lockFileStream = null;
-        }
-
-        private void CreateLockReleaseFile()
-        {
-            try
-            {
-                // Dispose immediately to release the file handle so it's easier to cleanup in any process.
-                using FileStream releaseFileStream = File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Unexpected exception attempting to create lock release signal file {file}", _releaseSignalFilePath);
-            }
-        }
-
-        private void DeleteLockReleaseFile()
-        {
-            List<Exception> encounteredExceptions = new();
-            for (var i = 0; i < s_maxTriesRemovingLockReleaseSignalFile; i++)
-            {
-                try
-                {
-                    File.Delete(_releaseSignalFilePath);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Unexpected exception attempting to delete release signal file {file}", _releaseSignalFilePath);
-                    encounteredExceptions.Add(ex);
-                    Thread.Sleep(500 * (i + 1));
-                }
-            }
-
-            throw new ApplicationException($"Failed to remove lock release signal file {_releaseSignalFilePath}", new AggregateException(encounteredExceptions));
         }
 
         private void ListeningLoop()
@@ -140,8 +108,14 @@ namespace Umbraco.Cms.Infrastructure.Runtime
                     break;
                 }
 
-                Thread.Sleep(2000);
+                Thread.Sleep(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval);
             }
+        }
+
+        public void Dispose()
+        {
+            _lockFileStream?.Close();
+            _lockFileStream = null;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Runtime;
+
+namespace Umbraco.Cms.Infrastructure.Runtime
+{
+    internal class FileSystemMainDomLock : IMainDomLock
+    {
+        private readonly ILogger<FileSystemMainDomLock> _log;
+
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+        private readonly string _lockFilePath;
+        private readonly string _releaseSignalFilePath;
+
+        private FileStream _lockFileStream;
+
+        public FileSystemMainDomLock(
+            ILogger<FileSystemMainDomLock> log,
+            IMainDomKeyGenerator mainDomKeyGenerator,
+            IHostingEnvironment hostingEnvironment)
+        {
+            _log = log;
+
+            var lockFileName = $"MainDom_{mainDomKeyGenerator.GenerateKey()}.lock";
+            _lockFilePath = Path.Combine(hostingEnvironment.LocalTempPath, lockFileName);
+            _releaseSignalFilePath = $"{_lockFilePath}_release";
+        }
+
+        public Task<bool> AcquireLockAsync(int millisecondsTimeout)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            do
+            {
+                try
+                {
+                    _log.LogDebug("Attempting to obtain MainDom lock file handle {lockFilePath}", _lockFilePath);
+                    _lockFileStream = File.Open(_lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                    DeleteLockReleaseFile();
+                    return Task.FromResult(true);
+                }
+                catch (IOException)
+                {
+                    _log.LogDebug("Couldn't obtain MainDom lock file handle, signalling for release of {lockFilePath}", _lockFilePath);
+                    CreateLockReleaseFile();
+                    Thread.Sleep(500);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogError(ex, "Unexpected exception attempting to obtain MainDom lock file handle {lockFilePath}, giving up", _lockFilePath);
+                    return Task.FromResult(false);
+                }
+            }
+            while (stopwatch.ElapsedMilliseconds < millisecondsTimeout);
+
+            return Task.FromResult(false);
+        }
+
+        // Create a long running task to poll to check if anyone has created a lock release file.
+        public Task ListenAsync() =>
+            Task.Factory.StartNew(
+                ListeningLoop,
+                _cancellationTokenSource.Token,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+
+        public void Dispose()
+        {
+            _lockFileStream?.Close();
+            _lockFileStream = null;
+        }
+
+        private void CreateLockReleaseFile()
+        {
+            try
+            {
+                // Dispose immediately to release the file handle so it's easier to cleanup in any process.
+                using FileStream releaseFileStream = File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+            }
+            catch (Exception ex)
+            {
+                _log.LogError(ex, "Unexpected exception attempting to create lock release signal file {file}", _releaseSignalFilePath);
+            }
+        }
+
+        private void DeleteLockReleaseFile()
+        {
+            while (File.Exists(_releaseSignalFilePath))
+            {
+                try
+                {
+                    File.Delete(_releaseSignalFilePath);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogError(ex, "Unexpected exception attempting to delete release signal file {file}", _releaseSignalFilePath);
+                    Thread.Sleep(500);
+                }
+            }
+        }
+
+        private void ListeningLoop()
+        {
+            while (true)
+            {
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    _log.LogDebug("ListenAsync Task canceled, exiting loop");
+                    return;
+                }
+
+                if (File.Exists(_releaseSignalFilePath))
+                {
+                    _log.LogDebug("Found lock release signal file, releasing lock on {lockFilePath}", _lockFilePath);
+                    _lockFileStream?.Close();
+                    _lockFileStream = null;
+                    break;
+                }
+
+                Thread.Sleep(2000);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -68,7 +68,8 @@ namespace Umbraco.Cms.Infrastructure.Runtime
         }
 
         public void CreateLockReleaseSignalFile() =>
-            _ = File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
+            File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete)
+                .Close();
 
         public void DeleteLockReleaseSignalFile() =>
             File.Delete(_releaseSignalFilePath);

--- a/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
@@ -40,53 +40,6 @@ namespace Umbraco.Cms.Infrastructure.Runtime
         private bool _hasTable = false;
         private bool _acquireWhenTablesNotAvailable = false;
 
-        // Note: Ignoring the two version notice rule as this class should probably be internal.
-        // We don't expect anyone downstream to be instantiating a SqlMainDomLock, only resolving IMainDomLock
-        [Obsolete("This constructor will be removed in version 10, please use an alternative constructor.")]
-        public SqlMainDomLock(
-            ILogger<SqlMainDomLock> logger,
-            ILoggerFactory loggerFactory,
-            IOptions<GlobalSettings> globalSettings,
-            IOptionsMonitor<ConnectionStrings> connectionStrings,
-            IDbProviderFactoryCreator dbProviderFactoryCreator,
-            IHostingEnvironment hostingEnvironment,
-            DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
-            NPocoMapperCollection npocoMappers,
-            string connectionStringName)
-            : this(
-                loggerFactory,
-                globalSettings,
-                connectionStrings,
-                dbProviderFactoryCreator,
-                StaticServiceProvider.Instance.GetRequiredService<IMainDomKeyGenerator>(),
-                databaseSchemaCreatorFactory,
-                npocoMappers)
-        {
-        }
-
-        // Note: Ignoring the two version notice rule as this class should probably be internal.
-        // We don't expect anyone downstream to be instantiating a SqlMainDomLock, only resolving IMainDomLock
-        [Obsolete("This constructor will be removed in version 10, please use an alternative constructor.")]
-        public SqlMainDomLock(
-            ILogger<SqlMainDomLock> logger,
-            ILoggerFactory loggerFactory,
-            IOptions<GlobalSettings> globalSettings,
-            IOptionsMonitor<ConnectionStrings> connectionStrings,
-            IDbProviderFactoryCreator dbProviderFactoryCreator,
-            IHostingEnvironment hostingEnvironment,
-            DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
-            NPocoMapperCollection npocoMappers)
-        : this(
-            loggerFactory,
-            globalSettings,
-            connectionStrings,
-            dbProviderFactoryCreator,
-            StaticServiceProvider.Instance.GetRequiredService<IMainDomKeyGenerator>(),
-            databaseSchemaCreatorFactory,
-            npocoMappers)
-        {
-        }
-
         public SqlMainDomLock(
             ILoggerFactory loggerFactory,
             IOptions<GlobalSettings> globalSettings,

--- a/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/SqlMainDomLock.cs
@@ -187,7 +187,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             {
                 // poll every couple of seconds
                 // local testing shows the actual query to be executed from client/server is approx 300ms but would change depending on environment/IO
-                Thread.Sleep(2000);
+                Thread.Sleep(_globalSettings.Value.MainDomReleaseSignalPollingInterval);
 
                 if (!_dbFactory.Configured)
                 {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -44,13 +45,23 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Runtime
         [TearDown]
         public void TearDown()
         {
-            while (File.Exists(LockFilePath))
+            CleanupTestFile(LockFilePath);
+            CleanupTestFile(LockReleaseFilePath);
+        }
+
+        private static void CleanupTestFile(string path)
+        {
+            for (var i = 0; i < 3; i++)
             {
-                File.Delete(LockFilePath);
-            }
-            while (File.Exists(LockReleaseFilePath))
-            {
-                File.Delete(LockReleaseFilePath);
+                try
+                {
+                    File.Delete(path);
+                    return;
+                }
+                catch
+                {
+                    Thread.Sleep(500 * (i + 1));
+                }
             }
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
@@ -1,0 +1,97 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Runtime;
+using Umbraco.Cms.Infrastructure.Runtime;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Runtime
+{
+    [TestFixture]
+    internal class FileSystemMainDomLockTests : UmbracoIntegrationTest
+    {
+        private IMainDomKeyGenerator MainDomKeyGenerator { get; set; }
+
+        private IHostingEnvironment HostingEnvironment { get; set; }
+
+        private FileSystemMainDomLock FileSystemMainDomLock { get; set; }
+
+        private string LockFilePath { get; set; }
+        private string LockReleaseFilePath { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            MainDomKeyGenerator = GetRequiredService<IMainDomKeyGenerator>();
+            HostingEnvironment = GetRequiredService<IHostingEnvironment>();
+
+            var lockFileName = $"MainDom_{MainDomKeyGenerator.GenerateKey()}.lock";
+            LockFilePath = Path.Combine(HostingEnvironment.LocalTempPath, lockFileName);
+            LockReleaseFilePath = LockFilePath + "_release";
+
+            var log = GetRequiredService<ILogger<FileSystemMainDomLock>>();
+            FileSystemMainDomLock = new FileSystemMainDomLock(log, MainDomKeyGenerator, HostingEnvironment);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            while (File.Exists(LockFilePath))
+            {
+                File.Delete(LockFilePath);
+            }
+            while (File.Exists(LockReleaseFilePath))
+            {
+                File.Delete(LockReleaseFilePath);
+            }
+        }
+
+        [Test]
+        public async Task AcquireLockAsync_WhenNoOtherHoldsLockFileHandle_ReturnsTrue()
+        {
+            using var sut = FileSystemMainDomLock;
+
+            var result = await sut.AcquireLockAsync(1000);
+
+            Assert.True(result);
+        }
+
+        [Test]
+        public async Task AcquireLockAsync_WhenTimeoutExceeded_ReturnsFalse()
+        {
+            await using var lockFile = File.Open(LockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+            using var sut = FileSystemMainDomLock;
+
+            var result = await sut.AcquireLockAsync(1000);
+
+            Assert.False(result);
+        }
+
+        [Test]
+        public async Task ListenAsync_WhenLockReleaseSignalFileFound_DropsLockFileHandle()
+        {
+            using var sut = FileSystemMainDomLock;
+
+            await sut.AcquireLockAsync(1000);
+
+            var before = await sut.AcquireLockAsync(1000);
+
+            await using (_ = File.Open(LockReleaseFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+            }
+
+            await sut.ListenAsync();
+
+            var after = await sut.AcquireLockAsync(1000);
+
+            Assert.Multiple(() =>
+            {
+                Assert.False(before);
+                Assert.True(after);
+            });
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ScheduledPublishingTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/ScheduledPublishingTests.cs
@@ -2,12 +2,15 @@
 // See LICENSE for more details.
 
 using System;
+using System.Data;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Runtime;
+using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
@@ -108,6 +111,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
 
             var mockServerMessenger = new Mock<IServerMessenger>();
 
+            var mockScopeProvider = new Mock<IScopeProvider>();
+            mockScopeProvider
+                .Setup(x => x.CreateScope(It.IsAny<IsolationLevel>(), It.IsAny<RepositoryCacheMode>(), It.IsAny<IScopedNotificationPublisher>(), It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(Mock.Of<IScope>());
+
             return new ScheduledPublishing(
                 mockRunTimeState.Object,
                 mockMainDom.Object,
@@ -115,7 +123,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.HostedServices
                 _mockContentService.Object,
                 mockUmbracoContextFactory.Object,
                 _mockLogger.Object,
-                mockServerMessenger.Object);
+                mockServerMessenger.Object,
+                mockScopeProvider.Object);
         }
 
         private void VerifyScheduledPublishingNotPerformed() => VerifyScheduledPublishingPerformed(Times.Never());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Runtime/DefaultMainDomKeyGeneratorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Runtime/DefaultMainDomKeyGeneratorTests.cs
@@ -1,0 +1,47 @@
+using AutoFixture.NUnit3;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Infrastructure.Runtime;
+using Umbraco.Cms.Tests.UnitTests.AutoFixture;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Runtime
+{
+    [TestFixture]
+    internal class DefaultMainDomKeyGeneratorTests
+    {
+        [Test]
+        [AutoMoqData]
+        public void GenerateKey_WithConfiguredDiscriminatorValue_AltersHash(
+            [Frozen] IHostingEnvironment hostingEnvironment,
+            [Frozen] GlobalSettings globalSettings,
+            [Frozen] IOptionsMonitor<GlobalSettings> globalSettingsMonitor,
+            DefaultMainDomKeyGenerator sut,
+            string aDiscriminator)
+        {
+            var withoutDiscriminator = sut.GenerateKey();
+            globalSettings.MainDomKeyDiscriminator = aDiscriminator;
+            var withDiscriminator = sut.GenerateKey();
+
+            Assert.AreNotEqual(withoutDiscriminator, withDiscriminator);
+        }
+
+        [Test]
+        [AutoMoqData]
+        public void GenerateKey_WithUnchangedDiscriminatorValue_ReturnsSameValue(
+            [Frozen] IHostingEnvironment hostingEnvironment,
+            [Frozen] GlobalSettings globalSettings,
+            [Frozen] IOptionsMonitor<GlobalSettings> globalSettingsMonitor,
+            DefaultMainDomKeyGenerator sut,
+            string aDiscriminator)
+        {
+            globalSettings.MainDomKeyDiscriminator = aDiscriminator;
+
+            var a = sut.GenerateKey();
+            var b = sut.GenerateKey();
+
+            Assert.AreEqual(a, b);
+        }
+    }
+}


### PR DESCRIPTION
Cheery picked changes from #12037 (v9)

---

* Extract MainDomKey generation to its own class to ease customization.

Also add discriminator config value to GlobalSettings for advanced users.
Prevents a mandatory custom implementation, should be good enough for
the vast majority of use cases.

* Prevent duplicate runs of ScheduledPublishing during slot swap.

* Add filesystem based MainDomLock

---
## Additional changes (v10)
+ Remove obsolete constructors from ScheduledPublishing & SqlMainDomLock
+ FileSystemMainDomLock promoted to default fallback for all platforms