### PR TITLE
Move msbuild target to correct location

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -14,7 +14,7 @@
       <PackagePath>buildTransitive</PackagePath>
     </None>
   </ItemGroup>
-  
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
@@ -63,17 +63,5 @@
       A fix was put in place in Web SDK to update for wwwwroot in case someone runs npm build etc in a target, we're borrowing their trick.
       https://github.com/dotnet/sdk/blob/e2b2b1a4ac56c955b84d62fe71cda3b6f258b42b/src/WebSdk/Publish/Targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
    -->
-  <Target Name="IncludeUmbracoFolderContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
-    <ItemGroup>
-      <_UmbracoFolderFiles Include="umbraco\config\**" />
-      <_UmbracoFolderFiles Include="umbraco\PartialViewMacros\**" />
-      <_UmbracoFolderFiles Include="umbraco\UmbracoBackOffice\**" />
-      <_UmbracoFolderFiles Include="umbraco\UmbracoInstall\**" />
-      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
-      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
-      <_UmbracoFolderFiles Include="umbraco\Licenses\**" />
-      <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
+++ b/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
@@ -27,19 +27,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="IncludeAppPluginsContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
-    <ItemGroup>
-      <_AppPluginsFiles Include="App_Plugins\**" />
-
-      <ContentWithTargetPath
-        Include="@(_AppPluginsFiles)"
-        Exclude="@(ContentWithTargetPath)"
-        TargetPath="%(Identity)"
-        CopyToOutputDirectory="PreserveNewest"
-        CopyToPublishDirectory="PreserveNewest"/>
-    </ItemGroup>
-  </Target>
-
   <Target Name="IncludeUmbracoFolderContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
     <ItemGroup>
       <_UmbracoFolderFiles Include="umbraco\config\**" />

--- a/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
+++ b/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
@@ -13,17 +13,43 @@
           DestinationFolder="$(MSBuildProjectDirectory)"
           SkipUnchangedFiles="true" />
   </Target>
-  
+
   <Target Name="IncludeAppPluginsContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
     <ItemGroup>
-        <_AppPluginsFiles Include="App_Plugins\**" />
+      <_AppPluginsFiles Include="App_Plugins\**" />
 
-        <ContentWithTargetPath
-            Include="@(_AppPluginsFiles)"
-            Exclude="@(ContentWithTargetPath)"
-            TargetPath="%(Identity)"
-            CopyToOutputDirectory="PreserveNewest"
-            CopyToPublishDirectory="PreserveNewest"/>
+      <ContentWithTargetPath
+        Include="@(_AppPluginsFiles)"
+        Exclude="@(ContentWithTargetPath)"
+        TargetPath="%(Identity)"
+        CopyToOutputDirectory="PreserveNewest"
+        CopyToPublishDirectory="PreserveNewest"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeAppPluginsContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
+    <ItemGroup>
+      <_AppPluginsFiles Include="App_Plugins\**" />
+
+      <ContentWithTargetPath
+        Include="@(_AppPluginsFiles)"
+        Exclude="@(ContentWithTargetPath)"
+        TargetPath="%(Identity)"
+        CopyToOutputDirectory="PreserveNewest"
+        CopyToPublishDirectory="PreserveNewest"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeUmbracoFolderContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
+    <ItemGroup>
+      <_UmbracoFolderFiles Include="umbraco\config\**" />
+      <_UmbracoFolderFiles Include="umbraco\PartialViewMacros\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoBackOffice\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoInstall\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
+      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
+      <_UmbracoFolderFiles Include="umbraco\Licenses\**" />
+      <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
+++ b/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
@@ -34,7 +34,6 @@
       <_UmbracoFolderFiles Include="umbraco\UmbracoBackOffice\**" />
       <_UmbracoFolderFiles Include="umbraco\UmbracoInstall\**" />
       <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
-      <_UmbracoFolderFiles Include="umbraco\UmbracoWebsite\**" />
       <_UmbracoFolderFiles Include="umbraco\Licenses\**" />
       <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>


### PR DESCRIPTION
The msbuild target that copies Umbraco folders was not in a target file, and thereby not part of the nuget file.