### PR TITLE
add a gap between icon and label of media menu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/navs.less
+++ b/src/Umbraco.Web.UI.Client/src/less/navs.less
@@ -272,6 +272,7 @@
     color: @ui-option-type;
     display: flex;
     justify-content: flex-start;
+    align-items: center;
     clear: both;
     font-weight: normal;
     line-height: 20px;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -54,7 +54,7 @@
                            <umb-dropdown-item ng-repeat="contentType in listViewAllowedTypes track by contentType.key | orderBy:'name':false">
                                <button type="button" ng-click="createBlank(entityType,contentType.alias)">
                                    <umb-icon icon="{{::contentType.icon}}"></umb-icon>
-                                   {{::contentType.name}} <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
+                                   <span style="padding-left:15px;">{{::contentType.name}}</span> <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
                                </button>
 
                                <button type="button" ng-repeat="blueprint in contentType.blueprints track by blueprint.id | orderBy:'name':false" ng-click="createFromBlueprint(entityType, contentType.alias, blueprint.id)">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -50,16 +50,15 @@
                            <span class="caret" aria-hidden="true"></span>
                        </button>
 
-                       <umb-dropdown ng-if="page.createDropdownOpen" on-close="page.createDropdownOpen = false">
+                       <umb-dropdown class="umb-actions" ng-if="page.createDropdownOpen" on-close="page.createDropdownOpen = false">
                            <umb-dropdown-item ng-repeat="contentType in listViewAllowedTypes track by contentType.key | orderBy:'name':false">
                                <button type="button" ng-click="createBlank(entityType,contentType.alias)">
                                    <umb-icon icon="{{::contentType.icon}}"></umb-icon>
-                                   <span style="padding-left:15px;">{{::contentType.name}}</span> <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
+                                   <span class="menu-label">{{::contentType.name}}</span> <span ng-show="contentType.blueprints" style="text-transform: lowercase;">(<localize key="blueprints_blankBlueprint">blank</localize>)</span>
                                </button>
-
                                <button type="button" ng-repeat="blueprint in contentType.blueprints track by blueprint.id | orderBy:'name':false" ng-click="createFromBlueprint(entityType, contentType.alias, blueprint.id)">
-                                   &nbsp;&nbsp;<umb-icon icon="{{::contentType.icon}}"></umb-icon>
-                                   {{::blueprint.name}}
+                                   <umb-icon icon="{{::contentType.icon}}"></umb-icon>
+                                   <span class="menu-label">{{::blueprint.name}}</span>
                                </button>
                            </umb-dropdown-item>
                        </umb-dropdown>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [V10 - Media Section - Create button dropdown - Fix the spacing between icons and text](https://github.com/umbraco/Umbraco-CMS/issues/12476)

- Going to the Media page
- Press Create menu
- A 15px space must exist between the menu icon and label

![image](https://user-images.githubusercontent.com/7125556/173235608-fa966a77-268a-48b8-bfbb-e97c7bf9243f.png)

I added span with an inline style of 15px space to:
- make the gap size consistent with other menus
- Keep the change as simple as possible