### PR TITLE
NRT amends for WithCollectionBuilder to improve API

### DIFF
--- a/src/Umbraco.Core/Composing/ComponentComposer.cs
+++ b/src/Umbraco.Core/Composing/ComponentComposer.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.Cms.Core.Composing
 {
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.Composing
         /// <inheritdoc />
         public virtual void Compose(IUmbracoBuilder builder)
         {
-            builder.Components()?.Append<TComponent>();
+            builder.Components().Append<TComponent>();
         }
 
         // note: thanks to this class, a component that does not compose anything can be

--- a/src/Umbraco.Core/DependencyInjection/IUmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/IUmbracoBuilder.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
         IProfiler Profiler { get; }
         AppCaches AppCaches { get; }
-        TBuilder? WithCollectionBuilder<TBuilder>() where TBuilder : ICollectionBuilder;
+        TBuilder WithCollectionBuilder<TBuilder>() where TBuilder : ICollectionBuilder;
         void Build();
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -1,4 +1,3 @@
-using System;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.Media;
@@ -21,7 +20,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddComponent<T>(this IUmbracoBuilder builder)
             where T : class, IComponent
         {
-            builder.Components()?.Append<T>();
+            builder.Components().Append<T>();
             return builder;
         }
 
@@ -33,7 +32,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddContentApp<T>(this IUmbracoBuilder builder)
             where T : class, IContentAppFactory
         {
-            builder.ContentApps()?.Append<T>();
+            builder.ContentApps().Append<T>();
             return builder;
         }
 
@@ -45,7 +44,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddContentFinder<T>(this IUmbracoBuilder builder)
             where T : class, IContentFinder
         {
-            builder.ContentFinders()?.Append<T>();
+            builder.ContentFinders().Append<T>();
             return builder;
         }
 
@@ -57,7 +56,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddDashboard<T>(this IUmbracoBuilder builder)
             where T : class, IDashboard
         {
-            builder.Dashboards()?.Add<T>();
+            builder.Dashboards().Add<T>();
             return builder;
         }
 
@@ -69,7 +68,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddMediaUrlProvider<T>(this IUmbracoBuilder builder)
             where T : class, IMediaUrlProvider
         {
-            builder.MediaUrlProviders()?.Append<T>();
+            builder.MediaUrlProviders().Append<T>();
             return builder;
         }
 
@@ -81,7 +80,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddEmbedProvider<T>(this IUmbracoBuilder builder)
             where T : class, IEmbedProvider
         {
-            builder.EmbedProviders()?.Append<T>();
+            builder.EmbedProviders().Append<T>();
             return builder;
         }
 
@@ -97,7 +96,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddSection<T>(this IUmbracoBuilder builder)
             where T : class, ISection
         {
-            builder.Sections()?.Append<T>();
+            builder.Sections().Append<T>();
             return builder;
         }
 
@@ -109,7 +108,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         public static IUmbracoBuilder AddUrlProvider<T>(this IUmbracoBuilder builder)
             where T : class, IUrlProvider
         {
-            builder.UrlProviders()?.Append<T>();
+            builder.UrlProviders().Append<T>();
             return builder;
         }
     }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -1,4 +1,3 @@
-using System;
 using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
@@ -10,7 +9,6 @@ using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Media.EmbedProviders;
-using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.Validators;
 using Umbraco.Cms.Core.Routing;
