### PR TITLE
Update examine to version 3

### DIFF
--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -22,7 +22,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="3.0.0-beta.6" />
+    <PackageReference Include="Examine" Version="3.0.0-beta.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -22,7 +22,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="3.0.0-beta.5" />
+    <PackageReference Include="Examine" Version="3.0.0-beta.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -22,7 +22,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Examine" Version="2.0.1" />
+    <PackageReference Include="Examine" Version="3.0.0-beta.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
@@ -64,34 +64,34 @@ namespace Umbraco.Cms.Infrastructure.Examine
             // Then we'll index the Value group all together.
             var invalidOrValid = values.GroupBy(v =>
             {
-                if (!v.Values.TryGetValue("path", out List<object>? paths) || paths.Count <= 0 || paths[0] == null)
+                if (!v.Values.TryGetValue("path", out IReadOnlyList<object>? paths) || paths.Count <= 0 || paths[0] == null)
                 {
-                    return ValueSetValidationResult.Failed;
+                    return ValueSetValidationStatus.Failed;
                 }
 
                 ValueSetValidationResult validationResult = ValueSetValidator.Validate(v);
 
-                return validationResult;
+                return validationResult.Status;
             }).ToList();
 
             var hasDeletes = false;
             var hasUpdates = false;
 
             // ordering by descending so that Filtered/Failed processes first
-            foreach (IGrouping<ValueSetValidationResult, ValueSet> group in invalidOrValid.OrderByDescending(x => x.Key))
+            foreach (IGrouping<ValueSetValidationStatus, ValueSet> group in invalidOrValid.OrderByDescending(x => x.Key))
             {
                 switch (group.Key)
                 {
-                    case ValueSetValidationResult.Valid:
+                    case ValueSetValidationStatus.Valid:
                         hasUpdates = true;
 
                         //these are the valid ones, so just index them all at once
                         base.PerformIndexItems(group.ToList(), onComplete);
                         break;
-                    case ValueSetValidationResult.Failed:
+                    case ValueSetValidationStatus.Failed:
                         // don't index anything that is invalid
                         break;
-                    case ValueSetValidationResult.Filtered:
+                    case ValueSetValidationStatus.Filtered:
                         hasDeletes = true;
 
                         // these are the invalid/filtered items so we'll delete them

--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Examine
 {
@@ -112,18 +113,22 @@ namespace Umbraco.Cms.Infrastructure.Examine
         {
             base.OnTransformingIndexValues(e);
 
+            var updatedValues = e.ValueSet.Values.ToDictionary(x => x.Key, x => (IEnumerable<object>) x.Value);
+
             //ensure special __Path field
             var path = e.ValueSet.GetValue("path");
             if (path != null)
             {
-                e.ValueSet.Set(UmbracoExamineFieldNames.IndexPathFieldName, path);
+                updatedValues[UmbracoExamineFieldNames.IndexPathFieldName] = path.Yield();
             }
 
             //icon
             if (e.ValueSet.Values.TryGetValue("icon", out var icon) && e.ValueSet.Values.ContainsKey(UmbracoExamineFieldNames.IconFieldName) == false)
             {
-                e.ValueSet.Values[UmbracoExamineFieldNames.IconFieldName] = icon;
+                updatedValues[UmbracoExamineFieldNames.IconFieldName] = icon;
             }
+
+            e.ValueSet = new ValueSet(e.ValueSet.Id, e.ValueSet.Category, updatedValues);
         }
 
         public Attempt<string?> IsHealthy() => _diagnostics.IsHealthy();

--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
@@ -128,7 +128,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
                 updatedValues[UmbracoExamineFieldNames.IconFieldName] = icon;
             }
 
-            e.ValueSet = new ValueSet(e.ValueSet.Id, e.ValueSet.Category, updatedValues);
+            e.ValueSet = new ValueSet(e.ValueSet.Id, e.ValueSet.Category,e.ValueSet.ItemType, updatedValues);
         }
 
         public Attempt<string?> IsHealthy() => _diagnostics.IsHealthy();

--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
@@ -128,7 +128,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
                 updatedValues[UmbracoExamineFieldNames.IconFieldName] = icon;
             }
 
-            e.ValueSet = new ValueSet(e.ValueSet.Id, e.ValueSet.Category,e.ValueSet.ItemType, updatedValues);
+            e.SetValues(updatedValues);
         }
 
         public Attempt<string?> IsHealthy() => _diagnostics.IsHealthy();

