### PR TITLE
Fix bulk property variant data updates

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -1128,18 +1128,24 @@ AND umbracoNode.id <> @id",
                 }
             }
 
-            //Now bulk update the table DocumentCultureVariationDto, once for edited = true, another for edited = false
+            // Now bulk update the table DocumentCultureVariationDto, once for edited = true, another for edited = false
             foreach (var editValue in toUpdate.GroupBy(x => x.Edited))
             {
-                Database.Execute(Sql().Update<DocumentCultureVariationDto>(u => u.Set(x => x.Edited, editValue.Key))
-                    .WhereIn<DocumentCultureVariationDto>(x => x.Id, editValue.Select(x => x.Id)));
+                foreach (var ids in editValue.Select(x => x.Id).InGroupsOf(Constants.Sql.MaxParameterCount))
+                {
+                    Database.Execute(Sql().Update<DocumentCultureVariationDto>(u => u.Set(x => x.Edited, editValue.Key))
+                        .WhereIn<DocumentCultureVariationDto>(x => x.Id, ids));
+                }
             }
 
-            //Now bulk update the umbracoDocument table
+            // Now bulk update the umbracoDocument table
             foreach (var editValue in editedDocument.GroupBy(x => x.Value))
             {
-                Database.Execute(Sql().Update<DocumentDto>(u => u.Set(x => x.Edited, editValue.Key))
-                    .WhereIn<DocumentDto>(x => x.NodeId, editValue.Select(x => x.Key)));
+                foreach (var ids in editValue.Select(x => x.Key).InGroupsOf(Constants.Sql.MaxParameterCount))
+                {
+                    Database.Execute(Sql().Update<DocumentDto>(u => u.Set(x => x.Edited, editValue.Key))
+                        .WhereIn<DocumentDto>(x => x.NodeId, ids));
+                }
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/10383.

### Description
Updating the `Vary by culture` setting of a property still resulted in an exception being thrown, as mentioned in https://github.com/umbraco/Umbraco-CMS/pull/11369#issuecomment-1134277678. This PR adds grouping on 2 bulk updates to ensure they also don't exceed the maximum amount of SQL parameters.

I've targeted v8, as that's what the above issue/PR used and we should be able to merge this up to the latest versions (the file moved from the `Umbraco.Core` to `Umbraco.Infrastructure` project though).

To test, you need a lot of content/variants (more than 2000) and then change the `Vary by culture` as described in the linked issue.