### PR TITLE
v9: Fix logic error WRT models builder flag out of date models.

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -46,7 +46,7 @@ namespace Umbraco.Cms.Core.Configuration.Models
 
             set
             {
-                if (!ModelsMode.IsAuto())
+                if (ModelsMode == ModelsMode.Nothing || ModelsMode.IsAuto())
                 {
                     _flagOutOfDateModels = false;
                     return;


### PR DESCRIPTION
FlagOutOfDateModels should occur when using SourceCodeManual.

At present this is always set to false when ModelsMode is not one of

+ InMemoryAuto 
+ SourceCodeAuto

In v8 this was forcibly set to false when ModelsMode is any of the following (via IsLive extension)

+ Nothing
+ PureLive
+ LiveAppData

IsLive was replaced by IsAuto in #10272

This was spotted whilst looking into https://our.umbraco.com/forum/using-umbraco-and-getting-started/108700-modelsbuilder-stopped-working