### PR TITLE
[8.18] Fixed issue with DataValueEditor.TryConvertValueToCrlType method incorrectly enclosing string values in double quotes

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -145,16 +145,25 @@ namespace Umbraco.Core.PropertyEditors
         /// <returns></returns>
         internal Attempt<object> TryConvertValueToCrlType(object value)
         {
-            if (value is JToken jsonValue)
+            if (value is JValue jsonValue)
             {
-                if (jsonValue is JContainer && jsonValue.HasValues == false)
+                // Calling the "ToString(Formatting)" method on a string value results in a new
+                // string enclosed in double quotes (which we don't want), as the method is declared
+                // in the JToken class. Calling either of the "ToString()" or "ToString(CultureInfo)"
+                // methods hits the overridden methods in the JValue class, which correctly doesn't
+                // enclose the value in double quotes.
+                value = jsonValue.ToString(CultureInfo.InvariantCulture);
+            }
+            else if (value is JToken jsonToken)
+            {
+                if (jsonToken is JContainer && jsonToken.HasValues == false)
                 {
                     // Empty JSON array/object
                     value = null;
                 }
                 else
                 {
-                    value = jsonValue.ToString(Formatting.None);
+                    value = jsonToken.ToString(Formatting.None);
                 }
             }
 


### PR DESCRIPTION
The 8.18.0 release changed some of the internal logic for the `DataValueEditor.TryConvertValueToCrlType` method:

![image](https://user-images.githubusercontent.com/3634580/158557282-4f48747e-4eaf-40bf-8e56-f6e55e133801.png)

8.17 and earlier checks whether `value` is an instance of `JValue`, and if so, calls the parameterless `ToString` method. This hits the [overriden method of the `JValue` class](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Linq/JValue.cs#L898) ensuring the value is correctly formatted.

The implementation in 8.18 has been updated to check against `JToken` instead, and then call the `ToString(Formatting)` method instead. This method is [declared in the `JToken` class](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Linq/JToken.cs#L442), but not overriden in the `JValue` class (which extends `JToken`).

The result is then that string values in 8.18 are now enclosed in double quotes, which wasn't the case before. This doesn't seem to affect the block list, but it does cause issues for my [Skybrud.Umbraco.Elements package](https://github.com/skybrud/Skybrud.Umbraco.Elements/blob/master/src/Skybrud.Umbraco.Elements/PublishedElementHelper.cs#L140) - and quite possible [the DTGE package](https://github.com/skttl/umbraco-doc-type-grid-editor/blob/develop/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs#L68), as I borrowed parts of my code from there.

Both packages allow representing `IPublishedElement` instances saved as JSON blobs, so for instance a property with the legacy media picker, where the value is saved as a UDI string, would result in the following error:

```
String ""umb://media/cd35513c27e54c388f8613dd56187135"" is not a valid udi.
```

The proposed fix adds a check to see whether `value` is an instance of `JValue`, and if so, calls the correct `ToString` method. While 8.17 and prior calls the parameterless overload, I went for the overload taking a `CultureInfo` instance making it culture invariant. I believe this is more correct, but then differs from the implementation prior to 8.18.

I've created this small snippet to illustrate the issue:

```cshtml
@using System.Globalization
@using System.Threading
@using Newtonsoft.Json
@using Newtonsoft.Json.Linq
@{

    JObject obj = new JObject {
        { "hello", "world" }
    };

    JProperty property = obj.Property("hello");

    JToken value = property.Value;

    <pre>@property.Value.GetType()</pre>

    <hr />
    
    string newValue1 = null;

    if (value is JValue jsonValue1)
    {
        newValue1 = jsonValue1.ToString(Formatting.None); // Method belongs to JToken --> wrong result
        newValue1 = jsonValue1.ToString(CultureInfo.InvariantCulture); // Method belongs to JValue --> correct result
    }
    else if (value is JToken jsonValue)
    {
        if (jsonValue is JContainer && jsonValue.HasValues == false)
        {
            // Empty JSON array/object
            newValue1 = null;
        }
        else
        {
            newValue1 = jsonValue.ToString(Formatting.None);
        }
    }
        
    <pre>@newValue1</pre>

    <hr />

    string newValue2 = null;

    if (value is JValue) {
        newValue2 = value.ToString();
    }
        
    <pre>@newValue2</pre>

}
```
`newValue1` is determined using my proposed fix, ensuring that `world` isn't enclosed in double quotes. Commenting out line 24 makes the example use similar logic to that of 8.18, resulting in `"world"` instead of the expected `world`.

`newValue2` is determined using logic similar to the implementation in 8.17, so it results in `world` as expected.