### PR TITLE
v9: Dont generate random guid when saving user

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -154,7 +154,7 @@
             formatUserPostData: function (displayModel) {
 
                 //create the save model from the display model
-                var saveModel = _.pick(displayModel, 'id', 'parentId', 'name', 'username', 'culture', 'email', 'startContentIds', 'startMediaIds', 'userGroups', 'message');
+                var saveModel = _.pick(displayModel, 'id', 'parentId', 'name', 'username', 'culture', 'email', 'startContentIds', 'startMediaIds', 'userGroups', 'message', 'key');
 
                 //make sure the userGroups are just a string array
                 var currGroups = saveModel.userGroups;


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12068
# Notes
- Issue was frontend was not sending key when calling PostSave, this PR remedies that

# How to test
- Install and run umbraco
- Go to user section and click your user
- Press the save button, this should no longer give you a random guid as a user key.