### PR TITLE
V8: Fix missing EditedCultures and Name in content saving notifications

### DIFF
--- a/src/Umbraco.Web/Editors/ContentController.cs
+++ b/src/Umbraco.Web/Editors/ContentController.cs
@@ -2080,6 +2080,12 @@ namespace Umbraco.Web.Editors
                 variantIndex++;
             }
 
+            // Map IsDirty cultures to edited cultures, to make it easier to verify changes on specific variants on Saving and Saved events.
+            var editedCultures = contentSave.PersistedContent.CultureInfos.Values
+                .Where(x => x.IsDirty())
+                .Select(x => x.Culture);
+            contentSave.PersistedContent.SetCultureEdited(editedCultures);
+
             // handle template
             if (string.IsNullOrWhiteSpace(contentSave.TemplateAlias)) // cleared: clear if not already null
             {


### PR DESCRIPTION
This fixes #12051.

The original issue reported that using the `ContentSavingNotification` on V9 you couldn't access the content that was being saved. 

After some additional testing, I found that this only happened when the content being saved had "allow varying by culture"  enabled and that the data was actually there, it was just buried inside the `CultureInfos` property but I do see how this can be confusing and not really obvious. 

Furthermore, I found that `EditedCultures` would never return any results making this even harder to work with.

To fix this I've changed the behaviour so now if you're renaming a multilingual content nodes default language variant that new name will be set as the name of the saved entity on the event if you, however, rename nodes non-default language this is still not reflected in the name of the saved entity. 

I've also updated it so `EditedCultures` will now contain all the cultures that were saved. 

### Testing
* Ensure that content still saves as expected
* Ensure that the `Name` property will always be the name that's about to be saved from the default culture
* Ensure that EditedCultures contain the culture of any variant about to the saved

I Used this component for testing

```C#
using System.Linq;
using Umbraco.Core.Composing;
using Umbraco.Core.Events;
using Umbraco.Core.Services;
using Umbraco.Core.Services.Implement;

namespace Umbraco.Web.UI
{
    public class ContentSavingComponent : IComponent
    {
        public void Initialize()
        {
            ContentService.Saving += ContentServiceOnSaving;
        }

        public void Terminate()
        {
            ContentService.Saving -= ContentServiceOnSaving;
        }

        private void ContentServiceOnSaving(IContentService sender, ContentSavingEventArgs e)
        {
            // Assume the default language is English
            var savedEntity = e.SavedEntities.First();

            // This will always be the name of the English variant about to be saved.
            var name = savedEntity.Name;

            // This will contain the culture of all variants being saved
            foreach (var editedCulture in savedEntity.EditedCultures)
            {
                if(savedEntity.CultureInfos.TryGetValue(editedCulture, out var editedCultureInfo))
                {
                    var cultureName = editedCultureInfo.Name;
                    var cultureTitle = savedEntity.GetValue<string>("title", editedCultureInfo.Culture);
                }
            }
        }
    }

    public class ContentSavingComposer : ComponentComposer<ContentSavingComponent>
    {

    }
}
```