### PR TITLE
Update NoUiSlider to 15.6.0

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -35,7 +35,7 @@
         "lazyload-js": "1.0.0",
         "moment": "2.29.3",
         "ng-file-upload": "12.2.13",
-        "nouislider": "15.5.1",
+        "nouislider": "15.6.0",
         "spectrum-colorpicker2": "2.0.9",
         "tinymce": "4.9.11",
         "typeahead.js": "0.11.1",
@@ -11715,9 +11715,9 @@
       }
     },
     "node_modules/nouislider": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.5.1.tgz",
-      "integrity": "sha512-V8LNPhLPXLNjkgXLfyzDRGDeKvzZeaiIx5YagMiHnOMqgcRzT75jqvEZYXbSrEffXouwcEShSd8Vllm2Nkwqew=="
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.6.0.tgz",
+      "integrity": "sha512-YJg+A6RQXTuFqhEwd42FeRaEGMGgDSSNnpIyVtT8XJrNl4VBEUkPI6Yj91bT3JjJIvNYi4VdppWeCV+z2gOnnw=="
     },
     "node_modules/now-and-later": {
       "version": "2.0.1",
@@ -25531,9 +25531,9 @@
       "dev": true
     },
     "nouislider": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.5.1.tgz",
-      "integrity": "sha512-V8LNPhLPXLNjkgXLfyzDRGDeKvzZeaiIx5YagMiHnOMqgcRzT75jqvEZYXbSrEffXouwcEShSd8Vllm2Nkwqew=="
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.6.0.tgz",
+      "integrity": "sha512-YJg+A6RQXTuFqhEwd42FeRaEGMGgDSSNnpIyVtT8XJrNl4VBEUkPI6Yj91bT3JjJIvNYi4VdppWeCV+z2gOnnw=="
     },
     "now-and-later": {
       "version": "2.0.1",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -46,7 +46,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.29.3",
     "ng-file-upload": "12.2.13",
-    "nouislider": "15.5.1",
+    "nouislider": "15.6.0",
     "spectrum-colorpicker2": "2.0.9",
     "tinymce": "4.9.11",
     "typeahead.js": "0.11.1",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This is a continuation of #12348 where the package-lock.json file has been updated and the slider has been tested in the backoffice.

### Description

NoUiSlider v15.6.0 has been released which allow [smooth steps behaviour](https://github.com/leongersen/noUiSlider/releases/tag/15.6.0) combined with steps.

See demo here: https://refreshless.com/nouislider/behaviour-option/#section-smooth-steps

### Screenshots

![nouislider-smooth](https://user-images.githubusercontent.com/752371/166692299-85ad37cd-f448-4dbc-ac20-669a5e513eee.gif)
