### PR TITLE
Redirects don't work when culture is empty string

### DIFF
--- a/build/templates/UmbracoPackage/.template.config/template.json
+++ b/build/templates/UmbracoPackage/.template.config/template.json
@@ -24,7 +24,7 @@
         "version": {
             "type": "parameter",
             "datatype": "string",
-            "defaultValue": "9.4.2",
+            "defaultValue": "9.4.3",
             "description": "The version of Umbraco to load using NuGet",
             "replaces": "UMBRACO_VERSION_FROM_TEMPLATE"
         },

--- a/build/templates/UmbracoProject/.template.config/template.json
+++ b/build/templates/UmbracoProject/.template.config/template.json
@@ -57,7 +57,7 @@
         "version": {
             "type": "parameter",
             "datatype": "string",
-            "defaultValue": "9.4.2",
+            "defaultValue": "9.4.3",
             "description": "The version of Umbraco to load using NuGet",
             "replaces": "UMBRACO_VERSION_FROM_TEMPLATE"
         },

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,10 +3,10 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <Version>9.4.2</Version>
-    <AssemblyVersion>9.4.2</AssemblyVersion>
-    <InformationalVersion>9.4.2</InformationalVersion>
-    <FileVersion>9.4.2</FileVersion>
+    <Version>9.4.3</Version>
+    <AssemblyVersion>9.4.3</AssemblyVersion>
+    <InformationalVersion>9.4.3</InformationalVersion>
+    <FileVersion>9.4.3</FileVersion>
     <LangVersion Condition="'$(LangVersion)' == ''">9.0</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Company>Umbraco CMS</Company>

--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -443,10 +443,18 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                 refreshedIdsA.Contains(x.ContentTypeId) &&
                 BuildKit(x, out _)))
             {
-                // replacing the node: must preserve the parents
+                // replacing the node: must preserve the relations
                 var node = GetHead(_contentNodes, kit.Node.Id)?.Value;
                 if (node != null)
+                {
+                    // Preserve children
                     kit.Node.FirstChildContentId = node.FirstChildContentId;
+                    kit.Node.LastChildContentId = node.LastChildContentId;
+
+                    // Also preserve siblings
+                    kit.Node.NextSiblingContentId = node.NextSiblingContentId;
+                    kit.Node.PreviousSiblingContentId = node.PreviousSiblingContentId;
+                }
 
                 SetValueLocked(_contentNodes, kit.Node.Id, kit.Node);
 

--- a/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             var assigned = domainCache.GetAssigned(documentId, includeWildcards);
 
             // It's super important that we always compare cultures with ignore case, since we can't be sure of the casing!
-            return culture is null ? assigned.Any() : assigned.Any(x => x.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
+           return string.IsNullOrEmpty( culture) ? assigned.Any() : assigned.Any(x => x.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Redirects don't work when culture is empty string. Previously GetAssignedWithCulture callers would convert empty string before calling to null. This pr handles the empty culture case.

How to test?
Create a parent and publish.
Set the parent to have a domain.
Create child node and publish.
Change child node name (this causes a redirect to be created.
There should be a new redirect record in the redirects table. The url should start with the parent nodes id.
Use the redirect url. Should redirect.

<!-- Thanks for contributing to Umbraco CMS! -->
