### PR TITLE
Add TypeForwards file with type forwarding

### DIFF
--- a/src/Umbraco.Infrastructure/TypeForwards.cs
+++ b/src/Umbraco.Infrastructure/TypeForwards.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:TypeForwardedTo(typeof(Umbraco.Cms.Core.PropertyEditors.ConfigurationEditor<>))]


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12457

# Notes
- Added TypeForwards file

# How to test
- Install 9.5 templates with `dotnet new -i Umbraco.Templates`
- Create 9.5 project with `dotnet new umbraco -n TestProject`
- Download my UmbraPack nupkg
[UmbraPack.1.0.0.nupkg.zip](https://github.com/umbraco/Umbraco-CMS/files/8761826/UmbraPack.1.0.0.nupkg.zip)
(Remove the .zip after download)
- Add the folder as a local nuget feed
- Install the UmbraPack nupkg in your new 9.5 project
- Run the project and install
- Try creating a new Datatype, you should see the test property editor
![image](https://user-images.githubusercontent.com/70372949/170011836-26296c15-a1e7-4401-87ae-f7d4263f07c5.png)

- Stop your project and upgrade it to 10.0.0-rc3 (remember to update your .NET version to 6 if it isn't)
- Run again and you should now get an error!
- Run dotnet pack in the root of this branch to generate nuget packages: `dotnet pack -o {Path to custom nuget feed}`
- Upgrade your project to the newly created nupkg files
- The project should now run