### PR TITLE
Reintroduce language files tests

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/EmbeddedResources/LanguageXmlTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/EmbeddedResources/LanguageXmlTests.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.EmbeddedResources
             var xmlDocument = new XmlDocument();
 
             var languageProvider = new EmbeddedFileProvider(typeof(IAssemblyProvider).Assembly, "Umbraco.Cms.Core.EmbeddedResources.Lang");
-            var files = languageProvider .GetDirectoryContents(string.Empty)
+            var files = languageProvider.GetDirectoryContents(string.Empty)
                                     .Where(x => !x.IsDirectory && x.Name.EndsWith(".xml"));
 
             foreach (var languageFile in files)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/EmbeddedResources/LanguageXmlTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/EmbeddedResources/LanguageXmlTests.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Microsoft.Extensions.FileProviders;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.EmbeddedResources
+{
+    [TestFixture]
+    public class LanguageXmlTests
+    {
+        [Test]
+        public void Can_Load_Language_Xml_Files()
+        {
+            var readFilesCount = 0;
+            var xmlDocument = new XmlDocument();
+
+            var languageProvider = new EmbeddedFileProvider(typeof(IAssemblyProvider).Assembly, "Umbraco.Cms.Core.EmbeddedResources.Lang");
+            var files = languageProvider .GetDirectoryContents(string.Empty)
+                                    .Where(x => !x.IsDirectory && x.Name.EndsWith(".xml"));
+
+            foreach (var languageFile in files)
+            {
+                using var stream = new StreamReader(languageFile.CreateReadStream());
+
+                // Load will throw an exception if the XML isn't valid.
+                xmlDocument.Load(stream);
+                readFilesCount++;
+            }
+
+            // Ensure that at least one file was read.
+            Assert.AreNotEqual(0, readFilesCount);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common
         }
 
         [Test]
-        public void LanguageFilesAreLowercase()
+        public void LanguageFilesAreLowerCase()
         {
             var languageProvider = new EmbeddedFileProvider(typeof(IAssemblyProvider).Assembly, "Umbraco.Cms.Core.EmbeddedResources.Lang");
             var files = languageProvider.GetDirectoryContents(string.Empty)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
@@ -8,10 +8,12 @@ using System.Threading.Tasks;
 using AutoFixture.NUnit3;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
@@ -94,6 +96,22 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common
 
             Assert.True(views.Contains(fileName), $"Expected {fileName} to exist, but it didn't");
         }
-        
+
+        [Test]
+        public void LanguageFilesAreLowercase()
+        {
+            var languageProvider = new EmbeddedFileProvider(typeof(IAssemblyProvider).Assembly, "Umbraco.Cms.Core.EmbeddedResources.Lang");
+            var files = languageProvider.GetDirectoryContents(string.Empty)
+                                    .Where(x => !x.IsDirectory && x.Name.EndsWith(".xml"))
+                                    .Select(x => x.Name);
+
+            foreach (var fileName in files)
+            {
+                Assert.AreEqual(
+                    fileName.ToLower(),
+                    fileName,
+                    $"Language files must be all lowercase but {fileName} is not lowercase.");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Details
- Since language files are now embedded resources, this PR reintroduces the language files tests removed in #12324

## Test
- Make sure the tests succeed;
- Make one of the language files located in `~\Umbraco.Core\EmbeddedResources\Lang` folder invalid and verify that the `Can_Load_Language_Xml_Files()` test fails;
- Add a new file in the same folder with an upper case name (ex: _BG.xml_) and verify that the `LanguageFilesAreLowerCase()` test fails with a message: `Language files must be all lowercase but BG.xml is not lowercase.`.