### PR TITLE
v10: Async support for content finders. Improve loging performance.

### DIFF
--- a/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -42,7 +43,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public bool TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
         {
             if(!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {
@@ -70,7 +71,10 @@ namespace Umbraco.Cms.Core.Routing
 
                 if (nodeId > 0)
                 {
-                    _logger.LogDebug("Id={NodeId}", nodeId);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Id={NodeId}", nodeId);
+                    }
                     node = umbracoContext?.Content?.GetById(nodeId);
 
                     if (node != null)
@@ -86,7 +90,10 @@ namespace Umbraco.Cms.Core.Routing
                         }
 
                         frequest.SetPublishedContent(node);
-                        _logger.LogDebug("Found node with id={PublishedContentId}", node.Id);
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            _logger.LogDebug("Found node with id={PublishedContentId}", node.Id);
+                        }
                     }
                     else
                     {
@@ -97,7 +104,10 @@ namespace Umbraco.Cms.Core.Routing
 
             if (nodeId == -1)
             {
-                _logger.LogDebug("Not a node id");
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Not a node id");
+                }
             }
 
             return node != null;

--- a/src/Umbraco.Core/Routing/ContentFinderByPageIdQuery.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByPageIdQuery.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Threading.Tasks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
@@ -27,7 +28,7 @@ namespace Umbraco.Cms.Core.Routing
         }
 
         /// <inheritdoc/>
-        public bool TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
         {
             if(!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
@@ -33,7 +34,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public virtual bool TryFindContent(IPublishedRequestBuilder frequest)
+        public virtual async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
         {
             if (!UmbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {
@@ -69,18 +70,26 @@ namespace Umbraco.Cms.Core.Routing
             {
                 throw new System.ArgumentNullException(nameof(docreq));
             }
-
-            _logger.LogDebug("Test route {Route}", route);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Test route {Route}", route);
+            }
 
             IPublishedContent? node = umbracoContext.Content?.GetByRoute(umbracoContext.InPreviewMode, route, culture: docreq.Culture);
             if (node != null)
             {
                 docreq.SetPublishedContent(node);
-                _logger.LogDebug("Got content, id={NodeId}", node.Id);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Got content, id={NodeId}", node.Id);
+                }
             }
             else
             {
-                _logger.LogDebug("No match.");
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("No match.");
+                }
             }
 
             return node;

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAlias.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAlias.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -42,7 +43,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public bool TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
         {
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {
@@ -62,7 +63,10 @@ namespace Umbraco.Cms.Core.Routing
                 if (node != null)
                 {
                     frequest.SetPublishedContent(node);
-                    _logger.LogDebug("Path '{UriAbsolutePath}' is an alias for id={PublishedContentId}", frequest.Uri.AbsolutePath, node.Id);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Path '{UriAbsolutePath}' is an alias for id={PublishedContentId}", frequest.Uri.AbsolutePath, node.Id);
+                    }
                 }
             }
 

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -49,7 +50,7 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
         /// <remarks>If successful, also assigns the template.</remarks>
-        public override bool TryFindContent(IPublishedRequestBuilder frequest)
+        public override async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
         {
             var path = frequest.AbsolutePathDecoded;
 
@@ -61,7 +62,10 @@ namespace Umbraco.Cms.Core.Routing
             // no template if "/"
             if (path == "/")
             {
-                _logger.LogDebug("No template in path '/'");
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("No template in path '/'");
+                }
                 return false;
             }
 
@@ -74,11 +78,16 @@ namespace Umbraco.Cms.Core.Routing
 
             if (template == null)
             {
-                _logger.LogDebug("Not a valid template: '{TemplateAlias}'", templateAlias);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Not a valid template: '{TemplateAlias}'", templateAlias);
+                }
                 return false;
             }
-
-            _logger.LogDebug("Valid template: '{TemplateAlias}'", templateAlias);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Valid template: '{TemplateAlias}'", templateAlias);
+            }
 
             // look for node corresponding to the rest of the route
             var route = frequest.Domain != null ? (frequest.Domain.ContentId + path) : path;
@@ -86,7 +95,10 @@ namespace Umbraco.Cms.Core.Routing
 
             if (node == null)
             {
-                _logger.LogDebug("Not a valid route to node: '{Route}'", route);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Not a valid route to node: '{Route}'", route);
+                }
                 return false;
             }
 

--- a/src/Umbraco.Core/Routing/IContentFinder.cs
+++ b/src/Umbraco.Core/Routing/IContentFinder.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Umbraco.Cms.Core.Routing
 {
     /// <summary>
@@ -11,6 +13,6 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="request">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
         /// <remarks>Optionally, can also assign the template or anything else on the document request, although that is not required.</remarks>
-        bool TryFindContent(IPublishedRequestBuilder request);
+        Task<bool> TryFindContent(IPublishedRequestBuilder request);
     }
 }

--- a/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
+++ b/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Examine;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -51,14 +52,16 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public bool TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
         {
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {
                 return false;
             }
-
-            _logger.LogDebug("Looking for a page to handle 404.");
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Looking for a page to handle 404.");
+            }
 
             int? domainContentId = null;
 
@@ -107,17 +110,24 @@ namespace Umbraco.Cms.Core.Routing
 
             if (error404.HasValue)
             {
-                _logger.LogDebug("Got id={ErrorNodeId}.", error404.Value);
-
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Got id={ErrorNodeId}.", error404.Value);
+                }
                 content = umbracoContext.Content?.GetById(error404.Value);
-
-                _logger.LogDebug(content == null
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(content == null
                     ? "Could not find content with that id."
                     : "Found corresponding content.");
+                }
             }
             else
             {
-                _logger.LogDebug("Got nothing.");
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Got nothing.");
+                }
             }
 
             frequest?

