### PR TITLE
Add a basic oEmbedProvider for LottieFiles animations

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -118,7 +118,8 @@ namespace Umbraco.Cms.Core.DependencyInjection
                 .Append<Soundcloud>()
                 .Append<Issuu>()
                 .Append<Hulu>()
-                .Append<Giphy>();
+                .Append<Giphy>()
+                .Append<LottieFiles>();
             builder.SearchableTrees().Add(() => builder.TypeLoader.GetTypes<ISearchableTree>());
             builder.BackOfficeAssets();
         }

--- a/src/Umbraco.Core/Media/EmbedProviders/LottieFiles.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/LottieFiles.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Cms.Core.Media.EmbedProviders
+{
+    /// <summary>
+    /// Embed Provider for lottiefiles.com the popular opensource JSON-based animation format platform.
+    /// </summary>
+    public class LottieFiles : OEmbedProviderBase
+    {
+        public LottieFiles(IJsonSerializer jsonSerializer) : base(jsonSerializer)
+        {
+
+        }
+
+        public override string ApiEndpoint => "https://embed.lottiefiles.com/oembed";
+
+        public override string[] UrlSchemeRegex => new string[]
+        {
+            @"lottiefiles\.com/*"
+        };
+        public override Dictionary<string, string> RequestParams => new Dictionary<string, string>();
+
+        public override string GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
+        {
+            var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
+            OEmbedResponse oembed = base.GetJsonResponse<OEmbedResponse>(requestUrl);
+            var html = oembed.GetHtml();
+            //LottieFiles doesn't seem to support maxwidth and maxheight via oembed
+            // this is therefore a hack... with regexes.. is that ok? HtmlAgility etc etc
+            // otherwise it always defaults to 300...
+            if (maxWidth > 0 && maxHeight > 0)
+            {
+
+                html = Regex.Replace(html, "width=\"([0-9]{1,4})\"", "width=\"" + maxWidth + "\"");
+                html = Regex.Replace(html, "height=\"([0-9]{1,4})\"", "height=\"" + maxHeight + "\"");
+
+            }
+            else
+            {
+                //if set to 0, let's default to 100% as an easter egg
+                html = Regex.Replace(html, "width=\"([0-9]{1,4})\"", "width=\"100%\"");
+                html = Regex.Replace(html, "height=\"([0-9]{1,4})\"", "height=\"100%\"");
+            }
+            return html;
+        }
+
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

LottieFiles (https://lottiefiles.com/) - The popular opensource JSON-based animation file format that enables designers to ship animations on any platform, has just started supporting OEmbed, from their gallery of community animations, which makes it a lovely candidate for adding an OEmbedProvider to Umbraco's Embed functionality for LottieFiles.

I was going to create a package for this but then it would be called Our.Umbraco.Lottie and I think that would be confusing for people, as they consider Our Umbraco Lottie to be @LottePitcher ... so I think therefore it MUST go in the core.

How to test?

Visit the LottieFiles gallery of 'free animations'

https://lottiefiles.com/featured

![picklottiefile](https://user-images.githubusercontent.com/260802/158972839-b07624b6-7cb3-4247-b1b2-f1a163fe0743.gif)

search and find the animation you want to embed, on the right hand side there is a panel of information about the animation, and one of the options is to copy the oEmbedUrl

grab that

Go back into Umbraco, and then inside a grid cell or Rich Text Area, click on the Embed option.

paste in the Oembed Url

Delight at seeing an animation in the embed panel

update your width and height as needs be...

Select and publish your page - your animation will appear!

![lottiefilespigeon](https://user-images.githubusercontent.com/260802/158972880-36abd81f-c171-4a3d-8423-805b4dabdd08.gif)

There is really lots more you can do with LottieFiles, and I'm sure someone will build a package to take advantage of the options, and allow you to upload the JSON into the media section etc, but for the timebeing, adding the oEmbedProvider might help spread the word about it's existence...

This PR just adds a new LottieFiles OEmbedProvider, and adds it to the stack of providers in the Umbraco Builder.

While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.

Thanks for considering this contributing to Umbraco CMS!
