### PR TITLE
v10: Wait for updated ConnectionStrings during install

### DIFF
--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -35,11 +35,6 @@ namespace Umbraco.Cms.Core.Configuration
 
         public void RemoveConnectionString()
         {
-            // Update and reload configuration
-            _configuration[UmbracoConnectionStringPath] = null;
-            _configuration[UmbracoConnectionStringProviderNamePath] = null;
-            (_configuration as IConfigurationRoot)?.Reload();
-
             // Remove keys from JSON
             var provider = GetJsonConfigurationProvider(UmbracoConnectionStringPath);
 
@@ -58,11 +53,6 @@ namespace Umbraco.Cms.Core.Configuration
 
         public void SaveConnectionString(string connectionString, string? providerName)
         {
-            // Update and reload configuration
-            _configuration[UmbracoConnectionStringPath] = connectionString;
-            _configuration[UmbracoConnectionStringProviderNamePath] = providerName;
-            (_configuration as IConfigurationRoot)?.Reload();
-
             // Save keys to JSON
             var provider = GetJsonConfigurationProvider();
 
@@ -84,10 +74,6 @@ namespace Umbraco.Cms.Core.Configuration
 
         public void SaveConfigValue(string key, object value)
         {
-            // Update and reload configuration
-            _configuration[key] = value?.ToString();
-            (_configuration as IConfigurationRoot)?.Reload();
-
             // Save key to JSON
             var provider = GetJsonConfigurationProvider();
 
@@ -122,10 +108,6 @@ namespace Umbraco.Cms.Core.Configuration
 
         public void SaveDisableRedirectUrlTracking(bool disable)
         {
-            // Update and reload configuration
-            _configuration["Umbraco:CMS:WebRouting:DisableRedirectUrlTracking"] = disable.ToString();
-            (_configuration as IConfigurationRoot)?.Reload();
-
             // Save key to JSON
             var provider = GetJsonConfigurationProvider();
 
@@ -147,10 +129,6 @@ namespace Umbraco.Cms.Core.Configuration
 
         public void SetGlobalId(string id)
         {
-            // Update and reload configuration
-            _configuration["Umbraco:CMS:Global:Id"] = id;
-            (_configuration as IConfigurationRoot)?.Reload();
-
             // Save key to JSON
             var provider = GetJsonConfigurationProvider();
 
@@ -336,17 +314,21 @@ namespace Umbraco.Cms.Core.Configuration
         {
             if (token is JObject obj)
             {
-
                 foreach (var property in obj.Properties())
                 {
                     if (name is null)
+                    {
                         return property.Value;
+                    }
+
                     if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                    {
                         return property.Value;
+                    }
                 }
             }
+
             return null;
         }
-
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12464.

### Description
We've seen some intermittent exceptions when the attended installer is used in the latest v10 RCs, but couldn't easily reproduce it when debugging (which indicates some kind of race-condition/timing issue).

The ASP.NET Core configuration system does support reloading, but when calling [`IConfigurationRoot.Reload()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.iconfigurationroot.reload?view=dotnet-plat-ext-6.0), it will reload all providers and apparently trigger `IOptionsMonitor<ConnectionStrings>.OnChange` multiple times: sometimes with the correct/updated value, but also sometimes with an empty value. The JSON configuration provider however [uses a delay before triggering a reload](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.fileconfigurationsource.reloaddelay?view=dotnet-plat-ext-6.0#microsoft-extensions-configuration-fileconfigurationsource-reloaddelay), so requires waiting for the changes to be applied.

This causes an issue when we're trying to update the JSON configuration with the connection string and don't wait for the changes to be applied... This PR removes the manual reload (to avoid the empty values in the `OnChange` callback) and waits for the JSON configuration to be reloaded. In case you don't have any JSON configuration providers or the file is read-only, the installer will throw an exception if the configuration isn't reloaded within 10 seconds.