### PR TITLE
GetCropUrl can now (easily) force return a file type

### DIFF
--- a/src/Umbraco.Core/Models/ImageCropperForcedFileTypes.cs
+++ b/src/Umbraco.Core/Models/ImageCropperForcedFileTypes.cs
@@ -2,6 +2,7 @@ namespace Umbraco.Cms.Core.Models
 {
     public enum ImageCropperForcedFileTypes
     {
+        Default,
         Jpg,
         WebP
     }

--- a/src/Umbraco.Core/Models/ImageCropperForcedFileTypes.cs
+++ b/src/Umbraco.Core/Models/ImageCropperForcedFileTypes.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Core.Models
+{
+    public enum ImageCropperForcedFileTypes
+    {
+        Jpg,
+        WebP
+    }
+}

--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -34,8 +34,9 @@ public static class FriendlyImageCropperTemplateExtensions
     public static string? GetCropUrl(
         this IPublishedContent mediaItem,
         string cropAlias,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
-        mediaItem.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
+        mediaItem.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider,fileType, urlMode);
 
     /// <summary>
     ///     Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias in the
@@ -43,43 +44,13 @@ public static class FriendlyImageCropperTemplateExtensions
     /// </summary>
     /// <param name="mediaWithCrops">The MediaWithCrops item.</param>
     /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="urlMode">The url mode.</param>
     /// <returns>
     ///     The URL of the cropped image.
     /// </returns>
-    public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, UrlMode urlMode = UrlMode.Default)
-        => mediaWithCrops.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
-
-    /// <summary>
-    ///     Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias in the
-    ///     MediaWithCrops content item) on the MediaWithCrops item and returns a specific fileType.
-    /// </summary>
-    /// <param name="mediaWithCrops">The MediaWithCrops item.</param>
-    /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
-    /// <param name="fileType">The type it should return.</param>
-    /// <param name="urlMode">The url mode.</param>
-    /// <returns>
-    ///     The URL of the cropped image.
-    /// </returns>
-    public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, ImageCropperForcedFileTypes fileType, UrlMode urlMode = UrlMode.Default)
+    public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default, UrlMode urlMode = UrlMode.Default)
         => mediaWithCrops.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, fileType, urlMode);
-
-    /// <summary>
-    ///     Gets the crop URL by using only the specified <paramref name="imageCropperValue" />.
-    /// </summary>
-    /// <param name="mediaItem">The media item.</param>
-    /// <param name="imageCropperValue">The image cropper value.</param>
-    /// <param name="cropAlias">The crop alias.</param>
-    /// <param name="urlMode">The url mode.</param>
-    /// <returns>
-    ///     The image crop URL.
-    /// </returns>
-    public static string? GetCropUrl(
-        this IPublishedContent mediaItem,
-        ImageCropperValue imageCropperValue,
-        string cropAlias,
-        UrlMode urlMode = UrlMode.Default)
-        => mediaItem.GetCropUrl(imageCropperValue, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
 
     /// <summary>
     ///     Gets the underlying image processing service URL by the crop alias using the specified property containing the
@@ -160,6 +131,7 @@ public static class FriendlyImageCropperTemplateExtensions
         bool useCropDimensions = false,
         bool cacheBuster = true,
         string? furtherOptions = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default)
         => mediaItem.GetCropUrl(
             ImageUrlGenerator,
@@ -176,6 +148,7 @@ public static class FriendlyImageCropperTemplateExtensions
             useCropDimensions,
             cacheBuster,
             furtherOptions,
+            fileType,
             urlMode);
 
     /// <summary>
@@ -225,6 +198,7 @@ public static class FriendlyImageCropperTemplateExtensions
         bool useCropDimensions = false,
         bool cacheBuster = true,
         string? furtherOptions = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default)
         => mediaWithCrops.GetCropUrl(
             ImageUrlGenerator,
@@ -241,6 +215,7 @@ public static class FriendlyImageCropperTemplateExtensions
             useCropDimensions,
             cacheBuster,
             furtherOptions,
+            fileType,
             urlMode);
 
     /// <summary>
