### PR TITLE
v10: Add depth property to ICoreScope

### DIFF
--- a/src/Umbraco.Core/Scoping/ICoreScope.cs
+++ b/src/Umbraco.Core/Scoping/ICoreScope.cs
@@ -1,4 +1,3 @@
-using System;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 
@@ -9,6 +8,14 @@ namespace Umbraco.Cms.Core.Scoping;
 /// </summary>
 public interface ICoreScope : IDisposable, IInstanceIdentifiable
 {
+    /// <summary>
+    /// Gets the distance from the root scope.
+    /// </summary>
+    /// <remarks>
+    /// A zero represents a root scope, any value greater than zero represents a child scope.
+    /// </remarks>
+    public int Depth => -1;
+
     /// <summary>
     /// Gets the scope notification publisher
     /// </summary>

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -478,6 +478,19 @@ namespace Umbraco.Cms.Infrastructure.Scoping
             }
         }
 
+        public int Depth
+        {
+            get
+            {
+                if (ParentScope == null)
+                {
+                    return 0;
+                }
+
+                return ParentScope.Depth + 1;
+            }
+        }
+
         public IScopedNotificationPublisher Notifications
         {
             get

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeUnitTests.cs
@@ -579,5 +579,34 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 Assert.IsNull(realScope.GetReadLocks());
             }
         }
+
+        [Test]
+        public void Depth_WhenRootScope_ReturnsZero()
+        {
+            var scopeProvider = GetScopeProvider(out var syntaxProviderMock);
+
+            using (var scope = scopeProvider.CreateScope())
+            {
+                Assert.AreEqual(0,scope.Depth);
+            }
+        }
+
+
+        [Test]
+        public void Depth_WhenChildScope_ReturnsDepth()
+        {
+            var scopeProvider = GetScopeProvider(out var syntaxProviderMock);
+
+            using (scopeProvider.CreateScope())
+            {
+                using (scopeProvider.CreateScope())
+                {
+                    using (var c2 = scopeProvider.CreateScope())
+                    {
+                        Assert.AreEqual(2, c2.Depth);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a depth property to ICoreScope so that you know how far a child scope is from the root scope.

This doesn't resolve any issues in particular but adds some clarity when debugging issues with nested scopes.