### PR TITLE
Move created packages out of webroot

### DIFF
--- a/src/Umbraco.Core/Constants-SystemDirectories.cs
+++ b/src/Umbraco.Core/Constants-SystemDirectories.cs
@@ -45,14 +45,10 @@ namespace Umbraco.Cms.Core
 
             public const string AppPlugins = "/App_Plugins";
 
-
             [Obsolete("Use PluginIcons instead")]
             public static string AppPluginIcons => "/Backoffice/Icons";
 
             public const string PluginIcons = "/backoffice/icons";
-
-            public const string CreatedPackages = "/created-packages";
-
 
             public const string MvcViews = "~/Views";
 
@@ -61,6 +57,8 @@ namespace Umbraco.Cms.Core
             public const string MacroPartials = MvcViews + "/MacroPartials/";
 
             public const string Packages = Data + "/packages";
+
+            public const string CreatedPackages = Data + "/CreatedPackages";
 
             public const string Preview = Data + "/preview";
 

--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -33,7 +32,7 @@ namespace Umbraco.Cms.Core.Packaging
         private readonly IEntityXmlSerializer _serializer;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly string _packageRepositoryFileName;
-        private readonly string _mediaFolderPath;
+        private readonly string _createdPackagesFolderPath;
         private readonly string _packagesFolderPath;
         private readonly string _tempFolderPath;
         private readonly PackageDefinitionXmlParser _parser;
@@ -93,7 +92,7 @@ namespace Umbraco.Cms.Core.Packaging
 
             _tempFolderPath = tempFolderPath ?? Constants.SystemDirectories.TempData.EnsureEndsWith('/') + "PackageFiles";
             _packagesFolderPath = packagesFolderPath ?? Constants.SystemDirectories.Packages;
-            _mediaFolderPath = mediaFolderPath ?? Path.Combine(globalSettings.Value.UmbracoMediaPhysicalRootPath, Constants.SystemDirectories.CreatedPackages);
+            _createdPackagesFolderPath = mediaFolderPath ?? Constants.SystemDirectories.CreatedPackages;
 
             _parser = new PackageDefinitionXmlParser();
             _mediaService = mediaService;
@@ -250,15 +249,8 @@ namespace Umbraco.Cms.Core.Packaging
                     }
                 }
 
-
-
-                var directoryName =
-                    _hostingEnvironment.MapPathWebRoot(Path.Combine(_mediaFolderPath, definition.Name.Replace(' ', '_')));
-
-                if (Directory.Exists(directoryName) == false)
-                {
-                    Directory.CreateDirectory(directoryName);
-                }
+                var directoryName = _hostingEnvironment.MapPathContentRoot(Path.Combine(_createdPackagesFolderPath, definition.Name.Replace(' ', '_')));
+                Directory.CreateDirectory(directoryName);
 
                 var finalPackagePath = Path.Combine(directoryName, fileName);
 
