### PR TITLE
Making `AddUmbracoOptions` extension method public

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
     public static partial class UmbracoBuilderExtensions
     {
 
-        private static IUmbracoBuilder AddUmbracoOptions<TOptions>(this IUmbracoBuilder builder, Action<OptionsBuilder<TOptions>> configure = null)
+        public static IUmbracoBuilder AddUmbracoOptions<TOptions>(this IUmbracoBuilder builder, Action<OptionsBuilder<TOptions>> configure = null)
             where TOptions : class
         {
             var umbracoOptionsAttribute = typeof(TOptions).GetCustomAttribute<UmbracoOptionsAttribute>();


### PR DESCRIPTION
In Umbraco 9, the `AddUmbracoOptions` extension method is currently private, meaning only Umbraco can use it.

I think the method is also useful to package developers and site implementers as well. For instance, I've now implemented similar logic in a number of our packages. But instead of re-inventing the wheel, maybe this method could just be public for others to use as well?

I noticed that that the method signature has changed slightly since v9.0.0. This is of course totally fine for internal methods, but going forward, by making the method public, it would be another area of Umbraco where HQ need to make sure not to introduce breaking changes, so this could be seen as a downside to making it public 😮 
