### PR TITLE
Possible NullReferenceException in MultiUrlPickerValueConverter

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -59,6 +59,12 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                 var links = new List<Link>();
                 var dtos = _jsonSerializer.Deserialize<IEnumerable<MultiUrlPickerValueEditor.LinkDto>>(inter.ToString());
                 var publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
+
+                if (dtos == null)
+                {
+                    return maxNumber == 1 ? null : Enumerable.Empty<Link>();
+                }
+
                 foreach (var dto in dtos)
                 {
                     var type = LinkType.External;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
             {
                 var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber;
 
-                if (inter == null)
+                if (string.IsNullOrWhiteSpace(inter?.ToString()))
                 {
                     return maxNumber == 1 ? null : Enumerable.Empty<Link>();
                 }
@@ -59,12 +59,6 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                 var links = new List<Link>();
                 var dtos = _jsonSerializer.Deserialize<IEnumerable<MultiUrlPickerValueEditor.LinkDto>>(inter.ToString());
                 var publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
-
-                if (dtos == null)
-                {
-                    return maxNumber == 1 ? null : Enumerable.Empty<Link>();
-                }
-
                 foreach (var dto in dtos)
                 {
                     var type = LinkType.External;


### PR DESCRIPTION
If the value for a MultiUrlPicker is an empty string or other invalid input, and you are using the Newtonsoft.Json deserializer, it will return a null in the value converter. This is the piece of code affected from MultiUrlPickerValueConverter.cs:

```
  var links = new List<Link>();
  var dtos = _jsonSerializer.Deserialize<IEnumerable<MultiUrlPickerValueEditor.LinkDto>>(inter.ToString());
  var publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot(); 
  foreach (var dto in dtos)
```

The call to _jsonSerializer.Deserialize results in the dtos variable being null if the input was invalid, but there is no check for this, so the following exception occurs when the foreach loop is reached:

> System.NullReferenceException: Object reference not set to an instance of an object.
> at Umbraco.Cms.Core.PropertyEditors.ValueConverters.MultiUrlPickerValueConverter.ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, Object inter, Boolean preview)
> at Umbraco.Cms.Core.Models.PublishedContent.PublishedPropertyType.ConvertInterToObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, Object inter, Boolean preview)
> at Umbraco.Cms.Core.PublishedCache.PublishedElementPropertyBase.GetValue(String culture, String segment)
> at Umbraco.Extensions.PublishedPropertyExtension.Value[T](IPublishedProperty property, IPublishedValueFallback publishedValueFallback, String culture, String segment, Fallback fallback, T defaultValue)
> at Umbraco.Extensions.PublishedElementExtensions.Value[T](IPublishedElement content, IPublishedValueFallback publishedValueFallback, String alias, String culture, String segment, Fallback fallback, T defaultValue)

My fix is to check whether dtos is null before it is used, and return null or an empty enumerable, as you would if the input value had been set to null.

I believe in our case that the invalid values (empty strings) had been set by our use of uSync, however the same could happen without uSync being involved, if an existing property with an empty string value (or other invalid value) was changed to then use the MultiUrlPicker property editor.

Our specific case could also be fixed by changing the null check further up the code to use IsNullOrWhiteSpace, but this method seems better as it deals with other possible invalid values, not just the empty string.
              
This is my first PR to Umbraco, so please let me know if anything has been done incorrectly and I will sort it.
