### PR TITLE
v9: Fix cannot replace default Rendercontroller with generic

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ControllerExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ControllerExtensions.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Extensions
         /// <returns></returns>
         public static string GetControllerName(Type controllerType)
         {
-            if (!controllerType.Name.EndsWith("Controller"))
+            if (!controllerType.Name.EndsWith("Controller") && !controllerType.Name.EndsWith("Controller`1"))
             {
                 throw new InvalidOperationException("The controller type " + controllerType + " does not follow conventions, MVC Controller class names must be suffixed with the term 'Controller'");
             }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12030
# Notes
- Added extra check for generic types
# How to test
- Follow step by step in issue