### PR TITLE
Fix media tracking of items added via macro parameters in RTE and Grid 

### DIFF
--- a/src/Umbraco.Core/Cache/MacroCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/MacroCacheRefresher.cs
@@ -46,6 +46,11 @@ namespace Umbraco.Cms.Core.Cache
         {
             var payloads = Deserialize(json);
 
+            Refresh(payloads);
+        }
+
+        public override void Refresh(JsonPayload[] payloads)
+        {
             foreach (var payload in payloads)
             {
                 foreach (var alias in GetCacheKeysForAlias(payload.Alias))
@@ -59,8 +64,9 @@ namespace Umbraco.Cms.Core.Cache
                 }
             }
 
-            base.Refresh(json);
+            base.Refresh(payloads);
         }
+
         #endregion
 
         #region Json

--- a/src/Umbraco.Core/Cache/MacroCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/MacroCacheRefresher.cs
@@ -55,6 +55,7 @@ namespace Umbraco.Cms.Core.Cache
                 if (macroRepoCache)
                 {
                     macroRepoCache.Result.Clear(RepositoryCacheKeys.GetKey<IMacro, int>(payload.Id));
+                    macroRepoCache.Result.Clear(RepositoryCacheKeys.GetKey<IMacro, string>(payload.Alias)); // Repository caching of macro definition by alias
                 }
             }
 

