### PR TITLE
v10: Prefer SQLite primitive types to flexible types

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -38,6 +38,20 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
             [typeof(Guid)] = new SqliteGuidScalarMapper(),
             [typeof(Guid?)] = new SqliteNullableGuidScalarMapper(),
         };
+
+        IntColumnDefinition = "INTEGER";
+        LongColumnDefinition = "INTEGER";
+        BoolColumnDefinition = "INTEGER";
+
+        GuidColumnDefinition = "TEXT";
+        DateTimeColumnDefinition = "TEXT";
+        DateTimeOffsetColumnDefinition = "TEXT";
+        TimeColumnDefinition = "TEXT";
+
+        RealColumnDefinition = "REAL";
+        DecimalColumnDefinition = "REAL";
+
+        BlobColumnDefinition = "BLOB";
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -47,9 +47,9 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
         DateTimeColumnDefinition = "TEXT";
         DateTimeOffsetColumnDefinition = "TEXT";
         TimeColumnDefinition = "TEXT";
+        DecimalColumnDefinition = "TEXT"; // REAL would be lossy. - https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/types
 
         RealColumnDefinition = "REAL";
-        DecimalColumnDefinition = "REAL";
 
         BlobColumnDefinition = "BLOB";
     }


### PR DESCRIPTION
Whilst SQLite has a flexible typing system it makes sense to stick to the natively supported types i.e TEXT,BLOB,INTEGER,REAL.

This PR ensures that we stick to one of the above types where possible when creating a database from scratch or running a migration for SQLite.

Should close #12524