### PR TITLE
Fix #12454 by having Coalesce handle null values

### DIFF
--- a/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
@@ -89,7 +89,7 @@ public sealed class HtmlStringUtilities
         return sb.ToString();
     }
 
-    public string Coalesce(params object[] args)
+    public string Coalesce(params object?[] args)
     {
         var arg = args
             .Select(x => x?.ToString())

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -910,7 +910,7 @@ public static class HtmlHelperRenderExtensions
     /// <summary>
     ///     Will take the first non-null value in the collection and return the value of it.
     /// </summary>
-    public static string Coalesce(this IHtmlHelper helper, params object[] args)
+    public static string Coalesce(this IHtmlHelper helper, params object?[] args)
         => s_stringUtilities.Coalesce(args);
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #12454 

### Description

This makes the Coalesce method able to handle null values again. This seems to have accidentally been removed in v10. Since the whole point of the Coleasce method is to choose the first non-null value from a list, this is a problem.
This PR uses the null coalescing operator to handle null values.

To test, call Html.Coleasce in a view, with one of the values being null. Without this PR, it will crash. With this PR, it should work like v9 and return the non-null value.