### PR TITLE
Publish invariant properties

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -16,6 +16,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
         internal const bool StaticKeepUserLoggedIn = false;
         internal const bool StaticHideDisabledUsersInBackOffice = false;
         internal const bool StaticAllowPasswordReset = true;
+        internal const bool StaticAllowEditInvariantFromNonDefault = false;
         internal const string StaticAuthCookieName = "UMB_UCONTEXT";
         internal const string StaticAllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\";
 
@@ -79,5 +80,11 @@ namespace Umbraco.Cms.Core.Configuration.Models
         /// </summary>
         [DefaultValue(StaticUserBypassTwoFactorForExternalLogins)]
         public bool UserBypassTwoFactorForExternalLogins { get; set; } = StaticUserBypassTwoFactorForExternalLogins;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow editing invariant properties from a non-default language variation.
+        /// </summary>
+        [DefaultValue(StaticAllowEditInvariantFromNonDefault)]
+        public bool AllowEditInvariantFromNonDefault { get; set; } = StaticAllowEditInvariantFromNonDefault;
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -326,6 +326,8 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             // Register a noop IHtmlSanitizer to be replaced
             Services.AddUnique<IHtmlSanitizer, NoopHtmlSanitizer>();
+
+            Services.AddUnique<ICultureImpactService, CultureImpactService>();
         }
     }
 }

--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -291,7 +291,8 @@ namespace Umbraco.Extensions
 
                 // maybe the specified culture did not impact the invariant culture, so PublishValues
                 // above would skip it, yet it *also* impacts invariant properties
-                if (impact.ImpactsAlsoInvariantProperties)
+                if (impact.ImpactsAlsoInvariantProperties &&
+                    (property.PropertyType.VariesByCulture() is false || impact.ImpactsOnlyDefaultCulture))
                 {
                     property.PublishValues(null);
                 }

