### PR TITLE
11921: Update CultureName after language change

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
@@ -174,6 +174,19 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 return ValidationProblem(ModelState);
             }
 
+            // Update language
+            CultureInfo cultureAfterChange;
+            try
+            {
+                // language has the CultureName of the previous lang so we get information about new culture.
+                cultureAfterChange = CultureInfo.GetCultureInfo(language.IsoCode);
+            }
+            catch (CultureNotFoundException)
+            {
+                ModelState.AddModelError("IsoCode", "No Culture found with name " + language.IsoCode);
+                return ValidationProblem(ModelState);
+            }
+            existingById.CultureName = cultureAfterChange.DisplayName;
             existingById.IsDefault = language.IsDefault;
             existingById.FallbackLanguageId = language.FallbackLanguageId;
             existingById.IsoCode = language.IsoCode;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

I implement fix to this issue #11921 . After fix, notification display correct language name :)

### Description
After changing the language option "swedish" to "dutch" it does use the dutch language for the pages but when you publish a page the notification popup at the bottom says "Content published: Swedish (Sweden) published and visible on the website" whilst it should be referring to "dutch (netherlands)".

Steps to reproduce:
1. Change the swedish language option to Dutch (netherlands) and save.
2. Publish a page in the changed language.

![image](https://user-images.githubusercontent.com/11333925/155593723-f14fef5c-e3f1-4f30-8858-dd08b6ecf7d2.png)
