### PR TITLE
Grid editors not working on Linux frontend

### DIFF
--- a/src/Umbraco.Web.UI/Views/Partials/grid/editors/base.cshtml
+++ b/src/Umbraco.Web.UI/Views/Partials/grid/editors/base.cshtml
@@ -15,7 +15,7 @@ catch (Exception ex)
     public static string EditorView(dynamic contentItem)
     {
         string view = contentItem.editor.render != null ? contentItem.editor.render.ToString() : contentItem.editor.view.ToString();
-        view = view.ToLower().Replace(".html", ".cshtml");
+        view = view.Replace(".html", ".cshtml");
 
         if (!view.Contains("/"))
         {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12262

### Prerequisites

- [x] I have added steps to test this contribution in the description below
- [x] Make a grid editor in App_Plugins add content & view it. Host on Linux.

If there's an existing issue for this PR then this fixes [https://github.com/umbraco/Umbraco-CMS/issues/12262]

### Description
Pretty small change - remove the ToLower() when finding the path to a grid editor so it works on Linux.


<!-- Thanks for contributing to Umbraco CMS! -->
