### PR TITLE
Fix saving content not updating the page

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -821,8 +821,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 defaultCulture);
 
             //get the updated model
-            var display = mapToDisplay(contentItem.PersistedContent);
-            bool isBlueprint = display.IsBlueprint;
+            bool isBlueprint = contentItem.PersistedContent.Blueprint;
 
             var contentSavedHeader = isBlueprint ? "editBlueprintSavedHeader" : "editContentSavedHeader";
             var contentSavedText = isBlueprint ? "editBlueprintSavedText" : "editContentSavedText";
@@ -923,7 +922,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             }
 
             // We have to map do display after we've actually saved the content, otherwise we'll miss information that's set when saving content, such as ID
-            display = mapToDisplay(contentItem.PersistedContent);
+            var display = mapToDisplay(contentItem.PersistedContent);
 
             //merge the tracked success messages with the outgoing model
             display.Notifications.AddRange(globalNotifications.Notifications);

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -922,6 +922,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                     throw new ArgumentOutOfRangeException();
             }
 
+            // We have to map do display after we've actually saved the content, otherwise we'll miss information that's set when saving content, such as ID
+            display = mapToDisplay(contentItem.PersistedContent);
+
             //merge the tracked success messages with the outgoing model
             display.Notifications.AddRange(globalNotifications.Notifications);
             foreach (var v in display.Variants.Where(x => x.Language != null))

--- a/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/relationTypes.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/Settings/relationTypes.ts
@@ -25,6 +25,8 @@ context('Relation Types', () => {
       cy.get('select[name="relationType-parent"]').select('Document');
 
       cy.get('select[name="relationType-child"]').select('Media');
+      
+      cy.get('[name="relationType-isdependency"]').last().click({force: true})
 
       cy.get(".btn-primary").click();
     });


### PR DESCRIPTION
There's been a change to the `ContentController.PostSaveInternal` that moved where we mapped to persisted content to display up before it was actually persisted, to check if it was a blueprint. 

This broke the UI (and cypress tests) when saving a piece of content causing it to not reload the page (see gif below), this is because certain properties like the ID is only set when the content is actually persisted. 

To fix this I moved the mapping back to where it was before, and get `isBlueprint` from `contentItem.PersistedContent.Blueprint`, all mapping to `ContentItemDisplay` does in this regard is 

```c# 
target.IsBlueprint = source.Blueprint;
```

So it's not needed to map to display twice.

![save-bug](https://user-images.githubusercontent.com/16456704/157205941-5039d7ce-b185-435a-b76b-2044cfa53056.gif)

This also fixes a broken cypress tests, this was just because there is a new option when creating a relation type we didn't click

## Testing

Try and save a piece of content and ensure that the UI updates automatically

