### PR TITLE
Ignore the views folder apart from required files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,10 @@ src/Umbraco.Web.UI/wwwroot/[Uu]mbraco/lib/*
 src/Umbraco.Web.UI/wwwroot/[Uu]mbraco/views/*
 src/Umbraco.Web.UI/wwwroot/Media/*
 src/Umbraco.Web.UI/Smidge/
+src/Umbraco.Web.UI/Views/
+!src/Umbraco.Web.UI/Views/Partials/blocklist/
+!src/Umbraco.Web.UI/Views/Partials/grid/
+!src/Umbraco.Web.UI/Views/_ViewImports.cshtml
 
 # Tests
 cypress.env.json

--- a/templates/Umbraco.Templates.nuspec
+++ b/templates/Umbraco.Templates.nuspec
@@ -23,6 +23,8 @@
       <file src="UmbracoProject\**" target="UmbracoProject" exclude="bin;obj" />
       <file src="..\src\Umbraco.Web.UI\Program.cs" target="UmbracoProject" />
       <file src="..\src\Umbraco.Web.UI\Startup.cs" target="UmbracoProject" />
-      <file src="..\src\Umbraco.Web.UI\Views\**" target="UmbracoProject\Views" />
+      <file src="..\src\Umbraco.Web.UI\Views\Partials\blocklist\**" target="UmbracoProject\Views\Partials\blocklist" />
+      <file src="..\src\Umbraco.Web.UI\Views\Partials\grid\**" target="UmbracoProject\Views\Partials\grid" />
+      <file src="..\src\Umbraco.Web.UI\Views\_ViewImports.cshtml" target="UmbracoProject\Views\_ViewImports.cshtml" />
   </files>
 </package>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When locally debugging Umbraco, I always boot it up and install the starter kit (or some other package with views). When I switch branches though, I do a proper clean (`git reset && git clean -df && git checkout -- . `) before checking out a new branch. This means the custom views of the starter kit / other package get deleted. 

I've always thought this was because of a package reinstall, but it turns out it's because of the branch switching! In this PR we're ignoring the whole Views folder, except for the required files that we do need in there for blocklist, grid and the default ViewImports. Now when switching branches (I do this anywhere between 2 and 30 times a day!) I don't have to jump through hoops to restore the views to be able to test something. 
Also, I don't have to be scared of losing some test code that I dropped into a view, which is even more important, I've wasted so much time losing that bit of test code just because I switched branches 😓 

To test, make changes in `_ViewImports.cshtml` and any of the files in `Partials/grid` and `Partials/grid` and `Partials/grid/editors` If you try to do a git commit (obviously, don't actually commit your changes) you'll see that the changes are being tracked. However, add any new .cshtml files (install the starter kit!) and note that those are not going to be commited to git. 

