### PR TITLE
v9 - Fix issue - changing a document type broke the nucache data structure

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -443,10 +443,18 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                 refreshedIdsA.Contains(x.ContentTypeId) &&
                 BuildKit(x, out _)))
             {
-                // replacing the node: must preserve the parents
+                // replacing the node: must preserve the relations
                 var node = GetHead(_contentNodes, kit.Node.Id)?.Value;
                 if (node != null)
+                {
+                    // Preserve children
                     kit.Node.FirstChildContentId = node.FirstChildContentId;
+                    kit.Node.LastChildContentId = node.LastChildContentId;
+
+                    // Also preserve siblings
+                    kit.Node.NextSiblingContentId = node.NextSiblingContentId;
+                    kit.Node.PreviousSiblingContentId = node.PreviousSiblingContentId;
+                }
 
                 SetValueLocked(_contentNodes, kit.Node.Id, kit.Node);
 


### PR DESCRIPTION
Cherry picked fix from v8 - see #12208 for details

Steps to repro as before but with v9 style e.g.

```json
{
  "Umbraco": {
    "CMS": {
      "ModelsBuilder": {
          "ModelsMode": "Nothing"
        }
      }
    }
}
```

```csharp
public class DemoController : Controller
{
    private readonly IPublishedSnapshotAccessor _accessor;

    public DemoController(IPublishedSnapshotAccessor accessor)
        => _accessor = accessor;

    [HttpGet("demo")]
    public IActionResult Demo()
    {
        _accessor.TryGetPublishedSnapshot(out var snapshot);
        return Ok(snapshot.Content.GetAtRoot().Select(x => x.Id));
    }
}
```