### PR TITLE
Make FindContent return type nullable

### DIFF
--- a/src/Umbraco.Web.Common/Controllers/IVirtualPageController.cs
+++ b/src/Umbraco.Web.Common/Controllers/IVirtualPageController.cs
@@ -11,5 +11,5 @@ public interface IVirtualPageController
     /// <summary>
     ///     Returns the <see cref="IPublishedContent" /> to use as the current page for the request
     /// </summary>
-    IPublishedContent FindContent(ActionExecutingContext actionExecutingContext);
+    IPublishedContent? FindContent(ActionExecutingContext actionExecutingContext);
 }


### PR DESCRIPTION
Makes FindContent of `IVirtualPageController`.

This is because in this context null is handled as "Not Found", otherwise you have to throw an error, which isn't the greatest idea since not found is expected behaviour