### PR TITLE
Fixed null check typo in CacheInstructionService. Fixes #12473.

### DIFF
--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -314,7 +314,7 @@ namespace Umbraco.Cms
             private static List<RefreshInstruction> GetAllInstructions(IEnumerable<JToken>? jsonInstructions)
             {
                 var result = new List<RefreshInstruction>();
-                if (jsonInstructions is not null)
+                if (jsonInstructions is null)
                 {
                     return result;
                 }

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -319,7 +319,7 @@ namespace Umbraco.Cms
                     return result;
                 }
 
-                foreach (JToken jsonItem in jsonInstructions!)
+                foreach (JToken jsonItem in jsonInstructions)
                 {
                     // Could be a JObject in which case we can convert to a RefreshInstruction.
                     // Otherwise it could be another JArray - in which case we'll iterate that.


### PR DESCRIPTION
### Prerequisites
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12473 which caused load balanced clients not to refresh content caches.

### Description
Really only changed `is not null` to `is null` to make the refreshers process the instructions properly.
