### PR TITLE
Item tracking fixes

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/ITrackedReferencesRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITrackedReferencesRepository.cs
@@ -1,14 +1,42 @@
-using System;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories
 {
     public interface ITrackedReferencesRepository
     {
-        IEnumerable<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency,out long totalRecords);
-        IEnumerable<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency,out long totalRecords);
-        IEnumerable<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency,out long totalRecords);
+        /// <summary>
+        /// Gets a page of items which are in relation with the current item.
+        /// Basically, shows the items which depend on the current item.
+        /// </summary>
+        /// <param name="ids">The identifier of the entity to retrieve relations for.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
+        /// <param name="totalRecords">The total count of the items with reference to the current item.</param>
+        /// <returns>An enumerable list of <see cref="RelationItem"/> objects.</returns>
+        IEnumerable<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
+
+        /// <summary>
+        /// Gets a page of items used in any kind of relation from selected integer ids.
+        /// </summary>
+        /// <param name="ids">The identifiers of the entities to check for relations.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
+        /// <param name="totalRecords">The total count of the items in any kind of relation.</param>
+        /// <returns>An enumerable list of <see cref="RelationItem"/> objects.</returns>
+        IEnumerable<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
+
+        /// <summary>
+        /// Gets a page of the descending items that have any references, given a parent id.
+        /// </summary>
+        /// <param name="parentId">The unique identifier of the parent to retrieve descendants for.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
+        /// <param name="totalRecords">The total count of descending items.</param>
+        /// <returns>An enumerable list of <see cref="RelationItem"/> objects.</returns>
+        IEnumerable<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/ITrackedReferencesRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITrackedReferencesRepository.cs
@@ -9,13 +9,13 @@ namespace Umbraco.Cms.Core.Persistence.Repositories
         /// Gets a page of items which are in relation with the current item.
         /// Basically, shows the items which depend on the current item.
         /// </summary>
-        /// <param name="ids">The identifier of the entity to retrieve relations for.</param>
+        /// <param name="id">The identifier of the entity to retrieve relations for.</param>
         /// <param name="pageIndex">The page index.</param>
         /// <param name="pageSize">The page size.</param>
         /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
         /// <param name="totalRecords">The total count of the items with reference to the current item.</param>
         /// <returns>An enumerable list of <see cref="RelationItem"/> objects.</returns>
-        IEnumerable<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
+        IEnumerable<RelationItem> GetPagedRelationsForItem(int id, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
 
         /// <summary>
         /// Gets a page of items used in any kind of relation from selected integer ids.

--- a/src/Umbraco.Core/Services/ITrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/ITrackedReferencesService.cs
@@ -4,12 +4,35 @@ namespace Umbraco.Cms.Core.Services
 {
     public interface ITrackedReferencesService
     {
+        /// <summary>
+        /// Gets a paged result of items which are in relation with the current item.
+        /// Basically, shows the items which depend on the current item.
+        /// </summary>
+        /// <param name="ids">The identifier of the entity to retrieve relations for.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
+        /// <returns>A paged result of <see cref="RelationItem"/> objects.</returns>
         PagedResult<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency);
 
-
+        /// <summary>
+        /// Gets a paged result of the descending items that have any references, given a parent id.
+        /// </summary>
+        /// <param name="parentId">The unique identifier of the parent to retrieve descendants for.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
+        /// <returns>A paged result of <see cref="RelationItem"/> objects.</returns>
         PagedResult<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency);
 
-
+        /// <summary>
+        /// Gets a paged result of items used in any kind of relation from selected integer ids.
+        /// </summary>
+        /// <param name="ids">The identifiers of the entities to check for relations.</param>
+        /// <param name="pageIndex">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
+        /// <returns>A paged result of <see cref="RelationItem"/> objects.</returns>
         PagedResult<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency);
     }
 }

