### PR TITLE
v10: Fix issue where languages files are not found in subdir of package dir

### DIFF
--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -1,11 +1,6 @@
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
@@ -17,6 +12,7 @@ namespace Umbraco.Extensions
     /// </summary>
     public static partial class UmbracoBuilderExtensions
     {
+
         /// <summary>
         /// Adds the supplementary localized texxt file sources from the various physical and virtual locations supported.
         /// </summary>
@@ -69,45 +65,52 @@ namespace Umbraco.Extensions
         private static IEnumerable<LocalizedTextServiceSupplementaryFileSource> GetPluginLanguageFileSources(
             IFileProvider fileProvider, string folder, bool overwriteCoreKeys)
         {
-            // locate all the *.xml files inside Lang folders inside folders of the main folder
-            // e.g. /app_plugins/plugin-name/lang/*.xml
-            var fileSources = new List<LocalizedTextServiceSupplementaryFileSource>();
-
-            var pluginFolders = fileProvider.GetDirectoryContents(folder)
-                    .Where(x => x.IsDirectory).ToList();
+            IEnumerable<IFileInfo> pluginFolders = fileProvider
+                .GetDirectoryContents(folder)
+                .Where(x => x.IsDirectory);
 
             foreach (IFileInfo pluginFolder in pluginFolders)
             {
                 // get the full virtual path for the plugin folder
                 var pluginFolderPath = WebPath.Combine(folder, pluginFolder.Name);
 
-                // get any lang folders in this plugin
-                IEnumerable<IFileInfo> langFolders = fileProvider.GetDirectoryContents(pluginFolderPath)
-                    .Where(x => x.IsDirectory && x.Name.InvariantEquals("lang"));
-
                 // loop through the lang folder(s)
                 //  - there could be multiple on case sensitive file system
-                foreach (var langFolder in langFolders)
+                foreach (var langFolder in GetLangFolderPaths(fileProvider, pluginFolderPath))
                 {
-                    // get the full 'virtual' path of the lang folder
-                    var langFolderPath = WebPath.Combine(pluginFolderPath, langFolder.Name);
-
                     // request all the files out of the path, these will have physicalPath set.
-                    var files = fileProvider.GetDirectoryContents(langFolderPath)
-                        .Where(x => x.Name.InvariantEndsWith(".xml") && !string.IsNullOrEmpty(x.PhysicalPath))
-                        .Select(x => new FileInfo(x.PhysicalPath))
-                        .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, overwriteCoreKeys))
-                        .ToList();
+                    IEnumerable<FileInfo> localizationFiles = fileProvider
+                        .GetDirectoryContents(langFolder)
+                        .Where(x => !string.IsNullOrEmpty(x.PhysicalPath))
+                        .Where(x => x.Name.InvariantEndsWith(".xml"))
+                        .Select(x => new FileInfo(x.PhysicalPath));
 
-                    // add any to our results
-                    if (files.Count > 0)
+                    foreach (FileInfo file in localizationFiles)
                     {
-                        fileSources.AddRange(files);
+                        yield return new LocalizedTextServiceSupplementaryFileSource(file, overwriteCoreKeys);
                     }
                 }
             }
+        }
 
-            return fileSources;
+        private static IEnumerable<string> GetLangFolderPaths(IFileProvider fileProvider, string path)
+        {
+            IEnumerable<IFileInfo> directories = fileProvider.GetDirectoryContents(path).Where(x => x.IsDirectory);
+
+            foreach (IFileInfo directory in directories)
+            {
+                var virtualPath = WebPath.Combine(path, directory.Name);
+
+                if (directory.Name.InvariantEquals("lang"))
+                {
+                    yield return virtualPath;
+                }
+
+                foreach (var nested in GetLangFolderPaths(fileProvider, virtualPath))
+                {
+                    yield return nested;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Languages files were discovered when placed at `~/App_Plugins/{{PackageName}}/lang/foo.xml` but not from sub directories e.g. `~/App_Plugins/{{PackageName}}/foo/bar/lang/foo.xml`.

This PR fixes the issue by recursively scanning for lang directories under a package directory.

Closes  #12521