--- a/src/Umbraco.Core/Persistence/Repositories/IMacroWithAliasRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMacroWithAliasRepository.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Cms.Core.Persistence.Repositories
     public interface IMacroWithAliasRepository : IMacroRepository
     {
         IMacro GetByAlias(string alias);
+
         IEnumerable<IMacro> GetAllByAlias(string[] aliases);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IMacroWithAliasRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMacroWithAliasRepository.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Persistence.Repositories
+{
+    [Obsolete("This interface will be merged with IMacroRepository in Umbraco 11")]
+    public interface IMacroWithAliasRepository : IMacroRepository
+    {
+        IMacro GetByAlias(string alias);
+        IEnumerable<IMacro> GetAllByAlias(string[] aliases);
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultipleContentPickerParameterEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultipleContentPickerParameterEditor.cs
@@ -1,5 +1,10 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -27,6 +32,56 @@ namespace Umbraco.Cms.Core.PropertyEditors.ParameterEditors
             DefaultConfiguration.Add("multiPicker", "1");
             DefaultConfiguration.Add("minNumber",0 );
             DefaultConfiguration.Add("maxNumber", 0);
+        }
+
+        protected override IDataValueEditor CreateValueEditor() => DataValueEditorFactory.Create<MultipleContentPickerParameterEditor.MultipleContentPickerParamateterValueEditor>(Attribute);
+
+        internal class MultipleContentPickerParamateterValueEditor : DataValueEditor, IDataValueReference
+        {
+            private readonly IEntityService _entityService;
+
+            public MultipleContentPickerParamateterValueEditor(
+                ILocalizedTextService localizedTextService,
+                IShortStringHelper shortStringHelper,
+                IJsonSerializer jsonSerializer,
+                IIOHelper ioHelper,
+                DataEditorAttribute attribute,
+                IEntityService entityService)
+                : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
+            {
+                _entityService = entityService;
+            }
+
+            public IEnumerable<UmbracoEntityReference> GetReferences(object value)
+            {
+                var asString = value is string str ? str : value?.ToString();
+
+                if (string.IsNullOrEmpty(asString))
+                {
+                    yield break;
+                }
+
+                foreach (var udiStr in asString.Split(','))
+                {
+                    if (UdiParser.TryParse(udiStr, out Udi udi))
+                    {
+                        yield return new UmbracoEntityReference(udi);
+                    }
+
+                    // this is needed to support the legacy case when the multiple media picker parameter editor stores ints not udis
+                    if (int.TryParse(udiStr, out var id))
+                    {
+                        Attempt<Guid> guidAttempt = _entityService.GetKey(id, UmbracoObjectTypes.Document);
+                        Guid guid = guidAttempt.Success ? guidAttempt.Result : Guid.Empty;
+
+                        if (guid != Guid.Empty)
+                        {
+                            yield return new UmbracoEntityReference(new GuidUdi(Constants.UdiEntityType.Media, guid));
+                        }
+
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultipleContentPickerParameterEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultipleContentPickerParameterEditor.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Hosting;
-using Umbraco.Cms.Core.IO;
+﻿using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -36,52 +31,14 @@ namespace Umbraco.Cms.Core.PropertyEditors.ParameterEditors
 
         protected override IDataValueEditor CreateValueEditor() => DataValueEditorFactory.Create<MultipleContentPickerParameterEditor.MultipleContentPickerParamateterValueEditor>(Attribute);
 
-        internal class MultipleContentPickerParamateterValueEditor : DataValueEditor, IDataValueReference
+        internal class MultipleContentPickerParamateterValueEditor : MultiplePickerParamateterValueEditorBase
         {
-            private readonly IEntityService _entityService;
-
-            public MultipleContentPickerParamateterValueEditor(
-                ILocalizedTextService localizedTextService,
-                IShortStringHelper shortStringHelper,
-                IJsonSerializer jsonSerializer,
-                IIOHelper ioHelper,
-                DataEditorAttribute attribute,
-                IEntityService entityService)
-                : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
+            public MultipleContentPickerParamateterValueEditor(ILocalizedTextService localizedTextService, IShortStringHelper shortStringHelper, IJsonSerializer jsonSerializer, IIOHelper ioHelper, DataEditorAttribute attribute, IEntityService entityService) : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute, entityService)
             {
-                _entityService = entityService;
             }
 
-            public IEnumerable<UmbracoEntityReference> GetReferences(object value)
-            {
-                var asString = value is string str ? str : value?.ToString();
-
-                if (string.IsNullOrEmpty(asString))
-                {
-                    yield break;
-                }
-
-                foreach (var udiStr in asString.Split(','))
-                {
-                    if (UdiParser.TryParse(udiStr, out Udi udi))
-                    {
-                        yield return new UmbracoEntityReference(udi);
-                    }
-
-                    // this is needed to support the legacy case when the multiple media picker parameter editor stores ints not udis
-                    if (int.TryParse(udiStr, out var id))
-                    {
-                        Attempt<Guid> guidAttempt = _entityService.GetKey(id, UmbracoObjectTypes.Document);
-                        Guid guid = guidAttempt.Success ? guidAttempt.Result : Guid.Empty;
-
-                        if (guid != Guid.Empty)
-                        {
-                            yield return new UmbracoEntityReference(new GuidUdi(Constants.UdiEntityType.Media, guid));
-                        }
-
-                    }
-                }
-            }
+            public override string UdiEntityType { get; } = Constants.UdiEntityType.Document;
+            public override UmbracoObjectTypes UmbracoObjectType { get; } = UmbracoObjectTypes.Document;
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultipleMediaPickerParameterEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultipleMediaPickerParameterEditor.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Hosting;
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -25,6 +28,56 @@ namespace Umbraco.Cms.Core.PropertyEditors.ParameterEditors
             : base(dataValueEditorFactory)
         {
             DefaultConfiguration.Add("multiPicker", "1");
+        }
+
+        protected override IDataValueEditor CreateValueEditor() => DataValueEditorFactory.Create<MultipleMediaPickerPropertyValueEditor>(Attribute);
+
+        internal class MultipleMediaPickerPropertyValueEditor : DataValueEditor, IDataValueReference
+        {
+            private readonly IEntityService _entityService;
+
+            public MultipleMediaPickerPropertyValueEditor(
+                ILocalizedTextService localizedTextService,
+                IShortStringHelper shortStringHelper,
+                IJsonSerializer jsonSerializer,
+                IIOHelper ioHelper,
+                DataEditorAttribute attribute,
+                IEntityService entityService)
+                : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
+            {
+                _entityService = entityService;
+            }
+
+            public IEnumerable<UmbracoEntityReference> GetReferences(object value)
+            {
+                var asString = value is string str ? str : value?.ToString();
+
+                if (string.IsNullOrEmpty(asString))
+                {
+                    yield break;
+                }
+
+                foreach (var udiStr in asString.Split(','))
+                {
+                    if (UdiParser.TryParse(udiStr, out Udi udi))
+                    {
+                        yield return new UmbracoEntityReference(udi);
+                    }
+
+                    // this is needed to support the legacy case when the multiple media picker parameter editor stores ints not udis
+                    if (int.TryParse(udiStr, out var id))
+                    {
+                        Attempt<Guid> guidAttempt = _entityService.GetKey(id, UmbracoObjectTypes.Media);
+                        Guid guid = guidAttempt.Success ? guidAttempt.Result : Guid.Empty;
+
+                        if (guid != Guid.Empty)
+                        {
+                            yield return new UmbracoEntityReference(new GuidUdi(Constants.UdiEntityType.Media, guid));
+                        }
+
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultiplePickerParamateterValueEditorBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/ParameterEditors/MultiplePickerParamateterValueEditorBase.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ParameterEditors
+{
+    internal abstract class MultiplePickerParamateterValueEditorBase : DataValueEditor, IDataValueReference
+    {
+        private readonly IEntityService _entityService;
+
+        public MultiplePickerParamateterValueEditorBase(
+            ILocalizedTextService localizedTextService,
+            IShortStringHelper shortStringHelper,
+            IJsonSerializer jsonSerializer,
+            IIOHelper ioHelper,
+            DataEditorAttribute attribute,
+            IEntityService entityService)
+            : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
+        {
+            _entityService = entityService;
+        }
+
+        public abstract  string UdiEntityType { get; }
+        public abstract UmbracoObjectTypes UmbracoObjectType { get; }
+        public IEnumerable<UmbracoEntityReference> GetReferences(object value)
+        {
+            var asString = value is string str ? str : value?.ToString();
+
+            if (string.IsNullOrEmpty(asString))
+            {
+                yield break;
+            }
+
+            foreach (var udiStr in asString.Split(','))
+            {
+                if (UdiParser.TryParse(udiStr, out Udi udi))
+                {
+                    yield return new UmbracoEntityReference(udi);
+                }
+
+                // this is needed to support the legacy case when the multiple media picker parameter editor stores ints not udis
+                if (int.TryParse(udiStr, out var id))
+                {
+                    Attempt<Guid> guidAttempt = _entityService.GetKey(id, UmbracoObjectType);
+                    Guid guid = guidAttempt.Success ? guidAttempt.Result : Guid.Empty;
+
+                    if (guid != Guid.Empty)
+                    {
+                        yield return new UmbracoEntityReference(new GuidUdi(Constants.UdiEntityType.Media, guid));
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Core/Services/IMacroService.cs
+++ b/src/Umbraco.Core/Services/IMacroService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Models;
 
@@ -16,13 +16,6 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="alias">Alias to retrieve an <see cref="IMacro"/> for</param>
         /// <returns>An <see cref="IMacro"/> object</returns>
         IMacro GetByAlias(string alias);
-
-        ///// <summary>
-        ///// Gets a list all available <see cref="IMacro"/> objects
-        ///// </summary>
-        ///// <param name="aliases">Optional array of aliases to limit the results</param>
-        ///// <returns>An enumerable list of <see cref="IMacro"/> objects</returns>
-        //IEnumerable<IMacro> GetAll(params string[] aliases);
 
         IEnumerable<IMacro> GetAll();
 

--- a/src/Umbraco.Core/Services/IMacroWithAliasService.cs
+++ b/src/Umbraco.Core/Services/IMacroWithAliasService.cs
@@ -10,8 +10,8 @@ namespace Umbraco.Cms.Core.Services
         /// <summary>
         /// Gets a list of available <see cref="IMacro"/> objects by alias.
         /// </summary>
-        /// <param name="aliases"></param>
-        /// <returns></returns>
+        /// <param name="aliases">Optional array of aliases to limit the results</param>
+        /// <returns>An enumerable list of <see cref="IMacro"/> objects</returns>
         IEnumerable<IMacro> GetAll(params string[] aliases);
     }
 }

--- a/src/Umbraco.Core/Services/IMacroWithAliasService.cs
+++ b/src/Umbraco.Core/Services/IMacroWithAliasService.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services
+{
+    [Obsolete("This interface will be merged with IMacroService in Umbraco 11")]
+    public interface IMacroWithAliasService : IMacroService
+    {
+        /// <summary>
+        /// Gets a list of available <see cref="IMacro"/> objects by alias.
+        /// </summary>
+        /// <param name="aliases"></param>
+        /// <returns></returns>
+        IEnumerable<IMacro> GetAll(params string[] aliases);
+    }
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Persistence.Repositories;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Extensions;
 
@@ -36,9 +35,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IExternalLoginRepository>(factory => factory.GetRequiredService<ExternalLoginRepository>());
             builder.Services.AddUnique<IExternalLoginWithKeyRepository>(factory => factory.GetRequiredService<ExternalLoginRepository>());
             builder.Services.AddUnique<ILanguageRepository, LanguageRepository>();
-            builder.Services.AddUnique<MacroRepository>();
-            builder.Services.AddUnique<IMacroRepository>(factory => factory.GetRequiredService<MacroRepository>());
-            builder.Services.AddUnique<IMacroWithAliasRepository>(factory => factory.GetRequiredService<MacroRepository>());
+            builder.Services.AddUnique<IMacroRepository, MacroRepository>();
             builder.Services.AddUnique<IMediaRepository, MediaRepository>();
             builder.Services.AddUnique<IMediaTypeContainerRepository, MediaTypeContainerRepository>();
             builder.Services.AddUnique<IMediaTypeRepository, MediaTypeRepository>();

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
@@ -36,7 +36,9 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IExternalLoginRepository>(factory => factory.GetRequiredService<ExternalLoginRepository>());
             builder.Services.AddUnique<IExternalLoginWithKeyRepository>(factory => factory.GetRequiredService<ExternalLoginRepository>());
             builder.Services.AddUnique<ILanguageRepository, LanguageRepository>();
-            builder.Services.AddUnique<IMacroRepository, MacroRepository>();
+            builder.Services.AddUnique<MacroRepository>();
+            builder.Services.AddUnique<IMacroRepository>(factory => factory.GetRequiredService<MacroRepository>());
+            builder.Services.AddUnique<IMacroWithAliasRepository>(factory => factory.GetRequiredService<MacroRepository>());
             builder.Services.AddUnique<IMediaRepository, MediaRepository>();
             builder.Services.AddUnique<IMediaTypeContainerRepository, MediaTypeContainerRepository>();
             builder.Services.AddUnique<IMediaTypeRepository, MediaTypeRepository>();

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -64,16 +64,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IEntityService, EntityService>();
             builder.Services.AddUnique<IRelationService, RelationService>();
             builder.Services.AddUnique<ITrackedReferencesService, TrackedReferencesService>();
-            builder.Services.AddUnique<MacroService>(factory => new MacroService(
-                factory.GetRequiredService<IScopeProvider>(),
-                factory.GetRequiredService<ILoggerFactory>(),
-                factory.GetRequiredService<IEventMessagesFactory>(),
-                factory.GetRequiredService<IMacroWithAliasRepository>(),
-                factory.GetRequiredService<IAuditRepository>()
-                ));
-            builder.Services.AddUnique<IMacroService>(factory => factory.GetRequiredService<MacroService>());
-            builder.Services.AddUnique<IMacroWithAliasService>(factory => factory.GetRequiredService<MacroService>());
-
+            builder.Services.AddUnique<IMacroService, MacroService>();
             builder.Services.AddUnique<IMemberTypeService, MemberTypeService>();
             builder.Services.AddUnique<IMemberGroupService, MemberGroupService>();
             builder.Services.AddUnique<INotificationService, NotificationService>();

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -18,9 +18,9 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Implement;
 using Umbraco.Cms.Infrastructure.Packaging;
-using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Services.Implement;
+using Umbraco.Cms.Infrastructure.Templates;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.DependencyInjection
@@ -64,7 +64,16 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IEntityService, EntityService>();
             builder.Services.AddUnique<IRelationService, RelationService>();
             builder.Services.AddUnique<ITrackedReferencesService, TrackedReferencesService>();
-            builder.Services.AddUnique<IMacroService, MacroService>();
+            builder.Services.AddUnique<MacroService>(factory => new MacroService(
+                factory.GetRequiredService<IScopeProvider>(),
+                factory.GetRequiredService<ILoggerFactory>(),
+                factory.GetRequiredService<IEventMessagesFactory>(),
+                factory.GetRequiredService<IMacroWithAliasRepository>(),
+                factory.GetRequiredService<IAuditRepository>()
+                ));
+            builder.Services.AddUnique<IMacroService>(factory => factory.GetRequiredService<MacroService>());
+            builder.Services.AddUnique<IMacroWithAliasService>(factory => factory.GetRequiredService<MacroService>());
+
             builder.Services.AddUnique<IMemberTypeService, MemberTypeService>();
             builder.Services.AddUnique<IMemberGroupService, MemberGroupService>();
             builder.Services.AddUnique<INotificationService, NotificationService>();
@@ -92,6 +101,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<ICreatedPackagesRepository, CreatedPackageSchemaRepository>();
             builder.Services.AddSingleton<PackageDataInstallation>();
             builder.Services.AddUnique<IPackageInstallation, PackageInstallation>();
+            builder.Services.AddUnique<IHtmlMacroParameterParser, HtmlMacroParameterParser>();
 
             return builder;
         }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MacroRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MacroRepository.cs
@@ -77,7 +77,10 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         public IEnumerable<IMacro> GetAllByAlias(string[] aliases)
         {
-            if (aliases.Any() == false) return base.GetMany();
+            if (aliases.Any() == false)
+            {
+                return base.GetMany();
+            }
 
             return _macroByAliasCachePolicy.GetAll(aliases, PerformGetAllByAlias);
         }
@@ -90,9 +93,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         private IEnumerable<IMacro> PerformGetAllByAlias(params string[] aliases)
         {
-            if (aliases.Any() == false) return base.GetMany();
+            if (aliases.Any() == false)
+            {
+                return base.GetMany();
+            }
 
-            var query = Query<IMacro>().WhereIn(x => x.Alias, aliases);
+            var query = Query<IMacro>().Where(x => aliases.Contains(x.Alias));
             return PerformGetByQuery(query);
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MacroRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MacroRepository.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         public IEnumerable<IMacro> GetAllByAlias(string[] aliases)
         {
-            if (aliases.Any() == false)
+            if (aliases.Any() is false)
             {
                 return base.GetMany();
             }
@@ -93,7 +93,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         private IEnumerable<IMacro> PerformGetAllByAlias(params string[] aliases)
         {
-            if (aliases.Any() == false)
+            if (aliases.Any() is false)
             {
                 return base.GetMany();
             }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MacroRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MacroRepository.cs
@@ -18,14 +18,16 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 {
-    internal class MacroRepository : EntityRepositoryBase<int, IMacro>, IMacroRepository
+    internal class MacroRepository : EntityRepositoryBase<int, IMacro>, IMacroWithAliasRepository
     {
         private readonly IShortStringHelper _shortStringHelper;
+        private readonly IRepositoryCachePolicy<IMacro, string> _macroByAliasCachePolicy;
 
         public MacroRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<MacroRepository> logger, IShortStringHelper shortStringHelper)
             : base(scopeAccessor, cache, logger)
         {
             _shortStringHelper = shortStringHelper;
+            _macroByAliasCachePolicy = new DefaultRepositoryCachePolicy<IMacro, string>(GlobalIsolatedCache, ScopeAccessor, DefaultOptions);
         }
 
         protected override IMacro PerformGet(int id)
@@ -66,6 +68,32 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         public bool Exists(Guid id)
         {
             return Get(id) != null;
+        }
+
+        public IMacro GetByAlias(string alias)
+        {
+            return _macroByAliasCachePolicy.Get(alias, PerformGetByAlias, PerformGetAllByAlias);
+        }
+
+        public IEnumerable<IMacro> GetAllByAlias(string[] aliases)
+        {
+            if (aliases.Any() == false) return base.GetMany();
+
+            return _macroByAliasCachePolicy.GetAll(aliases, PerformGetAllByAlias);
+        }
+
+        private IMacro PerformGetByAlias(string alias)
+        {
+            var query = Query<IMacro>().Where(x => x.Alias.Equals(alias));
+            return PerformGetByQuery(query).FirstOrDefault();
+        }
+
+        private IEnumerable<IMacro> PerformGetAllByAlias(params string[] aliases)
+        {
+            if (aliases.Any() == false) return base.GetMany();
+
+            var query = Query<IMacro>().WhereIn(x => x.Alias, aliases);
+            return PerformGetByQuery(query);
         }
 
         protected override IEnumerable<IMacro> PerformGetAll(params int[] ids)

--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
@@ -14,6 +15,8 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Templates;
+using Umbraco.Cms.Infrastructure.Templates;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors
@@ -37,6 +40,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         private readonly RichTextEditorPastedImages _pastedImages;
         private readonly HtmlLocalLinkParser _localLinkParser;
         private readonly IImageUrlGenerator _imageUrlGenerator;
+        private readonly IHtmlMacroParameterParser _macroParameterParser;
 
         public GridPropertyEditor(
             IDataValueEditorFactory dataValueEditorFactory,
@@ -45,7 +49,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
             RichTextEditorPastedImages pastedImages,
             HtmlLocalLinkParser localLinkParser,
             IIOHelper ioHelper,
-            IImageUrlGenerator imageUrlGenerator)
+            IImageUrlGenerator imageUrlGenerator,
+            IHtmlMacroParameterParser macroParameterParser)
             : base(dataValueEditorFactory)
         {
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -54,6 +59,20 @@ namespace Umbraco.Cms.Core.PropertyEditors
             _pastedImages = pastedImages;
             _localLinkParser = localLinkParser;
             _imageUrlGenerator = imageUrlGenerator;
+            _macroParameterParser = macroParameterParser;
+        }
+
+        [Obsolete("Use the constructor which takes an IHtmlMacroParameterParser instead")]
+        public GridPropertyEditor(
+            IDataValueEditorFactory dataValueEditorFactory,
+            IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+            HtmlImageSourceParser imageSourceParser,
+            RichTextEditorPastedImages pastedImages,
+            HtmlLocalLinkParser localLinkParser,
+            IIOHelper ioHelper,
+            IImageUrlGenerator imageUrlGenerator)
+            : this (dataValueEditorFactory, backOfficeSecurityAccessor, imageSourceParser, pastedImages, localLinkParser, ioHelper, imageUrlGenerator, StaticServiceProvider.Instance.GetRequiredService<IHtmlMacroParameterParser>())
+        {
         }
 
         public override IPropertyIndexValueFactory PropertyIndexValueFactory => new GridPropertyIndexValueFactory();
@@ -74,6 +93,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             private readonly RichTextPropertyEditor.RichTextPropertyValueEditor _richTextPropertyValueEditor;
             private readonly MediaPickerPropertyEditor.MediaPickerPropertyValueEditor _mediaPickerPropertyValueEditor;
             private readonly IImageUrlGenerator _imageUrlGenerator;
+            private readonly IHtmlMacroParameterParser _macroParameterParser;
 
             public GridPropertyValueEditor(
                 IDataValueEditorFactory dataValueEditorFactory,
@@ -85,7 +105,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 IShortStringHelper shortStringHelper,
                 IImageUrlGenerator imageUrlGenerator,
                 IJsonSerializer jsonSerializer,
-                IIOHelper ioHelper)
+                IIOHelper ioHelper,
+                IHtmlMacroParameterParser macroParameterParser)
                 : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
             {
                 _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -96,6 +117,25 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 _mediaPickerPropertyValueEditor =
                     dataValueEditorFactory.Create<MediaPickerPropertyEditor.MediaPickerPropertyValueEditor>(attribute);
                 _imageUrlGenerator = imageUrlGenerator;
+                _macroParameterParser = macroParameterParser;
+            }
+
+            [Obsolete("Use the constructor which takes an IHtmlMacroParameterParser instead")]
+            public GridPropertyValueEditor(
+                IDataValueEditorFactory dataValueEditorFactory,
+                DataEditorAttribute attribute,
+                IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+                ILocalizedTextService localizedTextService,
+                HtmlImageSourceParser imageSourceParser,
+                RichTextEditorPastedImages pastedImages,
+                IShortStringHelper shortStringHelper,
+                IImageUrlGenerator imageUrlGenerator,
+                IJsonSerializer jsonSerializer,
+                IIOHelper ioHelper)
+                : this (dataValueEditorFactory, attribute, backOfficeSecurityAccessor, localizedTextService,
+                        imageSourceParser, pastedImages, shortStringHelper, imageUrlGenerator, jsonSerializer, ioHelper,
+                        StaticServiceProvider.Instance.GetRequiredService<IHtmlMacroParameterParser>())
+            {
             }
 
             /// <summary>
@@ -120,7 +160,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 var mediaParent = config?.MediaParentId;
                 var mediaParentId = mediaParent == null ? Guid.Empty : mediaParent.Guid;
 
-                var grid = DeserializeGridValue(rawJson, out var rtes, out _);
+                var grid = DeserializeGridValue(rawJson, out var rtes, out _, out _);
 
                 var userId = _backOfficeSecurityAccessor?.BackOfficeSecurity?.CurrentUser?.Id ?? Constants.Security.SuperUserId;
 
@@ -154,7 +194,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 if (val.IsNullOrWhiteSpace())
                     return string.Empty;
 
-                var grid = DeserializeGridValue(val, out var rtes, out _);
+                var grid = DeserializeGridValue(val, out var rtes, out _, out _);
 
                 //process the rte values
                 foreach (var rte in rtes.ToList())
@@ -168,7 +208,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 return grid;
             }
 
-            private GridValue DeserializeGridValue(string rawJson, out IEnumerable<GridValue.GridControl> richTextValues, out IEnumerable<GridValue.GridControl> mediaValues)
+            private GridValue DeserializeGridValue(string rawJson, out IEnumerable<GridValue.GridControl> richTextValues, out IEnumerable<GridValue.GridControl> mediaValues, out IEnumerable<GridValue.GridControl> macroValues)
             {
                 var grid = JsonConvert.DeserializeObject<GridValue>(rawJson);
 
@@ -176,6 +216,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 var controls = grid.Sections.SelectMany(x => x.Rows.SelectMany(r => r.Areas).SelectMany(a => a.Controls)).ToArray();
                 richTextValues = controls.Where(x => x.Editor.Alias.ToLowerInvariant() == "rte");
                 mediaValues = controls.Where(x => x.Editor.Alias.ToLowerInvariant() == "media");
+
+                // Find all the macros
+                macroValues = controls.Where(x => x.Editor.Alias.ToLowerInvariant() == "macro");
 
                 return grid;
             }
@@ -192,7 +235,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 if (rawJson.IsNullOrWhiteSpace())
                     yield break;
 
-                DeserializeGridValue(rawJson, out var richTextEditorValues, out var mediaValues);
+                DeserializeGridValue(rawJson, out var richTextEditorValues, out var mediaValues, out var macroValues);
 
                 foreach (var umbracoEntityReference in richTextEditorValues.SelectMany(x =>
                     _richTextPropertyValueEditor.GetReferences(x.Value)))
@@ -200,6 +243,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
                 foreach (var umbracoEntityReference in mediaValues.Where(x => x.Value.HasValues)
                     .SelectMany(x => _mediaPickerPropertyValueEditor.GetReferences(x.Value["udi"])))
+                    yield return umbracoEntityReference;
+
+                foreach (var umbracoEntityReference in _macroParameterParser.FindUmbracoEntityReferencesFromGridControlMacros(macroValues))
                     yield return umbracoEntityReference;
             }
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
@@ -16,6 +15,8 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Templates;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Macros;
+using Umbraco.Cms.Infrastructure.Templates;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors
@@ -36,12 +37,13 @@ namespace Umbraco.Cms.Core.PropertyEditors
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
         private readonly HtmlImageSourceParser _imageSourceParser;
         private readonly HtmlLocalLinkParser _localLinkParser;
+        private readonly IHtmlMacroParameterParser _macroParameterParser;
         private readonly RichTextEditorPastedImages _pastedImages;
         private readonly IIOHelper _ioHelper;
         private readonly IImageUrlGenerator _imageUrlGenerator;
 
         /// <summary>
-        /// The constructor will setup the property editor based on the attribute if one is found
+        /// The constructor will setup the property editor based on the attribute if one is found.
         /// </summary>
         public RichTextPropertyEditor(
             IDataValueEditorFactory dataValueEditorFactory,
@@ -50,7 +52,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
             HtmlLocalLinkParser localLinkParser,
             RichTextEditorPastedImages pastedImages,
             IIOHelper ioHelper,
-            IImageUrlGenerator imageUrlGenerator)
+            IImageUrlGenerator imageUrlGenerator,
+            IHtmlMacroParameterParser macroParameterParser)
             : base(dataValueEditorFactory)
         {
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -59,6 +62,20 @@ namespace Umbraco.Cms.Core.PropertyEditors
             _pastedImages = pastedImages;
             _ioHelper = ioHelper;
             _imageUrlGenerator = imageUrlGenerator;
+            _macroParameterParser = macroParameterParser;
+        }
+
+        [Obsolete("Use the constructor which takes an IHtmlMacroParameterParser instead")]
+        public RichTextPropertyEditor(
+            IDataValueEditorFactory dataValueEditorFactory,
+            IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+            HtmlImageSourceParser imageSourceParser,
+            HtmlLocalLinkParser localLinkParser,
+            RichTextEditorPastedImages pastedImages,
+            IIOHelper ioHelper,
+            IImageUrlGenerator imageUrlGenerator)
+            : this (dataValueEditorFactory, backOfficeSecurityAccessor, imageSourceParser, localLinkParser, pastedImages, ioHelper, imageUrlGenerator, StaticServiceProvider.Instance.GetRequiredService<IHtmlMacroParameterParser>())
+        {
         }
 
         /// <summary>
@@ -79,6 +96,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
             private readonly HtmlImageSourceParser _imageSourceParser;
             private readonly HtmlLocalLinkParser _localLinkParser;
+            private readonly IHtmlMacroParameterParser _macroParameterParser;
             private readonly RichTextEditorPastedImages _pastedImages;
             private readonly IImageUrlGenerator _imageUrlGenerator;
             private readonly IHtmlSanitizer _htmlSanitizer;
@@ -94,7 +112,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 IImageUrlGenerator imageUrlGenerator,
                 IJsonSerializer jsonSerializer,
                 IIOHelper ioHelper,
-                IHtmlSanitizer htmlSanitizer)
+                IHtmlSanitizer htmlSanitizer,
+                IHtmlMacroParameterParser macroParameterParser)
                 : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
             {
                 _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -103,6 +122,26 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 _pastedImages = pastedImages;
                 _imageUrlGenerator = imageUrlGenerator;
                 _htmlSanitizer = htmlSanitizer;
+                _macroParameterParser = macroParameterParser;
+            }
+
+            [Obsolete("Use the constructor which takes an HtmlMacroParameterParser instead")]
+            public RichTextPropertyValueEditor(
+                DataEditorAttribute attribute,
+                IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+                ILocalizedTextService localizedTextService,
+                IShortStringHelper shortStringHelper,
+                HtmlImageSourceParser imageSourceParser,
+                HtmlLocalLinkParser localLinkParser,
+                RichTextEditorPastedImages pastedImages,
+                IImageUrlGenerator imageUrlGenerator,
+                IJsonSerializer jsonSerializer,
+                IIOHelper ioHelper,
+                IHtmlSanitizer htmlSanitizer)
+                : this(attribute, backOfficeSecurityAccessor, localizedTextService, shortStringHelper, imageSourceParser,
+                       localLinkParser, pastedImages, imageUrlGenerator, jsonSerializer, ioHelper, htmlSanitizer,
+                       StaticServiceProvider.Instance.GetRequiredService<IHtmlMacroParameterParser>())
+            {
             }
 
             /// <inheritdoc />
@@ -182,6 +221,10 @@ namespace Umbraco.Cms.Core.PropertyEditors
                     yield return new UmbracoEntityReference(udi);
 
                 //TODO: Detect Macros too ... but we can save that for a later date, right now need to do media refs
+                //UPDATE: We are getting the Macros in 'FindUmbracoEntityReferencesFromEmbeddedMacros' - perhaps we just return the macro Udis here too or do they need their own relationAlias?
+
+                foreach (var umbracoEntityReference in _macroParameterParser.FindUmbracoEntityReferencesFromEmbeddedMacros(asString))
+                    yield return umbracoEntityReference;
             }
         }
 

--- a/src/Umbraco.Infrastructure/Services/Implement/MacroService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/MacroService.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             if (_macroRepository is not IMacroWithAliasRepository macroWithAliasRepository)
             {
-                return GetAll().FirstOrDefault(x=>x.Alias == alias);
+                return GetAll().FirstOrDefault(x => x.Alias == alias);
             }
 
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
@@ -69,7 +69,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             if (_macroRepository is not IMacroWithAliasRepository macroWithAliasRepository)
             {
                 var hashset = new HashSet<string>(aliases);
-                return GetAll().Where(x=> hashset.Contains(x.Alias));
+                return GetAll().Where(x => hashset.Contains(x.Alias));
             }
 
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/src/Umbraco.Infrastructure/Services/Implement/MacroService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/MacroService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             if (_macroRepository is not IMacroWithAliasRepository macroWithAliasRepository)
             {
-                return GetAll().First();
+                return GetAll().FirstOrDefault(x=>x.Alias == alias);
             }
 
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
@@ -68,7 +68,8 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             if (_macroRepository is not IMacroWithAliasRepository macroWithAliasRepository)
             {
-                return GetAll();
+                var hashset = new HashSet<string>(aliases);
+                return GetAll().Where(x=> hashset.Contains(x.Alias));
             }
 
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/src/Umbraco.Infrastructure/Services/Implement/MacroService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/MacroService.cs
@@ -1,14 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
-using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Core.Services.Implement
 {
@@ -17,27 +15,14 @@ namespace Umbraco.Cms.Core.Services.Implement
     /// </summary>
     internal class MacroService : RepositoryService, IMacroWithAliasService
     {
-        private readonly IMacroWithAliasRepository _macroRepository;
+        private readonly IMacroRepository _macroRepository;
         private readonly IAuditRepository _auditRepository;
 
-        public MacroService(IScopeProvider provider, ILoggerFactory loggerFactory, IEventMessagesFactory eventMessagesFactory,
-            IMacroWithAliasRepository macroRepository, IAuditRepository auditRepository)
+        public MacroService(IScopeProvider provider, ILoggerFactory loggerFactory, IEventMessagesFactory eventMessagesFactory, IMacroRepository macroRepository, IAuditRepository auditRepository)
             : base(provider, loggerFactory, eventMessagesFactory)
         {
             _macroRepository = macroRepository;
             _auditRepository = auditRepository;
-        }
-
-        [Obsolete("Use ctor injecting IMacroWithAliasRepository instead")]
-        public MacroService(IScopeProvider provider, ILoggerFactory loggerFactory, IEventMessagesFactory eventMessagesFactory,
-            IMacroRepository macroRepository, IAuditRepository auditRepository)
-            : this (
-                  provider,
-                  loggerFactory,
-                  eventMessagesFactory,
-                  StaticServiceProvider.Instance.GetRequiredService<IMacroWithAliasRepository>(),
-                  auditRepository)
-        {
         }
 
         /// <summary>
@@ -47,9 +32,14 @@ namespace Umbraco.Cms.Core.Services.Implement
         /// <returns>An <see cref="IMacro"/> object</returns>
         public IMacro GetByAlias(string alias)
         {
+            if (_macroRepository is not IMacroWithAliasRepository macroWithAliasRepository)
+            {
+                return GetAll().First();
+            }
+
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                return _macroRepository.GetByAlias(alias);
+                return macroWithAliasRepository.GetByAlias(alias);
             }
         }
 
@@ -76,9 +66,14 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public IEnumerable<IMacro> GetAll(params string[] aliases)
         {
+            if (_macroRepository is not IMacroWithAliasRepository macroWithAliasRepository)
+            {
+                return GetAll();
+            }
+
             using (var scope = ScopeProvider.CreateScope(autoComplete: true))
             {
-                return _macroRepository.GetAllByAlias(aliases);
+                return macroWithAliasRepository.GetAllByAlias(aliases);
             }
         }
 

--- a/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
@@ -58,7 +58,7 @@ namespace Umbraco.Cms.Infrastructure.Templates
                 // Deserialise JSON of Macro Grid Control to a class
                 var gridMacro = macroGridControl.Value.ToObject<GridMacro>();
                 // Collect any macro parameters that contain the media udi format
-                if (gridMacro != null && gridMacro.MacroParameters != null && gridMacro.MacroParameters.Any())
+                if (gridMacro is not null && gridMacro.MacroParameters is not null && gridMacro.MacroParameters.Any())
                 {
                     foundMacros.Add(new Tuple<string, Dictionary<string, string>>(gridMacro.MacroAlias, gridMacro.MacroParameters));
                 }
@@ -94,7 +94,7 @@ namespace Umbraco.Cms.Infrastructure.Templates
                 }
                 foundMacroUmbracoEntityReferences.Add(new UmbracoEntityReference(Udi.Create(Constants.UdiEntityType.Macro, macroConfig.Key)));
                 // Only do this if the macros actually have parameters
-                if (macroConfig.Properties != null && macroConfig.Properties.Keys.Any(f => f != "macroAlias"))
+                if (macroConfig.Properties is not null && macroConfig.Properties.Keys.Any(f => f != "macroAlias"))
                 {
                     foreach (var umbracoEntityReference in GetUmbracoEntityReferencesFromMacroParameters(macro.Item2, macroConfig, _parameterEditors))
                     {
@@ -121,7 +121,7 @@ namespace Umbraco.Cms.Infrastructure.Templates
                     var parameterEditorAlias = parameter.EditorAlias;
                     // Lookup propertyEditor from the registered ParameterEditors with the implmementation to avoid looking up for each parameter
                     var parameterEditor = parameterEditors.FirstOrDefault(f => string.Equals(f.Alias, parameterEditorAlias, StringComparison.OrdinalIgnoreCase));
-                    if (parameterEditor != null)
+                    if (parameterEditor is not null)
                     {
                         // Get the ParameterValueEditor for this PropertyEditor (where the GetReferences method is implemented) - cast as IDataValueReference to determine if 'it is' implemented for the editor
                         if (parameterEditor.GetValueEditor() is IDataValueReference parameterValueEditor)

--- a/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Infrastructure.Templates
         /// <summary>
         /// Parses out media UDIs from an HTML string based on embedded macro parameter values.
         /// </summary>
-        /// <param name="text"></param>
+        /// <param name="text">HTML string</param>
         /// <returns></returns>
         public IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromEmbeddedMacros(string text)
         {
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Infrastructure.Templates
         }
 
         /// <summary>
-        /// Parses out media UDIs from Macro Grid Control Parameters.
+        /// Parses out media UDIs from Macro Grid Control parameters.
         /// </summary>
         /// <param name="macroGridControls"></param>
         /// <returns></returns>

--- a/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
@@ -88,6 +88,10 @@ namespace Umbraco.Cms.Infrastructure.Templates
             foreach (var macro in macros)
             {
                 var macroConfig = macroConfigs.FirstOrDefault(f => f.Alias == macro.Item1);
+                if (macroConfig is null)
+                {
+                    continue;
+                }
                 foundMacroUmbracoEntityReferences.Add(new UmbracoEntityReference(Udi.Create(Constants.UdiEntityType.Macro, macroConfig.Key)));
                 // Only do this if the macros actually have parameters
                 if (macroConfig.Properties != null && macroConfig.Properties.Keys.Any(f => f != "macroAlias"))

--- a/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
@@ -14,11 +14,11 @@ namespace Umbraco.Cms.Infrastructure.Templates
 {
     public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
     {
-        private readonly IMacroWithAliasService _macroService;
+        private readonly IMacroService _macroService;
         private readonly ILogger<HtmlMacroParameterParser> _logger;
         private readonly ParameterEditorCollection _parameterEditors;
 
-        public HtmlMacroParameterParser(IMacroWithAliasService macroService, ILogger<HtmlMacroParameterParser> logger, ParameterEditorCollection parameterEditors)
+        public HtmlMacroParameterParser(IMacroService macroService, ILogger<HtmlMacroParameterParser> logger, ParameterEditorCollection parameterEditors)
         {
             _macroService = macroService;
             _logger = logger;
@@ -72,12 +72,18 @@ namespace Umbraco.Cms.Infrastructure.Templates
 
         private IEnumerable<UmbracoEntityReference> GetUmbracoEntityReferencesFromMacros(List<Tuple<string, Dictionary<string, string>>> macros)
         {
+
+            if (_macroService is not IMacroWithAliasService macroWithAliasService)
+            {
+                yield break;
+            }
+
             var uniqueMacroAliases = macros.Select(f => f.Item1).Distinct();
             // TODO: Tracking Macro references
             // Here we are finding the used macros' Udis (there should be a Related Macro relation type - but Relations don't accept 'Macro' as an option)
             var foundMacroUmbracoEntityReferences = new List<UmbracoEntityReference>();
             // Get all the macro configs in one hit for these unique macro aliases - this is now cached with a custom cache policy
-            var macroConfigs = _macroService.GetAll(uniqueMacroAliases.ToArray());
+            var macroConfigs = macroWithAliasService.GetAll(uniqueMacroAliases.ToArray());
 
             foreach (var macro in macros)
             {

--- a/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Macros;
+
+namespace Umbraco.Cms.Infrastructure.Templates
+{
+    public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
+    {
+        private readonly IMacroWithAliasService _macroService;
+        private readonly ILogger<HtmlMacroParameterParser> _logger;
+        private readonly ParameterEditorCollection _parameterEditors;
+
+        public HtmlMacroParameterParser(IMacroWithAliasService macroService, ILogger<HtmlMacroParameterParser> logger, ParameterEditorCollection parameterEditors)
+        {
+            _macroService = macroService;
+            _logger = logger;
+            _parameterEditors = parameterEditors;
+        }
+
+        /// <summary>
+        /// Parses out media UDIs from an HTML string based on embedded macro parameter values.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromEmbeddedMacros(string text)
+        {
+            // There may be more than one macro with the same alias on the page so using a tuple
+            var foundMacros = new List<Tuple<string, Dictionary<string, string>>>();
+
+            // This legacy ParseMacros() already finds the macros within a Rich Text Editor using regexes
+            // It seems to lowercase the macro parameter alias - so making the dictionary case insensitive
+            MacroTagParser.ParseMacros(text, textblock => { }, (macroAlias, macroAttributes) => foundMacros.Add(new Tuple<string, Dictionary<string, string>>(macroAlias, new Dictionary<string, string>(macroAttributes, StringComparer.OrdinalIgnoreCase))));
+            foreach (var umbracoEntityReference in GetUmbracoEntityReferencesFromMacros(foundMacros))
+            {
+                yield return umbracoEntityReference;
+            }
+        }
+
+        /// <summary>
+        /// Parses out media UDIs from Macro Grid Control Parameters.
+        /// </summary>
+        /// <param name="macroGridControls"></param>
+        /// <returns></returns>
+        public IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromGridControlMacros(IEnumerable<GridValue.GridControl> macroGridControls)
+        {
+            var foundMacros = new List<Tuple<string, Dictionary<string, string>>>();
+
+            foreach (var macroGridControl in macroGridControls)
+            {
+                // Deserialise JSON of Macro Grid Control to a class
+                var gridMacro = macroGridControl.Value.ToObject<GridMacro>();
+                // Collect any macro parameters that contain the media udi format
+                if (gridMacro != null && gridMacro.MacroParameters != null && gridMacro.MacroParameters.Any())
+                {
+                    foundMacros.Add(new Tuple<string, Dictionary<string, string>>(gridMacro.MacroAlias, gridMacro.MacroParameters));
+                }
+            }
+
+            foreach (var umbracoEntityReference in GetUmbracoEntityReferencesFromMacros(foundMacros))
+            {
+                yield return umbracoEntityReference;
+            }
+        }
+
+        private IEnumerable<UmbracoEntityReference> GetUmbracoEntityReferencesFromMacros(List<Tuple<string, Dictionary<string, string>>> macros)
+        {
+            var uniqueMacroAliases = macros.Select(f => f.Item1).Distinct();
+            // TODO: Tracking Macro references
+            // Here we are finding the used macros' Udis (there should be a Related Macro relation type - but Relations don't accept 'Macro' as an option)
+            var foundMacroUmbracoEntityReferences = new List<UmbracoEntityReference>();
+            // Get all the macro configs in one hit for these unique macro aliases - this is now cached with a custom cache policy
+            var macroConfigs = _macroService.GetAll(uniqueMacroAliases.ToArray());
+
+            foreach (var macro in macros)
+            {
+                var macroConfig = macroConfigs.FirstOrDefault(f => f.Alias == macro.Item1);
+                foundMacroUmbracoEntityReferences.Add(new UmbracoEntityReference(Udi.Create(Constants.UdiEntityType.Macro, macroConfig.Key)));
+                // Only do this if the macros actually have parameters
+                if (macroConfig.Properties != null && macroConfig.Properties.Keys.Any(f => f != "macroAlias"))
+                {
+                    foreach (var umbracoEntityReference in GetUmbracoEntityReferencesFromMacroParameters(macro.Item2, macroConfig, _parameterEditors))
+                    {
+                        yield return umbracoEntityReference;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Finds media UDIs in Macro Parameter Values by calling the GetReference method for all the Macro Parameter Editors for a particular macro.
+        /// </summary>
+        /// <param name="macroParameters">The parameters for the macro a dictionary of key/value strings</param>
+        /// <param name="macroConfig">The macro configuration for this particular macro - contains the types of editors used for each parameter</param>
+        /// <param name="parameterEditors">A list of all the registered parameter editors used in the Umbraco implmentation - to look up the corresponding property editor for a macro parameter</param>
+        /// <returns></returns>
+        private IEnumerable<UmbracoEntityReference> GetUmbracoEntityReferencesFromMacroParameters(Dictionary<string, string> macroParameters, IMacro macroConfig, ParameterEditorCollection parameterEditors)
+        {
+            var foundUmbracoEntityReferences = new List<UmbracoEntityReference>();
+            foreach (var parameter in macroConfig.Properties)
+            {
+                if (macroParameters.TryGetValue(parameter.Alias, out string parameterValue))
+                {
+                    var parameterEditorAlias = parameter.EditorAlias;
+                    // Lookup propertyEditor from the registered ParameterEditors with the implmementation to avoid looking up for each parameter
+                    var parameterEditor = parameterEditors.FirstOrDefault(f => string.Equals(f.Alias, parameterEditorAlias, StringComparison.OrdinalIgnoreCase));
+                    if (parameterEditor != null)
+                    {
+                        // Get the ParameterValueEditor for this PropertyEditor (where the GetReferences method is implemented) - cast as IDataValueReference to determine if 'it is' implemented for the editor
+                        if (parameterEditor.GetValueEditor() is IDataValueReference parameterValueEditor)
+                        {
+                            foreach (var entityReference in parameterValueEditor.GetReferences(parameterValue))
+                            {
+                                foundUmbracoEntityReferences.Add(entityReference);
+                            }
+                        }
+                        else
+                        {
+                            _logger.LogInformation("{0} doesn't have a ValueEditor that implements IDataValueReference", parameterEditor.Alias);
+                        }
+                    }
+                }
+            }
+
+            return foundUmbracoEntityReferences;
+        }
+
+        // Poco class to deserialise the Json for a Macro Control
+        private class GridMacro
+        {
+            [JsonProperty("macroAlias")]
+            public string MacroAlias { get; set; }
+
+            [JsonProperty("macroParamsDictionary")]
+            public Dictionary<string, string> MacroParameters { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Templates/IHtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/IHtmlMacroParameterParser.cs
@@ -7,7 +7,6 @@ namespace Umbraco.Cms.Infrastructure.Templates
     /// <summary>
     /// Provides methods to parse referenced entities as Macro parameters.
     /// </summary>
-
     public interface IHtmlMacroParameterParser
     {
         /// <summary>

--- a/src/Umbraco.Infrastructure/Templates/IHtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/IHtmlMacroParameterParser.cs
@@ -4,10 +4,24 @@ using Umbraco.Cms.Core.Models.Editors;
 
 namespace Umbraco.Cms.Infrastructure.Templates
 {
+    /// <summary>
+    /// Provides methods to parse referenced entities as Macro parameters.
+    /// </summary>
+
     public interface IHtmlMacroParameterParser
     {
+        /// <summary>
+        /// Parses out media UDIs from an HTML string based on embedded macro parameter values.
+        /// </summary>
+        /// <param name="text">HTML string</param>
+        /// <returns></returns>
         IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromEmbeddedMacros(string text);
 
-        IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromGridControlMacros(IEnumerable<GridValue.GridControl> macroValues);
+        /// <summary>
+        /// Parses out media UDIs from Macro Grid Control parameters.
+        /// </summary>
+        /// <param name="macroGridControls"></param>
+        /// <returns></returns>
+        IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromGridControlMacros(IEnumerable<GridValue.GridControl> macroGridControls);
     }
 }

--- a/src/Umbraco.Infrastructure/Templates/IHtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/IHtmlMacroParameterParser.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
+
+namespace Umbraco.Cms.Infrastructure.Templates
+{
+    public interface IHtmlMacroParameterParser
+    {
+        IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromEmbeddedMacros(string text);
+
+        IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromGridControlMacros(IEnumerable<GridValue.GridControl> macroValues);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MacroServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MacroServiceTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -24,7 +23,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
     [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
     public class MacroServiceTests : UmbracoIntegrationTest
     {
-        private IMacroService MacroService => GetRequiredService<IMacroService>();
+        [Obsolete("After merging IMacroWithAliasService interface with IMacroService in Umbraco 11, this should go back to just being GetRequiredService<IMacroService>()")]
+        private IMacroWithAliasService MacroService => GetRequiredService<IMacroService>() as IMacroWithAliasService;
 
         [SetUp]
         public void SetupTest()
@@ -50,6 +50,19 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
             // Assert
             Assert.IsNotNull(macro);
             Assert.AreEqual("Test1", macro.Name);
+        }
+
+        [Test]
+        public void Can_Get_By_Aliases()
+        {
+            // Act
+            IEnumerable<IMacro> macros = MacroService.GetAll("test1", "test2");
+
+            // Assert
+            Assert.IsNotNull(macros);
+            Assert.AreEqual(2, macros.Count());
+            Assert.AreEqual("Test1", macros.ToArray()[0].Name);
+            Assert.AreEqual("Test2", macros.ToArray()[1].Name);
         }
 
         [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.NuCache/SnapDictionaryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.NuCache/SnapDictionaryTests.cs
@@ -323,6 +323,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.PublishedCache.NuCache
         }
 
         [Test]
+        [Retry(5)] // TODO make this test non-flaky.
         public async Task EventuallyCollectNulls()
         {
             var d = new SnapDictionary<int, string>();


### PR DESCRIPTION
## Details

Fixes #8131 for Umbraco 9

After adding the [item tracking improvements](https://github.com/umbraco/Umbraco-CMS/pull/11919), there was still the issue that media items were not tracked when added via macro parameters in Rich Text Editor and Grid layout. @marcemarc had made a [PR](https://github.com/umbraco/Umbraco-CMS/pull/8614) for Umbraco 8 resolving the issue (🎉 H5YR! 💪 ) and this is the fix for Umbraco 9. 

## Test
- Have the SK installed
  - Create a Partial View Macro File called `InsertFiles.cshtml` ( ❗ _Note: code below_)
  - Allow the macro with the same name to be used in Rich Text Editor and the Grid
  - Add a macro parameter (ex: `Files (files) :  Umbraco.MultipleMediaPicker`)
  - In a **Rich Text area** on a content node, insert the macro and pick a media item as the macro param
    - It should result in the following: 
![image](https://user-images.githubusercontent.com/21998037/158605232-83075143-4d49-4c5f-965b-4f371a63113b.png)

  - Save and Publish
  - View the media item in the backoffice, and you should see that this is now referenced from this page
    - If you pick a folder from the Media section, all its contents will be listed in the macro, but the reference is made to the folder itself and therefore can be found on the folder's info app
  - You can do the same thing with the **Grid**
      - Either pick a Macro directly
      - Or add a RTE in a Grid and reference the macro from there 


---
Contents of `InsertFiles.cshtml`: 
```cshtml
@inherits Umbraco.Cms.Web.Common.Macros.PartialViewMacroPage
@using Umbraco.Cms.Core.Models.PublishedContent
@using Umbraco.Cms.Core
@using Umbraco.Cms.Core.Routing
@using Umbraco.Extensions

@inject IPublishedContentQuery PublishedContentQuery
@inject IVariationContextAccessor VariationContextAccessor
@inject IPublishedUrlProvider PublishedUrlProvider


@{ var mediaIds = Model?.MacroParameters["files"] as string; }

@if (mediaIds != null)
{
    <div class="row">
        @foreach (var mediaId in mediaIds.Split(','))
        {
            var media = PublishedContentQuery.Media(mediaId);

            @* a single image *@
            if (!media.IsDocumentType("Folder"))
            {
                <div class="col-xs-6 col-md-3">
                    <a href="@media.Url(PublishedUrlProvider)" class="thumbnail">@media.Name</a> [@System.IO.Path.GetExtension(@media.Url(PublishedUrlProvider).ToString()).Substring(1)]
                </div>
            }

            @* a folder with images under it *@
            foreach (var image in media.Children(VariationContextAccessor))
            {
                <div class="col-xs-6 col-md-3">
                    <a href="@image.Url(PublishedUrlProvider)" class="thumbnail">@image.Name</a> [@System.IO.Path.GetExtension(@image.Url(PublishedUrlProvider).ToString()).Substring(1)]
                </div>
            }
        }
    </div>
} 
```
