### PR TITLE
Get lang files via FileProviders (and support Razor Class Libraries) 

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -116,31 +116,13 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
         private static LocalizedTextServiceFileSources SourcesFactory(IServiceProvider container)
         {
             var hostingEnvironment = container.GetRequiredService<IHostingEnvironment>();
-            var globalSettings = container.GetRequiredService<IOptions<GlobalSettings>>().Value;
             var mainLangFolder = new DirectoryInfo(hostingEnvironment.MapPathContentRoot(WebPath.Combine(Constants.SystemDirectories.Umbraco, "config", "lang")));
-            var appPlugins = new DirectoryInfo(hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.AppPlugins));
-            var configLangFolder = new DirectoryInfo(hostingEnvironment.MapPathContentRoot(WebPath.Combine(Constants.SystemDirectories.Config, "lang")));
-
-            var pluginLangFolders = appPlugins.Exists == false
-                ? Enumerable.Empty<LocalizedTextServiceSupplementaryFileSource>()
-                : appPlugins.GetDirectories()
-                    // Check for both Lang & lang to support case sensitive file systems.
-                    .SelectMany(x => x.GetDirectories("?ang", SearchOption.AllDirectories).Where(x => x.Name.InvariantEquals("lang")))
-                    .SelectMany(x => x.GetFiles("*.xml", SearchOption.TopDirectoryOnly))
-                    .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, false));
-
-            // user defined langs that overwrite the default, these should not be used by plugin creators
-            var userLangFolders = configLangFolder.Exists == false
-                ? Enumerable.Empty<LocalizedTextServiceSupplementaryFileSource>()
-                : configLangFolder
-                    .GetFiles("*.user.xml", SearchOption.TopDirectoryOnly)
-                    .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, true));
 
             return new LocalizedTextServiceFileSources(
                 container.GetRequiredService<ILogger<LocalizedTextServiceFileSources>>(),
                 container.GetRequiredService<AppCaches>(),
                 mainLangFolder,
-                pluginLangFolders.Concat(userLangFolders));
+                container.GetServices<LocalizedTextServiceSupplementaryFileSource>());
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services.Implement;
+
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="IUmbracoBuilder"/> for the Umbraco back office
+    /// </summary>
+    public static partial class UmbracoBuilderExtensions
+    {
+        /// <summary>
+        ///  Add the SupplementaryLocalizedTextFilesSources 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        private static IUmbracoBuilder AddSupplemenataryLocalizedTextFileSources(this IUmbracoBuilder builder)
+        {
+            builder.Services.AddTransient(sp =>
+            {
+                return GetSupplementaryFileSources(
+                    sp.GetRequiredService<IHostingEnvironment>(),
+                    sp.GetRequiredService<IWebHostEnvironment>());
+            });
+
+            return builder;
+        }
+
+
+        /// <summary>
+        ///  Loads the suplimentary localization files from plugins and user config
+        /// </summary>
+        private static IEnumerable<LocalizedTextServiceSupplementaryFileSource> GetSupplementaryFileSources(
+            IHostingEnvironment hostingEnvironment,
+            IWebHostEnvironment webHostEnvironment)
+        {
+            var webFileProvider = webHostEnvironment.WebRootFileProvider;
+            var contentFileProvider = webHostEnvironment.ContentRootFileProvider;
+
+            // plugins in /app_plugins
+            var pluginLangFolders = GetPluginLanguageFileSources(contentFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
+
+            // files in /wwwroot/app_plugins (or any virtual location that maps to this)
+            var razorPluginFolders = GetPluginLanguageFileSources(webFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
+
+            // user defined langs that overwrite the default, these should not be used by plugin creators
+            var configLangFolder = new DirectoryInfo(hostingEnvironment.MapPathContentRoot(WebPath.Combine(Cms.Core.Constants.SystemDirectories.Config, "lang")));
+
+            var userLangFolders = configLangFolder.Exists == false
+                ? Enumerable.Empty<LocalizedTextServiceSupplementaryFileSource>()
+                : configLangFolder
+                    .GetFiles("*.user.xml", SearchOption.TopDirectoryOnly)
+                    .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, true));
+
+            // returned in order where userLangFolders takes precedence over plugins
+            return pluginLangFolders
+                .Concat(razorPluginFolders)
+                .Concat(userLangFolders);
+        }
+
+
+        /// <summary>
+        ///  Loads the suplimentary localaization files via the file provider.
+        /// </summary>
+        /// <remarks>
+        ///  locates all *.xml files in the lang folder of any sub folder of the one provided.
+        ///  e.g /app_plugins/plugin-name/lang/*.xml
+        /// </remarks>
+        private static IEnumerable<LocalizedTextServiceSupplementaryFileSource> GetPluginLanguageFileSources(
+            IFileProvider fileProvider, string folder, bool overwriteCoreKeys)
+        {
+            // locate all the *.xml files inside Lang folders inside folders of the main folder
+            // e.g. /app_plugins/plugin-name/lang/*.xml
+
+            return fileProvider.GetDirectoryContents(folder)
+                .Where(x => x.IsDirectory)
+                .SelectMany(x => fileProvider.GetDirectoryContents(WebPath.Combine(folder, x.Name)))
+                .Where(x => x.IsDirectory && x.Name.InvariantEquals("lang"))
+                .Select(x => new DirectoryInfo(x.PhysicalPath))
+                .SelectMany(x => x.GetFiles("*.xml", SearchOption.TopDirectoryOnly))
+                .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, overwriteCoreKeys));
+        }
+    }
+}

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -7,11 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Services.Implement;
-
-using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Extensions
 {

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -56,7 +56,8 @@ namespace Umbraco.Extensions
                 .AddLogViewer()
                 .AddExamine()
                 .AddExamineIndexes()
-                .AddControllersWithAmbiguousConstructors();
+                .AddControllersWithAmbiguousConstructors()
+                .AddSupplemenataryLocalizedTextFileSources();
 
         public static IUmbracoBuilder AddUnattendedInstallInstallCreateUser(this IUmbracoBuilder builder)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Issue #11986  

Uses the WebHost FileProviders to get the files
this means they don't have to be in the physical root of the site and can be in other places,
so Razor class libraries which use a virtual path provider can be loaded along side files on the site

For testing - i have checked : 

- [x] physical path `/App_Plugins/plugin-name/lang/` 
- [x] physical path `/config/lang/en-us.user.xml`
- [x] razor class libraries :
    - [x]  during dev (linked project so files are in `/path-to-project/wwwroot/lang`
    - [x]  referenced via a nuget file `%userprofile%/.nuget/package/version/staticassets/lang`
 - [x] published site
   - [x]  razor files are physically on site `/wwwroot/app_plugins/plugin-name/lang`

# How to test. 

## Testing on a site in main solution: 
- Place a lang xml file (like the example below) in to the following locations 
    - /App_Plugins/Test/lang/en-us.xml
    - /config/lang/en-us.user.xml
    - /wwwroot/app_plugins/text/lang/en-us.xml

when you load the back office you shoud see the values in the `LocalizedText` file returned by umbraco (viewed via the browser console)
    
## Testing on a new project 
_Building the nuget packages for Umbraco and then starting a new site with dotnet new / package-ref_

- check the tests as above 

To check razor class libraries (RCL) work : 
- create a new Razor Class library project - which has the language file in `wwwroot/lang`, 
- add `<StaticWebAssetBasePath>App_Plugins/RazorPackageTest</StaticWebAssetBasePath>` to the RCL's .csproj file.
- add a project reference to the RCL in your website project. 

### During development (package is linked files are served out of the local nuget cache)
- when loading the umbraco back office the changes from the xml file will be visible (again in LocalizedText). 

### When a site is published (package files are put into the project folder structure). 
- Publish the site. 
- the published site (default `bin/debug/framework/published`) will have the files from the RCL in the `wwwroot/app_plugins/pluginname` folder. 

_Sample lang file for testing_
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<language alias="en" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
	<creator>
		<name>Umbraco</name>
		<link>https://umbraco.com</link>
	</creator>
	<area alias="custom">
		<key alias="testHello">Test Hello string</key>
	</area>
</language>
```


