### PR TITLE
Moved StackQueue to correct namespace

### DIFF
--- a/src/Umbraco.Core/Collections/StackQueue.cs
+++ b/src/Umbraco.Core/Collections/StackQueue.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Umbraco.Core.Collections
+﻿namespace Umbraco.Cms.Core.Collections
 {
     /// <summary>
     ///     Collection that can be both a queue and a stack.

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -11,9 +11,9 @@ using Umbraco.Cms.Core.DistributedLocking;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Infrastructure.Persistence;
-using Umbraco.Core.Collections;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Scoping

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Collections/StackQueueTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Collections/StackQueueTests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using Umbraco.Core.Collections;
+using Umbraco.Cms.Core.Collections;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Collections
 {


### PR DESCRIPTION
This was originally merged into v9 without updating the namespace to the new "Umbraco.Cms" pattern.

### Breaking changes:
- `StackQueue` has been moved from `Umbraco.Core.Collections` to `Umbraco.Cms.Core.Collections`  namespace.