### PR TITLE
busfy => busy

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -374,7 +374,7 @@
         }
 
         function enableUser() {
-            vm.enableUserButtonState = "busfy";
+            vm.enableUserButtonState = "busy";
             usersResource.enableUsers([vm.user.id]).then(function (data) {
                 vm.user.userState = "Active";
                 setUserDisplayState();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Found a typo in user controller - `busy` was spelled `busfy`. This PR corrects the typo, which will ensure the button state is set correctly when enabling a user.