### PR TITLE
Only send telemetry when runtime level is run

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/ReportSiteTask.cs
@@ -3,8 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Telemetry;
 using Umbraco.Cms.Core.Telemetry.Models;
 using Umbraco.Cms.Web.Common.DependencyInjection;
@@ -16,15 +18,26 @@ public class ReportSiteTask : RecurringHostedServiceBase
     private static HttpClient _httpClient = new();
     private readonly ILogger<ReportSiteTask> _logger;
     private readonly ITelemetryService _telemetryService;
+    private readonly IRuntimeState _runtimeState;
 
     public ReportSiteTask(
         ILogger<ReportSiteTask> logger,
-        ITelemetryService telemetryService)
-        : base(logger, TimeSpan.FromDays(1), TimeSpan.FromMinutes(1))
+        ITelemetryService telemetryService,
+        IRuntimeState runtimeState)
+        : base(logger, TimeSpan.FromDays(1), TimeSpan.FromMinutes(5))
     {
         _logger = logger;
         _telemetryService = telemetryService;
+        _runtimeState = runtimeState;
         _httpClient = new HttpClient();
+    }
+
+    [Obsolete("Use the constructor that takes IRuntimeState, scheduled for removal in V12")]
+    public ReportSiteTask(
+        ILogger<ReportSiteTask> logger,
+        ITelemetryService telemetryService)
+        : this(logger, telemetryService, StaticServiceProvider.Instance.GetRequiredService<IRuntimeState>())
+    {
     }
 
     [Obsolete("Use the constructor that takes ITelemetryService instead, scheduled for removal in V11")]
@@ -42,6 +55,12 @@ public class ReportSiteTask : RecurringHostedServiceBase
     /// </summary>
     public override async Task PerformExecuteAsync(object? state)
     {
+        if (_runtimeState.Level is not RuntimeLevel.Run)
+        {
+            // We probably haven't installed yet, so we can't get telemetry.
+            return;
+        }
+
         if (_telemetryService.TryGetTelemetryReportData(out TelemetryReportData? telemetryReportData) is false)
         {
             _logger.LogWarning("No telemetry marker found");


### PR DESCRIPTION
The report site task will throw an annoying error if you don't install within one minute, since it'll try to read from a non-existing database.

I've added a check so we now only try to send if the runtime level is run, otherwise we'll just skip.

I've also increased the initial delay to 5 minutes instead of one, to minimize this being skipped.

I don't think it's a major issue if we have to wait another day regardless, since people are likely running locally when installing.

Related issue #12584 