### PR TITLE
v8: Fix Block List settings exception and optimize PVCs

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockEditorConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockEditorConverter.cs
@@ -49,11 +49,14 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public Type GetModelType(Guid contentTypeKey)
         {
             var publishedContentType = GetContentType(contentTypeKey);
-            if (publishedContentType != null)
+            if (publishedContentType != null && publishedContentType.IsElement)
             {
-                var modelType = ModelType.For(publishedContentType.Alias);
-
-                return _publishedModelFactory.MapModelType(modelType);
+                // TODO Get the model type without having to construct a list
+                var listType = _publishedModelFactory.CreateModelList(publishedContentType.Alias).GetType();
+                if (listType.GenericTypeArguments.Length == 1)
+                {
+                    return listType.GenericTypeArguments[0];
+                }
             }
 
             return typeof(IPublishedElement);

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -10,7 +10,6 @@ using Umbraco.Core.PropertyEditors.ValueConverters;
 
 namespace Umbraco.Web.PropertyEditors.ValueConverters
 {
-
     [DefaultPropertyValueConverter(typeof(JsonValueConverter))]
     public class BlockListPropertyValueConverter : PropertyValueConverterBase
     {
@@ -30,7 +29,8 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.BlockList);
 
         /// <inheritdoc />
-        public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(BlockListModel);
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+            => typeof(BlockListModel);
 
         /// <inheritdoc />
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
@@ -38,24 +38,27 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         /// <inheritdoc />
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
-        {
-            return source?.ToString();
-        }
+            => source?.ToString();
 
         /// <inheritdoc />
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
         {
-            // NOTE: The intermediate object is just a json string, we don't actually convert from source -> intermediate since source is always just a json string
-
+            // NOTE: The intermediate object is just a JSON string, we don't actually convert from source -> intermediate since source is always just a JSON string
             using (_proflog.DebugDuration<BlockListPropertyValueConverter>($"ConvertPropertyToBlockList ({propertyType.DataType.Id})"))
             {
                 var value = (string)inter;
 
                 // Short-circuit on empty values
-                if (string.IsNullOrWhiteSpace(value)) return BlockListModel.Empty;
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return BlockListModel.Empty;
+                }
 
                 var converted = _blockListEditorDataConverter.Deserialize(value);
-                if (converted.BlockValue.ContentData.Count == 0) return BlockListModel.Empty;
+                if (converted.BlockValue.ContentData.Count == 0)
+                {
+                    return BlockListModel.Empty;
+                }
 
                 var blockListLayout = converted.Layout.ToObject<IEnumerable<BlockListLayoutItem>>();
 
@@ -68,77 +71,133 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                 var contentPublishedElements = new Dictionary<Guid, IPublishedElement>();
                 foreach (var data in converted.BlockValue.ContentData)
                 {
-                    if (!blockConfigMap.ContainsKey(data.ContentTypeKey)) continue;
+                    if (!blockConfigMap.ContainsKey(data.ContentTypeKey))
+                    {
+                        continue;
+                    }
 
                     var element = _blockConverter.ConvertToElement(data, referenceCacheLevel, preview);
-                    if (element == null) continue;
+                    if (element == null)
+                    {
+                        continue;
+                    }
 
                     contentPublishedElements[element.Key] = element;
                 }
 
                 // If there are no content elements, it doesn't matter what is stored in layout
-                if (contentPublishedElements.Count == 0) return BlockListModel.Empty;
+                if (contentPublishedElements.Count == 0)
+                {
+                    return BlockListModel.Empty;
+                }
 
                 // Convert the settings data
                 var settingsPublishedElements = new Dictionary<Guid, IPublishedElement>();
                 foreach (var data in converted.BlockValue.SettingsData)
                 {
-                    if (!validSettingsElementTypes.Contains(data.ContentTypeKey)) continue;
+                    if (!validSettingsElementTypes.Contains(data.ContentTypeKey))
+                    {
+                        continue;
+                    }
 
                     var element = _blockConverter.ConvertToElement(data, referenceCacheLevel, preview);
-                    if (element == null) continue;
+                    if (element == null)
+                    {
+                        continue;
+                    }
 
                     settingsPublishedElements[element.Key] = element;
                 }
 
-                var layout = new List<BlockListItem>();
+                // Cache constructors locally (it's tied to the current IPublishedSnapshot and IPublishedModelFactory)
+                var blockListItemActivator = new BlockListItemActivator(_blockConverter);
+
+                var list = new List<BlockListItem>();
                 foreach (var layoutItem in blockListLayout)
                 {
                     // Get the content reference
                     var contentGuidUdi = (GuidUdi)layoutItem.ContentUdi;
                     if (!contentPublishedElements.TryGetValue(contentGuidUdi.Guid, out var contentData))
+                    {
                         continue;
+                    }
 
                     if (!contentData.ContentType.TryGetKey(out var contentTypeKey))
+                    {
                         throw new InvalidOperationException("The content type was not of type " + typeof(IPublishedContentType2));
+                    }
 
                     if (!blockConfigMap.TryGetValue(contentTypeKey, out var blockConfig))
+                    {
                         continue;
+                    }
 
                     // Get the setting reference
                     IPublishedElement settingsData = null;
-                    var settingGuidUdi = layoutItem.SettingsUdi != null ? (GuidUdi)layoutItem.SettingsUdi : null;
+                    var settingGuidUdi = (GuidUdi)layoutItem.SettingsUdi;
                     if (settingGuidUdi != null)
+                    {
                         settingsPublishedElements.TryGetValue(settingGuidUdi.Guid, out settingsData);
+                    }
 
                     // This can happen if they have a settings type, save content, remove the settings type, and display the front-end page before saving the content again
                     // We also ensure that the content types match, since maybe the settings type has been changed after this has been persisted
                     if (settingsData != null)
                     {
                         if (!settingsData.ContentType.TryGetKey(out var settingsElementTypeKey))
+                        {
                             throw new InvalidOperationException("The settings element type was not of type " + typeof(IPublishedContentType2));
+                        }
 
                         if (!blockConfig.SettingsElementTypeKey.HasValue || settingsElementTypeKey != blockConfig.SettingsElementTypeKey)
+                        {
                             settingsData = null;
+                        }
                     }
 
-                    // Get settings type from configuration
-                    var settingsType = blockConfig.SettingsElementTypeKey.HasValue
-                        ? _blockConverter.GetModelType(blockConfig.SettingsElementTypeKey.Value)
-                        : typeof(IPublishedElement);
+                    // Create instance (use content/settings type from configuration)
+                    var layoutRef = blockListItemActivator.CreateInstance(blockConfig.ContentElementTypeKey, blockConfig.SettingsElementTypeKey, contentGuidUdi, contentData, settingGuidUdi, settingsData);
 
-                    // TODO: This should be optimized/cached, as calling Activator.CreateInstance is slow
-                    var layoutType = typeof(BlockListItem<,>).MakeGenericType(contentData.GetType(), settingsType);
-                    var layoutRef = (BlockListItem)Activator.CreateInstance(layoutType, contentGuidUdi, contentData, settingGuidUdi, settingsData);
-
-                    layout.Add(layoutRef);
+                    list.Add(layoutRef);
                 }
 
-                var model = new BlockListModel(layout);
-                return model;
+                return new BlockListModel(list);
             }
         }
 
+        private class BlockListItemActivator
+        {
+            private readonly BlockEditorConverter _blockConverter;
+            private readonly Dictionary<(Guid, Guid?), Func<Udi, IPublishedElement, Udi, IPublishedElement, BlockListItem>> _contructorCache = new();
 
+            public BlockListItemActivator(BlockEditorConverter blockConverter)
+                => _blockConverter = blockConverter;
+
+            public BlockListItem CreateInstance(Guid contentTypeKey, Guid? settingsTypeKey, Udi contentUdi, IPublishedElement contentData, Udi settingsUdi, IPublishedElement settingsData)
+            {
+                if (!_contructorCache.TryGetValue((contentTypeKey, settingsTypeKey), out var constructor))
+                {
+                    constructor = _contructorCache[(contentTypeKey, settingsTypeKey)] = EmitConstructor(contentTypeKey, settingsTypeKey);
+                }
+
+                return constructor(contentUdi, contentData, settingsUdi, settingsData);
+            }
+
+            private Func<Udi, IPublishedElement, Udi, IPublishedElement, BlockListItem> EmitConstructor(Guid contentTypeKey, Guid? settingsTypeKey)
+            {
+                var contentType = _blockConverter.GetModelType(contentTypeKey);
+                var settingsType = settingsTypeKey.HasValue ? _blockConverter.GetModelType(settingsTypeKey.Value) : typeof(IPublishedElement);
+                var type = typeof(BlockListItem<,>).MakeGenericType(contentType, settingsType);
+
+                var constructor = type.GetConstructor(new[] { typeof(Udi), contentType, typeof(Udi), settingsType });
+                if (constructor == null)
+                {
+                    throw new InvalidOperationException($"Could not find the required public constructor on {type}.");
+                }
+
+                // We use unsafe here, because we know the contructor parameter count and types match
+                return ReflectionUtilities.EmitConstructorUnsafe<Func<Udi, IPublishedElement, Udi, IPublishedElement, BlockListItem>>(constructor);
+            }
+        }
     }
 }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -25,9 +25,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         /// </summary>
         public NestedContentManyValueConverter(IPublishedSnapshotAccessor publishedSnapshotAccessor, IPublishedModelFactory publishedModelFactory, IProfilingLogger proflog)
             : base(publishedSnapshotAccessor, publishedModelFactory)