--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -235,43 +235,56 @@ namespace Umbraco.Extensions
         /// culture(s). The method may fail if required names are not set, but it does NOT validate property data</returns>
         public static bool PublishCulture(this IContent content, CultureImpact? impact)
         {
-            if (impact == null) throw new ArgumentNullException(nameof(impact));
+            if (impact == null)
+            {
+                throw new ArgumentNullException(nameof(impact));
+            }
 
             // the variation should be supported by the content type properties
             //  if the content type is invariant, only '*' and 'null' is ok
             //  if the content type varies, everything is ok because some properties may be invariant
             if (!content.ContentType.SupportsPropertyVariation(impact.Culture, "*", true))
+            {
                 throw new NotSupportedException($"Culture \"{impact.Culture}\" is not supported by content type \"{content.ContentType.Alias}\" with variation \"{content.ContentType.Variations}\".");
+            }
 
             // set names
             if (impact.ImpactsAllCultures)
             {
-                foreach (var c in content.AvailableCultures) // does NOT contain the invariant culture
+                foreach (var culture in content.AvailableCultures) // does NOT contain the invariant culture
                 {
-                    var name = content.GetCultureName(c);
+                    var name = content.GetCultureName(culture);
                     if (string.IsNullOrWhiteSpace(name))
+                    {
                         return false;
-                    content.SetPublishInfo(c, name, DateTime.Now);
+                    }
+
+                    content.SetPublishInfo(culture, name, DateTime.Now);
                 }
             }
             else if (impact.ImpactsOnlyInvariantCulture)
             {
                 if (string.IsNullOrWhiteSpace(content.Name))
+                {
                     return false;
+                }
                 // PublishName set by repository - nothing to do here
             }
             else if (impact.ImpactsExplicitCulture)
             {
                 var name = content.GetCultureName(impact.Culture);
                 if (string.IsNullOrWhiteSpace(name))
+                {
                     return false;
+                }
+
                 content.SetPublishInfo(impact.Culture, name, DateTime.Now);
             }
 
             // set values
             // property.PublishValues only publishes what is valid, variation-wise,
             // but accepts any culture arg: null, all, specific
-            foreach (var property in content.Properties)
+            foreach (IProperty property in content.Properties)
             {
                 // for the specified culture (null or all or specific)
                 property.PublishValues(impact.Culture);
@@ -279,7 +292,9 @@ namespace Umbraco.Extensions
                 // maybe the specified culture did not impact the invariant culture, so PublishValues
                 // above would skip it, yet it *also* impacts invariant properties
                 if (impact.ImpactsAlsoInvariantProperties)
+                {
                     property.PublishValues(null);
+                }
             }
 
             content.PublishedState = PublishedState.Publishing;

--- a/src/Umbraco.Core/Models/CultureImpact.cs
+++ b/src/Umbraco.Core/Models/CultureImpact.cs
@@ -64,13 +64,11 @@ namespace Umbraco.Cms.Core.Models
         /// <summary>
         /// Gets the impact of 'all' cultures (including the invariant culture).
         /// </summary>
-        [Obsolete("Use ICultureImpactService.CreateImpactAll instead, scheduled for removal in V12")]
         public static CultureImpact All { get; } = new CultureImpact("*");
 
         /// <summary>
         /// Gets the impact of the invariant culture.
         /// </summary>
-        [Obsolete("Use ICultureImpactService.CreateInvariant instead, scheduled for removal in V12")]
         public static CultureImpact Invariant { get; } = new CultureImpact(null);
 
         /// <summary>

--- a/src/Umbraco.Core/Models/CultureImpact.cs
+++ b/src/Umbraco.Core/Models/CultureImpact.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Umbraco.Extensions;
+﻿using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Models
 {

--- a/src/Umbraco.Core/Models/CultureImpact.cs
+++ b/src/Umbraco.Core/Models/CultureImpact.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Cms.Core.Models
         /// <param name="savingCultures"></param>
         /// <param name="defaultCulture"></param>
         /// <returns></returns>
+        [Obsolete("Use CultureImpactService instead, scheduled for removal in v12")]
         public static string? GetCultureForInvariantErrors(IContent? content, string?[] savingCultures, string? defaultCulture)
         {
             if (content == null) throw new ArgumentNullException(nameof(content));
@@ -43,7 +44,7 @@ namespace Umbraco.Cms.Core.Models
         /// <param name="culture">The culture code.</param>
         /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
         /// <param name="allowEditInvariantFromNonDefault">A value indicating if publishing invariant properties from non-default language.</param>
-        private CultureImpact(string? culture, bool isDefault = false, bool allowEditInvariantFromNonDefault = false)
+        internal CultureImpact(string? culture, bool isDefault = false, bool allowEditInvariantFromNonDefault = false)
         {
             if (culture != null && culture.IsNullOrWhiteSpace())
             {
@@ -65,11 +66,13 @@ namespace Umbraco.Cms.Core.Models
         /// <summary>
         /// Gets the impact of 'all' cultures (including the invariant culture).
         /// </summary>
+        [Obsolete("Use ICultureImpactService.CreateImpactAll instead, scheduled for removal in V12")]
         public static CultureImpact All { get; } = new CultureImpact("*");
 
         /// <summary>
         /// Gets the impact of the invariant culture.
         /// </summary>
+        [Obsolete("Use ICultureImpactService.CreateInvariant instead, scheduled for removal in V12")]
         public static CultureImpact Invariant { get; } = new CultureImpact(null);
 
         /// <summary>
@@ -78,7 +81,8 @@ namespace Umbraco.Cms.Core.Models
         /// <param name="culture">The culture code.</param>
         /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
         /// <param name="allowEditInvariantFromNonDefault">A value indicating if publishing invariant properties from non-default language.</param>
-        public static CultureImpact Explicit(string? culture, bool isDefault, bool allowEditInvariantFromNonDefault)
+        [Obsolete("Use ICultureImpactService instead.")]
+        public static CultureImpact Explicit(string? culture, bool isDefault)
         {
             if (culture == null)
             {
@@ -95,12 +99,8 @@ namespace Umbraco.Cms.Core.Models
                 throw new ArgumentException("Culture \"*\" is not explicit.");
             }
 
-            return new CultureImpact(culture, isDefault, allowEditInvariantFromNonDefault);
+            return new CultureImpact(culture, isDefault);
         }
-
-        [Obsolete("Use ICultureImpactService insead.")]
-        public static CultureImpact Explicit(string? culture, bool isDefault)
-            => Explicit(culture, isDefault, false);
 
         /// <summary>
         /// Creates an impact instance representing the impact of a culture set,
@@ -113,14 +113,7 @@ namespace Umbraco.Cms.Core.Models
         /// <remarks>
         /// <para>Validates that the culture is compatible with the variation.</para>
         /// </remarks>
-        public static CultureImpact? Create(string culture, bool isDefault, IContent content, bool allowEditInvariantFromNonDefault)
-        {
-            // throws if not successful
-            TryCreate(culture, isDefault, content.ContentType.Variations, true, allowEditInvariantFromNonDefault, out CultureImpact? impact);
-            return impact;
-        }
-
-        [Obsolete("Use ICultureImpactService instead.")]
+        [Obsolete("Use ICultureImpactService instead, scheduled for removal in V12")]
         public static CultureImpact? Create(string culture, bool isDefault, IContent content)
         {
             // throws if not successful
@@ -142,6 +135,7 @@ namespace Umbraco.Cms.Core.Models
         /// <remarks>
         /// <para>Validates that the culture is compatible with the variation.</para>
         /// </remarks>
+        // TODO: Remove this once Create() can be removed (V12), this already lives in CultureImpactService
         internal static bool TryCreate(string culture, bool isDefault, ContentVariation variation, bool throwOnFail, bool editInvariantFromNonDefault, out CultureImpact? impact)
         {
             impact = null;

--- a/src/Umbraco.Core/Models/CultureImpact.cs
+++ b/src/Umbraco.Core/Models/CultureImpact.cs
@@ -222,7 +222,7 @@ namespace Umbraco.Cms.Core.Models
         /// </summary>
         public bool ImpactsAlsoInvariantProperties => !ImpactsOnlyInvariantCulture &&
                                                       !ImpactsAllCultures &&
-                                                      ImpactsOnlyDefaultCulture;
+                                                      (ImpactsOnlyDefaultCulture || true /* TODO: If setting is set to true return true here as well, since it then also impacts invariant properties...*/);
 
         public Behavior CultureBehavior
         {

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1232,7 +1232,7 @@ namespace Umbraco.Cms.Core.Services
                 }
 
                 IEnumerable<CultureImpact> impacts =
-                    cultures.Select(x => _cultureImpactService.CreateImpactExplicit(x, IsDefaultCulture(allLangs, x)));
+                    cultures.Select(x => _cultureImpactService.ImpactExplicit(x, IsDefaultCulture(allLangs, x)));
 
                 // publish the culture(s)
                 // we don't care about the response here, this response will be rechecked below but we need to set the culture info values now.
@@ -1865,7 +1865,7 @@ namespace Umbraco.Cms.Core.Services
 
                             //publish the culture values and validate the property values, if validation fails, log the invalid properties so the develeper has an idea of what has failed
                             IProperty[]? invalidProperties = null;
-                            var impact = _cultureImpactService.CreateImpactExplicit(culture, IsDefaultCulture(allLangs.Value, culture));
+                            var impact = _cultureImpactService.ImpactExplicit(culture, IsDefaultCulture(allLangs.Value, culture));
                             var tryPublish = d.PublishCulture(impact) &&
                                              _propertyValidationService.Value.IsPropertyDataValid(d,
                                                  out invalidProperties, impact);
@@ -1959,8 +1959,8 @@ namespace Umbraco.Cms.Core.Services
                 });
             }
 
-            return content.PublishCulture(_cultureImpactService.CreateImpactInvariant())
-                   && _propertyValidationService.Value.IsPropertyDataValid(content, out _, _cultureImpactService.CreateImpactInvariant());
+            return content.PublishCulture(_cultureImpactService.ImpactInvariant())
+                   && _propertyValidationService.Value.IsPropertyDataValid(content, out _, _cultureImpactService.ImpactInvariant());
         }
 
         // utility 'ShouldPublish' func used by SaveAndPublishBranch
@@ -3091,9 +3091,9 @@ namespace Umbraco.Cms.Core.Services
             var variesByCulture = content.ContentType.VariesByCulture();
 
             CultureImpact[] impactsToPublish = culturesPublishing == null
-                ? new[] { _cultureImpactService.CreateImpactInvariant() } // if it's null it's invariant
+                ? new[] { _cultureImpactService.ImpactInvariant() } // if it's null it's invariant
                 : culturesPublishing.Select(x =>
-                    _cultureImpactService.CreateImpactExplicit(
+                    _cultureImpactService.ImpactExplicit(
                         x,
                         allLangs.Any(lang => lang.IsoCode.InvariantEquals(x) && lang.IsMandatory)))
                     .ToArray();

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1959,8 +1959,8 @@ namespace Umbraco.Cms.Core.Services
                 });
             }
 
-            return content.PublishCulture(_cultureImpactService.CreateInvariant())
-                   && _propertyValidationService.Value.IsPropertyDataValid(content, out _, _cultureImpactService.CreateInvariant());
+            return content.PublishCulture(_cultureImpactService.CreateImpactInvariant())
+                   && _propertyValidationService.Value.IsPropertyDataValid(content, out _, _cultureImpactService.CreateImpactInvariant());
         }
 
         // utility 'ShouldPublish' func used by SaveAndPublishBranch
