### PR TITLE
V10: history cleanup cleanup

### DIFF
--- a/src/Umbraco.Core/Models/ContentType.cs
+++ b/src/Umbraco.Core/Models/ContentType.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Models
     /// </summary>
     [Serializable]
     [DataContract(IsReference = true)]
-    public class ContentType : ContentTypeCompositionBase, IContentTypeWithHistoryCleanup
+    public class ContentType : ContentTypeCompositionBase, IContentType
     {
         public const bool SupportsPublishingConst = true;
 

--- a/src/Umbraco.Core/Models/IContentType.cs
+++ b/src/Umbraco.Core/Models/IContentType.cs
@@ -1,22 +1,7 @@
-using System;
-using System.Collections.Generic;
 using Umbraco.Cms.Core.Models.ContentEditing;
 
 namespace Umbraco.Cms.Core.Models
 {
-    /// <summary>
-    /// Defines a content type that contains a history cleanup policy.
-    /// </summary>
-    [Obsolete("This will be merged into IContentType in Umbraco 10.")]
-    public interface IContentTypeWithHistoryCleanup : IContentType
-    {
-        /// <summary>
-        /// Gets or sets the history cleanup configuration.
-        /// </summary>
-        /// <value>The history cleanup configuration.</value>
-        HistoryCleanup? HistoryCleanup { get; set; }
-    }
-
     /// <summary>
     ///     Defines a ContentType, which Content is based on
     /// </summary>
@@ -70,5 +55,11 @@ namespace Umbraco.Cms.Core.Models
         /// <param name="newAlias"></param>
         /// <returns></returns>
         IContentType DeepCloneWithResetIdentities(string newAlias);
+
+        /// <summary>
+        /// Gets or sets the history cleanup configuration.
+        /// </summary>
+        /// <value>The history cleanup configuration.</value>
+        HistoryCleanup? HistoryCleanup { get; set; }
     }
 }

--- a/src/Umbraco.Core/Models/Mapping/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentTypeMapDefinition.cs
@@ -130,11 +130,7 @@ namespace Umbraco.Cms.Core.Models.Mapping
         {
             MapSaveToTypeBase<DocumentTypeSave, PropertyTypeBasic>(source, target, context);
             MapComposition(source, target, alias => _contentTypeService.Get(alias));
-
-            if (target is IContentTypeWithHistoryCleanup targetWithHistoryCleanup)
-            {
-                MapHistoryCleanup(source, targetWithHistoryCleanup);
-            }
+            MapHistoryCleanup(source, target);
 
             target.AllowedTemplates = source.AllowedTemplates?
                 .Where(x => x != null)
@@ -147,7 +143,7 @@ namespace Umbraco.Cms.Core.Models.Mapping
                 : _fileService.GetTemplate(source.DefaultTemplate));
         }
 
-        private static void MapHistoryCleanup(DocumentTypeSave source, IContentTypeWithHistoryCleanup target)
+        private static void MapHistoryCleanup(DocumentTypeSave source, IContentType target)
         {
             // If source history cleanup is null we don't have to map all properties
             if (source.HistoryCleanup is null)
@@ -209,18 +205,15 @@ namespace Umbraco.Cms.Core.Models.Mapping
         {
             MapTypeToDisplayBase<DocumentTypeDisplay, PropertyTypeDisplay>(source, target);
 
-            if (source is IContentTypeWithHistoryCleanup sourceWithHistoryCleanup)
+            target.HistoryCleanup = new HistoryCleanupViewModel
             {
-                target.HistoryCleanup = new HistoryCleanupViewModel
-                {
-                    PreventCleanup = sourceWithHistoryCleanup.HistoryCleanup?.PreventCleanup ?? false,
-                    KeepAllVersionsNewerThanDays = sourceWithHistoryCleanup.HistoryCleanup?.KeepAllVersionsNewerThanDays,
-                    KeepLatestVersionPerDayForDays = sourceWithHistoryCleanup.HistoryCleanup?.KeepLatestVersionPerDayForDays,
-                    GlobalKeepAllVersionsNewerThanDays = _contentSettings.ContentVersionCleanupPolicy.KeepAllVersionsNewerThanDays,
-                    GlobalKeepLatestVersionPerDayForDays = _contentSettings.ContentVersionCleanupPolicy.KeepLatestVersionPerDayForDays,
-                    GlobalEnableCleanup = _contentSettings.ContentVersionCleanupPolicy.EnableCleanup
-                };
-            }
+                PreventCleanup = source.HistoryCleanup?.PreventCleanup ?? false,
+                KeepAllVersionsNewerThanDays = source.HistoryCleanup?.KeepAllVersionsNewerThanDays,
+                KeepLatestVersionPerDayForDays = source.HistoryCleanup?.KeepLatestVersionPerDayForDays,
+                GlobalKeepAllVersionsNewerThanDays = _contentSettings.ContentVersionCleanupPolicy.KeepAllVersionsNewerThanDays,
+                GlobalKeepLatestVersionPerDayForDays = _contentSettings.ContentVersionCleanupPolicy.KeepLatestVersionPerDayForDays,
+                GlobalEnableCleanup = _contentSettings.ContentVersionCleanupPolicy.EnableCleanup
+            };
 
             target.AllowCultureVariant = source.VariesByCulture();
             target.AllowSegmentVariant = source.VariesBySegment();

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -514,9 +514,9 @@ namespace Umbraco.Cms.Core.Services
                 genericProperties,
                 tabs);
 
