### PR TITLE
Update naming

### DIFF
--- a/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             if(!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/src/Umbraco.Core/Routing/ContentFinderByPageIdQuery.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByPageIdQuery.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Core.Routing
         }
 
         /// <inheritdoc/>
-        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             if(!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
         /// <remarks>Optionally, can also assign the template or anything else on the document request, although that is not required.</remarks>
-        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public virtual async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public virtual async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             if (!UmbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAlias.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAlias.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrlAndTemplate.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
         /// <remarks>If successful, also assigns the template.</remarks>
-        public override async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public override async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             var path = frequest.AbsolutePathDecoded;
 

--- a/src/Umbraco.Core/Routing/IContentFinder.cs
+++ b/src/Umbraco.Core/Routing/IContentFinder.cs
@@ -13,6 +13,6 @@ namespace Umbraco.Cms.Core.Routing
         /// <param name="request">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
         /// <remarks>Optionally, can also assign the template or anything else on the document request, although that is not required.</remarks>
-        Task<bool> TryFindContent(IPublishedRequestBuilder request);
+        Task<bool> TryFindContentAsync(IPublishedRequestBuilder request);
     }
 }

--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -436,7 +436,7 @@ namespace Umbraco.Cms.Core.Routing
                     {
                         _logger.LogDebug("Finder {ContentFinderType}", contentFinder.GetType().FullName);
                     }
-                    found = await contentFinder.TryFindContent(request);
+                    found = await contentFinder.TryFindContentAsync(request);
                     if (found)
                     {
                         break;
@@ -493,7 +493,7 @@ namespace Umbraco.Cms.Core.Routing
                     }
 
                     // if it fails then give up, there isn't much more that we can do