@@ -3091,7 +3091,7 @@ namespace Umbraco.Cms.Core.Services
             var variesByCulture = content.ContentType.VariesByCulture();
 
             CultureImpact[] impactsToPublish = culturesPublishing == null
-                ? new[] { _cultureImpactService.CreateInvariant() } // if it's null it's invariant
+                ? new[] { _cultureImpactService.CreateImpactInvariant() } // if it's null it's invariant
                 : culturesPublishing.Select(x =>
                     _cultureImpactService.CreateExplicit(
                         x,

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1232,7 +1232,7 @@ namespace Umbraco.Cms.Core.Services
                 }
 
                 IEnumerable<CultureImpact> impacts =
-                    cultures.Select(x => _cultureImpactService.CreateExplicit(x, IsDefaultCulture(allLangs, x)));
+                    cultures.Select(x => _cultureImpactService.CreateImpactExplicit(x, IsDefaultCulture(allLangs, x)));
 
                 // publish the culture(s)
                 // we don't care about the response here, this response will be rechecked below but we need to set the culture info values now.
@@ -1865,7 +1865,7 @@ namespace Umbraco.Cms.Core.Services
 
                             //publish the culture values and validate the property values, if validation fails, log the invalid properties so the develeper has an idea of what has failed
                             IProperty[]? invalidProperties = null;
-                            var impact = _cultureImpactService.CreateExplicit(culture, IsDefaultCulture(allLangs.Value, culture));
+                            var impact = _cultureImpactService.CreateImpactExplicit(culture, IsDefaultCulture(allLangs.Value, culture));
                             var tryPublish = d.PublishCulture(impact) &&
                                              _propertyValidationService.Value.IsPropertyDataValid(d,
                                                  out invalidProperties, impact);
@@ -3093,7 +3093,7 @@ namespace Umbraco.Cms.Core.Services
             CultureImpact[] impactsToPublish = culturesPublishing == null
                 ? new[] { _cultureImpactService.CreateImpactInvariant() } // if it's null it's invariant
                 : culturesPublishing.Select(x =>
-                    _cultureImpactService.CreateExplicit(
+                    _cultureImpactService.CreateImpactExplicit(
                         x,
                         allLangs.Any(lang => lang.IsoCode.InvariantEquals(x) && lang.IsMandatory)))
                     .ToArray();

--- a/src/Umbraco.Core/Services/CultureImpactService.cs
+++ b/src/Umbraco.Core/Services/CultureImpactService.cs
@@ -31,7 +31,7 @@ public class CultureImpactService : ICultureImpactService
     public CultureImpact CreateImpactInvariant() => new CultureImpact(null);
 
     /// <inheritdoc/>
-    public CultureImpact CreateExplicit(string? culture, bool isDefault)
+    public CultureImpact CreateImpactExplicit(string? culture, bool isDefault)
     {
         if (culture == null)
         {

--- a/src/Umbraco.Core/Services/CultureImpactService.cs
+++ b/src/Umbraco.Core/Services/CultureImpactService.cs
@@ -33,7 +33,7 @@ public class CultureImpactService : ICultureImpactService
     /// <inheritdoc/>
     public CultureImpact ImpactExplicit(string? culture, bool isDefault)
     {
-        if (culture == null)
+        if (culture is null)
         {
             throw new ArgumentException("Culture <null> is not explicit.");
         }
@@ -54,12 +54,12 @@ public class CultureImpactService : ICultureImpactService
     /// <inheritdoc/>
     public string? GetCultureForInvariantErrors(IContent? content, string?[] savingCultures, string? defaultCulture)
     {
-        if (content == null)
+        if (content is null)
         {
             throw new ArgumentNullException(nameof(content));
         }
 
-        if (savingCultures == null)
+        if (savingCultures is null)
         {
             throw new ArgumentNullException(nameof(savingCultures));
         }
@@ -154,7 +154,7 @@ public class CultureImpactService : ICultureImpactService
         }
 
         // if culture is specific, then variation must vary
-        if (!variation.VariesByCulture())
+        if (variation.VariesByCulture() is false)
         {
             if (throwOnFail)
             {

--- a/src/Umbraco.Core/Services/CultureImpactService.cs
+++ b/src/Umbraco.Core/Services/CultureImpactService.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+public class CultureImpactService : ICultureImpactService
+{
+    private SecuritySettings _securitySettings;
+
+    public CultureImpactService(IOptionsMonitor<SecuritySettings> securitySettings)
+    {
+        _securitySettings = securitySettings.CurrentValue;
+
+        securitySettings.OnChange(x => _securitySettings = x);
+    }
+
+    /// <inheritdoc/>
+    public CultureImpact? Create(string culture, bool isDefault, IContent content)
+        => CultureImpact.Create(culture, isDefault, content, _securitySettings.AllowEditInvariantFromNonDefault);
+
+    public CultureImpact CreateImpactAll() => CultureImpact.All;
+
+    public CultureImpact CreateInvariant() => CultureImpact.Invariant;
+
+    public CultureImpact CreateExplicit(string? culture, bool isDefault)
+        => CultureImpact.Explicit(culture, isDefault, _securitySettings.AllowEditInvariantFromNonDefault);
+
+    public string? GetCultureForInvariantErrors(IContent? content, string?[] savingCultures, string? defaultCulture)
+        => CultureImpact.GetCultureForInvariantErrors(content, savingCultures, defaultCulture);
+}

--- a/src/Umbraco.Core/Services/CultureImpactService.cs
+++ b/src/Umbraco.Core/Services/CultureImpactService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services;
 
@@ -16,16 +17,155 @@ public class CultureImpactService : ICultureImpactService
     }
 
     /// <inheritdoc/>
-    public CultureImpact? Create(string culture, bool isDefault, IContent content)
-        => CultureImpact.Create(culture, isDefault, content, _securitySettings.AllowEditInvariantFromNonDefault);
+    public CultureImpact? Create(string? culture, bool isDefault, IContent content)
+    {
+        TryCreate(culture, isDefault, content.ContentType.Variations, true, _securitySettings.AllowEditInvariantFromNonDefault, out CultureImpact? impact);
 
-    public CultureImpact CreateImpactAll() => CultureImpact.All;
+        return impact;
+    }
 
-    public CultureImpact CreateInvariant() => CultureImpact.Invariant;
+    /// <inheritdoc/>
+    public CultureImpact CreateImpactAll() => new CultureImpact("*");
 
+    /// <inheritdoc/>
+    public CultureImpact CreateImpactInvariant() => new CultureImpact(null);
+
+    /// <inheritdoc/>
     public CultureImpact CreateExplicit(string? culture, bool isDefault)
-        => CultureImpact.Explicit(culture, isDefault, _securitySettings.AllowEditInvariantFromNonDefault);
+    {
+        if (culture == null)
+        {
+            throw new ArgumentException("Culture <null> is not explicit.");
+        }
 
+        if (string.IsNullOrWhiteSpace(culture))
+        {
+            throw new ArgumentException("Culture \"\" is not explicit.");
+        }
+
+        if (culture == "*")
+        {
+            throw new ArgumentException("Culture \"*\" is not explicit.");
+        }
+
+        return new CultureImpact(culture, isDefault, _securitySettings.AllowEditInvariantFromNonDefault);
+    }
+
+    /// <inheritdoc/>
     public string? GetCultureForInvariantErrors(IContent? content, string?[] savingCultures, string? defaultCulture)
-        => CultureImpact.GetCultureForInvariantErrors(content, savingCultures, defaultCulture);
+    {
+        if (content == null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        if (savingCultures == null)
+        {
+            throw new ArgumentNullException(nameof(savingCultures));
+        }
+
+        if (savingCultures.Length == 0)
+        {
+            throw new ArgumentException(nameof(savingCultures));
+        }
+
+        var cultureForInvariantErrors = savingCultures.Any(x => x.InvariantEquals(defaultCulture))
+            // The default culture is being flagged for saving so use it
+            ? defaultCulture
+            // If the content has no published version, we need to affiliate validation with the first variant being saved.
+            // If the content has a published version we will not affiliate the validation with any culture (null)
+            : !content.Published ? savingCultures[0] : null;
+
+        return cultureForInvariantErrors;
+    }
+
+    /// <summary>
+    /// Tries to create an impact instance representing the impact of a culture set,
+    /// in the context of a content item variation.
+    /// </summary>
+    /// <param name="culture">The culture code.</param>
+    /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
+    /// <param name="variation">A content variation.</param>
+    /// <param name="throwOnFail">A value indicating whether to throw if the impact cannot be created.</param>
+    /// <param name="editInvariantFromNonDefault">A value indicating if publishing invariant properties from non-default language.</param>
+    /// <param name="impact">The impact if it could be created, otherwise null.</param>
+    /// <returns>A value indicating whether the impact could be created.</returns>
+    /// <remarks>
+    /// <para>Validates that the culture is compatible with the variation.</para>
+    /// </remarks>
+    internal bool TryCreate(string? culture, bool isDefault, ContentVariation variation, bool throwOnFail, bool editInvariantFromNonDefault, out CultureImpact? impact)
+    {
+        impact = null;
+
+        // if culture is invariant...
+        if (culture is null)
+        {
+            // ... then variation must not vary by culture ...
+            if (variation.VariesByCulture())
+            {
+                if (throwOnFail)
+                {
+                    throw new InvalidOperationException("The invariant culture is not compatible with a varying variation.");
+                }
+
+                return false;
+            }
+
+            // ... and it cannot be default
+            if (isDefault)
+            {
+                if (throwOnFail)
+                {
+                    throw new InvalidOperationException("The invariant culture can not be the default culture.");
+                }
+
+                return false;
+            }
+
+            impact = CreateImpactInvariant();
+            return true;
+        }
+
+        // if culture is 'all'...
+        if (culture == "*")
+        {
+            // ... it cannot be default
+            if (isDefault)
+            {
+                if (throwOnFail)
+                    throw new InvalidOperationException("The 'all' culture can not be the default culture.");
+                return false;
+            }
+
+            // if variation does not vary by culture, then impact is invariant
+            impact = variation.VariesByCulture() ? CreateImpactAll() : CreateImpactInvariant();
+            return true;
+        }
+
+        // neither null nor "*" - cannot be the empty string
+        if (culture.IsNullOrWhiteSpace())
+        {
+            if (throwOnFail)
+            {
+                throw new ArgumentException("Cannot be the empty string.", nameof(culture));
+            }
+
+            return false;
+        }
+
+        // if culture is specific, then variation must vary
+        if (!variation.VariesByCulture())
+        {
+            if (throwOnFail)
+            {
+                throw new InvalidOperationException($"The variant culture {culture} is not compatible with an invariant variation.");
+            }
+
+            return false;
+        }
+
+        // return specific impact
+        impact = new CultureImpact(culture, isDefault, editInvariantFromNonDefault);
+        return true;
+    }
 }

--- a/src/Umbraco.Core/Services/CultureImpactService.cs
+++ b/src/Umbraco.Core/Services/CultureImpactService.cs
@@ -25,13 +25,13 @@ public class CultureImpactService : ICultureImpactService
     }
 
     /// <inheritdoc/>
-    public CultureImpact CreateImpactAll() => new CultureImpact("*");
+    public CultureImpact ImpactAll() => CultureImpact.All;
 
     /// <inheritdoc/>
-    public CultureImpact CreateImpactInvariant() => new CultureImpact(null);
+    public CultureImpact ImpactInvariant() => CultureImpact.Invariant;
 
     /// <inheritdoc/>
-    public CultureImpact CreateImpactExplicit(string? culture, bool isDefault)
+    public CultureImpact ImpactExplicit(string? culture, bool isDefault)
     {
         if (culture == null)
         {
@@ -122,7 +122,7 @@ public class CultureImpactService : ICultureImpactService
                 return false;
             }
 
-            impact = CreateImpactInvariant();
+            impact = ImpactInvariant();
             return true;
         }
 
@@ -138,7 +138,7 @@ public class CultureImpactService : ICultureImpactService
             }
 
             // if variation does not vary by culture, then impact is invariant
-            impact = variation.VariesByCulture() ? CreateImpactAll() : CreateImpactInvariant();
+            impact = variation.VariesByCulture() ? ImpactAll() : ImpactInvariant();
             return true;
         }
 

--- a/src/Umbraco.Core/Services/ICultureImpactService.cs
+++ b/src/Umbraco.Core/Services/ICultureImpactService.cs
@@ -1,0 +1,41 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface ICultureImpactService
+{
+    /// <summary>
+    /// Creates an impact instance representing the impact of a culture set,
+    /// in the context of a content item variation.
+    /// </summary>
+    /// <param name="culture">The culture code.</param>
+    /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
+    /// <param name="content">The content item.</param>
+    /// <remarks>
+    /// <para>Validates that the culture is compatible with the variation.</para>
+    /// </remarks>
+    CultureImpact? Create(string culture, bool isDefault, IContent content);
+
+    /// <summary>
+    /// Gets the impact of 'all' cultures (including the invariant culture).
+    /// </summary>
+    CultureImpact CreateImpactAll();
+
+    /// <summary>
+    /// Gets the impact of the invariant culture.
+    /// </summary>
+    CultureImpact CreateInvariant();
+
+    /// <summary>
+    /// Creates an impact instance representing the impact of a specific culture.
+    /// </summary>
+    /// <param name="culture">The culture code.</param>
+    /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
+    CultureImpact CreateExplicit(string? culture, bool isDefault);
+
+    /// <summary>
+    /// Utility method to return the culture used for invariant property errors based on what cultures are being actively saved,
+    /// the default culture and the state of the current content item
+    /// </summary>
+    string? GetCultureForInvariantErrors(IContent? content, string?[] savingCultures, string? defaultCulture);
+}

--- a/src/Umbraco.Core/Services/ICultureImpactService.cs
+++ b/src/Umbraco.Core/Services/ICultureImpactService.cs
@@ -31,7 +31,7 @@ public interface ICultureImpactService
     /// </summary>
     /// <param name="culture">The culture code.</param>
     /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
-    CultureImpact CreateExplicit(string? culture, bool isDefault);
+    CultureImpact CreateImpactExplicit(string? culture, bool isDefault);
 
     /// <summary>
     /// Utility method to return the culture used for invariant property errors based on what cultures are being actively saved,

--- a/src/Umbraco.Core/Services/ICultureImpactService.cs
+++ b/src/Umbraco.Core/Services/ICultureImpactService.cs
@@ -24,7 +24,7 @@ public interface ICultureImpactService
     /// <summary>
     /// Gets the impact of the invariant culture.
     /// </summary>
-    CultureImpact CreateInvariant();
+    CultureImpact CreateImpactInvariant();
 
     /// <summary>
     /// Creates an impact instance representing the impact of a specific culture.

--- a/src/Umbraco.Core/Services/ICultureImpactService.cs
+++ b/src/Umbraco.Core/Services/ICultureImpactService.cs
@@ -19,19 +19,19 @@ public interface ICultureImpactService
     /// <summary>
     /// Gets the impact of 'all' cultures (including the invariant culture).
     /// </summary>
-    CultureImpact CreateImpactAll();
+    CultureImpact ImpactAll();
 
     /// <summary>
     /// Gets the impact of the invariant culture.
     /// </summary>
-    CultureImpact CreateImpactInvariant();
+    CultureImpact ImpactInvariant();
 
     /// <summary>
     /// Creates an impact instance representing the impact of a specific culture.
     /// </summary>
     /// <param name="culture">The culture code.</param>
     /// <param name="isDefault">A value indicating whether the culture is the default culture.</param>
-    CultureImpact CreateImpactExplicit(string? culture, bool isDefault);
+    CultureImpact ImpactExplicit(string? culture, bool isDefault);
 
     /// <summary>
     /// Utility method to return the culture used for invariant property errors based on what cultures are being actively saved,

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -437,7 +437,8 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         {"showAllowSegmentationForDocumentTypes", false},
                         {"minimumPasswordLength", _memberPasswordConfigurationSettings.RequiredLength},
                         {"minimumPasswordNonAlphaNum", _memberPasswordConfigurationSettings.GetMinNonAlphaNumericChars()},
-                        {"sanitizeTinyMce", _globalSettings.SanitizeTinyMce}
+                        {"sanitizeTinyMce", _globalSettings.SanitizeTinyMce},
+                        {"AllowEditInvariantFromNonDefault", _securitySettings.AllowEditInvariantFromNonDefault},
                     }
                 },
                 {

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1669,7 +1669,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             foreach (var variant in cultureVariants.Where(x => x.Publish))
             {
                 // publishing any culture, implies the invariant culture
-                var valid = persistentContent.PublishCulture(_cultureImpactService.CreateExplicit(variant.Culture, defaultCulture.InvariantEquals(variant.Culture)));
+                var valid = persistentContent.PublishCulture(_cultureImpactService.CreateImpactExplicit(variant.Culture, defaultCulture.InvariantEquals(variant.Culture)));
                 if (!valid)
                 {
                     AddVariantValidationError(variant.Culture, variant.Segment, "speechBubbles", "contentCultureValidationError");

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
@@ -33,6 +34,7 @@ using Umbraco.Cms.Web.BackOffice.Filters;
 using Umbraco.Cms.Web.BackOffice.ModelBinders;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.BackOffice.Controllers
@@ -63,12 +65,65 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly ISqlContext _sqlContext;
         private readonly IAuthorizationService _authorizationService;
         private readonly IContentVersionService _contentVersionService;
+        private readonly ICultureImpactService _cultureImpactService;
         private readonly Lazy<IDictionary<string, ILanguage>> _allLangs;
         private readonly ILogger<ContentController> _logger;
         private readonly ICoreScopeProvider _scopeProvider;
 
         public object? Domains { get; private set; }
 
+        [ActivatorUtilitiesConstructor]
+        public ContentController(
+            ICultureDictionary cultureDictionary,
+            ILoggerFactory loggerFactory,
+            IShortStringHelper shortStringHelper,
+            IEventMessagesFactory eventMessages,
+            ILocalizedTextService localizedTextService,
+            PropertyEditorCollection propertyEditors,
+            IContentService contentService,
+            IUserService userService,
+            IBackOfficeSecurityAccessor backofficeSecurityAccessor,
+            IContentTypeService contentTypeService,
+            IUmbracoMapper umbracoMapper,
+            IPublishedUrlProvider publishedUrlProvider,
+            IDomainService domainService,
+            IDataTypeService dataTypeService,
+            ILocalizationService localizationService,
+            IFileService fileService,
+            INotificationService notificationService,
+            ActionCollection actionCollection,
+            ISqlContext sqlContext,
+            IJsonSerializer serializer,
+            ICoreScopeProvider scopeProvider,
+            IAuthorizationService authorizationService,
+            IContentVersionService contentVersionService,
+            ICultureImpactService cultureImpactService)
+            : base(cultureDictionary, loggerFactory, shortStringHelper, eventMessages, localizedTextService, serializer)
+        {
+            _propertyEditors = propertyEditors;
+            _contentService = contentService;
+            _localizedTextService = localizedTextService;
+            _userService = userService;
+            _backofficeSecurityAccessor = backofficeSecurityAccessor;
+            _contentTypeService = contentTypeService;
+            _umbracoMapper = umbracoMapper;
+            _publishedUrlProvider = publishedUrlProvider;
+            _domainService = domainService;
+            _dataTypeService = dataTypeService;
+            _localizationService = localizationService;
+            _fileService = fileService;
+            _notificationService = notificationService;
+            _actionCollection = actionCollection;
+            _sqlContext = sqlContext;
+            _authorizationService = authorizationService;
+            _contentVersionService = contentVersionService;
+            _cultureImpactService = cultureImpactService;
+            _logger = loggerFactory.CreateLogger<ContentController>();
+            _scopeProvider = scopeProvider;
+            _allLangs = new Lazy<IDictionary<string, ILanguage>>(() => _localizationService.GetAllLanguages().ToDictionary(x => x.IsoCode, x => x, StringComparer.InvariantCultureIgnoreCase));
+        }
+
+        [Obsolete("Use constructor that accepts ICultureImpactService as a parameter, scheduled for removal in V12")]
         public ContentController(
             ICultureDictionary cultureDictionary,
             ILoggerFactory loggerFactory,
@@ -93,29 +148,33 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             ICoreScopeProvider scopeProvider,
             IAuthorizationService authorizationService,
             IContentVersionService contentVersionService)
-            : base(cultureDictionary, loggerFactory, shortStringHelper, eventMessages, localizedTextService, serializer)
-        {
-            _propertyEditors = propertyEditors;
-            _contentService = contentService;
-            _localizedTextService = localizedTextService;
-            _userService = userService;
-            _backofficeSecurityAccessor = backofficeSecurityAccessor;
-            _contentTypeService = contentTypeService;
-            _umbracoMapper = umbracoMapper;
-            _publishedUrlProvider = publishedUrlProvider;
-            _domainService = domainService;
-            _dataTypeService = dataTypeService;
-            _localizationService = localizationService;
-            _fileService = fileService;
-            _notificationService = notificationService;
-            _actionCollection = actionCollection;
-            _sqlContext = sqlContext;
-            _authorizationService = authorizationService;
-            _contentVersionService = contentVersionService;
-            _logger = loggerFactory.CreateLogger<ContentController>();
-            _scopeProvider = scopeProvider;
-            _allLangs = new Lazy<IDictionary<string, ILanguage>>(() => _localizationService.GetAllLanguages().ToDictionary(x => x.IsoCode, x => x, StringComparer.InvariantCultureIgnoreCase));
-        }
+            : this(
+                cultureDictionary,
+                loggerFactory,
+                shortStringHelper,
+                eventMessages,
+                localizedTextService,
+                propertyEditors,
+                contentService,
+                userService,
+                backofficeSecurityAccessor,
+                contentTypeService,
+                umbracoMapper,
+                publishedUrlProvider,
+                domainService,
+                dataTypeService,
+                localizationService,
+                fileService,
+                notificationService,
+                actionCollection,
+                sqlContext,
+                serializer,
+                scopeProvider,
+                authorizationService,
+                contentVersionService,
+                StaticServiceProvider.Instance.GetRequiredService<ICultureImpactService>())
+              {
+              }
 
         /// <summary>
         /// Return content for the specified ids
@@ -841,7 +900,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             //The default validation language will be either: The default languauge, else if the content is brand new and the default culture is
             // not marked to be saved, it will be the first culture in the list marked for saving.
             var defaultCulture = _allLangs.Value.Values.FirstOrDefault(x => x.IsDefault)?.IsoCode;
-            var cultureForInvariantErrors = CultureImpact.GetCultureForInvariantErrors(
+            var cultureForInvariantErrors = _cultureImpactService.GetCultureForInvariantErrors(
                 contentItem.PersistedContent,
                 contentItem.Variants.Where(x => x.Save).Select(x => x.Culture).ToArray(),
                 defaultCulture);
@@ -1610,7 +1669,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             foreach (var variant in cultureVariants.Where(x => x.Publish))
             {
                 // publishing any culture, implies the invariant culture
-                var valid = persistentContent.PublishCulture(CultureImpact.Explicit(variant.Culture, defaultCulture.InvariantEquals(variant.Culture)));
+                var valid = persistentContent.PublishCulture(_cultureImpactService.CreateExplicit(variant.Culture, defaultCulture.InvariantEquals(variant.Culture)));
                 if (!valid)
                 {
                     AddVariantValidationError(variant.Culture, variant.Segment, "speechBubbles", "contentCultureValidationError");

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1669,7 +1669,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             foreach (var variant in cultureVariants.Where(x => x.Publish))
             {
                 // publishing any culture, implies the invariant culture
-                var valid = persistentContent.PublishCulture(_cultureImpactService.CreateImpactExplicit(variant.Culture, defaultCulture.InvariantEquals(variant.Culture)));
+                var valid = persistentContent.PublishCulture(_cultureImpactService.ImpactExplicit(variant.Culture, defaultCulture.InvariantEquals(variant.Culture)));
                 if (!valid)
                 {
                     AddVariantValidationError(variant.Culture, variant.Segment, "speechBubbles", "contentCultureValidationError");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/CultureImpactTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/CultureImpactTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -172,19 +171,25 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
             Assert.AreSame(BasicImpactService.ImpactInvariant(), impact);
         }
 
-        private CultureImpactService createCultureImpactService(IOptionsMonitor<SecuritySettings> securitySettings = null)
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Edit_Invariant_From_Non_Default_Impacts_Invariant_Properties(bool allowEditInvariantFromNonDefault)
         {
-            if (securitySettings is null)
+            var sut = createCultureImpactService(new SecuritySettings { AllowEditInvariantFromNonDefault = allowEditInvariantFromNonDefault });
+            var impact = sut.ImpactExplicit("da", false);
+
+            Assert.AreEqual(allowEditInvariantFromNonDefault, impact.ImpactsAlsoInvariantProperties);
+        }
+
+        private CultureImpactService createCultureImpactService(SecuritySettings securitySettings = null)
+        {
+            securitySettings ??= new SecuritySettings
             {
-                var securitySettingsObject = new SecuritySettings
-                {
-                    AllowEditInvariantFromNonDefault = false,
-                };
+                AllowEditInvariantFromNonDefault = false,
+            };
 
-                securitySettings = new TestOptionsMonitor<SecuritySettings>(securitySettingsObject);
-            }
-
-            return new CultureImpactService(securitySettings);
+            return new CultureImpactService(new TestOptionsMonitor<SecuritySettings>(securitySettings));
         }
 
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/CultureImpactTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/CultureImpactTests.cs
@@ -95,7 +95,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
         [Test]
         public void TryCreate_Explicit_Default_Culture()
         {
-            var success = CultureImpact.TryCreate("en-US", true, ContentVariation.Culture, false, out CultureImpact impact);
+            var success = CultureImpact.TryCreate("en-US", true, ContentVariation.Culture, false, false, out CultureImpact impact);
             Assert.IsTrue(success);
 
             Assert.AreEqual(impact.Culture, "en-US");
@@ -111,7 +111,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
         [Test]
         public void TryCreate_Explicit_NonDefault_Culture()
         {
-            var success = CultureImpact.TryCreate("en-US", false, ContentVariation.Culture, false, out CultureImpact impact);
+            var success = CultureImpact.TryCreate("en-US", false, ContentVariation.Culture, false, false, out CultureImpact impact);
             Assert.IsTrue(success);
 
             Assert.AreEqual(impact.Culture, "en-US");
@@ -127,7 +127,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
         [Test]
         public void TryCreate_AllCultures_For_Invariant()
         {
-            var success = CultureImpact.TryCreate("*", false, ContentVariation.Nothing, false, out CultureImpact impact);
+            var success = CultureImpact.TryCreate("*", false, ContentVariation.Nothing, false, false, out CultureImpact impact);
             Assert.IsTrue(success);
 
             Assert.AreEqual(impact.Culture, null);
@@ -138,7 +138,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
         [Test]
         public void TryCreate_AllCultures_For_Variant()
         {
-            var success = CultureImpact.TryCreate("*", false, ContentVariation.Culture, false, out CultureImpact impact);
+            var success = CultureImpact.TryCreate("*", false, ContentVariation.Culture, false, false, out CultureImpact impact);
             Assert.IsTrue(success);
 
             Assert.AreEqual(impact.Culture, "*");
@@ -149,14 +149,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models
         [Test]
         public void TryCreate_Invariant_For_Variant()
         {
-            var success = CultureImpact.TryCreate(null, false, ContentVariation.Culture, false, out CultureImpact impact);
+            var success = CultureImpact.TryCreate(null, false, ContentVariation.Culture, false, false, out CultureImpact impact);
             Assert.IsFalse(success);
         }
 
         [Test]
         public void TryCreate_Invariant_For_Invariant()
         {
-            var success = CultureImpact.TryCreate(null, false, ContentVariation.Nothing, false, out CultureImpact impact);
+            var success = CultureImpact.TryCreate(null, false, ContentVariation.Nothing, false, false, out CultureImpact impact);
             Assert.IsTrue(success);
 
             Assert.AreSame(CultureImpact.Invariant, impact);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/ContentControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/ContentControllerTests.cs
@@ -262,7 +262,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers
                 Mock.Of<IJsonSerializer>(),
                 Mock.Of<IScopeProvider>(),
                 Mock.Of<IAuthorizationService>(),
-                Mock.Of<IContentVersionService>()
+                Mock.Of<IContentVersionService>(),
+                Mock.Of<ICultureImpactService>()
             );
 
             return controller;


### PR DESCRIPTION
Added the necessary backend changes to allow you to publish invariant properties from the non-default culture. 

This can be toggled on/off with the new `Umbraco:CMS:Security:AllowEditInvariantFromNonDefault` appsetting.

For now, I've also added the appsetting to server variables in case it's needed. 

While I'm here I've also tried to do a bit of cleaning up around the `CultureImpact` class, basically, I've tried to move as much logic as I can into the new `ICultureImpactService`, instead of having it in the "model". However currently we rely on some of the `CultureImpact`s to be static in order to do comparisons, so I've left those static in `CultureImpact` and just proxy them from the service.

## Testing

Set `Umbraco:CMS:Security:AllowEditInvariantFromNonDefault` to true and try and publish an invariant property value from a non-default language, verify that it's displayed correctly in the frontend.

Set the setting to false and ensure that the frontend is not updated when doing the same as above.