--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
@@ -146,7 +146,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
             if (pathValues[0].ToString().IsNullOrWhiteSpace()) return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
             var path = pathValues[0].ToString();
 
-            var filteredValueSet = new ValueSet(valueSet.Id, valueSet.Category, filteredValues.ToDictionary(x=>x.Key, x=> (object)x.Value));
+            var filteredValueSet = new ValueSet(valueSet.Id, valueSet.Category, valueSet.ItemType, filteredValues.ToDictionary(x=>x.Key, x=> (IEnumerable<object>)x.Value));
             // We need to validate the path of the content based on ParentId, protected content and recycle bin rules.
             // We cannot return FAILED here because we need the value set to get into the indexer and then deal with it from there
             // because we need to remove anything that doesn't pass by protected content in the cases that umbraco data is moved to an illegal parent.

--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
@@ -98,22 +98,24 @@ namespace Umbraco.Cms.Infrastructure.Examine
         public override ValueSetValidationResult Validate(ValueSet valueSet)
         {
             var baseValidate = base.Validate(valueSet);
-            if (baseValidate == ValueSetValidationResult.Failed)
-                return ValueSetValidationResult.Failed;
+            valueSet = baseValidate.ValueSet;
+            if (baseValidate.Status == ValueSetValidationStatus.Failed)
+                return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
 
-            var isFiltered = baseValidate == ValueSetValidationResult.Filtered;
+            var isFiltered = baseValidate.Status == ValueSetValidationStatus.Filtered;
 
+            var filteredValues = valueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
             //check for published content
             if (valueSet.Category == IndexTypes.Content && PublishedValuesOnly)
             {
                 if (!valueSet.Values.TryGetValue(UmbracoExamineFieldNames.PublishedFieldName, out var published))
                 {
-                    return ValueSetValidationResult.Failed;
+                    return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
                 }
 
                 if (!published[0].Equals("y"))
                 {
-                    return ValueSetValidationResult.Failed;
+                    return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
                 }
 
                 //deal with variants, if there are unpublished variants than we need to remove them from the value set
@@ -129,7 +131,7 @@ namespace Umbraco.Cms.Infrastructure.Examine
                             var cultureSuffix = publishField.Key.Substring(publishField.Key.LastIndexOf('_'));
                             foreach (var cultureField in valueSet.Values.Where(x => x.Key.InvariantEndsWith(cultureSuffix)).ToList())
                             {
-                                valueSet.Values.Remove(cultureField.Key);
+                                filteredValues.Remove(cultureField.Key);
                                 isFiltered = true;
                             }
                         }
@@ -138,21 +140,22 @@ namespace Umbraco.Cms.Infrastructure.Examine
             }
 
             //must have a 'path'
-            if (!valueSet.Values.TryGetValue(PathKey, out var pathValues)) return ValueSetValidationResult.Failed;
-            if (pathValues.Count == 0) return ValueSetValidationResult.Failed;
-            if (pathValues[0] == null) return ValueSetValidationResult.Failed;
-            if (pathValues[0].ToString().IsNullOrWhiteSpace()) return ValueSetValidationResult.Failed;
+            if (!valueSet.Values.TryGetValue(PathKey, out var pathValues)) return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
+            if (pathValues.Count == 0) return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
+            if (pathValues[0] == null) return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
+            if (pathValues[0].ToString().IsNullOrWhiteSpace()) return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
             var path = pathValues[0].ToString();
 
+            var filteredValueSet = new ValueSet(valueSet.Id, valueSet.Category, filteredValues.ToDictionary(x=>x.Key, x=> (object)x.Value));
             // We need to validate the path of the content based on ParentId, protected content and recycle bin rules.
             // We cannot return FAILED here because we need the value set to get into the indexer and then deal with it from there
             // because we need to remove anything that doesn't pass by protected content in the cases that umbraco data is moved to an illegal parent.
             if (!ValidatePath(path!, valueSet.Category)
                 || !ValidateRecycleBin(path!, valueSet.Category)
                 || !ValidateProtectedContent(path!, valueSet.Category))
-                return ValueSetValidationResult.Filtered;
+                return new ValueSetValidationResult(ValueSetValidationStatus.Filtered, filteredValueSet);
 