@@ -288,6 +263,7 @@ public static class FriendlyImageCropperTemplateExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         string? furtherOptions = null)
         => imageUrl.GetCropUrl(
             ImageUrlGenerator,
@@ -301,6 +277,7 @@ public static class FriendlyImageCropperTemplateExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
+            fileType,
             furtherOptions);
 
     /// <summary>
@@ -348,6 +325,7 @@ public static class FriendlyImageCropperTemplateExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         string? furtherOptions = null)
         => imageUrl.GetCropUrl(
             ImageUrlGenerator,
@@ -361,6 +339,7 @@ public static class FriendlyImageCropperTemplateExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
+            fileType,
             furtherOptions);
 
     [Obsolete(

--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Web.Common.DependencyInjection;
+using Umbraco.Cms.Web.Common.Models;
 
 namespace Umbraco.Extensions;
 
@@ -48,6 +49,20 @@ public static class FriendlyImageCropperTemplateExtensions
     /// </returns>
     public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, UrlMode urlMode = UrlMode.Default)
         => mediaWithCrops.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
+
+    /// <summary>
+    ///     Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias in the
+    ///     MediaWithCrops content item) on the MediaWithCrops item and returns a specific fileType.
+    /// </summary>
+    /// <param name="mediaWithCrops">The MediaWithCrops item.</param>
+    /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+    /// <param name="fileType">The type it should return.</param>
+    /// <param name="urlMode">The url mode.</param>
+    /// <returns>
+    ///     The URL of the cropped image.
+    /// </returns>
+    public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string cropAlias, ImageCropperForcedFileTypes fileType, UrlMode urlMode = UrlMode.Default)
+        => mediaWithCrops.GetCropUrl(cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, fileType, urlMode);
 
     /// <summary>
     ///     Gets the crop URL by using only the specified <paramref name="imageCropperValue" />.

--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -59,6 +59,7 @@ public static class FriendlyImageCropperTemplateExtensions
     /// <param name="mediaItem">The IPublishedContent item.</param>
     /// <param name="propertyAlias">The property alias of the property containing the JSON data e.g. umbracoFile.</param>
     /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="urlMode">The url mode.</param>
     /// <returns>
     ///     The URL of the cropped image.
@@ -67,8 +68,9 @@ public static class FriendlyImageCropperTemplateExtensions
         this IPublishedContent mediaItem,
         string propertyAlias,
         string cropAlias,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
-        mediaItem.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
+        mediaItem.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, fileType, urlMode);
 
     /// <summary>
     ///     Gets the underlying image processing service URL by the crop alias using the specified property containing the
@@ -77,12 +79,13 @@ public static class FriendlyImageCropperTemplateExtensions
     /// <param name="mediaWithCrops">The MediaWithCrops item.</param>
     /// <param name="propertyAlias">The property alias of the property containing the JSON data e.g. umbracoFile.</param>
     /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="urlMode">The url mode.</param>
     /// <returns>
     ///     The URL of the cropped image.
     /// </returns>
-    public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias, UrlMode urlMode = UrlMode.Default)
-        => mediaWithCrops.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, urlMode);
+    public static string? GetCropUrl(this MediaWithCrops mediaWithCrops, string propertyAlias, string cropAlias, ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default, UrlMode urlMode = UrlMode.Default)
+        => mediaWithCrops.GetCropUrl(propertyAlias, cropAlias, ImageUrlGenerator, PublishedValueFallback, PublishedUrlProvider, fileType, urlMode);
 
     /// <summary>
     ///     Gets the underlying image processing service URL from the IPublishedContent item.
@@ -114,6 +117,7 @@ public static class FriendlyImageCropperTemplateExtensions
     /// furtherOptions: "bgcolor=fff"
     /// ]]></example>
     /// </param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="urlMode">The url mode.</param>
     /// <returns>
     ///     The URL of the cropped image.
