### PR TITLE
add null check for case when index is not implementing LuceneDirector…

### DIFF
--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
@@ -27,7 +27,11 @@ namespace Umbraco.Cms.Infrastructure.Examine
             IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions)
         {
             _hostingEnvironment = hostingEnvironment;
-            _indexOptions = indexOptions.Get(index.Name);
+            if (indexOptions != null)
+            {
+                _indexOptions = indexOptions.Get(index.Name);
+
+            }
             Index = index;
             Logger = logger;
         }
@@ -35,7 +39,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
         public LuceneIndex Index { get; }
         public ILogger<LuceneIndexDiagnostics> Logger { get; }
 
-       
+
 
         public Attempt<string> IsHealthy()
         {
@@ -72,12 +76,12 @@ namespace Umbraco.Cms.Infrastructure.Examine
                     {
                         d[nameof(LuceneDirectoryIndexOptions.DirectoryFactory)] = _indexOptions.DirectoryFactory.GetType();
                     }
-                    
+
                     if (_indexOptions.IndexDeletionPolicy != null)
                     {
                         d[nameof(LuceneDirectoryIndexOptions.IndexDeletionPolicy)] = _indexOptions.IndexDeletionPolicy.GetType();
-                    } 
-                    
+                    }
+
                 }
 
                 return d;


### PR DESCRIPTION
…yIndexOptions

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Really small null check, as if you register any LuceneIndex, it will fail, as trying access index options, but if that is Lucene index (not Umbraco Lucene index), we passing null instead of index 
```
if (index is LuceneIndex luceneIndex)
                {
                    indexDiag = new LuceneIndexDiagnostics(
                        luceneIndex,
                        _loggerFactory.CreateLogger<LuceneIndexDiagnostics>(),
                        _hostingEnvironment,
                        null);
                }
```
so we need check before calling indexOptions.Get(index.Name)