@@ -33,12 +31,12 @@ namespace Umbraco.Cms.Core.DependencyInjection
         /// </summary>
         internal static void AddAllCoreCollectionBuilders(this IUmbracoBuilder builder)
         {
-            builder.CacheRefreshers()?.Add(() => builder.TypeLoader.GetCacheRefreshers());
-            builder.DataEditors()?.Add(() => builder.TypeLoader.GetDataEditors());
-            builder.Actions()?.Add(() => builder .TypeLoader.GetActions());
+            builder.CacheRefreshers().Add(() => builder.TypeLoader.GetCacheRefreshers());
+            builder.DataEditors().Add(() => builder.TypeLoader.GetDataEditors());
+            builder.Actions().Add(() => builder .TypeLoader.GetActions());
 
             // register known content apps
-            builder.ContentApps()?
+            builder.ContentApps()
                 .Append<ListViewContentAppFactory>()
                 .Append<ContentEditorContentAppFactory>()
                 .Append<ContentInfoContentAppFactory>()
@@ -51,24 +49,24 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             // all built-in finders in the correct order,
             // devs can then modify this list on application startup
-            builder.ContentFinders()?
+            builder.ContentFinders()
                 .Append<ContentFinderByPageIdQuery>()
                 .Append<ContentFinderByUrl>()
                 .Append<ContentFinderByIdPath>()
                 /*.Append<ContentFinderByUrlAndTemplate>() // disabled, this is an odd finder */
                 .Append<ContentFinderByUrlAlias>()
                 .Append<ContentFinderByRedirectUrl>();
-            builder.EditorValidators()?.Add(() => builder.TypeLoader.GetTypes<IEditorValidator>());
-            builder.HealthChecks()?.Add(() => builder.TypeLoader.GetTypes<HealthCheck>());
-            builder.HealthCheckNotificationMethods()?.Add(() => builder.TypeLoader.GetTypes<IHealthCheckNotificationMethod>());
+            builder.EditorValidators().Add(() => builder.TypeLoader.GetTypes<IEditorValidator>());
+            builder.HealthChecks().Add(() => builder.TypeLoader.GetTypes<HealthCheck>());
+            builder.HealthCheckNotificationMethods().Add(() => builder.TypeLoader.GetTypes<IHealthCheckNotificationMethod>());
             builder.TourFilters();
-            builder.UrlProviders()?
+            builder.UrlProviders()
                 .Append<AliasUrlProvider>()
                 .Append<DefaultUrlProvider>();
-            builder.MediaUrlProviders()?
+            builder.MediaUrlProviders()
                 .Append<DefaultMediaUrlProvider>();
             // register back office sections in the order we want them rendered
-            builder.Sections()?
+            builder.Sections()
                 .Append<ContentSection>()
                 .Append<MediaSection>()
                 .Append<SettingsSection>()
@@ -79,7 +77,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
                 .Append<TranslationSection>();
             builder.Components();
             // register core CMS dashboards and 3rd party types - will be ordered by weight attribute & merged with package.manifest dashboards
-            builder.Dashboards()?
+            builder.Dashboards()
                 .Add<ContentDashboard>()
                 .Add<ExamineDashboard>()
                 .Add<FormsDashboard>()
@@ -93,9 +91,9 @@ namespace Umbraco.Cms.Core.DependencyInjection
                 .Add<SettingsDashboard>()
                 .Add(builder.TypeLoader.GetTypes<IDashboard>());
             builder.DataValueReferenceFactories();
-            builder.PropertyValueConverters()?.Append(builder.TypeLoader.GetTypes<IPropertyValueConverter>());
-            builder.UrlSegmentProviders()?.Append<DefaultUrlSegmentProvider>();
-            builder.ManifestValueValidators()?
+            builder.PropertyValueConverters().Append(builder.TypeLoader.GetTypes<IPropertyValueConverter>());
+            builder.UrlSegmentProviders().Append<DefaultUrlSegmentProvider>();
+            builder.ManifestValueValidators()
                 .Add<RequiredValidator>()
                 .Add<RegexValidator>()
                 .Add<DelimitedValueValidator>()
@@ -105,7 +103,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             builder.ManifestFilters();
             builder.MediaUrlGenerators();
             // register OEmbed providers - no type scanning - all explicit opt-in of adding types, IEmbedProvider is not IDiscoverable
-            builder.EmbedProviders()?
+            builder.EmbedProviders()
                 .Append<YouTube>()
                 .Append<Twitter>()
                 .Append<Vimeo>()
@@ -120,7 +118,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
                 .Append<Hulu>()
                 .Append<Giphy>()
                 .Append<LottieFiles>();
-            builder.SearchableTrees()?.Add(() => builder.TypeLoader.GetTypes<ISearchableTree>());
+            builder.SearchableTrees().Add(() => builder.TypeLoader.GetTypes<ISearchableTree>());
             builder.BackOfficeAssets();
         }
 
@@ -128,141 +126,141 @@ namespace Umbraco.Cms.Core.DependencyInjection
         /// Gets the actions collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static ActionCollectionBuilder? Actions(this IUmbracoBuilder builder)
