### PR TITLE
Fix KeepAlive Config so that value from appsettings.json is used

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/KeepAliveSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/KeepAliveSettings.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
     public class KeepAliveSettings
     {
         internal const bool StaticDisableKeepAliveTask = false;
+        internal const string StaticKeepAlivePingUrl = "~/api/keepalive/ping";
 
         /// <summary>
         /// Gets or sets a value indicating whether the keep alive task is disabled.
@@ -22,6 +23,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// <summary>
         /// Gets a value for the keep alive ping URL.
         /// </summary>
-        public string KeepAlivePingUrl => "~/api/keepalive/ping";
+        [DefaultValue(StaticKeepAlivePingUrl)]
+        public string KeepAlivePingUrl { get; set; } = StaticKeepAlivePingUrl;
     }
 }

--- a/src/Umbraco.Core/Configuration/Models/KeepAliveSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/KeepAliveSettings.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         public bool DisableKeepAliveTask { get; set; } = StaticDisableKeepAliveTask;
 
         /// <summary>
-        /// Gets a value for the keep alive ping URL.
+        /// Gets or sets a value for the keep alive ping URL.
         /// </summary>
         [DefaultValue(StaticKeepAlivePingUrl)]
         public string KeepAlivePingUrl { get; set; } = StaticKeepAlivePingUrl;


### PR DESCRIPTION
Fix KeepAlive Config so that value from appsettings.json is used if present

Currently, any value in appsettings.json is ignored