### PR TITLE
Close umbraco lightbox when user press browser back button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umblightbox.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umblightbox.directive.js
@@ -94,6 +94,8 @@
                     for (var e in eventBindings) {
                         eventBindings[e]();
                     }
+                    
+                    el.remove();
                 });
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Current issue: [v10 - Packages section - Umbraco Lightbox close problem](https://github.com/umbraco/Umbraco-CMS/issues/12477)

### Description
Go to the dashboard
Visit the packages page,
Select a package that has some images( like Vendr)
Click by mouse on one of the images
Then if press the browser back button, the Umbraco lightbox must be closed properly.