### PR TITLE
v10: Add global usings

### DIFF
--- a/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.props
+++ b/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.props
@@ -5,4 +5,8 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);umbraco/Logs/**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);wwwroot/media/**</DefaultItemExcludes>
   </PropertyGroup>
+  <ItemGroup>
+    <Using Include="Umbraco.Cms.Core.DependencyInjection" />
+    <Using Include="Umbraco.Extensions" />
+  </ItemGroup>
 </Project>

--- a/src/Umbraco.Web.UI/Startup.cs
+++ b/src/Umbraco.Web.UI/Startup.cs
@@ -1,12 +1,3 @@
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Extensions;
-
 namespace Umbraco.Cms.Web.UI
 {
     public class Startup


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR automatically adds global usings for `Umbraco.Cms.Core.DependencyInjection` and `Umbraco.Extensions` to projects that reference the `Umbraco.Cms` NuGet package, removing to need to manually add them to each file.

In case you want to opt-out of this, you can remove these global usings by putting the following in your project file:
```xml
<ItemGroup>
    <Using Remove="Umbraco.Cms.Core.DependencyInjection" />
    <Using Remove="Umbraco.Extensions" />
</ItemGroup>
```