### PR TITLE
Update template gitignore for static assets now in Razor Class Library

### DIFF
--- a/templates/UmbracoProject/.gitignore
+++ b/templates/UmbracoProject/.gitignore
@@ -464,24 +464,6 @@ $RECYCLE.BIN/
 # Umbraco log files
 **/umbraco/Logs/
 
-# Umbraco backoffice language files
-# Nuget package Umbraco.Cms.StaticAssets will copy them in during dotnet build
-# Customize langguage files in /config/lang/{language}.user.xml
-**/umbraco/config/lang/
-
 # JSON Schema file for appsettings
 # This is auto generated from the build
 **/umbraco/config/appsettings-schema.json
-
-# This is the no-nodes, installer & upgrader pages from Umbraco
-# Nuget package Umbraco.Cms.StaticAssets will copy them in during dotnet build
-**/umbraco/UmbracoWebsite/
-**/umbraco/UmbracoInstall/
-**/umbraco/UmbracoBackOffice/
-
-# Comment out the line below if you wish to change or add any new templates to PartialView Macros
-**/umbraco/PartialViewMacros/
-
-# Umbraco Static Assets of Backoffice
-# Nuget package Umbraco.Cms.StaticAssets will copy them in during dotnet build
-**/wwwroot/umbraco/

--- a/templates/UmbracoProject/.gitignore
+++ b/templates/UmbracoProject/.gitignore
@@ -466,4 +466,4 @@ $RECYCLE.BIN/
 
 # JSON Schema file for appsettings
 # This is auto generated from the build
-**/umbraco/config/appsettings-schema.json
+appsettings-schema.json


### PR DESCRIPTION
Remove the rules for umbraco static assets as these are now served from a Razor Class Library

I have also updated the path of `appsettings-schema.json` in anticipation of https://github.com/umbraco/Umbraco-CMS/pull/12416 (it doesn't currently exist at all in v10)