### PR TITLE
Fix issue - changing a document type broke the nucache data structure

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/ContentStore.cs
@@ -433,10 +433,18 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 refreshedIdsA.Contains(x.ContentTypeId) &&
                 BuildKit(x, out _)))
             {
-                // replacing the node: must preserve the parents
+                // replacing the node: must preserve the relations
                 var node = GetHead(_contentNodes, kit.Node.Id)?.Value;
                 if (node != null)
+                {
+                    // Preserve children
                     kit.Node.FirstChildContentId = node.FirstChildContentId;
+                    kit.Node.LastChildContentId = node.LastChildContentId;
+
+                    // Also preserve siblings
+                    kit.Node.NextSiblingContentId = node.NextSiblingContentId;
+                    kit.Node.PreviousSiblingContentId = node.PreviousSiblingContentId;
+                }
 
                 SetValueLocked(_contentNodes, kit.Node.Id, kit.Node);
 


### PR DESCRIPTION
Closes #12110

## Steps to reproduce for brand new install

1) Checkout a v8 branch e.g. v8/8.18
2) Ensure models builder mode isn't PureLive i.e. set the following appsetting in `web.config` **IMPORTANT**
```xml
    <add key="Umbraco.ModelsBuilder.ModelsMode" value="Nothing"/>
```
3) Add the following demo controller to project
```csharp
public class DemoController : UmbracoApiController
{
    [HttpGet]
    public IHttpActionResult Demo()
    {
        var rootNodes = Current.PublishedSnapshot.Content.GetAtRoot();

        return Ok(rootNodes.Select(x => x.Id));
    }
}
```
    
4) Run site & create three identical doc types with a single textstring property (DoctypeA, DoctypeB, DoctypeC)
![image](https://user-images.githubusercontent.com/2056399/161283070-9493968e-e9d0-4020-b809-0a70b730befb.png)

4) Allow all of these doc types to be created at root
5) Create 3 content nodes at root, one for each doc type
![image](https://user-images.githubusercontent.com/2056399/161283240-ebe8ef0d-08a3-4111-bf55-8bfb100a7860.png)
6) Visit demo controller - note 3 entries (makes sense)
![image](https://user-images.githubusercontent.com/2056399/161283685-c81f97ee-b23f-4086-848d-e2eba08ac49e.png)
7) In back office alter the property name of the textstring for DoctypeA and save changes (this is a ContentTypeChangeTypes.RefreshMain as opposed to the simpler ContentTypeChangeTypes.RefreshOther)
![image](https://user-images.githubusercontent.com/2056399/161283875-e8f07d08-4760-4e9d-8547-790bcd2e856c.png)
8) Check demo controller again, only 1 node at root WAT?
![image](https://user-images.githubusercontent.com/2056399/161283938-331bf028-2986-49be-af82-68b8780ac0e3.png)

To see fix - checkout this branch, make changes to property names on doc types, then check api controller & confirm still get expected set of results (i.e. 3 id's at root)
