### PR TITLE
Unescape returnPath.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js
@@ -46,7 +46,7 @@
         vm.allowPasswordReset = Umbraco.Sys.ServerVariables.umbracoSettings.canSendRequiredEmail && Umbraco.Sys.ServerVariables.umbracoSettings.allowPasswordReset;
         vm.errorMsg = "";
         const tempUrl = new URL(Umbraco.Sys.ServerVariables.umbracoUrls.externalLoginsUrl, window.location.origin);
-        tempUrl.searchParams.append("redirectUrl", $location.search().returnPath ?? "")
+        tempUrl.searchParams.append("redirectUrl", decodeURIComponent($location.search().returnPath ?? ""))
 
         vm.externalLoginFormAction = tempUrl.pathname + tempUrl.search;
         vm.externalLoginProviders = externalLoginInfoService.getLoginProviders();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below
- [x] This fixes #12575 

### Description
I've unescaped `$location.search().returnPath` because `searchParams.append` will escape it.
This prevents the double escaping of `redirectUrl` parameter.

To test the change, you simply need an Umbraco with an External Login and connect with it.
