### PR TITLE
Bugfix: Reintroduces DefaultItemExcludes in Umbraco.Cms.StaticAssets

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -9,6 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="buildTransitive\**\*.*">
+      <Pack>true</Pack>
+      <PackagePath>buildTransitive</PackagePath>
+    </None>
+  </ItemGroup>
+  
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -34,7 +41,7 @@
     <Message Text="Generate the appsettings json schema." Importance="High" Condition="!Exists('$(JsonSchemaPath)') and '$(UmbracoBuild)' == ''" />
   </Target>
 
-  
+
   <Target Name="BelleBuild">
     <Exec WorkingDirectory="$(ProjectDir)/../Umbraco.Web.UI.Client/" Command="npm ci --no-fund --no-audit --prefer-offline" />
     <Exec WorkingDirectory="$(ProjectDir)/../Umbraco.Web.UI.Client/" Command="npm run build:skip-tests" />
@@ -54,5 +61,27 @@
     <Delete Files="$(JsonSchemaPath)" Condition="Exists('$(JsonSchemaPath)') and !Exists('$(SolutionDir)preserve.jsonschema')" />
   </Target>
 
-  
+
+  <!--
+      The set of files to publish is generated really early and doesn't currently account for files added by targets e.g. BeforeBuild.
+      A fix was put in place in Web SDK to update for wwwwroot in case someone runs npm build etc in a target, we're borrowing their trick.
+      https://github.com/dotnet/sdk/blob/e2b2b1a4ac56c955b84d62fe71cda3b6f258b42b/src/WebSdk/Publish/Targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
+   -->
+  <Target Name="IncludeUmbracoFolderContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
+    <ItemGroup>
+      <_UmbracoFolderFiles Include="umbraco\config\**" />
+      <_UmbracoFolderFiles Include="umbraco\PartialViewMacros\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoBackOffice\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoInstall\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
+      <_UmbracoFolderFiles Include="umbraco\Licenses\**" />
+
+      <!-- This could be handled in deploy if it's not already -->
+      <_UmbracoFolderFiles Include="umbraco\Deploy\**" />
+
+      <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -76,10 +76,6 @@
       <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
       <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
       <_UmbracoFolderFiles Include="umbraco\Licenses\**" />
-
-      <!-- This could be handled in deploy if it's not already -->
-      <_UmbracoFolderFiles Include="umbraco\Deploy\**" />
-
       <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>

--- a/src/Umbraco.Cms.StaticAssets/buildTransitive/Umbraco.Cms.StaticAssets.props
+++ b/src/Umbraco.Cms.StaticAssets/buildTransitive/Umbraco.Cms.StaticAssets.props
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);App_Plugins/**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);umbraco/Data/**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);umbraco/Logs/**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);wwwroot/media/**</DefaultItemExcludes>
+  </PropertyGroup>
+</Project>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -4,7 +4,9 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Umbraco.Cms.Web.UI</RootNamespace>
   </PropertyGroup>
-    
+
+  <Import Project="..\Umbraco.Cms.StaticAssets\buildTransitive\Umbraco.Cms.StaticAssets.props" />
+  
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DocumentationFile>bin/Release/Umbraco.Web.UI.xml</DocumentationFile>
   </PropertyGroup>
@@ -19,7 +21,6 @@
     <ProjectReference Include="../Umbraco.Web.Common/Umbraco.Web.Common.csproj" />
     <ProjectReference Include="../Umbraco.Web.Website/Umbraco.Web.Website.csproj" />
     <ProjectReference Include="..\Umbraco.Cms.StaticAssets\Umbraco.Cms.StaticAssets.csproj" />
-<!--    <ProjectReference Include="../Umbraco.Persistence.SqlCe/Umbraco.Persistence.SqlCe.csproj" Condition="'$(OS)' == 'Windows_NT'" />-->
     <ProjectReference Include="..\Umbraco.PublishedCache.NuCache\Umbraco.PublishedCache.NuCache.csproj" />
     <ProjectReference Include="..\Umbraco.Web.BackOffice\Umbraco.Web.BackOffice.csproj" />
     <ProjectReference Include="..\Umbraco.Web.Common\Umbraco.Web.Common.csproj" />


### PR DESCRIPTION
Reintroduces `DefaultItemExcludes` in Umbraco.Cms.StaticAssets