### PR TITLE
V9: fix relation issue when moving root item to recycle bin

### DIFF
--- a/src/Umbraco.Core/Models/RelationItem.cs
+++ b/src/Umbraco.Core/Models/RelationItem.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.Models
         public string NodeType { get; set; }
 
         [DataMember(Name = "udi")]
-        public Udi NodeUdi => Udi.Create(NodeType, NodeKey);
+        public Udi NodeUdi => NodeType == Constants.UdiEntityType.Unknown ? null : Udi.Create(NodeType, NodeKey);
 
         [DataMember(Name = "icon")]
         public string ContentTypeIcon { get; set; }


### PR DESCRIPTION
Fixes exception when viewing an item in recycle bin, that was deleted from root.

![image](https://user-images.githubusercontent.com/1561480/172793703-8ebda06d-6f15-4c35-86ff-bbe3a4695504.png)


This is now fixed, but the UX is still a bit weird, due to the fact the roots are fake nodes, and especially the name is a bit unfriendly.
![image](https://user-images.githubusercontent.com/1561480/172793833-a018f9ee-d920-4128-a085-76936713a9ac.png)