-                    if (await _contentLastChanceFinder.TryFindContent(request) == false)
+                    if (await _contentLastChanceFinder.TryFindContentAsync(request) == false)
                     {
                         if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
                         {

--- a/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
+++ b/src/Umbraco.Infrastructure/Routing/ContentFinderByConfigured404.cs
@@ -52,7 +52,7 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         /// <param name="frequest">The <c>PublishedRequest</c>.</param>
         /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
-        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+        public async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest)
         {
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {

--- a/tests/Umbraco.Tests.Common/TestLastChanceFinder.cs
+++ b/tests/Umbraco.Tests.Common/TestLastChanceFinder.cs
@@ -8,6 +8,6 @@ namespace Umbraco.Cms.Tests.Common
 {
     public class TestLastChanceFinder : IContentLastChanceFinder
     {
-        public async Task<bool> TryFindContent(IPublishedRequestBuilder frequest) => false;
+        public async Task<bool> TryFindContentAsync(IPublishedRequestBuilder frequest) => false;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasTests.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             var lookup =
                 new ContentFinderByUrlAlias(Mock.Of<ILogger<ContentFinderByUrlAlias>>(), Mock.Of<IPublishedValueFallback>(), VariationContextAccessor, umbracoContextAccessor);
 
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasWithDomainsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByAliasWithDomainsTests.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             }
 
             var finder = new ContentFinderByUrlAlias(Mock.Of<ILogger<ContentFinderByUrlAlias>>(), Mock.Of<IPublishedValueFallback>(), VariationContextAccessor, umbracoContextAccessor);
-            var result = await finder.TryFindContent(request);
+            var result = await finder.TryFindContentAsync(request);
 
             if (expectedNode > 0)
             {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByIdTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByIdTests.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
                 Mock.Of<ILogger<ContentFinderByIdPath>>(), Mock.Of<IRequestAccessor>(), umbracoContextAccessor);
 
 
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByPageIdQueryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByPageIdQueryTests.cs
@@ -54,7 +54,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             var lookup = new ContentFinderByPageIdQuery(mockRequestAccessor.Object, umbracoContextAccessor);
 
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAliasTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAliasTests.cs
@@ -55,7 +55,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Mock.Get(variationContextAccessor).Setup(x => x.VariationContext).Returns(variationContext);
             var publishedRequestBuilder = new PublishedRequestBuilder(new Uri(absoluteUrl, UriKind.Absolute), fileService);
             //Act
-            var result = await sut.TryFindContent(publishedRequestBuilder);
+            var result = await sut.TryFindContentAsync(publishedRequestBuilder);
 
             Assert.IsTrue(result);
             Assert.AreEqual(publishedRequestBuilder.PublishedContent.Id, nodeMatch);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAndTemplateTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAndTemplateTests.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
                 umbracoContextAccessor,
                 Mock.Of<IOptionsMonitor<WebRoutingSettings>>(x=>x.CurrentValue == webRoutingSettings));
 
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
 
             IPublishedRequest request = frequest.Build();
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlTests.cs
@@ -63,7 +63,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             if (urlString == "/home/sub1")
                 System.Diagnostics.Debugger.Break();
 
-            var result = await lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContentAsync(lookup.frequest);
 
             if (expectedId > 0)
             {
@@ -88,7 +88,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             Assert.IsFalse(GlobalSettings.HideTopLevelNodeFromPath);
 
-            var result = await lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContentAsync(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);
@@ -107,7 +107,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             var lookup = await GetContentFinder(urlString);
 
-            var result = await lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContentAsync(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);
@@ -132,7 +132,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             lookup.frequest.SetDomain(new DomainAndUri(new Domain(1, "mysite", -1, "en-US", false), new Uri("http://mysite/")));
 
-            var result = await lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContentAsync(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);
@@ -158,7 +158,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             lookup.frequest.SetDomain(new DomainAndUri(new Domain(1, "mysite/æøå", -1, "en-US", false), new Uri("http://mysite/æøå")));
 
-            var result = await lookup.finder.TryFindContent(lookup.frequest);
+            var result = await lookup.finder.TryFindContentAsync(lookup.frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, lookup.frequest.PublishedContent.Id);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlWithDomainsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlWithDomainsTests.cs
@@ -140,7 +140,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             publishedRouter.FindDomain(frequest);
 
             var lookup = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, frequest.PublishedContent.Id);
         }
@@ -183,7 +183,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Assert.AreEqual(expectedCulture, frequest.Culture);
 
             var lookup = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
             Assert.IsTrue(result);
             Assert.AreEqual(expectedId, frequest.PublishedContent.Id);
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/DomainsAndCulturesTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/DomainsAndCulturesTests.cs
@@ -304,7 +304,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Assert.AreEqual(expectedCulture, frequest.Culture);
 
             var finder = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = await finder.TryFindContent(frequest);
+            var result = await finder.TryFindContentAsync(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, expectedNode);
@@ -352,7 +352,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             // find document
             var finder = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = await finder.TryFindContent(frequest);
+            var result = await finder.TryFindContentAsync(frequest);
 
             // apply wildcard domain
             publishedRouter.HandleWildcardDomains(frequest);
@@ -388,7 +388,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
             Assert.AreEqual(expectedCulture, frequest.Culture);
 
             var finder = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = await finder.TryFindContent(frequest);
+            var result = await finder.TryFindContentAsync(frequest);
 
             Assert.IsTrue(result);
             Assert.AreEqual(frequest.PublishedContent.Id, expectedNode);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlsWithNestedDomains.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlsWithNestedDomains.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing
 
             // check that it's been routed
             var lookup = new ContentFinderByUrl(Mock.Of<ILogger<ContentFinderByUrl>>(), umbracoContextAccessor);
-            var result = await lookup.TryFindContent(frequest);
+            var result = await lookup.TryFindContentAsync(frequest);
             Assert.IsTrue(result);
             Assert.AreEqual(100111, frequest.PublishedContent.Id);
 


### PR DESCRIPTION
I'm not sure if there is a reason this wasn't done when the signature was updated as a breaking change in v10, but the naming convention for async methods is that it should have an `Async` suffix.

Targeting v11 currently, but can target v10 with obsoleted methods if that's the preference.