### PR TITLE
Fixes issue with redirects not being generated when an invariant cont…

### DIFF
--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -112,11 +112,9 @@ namespace Umbraco.Cms.Core.Routing
             // be nice with tests, assume things can be null, ultimately fall back to invariant
             // (but only for variant content of course)
             // We need to check all ancestors because urls are variant even for invariant content, if an ancestor is variant.
-            if (content.AncestorsOrSelf().Any(x=>x.ContentType.VariesByCulture()))
+            if (culture == null && content.AncestorsOrSelf().Any(x => x.ContentType.VariesByCulture()))
             {
-
-                if (culture == null)
-                    culture = _variationContextAccessor?.VariationContext?.Culture ?? "";
+                culture = _variationContextAccessor?.VariationContext?.Culture ?? "";
             }
 
             if (current == null)

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -111,14 +111,10 @@ namespace Umbraco.Cms.Core.Routing
             // this the ONLY place where we deal with default culture - IUrlProvider always receive a culture
             // be nice with tests, assume things can be null, ultimately fall back to invariant
             // (but only for variant content of course)
-            if (content.ContentType.VariesByCulture())
+            // We need to check all ancestors because urls are variant even for invariant content, if an ancestor is variant.
+            if (content.AncestorsOrSelf().Any(x=>x.ContentType.VariesByCulture()))
             {
-                if (culture == null)
-                    culture = _variationContextAccessor?.VariationContext?.Culture ?? "";
-            }
-            else if(content.Ancestors().Any(x=>x.ContentType.VariesByCulture()))
-            {
-                //We need to ensure all ancestors are also invariant, otherwise we have to set a culture to find the url
+
                 if (culture == null)
                     culture = _variationContextAccessor?.VariationContext?.Culture ?? "";
             }

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -116,13 +116,19 @@ namespace Umbraco.Cms.Core.Routing
                 if (culture == null)
                     culture = _variationContextAccessor?.VariationContext?.Culture ?? "";
             }
+            else if(content.Ancestors().Any(x=>x.ContentType.VariesByCulture()))
+            {
+                //We need to ensure all ancestors are also invariant, otherwise we have to set a culture to find the url
+                if (culture == null)
+                    culture = _variationContextAccessor?.VariationContext?.Culture ?? "";
+            }
 
             if (current == null)
             {
                 var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
                 current = umbracoContext.CleanedUmbracoUrl;
             }
-            
+
 
             var url = _urlProviders.Select(provider => provider.GetUrl(content, mode, culture, current))
                 .FirstOrDefault(u => u != null);
@@ -230,7 +236,7 @@ namespace Umbraco.Cms.Core.Routing
                 var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
                 current = umbracoContext.CleanedUmbracoUrl;
             }
-                
+
 
             var url = _mediaUrlProviders.Select(provider =>
                     provider.GetMediaUrl(content, propertyAlias, mode, culture, current))

--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
@@ -143,27 +143,22 @@ namespace Umbraco.Cms.Core.Routing
                 foreach (var culture in cultures)
                 {
                     var route = contentCache.GetRouteById(publishedContent.Id, culture);
-                    if (IsNotRoute(route))
-                    {
-                        //Retry using all languages, if this is invariant but has a variant ancestor
-                        if (string.IsNullOrEmpty(culture))
-                        {
-                            var languages = _localizationService.GetAllLanguages();
-
-                            foreach (var language in languages)
-                            {
-                                route = contentCache.GetRouteById(publishedContent.Id, language.IsoCode);
-
-                                if (!IsNotRoute(route))
-                                {
-                                    oldRoutes[new ContentIdAndCulture(publishedContent.Id, language.IsoCode)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
-                                }
-                            }
-                        }
-                    }
-                    else
+                    if (!IsNotRoute(route))
                     {
                         oldRoutes[new ContentIdAndCulture(publishedContent.Id, culture)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
+                    }
+                    else if (string.IsNullOrEmpty(culture))
+                    {
+                        // Retry using all languages, if this is invariant but has a variant ancestor
+                        var languages = _localizationService.GetAllLanguages();
+                        foreach (var language in languages)
+                        {
+                            route = contentCache.GetRouteById(publishedContent.Id, language.IsoCode);
+                            if (!IsNotRoute(route))
+                            {
+                                oldRoutes[new ContentIdAndCulture(publishedContent.Id, language.IsoCode)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
+                            }
+                        }
                     }
                 }
             }

--- a/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTrackingHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -13,6 +14,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Routing
@@ -35,6 +37,7 @@ namespace Umbraco.Cms.Core.Routing
         private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
         private readonly IRedirectUrlService _redirectUrlService;
         private readonly IVariationContextAccessor _variationContextAccessor;
+        private readonly ILocalizationService _localizationService;
 
         private const string NotificationStateKey = "Umbraco.Cms.Core.Routing.RedirectTrackingHandler";
 
@@ -43,14 +46,35 @@ namespace Umbraco.Cms.Core.Routing
             IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
             IRedirectUrlService redirectUrlService,
-            IVariationContextAccessor variationContextAccessor)
+            IVariationContextAccessor variationContextAccessor,
+            ILocalizationService localizationService)
         {
             _logger = logger;
             _webRoutingSettings = webRoutingSettings;
             _publishedSnapshotAccessor = publishedSnapshotAccessor;
             _redirectUrlService = redirectUrlService;
             _variationContextAccessor = variationContextAccessor;
+            _localizationService = localizationService;
         }
+
+        [Obsolete("Use ctor with all params")]
+        public RedirectTrackingHandler(
+            ILogger<RedirectTrackingHandler> logger,
+            IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IRedirectUrlService redirectUrlService,
+            IVariationContextAccessor variationContextAccessor)
+        :this(
+            logger,
+            webRoutingSettings,
+            publishedSnapshotAccessor,
+            redirectUrlService,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<ILocalizationService>())
+        {
+
+        }
+
 
         public void Handle(ContentPublishingNotification notification) => StoreOldRoutes(notification.PublishedEntities, notification);
 
@@ -121,10 +145,26 @@ namespace Umbraco.Cms.Core.Routing
                     var route = contentCache.GetRouteById(publishedContent.Id, culture);
                     if (IsNotRoute(route))
                     {
-                        continue;
-                    }
+                        //Retry using all languages, if this is invariant but has a variant ancestor
+                        if (string.IsNullOrEmpty(culture))
+                        {
+                            var languages = _localizationService.GetAllLanguages();
 
-                    oldRoutes[new ContentIdAndCulture(publishedContent.Id, culture)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
+                            foreach (var language in languages)
+                            {
+                                route = contentCache.GetRouteById(publishedContent.Id, language.IsoCode);
+
+                                if (!IsNotRoute(route))
+                                {
+                                    oldRoutes[new ContentIdAndCulture(publishedContent.Id, language.IsoCode)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        oldRoutes[new ContentIdAndCulture(publishedContent.Id, culture)] = new ContentKeyAndOldRoute(publishedContent.Key, route);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes issue with redirects not being generated when invariant content has variant ancestors. In this case, we want to create redirects for all languages

fixes https://github.com/umbraco/Umbraco-CMS/issues/12452
