### PR TITLE
Fix obsolete constructor in RecurringHostedServiceBase

### DIFF
--- a/src/Umbraco.Core/StaticApplicationLogging.cs
+++ b/src/Umbraco.Core/StaticApplicationLogging.cs
@@ -6,18 +6,14 @@ namespace Umbraco.Cms.Core
 {
     public static class StaticApplicationLogging
     {
-        private static ILoggerFactory _loggerFactory;
+        private static ILoggerFactory s_loggerFactory;
 
-        public static void Initialize(ILoggerFactory loggerFactory)
-        {
-            _loggerFactory = loggerFactory;
-        }
+        public static void Initialize(ILoggerFactory loggerFactory) => s_loggerFactory = loggerFactory;
 
         public static ILogger<object> Logger => CreateLogger<object>();
 
-        public static ILogger<T> CreateLogger<T>()
-        {
-            return _loggerFactory?.CreateLogger<T>() ?? NullLoggerFactory.Instance.CreateLogger<T>();
-        }
+        public static ILogger<T> CreateLogger<T>() => s_loggerFactory?.CreateLogger<T>() ?? NullLoggerFactory.Instance.CreateLogger<T>();
+
+        public static ILogger CreateLogger(Type type) => s_loggerFactory?.CreateLogger(type) ?? NullLogger.Instance;
     }
 }

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
+using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         // Scheduled for removal in V11
         [Obsolete("Please use constructor that takes an ILogger instead")]
         protected RecurringHostedServiceBase(TimeSpan period, TimeSpan delay)
-            : this(NullLogger.Instance, period, delay)
+            : this(null, period, delay)
         { }
 
         /// <inheritdoc/>
@@ -78,7 +78,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unhandled exception in recurring hosted service.");
+                ILogger logger = _logger ?? StaticApplicationLogging.CreateLogger(GetType());
+                logger.LogError(ex, "Unhandled exception in recurring hosted service.");
             }
             finally
             {

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Web.Common.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices
 {
@@ -46,11 +45,8 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
         // Scheduled for removal in V11
         [Obsolete("Please use constructor that takes an ILogger instead")]
         protected RecurringHostedServiceBase(TimeSpan period, TimeSpan delay)
-        {
-            _period = period;
-            _delay = delay;
-            _logger = StaticServiceProvider.Instance.GetRequiredService<ILoggerFactory>().CreateLogger(GetType());
-        }
+            : this(NullLogger.Instance, period, delay)
+        { }
 
         /// <inheritdoc/>
         public Task StartAsync(CancellationToken cancellationToken)
@@ -108,7 +104,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices
             {
                 if (disposing)
                 {
-                     _timer?.Dispose();
+                    _timer?.Dispose();
                 }
 
                 _disposedValue = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12170.

### Description
There's a regression in 9.4 when you've inheriting from `RecurringHostedServiceBase` and using the previous (now obsoleted) constructor, because the `StaticServiceProvider.Instance` is still `null` here:

https://github.com/umbraco/Umbraco-CMS/blob/7114c564da5f0b753e2f42d01a4a1cf4e08d78fb/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs#L52

This is because it's set when the `IRuntime` is started, which is also an `IHostedService` and resolved from the service provider at the same time:

https://github.com/umbraco/Umbraco-CMS/blob/864fd2a45a6afba067cc2d03cafed0d54b602889/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs#L159

I've first tried fixing this by using the `NullLogger` in the constructor instead, but that wouldn't log any exceptions, so I've resorted to creating the missing logger just before trying to use it...