@@ -181,6 +185,7 @@ public static class FriendlyImageCropperTemplateExtensions
     /// furtherOptions: "bgcolor=fff"
     /// ]]></example>
     /// </param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="urlMode">The url mode.</param>
     /// <returns>
     ///     The URL of the cropped image.
@@ -241,6 +246,7 @@ public static class FriendlyImageCropperTemplateExtensions
     ///     Add a serialized date of the last edit of the item to ensure client cache refresh when
     ///     updated.
     /// </param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="furtherOptions">
     ///     These are any query string parameters (formatted as query strings) that the underlying image processing service
     ///     supports. For example:
@@ -303,6 +309,7 @@ public static class FriendlyImageCropperTemplateExtensions
     ///     Add a serialized date of the last edit of the item to ensure client cache refresh when
     ///     updated.
     /// </param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="furtherOptions">
     ///     These are any query string parameters (formatted as query strings) that the underlying image processing service
     ///     supports. For example:

--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -92,6 +92,7 @@ public static class ImageCropperTemplateCoreExtensions
         IImageUrlGenerator imageUrlGenerator,
         IPublishedValueFallback publishedValueFallback,
         IPublishedUrlProvider publishedUrlProvider,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
         mediaItem.GetCropUrl(
             imageUrlGenerator,
@@ -101,6 +102,7 @@ public static class ImageCropperTemplateCoreExtensions
             true,
             cropAlias: cropAlias,
             useCropDimensions: true,
+            fileType: fileType,
             urlMode: urlMode);
 
     /// <summary>
@@ -124,6 +126,7 @@ public static class ImageCropperTemplateCoreExtensions
         IImageUrlGenerator imageUrlGenerator,
         IPublishedValueFallback publishedValueFallback,
         IPublishedUrlProvider publishedUrlProvider,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
         mediaItem.GetCropUrl(
             imageUrlGenerator,
@@ -132,6 +135,7 @@ public static class ImageCropperTemplateCoreExtensions
             propertyAlias: propertyAlias,
             cropAlias: cropAlias,
             useCropDimensions: true,
+            fileType: fileType,
             urlMode: urlMode);
 
     /// <summary>

--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -68,6 +68,37 @@ public static class ImageCropperTemplateCoreExtensions
             urlMode: urlMode);
 
     /// <summary>
+    ///     Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias in the
+    ///     MediaWithCrops content item) on the MediaWithCrops item forced to a certain file type.
+    /// </summary>
+    /// <param name="mediaWithCrops">The MediaWithCrops item.</param>
+    /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
+    /// <param name="imageUrlGenerator">The image URL generator.</param>
+    /// <param name="publishedValueFallback">The published value fallback.</param>
+    /// <param name="publishedUrlProvider">The published URL provider.</param>
+    /// <param name="fileType">The file type that should be returned.</param>
+    /// <param name="urlMode">The url mode.</param>
+    /// <returns>
+    ///     The URL of the cropped image.
+    /// </returns>
+    public static string? GetCropUrl(
+        this MediaWithCrops mediaWithCrops,
+        string cropAlias,
+        IImageUrlGenerator imageUrlGenerator,
+        IPublishedValueFallback publishedValueFallback,
+        IPublishedUrlProvider publishedUrlProvider,
+        ImageCropperForcedFileTypes fileType,
+        UrlMode urlMode = UrlMode.Default) =>
+        mediaWithCrops.GetCropUrl(
+            imageUrlGenerator,
+            publishedValueFallback,
+            publishedUrlProvider,
+            cropAlias: cropAlias,
+            furtherOptions: "&format=" + fileType.ToString().ToLower(),
+            useCropDimensions: true,
+            urlMode: urlMode);
+
+    /// <summary>
     ///     Gets the crop URL by using only the specified <paramref name="imageCropperValue" />.
     /// </summary>
     /// <param name="mediaItem">The media item.</param>

--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -20,6 +20,7 @@ public static class ImageCropperTemplateCoreExtensions
     /// <param name="imageUrlGenerator">The image URL generator.</param>
     /// <param name="publishedValueFallback">The published value fallback.</param>
     /// <param name="publishedUrlProvider">The published URL provider.</param>
