### PR TITLE
v10: Make ActionDelete.ActionAlias public again

### DIFF
--- a/src/Umbraco.Core/Actions/ActionDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionDelete.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.Actions
         /// <summary>
         /// The unique action alias
         /// </summary>
-        private const string ActionAlias = "delete";
+        public const string ActionAlias = "delete";
 
         /// <summary>
         /// The unique action letter


### PR DESCRIPTION
`ActionDelete.ActionAlias` used to be public but it seems to have been made private without warning. This reverses that change and makes it public again.