### PR TITLE
Reintroduce MSBuild target that includes App_Plugins content when publishing

### DIFF
--- a/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
+++ b/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
@@ -13,4 +13,17 @@
           DestinationFolder="$(MSBuildProjectDirectory)"
           SkipUnchangedFiles="true" />
   </Target>
+  
+  <Target Name="IncludeAppPluginsContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
+    <ItemGroup>
+        <_AppPluginsFiles Include="App_Plugins\**" />
+
+        <ContentWithTargetPath
+            Include="@(_AppPluginsFiles)"
+            Exclude="@(ContentWithTargetPath)"
+            TargetPath="%(Identity)"
+            CopyToOutputDirectory="PreserveNewest"
+            CopyToPublishDirectory="PreserveNewest"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-rc3",
+  "version": "10.0.0-rc4",
   "assemblyVersion": {
     "precision": "Build" // optional. Use when you want a more precise assembly version than the default major.minor.
   },


### PR DESCRIPTION
Bump version and added missing msbuild target, that copies App_Plugins to publish folder.