-            return isFiltered ? ValueSetValidationResult.Filtered : ValueSetValidationResult.Valid;
+            return new ValueSetValidationResult(isFiltered ? ValueSetValidationStatus.Filtered : ValueSetValidationStatus.Valid, filteredValueSet);
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Examine/ValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ValueSetValidator.cs
@@ -60,18 +60,19 @@ namespace Umbraco.Cms.Infrastructure.Examine
         public virtual ValueSetValidationResult Validate(ValueSet valueSet)
         {
             if (ValidIndexCategories != null && !ValidIndexCategories.InvariantContains(valueSet.Category))
-                return ValueSetValidationResult.Failed;
+                return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
 
             //check if this document is of a correct type of node type alias
             if (IncludeItemTypes != null && !IncludeItemTypes.InvariantContains(valueSet.ItemType))
-                return ValueSetValidationResult.Failed;
+                return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
 
             //if this node type is part of our exclusion list
             if (ExcludeItemTypes != null && ExcludeItemTypes.InvariantContains(valueSet.ItemType))
-                return ValueSetValidationResult.Failed;
+                return new ValueSetValidationResult(ValueSetValidationStatus.Failed, valueSet);
 
             var isFiltered = false;
 
+            var filteredValues = valueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
             //filter based on the fields provided (if any)
             if (IncludeFields != null || ExcludeFields != null)
             {
@@ -79,20 +80,20 @@ namespace Umbraco.Cms.Infrastructure.Examine
                 {
                     if (IncludeFields != null && !IncludeFields.InvariantContains(key))
                     {
-                        valueSet.Values.Remove(key); //remove any value with a key that doesn't match the inclusion list
+                        filteredValues.Remove(key); //remove any value with a key that doesn't match the inclusion list
                         isFiltered = true;
                     }
 
                     if (ExcludeFields != null && ExcludeFields.InvariantContains(key))
                     {
-                        valueSet.Values.Remove(key); //remove any value with a key that matches the exclusion list
+                        filteredValues.Remove(key); //remove any value with a key that matches the exclusion list
                         isFiltered = true;
                     }
 
                 }
             }
-
-            return isFiltered ? ValueSetValidationResult.Filtered : ValueSetValidationResult.Valid;
+            var filteredValueSet = new ValueSet(valueSet.Id, valueSet.Category, filteredValues.ToDictionary(x=>x.Key, x=> (object)x.Value));
+            return new ValueSetValidationResult(isFiltered ? ValueSetValidationStatus.Filtered : ValueSetValidationStatus.Valid, filteredValueSet);
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Examine/ValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ValueSetValidator.cs
@@ -92,7 +92,8 @@ namespace Umbraco.Cms.Infrastructure.Examine
 
                 }
             }
-            var filteredValueSet = new ValueSet(valueSet.Id, valueSet.Category, filteredValues.ToDictionary(x=>x.Key, x=> (object)x.Value));
+
+            var filteredValueSet = new ValueSet(valueSet.Id, valueSet.Category, valueSet.ItemType, filteredValues.ToDictionary(x => x.Key, x => (IEnumerable<object>)x.Value));
             return new ValueSetValidationResult(isFiltered ? ValueSetValidationStatus.Filtered : ValueSetValidationStatus.Valid, filteredValueSet);
         }
     }

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -53,7 +53,7 @@
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
-      <PackageReference Include="Examine.Core" Version="3.0.0-beta.5" />
+      <PackageReference Include="Examine.Core" Version="3.0.0-beta.6" />
       <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -53,7 +53,7 @@
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
-      <PackageReference Include="Examine.Core" Version="2.0.1" />
+      <PackageReference Include="Examine.Core" Version="3.0.0-beta.5" />
       <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -53,7 +53,7 @@
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
-      <PackageReference Include="Examine.Core" Version="3.0.0-beta.6" />
+      <PackageReference Include="Examine.Core" Version="3.0.0-beta.9" />
       <PackageReference Include="Umbraco.Code" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineExtensions.cs
@@ -83,8 +83,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
             //we will use this as the item type, but we also need to add this as the 'nodeTypeAlias' as part of the properties
             //since this is what Umbraco expects
             var nodeTypeAlias = xml.ExamineNodeTypeAlias();
+
+            allVals["nodeTypeAlias"] = nodeTypeAlias;
             var set = new ValueSet(id, indexCategory, nodeTypeAlias, allVals);
