### PR TITLE
fix: #12254 - returning emptyresult from previewcontroller enterpreview

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
@@ -131,7 +131,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             var user = _backofficeSecurityAccessor.BackOfficeSecurity.CurrentUser;
             _cookieManager.SetCookieValue(Constants.Web.PreviewCookieName, "preview");
 
-            return null;
+            return new EmptyResult();
         }
 
         public ActionResult End(string redir = null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Please read about this on MSDN: https://docs.microsoft.com/en-us/dotnet/api/system.web.mvc.emptyresult?view=aspnet-mvc-5.2 

<!-- Thanks for contributing to Umbraco CMS! -->
