### PR TITLE
Add allowedChildren call to Outgoing Editor events

### DIFF
--- a/src/Umbraco.Core/Notifications/SendingAllowedChildrenNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendingAllowedChildrenNotification.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Core.Notifications
+{
+    public class SendingAllowedChildrenNotification : INotification
+    {
+        public IUmbracoContext UmbracoContext { get; }
+
+        public IEnumerable<ContentTypeBasic> Children { get; set; }
+
+        public SendingAllowedChildrenNotification(IEnumerable<ContentTypeBasic> children, IUmbracoContext umbracoContext)
+        {
+            UmbracoContext = umbracoContext;
+            Children = children;
+        }
+    }
+}

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -22,6 +22,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Packaging;
+using Umbraco.Cms.Web.BackOffice.Filters;
 using Umbraco.Cms.Web.Common.ActionsResults;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -452,6 +453,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// </summary>
         /// <param name="contentId"></param>
         [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
+        [OutgoingEditorModelEvent]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
         {
             if (contentId == Constants.System.RecycleBinContent)

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Web.BackOffice.Filters;
 using Umbraco.Cms.Web.Common.ActionsResults;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -339,6 +340,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// </summary>
         /// <param name="contentId"></param>
         [Authorize(Policy = AuthorizationPolicies.TreeAccessMediaOrMediaTypes)]
+        [OutgoingEditorModelEvent]
         public IEnumerable<ContentTypeBasic> GetAllowedChildren(int contentId)
         {
             if (contentId == Constants.System.RecycleBinContent)

--- a/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
@@ -84,6 +84,12 @@ namespace Umbraco.Cms.Web.BackOffice.Filters
                             case IEnumerable<Tab<IDashboardSlim>> dashboards:
                                 _eventAggregator.Publish(new SendingDashboardsNotification(dashboards, umbracoContext));
                                 break;
+                            case IEnumerable<ContentTypeBasic> allowedChildren:
+                                // Changing the Enumerable will generate a new instance, so we need to update the context result with the new content
+                                var notification = new SendingAllowedChildrenNotification(allowedChildren, umbracoContext);
+                                _eventAggregator.Publish(notification);
+                                context.Result = new ObjectResult(notification.Children);
+                                break;
                         }
                     }
                 }


### PR DESCRIPTION
This is a ported version of this v8 PR: https://github.com/umbraco/Umbraco-CMS/pull/9906
Most of the description of that PR still applies to this one. Although, the code example is a bit different now.

https://user-images.githubusercontent.com/11466511/109339815-77656e00-7868-11eb-8aef-3a93076da116.gif
Can be done with the following handler:
```
public class TestCode : INotificationHandler<SendingAllowedChildrenNotification>
    {
        public void Handle(SendingAllowedChildrenNotification notification)
        {
            var children = notification.Children.ToArray();
            if (children.All(it => it.Alias != "settings"))
                return;

            var currentSettings = notification.UmbracoContext.Content.GetSingleByXPath("//settings");
            if (currentSettings is null)
                return;

            notification.Children = children.Where(it => it.Alias != "settings");
        }
    }
```

I think this feature is a long requested feature and would also allow package developers to create UI's based on this.