-            set.Set("nodeTypeAlias", nodeTypeAlias);
             return set;
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
                 var values = valueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
                 values["path"] = new List<object> { "-1,999," + valueSet.Id };
                 var newValueSet = new ValueSet(valueSet.Id, valueSet.Category, valueSet.ItemType,
-                    values.ToDictionary(x => x.Key, x => (object)x.Value));
+                    values.ToDictionary(x => x.Key, x => (IEnumerable<object>)x.Value));
                 index.IndexItems(new[] { newValueSet });
                 Assert.AreEqual(1, searcher.CreateQuery().Id(valueSet.Id).Execute().TotalItemCount);
             }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
                 // Change so that it's under 999 and verify
                 var values = valueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
                 values["path"] = new List<object> { "-1,999," + valueSet.Id };
-                var newValueSet = new ValueSet(valueSet.Id, valueSet.Category,
+                var newValueSet = new ValueSet(valueSet.Id, valueSet.Category, valueSet.ItemType,
                     values.ToDictionary(x => x.Key, x => (object)x.Value));
                 index.IndexItems(new[] { newValueSet });
                 Assert.AreEqual(1, searcher.CreateQuery().Id(valueSet.Id).Execute().TotalItemCount);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -43,8 +43,11 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine
                 Assert.AreEqual(0, searcher.CreateQuery().Id(valueSet.Id).Execute().TotalItemCount);
 
                 // Change so that it's under 999 and verify
-                valueSet.Values["path"] = new List<object> { "-1,999," + valueSet.Id };
-                index.IndexItems(new[] { valueSet });
+                var values = valueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
+                values["path"] = new List<object> { "-1,999," + valueSet.Id };
+                var newValueSet = new ValueSet(valueSet.Id, valueSet.Category,
+                    values.ToDictionary(x => x.Key, x => (object)x.Value));
+                index.IndexItems(new[] { newValueSet });
                 Assert.AreEqual(1, searcher.CreateQuery().Id(valueSet.Id).Execute().TotalItemCount);
             }
         }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -84,7 +84,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="3.0.0-beta.5" />
+    <PackageReference Include="Examine.Lucene" Version="3.0.0-beta.6" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
     <PackageReference Include="Bogus" Version="34.0.2" />

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -84,7 +84,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="3.0.0-beta.6" />
+    <PackageReference Include="Examine.Lucene" Version="3.0.0-beta.9" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
     <PackageReference Include="Bogus" Version="34.0.2" />

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -84,7 +84,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine.Lucene" Version="2.0.1" />
+    <PackageReference Include="Examine.Lucene" Version="3.0.0-beta.5" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
     <PackageReference Include="Bogus" Version="34.0.2" />

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
@@ -28,13 +28,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 Mock.Of<IScopeProvider>());
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("777", IndexTypes.Media, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", "invalid-category", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
         }
 
         [Test]
@@ -47,10 +47,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 Mock.Of<IScopeProvider>());
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -64,16 +64,16 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 555);
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,444" }));
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555,777" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555,777,999" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -87,11 +87,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
 
             var valueSet = ValueSet.FromObject("555", IndexTypes.Content, "test-content", new { hello = "world", path = "-1,555", world = "your oyster" });
             ValueSetValidationResult result = validator.Validate(valueSet);
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
-            Assert.IsFalse(valueSet.Values.ContainsKey("path"));
-            Assert.IsTrue(valueSet.Values.ContainsKey("hello"));
-            Assert.IsTrue(valueSet.Values.ContainsKey("world"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("path"));
+            Assert.IsTrue(result.ValueSet.Values.ContainsKey("hello"));
+            Assert.IsTrue(result.ValueSet.Values.ContainsKey("world"));
         }
 
         [Test]
@@ -105,11 +105,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
 
             var valueSet = ValueSet.FromObject("555", IndexTypes.Content, "test-content", new { hello = "world", path = "-1,555", world = "your oyster" });
             ValueSetValidationResult result = validator.Validate(valueSet);
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
-            Assert.IsTrue(valueSet.Values.ContainsKey("path"));
-            Assert.IsFalse(valueSet.Values.ContainsKey("hello"));
-            Assert.IsFalse(valueSet.Values.ContainsKey("world"));
+            Assert.IsTrue(result.ValueSet.Values.ContainsKey("path"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("hello"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("world"));
         }
 
         [Test]
@@ -123,11 +123,11 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
 
             var valueSet = ValueSet.FromObject("555", IndexTypes.Content, "test-content", new { hello = "world", path = "-1,555", world = "your oyster" });
             ValueSetValidationResult result = validator.Validate(valueSet);
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
-            Assert.IsFalse(valueSet.Values.ContainsKey("path"));
-            Assert.IsTrue(valueSet.Values.ContainsKey("hello"));
-            Assert.IsFalse(valueSet.Values.ContainsKey("world"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("path"));
+            Assert.IsTrue(result.ValueSet.Values.ContainsKey("hello"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("world"));
         }
 
         [Test]
@@ -141,13 +141,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 includeItemTypes: new List<string> { "include-content" });
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "test-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "include-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -161,13 +161,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 excludeItemTypes: new List<string> { "exclude-content" });
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "test-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "exclude-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
         }
 
         [Test]