@@ -276,14 +268,14 @@ namespace Umbraco.Cms.Core.Packaging
             }
             finally
             {
-                //Clean up
+                // Clean up
                 Directory.Delete(temporaryPath, true);
             }
         }
 
         private void ValidatePackage(PackageDefinition definition)
         {
-            //ensure it's valid
+            // ensure it's valid
             var context = new ValidationContext(definition, serviceProvider: null, items: null);
             var results = new List<ValidationResult>();
             var isValid = Validator.TryValidateObject(definition, context, results);
@@ -732,7 +724,6 @@ namespace Umbraco.Cms.Core.Packaging
         private XDocument EnsureStorage(out string packagesFile)
         {
             var packagesFolder = _hostingEnvironment.MapPathContentRoot(_packagesFolderPath);
-            //ensure it exists
             Directory.CreateDirectory(packagesFolder);
 
             packagesFile = _hostingEnvironment.MapPathContentRoot(CreatedPackagesFile);
@@ -740,6 +731,8 @@ namespace Umbraco.Cms.Core.Packaging
             {
                 var xml = new XDocument(new XElement("packages"));
                 xml.Save(packagesFile);
+
+                return xml;
             }
 
             var packagesXml = XDocument.Load(packagesFile);
@@ -749,9 +742,16 @@ namespace Umbraco.Cms.Core.Packaging
         public void DeleteLocalRepositoryFiles()
         {
             var packagesFile = _hostingEnvironment.MapPathContentRoot(CreatedPackagesFile);
-            File.Delete(packagesFile);
+            if (File.Exists(packagesFile))
+            {
+                File.Delete(packagesFile);
+            }
+
             var packagesFolder = _hostingEnvironment.MapPathContentRoot(_packagesFolderPath);
-            Directory.Delete(packagesFolder);
+            if (Directory.Exists(packagesFolder))
+            {
+                Directory.Delete(packagesFolder);
+            }
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CreatedPackageSchemaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CreatedPackageSchemaRepository.cs
@@ -39,7 +39,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         private readonly IMacroService _macroService;
         private readonly IContentTypeService _contentTypeService;
         private readonly string _tempFolderPath;
-        private readonly string _mediaFolderPath;
+        private readonly string _createdPackagesFolderPath;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CreatedPackageSchemaRepository"/> class.
@@ -76,9 +76,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             _macroService = macroService;
             _contentTypeService = contentTypeService;
             _xmlParser = new PackageDefinitionXmlParser();
-            _mediaFolderPath = mediaFolderPath ?? Path.Combine(globalSettings.Value.UmbracoMediaPhysicalRootPath,  Constants.SystemDirectories.CreatedPackages);
-            _tempFolderPath =
-                tempFolderPath ?? Constants.SystemDirectories.TempData.EnsureEndsWith('/') + "PackageFiles";
+            _createdPackagesFolderPath = mediaFolderPath ?? Constants.SystemDirectories.CreatedPackages;
+            _tempFolderPath = tempFolderPath ?? Constants.SystemDirectories.TempData + "/PackageFiles";
         }
 
         public IEnumerable<PackageDefinition> GetAll()
@@ -192,17 +191,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         public string ExportPackage(PackageDefinition definition)
         {
-
             // Ensure it's valid
             ValidatePackage(definition);
 
             // Create a folder for building this package
-            var temporaryPath =
-                _hostingEnvironment.MapPathContentRoot(_tempFolderPath.EnsureEndsWith('/') + Guid.NewGuid());
-            if (Directory.Exists(temporaryPath) == false)
-            {
-                Directory.CreateDirectory(temporaryPath);
-            }
+            var temporaryPath = _hostingEnvironment.MapPathContentRoot(Path.Combine(_tempFolderPath, Guid.NewGuid().ToString()));
+            Directory.CreateDirectory(temporaryPath);
 
             try
             {
@@ -218,8 +212,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 PackageTemplates(definition, root);
                 PackageStylesheets(definition, root);
                 PackageStaticFiles(definition.Scripts, root, "Scripts", "Script", _fileSystems.ScriptsFileSystem);
-                PackageStaticFiles(definition.PartialViews, root, "PartialViews", "View",
-                    _fileSystems.PartialViewsFileSystem);
+                PackageStaticFiles(definition.PartialViews, root, "PartialViews", "View", _fileSystems.PartialViewsFileSystem);
                 PackageMacros(definition, root);
                 PackageDictionaryItems(definition, root);
                 PackageLanguages(definition, root);
@@ -265,27 +258,25 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                     }
                 }
 
-                var directoryName =
-                    _hostingEnvironment.MapPathWebRoot(
-                        Path.Combine(_mediaFolderPath, definition.Name.Replace(' ', '_')));
-
-                if (Directory.Exists(directoryName) == false)
-                {
-                    Directory.CreateDirectory(directoryName);
-                }
+                var directoryName = _hostingEnvironment.MapPathContentRoot(Path.Combine(_createdPackagesFolderPath, definition.Name.Replace(' ', '_')));
+                Directory.CreateDirectory(directoryName);
 
                 var finalPackagePath = Path.Combine(directoryName, fileName);
 
-                if (File.Exists(finalPackagePath))
+                // Clean existing XML and ZIP files
+                foreach (var packagePath in new[]
                 {
-                    File.Delete(finalPackagePath);
+                    Path.ChangeExtension(finalPackagePath, "xml"),
+                    Path.ChangeExtension(finalPackagePath, "zip")
+                })
+                {
+                    if (File.Exists(packagePath))
+                    {
+                        File.Delete(packagePath);
+                    }
                 }
 
-                if (File.Exists(finalPackagePath.Replace("zip", "xml")))
-                {
-                    File.Delete(finalPackagePath.Replace("zip", "xml"));
-                }
-
+                // Move to final package path
                 File.Move(tempPackagePath, finalPackagePath);
 
                 definition.PackagePath = finalPackagePath;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CreatedPackageSchemaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CreatedPackageSchemaRepository.cs
@@ -263,11 +263,11 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
                 var finalPackagePath = Path.Combine(directoryName, fileName);
 
-                // Clean existing XML and ZIP files
+                // Clean existing files
                 foreach (var packagePath in new[]
                 {
-                    Path.ChangeExtension(finalPackagePath, "xml"),
-                    Path.ChangeExtension(finalPackagePath, "zip")
+                    definition.PackagePath,
+                    finalPackagePath
                 })
                 {
                     if (File.Exists(packagePath))


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/11654 already moved the `umbraco/Data/Packages/createdPackages.config` file into the database, but the new service still saved the actual `package.xml`/`package.zip` into the media folder in the webroot (`wwwroot/media/created-packages`). PR https://github.com/umbraco/Umbraco-CMS/pull/11783 unintentionally changed this to `wwwroot/created-packages` (because of the leading slash on the `Constants.SystemDirectories.CreatedPackages`, making it relative to the webroot).

By saving these files inside the webroot, they are automatically downloadable by everyone (if you can guess the package name). This has always been the case, but because the package manifest can contain sensitive data (author names, dates, unpublished content, source code of templates/views/partial views, etc.), I would argue we simply shouldn't do this.

This PR ensures the created packages are now stored in `umbraco/Data/CreatedPackages`. If you've already created packages in the backoffice, those won't be moved and can still be downloaded, because the package file path is retrieved from the package manifest: https://github.com/umbraco/Umbraco-CMS/blob/8eb3ef65f686619d09af478bd6fd563fc90580b2/src/Umbraco.Web.BackOffice/Controllers/PackageController.cs#L138

To test:
- Create a few packages before applying this PR (to test the download/save/cleanup later), preferably some with media (as that creates a ZIP instead of XML file)
- Apply this PR and create additional packages
- Ensure the existing and newly created packages can all be downloaded
- Ensure re-saving an existing package will write the file to the new location (and clean up the file in the previous path) and can still be downloaded
- Ensure that when you add/remove media from a package, either the `package.xml` or `package.zip` is created and the previous file is cleaned up