### PR TITLE
v9 fix misc issues external member login

### DIFF
--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -535,6 +535,37 @@ namespace Umbraco.Cms.Core.Security
             return found;
         }
 
+        /// <summary>
+        /// Overridden to support Umbraco's own data storage requirements
+        /// </summary>
+        /// <remarks>
+        /// The base class's implementation of this calls into FindTokenAsync and AddUserTokenAsync, both methods will only work with ORMs that are change
+        /// tracking ORMs like EFCore.
+        /// </remarks>
+        /// <inheritdoc />
+        public override Task SetTokenAsync(MemberIdentityUser user, string loginProvider, string name, string value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            IIdentityUserToken token = user.LoginTokens.FirstOrDefault(x => x.LoginProvider.InvariantEquals(loginProvider) && x.Name.InvariantEquals(name));
+            if (token == null)
+            {
+                user.LoginTokens.Add(new IdentityUserToken(loginProvider, name, value, user.Id));
+            }
+            else
+            {
+                token.Value = value;
+            }
+
+            return Task.CompletedTask;
+        }
+
         private MemberIdentityUser AssignLoginsCallback(MemberIdentityUser user)
         {
             if (user != null)

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -181,6 +181,7 @@ namespace Umbraco.Cms.Core.Security
                 {
                     // we have to remember whether Logins property is dirty, since the UpdateMemberProperties will reset it.
                     var isLoginsPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.Logins));
+                    var isTokensPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.LoginTokens));
 
                     MemberDataChangeType memberChangeType = UpdateMemberProperties(found, user);
                     if (memberChangeType == MemberDataChangeType.FullSave)
@@ -202,6 +203,16 @@ namespace Umbraco.Cms.Core.Security
                                 x.LoginProvider,
                                 x.ProviderKey,
                                 x.UserData)));
+                    }
+
+                    if (isTokensPropertyDirty)
+                    {
+                        _externalLoginService.Save(
+                            found.Key,
+                            user.LoginTokens.Select(x => new ExternalLoginToken(
+                                x.LoginProvider,
+                                x.Name,
+                                x.Value)));
                     }
                 }
 

--- a/src/Umbraco.Web.Website/Security/MemberAuthenticationBuilder.cs
+++ b/src/Umbraco.Web.Website/Security/MemberAuthenticationBuilder.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Cms.Web.Website.Security
             // Validate that the prefix is set
             if (!authenticationScheme.StartsWith(Constants.Security.MemberExternalAuthenticationTypePrefix))
             {
-                throw new InvalidOperationException($"The {nameof(authenticationScheme)} is not prefixed with {Constants.Security.BackOfficeExternalAuthenticationTypePrefix}. The scheme must be created with a call to the method {nameof(SchemeForMembers)}");
+                throw new InvalidOperationException($"The {nameof(authenticationScheme)} is not prefixed with {Constants.Security.MemberExternalAuthenticationTypePrefix}. The scheme must be created with a call to the method {nameof(SchemeForMembers)}");
             }
 
             // add our login provider to the container along with a custom options configuration


### PR DESCRIPTION
Resolves a couple of issues with external logins.

- Exception message was misleading for auth scheme validation, when missing "UmbracoMembers." prefix  it suggested to use "Umbraco." 
- SetTokenAsync implementation was missing for MemberUserStore which made login impossible for some IdPs
- Persist new tokens on update