+        public static ActionCollectionBuilder Actions(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<ActionCollectionBuilder>();
 
         /// <summary>
         /// Gets the content apps collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static ContentAppFactoryCollectionBuilder? ContentApps(this IUmbracoBuilder builder)
+        public static ContentAppFactoryCollectionBuilder ContentApps(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<ContentAppFactoryCollectionBuilder>();
 
         /// <summary>
         /// Gets the content finders collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static ContentFinderCollectionBuilder? ContentFinders(this IUmbracoBuilder builder)
+        public static ContentFinderCollectionBuilder ContentFinders(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<ContentFinderCollectionBuilder>();
 
         /// <summary>
         /// Gets the editor validators collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static EditorValidatorCollectionBuilder? EditorValidators(this IUmbracoBuilder builder)
+        public static EditorValidatorCollectionBuilder EditorValidators(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<EditorValidatorCollectionBuilder>();
 
         /// <summary>
         /// Gets the health checks collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static HealthCheckCollectionBuilder? HealthChecks(this IUmbracoBuilder builder)
+        public static HealthCheckCollectionBuilder HealthChecks(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<HealthCheckCollectionBuilder>();
 
-        public static HealthCheckNotificationMethodCollectionBuilder? HealthCheckNotificationMethods(this IUmbracoBuilder builder)
+        public static HealthCheckNotificationMethodCollectionBuilder HealthCheckNotificationMethods(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<HealthCheckNotificationMethodCollectionBuilder>();
 
         /// <summary>
         /// Gets the TourFilters collection builder.
         /// </summary>
-        public static TourFilterCollectionBuilder? TourFilters(this IUmbracoBuilder builder)
+        public static TourFilterCollectionBuilder TourFilters(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<TourFilterCollectionBuilder>();
 
         /// <summary>
         /// Gets the URL providers collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static UrlProviderCollectionBuilder? UrlProviders(this IUmbracoBuilder builder)
+        public static UrlProviderCollectionBuilder UrlProviders(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<UrlProviderCollectionBuilder>();
 
         /// <summary>
         /// Gets the media url providers collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static MediaUrlProviderCollectionBuilder? MediaUrlProviders(this IUmbracoBuilder builder)
+        public static MediaUrlProviderCollectionBuilder MediaUrlProviders(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<MediaUrlProviderCollectionBuilder>();
 
         /// <summary>
         /// Gets the backoffice sections/applications collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static SectionCollectionBuilder? Sections(this IUmbracoBuilder builder)
+        public static SectionCollectionBuilder Sections(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<SectionCollectionBuilder>();
 
         /// <summary>
         /// Gets the components collection builder.
         /// </summary>
-        public static ComponentCollectionBuilder? Components(this IUmbracoBuilder builder)
+        public static ComponentCollectionBuilder Components(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<ComponentCollectionBuilder>();
 
         /// <summary>
         /// Gets the backoffice dashboards collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static DashboardCollectionBuilder? Dashboards(this IUmbracoBuilder builder)
+        public static DashboardCollectionBuilder Dashboards(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<DashboardCollectionBuilder>();
 
         /// <summary>
         /// Gets the cache refreshers collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static CacheRefresherCollectionBuilder? CacheRefreshers(this IUmbracoBuilder builder)
+        public static CacheRefresherCollectionBuilder CacheRefreshers(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<CacheRefresherCollectionBuilder>();
 
         /// <summary>
         /// Gets the map definitions collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static MapDefinitionCollectionBuilder? MapDefinitions(this IUmbracoBuilder builder)
+        public static MapDefinitionCollectionBuilder MapDefinitions(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>();
 
         /// <summary>
         /// Gets the data editor collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static DataEditorCollectionBuilder? DataEditors(this IUmbracoBuilder builder)
+        public static DataEditorCollectionBuilder DataEditors(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<DataEditorCollectionBuilder>();
 
         /// <summary>
         /// Gets the data value reference factory collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static DataValueReferenceFactoryCollectionBuilder? DataValueReferenceFactories(this IUmbracoBuilder builder)
+        public static DataValueReferenceFactoryCollectionBuilder DataValueReferenceFactories(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<DataValueReferenceFactoryCollectionBuilder>();
 
         /// <summary>
         /// Gets the property value converters collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static PropertyValueConverterCollectionBuilder? PropertyValueConverters(this IUmbracoBuilder builder)
+        public static PropertyValueConverterCollectionBuilder PropertyValueConverters(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<PropertyValueConverterCollectionBuilder>();
 
         /// <summary>
         /// Gets the url segment providers collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static UrlSegmentProviderCollectionBuilder? UrlSegmentProviders(this IUmbracoBuilder builder)
+        public static UrlSegmentProviderCollectionBuilder UrlSegmentProviders(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<UrlSegmentProviderCollectionBuilder>();
 
         /// <summary>
         /// Gets the validators collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        internal static ManifestValueValidatorCollectionBuilder? ManifestValueValidators(this IUmbracoBuilder builder)
+        internal static ManifestValueValidatorCollectionBuilder ManifestValueValidators(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<ManifestValueValidatorCollectionBuilder>();
 
         /// <summary>
         /// Gets the manifest filter collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static ManifestFilterCollectionBuilder? ManifestFilters(this IUmbracoBuilder builder)
+        public static ManifestFilterCollectionBuilder ManifestFilters(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<ManifestFilterCollectionBuilder>();
 
         /// <summary>
         /// Gets the content finders collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static MediaUrlGeneratorCollectionBuilder? MediaUrlGenerators(this IUmbracoBuilder builder)
+        public static MediaUrlGeneratorCollectionBuilder MediaUrlGenerators(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<MediaUrlGeneratorCollectionBuilder>();
 
         /// <summary>
@@ -270,26 +268,26 @@ namespace Umbraco.Cms.Core.DependencyInjection
         /// </summary>
         /// <param name="builder">The builder.</param>
         [Obsolete("Use EmbedProviders() instead")]
-        public static EmbedProvidersCollectionBuilder? OEmbedProviders(this IUmbracoBuilder builder)
+        public static EmbedProvidersCollectionBuilder OEmbedProviders(this IUmbracoBuilder builder)
             => EmbedProviders(builder);
 
         /// <summary>
         /// Gets the backoffice Embed Providers collection builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        public static EmbedProvidersCollectionBuilder? EmbedProviders(this IUmbracoBuilder builder)
+        public static EmbedProvidersCollectionBuilder EmbedProviders(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<EmbedProvidersCollectionBuilder>();
 
         /// <summary>
         /// Gets the back office searchable tree collection builder
         /// </summary>
-        public static SearchableTreeCollectionBuilder? SearchableTrees(this IUmbracoBuilder builder)
+        public static SearchableTreeCollectionBuilder SearchableTrees(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<SearchableTreeCollectionBuilder>();
 
         /// <summary>
         /// Gets the back office custom assets collection builder
         /// </summary>
-        public static CustomBackOfficeAssetsCollectionBuilder? BackOfficeAssets(this IUmbracoBuilder builder)
+        public static CustomBackOfficeAssetsCollectionBuilder BackOfficeAssets(this IUmbracoBuilder builder)
             => builder.WithCollectionBuilder<CustomBackOfficeAssetsCollectionBuilder>();
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +23,6 @@ using Umbraco.Cms.Core.Install;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Mail;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Packaging;
@@ -48,7 +45,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
 {
     public class UmbracoBuilder : IUmbracoBuilder
     {
-        private readonly Dictionary<Type, ICollectionBuilder?> _builders = new Dictionary<Type, ICollectionBuilder?>();
+        private readonly Dictionary<Type, ICollectionBuilder> _builders = new Dictionary<Type, ICollectionBuilder>();
 
         public IServiceCollection Services { get; }
 
@@ -101,18 +98,17 @@ namespace Umbraco.Cms.Core.DependencyInjection
         /// </summary>
         /// <typeparam name="TBuilder">The type of the collection builder.</typeparam>
         /// <returns>The collection builder.</returns>
-        public TBuilder? WithCollectionBuilder<TBuilder>()
+        public TBuilder WithCollectionBuilder<TBuilder>()
             where TBuilder : ICollectionBuilder
         {
             Type typeOfBuilder = typeof(TBuilder);
 
-            if (_builders.TryGetValue(typeOfBuilder, out ICollectionBuilder? o))
+            if (_builders.TryGetValue(typeOfBuilder, out ICollectionBuilder o))
             {
-                return (TBuilder?)o;
+                return (TBuilder)o;
             }
 
-            TBuilder? builder;
-
+            TBuilder builder;
             if (typeof(TBuilder).GetConstructor(Type.EmptyTypes) != null)
             {
                 builder = Activator.CreateInstance<TBuilder>();
@@ -120,7 +116,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             else if (typeof(TBuilder).GetConstructor(new[] { typeof(IUmbracoBuilder) }) != null)
             {
                 // Handle those collection builders which need a reference to umbraco builder i.e. DistributedLockingCollectionBuilder.
-                builder = (TBuilder?)Activator.CreateInstance(typeof(TBuilder), this);
+                builder = (TBuilder)Activator.CreateInstance(typeof(TBuilder), this)!;
             }
             else
             {
@@ -133,9 +129,9 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
         public void Build()
         {
-            foreach (ICollectionBuilder? builder in _builders.Values)
+            foreach (ICollectionBuilder builder in _builders.Values)
             {
-                builder?.RegisterWith(Services);
+                builder.RegisterWith(Services);
             }
 
             _builders.Clear();

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -103,7 +103,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
         {
             Type typeOfBuilder = typeof(TBuilder);
 
-            if (_builders.TryGetValue(typeOfBuilder, out ICollectionBuilder o))
+            if (_builders.TryGetValue(typeOfBuilder, out ICollectionBuilder? o))
             {
                 return (TBuilder)o;
             }

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -117,7 +117,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             // register the manifest filter collection builder (collection is empty by default)
             builder.ManifestFilters();
 
-            builder.MediaUrlGenerators()?
+            builder.MediaUrlGenerators()
                 .Add<FileUploadPropertyEditor>()
                 .Add<ImageCropperPropertyEditor>();
 
@@ -147,7 +147,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             // both TinyMceValueConverter (in Core) and RteMacroRenderingValueConverter (in Web) will be
             // discovered when CoreBootManager configures the converters. We will remove the basic one defined
             // in core so that the more enhanced version is active.
-            builder.PropertyValueConverters()?
+            builder.PropertyValueConverters()
                 .Remove<SimpleTinyMceValueConverter>();
 
             // register *all* checks, except those marked [HideFromTypeFinder] of course
@@ -260,7 +260,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
 
         private static IUmbracoBuilder AddPreValueMigrators(this IUmbracoBuilder builder)
         {
-            builder.WithCollectionBuilder<PreValueMigratorCollectionBuilder>()?
+            builder.WithCollectionBuilder<PreValueMigratorCollectionBuilder>()
                 .Append<RenamingPreValueMigrator>()
                 .Append<RichTextPreValueMigrator>()
                 .Append<UmbracoSliderPreValueMigrator>()

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.MappingProfiles.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.MappingProfiles.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
         {
             builder.Services.AddUnique<IUmbracoMapper, UmbracoMapper>();
 
-            builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()?
+            builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
                 .Add<AuditMapDefinition>()
                 .Add<CodeFileMapDefinition>()
                 .Add<ContentPropertyMapDefinition>()

--- a/src/Umbraco.Web.BackOffice/Extensions/WebMappingProfiles.cs
+++ b/src/Umbraco.Web.BackOffice/Extensions/WebMappingProfiles.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Extensions
     {
         public static IUmbracoBuilder AddWebMappingProfiles(this IUmbracoBuilder builder)
         {
-            builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()?
+            builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
                 .Add<ContentMapDefinition>()
                 .Add<MediaMapDefinition>()
                 .Add<MemberMapDefinition>();

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -338,7 +338,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IBackOfficeSecurityAccessor, BackOfficeSecurityAccessor>();
 
         var umbracoApiControllerTypes = builder.TypeLoader.GetUmbracoApiControllers().ToList();
-        builder.WithCollectionBuilder<UmbracoApiControllerTypeCollectionBuilder>()?
+        builder.WithCollectionBuilder<UmbracoApiControllerTypeCollectionBuilder>()
             .Add(umbracoApiControllerTypes);
 
         builder.Services.AddSingleton<UmbracoRequestLoggingMiddleware>();

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static partial class UmbracoBuilderExtensions
     /// </summary>
     public static IUmbracoBuilder AddWebsite(this IUmbracoBuilder builder)
     {
-        builder.WithCollectionBuilder<SurfaceControllerTypeCollectionBuilder>()?
+        builder.WithCollectionBuilder<SurfaceControllerTypeCollectionBuilder>()
             .Add(builder.TypeLoader.GetSurfaceControllers());
 
         // Configure MVC startup options for custom view locations


### PR DESCRIPTION
I noticed `WithCollectionBuilder()` and any of the shortcuts/helper methods retuned a nullable type, which can't occur (it throws an exception otherwise).

This requires all calls to these methods to include a null-check or use the null-conditional operator, making the API a bit more verbose then necessary:

```c#
builder.ContentFinders()?.Append<MyCustomContentFinder>();
// vs
builder.ContentFinders().Append<MyCustomContentFinder>();
```