-        {
-            _proflog = proflog;
-        }
+            => _proflog = proflog;
 
         /// <inheritdoc />
         public override bool IsConverter(IPublishedPropertyType propertyType)
@@ -37,6 +35,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
         {
             var contentTypes = propertyType.DataType.ConfigurationAs<NestedContentConfiguration>().ContentTypes;
+
             return contentTypes.Length == 1
                 ? typeof(IEnumerable<>).MakeGenericType(ModelType.For(contentTypes[0].Alias))
                 : typeof(IEnumerable<IPublishedElement>);
@@ -48,9 +47,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         /// <inheritdoc />
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
-        {
-            return source?.ToString();
-        }
+            => source?.ToString();
 
         /// <inheritdoc />
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
@@ -64,16 +61,24 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
                     : new List<IPublishedElement>();
 
                 var value = (string)inter;
-                if (string.IsNullOrWhiteSpace(value)) return elements;
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return elements;
+                }
 
                 var objects = JsonConvert.DeserializeObject<List<JObject>>(value);
-                if (objects.Count == 0) return elements;
+                if (objects.Count == 0)
+                {
+                    return elements;
+                }
 
                 foreach (var sourceObject in objects)
                 {
                     var element = ConvertToElement(sourceObject, referenceCacheLevel, preview);
                     if (element != null)
+                    {
                         elements.Add(element);
+                    }
                 }
 
                 return elements;

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -24,9 +24,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         /// </summary>
         public NestedContentSingleValueConverter(IPublishedSnapshotAccessor publishedSnapshotAccessor, IPublishedModelFactory publishedModelFactory, IProfilingLogger proflog)
             : base(publishedSnapshotAccessor, publishedModelFactory)
