### PR TITLE
v10: Support System.Data.SqlClient provider name

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/UmbracoBuilderExtensions.cs
@@ -2,6 +2,7 @@ using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.DistributedLocking;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -36,6 +37,15 @@ public static class UmbracoBuilderExtensions
 
         DbProviderFactories.UnregisterFactory(Constants.ProviderName);
         DbProviderFactories.RegisterFactory(Constants.ProviderName, SqlClientFactory.Instance);
+
+        // Support provider name set by the configuration API for connection string environment variables
+        builder.Services.ConfigureAll<ConnectionStrings>(options =>
+        {
+            if (options.ProviderName == "System.Data.SqlClient")
+            {
+                options.ProviderName = Constants.ProviderName;
+            }
+        });
 
         return builder;
     }

--- a/src/Umbraco.Cms.Persistence.Sqlite/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/UmbracoBuilderExtensions.cs
@@ -39,28 +39,21 @@ public static class UmbracoBuilderExtensions
         DbProviderFactories.UnregisterFactory(Constants.ProviderName);
         DbProviderFactories.RegisterFactory(Constants.ProviderName, Microsoft.Data.Sqlite.SqliteFactory.Instance);
 
-
-        builder.Services.PostConfigure<ConnectionStrings>(Core.Constants.System.UmbracoConnectionName, opt =>
+        // Prevent accidental creation of SQLite database files
+        builder.Services.PostConfigureAll<ConnectionStrings>(options =>
         {
-            if (!opt.IsConnectionStringConfigured())
+            // Skip empty connection string and other providers
+            if (!options.IsConnectionStringConfigured() || options.ProviderName != Constants.ProviderName)
             {
                 return;
             }
 
-            if (opt.ProviderName != Constants.ProviderName)
-            {
-                // Not us.
-                return;
-            }
-
-            // Prevent accidental creation of database files.
-            var connectionStringBuilder = new SqliteConnectionStringBuilder(opt.ConnectionString);
+            var connectionStringBuilder = new SqliteConnectionStringBuilder(options.ConnectionString);
             if (connectionStringBuilder.Mode == SqliteOpenMode.ReadWriteCreate)
             {
                 connectionStringBuilder.Mode = SqliteOpenMode.ReadWrite;
+                options.ConnectionString = connectionStringBuilder.ConnectionString;
             }
-
-            opt.ConnectionString = connectionStringBuilder.ConnectionString;
         });
 
         return builder;

--- a/src/Umbraco.Core/Configuration/ConfigureConnectionStrings.cs
+++ b/src/Umbraco.Core/Configuration/ConfigureConnectionStrings.cs
@@ -18,11 +18,12 @@ public class ConfigureConnectionStrings : IConfigureNamedOptions<ConnectionStrin
     public ConfigureConnectionStrings(IConfiguration configuration) => _configuration = configuration;
 
     /// <inheritdoc />
-    public void Configure(ConnectionStrings options) => Configure(Constants.System.UmbracoConnectionName, options);
+    public void Configure(ConnectionStrings options) => Configure(Options.DefaultName, options);
 
     /// <inheritdoc />
     public void Configure(string name, ConnectionStrings options)
     {
+        // Default to using UmbracoConnectionName
         if (name == Options.DefaultName)
         {
             name = Constants.System.UmbracoConnectionName;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When using the [connection string environment variables](https://docs.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#connection-string-prefixes), the provider name is set to `System.Data.SqlClient`. Umbraco/NPoco 5 however uses the `Microsoft.Data.SqlClient` provider and would therefore not find the correct provider to use.

You can test this by setting this environment variable and running the Umbraco.Web.UI project:

```powershell
❯ Set-Item Env:\SQLCONNSTR_umbracoDbDSN "Data Source=(localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\Umbraco.mdf;Integrated Security=True"
❯ dotnet run

Building...
[INF] Acquiring MainDom.
[INF] Acquired MainDom.
[WRN] Could not check the upgrade state.
System.ArgumentException: The specified invariant name 'System.Data.SqlClient' wasn't found in the list of registered .NET Data Providers.
   at System.Data.Common.DbProviderFactories.GetFactory(String providerInvariantName, Boolean throwOnError)
   at System.Data.Common.DbProviderFactories.GetFactory(String providerInvariantName)
   at Umbraco.Cms.Infrastructure.Persistence.DbProviderFactoryCreator.CreateFactory(String providerName)
   at Umbraco.Cms.Infrastructure.Persistence.UmbracoDatabaseFactory.get_DbProviderFactory()
   at Umbraco.Cms.Infrastructure.Persistence.UmbracoDatabaseFactory.get_CanConnect()
   at Umbraco.Cms.Infrastructure.Runtime.RuntimeState.TryDbConnect(IUmbracoDatabaseFactory databaseFactory)
   at Umbraco.Cms.Infrastructure.Runtime.RuntimeState.GetUmbracoDatabaseState(IUmbracoDatabaseFactory databaseFactory)
[ERR] Boot Failed
Umbraco.Cms.Core.Exceptions.BootFailedException: Could not check the upgrade state.
 ---> System.ArgumentException: The specified invariant name 'System.Data.SqlClient' wasn't found in the list of registered .NET Data Providers.
...
```

This PR updates the provider name from `System.Data.SqlClient` to `Microsoft.Data.SqlClient` on the `ConnectionStrings` options class, so we don't have to introduce additional features to support alternative provider names.
