### PR TITLE
v10: Remove LegacyDistinctBy

### DIFF
--- a/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
@@ -75,19 +75,6 @@ namespace Umbraco.Extensions
                     yield return result;
         }
 
-        /// <summary>The legacy distinct by.</summary>
-        /// <param name="source">The source.</param>
-        /// <param name="keySelector">The key selector.</param>
-        /// <typeparam name="TSource">Source type</typeparam>
-        /// <typeparam name="TKey">Key type</typeparam>
-        /// <returns>the unique list</returns>
-        [Obsolete("Use the DistinctBy extension method added in .NET 6 instead.")]
-        public static IEnumerable<TSource> LegacyDistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource?, TKey> keySelector)
-            where TKey : IEquatable<TKey>
-        {
-            return source.Distinct(DelegateEqualityComparer<TSource>.CompareMember(keySelector));
-        }
-
         /// <summary>
         /// Returns a sequence of length <paramref name="count"/> whose elements are the result of invoking <paramref name="factory"/>.
         /// </summary>

--- a/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
@@ -81,6 +81,7 @@ namespace Umbraco.Extensions
         /// <typeparam name="TSource">Source type</typeparam>
         /// <typeparam name="TKey">Key type</typeparam>
         /// <returns>the unique list</returns>
+        [Obsolete("Use the DistinctBy extension method added in .NET 6 instead.")]
         public static IEnumerable<TSource> LegacyDistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource?, TKey> keySelector)
             where TKey : IEquatable<TKey>
         {

--- a/src/Umbraco.Core/Packaging/PackagesRepository.cs
+++ b/src/Umbraco.Core/Packaging/PackagesRepository.cs
@@ -577,7 +577,7 @@ namespace Umbraco.Cms.Core.Packaging
 
                         ////Now, we have all property Ids/Aliases and their referenced document Ids and tags
                         //var allExportedTaggedEntities = allTaggedEntities.Where(x => allExportedIds.Contains(x.EntityId))
-                        //    .LegacyDistinctBy(x => x.EntityId)
+                        //    .DistinctBy(x => x.EntityId)
                         //    .OrderBy(x => x.EntityId);
 
                         //foreach (var taggedEntity in allExportedTaggedEntities)

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -33,55 +29,16 @@ namespace Umbraco.Extensions
             UriUtility uriUtility,
             IPublishedUrlProvider publishedUrlProvider)
         {
-            if (content == null)
-            {
-                throw new ArgumentNullException(nameof(content));
-            }
-
-            if (publishedRouter == null)
-            {
-                throw new ArgumentNullException(nameof(publishedRouter));
-            }
-
-            if (umbracoContext == null)
-            {
-                throw new ArgumentNullException(nameof(umbracoContext));
-            }
-
-            if (localizationService == null)
-            {
-                throw new ArgumentNullException(nameof(localizationService));
-            }
-
-            if (textService == null)
-            {
-                throw new ArgumentNullException(nameof(textService));
-            }
-
-            if (contentService == null)
-            {
-                throw new ArgumentNullException(nameof(contentService));
-            }
-
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            if (publishedUrlProvider == null)
-            {
-                throw new ArgumentNullException(nameof(publishedUrlProvider));
-            }
-
-            if (uriUtility == null)
-            {
-                throw new ArgumentNullException(nameof(uriUtility));
-            }
-
-            if (variationContextAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(variationContextAccessor));
-            }
+            ArgumentNullException.ThrowIfNull(content);
+            ArgumentNullException.ThrowIfNull(publishedRouter);
+            ArgumentNullException.ThrowIfNull(umbracoContext);
+            ArgumentNullException.ThrowIfNull(localizationService);
+            ArgumentNullException.ThrowIfNull(textService);
+            ArgumentNullException.ThrowIfNull(contentService);
+            ArgumentNullException.ThrowIfNull(variationContextAccessor);
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(uriUtility);
+            ArgumentNullException.ThrowIfNull(publishedUrlProvider);
 
             var result = new List<UrlInfo>();
 
@@ -107,9 +64,7 @@ namespace Umbraco.Extensions
 
             // get all URLs for all cultures
             // in a HashSet, so de-duplicates too
-            foreach (UrlInfo cultureUrl in await GetContentUrlsByCultureAsync(content, cultures, publishedRouter,
-                umbracoContext, contentService, textService, variationContextAccessor, logger, uriUtility,
-                publishedUrlProvider))
+            foreach (UrlInfo cultureUrl in await GetContentUrlsByCultureAsync(content, cultures, publishedRouter, umbracoContext, contentService, textService, variationContextAccessor, logger, uriUtility, publishedUrlProvider))
             {
                 urls.Add(cultureUrl);
             }
