### PR TITLE
Fix invariant redirect tracking

### DIFF
--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -159,7 +159,7 @@ namespace Umbraco.Cms.Core.Routing
                 : DomainUtilities.DomainForNode(umbracoContext.PublishedSnapshot.Domains, _siteDomainMapper, int.Parse(route.Substring(0, pos), CultureInfo.InvariantCulture), current, culture);
 
             var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();
-            if (domainUri is not null || culture is null || culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
+            if (domainUri is not null || string.IsNullOrEmpty(culture) || culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
             {
                 var url = AssembleUrl(domainUri, path, current, mode).ToString();
                 return UrlInfo.Url(url, culture);

--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
@@ -118,8 +118,7 @@ namespace Umbraco.Cms.Core.Routing
 
                 foreach (var culture in cultures)
                 {
-                    var checkedCulture = string.IsNullOrEmpty(culture) ? null : culture;
-                    var route = contentCache.GetRouteById(publishedContent.Id, checkedCulture);
+                    var route = contentCache.GetRouteById(publishedContent.Id, culture);
                     if (IsNotRoute(route))
                     {
                         continue;
@@ -147,14 +146,13 @@ namespace Umbraco.Cms.Core.Routing
 
             foreach (KeyValuePair<ContentIdAndCulture, ContentKeyAndOldRoute> oldRoute in oldRoutes)
             {
-                var culture = string.IsNullOrWhiteSpace(oldRoute.Key.Culture) ? null : oldRoute.Key.Culture;
-                var newRoute = contentCache.GetRouteById(oldRoute.Key.ContentId, culture);
+                var newRoute = contentCache.GetRouteById(oldRoute.Key.ContentId, oldRoute.Key.Culture);
                 if (IsNotRoute(newRoute) || oldRoute.Value.OldRoute == newRoute)
                 {
                     continue;
                 }
 
-                _redirectUrlService.Register(oldRoute.Value.OldRoute, oldRoute.Value.ContentKey, culture);
+                _redirectUrlService.Register(oldRoute.Value.OldRoute, oldRoute.Value.ContentKey, oldRoute.Key.Culture);
             }
         }
 

--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
@@ -99,25 +99,33 @@ namespace Umbraco.Cms.Core.Routing
             {
                 return;
             }
-            var contentCache = publishedSnapshot.Content;
-            var entityContent = contentCache?.GetById(entity.Id);
+
+            IPublishedContentCache contentCache = publishedSnapshot.Content;
+            IPublishedContent entityContent = contentCache?.GetById(entity.Id);
             if (entityContent == null)
+            {
                 return;
+            }
 
             // get the default affected cultures by going up the tree until we find the first culture variant entity (default to no cultures)
             var defaultCultures = entityContent.AncestorsOrSelf()?.FirstOrDefault(a => a.Cultures.Any())?.Cultures.Keys.ToArray()
                 ?? new[] { (string)null };
-            foreach (var x in entityContent.DescendantsOrSelf(_variationContextAccessor))
+
+            foreach (IPublishedContent publishedContent in entityContent.DescendantsOrSelf(_variationContextAccessor))
             {
                 // if this entity defines specific cultures, use those instead of the default ones
-                var cultures = x.Cultures.Any() ? x.Cultures.Keys : defaultCultures;
+                IEnumerable<string> cultures = publishedContent.Cultures.Any() ? publishedContent.Cultures.Keys : defaultCultures;
 
                 foreach (var culture in cultures)
                 {
-                    var route = contentCache.GetRouteById(x.Id, culture);
+                    var checkedCulture = string.IsNullOrEmpty(culture) ? null : culture;
+                    var route = contentCache.GetRouteById(publishedContent.Id, checkedCulture);
                     if (IsNotRoute(route))
+                    {
                         continue;
-                    oldRoutes[new ContentIdAndCulture(x.Id, culture)] = new ContentKeyAndOldRoute(x.Key, route);
+                    }
+
+                    oldRoutes[new ContentIdAndCulture(publishedContent.Id, culture)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
                 }
             }
         }
@@ -135,14 +143,18 @@ namespace Umbraco.Cms.Core.Routing
             {
                 _logger.LogWarning("Could not track redirects because there is no current published snapshot available.");
                 return;
-            } 
+            }
 
-            foreach (var oldRoute in oldRoutes)
+            foreach (KeyValuePair<ContentIdAndCulture, ContentKeyAndOldRoute> oldRoute in oldRoutes)
             {
-                var newRoute = contentCache.GetRouteById(oldRoute.Key.ContentId, oldRoute.Key.Culture);
+                var culture = string.IsNullOrWhiteSpace(oldRoute.Key.Culture) ? null : oldRoute.Key.Culture;
+                var newRoute = contentCache.GetRouteById(oldRoute.Key.ContentId, culture);
                 if (IsNotRoute(newRoute) || oldRoute.Value.OldRoute == newRoute)
+                {
                     continue;
-                _redirectUrlService.Register(oldRoute.Value.OldRoute, oldRoute.Value.ContentKey, oldRoute.Key.Culture);
+                }
+
+                _redirectUrlService.Register(oldRoute.Value.OldRoute, oldRoute.Value.ContentKey, culture);
             }
         }
 

--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
@@ -102,7 +102,7 @@ namespace Umbraco.Cms.Core.Routing
 
             IPublishedContentCache contentCache = publishedSnapshot.Content;
             IPublishedContent entityContent = contentCache?.GetById(entity.Id);
-            if (entityContent == null)
+            if (entityContent is null)
             {
                 return;
             }

--- a/src/Umbraco.PublishedCache.NuCache/CacheKeys.cs
+++ b/src/Umbraco.PublishedCache.NuCache/CacheKeys.cs
@@ -13,9 +13,7 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static string LangId(string culture)
-        {
-            return culture != null ? ("-L:" + culture) : string.Empty;
-        }
+            => string.IsNullOrEmpty(culture) ? string.Empty : ("-L:" + culture);
 
         public static string PublishedContentChildren(Guid contentUid, bool previewing)
         {


### PR DESCRIPTION
This closes #11984.

While testing the above issue I was unable to replicate the exact issue, and the original issue creator has returned and mentioned that they can no longer reproduce this. 

However when doing some testing I noticed that redirect tracking is broken for invariant content types, as is also confirmed by a commenter on issue #11695, this PR fixes this issue with invariant redirect tracking.

I found two problems, the first of which are that whenever you publish or move some content a notification is handled by a `RedirectTrackingHandler`, in this request the culture of an invariant content node will have a culture as an empty string `""`, and not null. This mean that when we tried to generate the route from the cache it looked for something with a culture of empty string, instead of null as it expected. To fix this I've updated `LangId` on `CacheKeys` to consider an empty string or null as invariant culture.

The second issue was now the other way around, when the request is incoming to a redirect URL we try to get the redirectUrl from the `RedirectUrlService` and because we save the culture as an empty string, the culture of the `IRedirectUrl` will also be an empty string, and this broke `DefaultUrlProvider` because it only checked the culture with `culture is null` now we instead check it with `string.IsNullOrEmpty`, resolving the issue. 

## Testing

Test this with both invariant and variant content 

* Create a document type
* Create a piece of root content and a child 
* Try and rename the child
* Ensure that a redirect URL is generated in the redirection dashboard and that this will redirect to the new URL 