### PR TITLE
DisposableTimer Logging optimization

### DIFF
--- a/src/Umbraco.Core/Logging/DisposableTimer.cs
+++ b/src/Umbraco.Core/Logging/DisposableTimer.cs
@@ -53,14 +53,21 @@ namespace Umbraco.Cms.Core.Logging
                     case LogLevel.Debug:
                         if (startMessageArgs == null)
                         {
-                            logger.LogDebug("{StartMessage} [Timing {TimingId}]", startMessage, _timingId);
+                            if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                            {
+                                logger.LogDebug("{StartMessage} [Timing {TimingId}]", startMessage, _timingId);
+                            }
                         }
                         else
                         {
-                            var args = new object[startMessageArgs.Length + 1];
-                            startMessageArgs.CopyTo(args, 0);
-                            args[startMessageArgs.Length] = _timingId;
-                            logger.LogDebug(startMessage + " [Timing {TimingId}]", args);
+                            if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                            {
+                                var args = new object[startMessageArgs.Length + 2];
+                                startMessageArgs.CopyTo(args, 0);
+                                args[startMessageArgs.Length - 1] = startMessage;
+                                args[startMessageArgs.Length] = _timingId;
+                                logger.LogDebug("{StartMessage} [Timing {TimingId}]", args);
+                            }
                         }
                         break;
                     case LogLevel.Information:
@@ -70,10 +77,11 @@ namespace Umbraco.Cms.Core.Logging
                         }
                         else
                         {
-                            var args = new object[startMessageArgs.Length + 1];
+                            var args = new object[startMessageArgs.Length + 2];
                             startMessageArgs.CopyTo(args, 0);
+                            args[startMessageArgs.Length - 1] = startMessage;
                             args[startMessageArgs.Length] = _timingId;
-                            logger.LogInformation(startMessage + " [Timing {TimingId}]", args);
+                            logger.LogInformation("{StartMessage} [Timing {TimingId}]", args);
                         }
                         break;
                     default:
@@ -124,11 +132,13 @@ namespace Umbraco.Cms.Core.Logging
                     }
                     else
                     {
-                        var args = new object[_failMessageArgs.Length + 2];
+                        var args = new object[_failMessageArgs.Length + 4];
                         _failMessageArgs.CopyTo(args, 0);
+                        args[_failMessageArgs.Length - 3] = _failException;
+                        args[_failMessageArgs.Length - 2] = _failMessage;
                         args[_failMessageArgs.Length - 1] = Stopwatch.ElapsedMilliseconds;
                         args[_failMessageArgs.Length] = _timingId;
-                        _logger.LogError(_failException, _failMessage + " ({Duration}ms) [Timing {TimingId}]", args);
+                        _logger.LogError("{FailException}, {FailMessage} ({Duration}ms) [Timing {TimingId}]", args);
                     }
                 }
                 else
@@ -138,15 +148,22 @@ namespace Umbraco.Cms.Core.Logging
                         case LogLevel.Debug:
                             if (_endMessageArgs == null)
                             {
-                                _logger.LogDebug("{EndMessage} ({Duration}ms) [Timing {TimingId}]", _endMessage, Stopwatch.ElapsedMilliseconds, _timingId);
+                                if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                                {
+                                    _logger.LogDebug("{EndMessage} ({Duration}ms) [Timing {TimingId}]", _endMessage, Stopwatch.ElapsedMilliseconds, _timingId);
+                                }
                             }
                             else
                             {
-                                var args = new object[_endMessageArgs.Length + 2];
-                                _endMessageArgs.CopyTo(args, 0);
-                                args[args.Length - 1] = Stopwatch.ElapsedMilliseconds;
-                                args[args.Length] = _timingId;
-                                _logger.LogDebug(_endMessage + " ({Duration}ms) [Timing {TimingId}]", args);
+                                if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                                {
+                                    var args = new object[_endMessageArgs.Length + 3];
+                                    _endMessageArgs.CopyTo(args, 0);
+                                    args[args.Length - 2] = _endMessage;
+                                    args[args.Length - 1] = Stopwatch.ElapsedMilliseconds;
+                                    args[args.Length] = _timingId;
+                                    _logger.LogDebug("{EndMessage} ({Duration}ms) [Timing {TimingId}]", args);
+                                }
                             }
                             break;
                         case LogLevel.Information:
@@ -156,11 +173,12 @@ namespace Umbraco.Cms.Core.Logging
                             }
                             else
                             {
-                                var args = new object[_endMessageArgs.Length + 2];
+                                var args = new object[_endMessageArgs.Length + 3];
                                 _endMessageArgs.CopyTo(args, 0);
+                                args[args.Length - 2] = _endMessage;
                                 args[_endMessageArgs.Length - 1] = Stopwatch.ElapsedMilliseconds;
                                 args[_endMessageArgs.Length] = _timingId;
-                                _logger.LogInformation(_endMessage + " ({Duration}ms) [Timing {TimingId}]", args);
+                                _logger.LogInformation("{EndMessage} ({Duration}ms) [Timing {TimingId}]", args);
                             }
                             break;
                             // filtered in the ctor

--- a/src/Umbraco.Core/Logging/DisposableTimer.cs
+++ b/src/Umbraco.Core/Logging/DisposableTimer.cs
@@ -175,7 +175,7 @@ namespace Umbraco.Cms.Core.Logging
                             {
                                 var args = new object[_endMessageArgs.Length + 3];
                                 _endMessageArgs.CopyTo(args, 0);
-                                args[args.Length - 2] = _endMessage;
+                                args[_endMessageArgs.Length - 2] = _endMessage;
                                 args[_endMessageArgs.Length - 1] = Stopwatch.ElapsedMilliseconds;
                                 args[_endMessageArgs.Length] = _timingId;
                                 _logger.LogInformation("{EndMessage} ({Duration}ms) [Timing {TimingId}]", args);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
DisposableTimer Logging optimization
Avoids allocating params[] for debug level logs in DisposableTimer used by the profiling logger
MessageTemplate should be a constant string as it's cached.

How to test?

Existing tests pass.

<!-- Thanks for contributing to Umbraco CMS! -->