@@ -120,25 +75,19 @@ namespace Umbraco.Extensions
                 // in some cases there will be the same URL for multiple cultures:
                 // * The entire branch is invariant
                 // * If there are less domain/cultures assigned to the branch than the number of cultures/languages installed
-
                 if (urlGroup.Key)
                 {
-                    result.AddRange(urlGroup.LegacyDistinctBy(x => x!.Text.ToUpperInvariant())
-                        .OrderBy(x => x.Text).ThenBy(x => x.Culture));
+                    result.AddRange(urlGroup.DistinctBy(x => x.Text, StringComparer.OrdinalIgnoreCase).OrderBy(x => x.Text).ThenBy(x => x.Culture));
                 }
                 else
                 {
                     result.AddRange(urlGroup);
                 }
-
-
-
             }
 
             // get the 'other' URLs - ie not what you'd get with GetUrl() but URLs that would route to the document, nevertheless.
             // for these 'other' URLs, we don't check whether they are routable, collide, anything - we just report them.
-            foreach (UrlInfo otherUrl in publishedUrlProvider.GetOtherUrls(content.Id).OrderBy(x => x.Text)
-                .ThenBy(x => x.Culture))
+            foreach (UrlInfo otherUrl in publishedUrlProvider.GetOtherUrls(content.Id).OrderBy(x => x.Text).ThenBy(x => x.Culture))
             {
                 // avoid duplicates
                 if (urls.Add(otherUrl))
@@ -202,8 +151,7 @@ namespace Umbraco.Extensions
                     // got a URL, deal with collisions, add URL
                     default:
                         // detect collisions, etc
-                        Attempt<UrlInfo?> hasCollision = await DetectCollisionAsync(logger, content, url, culture,
-                            umbracoContext, publishedRouter, textService, variationContextAccessor, uriUtility);
+                        Attempt<UrlInfo?> hasCollision = await DetectCollisionAsync(logger, content, url, culture, umbracoContext, publishedRouter, textService, variationContextAccessor, uriUtility);
                         if (hasCollision.Success && hasCollision.Result is not null)
                         {
                             result.Add(hasCollision.Result);
@@ -220,8 +168,7 @@ namespace Umbraco.Extensions
             return result;
         }
 
-        private static UrlInfo HandleCouldNotGetUrl(IContent content, string culture, IContentService contentService,
-            ILocalizedTextService textService)
+        private static UrlInfo HandleCouldNotGetUrl(IContent content, string culture, IContentService contentService, ILocalizedTextService textService)
         {
             // document has a published version yet its URL is "#" => a parent must be
             // unpublished, walk up the tree until we find it, and report.
@@ -229,8 +176,8 @@ namespace Umbraco.Extensions
             do
             {
                 parent = parent.ParentId > 0 ? contentService.GetParent(parent) : null;
-            } while (parent != null && parent.Published &&
-                     (!parent.ContentType.VariesByCulture() || parent.IsCulturePublished(culture)));
+            }
+            while (parent != null && parent.Published && (!parent.ContentType.VariesByCulture() || parent.IsCulturePublished(culture)));
 
             if (parent == null)
             {
@@ -241,18 +188,22 @@ namespace Umbraco.Extensions
             if (!parent.Published)
             {
                 // totally not published
-                return UrlInfo.Message(textService.Localize("content", "parentNotPublished", new[] { parent.Name }),
-                    culture);
+                return UrlInfo.Message(textService.Localize("content", "parentNotPublished", new[] { parent.Name }), culture);
             }
 
             // culture not published
-            return UrlInfo.Message(textService.Localize("content", "parentCultureNotPublished", new[] { parent.Name }),
-                culture);
+            return UrlInfo.Message(textService.Localize("content", "parentCultureNotPublished", new[] { parent.Name }), culture);
         }
 
-        private static async Task<Attempt<UrlInfo?>> DetectCollisionAsync(ILogger logger, IContent content, string url,
-            string culture, IUmbracoContext umbracoContext, IPublishedRouter publishedRouter,
-            ILocalizedTextService textService, IVariationContextAccessor variationContextAccessor,
+        private static async Task<Attempt<UrlInfo?>> DetectCollisionAsync(
+            ILogger logger,
+            IContent content,
+            string url,
+            string culture,
+            IUmbracoContext umbracoContext,
+            IPublishedRouter publishedRouter,
+            ILocalizedTextService textService,
+            IVariationContextAccessor variationContextAccessor,
             UriUtility uriUtility)
         {
             // test for collisions on the 'main' URL
@@ -264,14 +215,11 @@ namespace Umbraco.Extensions
 
             uri = uriUtility.UriToUmbraco(uri);
             IPublishedRequestBuilder builder = await publishedRouter.CreateRequestAsync(uri);
-            IPublishedRequest pcr =
-                await publishedRouter.RouteRequestAsync(builder, new RouteRequestOptions(RouteDirection.Outbound));
+            IPublishedRequest pcr = await publishedRouter.RouteRequestAsync(builder, new RouteRequestOptions(RouteDirection.Outbound));
 
             if (!pcr.HasPublishedContent())
             {
-                const string logMsg = nameof(DetectCollisionAsync) +
-                             " did not resolve a content item for original url: {Url}, translated to {TranslatedUrl} and culture: {Culture}";
-
+                const string logMsg = nameof(DetectCollisionAsync) + " did not resolve a content item for original url: {Url}, translated to {TranslatedUrl} and culture: {Culture}";
                 logger.LogDebug(logMsg, url, uri, culture);
 
                 var urlInfo = UrlInfo.Message(textService.Localize("content", "routeErrorCannotRoute"), culture);

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -623,7 +623,7 @@ namespace Umbraco.Cms.Core.Services
 
                 scope.Notifications.Publish(GetContentTypeChangedNotification(changes, eventMessages));
 
-                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.LegacyDistinctBy(x => x!.Id), eventMessages);
+                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.DistinctBy(x => x.Id), eventMessages);
                 deletedNotification.WithStateFrom(deletingNotification);
                 scope.Notifications.Publish(deletedNotification);
 
@@ -649,9 +649,7 @@ namespace Umbraco.Cms.Core.Services
                 scope.WriteLock(WriteLockIds);
 
                 // all descendants are going to be deleted
-                TItem[] allDescendantsAndSelf = itemsA.SelectMany(xx => GetDescendants(xx.Id, true))
-                    .LegacyDistinctBy(x => x!.Id)
-                    .ToArray();
+                TItem[] allDescendantsAndSelf = itemsA.SelectMany(xx => GetDescendants(xx.Id, true)).DistinctBy(x => x.Id).ToArray();
                 TItem[] deleted = allDescendantsAndSelf;
 
                 // all impacted (through composition) probably lose some properties
@@ -681,7 +679,7 @@ namespace Umbraco.Cms.Core.Services
 
                 scope.Notifications.Publish(GetContentTypeChangedNotification(changes, eventMessages));
 
-                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.LegacyDistinctBy(x => x!.Id), eventMessages);
+                DeletedNotification<TItem> deletedNotification = GetDeletedNotification(deleted.DistinctBy(x => x.Id), eventMessages);
                 deletedNotification.WithStateFrom(deletingNotification);
                 scope.Notifications.Publish(deletedNotification);
 

--- a/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
+++ b/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
@@ -140,6 +140,7 @@ namespace Umbraco.Cms.Core.Manifest
                         scriptsPerBundleOption = new List<ManifestAssets>();
                         scripts[manifest.BundleOptions] = scriptsPerBundleOption;
                     }
