### PR TITLE
Adding null check to IsCulturePublished on IContent

### DIFF
--- a/src/Umbraco.Core/Models/Content.cs
+++ b/src/Umbraco.Core/Models/Content.cs
@@ -237,7 +237,7 @@ namespace Umbraco.Cms.Core.Models
         public bool IsCulturePublished(string culture)
             // just check _publishInfos
             // a non-available culture could not become published anyways
-            => _publishInfos != null && _publishInfos.ContainsKey(culture);
+            => !culture.IsNullOrWhiteSpace() && _publishInfos != null && _publishInfos.ContainsKey(culture);
 
         /// <inheritdoc />
         public bool IsCultureEdited(string culture)


### PR DESCRIPTION
Currently if you pass `null` into `IsCulturePublished` it throws an `ArgumentNullException` - this is because (rightfully) the `publishedInfos` dictionary cannot contain `null` keys. Passing an empty string for the culture instead returns `false`. It seems to have been this way since V8.

Many of the other methods on `IContent` that take a culture defend against this, e.g. `GetCultureName`, so I found it weird that this method didn't. For now I have just [added a null check in my package](https://github.com/callumbwhyte/meganav/blob/v9/dev/src/Our.Umbraco.Meganav/PropertyEditors/MeganavValueEditor.cs#L81) when calling the method.

This PR adds a NullOrWhitespace check on the culture before checking the dictionary to prevent any issues.