### PR TITLE
Also read the plugin files using the content provider.

### DIFF
--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -41,6 +41,8 @@ namespace Umbraco.Extensions
             IFileProvider webFileProvider = webHostEnvironment.WebRootFileProvider;
             IFileProvider contentFileProvider = webHostEnvironment.ContentRootFileProvider;
 
+            IEnumerable<LocalizedTextServiceSupplementaryFileSource> localPluginFileSources = GetPluginLanguageFileSources(contentFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
+
             // gets all langs files in /app_plugins real or virtual locations
             IEnumerable<LocalizedTextServiceSupplementaryFileSource> pluginLangFileSources = GetPluginLanguageFileSources(webFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
 
@@ -54,7 +56,9 @@ namespace Umbraco.Extensions
                     .SelectMany(x => x.GetFiles("*.user.xml", SearchOption.TopDirectoryOnly))
                     .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, true));
 
-            return pluginLangFileSources
+            return
+                localPluginFileSources
+                .Concat(pluginLangFileSources)
                 .Concat(userLangFileSources);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With #12206  Lang files are loaded via the `WebRootFileProvider` - which if called once the site has started up, contains all the file providers to find lang files in app_plugins, wwwroot and and Razor class libraries. 

however if for what ever reason the LanguageServices are called before startup the `WebRootFileProvider` doesn't contain the UmbracoStatic provider for app_plugins. 

As the Languages are loaded only once and cached, if this happens then any lang files in the app_plugins folder are not loaded. 

this PR 'fixes' this by also loading and files it finds via the `ContentRootFileProvider`. (we removed this in the last PR becuase we thought it was redundant). 

This means if the languages are loaded early the `app_plugins` folder is still found (and the RCL and `wwwroot` as they are already loaded at this point).

if the languages are loaded after startup then this method will find the lang files in app_plugins twice, but it won't alter the outcome, as the first set of values found will be overridden by the ones from the `WebRootFileProvider`

### Notes: 
We could just tell people not to do any real work before they are loaded (e.g don't load things in UmbracoApplicationStarting use UmbracoApplicationStarted) but this behaviour is a bit hard to track down when it does happen so i think should be mitigated - should someone do it. 

This may not be a "perfect" solution, and happy to pivot this PR to fix it another way ? 

e.g 
1. Don't let user code run before all the FileProviders are loaded (e.g move `UmbracoApplicationStartingNotification` back a bit?)
2. Ensure the FileProvider is loaded sooner in the pipeline so any calls to load the language files will always have all the providers ? 


not sure if these are viable or possible, but the PR as submitted does solve this problem. 

## Testing
- Same tests as in #12206 
- Additional test is to add a package that does trigger loading in ApplicationStarting notification
   - [x] add Contentment package to solution  
   - [x] add uSync (v10-beta1) to solution
   - [x] run solution check `LocalizedText` request contains both contentment and uSync localizations 
