### PR TITLE
Use icon component for icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-property-file-upload.html
@@ -1,20 +1,17 @@
-﻿<div class="umb-property-file-upload">
+<div class="umb-property-file-upload">
   <ng-form name="vm.fileUploadForm" ng-class="{ 'drag-over': vm.dragover }">
     <input
       type="hidden"
       ng-model="mandatoryValidator"
-      ng-required="vm.required && !vm.files.length"
-    />
+      ng-required="vm.required && !vm.files.length" />
 
     <div
       class="fileinput-button umb-upload-button-big"
-      ng-hide="vm.files.length > 0"
-    >
+      ng-hide="vm.files.length > 0">
       <umb-icon icon="icon-page-up" class="icon"></umb-icon>
       <p><localize key="media_clickToUpload">Click to upload</localize></p>
-      <umb-single-file-upload
-        accept-file-ext="vm.acceptFileExt"
-      ></umb-single-file-upload>
+      <umb-single-file-upload accept-file-ext="vm.acceptFileExt">
+      </umb-single-file-upload>
     </div>
 
     <div ng-if="vm.files.length > 0">
@@ -25,38 +22,31 @@
             source="file.fileSrc"
             name="file.fileName"
             client-side="file.isClientSide"
-            client-side-data="file.fileData"
-          ></umb-media-preview>
+            client-side-data="file.fileData">
+          </umb-media-preview>
         </div>
         <div class="umb-property-file-upload--actions">
           <button
             type="button"
             class="btn btn-link"
             aria-hidden="true"
-            ng-click="vm.clear()"
-          >
-            <i class="icon-trash"></i>
+            ng-click="vm.clear()">
+            <umb-icon icon="icon-trash"></umb-icon>
             <localize key="content_uploadClear">Remove file</localize>
           </button>
           <button
             type="button"
             class="sr-only"
             ng-if="file.isImage"
-            ng-click="vm.clear()"
-          >
-            <localize key="content_uploadClearImageContext"
-              >Click here to remove the image from the media item</localize
-            >
+            ng-click="vm.clear()">
+            <localize key="content_uploadClearImageContext">Click here to remove the image from the media item</localize>
           </button>
           <button
             type="button"
             class="sr-only"
             ng-if="!file.isImage"
-            ng-click="vm.clear()"
-          >
-            <localize key="content_uploadClearFileContext"
-              >Click here to remove the file from the media item</localize
-            >
+            ng-click="vm.clear()">
+            <localize key="content_uploadClearFileContext">Click here to remove the file from the media item</localize>
           </button>
         </div>
       </div>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -300,9 +300,9 @@
                             <div class="umb-package-details__section-title"><localize key="packager_packageExternalSources">External sources</localize></div>
                             <div>
                                 <div class="umb-package-details__information-item" ng-repeat="externalSource in vm.package.externalSources">
-                                    <a class="umb-package-details__link" href="{{ externalSource.url }}" target="_blank" rel="noopener noreferrer">
-                                        <i class="icon-out" aria-hidden="true"></i>
-                                        {{ externalSource.name }}
+                                    <a class="umb-package-details__link" href="{{externalSource.url}}" target="_blank" rel="noopener noreferrer">
+                                        <umb-icon icon="icon-out"></umb-icon>
+                                        {{externalSource.name}}
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I have previous replaced most icons in backoffice to use `<umb-icon>` component, instead of the legacy `<i>` element, which was mainly used/needed for font icons.

However it seems we not have a few of these back in the UI, e.g. in trash icon in file upload component.

![image](https://user-images.githubusercontent.com/2919859/161446880-d697c8c2-51bd-406b-a709-ea1b1b1f1765.png)
