### PR TITLE
Only show groups the user has access to

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.controller.js
@@ -26,7 +26,7 @@
             userService.getCurrentUser().then(function(user) {
                 currentUser = user;
                 // Get usergroups
-                userGroupsResource.getUserGroups({ onlyCurrentUserGroups: false }).then(function (userGroups) {
+                userGroupsResource.getUserGroups().then(function (userGroups) {
 
                     // only allow editing and selection if user is member of the group or admin
                     vm.userGroups = _.map(userGroups, function (ug) {


### PR DESCRIPTION
Currently users can see groups they don't have access to.
This PR will fix this based on the suggestion made by [lbras](https://github.com/lbras) in issue #12168

### Prerequisites

- [x] I have added steps to test this contribution in the description below

There's an existing issue for this PR:  #12168

### How to test

- Create a user
- Assign him a group that has access to the User section
- Login as the created user go to the User section, open the Groups list and make sure he can only see Groups he has access to
- For more detail see #12168
