### PR TITLE
Added menu action export/import for dictionary items

### DIFF
--- a/src/Umbraco.Core/Models/DictionaryImportModel.cs
+++ b/src/Umbraco.Core/Models/DictionaryImportModel.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Core.Models
+{
+    [DataContract(Name = "dictionaryImportModel")]
+    public class DictionaryImportModel : INotificationModel
+    {
+        [DataMember(Name = "dictionaryItems")]
+        public List<string> DictionaryItems { get; set; }
+
+        [DataMember(Name = "notifications")]
+        public List<BackOfficeNotification> Notifications { get; } = new List<BackOfficeNotification>();
+
+        [DataMember(Name = "tempFileName")]
+        public string TempFileName { get; set; }
+    }
+}

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -1253,6 +1253,12 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             return ImportDictionaryItems(dictionaryItemElementList, languages, null, userId);
         }
 
+        public IEnumerable<IDictionaryItem> ImportDictionaryItem(XElement dictionaryItemElement, int userId)
+        {
+            var languages = _localizationService.GetAllLanguages().ToList();
+            return ImportDictionaryItem(dictionaryItemElement, languages, null, userId);
+        }
+
         private IReadOnlyList<IDictionaryItem> ImportDictionaryItems(IEnumerable<XElement> dictionaryItemElementList, List<ILanguage> languages, Guid? parentId, int userId)
         {
             var items = new List<IDictionaryItem>();

--- a/src/Umbraco.Web.BackOffice/Controllers/DictionaryController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DictionaryController.cs
@@ -1,21 +1,27 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
+using System.Xml;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Packaging;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Extensions;
@@ -42,6 +48,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly GlobalSettings _globalSettings;
         private readonly ILocalizedTextService _localizedTextService;
         private readonly IUmbracoMapper _umbracoMapper;
+        private readonly IEntityXmlSerializer _serializer;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly PackageDataInstallation _packageDataInstallation;
 
         public DictionaryController(
             ILogger<DictionaryController> logger,
@@ -49,8 +58,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IBackOfficeSecurityAccessor backofficeSecurityAccessor,
             IOptions<GlobalSettings> globalSettings,
             ILocalizedTextService localizedTextService,
-            IUmbracoMapper umbracoMapper
-            )
+            IUmbracoMapper umbracoMapper,
+            IEntityXmlSerializer serializer,
+            IHostingEnvironment hostingEnvironment,
+            PackageDataInstallation packageDataInstallation)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
@@ -58,6 +69,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _globalSettings = globalSettings.Value ?? throw new ArgumentNullException(nameof(globalSettings));
             _localizedTextService = localizedTextService ?? throw new ArgumentNullException(nameof(localizedTextService));
             _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
+            _packageDataInstallation = packageDataInstallation ?? throw new ArgumentNullException(nameof(packageDataInstallation));
         }
 
         /// <summary>
@@ -346,6 +360,102 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                 GetChildItemsForList(childItem, level + 1, list);
             }