+    /// <param name="fileType">The fileType to return.</param>
     /// <param name="urlMode">The url mode.</param>
     /// <returns>
     ///     The URL of the cropped image.
@@ -30,12 +31,14 @@ public static class ImageCropperTemplateCoreExtensions
         IImageUrlGenerator imageUrlGenerator,
         IPublishedValueFallback publishedValueFallback,
         IPublishedUrlProvider publishedUrlProvider,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
         mediaItem.GetCropUrl(
             imageUrlGenerator,
             publishedValueFallback,
             publishedUrlProvider,
             cropAlias: cropAlias,
+            furtherOptions: fileType == ImageCropperForcedFileTypes.Default ? string.Empty : "&format=" + fileType.ToString().ToLower(),
             useCropDimensions: true,
             urlMode: urlMode);
 
@@ -58,43 +61,14 @@ public static class ImageCropperTemplateCoreExtensions
         IImageUrlGenerator imageUrlGenerator,
         IPublishedValueFallback publishedValueFallback,
         IPublishedUrlProvider publishedUrlProvider,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
         mediaWithCrops.GetCropUrl(
             imageUrlGenerator,
             publishedValueFallback,
             publishedUrlProvider,
             cropAlias: cropAlias,
-            useCropDimensions: true,
-            urlMode: urlMode);
-
-    /// <summary>
-    ///     Gets the underlying image processing service URL by the crop alias (from the "umbracoFile" property alias in the
-    ///     MediaWithCrops content item) on the MediaWithCrops item forced to a certain file type.
-    /// </summary>
-    /// <param name="mediaWithCrops">The MediaWithCrops item.</param>
-    /// <param name="cropAlias">The crop alias e.g. thumbnail.</param>
-    /// <param name="imageUrlGenerator">The image URL generator.</param>
-    /// <param name="publishedValueFallback">The published value fallback.</param>
-    /// <param name="publishedUrlProvider">The published URL provider.</param>
-    /// <param name="fileType">The file type that should be returned.</param>
-    /// <param name="urlMode">The url mode.</param>
-    /// <returns>
-    ///     The URL of the cropped image.
-    /// </returns>
-    public static string? GetCropUrl(
-        this MediaWithCrops mediaWithCrops,
-        string cropAlias,
-        IImageUrlGenerator imageUrlGenerator,
-        IPublishedValueFallback publishedValueFallback,
-        IPublishedUrlProvider publishedUrlProvider,
-        ImageCropperForcedFileTypes fileType,
-        UrlMode urlMode = UrlMode.Default) =>
-        mediaWithCrops.GetCropUrl(
-            imageUrlGenerator,
-            publishedValueFallback,
-            publishedUrlProvider,
-            cropAlias: cropAlias,
-            furtherOptions: "&format=" + fileType.ToString().ToLower(),
+            furtherOptions: fileType == ImageCropperForcedFileTypes.Default ? string.Empty : "&format=" + fileType.ToString().ToLower(),
             useCropDimensions: true,
             urlMode: urlMode);
 
@@ -243,6 +217,7 @@ public static class ImageCropperTemplateCoreExtensions
         bool useCropDimensions = false,
         bool cacheBuster = true,
         string? furtherOptions = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default) =>
         mediaItem.GetCropUrl(
             imageUrlGenerator,
@@ -261,6 +236,7 @@ public static class ImageCropperTemplateCoreExtensions
             useCropDimensions,
             cacheBuster,
             furtherOptions,
+            fileType,
             urlMode);
 
     /// <summary>
@@ -315,6 +291,7 @@ public static class ImageCropperTemplateCoreExtensions
         bool useCropDimensions = false,
         bool cacheBuster = true,
         string? furtherOptions = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default)
     {
         if (mediaWithCrops == null)
@@ -339,6 +316,7 @@ public static class ImageCropperTemplateCoreExtensions
             useCropDimensions,
             cacheBuster,
             furtherOptions,
+            fileType,
             urlMode);
     }
 
