### PR TITLE
Add  missing copy member type menu action

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -252,5 +252,19 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
             return display;
         }
+
+        /// <summary>
+        /// Copy the member type
+        /// </summary>
+        /// <param name="copy"></param>
+        /// <returns></returns>
+        [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+        public IActionResult PostCopy(MoveOrCopy copy)
+        {
+            return PerformCopy(
+                copy,
+                i => _memberTypeService.Get(i),
+                (type, i) => _memberTypeService.Copy(type, i));
+        }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Trees/MemberGroupTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberGroupTreeController.cs
@@ -26,8 +26,9 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
             IMenuItemCollectionFactory menuItemCollectionFactory,
             IMemberGroupService memberGroupService,
-            IEventAggregator eventAggregator)
-            : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory, eventAggregator)
+            IEventAggregator eventAggregator,
+            IMemberTypeService memberTypeService)
+            : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory, eventAggregator, memberTypeService)
             => _memberGroupService = memberGroupService;
 
         protected override IEnumerable<TreeNode> GetTreeNodesFromService(string id, FormCollection queryStrings)

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -59,7 +59,6 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             }
             else
             {
-                //delete member type/group
                 var memberType = _memberTypeService.Get(int.Parse(id));
                 if (memberType != null)
                 {

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Events;
@@ -8,6 +10,7 @@ using Umbraco.Cms.Core.Models.Trees;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Trees;
 using Umbraco.Cms.Web.Common.Attributes;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 using Constants = Umbraco.Cms.Core.Constants;
 
@@ -32,6 +35,21 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             MenuItemCollectionFactory = menuItemCollectionFactory;
 
             _memberTypeService = memberTypeService;
+        }
+
+        [Obsolete("Use ctor injecting IMemberTypeService")]
+        protected MemberTypeAndGroupTreeControllerBase(
+            ILocalizedTextService localizedTextService,
+            UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
+            IMenuItemCollectionFactory menuItemCollectionFactory,
+            IEventAggregator eventAggregator)
+            : this(
+                localizedTextService,
+                umbracoApiControllerTypeCollection,
+                menuItemCollectionFactory,
+                eventAggregator,
+                StaticServiceProvider.Instance.GetRequiredService<IMemberTypeService>())
+        {
         }
 
         protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
@@ -38,7 +38,6 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             _memberTypeService = memberTypeService;
         }
 
-
         protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
         {
             var rootResult = base.CreateRootNode(queryStrings);

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             UmbracoTreeSearcher treeSearcher,
             IMemberTypeService memberTypeService,
             IEventAggregator eventAggregator)
-            : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory, eventAggregator)
+            : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory, eventAggregator, memberTypeService)
         {
             _treeSearcher = treeSearcher;
             _memberTypeService = memberTypeService;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
For some reason the copy member type feature included in v8, wasn't merged up to v9. The copy dialog etc. exists, but the tree menu action wasn't added.
https://github.com/umbraco/Umbraco-CMS/pull/10020

However it seems we don't have access to `Services.MemberTypeService` like in v8 and I guess it would be a breaking change when changing the signature of the constructor.

https://user-images.githubusercontent.com/2919859/156375440-216c9bba-3761-4e81-8b2d-e7b90f48b01b.mp4

Furthermore I am not sure why the `PostSave` method dosn't have `[Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]` https://github.com/umbraco/Umbraco-CMS/blob/v9/contrib/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs#L193

In MediaTypeController it does have `[Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]`
https://github.com/umbraco/Umbraco-CMS/blob/v9/contrib/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs#L283-L284

And in `[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]` in https://github.com/umbraco/Umbraco-CMS/blob/v9/contrib/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs#L314-L315