+
                     scriptsPerBundleOption.Add(new ManifestAssets(manifest.PackageName, manifest.Scripts));
                 }
 
@@ -150,15 +151,39 @@ namespace Umbraco.Cms.Core.Manifest
                         stylesPerBundleOption = new List<ManifestAssets>();
                         stylesheets[manifest.BundleOptions] = stylesPerBundleOption;
                     }
+
                     stylesPerBundleOption.Add(new ManifestAssets(manifest.PackageName, manifest.Stylesheets));
                 }
 
-                if (manifest.PropertyEditors != null) propertyEditors.AddRange(manifest.PropertyEditors);
-                if (manifest.ParameterEditors != null) parameterEditors.AddRange(manifest.ParameterEditors);
-                if (manifest.GridEditors != null) gridEditors.AddRange(manifest.GridEditors);
-                if (manifest.ContentApps != null) contentApps.AddRange(manifest.ContentApps);
-                if (manifest.Dashboards != null) dashboards.AddRange(manifest.Dashboards);
-                if (manifest.Sections != null) sections.AddRange(manifest.Sections.LegacyDistinctBy(x => x!.Alias.ToLowerInvariant()));
+                if (manifest.PropertyEditors != null)
+                {
+                    propertyEditors.AddRange(manifest.PropertyEditors);
+                }
+
+                if (manifest.ParameterEditors != null)
+                {
+                    parameterEditors.AddRange(manifest.ParameterEditors);
+                }
+
+                if (manifest.GridEditors != null)
+                {
+                    gridEditors.AddRange(manifest.GridEditors);
+                }
+
+                if (manifest.ContentApps != null)
+                {
+                    contentApps.AddRange(manifest.ContentApps);
+                }
+
+                if (manifest.Dashboards != null)
+                {
+                    dashboards.AddRange(manifest.Dashboards);
+                }
+
+                if (manifest.Sections != null)
+                {
+                    sections.AddRange(manifest.Sections.DistinctBy(x => x.Alias, StringComparer.OrdinalIgnoreCase));
+                }
             }
 
             return new CompositePackageManifest(

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/KeysAndIndexes/DeleteKeysAndIndexesBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/KeysAndIndexes/DeleteKeysAndIndexesBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NPoco;
 using Umbraco.Cms.Infrastructure.Migrations.Expressions.Common;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
@@ -44,10 +44,10 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.KeysAndIndexe
             _context.BuildingExpression = false;
 
             //get a list of all constraints - this will include all PK, FK and unique constraints
-            var tableConstraints = _context.SqlContext.SqlSyntax.GetConstraintsPerTable(_context.Database).LegacyDistinctBy(x => x!.Item2).ToList();
+            var tableConstraints = _context.SqlContext.SqlSyntax.GetConstraintsPerTable(_context.Database).DistinctBy(x => x.Item2).ToList();
 
             //get a list of defined indexes - this will include all indexes, unique indexes and unique constraint indexes
-            var indexes = _context.SqlContext.SqlSyntax.GetDefinedIndexesDefinitions(_context.Database).LegacyDistinctBy(x => x!.IndexName).ToList();
+            var indexes = _context.SqlContext.SqlSyntax.GetDefinedIndexesDefinitions(_context.Database).DistinctBy(x => x.IndexName).ToList();
 
             var uniqueConstraintNames = tableConstraints.Where(x => !x.Item2.InvariantStartsWith("PK_") && !x.Item2.InvariantStartsWith("FK_")).Select(x => x.Item2);
             var indexNames = indexes.Select(x => x.IndexName).ToList();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .ForUpdate();
 
             // deduplicate the logins
-            logins = logins.LegacyDistinctBy(x => x!.ProviderKey + x.LoginProvider).ToList();
+            logins = logins.DistinctBy(x => x.ProviderKey + x.LoginProvider).ToList();
 
             var toUpdate = new Dictionary<int, IExternalLogin>();
             var toDelete = new List<int>();
@@ -241,7 +241,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .ToDictionary(x => x.LoginProvider, x => x.Id);
 
             // deduplicate the tokens
-            tokens = tokens.LegacyDistinctBy(x => x!.LoginProvider + x.Name).ToList();
+            tokens = tokens.DistinctBy(x => x.LoginProvider + x.Name).ToList();
 
             var providers = tokens.Select(x => x.LoginProvider).Distinct().ToList();
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -183,7 +183,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .Where<Member2MemberGroupDto>(x => x.Member == memberId);
 
             return Database.Fetch<NodeDto>(sql)
-                .LegacyDistinctBy(dto => dto!.NodeId)
+                .DistinctBy(dto => dto.NodeId)
                 .Select(x => MemberGroupFactory.BuildEntity(x));
         }
 