@@ -389,6 +367,7 @@ public static class ImageCropperTemplateCoreExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         string? furtherOptions = null)
     {
         if (string.IsNullOrWhiteSpace(imageUrl))
@@ -416,6 +395,7 @@ public static class ImageCropperTemplateCoreExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
+            fileType,
             furtherOptions);
     }
 
@@ -469,6 +449,7 @@ public static class ImageCropperTemplateCoreExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         string? furtherOptions = null)
     {
         if (string.IsNullOrWhiteSpace(imageUrl))
@@ -521,6 +502,11 @@ public static class ImageCropperTemplateCoreExtensions
         options.Width = width;
         options.Height = height;
         options.FurtherOptions = furtherOptions;
+        if (fileType != ImageCropperForcedFileTypes.Default)
+        {
+            options.FurtherOptions = (furtherOptions != null && furtherOptions.Contains("&format")) ? furtherOptions : "&format=" + fileType.ToString().ToLower();
+        }
+
         options.CacheBusterValue = cacheBusterValue;
 
         return imageUrlGenerator.GetImageUrl(options);
@@ -544,6 +530,7 @@ public static class ImageCropperTemplateCoreExtensions
         bool useCropDimensions = false,
         bool cacheBuster = true,
         string? furtherOptions = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default)
     {
         if (mediaItem == null)
@@ -604,6 +591,7 @@ public static class ImageCropperTemplateCoreExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
+            fileType,
             furtherOptions);
     }
 }

--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -265,25 +265,25 @@ public static class UrlHelperExtensions
         return $"{version}.{runtimeMinifier.CacheBuster}".GenerateHash();
     }
 
-    public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent? mediaItem, string cropAlias, bool htmlEncode = true, UrlMode urlMode = UrlMode.Default)
+    public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent? mediaItem, string cropAlias, bool htmlEncode = true, ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default, UrlMode urlMode = UrlMode.Default)
     {
         if (mediaItem == null)
         {
             return HtmlString.Empty;
         }
 
-        var url = mediaItem.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
+        var url = mediaItem.GetCropUrl(cropAlias: cropAlias, useCropDimensions: true, fileType: fileType, urlMode: urlMode);
         return CreateHtmlString(url, htmlEncode);
     }
 
-    public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent? mediaItem, string propertyAlias, string cropAlias, bool htmlEncode = true, UrlMode urlMode = UrlMode.Default)
+    public static IHtmlContent GetCropUrl(this IUrlHelper urlHelper, IPublishedContent? mediaItem, string propertyAlias, string cropAlias, bool htmlEncode = true, ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default, UrlMode urlMode = UrlMode.Default)
     {
         if (mediaItem == null)
         {
             return HtmlString.Empty;
         }
 
-        var url = mediaItem.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true, urlMode: urlMode);
+        var url = mediaItem.GetCropUrl(propertyAlias: propertyAlias, cropAlias: cropAlias, useCropDimensions: true, fileType: fileType, urlMode: urlMode);
         return CreateHtmlString(url, htmlEncode);
     }
 
@@ -302,6 +302,7 @@ public static class UrlHelperExtensions
         bool cacheBuster = true,
         string? furtherOptions = null,
         bool htmlEncode = true,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         UrlMode urlMode = UrlMode.Default)
     {
         if (mediaItem == null)
@@ -321,6 +322,7 @@ public static class UrlHelperExtensions
             useCropDimensions,
             cacheBuster,
             furtherOptions,
+            fileType,
             urlMode);
 
         return CreateHtmlString(url, htmlEncode);
@@ -339,6 +341,7 @@ public static class UrlHelperExtensions
         bool useCropDimensions = true,
         string? cacheBusterValue = null,
         string? furtherOptions = null,
+        ImageCropperForcedFileTypes fileType = ImageCropperForcedFileTypes.Default,
         bool htmlEncode = true)
     {
         if (imageCropperValue == null)
@@ -358,6 +361,7 @@ public static class UrlHelperExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
+            fileType,
             furtherOptions);
 
         return CreateHtmlString(url, htmlEncode);


