### PR TITLE
Use static global id in pipelines

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -2,6 +2,7 @@ name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd
 variables:
     buildConfiguration: Release
     SA_PASSWORD: UmbracoIntegration123!
+    UMBRACO__CMS_GLOBAL__ID: 00000000-0000-0000-0000-000000000042
     UmbracoBuild: AzurePipeline
     nodeVersion: 14.18.1
 resources:
@@ -271,10 +272,8 @@ stages:
                     gulpFile: src\Umbraco.Web.UI.Client\gulpfile.js
                     targets: build
                     workingDirectory: src\Umbraco.Web.UI.Client
-                - powershell: Start-Process -FilePath "dotnet" -ArgumentList "run", "-p", "src\Umbraco.Web.UI\Umbraco.Web.UI.csproj /Umbraco:CMS:Global:Id=0000000-0000-0000-0000-000000000042"
+                - powershell: Start-Process -FilePath "dotnet" -ArgumentList "run", "--project", "src\Umbraco.Web.UI\Umbraco.Web.UI.csproj"
                   displayName: dotnet run
-#                - powershell: dotnet run --no-build -p .\src\Umbraco.Web.UI\Umbraco.Web.UI.csproj
-#                  displayName: dotnet run
                 - task: PowerShell@1
                   displayName: Generate Cypress.env.json
                   inputs:
@@ -375,7 +374,7 @@ stages:
                   displayName: dotnet run
                   inputs:
                     targetType: 'inline'
-                    script: 'nohup dotnet run --no-build -p ./src/Umbraco.Web.UI/ /Umbraco:CMS:Global:Id=0000000-0000-0000-0000-000000000042 > $(Build.ArtifactStagingDirectory)/dotnet_run_log_linux.txt &'
+                    script: 'nohup dotnet run --no-build --project ./src/Umbraco.Web.UI/ > $(Build.ArtifactStagingDirectory)/dotnet_run_log_linux.txt &'
                 - task: Bash@3
                   displayName: Generate Cypress.env.json
                   inputs:
@@ -500,7 +499,7 @@ stages:
                       testResultsFiles: 'tests/Umbraco.Tests.AcceptanceTest/results/test-output-D-*.xml'
                       mergeTestResults: true
                       testRunTitle: "Test results Desktop"
-              
+
                 - task: PublishPipelineArtifact@1
                   displayName: "Publish test artifacts"
                   inputs:


### PR DESCRIPTION
This PR fixed deprecation warning (-p changed to --project) and sets the global id as an environment variable instead of pushing directly into each ´dotnet run´. Also fixed to use valid guid 🤦 