-        {
-            _proflog = proflog;
-        }
+            => _proflog = proflog;
 
         /// <inheritdoc />
         public override bool IsConverter(IPublishedPropertyType propertyType)
@@ -36,9 +34,10 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
         {
             var contentTypes = propertyType.DataType.ConfigurationAs<NestedContentConfiguration>().ContentTypes;
-            return contentTypes.Length > 1
-                ? typeof(IPublishedElement)
-                : ModelType.For(contentTypes[0].Alias);
+
+            return contentTypes.Length == 1
+                ? ModelType.For(contentTypes[0].Alias)
+                : typeof(IPublishedElement);
         }
 
         /// <inheritdoc />
@@ -47,9 +46,7 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         /// <inheritdoc />
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
-        {
-            return source?.ToString();
-        }
+            => source?.ToString();
 
         /// <inheritdoc />
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
@@ -57,14 +54,18 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
             using (_proflog.DebugDuration<NestedContentSingleValueConverter>($"ConvertPropertyToNestedContent ({propertyType.DataType.Id})"))
             {
                 var value = (string)inter;
-                if (string.IsNullOrWhiteSpace(value)) return null;
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return null;
+                }
 
                 var objects = JsonConvert.DeserializeObject<List<JObject>>(value);
                 if (objects.Count == 0)
