### PR TITLE
v10: Remove ambient scope stack from httpcontext.items.

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -95,11 +95,14 @@ namespace Umbraco.Cms.Infrastructure.DependencyInjection
             builder.Mappers()?.AddCoreMappers();
 
             // register the scope provider
-            builder.Services.AddSingleton<ScopeProvider>(); // implements IScopeProvider, IScopeAccessor
+            builder.Services.AddSingleton<ScopeProvider>(sp => ActivatorUtilities.CreateInstance<ScopeProvider>(sp, sp.GetRequiredService<IAmbientScopeStack>())); // implements IScopeProvider, IScopeAccessor
             builder.Services.AddSingleton<ICoreScopeProvider>(f => f.GetRequiredService<ScopeProvider>());
             builder.Services.AddSingleton<Infrastructure.Scoping.IScopeProvider>(f => f.GetRequiredService<ScopeProvider>());
             builder.Services.AddSingleton<Core.Scoping.IScopeProvider>(f => f.GetRequiredService<ScopeProvider>());
-            builder.Services.AddSingleton<IScopeAccessor>(f => f.GetRequiredService<ScopeProvider>());
+
+            builder.Services.AddSingleton<IAmbientScopeStack, AmbientScopeStack>();
+            builder.Services.AddSingleton<IScopeAccessor>(f => f.GetRequiredService<IAmbientScopeStack>());
+            builder.Services.AddSingleton<IAmbientScopeContextStack, AmbientScopeContextStack>();
 
             builder.Services.AddScoped<IHttpScopeReference, HttpScopeReference>();
 

--- a/src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
@@ -1,0 +1,39 @@
+using System.Collections.Concurrent;
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Cms.Infrastructure.Scoping;
+
+internal class AmbientScopeContextStack : IAmbientScopeContextStack
+{
+    private static AsyncLocal<ConcurrentStack<IScopeContext>> _stack = new();
+
+    public IScopeContext? AmbientContext
+    {
+        get
+        {
+            if (_stack.Value?.TryPeek(out IScopeContext? ambientContext) ?? false)
+            {
+                return ambientContext;
+            }
+
+            return null;
+        }
+    }
+
+    public IScopeContext Pop()
+    {
+        if (_stack.Value?.TryPop(out IScopeContext? ambientContext) ?? false)
+        {
+            return ambientContext;
+        }
+
+        throw new InvalidOperationException("No AmbientContext was found.");
+    }
+
+    public void Push(IScopeContext scope)
+    {
+        _stack.Value ??= new ConcurrentStack<IScopeContext>();
+
+        _stack.Value.Push(scope);
+    }
+}

