### PR TITLE
added option to disable automatic expand of single nc item

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/NestedContentConfiguration.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Show the Element Type icons.")]
         public bool ShowIcons { get; set; } = true;
 
-        [ConfigurationField("expandsOnLoad", "Expands on load", "boolean", Description = "First item is automatically expanded")]
+        [ConfigurationField("expandsOnLoad", "Expands on load", "boolean", Description = "A single item is automatically expanded")]
         public bool ExpandsOnLoad { get; set; } = true;
 
         [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Hide the property label and let the item list span the full width of the editor window.")]

--- a/src/Umbraco.Core/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/NestedContentConfiguration.cs
@@ -23,6 +23,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
         [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Show the Element Type icons.")]
         public bool ShowIcons { get; set; } = true;
 
+        [ConfigurationField("expandsOnLoad", "Expands on load", "boolean", Description = "Item is automatically expanded when there is one max item available")]
+        public bool ExpandsOnLoad { get; set; } = true;
+
         [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Hide the property label and let the item list span the full width of the editor window.")]
         public bool HideLabel { get; set; }
 

--- a/src/Umbraco.Core/PropertyEditors/NestedContentConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/NestedContentConfiguration.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         [ConfigurationField("showIcons", "Show Icons", "boolean", Description = "Show the Element Type icons.")]
         public bool ShowIcons { get; set; } = true;
 
-        [ConfigurationField("expandsOnLoad", "Expands on load", "boolean", Description = "Item is automatically expanded when there is one max item available")]
+        [ConfigurationField("expandsOnLoad", "Expands on load", "boolean", Description = "First item is automatically expanded")]
         public bool ExpandsOnLoad { get; set; } = true;
 
         [ConfigurationField("hideLabel", "Hide Label", "boolean", Description = "Hide the property label and let the item list span the full width of the editor window.")]

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -1,4 +1,4 @@
-﻿(function () {
+(function () {
     'use strict';
 
     /**
@@ -93,7 +93,8 @@
         if (vm.maxItems === 0)
             vm.maxItems = 1000;
 
-        vm.singleMode = vm.minItems === 1 && vm.maxItems === 1 && model.config.contentTypes.length === 1;;
+        vm.singleMode = vm.minItems === 1 && vm.maxItems === 1 && model.config.contentTypes.length === 1;
+        vm.expandsOnLoad = Object.toBoolean(model.config.expandsOnLoad)
         vm.showIcons = Object.toBoolean(model.config.showIcons);
         vm.wideMode = Object.toBoolean(model.config.hideLabel);
         vm.hasContentTypes = model.config.contentTypes.length > 0;
@@ -617,7 +618,7 @@
             }
 
             // If there is only one item, set it as current node
-            if (vm.singleMode || (vm.nodes.length === 1 && vm.maxItems === 1)) {
+            if (vm.singleMode || (vm.expandsOnLoad && vm.nodes.length === 1 && vm.maxItems === 1)) {
                 setCurrentNode(vm.nodes[0], false);
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -617,8 +617,8 @@
                 modelWasChanged = true;
             }
 
-            // If there is only one item, set it as current node
-            if (vm.singleMode || (vm.expandsOnLoad && vm.nodes.length === 1 && vm.maxItems === 1)) {
+            // If there is only one item and expandsOnLoad property is true, set it as current node
+            if (vm.singleMode || (vm.expandsOnLoad && vm.nodes.length === 1)) {
                 setCurrentNode(vm.nodes[0], false);
             }
 


### PR DESCRIPTION
This feature is a reimplementation of PR: https://github.com/umbraco/Umbraco-CMS/pull/9883 of @patrickdemooij9 to add an option to disable nested content automatically expanding if the max items is set to 1 and the slider is turned off.
Visual of how this works is posted in attached closed PR.

Can be checked with:

- Create a new nested content with min 0, max 1.
- Whenever you open it on a node, it will automatically open if you have an item in it.
- If you uncheck the new option, it'll not automatically open on load.