+                {
                     return null;
-                if (objects.Count > 1)
-                    throw new InvalidOperationException();
+                }
 
+                // Only return the first (existing data might contain more than is currently configured)
                 return ConvertToElement(objects[0], referenceCacheLevel, preview);
             }
         }

--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentValueConverterBase.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/NestedContentValueConverterBase.cs
@@ -12,52 +12,54 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
     {
         private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
 
+        protected IPublishedModelFactory PublishedModelFactory { get; }
+
         protected NestedContentValueConverterBase(IPublishedSnapshotAccessor publishedSnapshotAccessor, IPublishedModelFactory publishedModelFactory)
         {
             _publishedSnapshotAccessor = publishedSnapshotAccessor;
             PublishedModelFactory = publishedModelFactory;
         }
 
-        protected IPublishedModelFactory PublishedModelFactory { get; }
-
         public static bool IsNested(IPublishedPropertyType publishedProperty)
-        {
-            return publishedProperty.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.NestedContent);
-        }
+            => publishedProperty.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.NestedContent);
 
-        public static bool IsNestedSingle(IPublishedPropertyType publishedProperty)
+        private static bool IsSingle(IPublishedPropertyType publishedProperty)
         {
-            if (!IsNested(publishedProperty))
-                return false;
-
             var config = publishedProperty.DataType.ConfigurationAs<NestedContentConfiguration>();
+
             return config.MinItems == 1 && config.MaxItems == 1;
         }
 
+        public static bool IsNestedSingle(IPublishedPropertyType publishedProperty)
+            => IsNested(publishedProperty) && IsSingle(publishedProperty);
+
         public static bool IsNestedMany(IPublishedPropertyType publishedProperty)
