### PR TITLE
Make GridPropertyEditor dirty if a control is removed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -667,6 +667,7 @@ angular.module("umbraco")
             $scope.removeControl = function (cell, $index) {
                 $scope.currentControl = null;
                 cell.controls.splice($index, 1);
+                currentForm.$setDirty();
             };
 
             $scope.percentage = function (spans) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12095
### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

The currentForm.$setDirty(); was missing when removing an control from a grid.

- Install Umbraco with the starterkit;
- In Umbraco Backoffice go to "About us"
- Remove the headline "Oooh la la";
- Navigate to any other page

The "You have unsaved changes" prompt should now appear;

<!-- Thanks for contributing to Umbraco CMS! -->
