### PR TITLE
v9: Fix image thumbnails not showing if filename contains non ascii characters

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ImagesController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ImagesController.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Web;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Extensions;
 using Constants = Umbraco.Cms.Core.Constants;
@@ -53,20 +55,25 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// </remarks>
         public IActionResult GetResized(string imagePath, int width)
         {
-            var ext = Path.GetExtension(imagePath);
-            
+            // We have to use HttpUtility to encode the path here, for non-ASCII characters
+            // We cannot use the WebUtility, as we only want to encode the path, and not the entire string
+            var encodedImagePath = HttpUtility.UrlPathEncode(imagePath);
+
+
+            var ext = Path.GetExtension(encodedImagePath);
+
             // check if imagePath is local to prevent open redirect
-            if (!Uri.IsWellFormedUriString(imagePath, UriKind.Relative))
+            if (!Uri.IsWellFormedUriString(encodedImagePath, UriKind.Relative))
             {
                 return Unauthorized();
             }
-            
+
             // we need to check if it is an image by extension
             if (_imageUrlGenerator.IsSupportedImageFormat(ext) == false)
             {
                 return NotFound();
             }
-            
+
             // redirect to ImageProcessor thumbnail with rnd generated from last modified time of original media file
             DateTimeOffset? imageLastModified = null;
             try
@@ -82,7 +89,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             }
 
             var rnd = imageLastModified.HasValue ? $"&rnd={imageLastModified:yyyyMMddHHmmss}" : null;
-            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions(imagePath)
+            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions(encodedImagePath)
             {
                 Width = width,
                 ImageCropMode = ImageCropMode.Max,


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12105
# Notes
Seems that when we call the GetResized function the url is not encoded (as expected) but we never encode it ourselfs and therefore it will fail if url contains non-ascii characters.
- Added url encoding to GetResized()

# How to test
- Go to the media section and add some images with non-ascii characters in the filename like "ččřiřiřiřičr" (please do test other characters aswell)
- Create a document type with a Image media picker
- Create some content and when using the media picker you should now see a thumbnail for the image, even if the filename contains non ascii characters