@@ -182,16 +182,16 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 excludeItemTypes: new List<string> { "exclude-content" });
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "test-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "exclude-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, "include-content", new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -204,13 +204,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 Mock.Of<IScopeProvider>());
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,-20,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,-20,555,777" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(new ValueSet(
                 "555",
@@ -221,7 +221,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                     ["path"] = "-1,555",
                     [UmbracoExamineFieldNames.PublishedFieldName] = "y"
                 }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -234,13 +234,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 Mock.Of<IScopeProvider>());
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Media, new { hello = "world", path = "-1,-21,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Media, new { hello = "world", path = "-1,-21,555,777" }));
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Media, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 Mock.Of<IScopeProvider>());
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(new ValueSet(
                 "555",
@@ -264,7 +264,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                     ["path"] = "-1,555",
                     [UmbracoExamineFieldNames.PublishedFieldName] = "n"
                 }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(new ValueSet(
                 "555",
@@ -275,7 +275,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                     ["path"] = "-1,555",
                     [UmbracoExamineFieldNames.PublishedFieldName] = "y"
                 }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
 
         [Test]
@@ -296,7 +296,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                     [UmbracoExamineFieldNames.VariesByCultureFieldName] = "y",
                     [UmbracoExamineFieldNames.PublishedFieldName] = "n"
                 }));
-            Assert.AreEqual(ValueSetValidationResult.Failed, result);
+            Assert.AreEqual(ValueSetValidationStatus.Failed, result.Status);
 
             result = validator.Validate(new ValueSet(
                 "555",
@@ -308,7 +308,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                     [UmbracoExamineFieldNames.VariesByCultureFieldName] = "y",
                     [UmbracoExamineFieldNames.PublishedFieldName] = "y"
                 }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             var valueSet = new ValueSet(
                 "555",
@@ -332,12 +332,12 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
             Assert.IsTrue(valueSet.Values.ContainsKey("title_es-ES"));
 
             result = validator.Validate(valueSet);
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
-            Assert.AreEqual(7, valueSet.Values.Count()); // filtered to 7 values (removes es-es values)
-            Assert.IsFalse(valueSet.Values.ContainsKey($"{UmbracoExamineFieldNames.PublishedFieldName}_es-es"));
-            Assert.IsFalse(valueSet.Values.ContainsKey("hello_es-ES"));
-            Assert.IsFalse(valueSet.Values.ContainsKey("title_es-ES"));
+            Assert.AreEqual(7, result.ValueSet.Values.Count()); // filtered to 7 values (removes es-es values)
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey($"{UmbracoExamineFieldNames.PublishedFieldName}_es-es"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("hello_es-ES"));
+            Assert.IsFalse(result.ValueSet.Values.ContainsKey("title_es-ES"));
         }
 
         [Test]
@@ -355,10 +355,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                 Mock.Of<IScopeProvider>());
 
             ValueSetValidationResult result = validator.Validate(ValueSet.FromObject("555", IndexTypes.Content, new { hello = "world", path = "-1,555" }));
-            Assert.AreEqual(ValueSetValidationResult.Filtered, result);
+            Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
 
             result = validator.Validate(ValueSet.FromObject("777", IndexTypes.Content, new { hello = "world", path = "-1,777" }));
-            Assert.AreEqual(ValueSetValidationResult.Valid, result);
+            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
         }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
@@ -308,7 +308,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine
                     [UmbracoExamineFieldNames.VariesByCultureFieldName] = "y",
                     [UmbracoExamineFieldNames.PublishedFieldName] = "y"
                 }));
-            Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
+             Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
             var valueSet = new ValueSet(
                 "555",


### PR DESCRIPTION
This PR updates examine to version 3.

And fixes the breaking changes..

## Breaking changes:
- Examine 3 breaking changes
   - `ValueSet` immutable. 
   - `ValueSetValidationResult` is renamed to `ValueSetValidationStatus` and `ValueSetValidationResult` is now a type