### PR DESCRIPTION
Now that WebP is fully supported, this seems like a great addition.

I've added an optional parameter to GetCropUrl so any file type that gets retrieved by it can be forced to a predefined (Enum) fileType. Currently I've added Jpg and WebP as formats.
I thought about adding Png but that just seems way off to do so. And if someone would really need it (for some reason) he could fall back to use the 'furtherOptions:' parameter.

You can easily test this by spinning up a installation and test using the MediaPicker (with crops) or just the ImageCropper.

Example code to easily test this. Just put this in a view with a CropItem (ImageCropper datatype) and a MediaItem (MediaPicker datatype) property.

```
<h2>Current functionality</h2>
<strong>Method: Model.CropItem</strong>
<span>Result:</span> @Model.CropItem
<br/>

<strong>Method: Url.GetCropUrl(Model.CropItem, "Small")</strong>
<span>Result:</span> @Url.GetCropUrl(Model.CropItem, "Small")
<br/>

<strong>Method: Url.GetCropUrl(Model.CropItem, "Normal")</strong>
<span>Result:</span> @Url.GetCropUrl(Model.CropItem, "Normal")
<br/>

<strong>Method: Url.GetCropUrl(Model.MediaItem, 500, 300, furtherOptions: "&format=webp")</strong>
<span>Result:</span> @Url.GetCropUrl(Model.MediaItem, 500, 300, furtherOptions: "&format=webp")
<br/>

<strong>Method: Model.MediaItem.GetCropUrl("Small")</strong>
<span>Result:</span>  @Model.MediaItem.GetCropUrl("Small");
<br/>


<h2>New functionality</h2>
<strong>Method: Url.GetCropUrl(Model.CropItem, "Small", fileType:ImageCropperForcedFileTypes.WebP)</strong>
<span>Result:</span> @Url.GetCropUrl(Model.CropItem, "Small", fileType:ImageCropperForcedFileTypes.WebP)
<br/><br/>

<strong>Method: Url.GetCropUrl(Model.CropItem, "Normal", fileType:ImageCropperForcedFileTypes.WebP)</strong>
<span>Result:</span> @Url.GetCropUrl(Model.CropItem, "Normal", fileType:ImageCropperForcedFileTypes.WebP)
<br/>

<strong>Method: Url.GetCropUrl(Model.MediaItem, 500, 300, furtherOptions: "&format=webp", fileType:ImageCropperForcedFileTypes.WebP)</strong>
<span>Result:</span> @Url.GetCropUrl(Model.MediaItem, 500, 300, fileType:ImageCropperForcedFileTypes.WebP)
<br/>

<strong>Method: Url.GetCropUrl(Model.MediaItem, 500, 300, furtherOptions: "&format=webp", fileType:ImageCropperForcedFileTypes.WebP) (Extra check to see it throws no errors)</strong>
<span>Result:</span> @Url.GetCropUrl(Model.MediaItem, 500, 300, furtherOptions: "&format=webp", fileType:ImageCropperForcedFileTypes.WebP)
<br/>

<strong>Method: Model.MediaItem.GetCropUrl("Small", fileType:ImageCropperForcedFileTypes.WebP)</strong>
<span>Result:</span>  @Model.MediaItem.GetCropUrl("Small", fileType:ImageCropperForcedFileTypes.WebP);
<br/>

<strong>Method: Model.MediaItem.GetCropUrl("Small", ImageCropperForcedFileTypes.WebP)</strong>
<span>Result:</span>  @Model.MediaItem.GetCropUrl("Small", ImageCropperForcedFileTypes.WebP)
<br/>

<strong>Method: Model.MediaItem.GetCropUrl("Small", ImageCropperForcedFileTypes.WebP)</strong>
<span>Result:</span>  @Model.MediaItem.GetCropUrl("Normal", ImageCropperForcedFileTypes.WebP)
```
