### PR TITLE
v10 Fix attempting to write lock files to LocalTempPath before it exists

### DIFF
--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Diagnostics;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -14,6 +10,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
     internal class FileSystemMainDomLock : IMainDomLock
     {
         private readonly ILogger<FileSystemMainDomLock> _logger;
+        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
         private readonly CancellationTokenSource _cancellationTokenSource = new();
         private readonly string _lockFilePath;
@@ -29,6 +26,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             IOptionsMonitor<GlobalSettings> globalSettings)
         {
             _logger = logger;
+            _hostingEnvironment = hostingEnvironment;
             _globalSettings = globalSettings;
 
             var lockFileName = $"MainDom_{mainDomKeyGenerator.GenerateKey()}.lock";
@@ -45,6 +43,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime
             {
                 try
                 {
+                    Directory.CreateDirectory(_hostingEnvironment.LocalTempPath);
                     _logger.LogDebug("Attempting to obtain MainDom lock file handle {lockFilePath}", _lockFilePath);
                     _lockFileStream = File.Open(_lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                     DeleteLockReleaseSignalFile();


### PR DESCRIPTION
Prevents DirectoryNotFoundException being thrown for /tmp/UmbracoData/{{hash}} thrown when trying to create lock / lock release files as the path doesn't exist yet when using LocalTempStorageLocation = EnvironmentTemp.

Fixes #12562
