### PR TITLE
V10: assigndomain key not found

### DIFF
--- a/src/Umbraco.Core/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Core/Actions/ActionAssignDomain.cs
@@ -17,7 +17,8 @@ public class ActionAssignDomain : IAction
     public char Letter => ActionLetter;
 
     /// <inheritdoc/>
-    public string Alias => "assignDomain";
+    // This is all lower-case because of case sensitive filesystems, see issue: https://github.com/umbraco/Umbraco-CMS/issues/11670
+    public string Alias => "assigndomain";
 
     /// <inheritdoc/>
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12358

# Notes
- As @nathanwoulfe mentions in the issue, this is related to https://github.com/umbraco/Umbraco-CMS/pull/11784, here we fixed the casing of `assignDomain` to be all lowercase to handle case sensitive file-systems.
- After this, it seems a merge conflict was not handled correctly here: https://github.com/umbraco/Umbraco-CMS/commit/235918ecfccf3501fa1a046fdac6c77f8ddf6ea4, and this was reverted to camelCase
Which is also why this is not a problem in v9

![image](https://user-images.githubusercontent.com/70372949/169767425-9861fd9a-dc42-49df-988b-e90694bb0445.png)


# How to test
- Create an empty document type and allow as root
- Create some content
- Right click on your new action node, it should now display "Culture and Hostnames"
- Please also verify this is the same by click the "Action" button when on a content node
![image](https://user-images.githubusercontent.com/70372949/169767670-14a41b59-65cf-4b44-b203-661812b891b4.png)