--- a/tests/Umbraco.Tests.Common/TestLastChanceFinder.cs
+++ b/tests/Umbraco.Tests.Common/TestLastChanceFinder.cs
@@ -1,12 +1,13 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Threading.Tasks;
 using Umbraco.Cms.Core.Routing;
 
 namespace Umbraco.Cms.Tests.Common
 {
     public class TestLastChanceFinder : IContentLastChanceFinder
     {
-        public bool TryFindContent(IPublishedRequestBuilder frequest) => false;
+        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest) => false;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasTests.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             var lookup =
                 new ContentFinderByUrlAlias(Mock.Of<ILogger<ContentFinderByUrlAlias>>(), Mock.Of<IPublishedValueFallback>(), VariationContextAccessor, umbracoContextAccessor);
 
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasWithDomainsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasWithDomainsTests.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             }
 
             var finder = new ContentFinderByUrlAlias(Mock.Of<ILogger<ContentFinderByUrlAlias>>(), Mock.Of<IPublishedValueFallback>(), VariationContextAccessor, umbracoContextAccessor);
-            var result = finder.TryFindContent(request);
+            var result = await finder.TryFindContent(request);
 
             if (expectedNode > 0)
             {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByIdTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByIdTests.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
                 Mock.Of<ILogger<ContentFinderByIdPath>>(), Mock.Of<IRequestAccessor>(), umbracoContextAccessor);
 
 
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByPageIdQueryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByPageIdQueryTests.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             var lookup = new ContentFinderByPageIdQuery(mockRequestAccessor.Object, umbracoContextAccessor);
 
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAliasTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAliasTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using AutoFixture.NUnit3;
 using Moq;
 using NUnit.Framework;
@@ -24,7 +25,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
         [InlineAutoMoqData("/only/one/alias", 100111)]
         [InlineAutoMoqData("/ONLY/one/Alias", 100111)]
         [InlineAutoMoqData("/alias43", 100121)]
-        public void Lookup_By_Url_Alias (
+        public async Task Lookup_By_Url_Alias (
             string relativeUrl,
             int nodeMatch,
             [Frozen] IPublishedContentCache publishedContentCache,
@@ -54,7 +55,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Mock.Get(variationContextAccessor).Setup(x => x.VariationContext).Returns(variationContext);
             var publishedRequestBuilder = new PublishedRequestBuilder(new Uri(absoluteUrl, UriKind.Absolute), fileService);
             //Act
-            var result = sut.TryFindContent(publishedRequestBuilder);
+            var result = await sut.TryFindContent(publishedRequestBuilder);
 
             Assert.IsTrue(result);
             Assert.AreEqual(publishedRequestBuilder.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAndTemplateTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAndTemplateTests.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
                 umbracoContextAccessor,
                 Mock.Of<IOptionsMonitor<WebRoutingSettings>>(x=>x.CurrentValue == webRoutingSettings));
 
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
 
             IPublishedRequest request = frequest.Build();
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlTests.cs
@@ -63,7 +63,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             if (urlString == "/home/sub1")
                 System.Diagnostics.Debugger.Break();
 
-            var result = lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContent(lookup.frequest);
 
             if (expectedId > 0)
             {
@@ -88,7 +88,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             Assert.IsFalse(GlobalSettings.HideTopLevelNodeFromPath);
 
-            var result = lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContent(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);
@@ -107,7 +107,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             var lookup = await GetContentFinder(urlString);
 
-            var result = lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContent(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);
@@ -132,7 +132,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             lookup.frequest.SetDomain(new DomainAndUri(new Domain(1, "mysite", -1, "en-US", false), new Uri("http://mysite/")));
 
-            var result = lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContent(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);
@@ -158,7 +158,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             lookup.frequest.SetDomain(new DomainAndUri(new Domain(1, "mysite/æøå", -1, "en-US", false), new Uri("http://mysite/æøå")));
 
-            var result = lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContent(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlWithDomainsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlWithDomainsTests.cs
@@ -140,7 +140,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             publishedRouter.FindDomain(frequest);
 
             var lookup = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, frequest.PublishedContent.Id);
         }
@@ -183,7 +183,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Assert.AreEqual(expectedCulture, frequest.Culture);
 
             var lookup = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, frequest.PublishedContent.Id);
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/DomainsAndCulturesTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/DomainsAndCulturesTests.cs
@@ -304,7 +304,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Assert.AreEqual(expectedCulture, frequest.Culture);
 
             var finder = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = finder.TryFindContent(frequest);
+            var result = await finder.TryFindContent(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, expectedNode);
@@ -352,7 +352,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             // find document
             var finder = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = finder.TryFindContent(frequest);
+            var result = await finder.TryFindContent(frequest);
 
             // apply wildcard domain
             publishedRouter.HandleWildcardDomains(frequest);
@@ -388,7 +388,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Assert.AreEqual(expectedCulture, frequest.Culture);
 
             var finder = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = finder.TryFindContent(frequest);
+            var result = await finder.TryFindContent(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, expectedNode);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlsWithNestedDomains.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlsWithNestedDomains.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             // check that it's been routed
             var lookup = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContent(frequest);
             Assert.IsTrue(result);
             Assert.AreEqual(100111, frequest.PublishedContent.Id);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
The published router is async, however the content finders are not. This limits routing scalability as we are unable to use async code to route.
This changes contentfinders to be async, and improves logging by not calling log debug when debug level logging is not enabled, saving on allocations.

How to test?
Existing tests pass.

<!-- Thanks for contributing to Umbraco CMS! -->
