### PR TITLE
V9: Send content type notifications on copy

### DIFF
--- a/src/Umbraco.Infrastructure/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -730,7 +730,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
         public Attempt<OperationResult<MoveOperationStatusType, TItem>> Copy(TItem copying, int containerId)
         {
-            var evtMsgs = EventMessagesFactory.Get();
+            var eventMessages = EventMessagesFactory.Get();
 
             TItem copy;
             using (var scope = ScopeProvider.CreateScope())
@@ -765,16 +765,34 @@ namespace Umbraco.Cms.Core.Services.Implement
                     }
 
                     copy.ParentId = containerId;
+
+                    SavingNotification<TItem> savingNotification = GetSavingNotification(copy, eventMessages);
+                    if (scope.Notifications.PublishCancelable(savingNotification))
+                    {
+                        scope.Complete();
+                        return OperationResult.Attempt.Fail(MoveOperationStatusType.FailedCancelledByEvent, eventMessages, copy);
+                    }
+
                     Repository.Save(copy);
+
+                    ContentTypeChange<TItem>[] changes = ComposeContentTypeChanges(copy).ToArray();
+
+                    _eventAggregator.Publish(GetContentTypeRefreshedNotification(changes, eventMessages));
+                    scope.Notifications.Publish(GetContentTypeChangedNotification(changes, eventMessages));
+
+                    SavedNotification<TItem> savedNotification = GetSavedNotification(copy, eventMessages);
+                    savedNotification.WithStateFrom(savingNotification);
+                    scope.Notifications.Publish(savedNotification);
+
                     scope.Complete();
                 }
                 catch (DataOperationException<MoveOperationStatusType> ex)
                 {
-                    return OperationResult.Attempt.Fail<MoveOperationStatusType, TItem>(ex.Operation, evtMsgs); // causes rollback
+                    return OperationResult.Attempt.Fail<MoveOperationStatusType, TItem>(ex.Operation, eventMessages); // causes rollback
                 }
             }
 
-            return OperationResult.Attempt.Succeed(MoveOperationStatusType.Success, evtMsgs, copy);
+            return OperationResult.Attempt.Succeed(MoveOperationStatusType.Success, eventMessages, copy);
         }
 
         #endregion


### PR DESCRIPTION
This PR migrates #12330 to V9, adding the missing content type events when copying:

* MemberTypes
* DocumentTypes
* MediaTypes

These missing events are: 
* Saving
* Changed
* Saved

### Testing

Add notifications handlers the the expected event and try and copy the different content types.

I used this notification handler and put a breakpoint on each handle method:

```C#
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI
{
    public class TestHandler :
        INotificationHandler<MemberTypeSavedNotification>,
        INotificationHandler<MemberTypeChangedNotification>,
        INotificationHandler<MemberTypeSavingNotification>,
        INotificationHandler<ContentTypeSavedNotification>,
        INotificationHandler<ContentTypeSavingNotification>,
        INotificationHandler<ContentTypeChangedNotification>,
        INotificationHandler<MediaTypeSavedNotification>,
        INotificationHandler<MediaTypeChangedNotification>,
        INotificationHandler<MediaTypeSavingNotification>
    {
        private readonly ILogger<TestHandler> _logger;

        public TestHandler(ILogger<TestHandler> logger) => _logger = logger;

        public void Handle(MemberTypeSavingNotification notification) => _logger.LogInformation("Member type saving notification received");

        public void Handle(MemberTypeChangedNotification notification) => _logger.LogInformation("Member type changed notification received");

        public void Handle(MemberTypeSavedNotification notification) => _logger.LogInformation("Member type saved notification received");

        public void Handle(ContentTypeSavingNotification notification) => _logger.LogInformation("Content type saving notification received");

        public void Handle(ContentTypeChangedNotification notification) => _logger.LogInformation("Content type changed notification received");

        public void Handle(ContentTypeSavedNotification notification) => _logger.LogInformation("Content type saved notification received");

        public void Handle(MediaTypeSavingNotification notification) => _logger.LogInformation("MediaTypeSavingNotification received");

        public void Handle(MediaTypeChangedNotification notification) => _logger.LogInformation("Media type changed notification received");

        public void Handle(MediaTypeSavedNotification notification) => _logger.LogInformation("Media type saved notification received");

    }

    public class TestHandlerComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder) =>
            builder
                .AddNotificationHandler<MemberTypeSavedNotification, TestHandler>()
                .AddNotificationHandler<MemberTypeChangedNotification, TestHandler>()
                .AddNotificationHandler<MemberTypeSavingNotification, TestHandler>()
                .AddNotificationHandler<ContentTypeSavedNotification, TestHandler>()
                .AddNotificationHandler<ContentTypeChangedNotification, TestHandler>()
                .AddNotificationHandler<ContentTypeSavingNotification, TestHandler>()
                .AddNotificationHandler<MediaTypeSavedNotification, TestHandler>()
                .AddNotificationHandler<MediaTypeChangedNotification, TestHandler>()
                .AddNotificationHandler<MediaTypeSavingNotification, TestHandler>();
    }
}

```