### PR TITLE
v9: fix cannot map mvc route to client side request

### DIFF
--- a/src/Umbraco.Web.Common/Filters/UmbracoVirtualPageFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/UmbracoVirtualPageFilterAttribute.cs
@@ -2,10 +2,12 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
@@ -54,12 +56,14 @@ namespace Umbraco.Cms.Web.Common.Filters
         {
             if (content != null)
             {
-                IUmbracoContextAccessor umbracoContextAccessor = context.HttpContext.RequestServices.GetRequiredService<IUmbracoContextAccessor>();
+                UriUtility uriUtility = context.HttpContext.RequestServices.GetRequiredService<UriUtility>();
+
+                Uri originalRequestUrl = new Uri(context.HttpContext.Request.GetEncodedUrl());
+                Uri cleanedUrl = uriUtility.UriToUmbraco(originalRequestUrl);
+
                 IPublishedRouter router = context.HttpContext.RequestServices.GetRequiredService<IPublishedRouter>();
 
-                var umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
-
-                IPublishedRequestBuilder requestBuilder = await router.CreateRequestAsync(umbracoContext.CleanedUmbracoUrl);
+                IPublishedRequestBuilder requestBuilder = await router.CreateRequestAsync(cleanedUrl);
                 requestBuilder.SetPublishedContent(content);
                 IPublishedRequest publishedRequest = requestBuilder.Build();
 

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -145,7 +145,7 @@ namespace Umbraco.Cms.Web.Common.Middleware
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
             // do not process if client-side request
-            if (context.Request.IsClientSideRequest() && _umbracoRequestOptions.Value.HandleAsClientSideRequest(context.Request))
+            if (context.Request.IsClientSideRequest() && !_umbracoRequestOptions.Value.HandleAsServerSideRequest(context.Request))
             {
                 // we need this here because for bundle requests, these are 'client side' requests that we need to handle
                 LazyInitializeBackOfficeServices(context.Request.Path);

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -22,6 +22,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.PublishedCache;
 using Umbraco.Cms.Infrastructure.WebAssets;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Cms.Web.Common.Profiler;
 using Umbraco.Cms.Web.Common.Routing;
 using Umbraco.Extensions;
@@ -67,6 +68,43 @@ namespace Umbraco.Cms.Web.Common.Middleware
         private static bool s_firstBackOfficeReqestFlag;
         private static object s_firstBackOfficeRequestLocker = new object();
 #pragma warning restore IDE0044 // Add readonly modifier
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoRequestMiddleware"/> class.
+        /// </summary>
+        // Obsolete, scheduled for removal in V11
+        [Obsolete("Use constructor that takes an IOptions<UmbracoRequestOptions>")]
+        public UmbracoRequestMiddleware(
+            ILogger<UmbracoRequestMiddleware> logger,
+            IUmbracoContextFactory umbracoContextFactory,
+            IRequestCache requestCache,
+            PublishedSnapshotServiceEventHandler publishedSnapshotServiceEventHandler,
+            IEventAggregator eventAggregator,
+            IProfiler profiler,
+            IHostingEnvironment hostingEnvironment,
+            UmbracoRequestPaths umbracoRequestPaths,
+            BackOfficeWebAssets backOfficeWebAssets,
+            IOptions<SmidgeOptions> smidgeOptions,
+            IRuntimeState runtimeState,
+            IVariationContextAccessor variationContextAccessor,
+            IDefaultCultureAccessor defaultCultureAccessor)
+            : this(
+                logger,
+                umbracoContextFactory,
+                requestCache,
+                publishedSnapshotServiceEventHandler,
+                eventAggregator,
+                profiler,
+                hostingEnvironment,
+                umbracoRequestPaths,
+                backOfficeWebAssets,
+                smidgeOptions,
+                runtimeState,
+                variationContextAccessor,
+                defaultCultureAccessor,
+                StaticServiceProvider.Instance.GetRequiredService<IOptions<UmbracoRequestOptions>>())
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoRequestMiddleware"/> class.

--- a/src/Umbraco.Web.Common/Routing/UmbracoRequestOptions.cs
+++ b/src/Umbraco.Web.Common/Routing/UmbracoRequestOptions.cs
@@ -9,6 +9,6 @@ namespace Umbraco.Cms.Web.Common.Routing
         /// Gets the delegate that checks if we're gonna handle a request as a client-side request
         /// this returns true by default and can be overwritten in Startup.cs
         /// </summary>
-        public Func<HttpRequest, bool> HandleAsClientSideRequest { get; set; } = x => true;
+        public Func<HttpRequest, bool> HandleAsServerSideRequest { get; set; } = x => false;
     }
 }

--- a/src/Umbraco.Web.Common/Routing/UmbracoRequestOptions.cs
+++ b/src/Umbraco.Web.Common/Routing/UmbracoRequestOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Umbraco.Cms.Web.Common.Routing
+{
+    public class UmbracoRequestOptions
+    {
+        /// <summary>
+        /// Gets the delegate that checks if we're gonna handle a request as a client-side request
+        /// this returns true by default and can be overwritten in Startup.cs
+        /// </summary>
+        public Func<HttpRequest, bool> HandleAsClientSideRequest { get; set; } = x => true;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12083
# Notes
As described in the issue, this stems from "/sitemap.xml" being treated as a Client request and therefore we have no UmbracoContext and it throws an exception, I've come up with a solution that I hope is satisfying, where you can now "AllowList" some routes in your startup.cs/ConfigureServices
For a single route: 
```
services.Configure<UmbracoRequestOptions>(options =>
{
    options.HandleAsClientSideRequest = httpRequest =>
    {
        return httpRequest.Path.StartsWithSegments("/sitemap.xml");
    };
});
``` 
For multiple routes:
``` 
services.Configure<UmbracoRequestOptions>(options =>
{
    string[] allowList = new[] {"/sitemap.xml", ...};
    options.HandleAsServerSideRequest = httpRequest =>
    {
        foreach (string route in allowList)
        {
            if (httpRequest.Path.StartsWithSegments(route))
            {
                return true;
            }
        }

        return false;
    };
});
```

# How to test
- Follow steps in original issue.

- Create a controller with the snippet provided below
- Paste the Startup snippet into your Startup.cs file
- Copy the example for a single route above in your startup.cs
- Install and run Umbraco
- Create a document type and some content
- Navigate to /sitemap.xml and it should now display the Name of the contents!

# Startup snippet

```
app.UseUmbraco()
    .WithMiddleware(u =>
    {
        u.UseBackOffice();
        u.UseWebsite();
    })
    .WithEndpoints(u =>
    {
        u.EndpointRouteBuilder.MapControllerRoute(
            "Sitemap Controller",
            "/sitemap.xml",
            new { Controller = "SiteMap", Action = "Index" });
        u.UseInstallerEndpoints();
        u.UseBackOfficeEndpoints();
        u.UseWebsiteEndpoints();
    });
```

# Controller snippet
```
    public class SiteMapController : UmbracoPageController, IVirtualPageController
    {
        private readonly IUmbracoContextAccessor _umbracoContextAccessor;

        public SiteMapController(
            ILogger<UmbracoPageController> logger,
            ICompositeViewEngine compositeViewEngine,
            IUmbracoContextAccessor umbracoContextAccessor)
            : base(logger, compositeViewEngine)
        {
            _umbracoContextAccessor = umbracoContextAccessor;
        }

        [HttpGet]
        public IActionResult Index()
        {
            return Content(CurrentPage.Name);
        }


        public IPublishedContent FindContent(ActionExecutingContext actionExecutingContext)
        {
            var _umbracoContextFactory = actionExecutingContext.HttpContext.RequestServices
                .GetRequiredService<IUmbracoContextFactory>();
            IPublishedContent content = default(IPublishedContent);
            var context = _umbracoContextAccessor.GetRequiredUmbracoContext();

            content = context.Content.GetAtRoot().FirstOrDefault();

            return content;
        }
    }
```