### PR TITLE
Tune Debug logging to improve ContentStore boot performance

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -608,7 +608,10 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                 throw new ArgumentException("Kit content cannot have children.", nameof(kit));
             // ReSharper restore LocalizableElement
 
-            _logger.LogDebug("Set content ID: {KitNodeId}", kit.Node.Id);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Set content ID: {KitNodeId}", kit.Node.Id);
+            }
 
             // get existing
             _contentNodes.TryGetValue(kit.Node.Id, out var link);
@@ -727,7 +730,11 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                     previousNode = null; // there is no previous sibling
                 }
 
-                _logger.LogDebug("Set {thisNodeId} with parent {thisNodeParentContentId}", thisNode.Id, thisNode.ParentContentId);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Set {thisNodeId} with parent {thisNodeParentContentId}", thisNode.Id, thisNode.ParentContentId);
+                }
+
                 SetValueLocked(_contentNodes, thisNode.Id, thisNode);
 
                 // if we are initializing from the database source ensure the local db is updated
@@ -784,7 +791,12 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                     ok = false;
                     continue; // skip that one
                 }
-                _logger.LogDebug("Set {kitNodeId} with parent {kitNodeParentContentId}", kit.Node.Id, kit.Node.ParentContentId);
+
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Set {kitNodeId} with parent {kitNodeParentContentId}", kit.Node.Id, kit.Node.ParentContentId);
+                }
+
                 SetValueLocked(_contentNodes, kit.Node.Id, kit.Node);
 
                 if (_localDb != null) RegisterChange(kit.Node.Id, kit);
@@ -873,7 +885,11 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             if (link?.Value == null) return false;
 
             var content = link.Value;
-            _logger.LogDebug("Clear content ID: {ContentId}", content.Id);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Clear content ID: {ContentId}", content.Id);
+            }
 
             // clear the entire branch
             ClearBranchLocked(content);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Check Debug logs are enabled for contentstore hot path. The more content you have, the slower the startup due to debug logging for content items.

<!-- Thanks for contributing to Umbraco CMS! -->
