### PR TITLE
Porting fix from #12109

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             {
                 var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>().MaxNumber;
 
-                if (inter == null)
+                if (string.IsNullOrWhiteSpace(inter?.ToString()))
                 {
                     return maxNumber == 1 ? null : Enumerable.Empty<Link>();
                 }


### PR DESCRIPTION
Possible NullReferenceException in MultiUrlPickerValueConverter, seems to work for v8 too with bugging Multi Url Pickers in Doc Type Grid Editor.

If there's an existing issue for this PR then this fixes #12109