--- a/src/Umbraco.Core/Services/ITrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/ITrackedReferencesService.cs
@@ -8,12 +8,12 @@ namespace Umbraco.Cms.Core.Services
         /// Gets a paged result of items which are in relation with the current item.
         /// Basically, shows the items which depend on the current item.
         /// </summary>
-        /// <param name="ids">The identifier of the entity to retrieve relations for.</param>
+        /// <param name="id">The identifier of the entity to retrieve relations for.</param>
         /// <param name="pageIndex">The page index.</param>
         /// <param name="pageSize">The page size.</param>
         /// <param name="filterMustBeIsDependency">A boolean indicating whether to filter only the RelationTypes which are dependencies (isDependency field is set to true).</param>
         /// <returns>A paged result of <see cref="RelationItem"/> objects.</returns>
-        PagedResult<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency);
+        PagedResult<RelationItem> GetPagedRelationsForItem(int id, long pageIndex, int pageSize, bool filterMustBeIsDependency);
 
         /// <summary>
         /// Gets a paged result of the descending items that have any references, given a parent id.

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -659,6 +659,12 @@ namespace Umbraco.Extensions
             return sql;
         }
 
+        public static Sql<ISqlContext> SelectDistinct(this Sql<ISqlContext> sql, params object[] columns)
+        {
+            sql.Append("SELECT DISTINCT " + string.Join(", ", columns));
+            return sql;
+        }
+
         //this.Append("SELECT " + string.Join(", ", columns), new object[0]);
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -253,9 +253,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             });
         }
 
-
-
-
         public void Save(IEnumerable<IRelation> relations)
         {
             foreach (var hasIdentityGroup in relations.GroupBy(r => r.HasIdentity))

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -198,22 +198,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             });
         }
 