-        {
-            return IsNested(publishedProperty) && !IsNestedSingle(publishedProperty);
-        }
+            => IsNested(publishedProperty) && !IsSingle(publishedProperty);
 
         protected IPublishedElement ConvertToElement(JObject sourceObject, PropertyCacheLevel referenceCacheLevel, bool preview)
         {
             var elementTypeAlias = sourceObject[NestedContentPropertyEditor.ContentTypeAliasPropertyKey]?.ToObject<string>();
             if (string.IsNullOrEmpty(elementTypeAlias))
+            {
                 return null;
+            }
 
-            // only convert element types - content types will cause an exception when PublishedModelFactory creates the model
+            // Only convert element types - content types will cause an exception when PublishedModelFactory creates the model
             var publishedContentType = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetContentType(elementTypeAlias);
             if (publishedContentType == null || publishedContentType.IsElement == false)
+            {
                 return null;
+            }
 
             var propertyValues = sourceObject.ToObject<Dictionary<string, object>>();
-
-            if (!propertyValues.TryGetValue("key", out var keyo)
-                || !Guid.TryParse(keyo.ToString(), out var key))
+            if (!propertyValues.TryGetValue("key", out var keyo) || !Guid.TryParse(keyo.ToString(), out var key))
+            {
                 key = Guid.Empty;
+            }
 
             IPublishedElement element = new PublishedElement(publishedContentType, key, propertyValues, preview, referenceCacheLevel, _publishedSnapshotAccessor);
             element = PublishedModelFactory.CreateModel(element);
+
             return element;
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/11712.

### Description
This is a backport of v9 PR https://github.com/umbraco/Umbraco-CMS/pull/12256 to fix a regression bug introduced by in 8.17.0 (by PR https://github.com/umbraco/Umbraco-CMS/pull/8854) when using Block List settings and ModelsBuilder mode `Nothing` together (see the first PR for details on the issue).

Testing can be done using similar steps as for v9, but using slightly different settings/code:
- Create a document type with 2 properties:
  - `blocks` using the Block List editor with 2 configured blocks:
    1. Content model: `Text`, settings model: `TextSettings`
    2. Content model: `Text2`
  - `nested` using Nested Content with 2 element types:
    1. `Text`
    2. `Text2`
- Add the following to the template of that document type:

```cshtml
@inherits Umbraco.Web.Mvc.UmbracoViewPage
@using Umbraco.Core.Models.PublishedContent;
@using Umbraco.Core.Models.Blocks;
@{
	Layout = null;
}
<h1>Blocks: @Model.Value("blocks").GetType()</h1>
@foreach (var blockListItem in Model.Value<BlockListModel>("blocks"))
{
    <h2>Block: @blockListItem.GetType()</h2>
    <h3>Block content: @blockListItem.Content.GetType()</h3>
    if (blockListItem.Settings != null)
    {
       <h3>Block settings: @blockListItem.Settings.GetType()</h3>
    }
}
<h1>Nested: @Model.Value("nested").GetType()</h1>
@foreach (var nestedContentItem in Model.Value<IEnumerable<IPublishedElement>>("nested"))
{
    <h2>Content: @nestedContentItem.GetType()</h2>
}
```

After adding a `Text` and `Text2` content item to both editors and publishing the page, you should get the following output when using the default `Umbraco.ModelsBuilder.ModelsMode` setting that's set to `PureLive`:
```
Blocks: Umbraco.Core.Models.Blocks.BlockListModel
Block: Umbraco.Core.Models.Blocks.BlockListItem`2[Umbraco.Web.PublishedModels.Text,Umbraco.Web.PublishedModels.TextSettings]
Block content: Umbraco.Web.PublishedModels.Text
Block settings: Umbraco.Web.PublishedModels.TextSettings
Block: Umbraco.Core.Models.Blocks.BlockListItem`2[Umbraco.Web.PublishedModels.Text2,Umbraco.Core.Models.PublishedContent.IPublishedElement]
Block content: Umbraco.Web.PublishedModels.Text2
Nested: System.Collections.Generic.List`1[Umbraco.Core.Models.PublishedContent.IPublishedElement]
Content: Umbraco.Web.PublishedModels.Text
Content: Umbraco.Web.PublishedModels.Text2
```

And changing the ModelsBuilder mode to `Nothing` and restarting should now show:
```
Blocks: Umbraco.Core.Models.Blocks.BlockListModel
Block: Umbraco.Core.Models.Blocks.BlockListItem`2[Umbraco.Core.Models.PublishedContent.IPublishedElement,Umbraco.Core.Models.PublishedContent.IPublishedElement]
Block content: Umbraco.Web.PublishedCache.PublishedElement
Block settings: Umbraco.Web.PublishedCache.PublishedElement
Block: Umbraco.Core.Models.Blocks.BlockListItem`2[Umbraco.Core.Models.PublishedContent.IPublishedElement,Umbraco.Core.Models.PublishedContent.IPublishedElement]
Block content: Umbraco.Web.PublishedCache.PublishedElement
Nested: System.Collections.Generic.List`1[Umbraco.Core.Models.PublishedContent.IPublishedElement]
Content: Umbraco.Web.PublishedCache.PublishedElement
Content: Umbraco.Web.PublishedCache.PublishedElement
```