### PR TITLE
V10: Fix "Save and close"/"Publish and close" for infinite editing of language variant content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -673,7 +673,8 @@
             }
         };
 
-        $scope.saveAndPublish = function () {
+        $scope.saveAndPublish = function (submitButtonLabelKey) {
+            var deferred = $q.defer();
             clearNotifications($scope.content);
             if (hasVariants($scope.content)) {
                 //before we launch the dialog we want to execute all client side validations first
@@ -683,7 +684,7 @@
                         view: "views/content/overlays/publish.html",
                         variants: $scope.content.variants, //set a model property for the dialog
                         skipFormValidation: true, //when submitting the overlay form, skip any client side validation
-                        submitButtonLabelKey: "buttons_saveAndPublish",
+                        submitButtonLabelKey: submitButtonLabelKey || "buttons_saveAndPublish",
                         submit: function (model) {
                             model.submitButtonState = "busy";
                             clearNotifications($scope.content);
@@ -697,6 +698,7 @@
                                 formHelper.showNotifications(data);
                                 clearNotifications($scope.content);
                                 overlayService.close();
+                                deferred.resolve();
                                 return $q.when(data);
                             }, function (err) {
                                 clearDirtyState($scope.content.variants);
@@ -709,16 +711,19 @@
                                 clearNotifications($scope.content);
                                 
                                 handleHttpException(err);
+                                deferred.reject(err);
                             });
                         },
                         close: function () {
                             overlayService.close();
+                            deferred.reject();
                         }
                     };
                     overlayService.open(dialog);
                 }
                 else {
                     showValidationNotification();
+                    deferred.reject();
                 }
             }
             else {
@@ -731,14 +736,19 @@
                     action: "publish"
                 }).then(function () {
                     $scope.page.buttonGroupState = "success";
+                    deferred.resolve();
                 }, function (err) {
                     $scope.page.buttonGroupState = "error";
                     handleHttpException(err);
+                    deferred.reject(err);
                 });
             }
+
+            return deferred.promise;
         };
 
-        $scope.save = function () {
+        $scope.save = function (submitButtonLabelKey) {
+            var deferred = $q.defer();
             clearNotifications($scope.content);
             // TODO: Add "..." to save button label if there are more than one variant to publish - currently it just adds the elipses if there's more than 1 variant
             if (hasVariants($scope.content)) {
@@ -747,7 +757,7 @@
                     view: "views/content/overlays/save.html",
                     variants: $scope.content.variants, //set a model property for the dialog
                     skipFormValidation: true, //when submitting the overlay form, skip any client side validation
-                    submitButtonLabelKey: "buttons_save",
+                    submitButtonLabelKey: submitButtonLabelKey || "buttons_save",
                     submit: function (model) {
                         model.submitButtonState = "busy";
                         clearNotifications($scope.content);
@@ -762,6 +772,7 @@
                             formHelper.showNotifications(data);
                             clearNotifications($scope.content);
                             overlayService.close();
+                            deferred.resolve();
                             return $q.when(data);
                         }, function (err) {
                             clearDirtyState($scope.content.variants);
@@ -780,10 +791,12 @@
 
                                 handleHttpException(err);
                             }
+                            deferred.reject();
                         })
                     },
                     close: function (oldModel) {
                         overlayService.close();
+                        deferred.reject();
                     }
                 };
 
@@ -799,6 +812,7 @@
                     skipValidation: true
                 }).then(function () {
                     $scope.page.saveButtonState = "success";
+                    deferred.resolve();
                 }, function (err) {
                     // Because this is the "save"-action, then we actually save though there was a validation error, therefor we will show success and display the validation errors politely.
                     if(err && err.data && err.data.ModelState && Object.keys(err.data.ModelState).length > 0) {
@@ -807,9 +821,11 @@
                         $scope.page.saveButtonState = "error";
                     }
                     handleHttpException(err);
+                    deferred.reject();
                 });
             }
 
+            return deferred.promise;
         };
 
         $scope.schedule = function () {
@@ -976,25 +992,35 @@
         /* publish method used in infinite editing */
         $scope.publishAndClose = function (content) {
             $scope.publishAndCloseButtonState = "busy";
-            performSave({ saveMethod: contentResource.publish, action: "publish" }).then(function () {
-                if ($scope.infiniteModel.submit) {
-                    $scope.infiniteModel.contentNode = content;
-                    $scope.infiniteModel.submit($scope.infiniteModel);
+            $scope.saveAndPublish("buttons_publishAndClose").then(
+                function() {
+                    if ($scope.infiniteModel.submit) {
+                        $scope.infiniteModel.contentNode = content;
+                        $scope.infiniteModel.submit($scope.infiniteModel);
+                    }
+                    $scope.publishAndCloseButtonState = "success";
+                },
+                function() {
+                    $scope.publishAndCloseButtonState = "error";
                 }
-                $scope.publishAndCloseButtonState = "success";
-            });
+            );
         };
 
         /* save method used in infinite editing */
         $scope.saveAndClose = function (content) {
             $scope.saveAndCloseButtonState = "busy";
-            performSave({ saveMethod: $scope.saveMethod(), action: "save" }).then(function () {
-                if ($scope.infiniteModel.submit) {
-                    $scope.infiniteModel.contentNode = content;
-                    $scope.infiniteModel.submit($scope.infiniteModel);
+            $scope.save("buttons_saveAndClose").then(
+                function() {
+                    if ($scope.infiniteModel.submit) {
+                        $scope.infiniteModel.contentNode = content;
+                        $scope.infiniteModel.submit($scope.infiniteModel);
+                    }
+                    $scope.saveAndCloseButtonState = "success";
+                },
+                function() {
+                    $scope.saveAndCloseButtonState = "error";
                 }
-                $scope.saveAndCloseButtonState = "success";
-            });
+            );
         };
 
         /**


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When editing language variant content in an infinite editor, the "Save and close"/"Publish and close" buttons don't really work:

![infinite-edit-variant-content](https://user-images.githubusercontent.com/7405322/173310593-dfca532f-ee06-42ec-9102-c861e71c3411.gif)

The dev console sheds a little more light on the error: `{"errorMsg":"An error occurred","data":{"Message":"No variants flagged for saving"},"status":404}`

Turns out neither method in the Angular controller has support for language variants. 

This PR fixes it. I have opted to reuse the existing "Save"/"Save and publish" methods for handling "Save and close"/"Publish and close". This results in a slightly increased complexity in these methods, but the alternative would be to duplicate a lot (like a lot!) of code in the controller. I reckon the added complexity is the better solution.

### Testing this PR

To test this PR, you need something that opens content for editing in an infinite editor with the "Save and close"/"Publish and close" buttons enabled.

[This plugin](https://github.com/umbraco/Umbraco-CMS/files/8889356/MyDashboard.zip) can be used; it is the dashboard used in the screencast above. You will have to update the ID of the edited content in the dashboard controller to match the ID of a language variant piece of content in your content tree:

![image](https://user-images.githubusercontent.com/7405322/173311787-9b8ec36b-150e-4fe9-9c94-eff33f8ae6a6.png)

