### PR TITLE
12188 - Backoffice memory leak

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1599,6 +1599,11 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 syncContent();
             });
 
+            // When the element is removed from the DOM, we need to terminate
+            // any active watchers to ensure scopes are disposed and do not leak.
+            // No need to sync content as that has already happened.
+            args.editor.on('remove', () => stopWatch());
+
             args.editor.on('ObjectResized', function (e) {
                 var srcAttr = $(e.target).attr("src");
                 var path = srcAttr.split("?")[0];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #12188 

### Description

Navigating around the content tree causes the JS heap to grow without effective garbage collection (refer to the linked issue for more detail). This growth is due to AngularJs scopes not being properly disposed (or AngularJs not being able to dispose those scopes) due to references still existing. 

Seems the worst offender is TinyMCE, where the editor remains on the heap after the parent component has been destroyed, which has a cascade effect, causing other scopes to be retained because they in turn have references to scopes referencing the TinyMCE scope. 

I'm not super well-versed in how this all works, but the solution seems to be straightforward - terminate any listeners set in tinymce.service when the editor is removed. Watchers set on $rootScope may also compound the problem, not sure.

### Verification

To verify, follow the example in #12188 - without these changes, navigate the content section, take a heap snapshot and note the retained items (filtering by 'controller' is useful). Also, note the size of the heap. Repeat again with these changes in place - heap will be small, and stay small, and won't retain lots of garbage.

There are likely other places where similar changes would see improvements, but wanted to keep this PR small and focused to best highlight the impact of the change.