@@ -200,7 +200,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .Where("cmsMember.LoginName=@loginName", new { loginName = username });
 
             return Database.Fetch<NodeDto>(sql)
-                .LegacyDistinctBy(dto => dto!.NodeId)
+                .DistinctBy(dto => dto.NodeId)
                 .Select(x => MemberGroupFactory.BuildEntity(x));
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -284,7 +284,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         protected override IEnumerable<IUser> PerformGetByQuery(IQuery<IUser> query)
         {
             var dtos = GetDtosWith(sql => new SqlTranslator<IUser>(sql, query).Translate(), true)
-                .LegacyDistinctBy(x => x!.Id)
+                .DistinctBy(x => x.Id)
                 .ToList();
 
             var users = new IUser[dtos.Count];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/11652 updated the target framework to .NET 6 and renamed the existing `DistinctBy` extension method to `LegacyDistinctBy`, because that was clashing with the [one introduced in .NET 6](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.distinctby?view=net-6.0).

I've split the work into 3 commits, so we can optionally cherry-pick/revert parts if we want:
1. Obsolete `LegacyDistinctBy` - users should use the default framework extension method instead
2. Remove usage of `LegacyDistinctBy` - we don't want to use obsolete methods in our own codebase (this also includes some performance enhancements, because you can pass in a custom `IEqualityComparer` to do case insensitive comparisons, instead of converting the key into upper/lowercase)
3. Remove `LegacyDistinctBy` - I noticed this method isn't shipped yet, so it's safe to remove again