### PR TITLE
Fix Dictionary item not working in block description

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -438,8 +438,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             display.ContentTypeName = _localizedTextService.UmbracoDictionaryTranslate(CultureDictionary, display.ContentTypeName);
             // if your user type doesn't have access to the Settings section it would not get this property mapped
             if (display.DocumentType != null)
+            {
                 display.DocumentType.Name = _localizedTextService.UmbracoDictionaryTranslate(CultureDictionary, display.DocumentType.Name);
-
+                display.DocumentType.Description = _localizedTextService.UmbracoDictionaryTranslate(CultureDictionary, display.DocumentType.Description);
+            }
             //remove the listview app if it exists
             display.ContentApps = display.ContentApps.Where(x => x.Alias != "umbListView").ToList();
 


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco-CMS/issues/12310

Together with `ContentItemDisplay.Name` also translate `ContentItemDisplay.Description`.

This allows editors to use the `#label` notation.

Fixes issue for Block List and Nested Content