--- a/src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
@@ -1,0 +1,39 @@
+using System.Collections.Concurrent;
+
+namespace Umbraco.Cms.Infrastructure.Scoping
+{
+    internal class AmbientScopeStack : IAmbientScopeStack
+    {
+        private static AsyncLocal<ConcurrentStack<IScope>> _stack = new ();
+
+        public IScope? AmbientScope
+        {
+            get
+            {
+                if (_stack.Value?.TryPeek(out IScope? ambientScope) ?? false)
+                {
+                    return ambientScope;
+                }
+
+                return null;
+            }
+        }
+
+        public IScope Pop()
+        {
+            if (_stack.Value?.TryPop(out IScope? ambientScope) ?? false)
+            {
+                return ambientScope;
+            }
+
+            throw new InvalidOperationException("No AmbientScope was found.");
+        }
+
+        public void Push(IScope scope)
+        {
+            _stack.Value ??= new ConcurrentStack<IScope>();
+
+            _stack.Value.Push(scope);
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Scoping/IAmbientScopeContextStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/IAmbientScopeContextStack.cs
@@ -1,0 +1,10 @@
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Cms.Infrastructure.Scoping;
+
+internal interface IAmbientScopeContextStack
+{
+    IScopeContext? AmbientContext { get; }
+    IScopeContext Pop();
+    void Push(IScopeContext scope);
+}

--- a/src/Umbraco.Infrastructure/Scoping/IAmbientScopeStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/IAmbientScopeStack.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Cms.Infrastructure.Scoping;
+
+internal interface IAmbientScopeStack : IScopeAccessor
+{
+    IScope Pop();
+    void Push(IScope scope);
+}

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -40,7 +40,6 @@ namespace Umbraco.Cms.Infrastructure.Scoping
         private readonly bool? _scopeFileSystem;
 
         private readonly ScopeProvider _scopeProvider;
-        private bool _callContext;
         private bool? _completed;
         private IUmbracoDatabase? _database;
 
@@ -93,7 +92,6 @@ namespace Umbraco.Cms.Infrastructure.Scoping
             _eventDispatcher = eventDispatcher;
             _notificationPublisher = notificationPublisher;
             _scopeFileSystem = scopeFileSystems;
-            _callContext = callContext;
             _autoComplete = autoComplete;
             Detachable = detachable;
             _dictionaryLocker = new object();
@@ -259,24 +257,15 @@ namespace Umbraco.Cms.Infrastructure.Scoping
         {
         }
 
+        [Obsolete("Scopes are never stored on HttpContext.Items anymore, so CallContext is always true.")]
         // a value indicating whether to force call-context
         public bool CallContext
         {
-            get
+            get => true;
+            set
             {
-                if (_callContext)
-                {
-                    return true;
-                }
-
-                if (ParentScope != null)
-                {
-                    return ParentScope.CallContext;
-                }
-
-                return false;
+                // NOOP - always true.
             }
-            set => _callContext = value;
         }
 
         public bool ScopedFileSystems
@@ -551,7 +540,7 @@ namespace Umbraco.Cms.Infrastructure.Scoping
                 }
             }
 
-            _scopeProvider.PopAmbientScope(this); // might be null = this is how scopes are removed from context objects
+            _scopeProvider.PopAmbientScope(); // might be null = this is how scopes are removed from context objects
 
 #if DEBUG_SCOPES
             _scopeProvider.Disposed(this);
@@ -903,7 +892,7 @@ namespace Umbraco.Cms.Infrastructure.Scoping
                     // by Deploy which I don't fully understand since there is limited tests on this in the CMS
                     if (OrigScope != _scopeProvider.AmbientScope)
                     {
-                        _scopeProvider.PopAmbientScope(_scopeProvider.AmbientScope);
+                        _scopeProvider.PopAmbientScope();
                     }
 
                     if (OrigContext != _scopeProvider.AmbientContext)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -227,56 +227,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
         }
 
         [Test]
