### PR TITLE
Fix MultiUrlPickerValueConvert IsValue function

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Snapshot;
 
-        public override bool? IsValue(object value, PropertyValueLevel level) => value?.ToString() != "[]";
+        public override bool? IsValue(object value, PropertyValueLevel level) => value != null && value.ToString() != "[]";
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview) => source?.ToString();
 


### PR DESCRIPTION
Fixing issue #12186 by adding an additional null check

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### How to test
- Make sure there are 2 languages, for example Dutch, with fallback to English.
- Add culture variant property to documenttype with Multi Url Picker type.
- Create node in Dutch, don't fill the newly added property
-  Publish
- Go to English and pick random node to property
-  Publish
-  Publish
-  In the view try to get value for property: Model.Value<IEnumerable<Umbraco.Cms.Core.Models.Link>>("newProperty", "nl", Culture, fallback: Fallback.ToLanguage)
- this should show the value of the english language

For more information see #12186 