### PR TITLE
V9: Fix URL generation when publishing invariant content with domains

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
@@ -164,10 +164,10 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             // walk up from that node until we hit a node with a domain,
             // or we reach the content root, collecting URLs in the way
             var pathParts = new List<string>();
-            IPublishedContent n = node;
-            var urlSegment = n.UrlSegment(_variationContextAccessor, culture);
-            var hasDomains = _domainCache.GetAssignedWithCulture(culture, n.Id);
-            while (hasDomains == false && n != null) // n is null at root
+            IPublishedContent content = node;
+            var urlSegment = content.UrlSegment(_variationContextAccessor, culture);
+            var hasDomains = _domainCache.GetAssignedWithCulture(culture, content.Id);
+            while (hasDomains == false && content != null) // content is null at root
             {
                 // no segment indicates this is not published when this is a variant
                 if (urlSegment.IsNullOrWhiteSpace())
@@ -178,13 +178,13 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                 pathParts.Add(urlSegment);
 
                 // move to parent node
-                n = n.Parent;
-                if (n != null)
+                content = content.Parent;
+                if (content != null)
                 {
-                    urlSegment = n.UrlSegment(_variationContextAccessor, culture);
+                    urlSegment = content.UrlSegment(_variationContextAccessor, culture);
                 }
 
-                hasDomains = n != null && _domainCache.GetAssignedWithCulture(culture, n.Id);
+                hasDomains = content != null && _domainCache.GetAssignedWithCulture(culture, content.Id);
             }
 
             // at this point this will be the urlSegment of the root, no segment indicates this is not published when this is a variant
@@ -204,7 +204,7 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             var path = "/" + string.Join("/", pathParts); // will be "/" or "/foo" or "/foo/bar" etc
             //prefix the root node id containing the domain if it exists (this is a standard way of creating route paths)
             //and is done so that we know the ID of the domain node for the path
-            var route = (n?.Id.ToString(CultureInfo.InvariantCulture) ?? "") + path;
+            var route = (content?.Id.ToString(CultureInfo.InvariantCulture) ?? "") + path;
 
             return route;
         }

--- a/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
@@ -11,7 +11,8 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             var assigned = domainCache.GetAssigned(documentId, includeWildcards);
 
             // It's super important that we always compare cultures with ignore case, since we can't be sure of the casing!
-            return culture is null ? assigned.Any() : assigned.Any(x => x.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
+            // Comparing with string.IsNullOrEmpty since both empty string and null signifies invariant.
+            return string.IsNullOrEmpty(culture) ? assigned.Any() : assigned.Any(x => x.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
This fixes #12331.

This is another issue related to the fact that invariant culture is sometimes referenced with an empty string sometimes, and other times a null value.

The issue was that we have an extension method `GetAssignedWithCulture` which returns true if there's a domain associated with a node, otherwise false. 

This endpoint will try and find the specific domain for a particular culture if a culture is specified, and only return true if it finds something, however, with invariant nodes it should just return true if there are **any** domains. This invariant node check would sometimes fail because an empty string was passed in, instead of null, however, both mean invariant, so I've updated the check with a  `string.IsNullOrEmpty(culture)`, so it's always caught now. 

## Testing

Follow the reproduction steps on the issue.