-            if (contentType is IContentTypeWithHistoryCleanup withCleanup && withCleanup.HistoryCleanup is not null)
+            if (contentType.HistoryCleanup is not null)
             {
-                xml.Add(SerializeCleanupPolicy(withCleanup.HistoryCleanup));
+                xml.Add(SerializeCleanupPolicy(contentType.HistoryCleanup));
             }
 
             var folderNames = string.Empty;

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -885,49 +885,46 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             {
                 UpdateContentTypesAllowedTemplates(contentTypex, infoElement.Element("AllowedTemplates"),
                     defaultTemplateElement);
+
+                UpdateHistoryCleanupPolicy(contentTypex, documentType.Element("HistoryCleanupPolicy"));
             }
 
             UpdateContentTypesPropertyGroups(contentType, documentType.Element("Tabs"));
             UpdateContentTypesProperties(contentType, documentType.Element("GenericProperties"));
 
-            if (contentType is IContentTypeWithHistoryCleanup withCleanup)
-            {
-                UpdateHistoryCleanupPolicy(withCleanup, documentType.Element("HistoryCleanupPolicy"));
-            }
-
             return contentType;
         }
 
-        private void UpdateHistoryCleanupPolicy(IContentTypeWithHistoryCleanup withCleanup, XElement? element)
+        private void UpdateHistoryCleanupPolicy(IContentType contentType, XElement? element)
         {
             if (element == null)
             {
                 return;
             }
 
-            withCleanup.HistoryCleanup ??= new Core.Models.ContentEditing.HistoryCleanup();
+            contentType.HistoryCleanup ??= new Core.Models.ContentEditing.HistoryCleanup();
 
             if (bool.TryParse(element.Attribute("preventCleanup")?.Value, out var preventCleanup))
             {
-                withCleanup.HistoryCleanup.PreventCleanup = preventCleanup;
+                contentType.HistoryCleanup.PreventCleanup = preventCleanup;
             }
 
             if (int.TryParse(element.Attribute("keepAllVersionsNewerThanDays")?.Value, out var keepAll))
             {
-                withCleanup.HistoryCleanup.KeepAllVersionsNewerThanDays = keepAll;
+                contentType.HistoryCleanup.KeepAllVersionsNewerThanDays = keepAll;
             }
             else
             {
-                withCleanup.HistoryCleanup.KeepAllVersionsNewerThanDays = null;
+                contentType.HistoryCleanup.KeepAllVersionsNewerThanDays = null;
             }
 
             if (int.TryParse(element.Attribute("keepLatestVersionPerDayForDays")?.Value, out var keepLatest))
             {
-                withCleanup.HistoryCleanup.KeepLatestVersionPerDayForDays = keepLatest;
+                contentType.HistoryCleanup.KeepLatestVersionPerDayForDays = keepLatest;
             }
             else
             {
-                withCleanup.HistoryCleanup.KeepLatestVersionPerDayForDays = null;
+                contentType.HistoryCleanup.KeepLatestVersionPerDayForDays = null;
             }
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -302,19 +302,15 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             // historyCleanup property is not mandatory for api endpoint, handle the case where it's not present.
             // DocumentTypeSave doesn't handle this for us like ContentType constructors do.
-            if (entity is IContentTypeWithHistoryCleanup entityWithHistoryCleanup)
+            var dto = new ContentVersionCleanupPolicyDto
             {
-                ContentVersionCleanupPolicyDto dto = new ContentVersionCleanupPolicyDto()
-                {
-                    ContentTypeId = entity.Id,
-                    Updated = DateTime.Now,
-                    PreventCleanup = entityWithHistoryCleanup.HistoryCleanup?.PreventCleanup ?? false,
-                    KeepAllVersionsNewerThanDays = entityWithHistoryCleanup.HistoryCleanup?.KeepAllVersionsNewerThanDays,
-                    KeepLatestVersionPerDayForDays = entityWithHistoryCleanup.HistoryCleanup?.KeepLatestVersionPerDayForDays
-                };
-                Database.InsertOrUpdate(dto);
-            }
-
+                ContentTypeId = entity.Id,
+                Updated = DateTime.Now,
+                PreventCleanup = entity.HistoryCleanup?.PreventCleanup ?? false,
+                KeepAllVersionsNewerThanDays = entity.HistoryCleanup?.KeepAllVersionsNewerThanDays,
+                KeepLatestVersionPerDayForDays = entity.HistoryCleanup?.KeepLatestVersionPerDayForDays
+            };
+            Database.InsertOrUpdate(dto);
         }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -776,7 +776,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             // Act
             var contentTypes = PackageDataInstallation
                 .ImportDocumentType(withoutCleanupPolicy, 0)
-                .OfType<IContentTypeWithHistoryCleanup>();
+                .OfType<IContentType>();
 
             // Assert
             Assert.Multiple(() =>
@@ -795,7 +795,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             // Act
             var contentTypes = PackageDataInstallation
                 .ImportDocumentType(docTypeElement, 0)
-                .OfType<IContentTypeWithHistoryCleanup>();
+                .OfType<IContentType>();
 
             // Assert
             Assert.Multiple(() =>
@@ -817,11 +817,11 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Packaging
             // Act
             var contentTypes = PackageDataInstallation
                 .ImportDocumentType(withCleanupPolicy, 0)
-                .OfType<IContentTypeWithHistoryCleanup>();
+                .OfType<IContentType>();
 
             var contentTypesUpdated = PackageDataInstallation
                 .ImportDocumentType(withoutCleanupPolicy, 0)
-                .OfType<IContentTypeWithHistoryCleanup>();
+                .OfType<IContentType>();
 
             // Assert
             Assert.Multiple(() =>


### PR DESCRIPTION
IContentTypeWithHistoryCleanup was marked obsolete and announced to be merged with IContentType, this PR makes that change.

## Breaking changes 

- Adds new property to IContentType
- Removes IContentTypeWithHistoryCleanup interface, use IContentType instead.
