### PR TITLE
Limit link picker to content tree in content section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -1,6 +1,6 @@
 //used for the media picker dialog
 angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
-    function ($scope, eventsService, entityResource, mediaResource, mediaHelper, udiParser, userService, localizationService, editorService) {
+    function ($scope, eventsService, entityResource, mediaResource, udiParser, userService, localizationService, editorService) {
 
         var vm = this;
         var dialogOptions = $scope.model;
@@ -20,6 +20,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
                     $scope.model.title = value;
                 });
         }
+        
         $scope.customTreeParams = dialogOptions.dataTypeKey ? "dataTypeKey=" + dialogOptions.dataTypeKey : "";
         $scope.dialogTreeApi = {};
         $scope.model.target = {};

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
@@ -85,6 +85,7 @@
 
                             <div ng-hide="searchInfo.showSearch">
                                 <umb-tree section="content"
+                                          treealias="content"
                                           hideheader="true"
                                           hideoptions="true"
                                           api="dialogTreeApi"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12309

### Description

When having multiple tree root nodes in content section besides default configuration, e.g. moving Content Templates and Dictionary trees, the link picker was showing all trees and not limited to just content tree.

**Before**

![image](https://user-images.githubusercontent.com/2919859/165397163-973b322d-1e0c-4b76-b7e3-c0315d065284.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/165396404-fdd5ad40-13ab-4ef8-b63a-3b3083216ed1.png)

Content Picker / MNTP already restrict the tree picker to content tree here:
https://github.com/umbraco/Umbraco-CMS/blob/v9/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js#L190