+        }
+
+        public IActionResult ExportDictionary(int id, bool includeChildren = false)
+        {
+            var dictionaryItem = _localizationService.GetDictionaryItemById(id);
+            if (dictionaryItem == null)
+                throw new NullReferenceException("No dictionary item found with id " + id);
+
+            var xml = _serializer.Serialize(dictionaryItem, includeChildren);
+
+            var fileName = $"{dictionaryItem.ItemKey}.udt";
+            // Set custom header so umbRequestHelper.downloadFile can save the correct filename
+            HttpContext.Response.Headers.Add("x-filename", fileName);
+
+            return File(Encoding.UTF8.GetBytes(xml.ToDataString()), MediaTypeNames.Application.Octet, fileName);
+        }
+
+        public IActionResult ImportDictionary(string file)
+        {
+            var filePath = Path.Combine(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.Data), file);
+            if (string.IsNullOrEmpty(file) || !System.IO.File.Exists(filePath))
+                return NotFound();
+
+            var xd = new XmlDocument { XmlResolver = null };
+            xd.Load(filePath);
+
+            var userId = _backofficeSecurityAccessor.BackOfficeSecurity.GetUserId().ResultOr(0);
+            var element = XElement.Parse(xd.InnerXml);
+
+            var dictionaryItems = _packageDataInstallation.ImportDictionaryItem(element, userId);
+
+            // Try to clean up the temporary file.
+            try
+            {
+                System.IO.File.Delete(filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error cleaning up temporary udt file in {File}", filePath);
+            }
+
+            var model = _umbracoMapper.Map<IDictionaryItem, DictionaryDisplay>(dictionaryItems.FirstOrDefault());
+
+            return Content(model.Path, MediaTypeNames.Text.Plain, Encoding.UTF8);
+        }
+
+        public ActionResult<DictionaryImportModel> Upload(IFormFile file)
+        {
+            var model = new DictionaryImportModel()
+            {
+                DictionaryItems = new List<string>()
+            };
+
+            var fileName = file.FileName.Trim(Constants.CharArrays.DoubleQuote);
+            var ext = fileName.Substring(fileName.LastIndexOf('.') + 1).ToLower();
+            var root = _hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads);
+            var tempPath = Path.Combine(root, fileName);
+
+            if (Path.GetFullPath(tempPath).StartsWith(Path.GetFullPath(root)))
+            {
+                using (var stream = System.IO.File.Create(tempPath))
+                {
+                    file.CopyToAsync(stream).GetAwaiter().GetResult();
+                }
+
+                if (ext.InvariantEquals("udt"))
+                {
+                    model.TempFileName = Path.Combine(root, fileName);
+
+                    var xd = new XmlDocument
+                    {
+                        XmlResolver = null
+                    };
+                    xd.Load(model.TempFileName);
+
+                    if (xd.DocumentElement != null)
+                        foreach (XmlNode dictionaryItem in xd.GetElementsByTagName("DictionaryItem"))
+                            model.DictionaryItems.Add(dictionaryItem.Attributes.GetNamedItem("Name")?.Value);
+                }
+                else
+                {
+                    model.Notifications.Add(new BackOfficeNotification(
+                        _localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                        _localizedTextService.Localize("media", "disallowedFileType"),
+                        NotificationStyle.Warning));
+                }
+            }
+            else
+            {
+                model.Notifications.Add(new BackOfficeNotification(
+                    _localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                    _localizedTextService.Localize("media", "invalidFileName"),
+                    NotificationStyle.Warning));
+            }
+
+            return model;
         }
 
         private static Func<IDictionaryItem, string> ItemSort() => item => item.ItemKey;

--- a/src/Umbraco.Web.BackOffice/Trees/DictionaryTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/DictionaryTreeController.cs
@@ -127,8 +127,23 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
 
             if (id != Constants.System.RootString)
             {
-                menu.Items.Add<ActionDelete>(LocalizedTextService, true, opensDialog: true);
                 menu.Items.Add<ActionMove>(LocalizedTextService, true, opensDialog: true);
+                menu.Items.Add(new MenuItem("export", LocalizedTextService)
+                {
+                    Icon = "download-alt",
+                    SeparatorBefore = true,
+                    OpensDialog = true
+                });
+                menu.Items.Add<ActionDelete>(LocalizedTextService, true, opensDialog: true);
+            }
+            else
+            {
+                menu.Items.Add(new MenuItem("import", LocalizedTextService)
+                {
+                    Icon = "page-up",
+                    SeparatorBefore = true,
+                    OpensDialog = true
+                });
             }
 
 

--- a/src/Umbraco.Web.UI.Client/src/common/resources/dictionary.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/dictionary.resource.js
@@ -3,7 +3,7 @@
     * @name umbraco.resources.dictionaryResource
     * @description Loads in data for dictionary items
 **/
