### PR TITLE
Fixed ICU problem with userId (int) converted to string

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/TwoFactorLoginController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TwoFactorLoginController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -68,7 +69,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<UserTwoFactorProviderModel>>> Get2FAProvidersForUser(int userId)
         {
-            var user = await _backOfficeUserManager.FindByIdAsync(userId.ToString());
+            var user = await _backOfficeUserManager.FindByIdAsync(userId.ToString(CultureInfo.InvariantCulture));
 
             var enabledProviderNameHashSet = new HashSet<string>(await _twoFactorLoginService.GetEnabledTwoFactorProviderNamesAsync(user.Key));
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12384

We need to use invariant culture when doing ToString of user ints

To test change user culture to e.g Swedish and open the user panel