-        public IEnumerable<IUmbracoEntity> GetPagedParentEntitiesByChildIds(int[] childIds, long pageIndex, int pageSize, out long totalRecords, int[] relationTypes, params Guid[] entityTypes)
-        {
-            return _entityRepository.GetPagedResultsByQuery(Query<IUmbracoEntity>(), entityTypes, pageIndex, pageSize, out totalRecords, null, null, sql =>
-            {
-                SqlJoinRelations(sql);
-
-                sql.WhereIn<RelationDto>(rel => rel.ChildId, childIds);
-                sql.WhereAny(s => s.WhereIn<RelationDto>(rel => rel.ParentId, childIds), s => s.WhereNotIn<NodeDto>(node => node.NodeId, childIds));
-
-                if (relationTypes != null && relationTypes.Any())
-                {
-                    sql.WhereIn<RelationDto>(rel => rel.RelationType, relationTypes);
-                }
-            });
-        }
-
         public IEnumerable<IUmbracoEntity> GetPagedChildEntitiesByParentId(int parentId, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes)
         {
             return GetPagedChildEntitiesByParentId(parentId, pageIndex, pageSize, out totalRecords, new int[0], entityTypes);
@@ -238,18 +222,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 {
                     sql.WhereIn<RelationDto>(rel => rel.RelationType, relationTypes);
                 }
-            });
-        }
-
-        public IEnumerable<IUmbracoEntity> GetPagedEntitiesForItemsInRelation(int[] itemIds, long pageIndex, int pageSize, out long totalRecords, params Guid[] entityTypes)
-        {
-            return _entityRepository.GetPagedResultsByQuery(Query<IUmbracoEntity>(), entityTypes, pageIndex, pageSize, out totalRecords, null, null, sql =>
-            {
-                SqlJoinRelations(sql);
-
-                sql.WhereIn<RelationDto>(rel => rel.ChildId, itemIds);
-                sql.Where<RelationDto, NodeDto>((rel, node) => rel.ChildId == node.NodeId);
-                sql.Where<RelationTypeDto>(type => type.IsDependency);
             });
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -475,8 +475,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         [Column(Name = "contentTypeName")]
         public string ChildContentTypeName { get; set; }
 
-
-
         [Column(Name = "relationTypeName")]
         public string RelationTypeName { get; set; }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         /// </summary>
         public IEnumerable<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords)
         {
-            var sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().Select(
+            var sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().SelectDistinct(
                     "[pn].[id] as nodeId",
                     "[pn].[uniqueId] as nodeKey",
                     "[pn].[text] as nodeName",
@@ -100,7 +100,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             }
 
             // Get all relations where parent is in the sub query
-            var sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().Select(
+            var sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().SelectDistinct(
                     "[pn].[id] as nodeId",
                     "[pn].[uniqueId] as nodeKey",
                     "[pn].[text] as nodeName",
@@ -141,7 +141,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         /// </summary>
         public IEnumerable<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords)
         {
-            var sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().Select(
+            var sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().SelectDistinct(
                     "[cn].[id] as nodeId",
                     "[cn].[uniqueId] as nodeKey",
                     "[cn].[text] as nodeName",

--- a/src/Umbraco.Infrastructure/Services/Implement/TrackedReferencesService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/TrackedReferencesService.cs
@@ -1,4 +1,3 @@
-﻿using System.Linq;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
@@ -18,22 +17,32 @@ namespace Umbraco.Cms.Core.Services.Implement
             _entityService = entityService;
         }
 
-        public PagedResult<RelationItem> GetPagedRelationsForItems(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency)
+        /// <summary>
+        /// Gets a paged result of items which are in relation with the current item.
+        /// Basically, shows the items which depend on the current item.
+        /// </summary>
+        public PagedResult<RelationItem> GetPagedRelationsForItem(int id, long pageIndex, int pageSize, bool filterMustBeIsDependency)
         {
             using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
-            var items =  _trackedReferencesRepository.GetPagedRelationsForItems(ids, pageIndex, pageSize,  filterMustBeIsDependency, out var totalItems);
+            var items = _trackedReferencesRepository.GetPagedRelationsForItem(id, pageIndex, pageSize, filterMustBeIsDependency, out var totalItems);
 
-            return new PagedResult<RelationItem>(totalItems, pageIndex+1, pageSize) { Items = items };
+            return new PagedResult<RelationItem>(totalItems, pageIndex + 1, pageSize) { Items = items };
         }
 
+        /// <summary>
+        /// Gets a paged result of items used in any kind of relation from selected integer ids.
+        /// </summary>
         public PagedResult<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency)
         {
             using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
-            var items =  _trackedReferencesRepository.GetPagedItemsWithRelations(ids, pageIndex, pageSize,  filterMustBeIsDependency, out var totalItems);
+            var items = _trackedReferencesRepository.GetPagedItemsWithRelations(ids, pageIndex, pageSize, filterMustBeIsDependency, out var totalItems);
 
-            return new PagedResult<RelationItem>(totalItems, pageIndex+1, pageSize) { Items = items };
+            return new PagedResult<RelationItem>(totalItems, pageIndex + 1, pageSize) { Items = items };
         }
 
+        /// <summary>
+        /// Gets a paged result of the descending items that have any references, given a parent id.
+        /// </summary>
         public PagedResult<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency)
         {
             using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
@@ -44,7 +53,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                 pageSize,
                 filterMustBeIsDependency,
                 out var totalItems);
-            return new PagedResult<RelationItem>(totalItems, pageIndex+1, pageSize) { Items = items };
+            return new PagedResult<RelationItem>(totalItems, pageIndex + 1, pageSize) { Items = items };
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -1082,7 +1082,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             return new ActionResult<IMedia>(toMove);
         }
 
-        [Obsolete("Please use TrackedReferencesController.GetPagedReferences() instead. Scheduled for removal in V11.")]
+        [Obsolete("Please use TrackedReferencesController.GetPagedRelationsForItem() instead. Scheduled for removal in V11.")]
         public PagedResult<EntityBasic> GetPagedReferences(int id, string entityType, int pageNumber = 1, int pageSize = 100)
         {
             if (pageNumber <= 0 || pageSize <= 0)

--- a/src/Umbraco.Web.BackOffice/Controllers/TrackedReferencesController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TrackedReferencesController.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// </summary>
         /// <remarks>
         /// Used by info tabs on content, media etc. and for the delete and unpublish of single items.
-        /// This is basically finding childs of relations.
+        /// This is basically finding parents of relations.
         /// </remarks>
         public ActionResult<PagedResult<RelationItem>> GetPagedReferences(int id, int pageNumber = 1, int pageSize = 100, bool filterMustBeIsDependency = false)
         {
@@ -34,17 +34,15 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 return BadRequest("Both pageNumber and pageSize must be greater than zero");
             }
 
-            return _relationService.GetPagedRelationsForItems(new[] { id }, pageNumber - 1, pageSize, filterMustBeIsDependency);
+            return _relationService.GetPagedRelationsForItem(id, pageNumber - 1, pageSize, filterMustBeIsDependency);
         }
-
-        // Used on delete, finds
 
         /// <summary>
         /// Gets a page list of the child nodes of the current item used in any kind of relation.
         /// </summary>
         /// <remarks>
         /// Used when deleting and unpublishing a single item to check if this item has any descending items that are in any kind of relation.
-        /// This is basically finding ...
+        /// This is basically finding the descending items which are children in relations.
         /// </remarks>
         public ActionResult<PagedResult<RelationItem>> GetPagedDescendantsInReferences(int parentId, int pageNumber = 1, int pageSize = 100, bool filterMustBeIsDependency = true)
         {
@@ -56,14 +54,12 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             return _relationService.GetPagedDescendantsInReferences(parentId, pageNumber - 1, pageSize, filterMustBeIsDependency);
         }
 
-        // Used by unpublish content. So this is basically finding parents of relations.
-
         /// <summary>
         /// Gets a page list of the items used in any kind of relation from selected integer ids.
         /// </summary>
         /// <remarks>
         /// Used when bulk deleting content/media and bulk unpublishing content (delete and unpublish on List view).
-        /// This is basically finding ...
+        /// This is basically finding children of relations.
         /// </remarks>
         [HttpGet]
         [HttpPost]

--- a/src/Umbraco.Web.BackOffice/Controllers/TrackedReferencesController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TrackedReferencesController.cs
@@ -1,12 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.ContentEditing;
-using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.BackOffice.ModelBinders;
 using Umbraco.Cms.Web.Common.Attributes;
@@ -19,28 +14,38 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
     public class TrackedReferencesController : BackOfficeNotificationsController
     {
         private readonly ITrackedReferencesService _relationService;
-        private readonly IEntityService _entityService;
 
-        public TrackedReferencesController(ITrackedReferencesService relationService,
-            IEntityService entityService)
+        public TrackedReferencesController(ITrackedReferencesService relationService)
         {
             _relationService = relationService;
-            _entityService = entityService;
         }
 
-        // Used by info tabs on content, media etc. So this is basically finding childs of relations.
-        public ActionResult<PagedResult<RelationItem>> GetPagedReferences(int id, int pageNumber = 1,
-            int pageSize = 100, bool filterMustBeIsDependency = false)
+        /// <summary>
+        /// Gets a page list of tracked references for the current item, so you can see where an item is being used.
+        /// </summary>
+        /// <remarks>
+        /// Used by info tabs on content, media etc. and for the delete and unpublish of single items.
+        /// This is basically finding childs of relations.
+        /// </remarks>
+        public ActionResult<PagedResult<RelationItem>> GetPagedReferences(int id, int pageNumber = 1, int pageSize = 100, bool filterMustBeIsDependency = false)
         {
             if (pageNumber <= 0 || pageSize <= 0)
             {
                 return BadRequest("Both pageNumber and pageSize must be greater than zero");
             }
 
-            return _relationService.GetPagedRelationsForItems(new []{id}, pageNumber - 1, pageSize, filterMustBeIsDependency);
+            return _relationService.GetPagedRelationsForItems(new[] { id }, pageNumber - 1, pageSize, filterMustBeIsDependency);
         }
 
         // Used on delete, finds
+
+        /// <summary>
+        /// Gets a page list of the child nodes of the current item used in any kind of relation.
+        /// </summary>
+        /// <remarks>
+        /// Used when deleting and unpublishing a single item to check if this item has any descending items that are in any kind of relation.
+        /// This is basically finding ...
+        /// </remarks>
         public ActionResult<PagedResult<RelationItem>> GetPagedDescendantsInReferences(int parentId, int pageNumber = 1, int pageSize = 100, bool filterMustBeIsDependency = true)
         {
             if (pageNumber <= 0 || pageSize <= 0)
@@ -48,12 +53,18 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 return BadRequest("Both pageNumber and pageSize must be greater than zero");
             }
 
-
             return _relationService.GetPagedDescendantsInReferences(parentId, pageNumber - 1, pageSize, filterMustBeIsDependency);
-
         }
 
         // Used by unpublish content. So this is basically finding parents of relations.
+
+        /// <summary>
+        /// Gets a page list of the items used in any kind of relation from selected integer ids.
+        /// </summary>
+        /// <remarks>
+        /// Used when bulk deleting content/media and bulk unpublishing content (delete and unpublish on List view).
+        /// This is basically finding ...
+        /// </remarks>
         [HttpGet]
         [HttpPost]
         public ActionResult<PagedResult<RelationItem>> GetPagedReferencedItems([FromJsonPath] int[] ids, int pageNumber = 1, int pageSize = 100, bool filterMustBeIsDependency = true)
@@ -64,8 +75,6 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             }
 
             return _relationService.GetPagedItemsWithRelations(ids, pageNumber - 1, pageSize, filterMustBeIsDependency);
-
         }
     }