-function dictionaryResource($q, $http, $location, umbRequestHelper, umbDataFormatter) {
+function dictionaryResource($q, $http, $location, localizationService, umbRequestHelper, umbDataFormatter) {
 
   /**
          * @ngdoc method
@@ -160,6 +160,76 @@ function dictionaryResource($q, $http, $location, umbRequestHelper, umbDataForma
             "Failed to save data for dictionary id " + dictionary.id);
     }
 
+      /**
+        * @ngdoc method
+        * @name umbraco.resources.dictionaryResource#export
+        * @methodOf umbraco.resources.dictionaryResource
+        *
+        * @description
+        * Export dictionary items of a given id.
+        *
+        * ##usage
+        * <pre>
+        * dictionaryResource.exportItem(1234){
+        *    .then(function() {
+        *       Do stuff..
+        *    });
+        * </pre>
+        *
+        * @param {Int} id the ID of the dictionary item so export
+        * @param {Bool?} includeChildren if children should also be exported
+        * @returns {Promise} resourcePromise object.
+        *
+        */
+      function exportItem(id, includeChildren) {
+          if (!id) {
+              throw "id cannot be null";
+          }
+
+          var url = umbRequestHelper.getApiUrl("dictionaryApiBaseUrl", "ExportDictionary", { id: id, includeChildren: includeChildren });
+
+          return umbRequestHelper.downloadFile(url).then(function () {
+              localizationService.localize("speechBubbles_dictionaryItemExportedSuccess").then(function(value) {
+                  notificationsService.success(value);
+              });
+          }, function (data) {
+              localizationService.localize("speechBubbles_dictionaryItemExportedError").then(function(value) {
+                  notificationsService.error(value);
+              });
+          });
+      }
+
+    /**
+        * @ngdoc method
+        * @name umbraco.resources.dictionaryResource#import
+        * @methodOf umbraco.resources.dictionaryResource
+        *
+        * @description
+        * Import a dictionary item from a file
+        *
+        * ##usage
+        * <pre>
+        * dictionaryResource.importItem("path to file"){
+        *    .then(function() {
+        *       Do stuff..
+        *    });
+        * </pre>
+        *
+        * @param {String} file path of the file to import
+        * @returns {Promise} resourcePromise object.
+        *
+        */
+    function importItem(file) {
+        if (!file) {
+            throw "file cannot be null";
+        }
+
+        return umbRequestHelper.resourcePromise(
+            $http.post(umbRequestHelper.getApiUrl("dictionaryApiBaseUrl", "ImportDictionary", { file: file })),
+            "Failed to import dictionary item " + file
+        );
+    }
+
     /**
          * @ngdoc method
          * @name umbraco.resources.dictionaryResource#getList
@@ -194,6 +264,8 @@ function dictionaryResource($q, $http, $location, umbRequestHelper, umbDataForma
     getById: getById,
     save: save,
     move: move,
+    exportItem: exportItem,
+    importItem: importItem,
     getList : getList
   };
 

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/export.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/export.controller.js
@@ -1,0 +1,18 @@
+angular.module("umbraco")
+    .controller("Umbraco.Editors.Dictionary.ExportController",
+        function ($scope, dictionaryResource, navigationService) {
+            $scope.includeChildren = false;
+
+            $scope.toggleHandler = function () {
+              $scope.includeChildren = !$scope.includeChildren
+            };
+
+            $scope.export = function () {
+                dictionaryResource.exportItem($scope.currentNode.id, $scope.includeChildren);
+                navigationService.hideMenu();
+            };
+
+            $scope.cancel = function () {
+                navigationService.hideDialog();
+            };
+        });

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/export.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/export.html
@@ -1,0 +1,17 @@
+<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.Dictionary.ExportController">
+  <div class="umb-dialog-body form-horizontal" ng-cloak>
+      <umb-pane>
+        <umb-control-group localize="label" label="@defaultdialogs_includeDescendants">
+          <umb-toggle checked="includeChildren" on-click="toggleHandler()"></umb-toggle>
+        </umb-control-group>
+      </umb-pane>
+  </div>
+  <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+    <button type="button" class="btn btn-link" ng-click="cancel()">
+      <localize key="general_cancel">Cancel</localize>
+    </button>
+    <button class="btn btn-primary" ng-click="export()">
+      <localize key="actions_export">Export</localize>
+    </button>
+  </div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/import.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/import.controller.js
@@ -1,0 +1,81 @@
+angular.module("umbraco")
+  .controller("Umbraco.Editors.Dictionary.ImportController",
+    function ($scope, dictionaryResource, navigationService, Upload, umbRequestHelper) {
+            var vm = this;
+            vm.serverErrorMessage = "";
+            vm.state = "upload";
+            vm.model = {};
+            vm.uploadStatus = "";
+
+            vm.cancelButtonLabel = "cancel";
+
+            $scope.handleFiles = function (files, event, invalidFiles) {
+                if (files && files.length > 0) {
+                    $scope.upload(files[0]);
+                }
+            };
+
+            $scope.upload = function (file) {
+                Upload.upload({
+                  url: umbRequestHelper.getApiUrl("dictionaryApiBaseUrl", "Upload"),
+                    fields: {},
+                    file: file
+                }).success(function (data, status, headers, config) {
+                    if (data.notifications && data.notifications.length > 0) {
+
+                        // set error status on file
+                        vm.uploadStatus = "error";
+
+                        // Throw message back to user with the cause of the error
+                        vm.serverErrorMessage = data.notifications[0].message;
+                    } else {
+                        // set done status on file
+                        vm.uploadStatus = "done";
+                        vm.model = data;
+                        vm.state = "confirm";
+                    }
+                }).error(function (evt, status, headers, config) {
+
+                    // set status done
+                    $scope.uploadStatus = "error";
+
+                    // If file not found, server will return a 404 and display this message
+                    if (status === 404) {
+                        $scope.serverErrorMessage = "File not found";
+                    }
+                    else if (status == 400) {
+                        //it's a validation error
+                        $scope.serverErrorMessage = evt.message;
+                    }
+                    else {
+                        //it's an unhandled error
+                        //if the service returns a detailed error
+                        if (evt.InnerException) {
+                            $scope.serverErrorMessage = evt.InnerException.ExceptionMessage;
+
+                            //Check if its the common "too large file" exception
+                            if (evt.InnerException.StackTrace && evt.InnerException.StackTrace.indexOf("ValidateRequestEntityLength") > 0) {
+                                $scope.serverErrorMessage = "File too large to upload";
+                            }
+
+                        } else if (evt.Message) {
+                            $scope.serverErrorMessage = evt.Message;
+                        }
+                    }
+                });
+            };
+
+            $scope.import = function () {
+                dictionaryResource.importItem(vm.model.tempFileName).then(function (path) {
+                    navigationService.syncTree({ tree: "dictionary", path: path, forceReload: true, activate: false });
+      
+                    vm.state = "done";
+                    vm.cancelButtonLabel = "general_close";
+                });         
+            };
+
+            $scope.close = function () {
+                navigationService.hideDialog();
+            };
+
+        });

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/import.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/import.html
@@ -1,0 +1,57 @@
+<div class="umb-dialog" ng-controller="Umbraco.Editors.Dictionary.ImportController as vm">
+
+  <div class="umb-dialog-body with-footer">
+    <div class="umb-pane">
+      <div ng-if="vm.state === 'upload'">
+        <p>
+          <localize key="dictionary_importDictionaryItemHelp">
+            To import a Dictionary item, find the '.udt' file on your computer by clicking the 'Import' button (you'll be
+            asked for confirmation on the next screen)
+          </localize>
+        </p>
+
+        <form name="importDictionaryItem">
+
+          <!-- Select files -->
+          <button accept=".udt"
+                  class="btn btn-action"
+                  name="file"
+                  ng-model="filesHolder"
+                  ngf-change="handleFiles($files, $event, $invalidFiles)"
+                  ngf-multiple="true"
+                  ngf-pattern="*.udt"
+                  ngf-select>
+            <localize key="general_import">Import</localize>
+          </button>
+        </form>
+
+        <div ng-if="importDoctype.file.$error.pattern">Please choose a .udt file to import</div>
+
+      </div>
+      <div ng-if="vm.state === 'confirm'">
+        <strong>
+          <localize key="dictionaryListCaption">Dictionary items</localize>
+          :
+        </strong>
+        <span ng-repeat="dictionaryItem in vm.model.dictionaryItems"><br />{{dictionaryItem}}</span>       
+        <br/>
+        <br/>
+        <button class="btn btn-primary" ng-click="import()">
+          <localize key="actions_importDocumentType">Import</localize>
+        </button>
+      </div>
+      <div ng-if="vm.state === 'done'">
+        <strong> The following dictionary item(s) has been imported!</strong>
+        <span ng-repeat="dictionaryItem in vm.model.dictionaryItems"><br />{{dictionaryItem}}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+    <umb-button action="close()"
+                button-style="link"
+                label-key="{{vm.cancelButtonLabel}}"
+                type="button">
+    </umb-button>
+  </div>
+</div>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en.xml
@@ -569,6 +569,10 @@
     <key alias="deletingALayout">Modifying layout will result in loss of data for any existing content that is based on this configuration.</key>
   </area>
   <area alias="dictionary">
+    <key alias="importDictionaryItemHelp">
+      To import a dictionary item, find the ".udt" file on your computer by clicking the
+      "Import" button (you'll be asked for confirmation on the next screen)
+    </key>
     <key alias="itemDoesNotExists">Dictionary item does not exist.</key>
     <key alias="parentDoesNotExists">Parent item does not exist.</key>
     <key alias="noItems">There are no dictionary items.</key>
@@ -1582,6 +1586,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="resendInviteSuccess">Invitation has been re-sent to %0%</key>
     <key alias="documentTypeExportedSuccess">Document Type was exported to file</key>
     <key alias="documentTypeExportedError">An error occurred while exporting the Document Type</key>
+    <key alias="dictionaryItemExportedSuccess">Dictionary item(s) was exported to file</key>
+    <key alias="dictionaryItemExportedError">An error occurred while exporting the dictionary item(s)</key>
     <key alias="publishWithNoDomains">Domains are not configured for multilingual site, please contact an administrator,
       see log for more information
     </key>

--- a/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/umbraco/config/lang/en_us.xml
@@ -579,6 +579,10 @@
     <key alias="deletingALayout">Modifying layout will result in loss of data for any existing content that is based on this configuration.</key>
   </area>
   <area alias="dictionary">
+    <key alias="importDictionaryItemHelp">
+      To import a dictionary item, find the ".udt" file on your computer by clicking the
+      "Import" button (you'll be asked for confirmation on the next screen)
+    </key>
     <key alias="itemDoesNotExists">Dictionary item does not exist.</key>
     <key alias="parentDoesNotExists">Parent item does not exist.</key>
     <key alias="noItems">There are no dictionary items.</key>
@@ -1620,6 +1624,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="contentCultureValidationError">Validation failed for language '%0%'</key>
     <key alias="documentTypeExportedSuccess">Document Type was exported to file</key>
     <key alias="documentTypeExportedError">An error occurred while exporting the Document Type</key>
+    <key alias="dictionaryItemExportedSuccess">Dictionary item(s) was exported to file</key>
+    <key alias="dictionaryItemExportedError">An error occurred while exporting the dictionary item(s)</key>
     <key alias="scheduleErrReleaseDate1">The release date cannot be in the past</key>
     <key alias="scheduleErrReleaseDate2">Cannot schedule the document for publishing since the required '%0%' is not
       published


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I tend to work with dictionaries. And as of right now there is no simple to export dictionaries from1 site to another. By being able to export and import dictionaries you can easily export default dictionary such as "cookie consent", "read more" etc etc. And then import them to the desired site.

Back in Umbraco 8. You would have to create a package and then install it on the desired site. But I noticed that if you have a well organized dictionary list and then install them. All items would end up in the root. (I don't know if this is happening in. Umbraco 9)