-        public void NestedMigrateScope()
-        {
-            // Get the request cache mock and re-configure it to be available and used
-            var requestCacheDictionary = new Dictionary<string, object>();            
-            IRequestCache requestCache = AppCaches.RequestCache;
-            var requestCacheMock = Mock.Get(requestCache);
-            requestCacheMock
-                .Setup(x => x.IsAvailable)
-                .Returns(true);
-            requestCacheMock
-                .Setup(x => x.Set(It.IsAny<string>(), It.IsAny<object>()))
-                .Returns((string key, object val) =>
-                {
-                    requestCacheDictionary.Add(key, val);
-                    return true;
-                });
-            requestCacheMock
-                .Setup(x => x.Get(It.IsAny<string>()))
-                .Returns((string key) => requestCacheDictionary.TryGetValue(key, out var val) ? val : null);
-
-            ScopeProvider scopeProvider = ScopeProvider;
-            Assert.IsNull(scopeProvider.AmbientScope);
-
-            using (IScope scope = scopeProvider.CreateScope())
-            {
-                Assert.IsInstanceOf<Scope>(scope);
-                Assert.IsNotNull(scopeProvider.AmbientScope);
-                Assert.AreSame(scope, scopeProvider.AmbientScope);
-
-                using (IScope nested = scopeProvider.CreateScope(callContext: true))
-                {
-                    Assert.IsInstanceOf<Scope>(nested);
-                    Assert.IsNotNull(scopeProvider.AmbientScope);
-                    Assert.AreSame(nested, scopeProvider.AmbientScope);
-                    Assert.AreSame(scope, ((Scope)nested).ParentScope);
-
-                    // it's moved over to call context
-                    ConcurrentStack<IScope> callContextScope = scopeProvider.GetCallContextScopeValue();
-
-                    Assert.IsNotNull(callContextScope);
-                    Assert.AreEqual(2, callContextScope.Count);
-                }
-
-                // it's naturally back in http context
-            }
-
-            Assert.IsNull(scopeProvider.AmbientScope);
-        }
-
-        [Test]
         public void NestedCreateScopeContext()
         {
             ScopeProvider scopeProvider = ScopeProvider;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ThreadSafetyServiceTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ThreadSafetyServiceTest.cs
@@ -134,11 +134,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
                 {
                     try
                     {
-                        ConcurrentStack<IScope>
-                            currentStack = ((ScopeProvider)ScopeProvider).GetCallContextScopeValue();
-                        log.LogInformation("[{ThreadId}] Current Stack? {CurrentStack}",
-                            Thread.CurrentThread.ManagedThreadId, currentStack?.Count);
-
                         // NOTE: This is NULL because we have supressed the execution context flow.
                         // If we don't do that we will get various exceptions because we're trying to run concurrent threads
                         // against an ambient context which cannot be done due to the rules of scope creation and completion.
@@ -234,11 +229,6 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
                 {
                     try
                     {
-                        ConcurrentStack<IScope>
-                            currentStack = ((ScopeProvider)ScopeProvider).GetCallContextScopeValue();
-                        log.LogInformation("[{ThreadId}] Current Stack? {CurrentStack}",
-                            Thread.CurrentThread.ManagedThreadId, currentStack?.Count);
-
                         // NOTE: This is NULL because we have supressed the execution context flow.
                         // If we don't do that we will get various exceptions because we're trying to run concurrent threads
                         // against an ambient context which cannot be done due to the rules of scope creation and completion.

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -71,7 +71,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Components
                 Mock.Of<IServiceProvider>(),
                 Options.Create(new ContentSettings()));
             IEventAggregator eventAggregator = Mock.Of<IEventAggregator>();
-            var scopeProvider = new ScopeProvider(Mock.Of<IDistributedLockingMechanismFactory>(),f , fs, new TestOptionsMonitor<CoreDebugSettings>(coreDebug), mediaFileManager, loggerFactory, NoAppCache.Instance, eventAggregator);
+            var scopeProvider = new ScopeProvider(new AmbientScopeStack(), new AmbientScopeContextStack(), Mock.Of<IDistributedLockingMechanismFactory>(),f , fs, new TestOptionsMonitor<CoreDebugSettings>(coreDebug), mediaFileManager, loggerFactory, eventAggregator);
 
             mock.Setup(x => x.GetService(typeof(ILogger))).Returns(logger);
             mock.Setup(x => x.GetService(typeof(ILogger<ComponentCollection>))).Returns(loggerFactory.CreateLogger<ComponentCollection>);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
@@ -93,13 +93,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Scoping
             eventAggregatorMock = new Mock<IEventAggregator>();
 
             return new ScopeProvider(
+                new AmbientScopeStack(),
+                new AmbientScopeContextStack(),
                 Mock.Of<IDistributedLockingMechanismFactory>(),
                 Mock.Of<IUmbracoDatabaseFactory>(),
                 fileSystems,
                 new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),
                 mediaFileManager,
                 loggerFactory,
-                Mock.Of<IRequestCache>(),
                 eventAggregatorMock.Object
             );
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
@@ -71,13 +71,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
             sqlContext.Setup(x => x.SqlSyntax).Returns(syntaxProviderMock.Object);
 
             return new ScopeProvider(
+                new AmbientScopeStack(),
+                new AmbientScopeContextStack(),
                 lockingMechanismFactory.Object,
                 databaseFactory.Object,
                 fileSystems,
                 new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),
                 mediaFileManager,
                 loggerFactory,
-                Mock.Of<IRequestCache>(),
                 Mock.Of<IEventAggregator>());
         }
 


### PR DESCRIPTION
This change makes it easier to use service calls in parallel whilst a httpcontext is available.
