### PR TITLE
V9: Fix member properties always being sensitive

### DIFF
--- a/src/Umbraco.Core/Models/MemberType.cs
+++ b/src/Umbraco.Core/Models/MemberType.cs
@@ -161,7 +161,7 @@ namespace Umbraco.Cms.Core.Models
             }
             else
             {
-                var tuple = new MemberTypePropertyProfileAccess(false, false, true);
+                var tuple = new MemberTypePropertyProfileAccess(false, false, value);
                 _memberTypePropertyTypes.Add(propertyTypeAlias, tuple);
             }
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTypeTests.cs
@@ -310,6 +310,33 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
             Debug.Print(json);
         }
 
+        [Test]
+        [TestCase(false, false, false)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, false)]
+        [TestCase(true, true, true)]
+        public void Can_Set_Is_Member_Specific_Property_Type_Options(bool isSensitive, bool canView, bool canEdit)
+        {
+            var propertyTypeAlias = "testType";
+            MemberType memberType = BuildMemberType();
+            var propertyType = new PropertyTypeBuilder()
+                .WithAlias("testType")
+                .Build();
+
+            memberType.AddPropertyType(propertyType);
+
+            memberType.SetIsSensitiveProperty(propertyTypeAlias, isSensitive);
+            memberType.SetMemberCanViewProperty(propertyTypeAlias, canView);
+            memberType.SetMemberCanEditProperty(propertyTypeAlias, canEdit);
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(isSensitive, memberType.IsSensitiveProperty(propertyTypeAlias));
+                Assert.AreEqual(canView, memberType.MemberCanViewProperty(propertyTypeAlias));
+                Assert.AreEqual(canEdit, memberType.MemberCanEditProperty(propertyTypeAlias));
+            });
+        }
+
         private static MemberType BuildMemberType()
         {
             var builder = new MemberTypeBuilder();


### PR DESCRIPTION
Fixes a bug where no matter what custom member properties will always be marked as sensitive (see gif)
![Member property bug](https://user-images.githubusercontent.com/16456704/164425866-b2aed4f2-ca9d-445b-9046-2b019ee49493.gif)


This was caused by a combination of 2 things. 

1. When mapping the content type DTO, "Is sensitive" is always set first
2. If "Is sensitive" was updated as the first custom member acces modifier, a `MemberTypePropertyProfileAccess` will be created and here the `isSensitive` parameter was hardcoded to true, instead of using the `value` parameter


### Testing

Follow the same steps as in the GIF and ensure that "Is Sensitive" is correctly set.