### PR TITLE
Menu action icons

### DIFF
--- a/src/Umbraco.Core/Models/Trees/ActionMenuItem.cs
+++ b/src/Umbraco.Core/Models/Trees/ActionMenuItem.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Models.Trees
@@ -27,22 +27,24 @@ namespace Umbraco.Cms.Core.Models.Trees
         /// </summary>
         public virtual string? AngularServiceMethodName { get; } = null;
 
-        protected ActionMenuItem(string alias, string name) : base(alias, name)
+        protected ActionMenuItem(string alias, string name)
+            : base(alias, name)
         {
             Initialize();
         }
 
-        protected ActionMenuItem(string alias, ILocalizedTextService textService) : base(alias, textService)
+        protected ActionMenuItem(string alias, ILocalizedTextService textService)
+            : base(alias, textService)
         {
             Initialize();
         }
 
         private void Initialize()
         {
-            //add the current type to the metadata
+            // add the current type to the metadata
             if (AngularServiceMethodName.IsNullOrWhiteSpace())
             {
-                //if no method name is supplied we will assume that the menu action is the type name of the current menu class
+                // if no method name is supplied we will assume that the menu action is the type name of the current menu class
                 ExecuteJsMethod($"{AngularServiceName}.{this.GetType().Name}");
             }
             else

--- a/src/Umbraco.Core/Models/Trees/ExportMember.cs
+++ b/src/Umbraco.Core/Models/Trees/ExportMember.cs
@@ -9,9 +9,10 @@ namespace Umbraco.Cms.Core.Models.Trees
     {
         public override string AngularServiceName => "umbracoMenuActions";
 
-        public ExportMember(ILocalizedTextService textService) : base("export", textService)
+        public ExportMember(ILocalizedTextService textService)
+            : base("export", textService)
         {
-            Icon = "download-alt";
+            Icon = "icon-download-alt";
             UseLegacyIcon = false;
         }
     }

--- a/src/Umbraco.Core/Models/Trees/MenuItem.cs
+++ b/src/Umbraco.Core/Models/Trees/MenuItem.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Core.Models.Trees
         {
             Alias = alias;
             Name = textService.Localize("actions", Alias);
-            TextDescription =  textService.Localize("visuallyHiddenTexts", alias + "_description", Thread.CurrentThread.CurrentUICulture);
+            TextDescription = textService.Localize("visuallyHiddenTexts", alias + "_description", Thread.CurrentThread.CurrentUICulture);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Models/Trees/MenuItem.cs
+++ b/src/Umbraco.Core/Models/Trees/MenuItem.cs
@@ -91,6 +91,7 @@ namespace Umbraco.Cms.Core.Models.Trees
         [DataMember(Name = "icon")]
         public string Icon { get; set; }
 
+        /// <summary>
         /// Used in the UI to indicate whether icons should be prefixed with "icon-".
         /// If not legacy icon full icon name should be specified.
         /// </summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
A minor oversight in https://github.com/umbraco/Umbraco-CMS/pull/12403 where the export member action is missing the `icon-` prefix as it now specify full icon name (for future development and sometime later we can probably remove the `useLegacyIcon` property).

![chrome_nhkiYelkOq](https://user-images.githubusercontent.com/2919859/168857472-0ce876d9-f3e3-42cf-a5ac-d67f1ec570b7.png)

![image](https://user-images.githubusercontent.com/2919859/168857685-d7400b74-2e4c-498e-80ff-d694d65fcc4d.png)

// @nathanwoulfe 
