### PR TITLE
Fixes RedirectToUmbracoPageResult to handle redirects to pages with domains defined on them

### DIFF
--- a/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
+++ b/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
@@ -122,8 +123,17 @@ namespace Umbraco.Cms.Web.Website.ActionResults
             }
 
             HttpContext httpContext = context.HttpContext;
-            IIOHelper ioHelper = httpContext.RequestServices.GetRequiredService<IIOHelper>();
-            string destinationUrl = ioHelper.ResolveUrl(Url);
+
+            string destinationUrl;
+            if (IsUrlAbsolute(Url))
+            {
+                destinationUrl = Url;
+            }
+            else
+            {
+                IHostingEnvironment ioHelper = httpContext.RequestServices.GetRequiredService<IHostingEnvironment>();
+                destinationUrl = ioHelper.ToAbsolute(Url);
+            }
 
             if (_queryString.HasValue)
             {
@@ -135,5 +145,6 @@ namespace Umbraco.Cms.Web.Website.ActionResults
             return Task.CompletedTask;
         }
 
+        private static bool IsUrlAbsolute(string url) => url.Contains("//");
     }
 }

--- a/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
+++ b/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
@@ -123,17 +123,8 @@ namespace Umbraco.Cms.Web.Website.ActionResults
             }
 
             HttpContext httpContext = context.HttpContext;
-
-            string destinationUrl;
-            if (IsUrlAbsolute(Url))
-            {
-                destinationUrl = Url;
-            }
-            else
-            {
-                IHostingEnvironment hostingEnvironment = httpContext.RequestServices.GetRequiredService<IHostingEnvironment>();
-                destinationUrl = hostingEnvironment.ToAbsolute(Url);
-            }
+            var urlHelper = httpContext.RequestServices.GetRequiredService<IUrlHelper>();
+            string destinationUrl = urlHelper.Content(Url);
 
             if (_queryString.HasValue)
             {
@@ -144,7 +135,5 @@ namespace Umbraco.Cms.Web.Website.ActionResults
 
             return Task.CompletedTask;
         }
-
-        private static bool IsUrlAbsolute(string url) => url.Contains("//");
     }
 }

--- a/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
+++ b/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
@@ -2,10 +2,9 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Hosting;
-using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
@@ -123,7 +122,8 @@ namespace Umbraco.Cms.Web.Website.ActionResults
             }
 
             HttpContext httpContext = context.HttpContext;
-            var urlHelper = httpContext.RequestServices.GetRequiredService<IUrlHelper>();
+            IUrlHelperFactory urlHelperFactory = httpContext.RequestServices.GetRequiredService<IUrlHelperFactory>();
+            IUrlHelper urlHelper = urlHelperFactory.GetUrlHelper(context);
             string destinationUrl = urlHelper.Content(Url);
 
             if (_queryString.HasValue)

--- a/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
+++ b/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
@@ -131,8 +131,8 @@ namespace Umbraco.Cms.Web.Website.ActionResults
             }
             else
             {
-                IHostingEnvironment ioHelper = httpContext.RequestServices.GetRequiredService<IHostingEnvironment>();
-                destinationUrl = ioHelper.ToAbsolute(Url);
+                IHostingEnvironment hostingEnvironment = httpContext.RequestServices.GetRequiredService<IHostingEnvironment>();
+                destinationUrl = hostingEnvironment.ToAbsolute(Url);
             }
 
             if (_queryString.HasValue)


### PR DESCRIPTION
Fixes #12258.

To Test:

- Following the reproduction steps described on the issue, and confirm that the redirect occurs as expected whether or not a domain is defined.
- Check that providing a querystring (e.g. with the code below) works too with both pages with domains defined and those without.

```
    var querystring = QueryString.Create("foo", "bar");
    return RedirectToUmbracoPage(Guid.Parse("f62a9934-0491-439c-9a04-f2562a597718"), querystring);
```
