### PR TITLE
Updated for v10 - Get lang files via FileProviders (and support Razor Class Libraries)

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Services.AddUnique<IPackagingService, PackagingService>();
             builder.Services.AddUnique<IServerRegistrationService, ServerRegistrationService>();
             builder.Services.AddUnique<ITwoFactorLoginService, TwoFactorLoginService>();
-            builder.Services.AddTransient(SourcesFactory);
+            builder.Services.AddTransient(LocalizedTextServiceFileSourcesFactory);
             builder.Services.AddUnique(factory => CreatePackageRepository(factory, "createdPackages.config"));
             builder.Services.AddUnique<ICreatedPackagesRepository, CreatedPackageSchemaRepository>();
             builder.Services.AddSingleton<PackageDataInstallation>();
@@ -73,7 +73,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
                 factory.GetRequiredService<FileSystems>(),
                 packageRepoFileName);
 
-        private static LocalizedTextServiceFileSources SourcesFactory(IServiceProvider container)
+        private static LocalizedTextServiceFileSources LocalizedTextServiceFileSourcesFactory(IServiceProvider container)
         {
             var hostingEnvironment = container.GetRequiredService<IHostingEnvironment>();
             var mainLangFolder = new DirectoryInfo(hostingEnvironment.MapPathContentRoot(WebPath.Combine(Constants.SystemDirectories.Umbraco, "config", "lang")));

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -97,6 +97,7 @@ namespace Umbraco.Extensions
                     // request all the files out of the path, these will have physicalPath set.
                     var files = fileProvider.GetDirectoryContents(langFolderPath)
                         .Where(x => x.Name.InvariantEndsWith(".xml"))
+                        .Where(x => !string.IsNullOrEmpty(x.PhysicalPath))
                         .Select(x => new FileInfo(x.PhysicalPath))
                         .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, overwriteCoreKeys))
                         .ToList();

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -18,10 +18,8 @@ namespace Umbraco.Extensions
     public static partial class UmbracoBuilderExtensions
     {
         /// <summary>
-        ///  Add the SupplementaryLocalizedTextFilesSources 
+        /// Adds the supplementary localized texxt file sources from the various physical and virtual locations supported.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <returns></returns>
         private static IUmbracoBuilder AddSupplemenataryLocalizedTextFileSources(this IUmbracoBuilder builder)
         {
             builder.Services.AddTransient(sp =>
@@ -40,24 +38,24 @@ namespace Umbraco.Extensions
         private static IEnumerable<LocalizedTextServiceSupplementaryFileSource> GetSupplementaryFileSources(
             IWebHostEnvironment webHostEnvironment)
         {
-            var webFileProvider = webHostEnvironment.WebRootFileProvider;
-            var contentFileProvider = webHostEnvironment.ContentRootFileProvider;
+            IFileProvider webFileProvider = webHostEnvironment.WebRootFileProvider;
+            IFileProvider contentFileProvider = webHostEnvironment.ContentRootFileProvider;
 
             // gets all langs files in /app_plugins real or virtual locations
-            var pluginLangFolders = GetPluginLanguageFileSources(webFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
+            IEnumerable<LocalizedTextServiceSupplementaryFileSource> pluginLangFileSources = GetPluginLanguageFileSources(webFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
 
             // user defined langs that overwrite the default, these should not be used by plugin creators
             var userConfigLangFolder = Cms.Core.Constants.SystemDirectories.Config
                                             .TrimStart(Cms.Core.Constants.CharArrays.Tilde);
 
-            var userLangFolders = contentFileProvider.GetDirectoryContents(userConfigLangFolder)
+            IEnumerable<LocalizedTextServiceSupplementaryFileSource> userLangFileSources = contentFileProvider.GetDirectoryContents(userConfigLangFolder)
                     .Where(x => x.IsDirectory && x.Name.InvariantEquals("lang"))
                     .Select(x => new DirectoryInfo(x.PhysicalPath))
                     .SelectMany(x => x.GetFiles("*.user.xml", SearchOption.TopDirectoryOnly))
                     .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, true));
 
-            return pluginLangFolders
-                .Concat(userLangFolders);
+            return pluginLangFileSources
+                .Concat(userLangFileSources);
         }
 
 
@@ -78,13 +76,13 @@ namespace Umbraco.Extensions
             var pluginFolders = fileProvider.GetDirectoryContents(folder)
                     .Where(x => x.IsDirectory).ToList();
 
-            foreach (var pluginFolder in pluginFolders)
+            foreach (IFileInfo pluginFolder in pluginFolders)
             {
                 // get the full virtual path for the plugin folder
                 var pluginFolderPath = WebPath.Combine(folder, pluginFolder.Name);
 
                 // get any lang folders in this plugin
-                var langFolders = fileProvider.GetDirectoryContents(pluginFolderPath)
+                IEnumerable<IFileInfo> langFolders = fileProvider.GetDirectoryContents(pluginFolderPath)
                     .Where(x => x.IsDirectory && x.Name.InvariantEquals("lang"));
 
                 // loop through the lang folder(s)
@@ -96,8 +94,7 @@ namespace Umbraco.Extensions
 
                     // request all the files out of the path, these will have physicalPath set.
                     var files = fileProvider.GetDirectoryContents(langFolderPath)
-                        .Where(x => x.Name.InvariantEndsWith(".xml"))
-                        .Where(x => !string.IsNullOrEmpty(x.PhysicalPath))
+                        .Where(x => x.Name.InvariantEndsWith(".xml") && !string.IsNullOrEmpty(x.PhysicalPath))
                         .Select(x => new FileInfo(x.PhysicalPath))
                         .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, overwriteCoreKeys))
                         .ToList();


### PR DESCRIPTION
### This is an updated version of PR #12206 - working on .net 6 and for current v10/dev build. 

Turns out in .net 6 - getting directory contents with the Composite file provider on `IWebHostEnvironment `no longer includes the physical path. 

this version of the method builds the path to the lang folder then requests the files directly via the provider to get the physical file locations. 

also in .net 6 the `WebRootFileProvider `returns a complete composite of /app_plugins that includes files in the physical /app_plugins, wwwroot/app_plugins and and files in app_plugins from a razor class library, so there is no longer the need perform the check twice (once for each folder location) as was being done previously

testing as before 

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Issue #11986  

Uses the WebHost FileProviders to get the files
this means they don't have to be in the physical root of the site and can be in other places,
so Razor class libraries which use a virtual path provider can be loaded along side files on the site

For testing - i have checked : 

- [x] physical path `/App_Plugins/plugin-name/lang/` 
- [x] physical path `/config/lang/en-us.user.xml`
- [x] razor class libraries :
    - [x]  during dev (linked project so files are in `/path-to-project/wwwroot/lang`
    - [x]  referenced via a nuget file `%userprofile%/.nuget/package/version/staticassets/lang`
 - [x] published site
   - [x]  razor files are physically on site `/wwwroot/app_plugins/plugin-name/lang`

# How to test. 

## Testing on a site in main solution: 
- Place a lang xml file (like the example below) in to the following locations 
    - /App_Plugins/Test/lang/en-us.xml
    - /config/lang/en-us.user.xml
    - /wwwroot/app_plugins/text/lang/en-us.xml

when you load the back office you should see the values in the `LocalizedText` file returned by umbraco (viewed via the browser console)
    
## Testing on a new project 
_Building the nuget packages for Umbraco and then starting a new site with dotnet new / package-ref_

- check the tests as above 

To check razor class libraries (RCL) work : 
- create a new Razor Class library project - which has the language file in `wwwroot/lang`, 
- add `<StaticWebAssetBasePath>App_Plugins/RazorPackageTest</StaticWebAssetBasePath>` to the RCL's .csproj file.
- add a project reference to the RCL in your website project. 

### During development (package is linked files are served out of the local nuget cache)
- when loading the umbraco back office the changes from the xml file will be visible (again in LocalizedText). 

### When a site is published (package files are put into the project folder structure). 
- Publish the site. 
- the published site (default `bin/debug/framework/published`) will have the files from the RCL in the `wwwroot/app_plugins/pluginname` folder. 

_Sample lang file for testing_
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<language alias="en" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
	<creator>
		<name>Umbraco</name>
		<link>https://umbraco.com</link>
	</creator>
	<area alias="custom">
		<key alias="testHello">Test Hello string</key>
	</area>
</language>
```



