### PR TITLE
Update `aria-invalid` based on valid length

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -9,7 +9,8 @@
             ng-keyup="change()"
             ng-trim="false"
             ng-required="model.validation.mandatory"
-            aria-required="{{model.validation.mandatory}}">
+            aria-required="{{model.validation.mandatory}}"
+            aria-invalid="{{validLength ? false : true}}">
         </textarea>
 
         <span ng-messages="textareaFieldForm.textarea.$error" show-validation-on-submit >

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html
@@ -8,7 +8,7 @@
                val-server="value"
                ng-required="model.validation.mandatory"
                aria-required="{{model.validation.mandatory}}"
-               aria-invalid="False"
+               aria-invalid="{{validLength ? false : true}}"
                ng-trim="false"
                ng-change="change()" />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12427

### Description
Previously value in textbox property editor was always valid (or at least below 512 characters), but not it is invalid based on the validation limit. The same for textarea property editor.

Note it isn't enough to check on form `$invalid` property and this only change on submit and not when changing from invalid to valid.