### PR TITLE
Skip surrogate pairs (e.g. emojis) when making clean stings.

### DIFF
--- a/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
+++ b/src/Umbraco.Core/Strings/DefaultShortStringHelper.cs
@@ -345,11 +345,14 @@ namespace Umbraco.Cms.Core.Strings
                 var isUpper = char.IsUpper(c); // false for digits, symbols...
                 //var isLower = char.IsLower(c); // false for digits, symbols...
 
-                // what should I do with surrogates?
-                // no idea, really, so they are not supported at the moment
+                // what should I do with surrogates? - E.g emojis like 🎈
+                // no idea, really, so they are not supported at the moment and we just continue
                 var isPair = char.IsSurrogate(c);
                 if (isPair)
-                    throw new NotSupportedException("Surrogate pairs are not supported.");
+                {
+                    continue;
+                }
+
 
                 switch (state)
                 {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/DefaultShortStringHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/DefaultShortStringHelperTests.cs
@@ -109,6 +109,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         [TestCase("whatIfWeDoItAgain", "whatIfWeDoItAgain")]
         [TestCase("WhatIfWEDOITAgain", "WhatIfWEDOITAgain")]
         [TestCase("WhatIfWe doItAgain", "WhatIfWeDoItAgain")]
+        [TestCase("What if I have emojis 🎈", "WhatIfIHaveEmojis")]
         public void CleanStringForSafeAlias(string input, string expected)
         {
             var output = ShortStringHelper.CleanStringForSafeAlias(input);
@@ -123,6 +124,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         [TestCase("汉#字*/漢?字", "")]
         [TestCase("Réalösk fix bran#lo'sk", "realosk-fix-bran-losk")]
         [TestCase("200 ways to be happy", "200-ways-to-be-happy")]
+        [TestCase("What if I have emojis 🎈", "what-if-i-have-emojis")]
         public void CleanStringForUrlSegment(string input, string expected)
         {
             var output = ShortStringHelper.CleanStringForUrlSegment(input);
@@ -137,6 +139,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         [TestCase("ThisIsTHEEndMyFriendXYZ", "This Is THE End My Friend XYZ")]
         [TestCase("ThisIsTHEEndMyFriendXYZt", "This Is THE End My Friend XY Zt")]
         [TestCase("UneÉlévationÀPartir", "Une Élévation À Partir")]
+        [TestCase("WhatIfIHaveEmojis🎈", "What If I Have Emojis🎈")]
         public void SplitPascalCasing(string input, string expected)
         {
             var output = ShortStringHelper.SplitPascalCasing(input, ' ');
@@ -172,6 +175,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper
         [TestCase("yop.Straße Zvöskî", "yop.strasse-zvoski")]
         [TestCase("yop.Straße Zvös--kî", "yop.strasse-zvos-ki")]
         [TestCase("ma--ma---ma.ma-----ma", "ma-ma-ma.ma-ma")]
+        [TestCase("What if I have emojis 🎈", "what-if-i-have-emojis")]
         public void CleanStringForSafeFileName(string input, string expected)
         {
             var output = ShortStringHelper.CleanStringForSafeFileName(input);


### PR DESCRIPTION
Skip surrogate pairs (e.g. emojis) when making clean stings, instead of throwing exceptions

Fixes https://github.com/umbraco/Umbraco-CMS/issues/12276