-
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -12,6 +12,7 @@
             scope.publishStatus = [];
             scope.currentVariant = null;
             scope.currentUrls = [];
+            scope.loadingReferences = false;
 
             scope.disableTemplates = Umbraco.Sys.ServerVariables.features.disabledFeatures.disableTemplates;
             scope.allowChangeDocumentType = false;
@@ -229,6 +230,10 @@
                     });
 
             }
+
+            function loadReferences(){
+              scope.loadingReferences = true;
+            }
             function loadRedirectUrls() {
                 scope.loadingRedirectUrls = true;
                 //check if Redirect URL Management is enabled
@@ -335,6 +340,7 @@
                         loadRedirectUrls();
                         setNodePublishStatus();
                         formatDatesToLocal();
+                        loadReferences();
                     } else {
                         isInfoTab = false;
                     }
@@ -352,6 +358,7 @@
                     loadRedirectUrls();
                     setNodePublishStatus();
                     formatDatesToLocal();
+                    loadReferences();
                 }
                 updateCurrentUrls();
             });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/references/umbtrackedreferences.component.js
@@ -16,8 +16,8 @@
 
         function onInit() {
 
-            vm.referencesTitle = this.hideNoneDependencies ? "The following items depends on this" : "Referenced by the following items";
-            vm.referencedDescendantsTitle = this.hideNoneDependencies ? "The following descending items has dependencies" : "The following descending items are referenced";
+            vm.referencesTitle = this.hideNoneDependencies ? "The following items depend on this" : "Referenced by the following items";
+            vm.referencedDescendantsTitle = this.hideNoneDependencies ? "The following descending items have dependencies" : "The following descending items are referenced";
     
             localizationService.localize(this.hideNoneDependencies ? "references_labelDependsOnThis" : "references_labelUsedByItems").then(function (value) {
                 vm.referencesTitle = value;

--- a/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/trackedreferences.resource.js
@@ -162,7 +162,7 @@ function trackedReferencesResource($q, $http, umbRequestHelper) {
                 $http.post(
                     umbRequestHelper.getApiUrl(
                         "trackedReferencesApiBaseUrl",
-                        "getPagedReferencedItems",
+                        "GetPagedReferencedItems",
                         query),
                         {
                             ids: ids,

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -21,7 +21,7 @@
             </umb-box-content>
         </umb-box>
 
-        <umb-tracked-references id="node.id"></umb-tracked-references>
+        <umb-tracked-references id="node.id" ng-if="loadingReferences" ></umb-tracked-references>
 
         <umb-box data-element="node-info-redirects" ng-cloak ng-show="!urlTrackerDisabled && hasRedirects">
             <umb-box-header title-key="redirectUrls_redirectUrlManagement"></umb-box-header>

--- a/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references-table.html
@@ -7,8 +7,8 @@
         <div class="umb-table-head">
             <div class="umb-table-row">
                 <div class="umb-table-cell"></div>
-                <div class="umb-table-cell umb-table__name not-fixed"><localize key="general_nodename">Node Name</localize></div>
-                <div ng-if="vm.showTypeName" class="umb-table-cell"><localize key="general_typename">Type Name</localize></div>
+                <div class="umb-table-cell umb-table__name not-fixed"><localize key="general_nodeName">Node Name</localize></div>
+                <div ng-if="vm.showTypeName" class="umb-table-cell"><localize key="general_typeName">Type Name</localize></div>
                 <div ng-if="vm.showType" class="umb-table-cell"><localize key="general_type">Type</localize></div>
                 <div ng-if="vm.showRelationTypeName" class="umb-table-cell"><localize key="relationType_relation">Relation</localize></div>
             </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references.html
@@ -26,11 +26,11 @@
     </div>
 
     <div ng-if="vm.hasReferencesInDescendants">
-        <umb-tracked-references-table  items="vm.referencedDescendants.items"
-                                                total-pages="vm.referencedDescendants.totalPages"
-                                                page-number="vm.referencedDescendants.pageNumber"
-                                                headline="vm.referencedDescendantsTitle"
-                                                on-page-changed="vm.changeDescendantsPageNumber(pageNumber)">
+        <umb-tracked-references-table items="vm.referencedDescendants.items"
+                                      total-pages="vm.referencedDescendants.totalPages"
+                                      page-number="vm.referencedDescendants.pageNumber"
+                                      headline="vm.referencedDescendantsTitle"
+                                      on-page-changed="vm.changeDescendantsPageNumber(pageNumber)">
         </umb-tracked-references-table>
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -374,7 +374,7 @@
         }
 
         function enableUser() {
-            vm.enableUserButtonState = "busfy";
+            vm.enableUserButtonState = "busy";
             usersResource.enableUsers([vm.user.id]).then(function (data) {
                 vm.user.userState = "Active";
                 setUserDisplayState();

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -788,6 +788,7 @@
     <key alias="new">New</key>
     <key alias="next">Next</key>
     <key alias="no">No</key>
+    <key alias="nodeName">Node Name</key>
     <key alias="of">of</key>
     <key alias="off">Off</key>
     <key alias="ok">OK</key>
@@ -829,6 +830,7 @@
     <key alias="submit">Submit</key>
     <key alias="success">Success</key>
     <key alias="type">Type</key>
+    <key alias="typeName">Type Name</key>
     <key alias="typeToSearch">Type to search...</key>
     <key alias="under">under</key>
     <key alias="up">Up</key>
@@ -2388,6 +2390,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="parent">Parent</key>
     <key alias="child">Child</key>
     <key alias="count">Count</key>
+    <key alias="relation">Relation</key>
     <key alias="relations">Relations</key>
     <key alias="created">Created</key>
     <key alias="comment">Comment</key>
@@ -2468,18 +2471,13 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
   <area alias="references">
     <key alias="tabName">References</key>
     <key alias="DataTypeNoReferences">This Data Type has no references.</key>
+    <key alias="itemHasNoReferences">This item has no references.</key>
     <key alias="labelUsedByDocumentTypes">Used in Document Types</key>
     <key alias="labelUsedByMediaTypes">Used in Media Types</key>
     <key alias="labelUsedByMemberTypes">Used in Member Types</key>
     <key alias="usedByProperties">Used by</key>
-    <key alias="labelUsedByDocuments">Used in Documents</key>
-    <key alias="labelUsedByMembers">Used in Members</key>
-    <key alias="labelUsedByMedia">Used in Media</key>
     <key alias="labelUsedItems">Items in use</key>
     <key alias="labelUsedDescendants">Descendants in use</key>
-    <key alias="labelUsedInMediaDescendants">One or more of this item's descendants is being used in a media item.</key>
-    <key alias="labelUsedInContentDescendants">One or more of this item's descendants is being used in a content item.</key>
-    <key alias="labelUsedInMemberDescendants">One or more of this item's descendants is being used in a member.</key>
     <key alias="deleteWarning">This item or its descendants is being used. Deletion can lead to broken links on your website.</key>
     <key alias="unpublishWarning">This item or its descendants is being used. Unpublishing can lead to broken links on your website. Please take the appropriate actions.</key>
     <key alias="deleteDisabledWarning">This item or its descendants is being used. Therefore, deletion has been disabled.</key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -809,7 +809,7 @@
     <key alias="new">New</key>
     <key alias="next">Next</key>
     <key alias="no">No</key>
-    <key alias="nodename">Node Name</key>
+    <key alias="nodeName">Node Name</key>
     <key alias="of">of</key>
     <key alias="off">Off</key>
     <key alias="ok">OK</key>
@@ -850,7 +850,7 @@
     <key alias="submit">Submit</key>
     <key alias="success">Success</key>
     <key alias="type">Type</key>
-    <key alias="typename">Type Name</key>
+    <key alias="typeName">Type Name</key>
     <key alias="typeToSearch">Type to search...</key>
     <key alias="under">under</key>
     <key alias="up">Up</key>
@@ -2559,16 +2559,10 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="labelUsedByMemberTypes">Referenced by the following Member Types</key>
     <key alias="usedByProperties">Referenced by</key>
     <key alias="labelUsedByItems">Referenced by the following items</key>
-    <key alias="labelDependsOnThis">The following items depends on this</key>
-    <key alias="labelUsedByDocuments">Referenced by the following Documents</key>
-    <key alias="labelUsedByMembers">Referenced by the following Members</key>
-    <key alias="labelUsedByMedia">Referenced by the following Media</key>
+    <key alias="labelDependsOnThis">The following items depend on this</key>
     <key alias="labelUsedItems">The following items are referenced</key>
     <key alias="labelUsedDescendants">The following descending items are referenced</key>
-    <key alias="labelDependentDescendants">The following descending items has dependencies</key>
-    <key alias="labelUsedInMediaDescendants">One or more of this item's descendants is being referenced in a media item.</key>
-    <key alias="labelUsedInContentDescendants">One or more of this item's descendants is being referenced in a content item.</key>
-    <key alias="labelUsedInMemberDescendants">One or more of this item's descendants is being referenced in a member.</key>
+    <key alias="labelDependentDescendants">The following descending items have dependencies</key>
     <key alias="deleteWarning">This item or its descendants is being referenced. Deletion can lead to broken links on your website.</key>
     <key alias="unpublishWarning">This item or its descendants is being referenced. Unpublishing can lead to broken links on your website. Please take the appropriate actions.</key>
     <key alias="deleteDisabledWarning">This item or its descendants is being referenced. Therefore, deletion has been disabled.</key>


### PR DESCRIPTION
## Details
This PR fixes some of the issues mentioned as comments in https://github.com/umbraco/Umbraco-CMS/pull/11919, together with a bug where duplicate items were displayed on the items tracking result:
- Adding xdoc comments on public interfaces;
- Fixing some wording and other minor fixes;
- Removing duplicate items when displaying references. 

## Test
- Reference the same items in several different places;
- Make sure all the references appear;
- Make sure that when this item is part of bulk deletion/unpublishing or when deleting/unpublishing the parent of the item, it doesn't appear several times in the result since it has more than 1 reference.