### PR TITLE
V10: Fix URL generation when publishing invariant content with domains

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
@@ -164,10 +164,10 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             // walk up from that node until we hit a node with a domain,
             // or we reach the content root, collecting URLs in the way
             var pathParts = new List<string>();
-            IPublishedContent? n = node;
-            var urlSegment = n.UrlSegment(_variationContextAccessor, culture);
-            var hasDomains = _domainCache.GetAssignedWithCulture(culture, n.Id);
-            while (hasDomains == false && n != null) // n is null at root
+            IPublishedContent? content = node;
+            var urlSegment = content.UrlSegment(_variationContextAccessor, culture);
+            var hasDomains = _domainCache.GetAssignedWithCulture(culture, content.Id);
+            while (hasDomains == false && content != null) // content is null at root
             {
                 // no segment indicates this is not published when this is a variant
                 if (urlSegment.IsNullOrWhiteSpace())
@@ -178,13 +178,13 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
                 pathParts.Add(urlSegment!);
 
                 // move to parent node
-                n = n.Parent;
-                if (n != null)
+                content = content.Parent;
+                if (content != null)
                 {
-                    urlSegment = n.UrlSegment(_variationContextAccessor, culture);
+                    urlSegment = content.UrlSegment(_variationContextAccessor, culture);
                 }
 
-                hasDomains = n != null && _domainCache.GetAssignedWithCulture(culture, n.Id);
+                hasDomains = content != null && _domainCache.GetAssignedWithCulture(culture, content.Id);
             }
 
             // at this point this will be the urlSegment of the root, no segment indicates this is not published when this is a variant
@@ -204,7 +204,7 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             var path = "/" + string.Join("/", pathParts); // will be "/" or "/foo" or "/foo/bar" etc
             //prefix the root node id containing the domain if it exists (this is a standard way of creating route paths)
             //and is done so that we know the ID of the domain node for the path
-            var route = (n?.Id.ToString(CultureInfo.InvariantCulture) ?? "") + path;
+            var route = (content?.Id.ToString(CultureInfo.InvariantCulture) ?? "") + path;
 
             return route;
         }

--- a/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DomainCacheExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Infrastructure.PublishedCache
@@ -11,7 +9,8 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache
             var assigned = domainCache.GetAssigned(documentId, includeWildcards);
 
             // It's super important that we always compare cultures with ignore case, since we can't be sure of the casing!
-            return culture is null ? assigned.Any() : assigned.Any(x => x.Culture?.Equals(culture, StringComparison.InvariantCultureIgnoreCase) ?? false);
+            // Comparing with string.IsNullOrEmpty since both empty string and null signifies invariant.
+            return string.IsNullOrEmpty(culture) ? assigned.Any() : assigned.Any(x => x.Culture?.Equals(culture, StringComparison.InvariantCultureIgnoreCase) ?? false);
         }
     }
 }


### PR DESCRIPTION
This is the V10 version of #12404, the code here is exactly the same, so if the V9 version checks out, this should be good too. See he V9 PR for more information