### PR TITLE
Fix StripHtmlTagsMethod by adding Regex

### DIFF
--- a/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Html;
 

--- a/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Html;
 
@@ -30,7 +31,17 @@ public sealed class HtmlStringUtilities
     public HtmlString StripHtmlTags(string html, params string[]? tags)
     {
         var doc = new HtmlDocument();
-        doc.LoadHtml("<p>" + html + "</p>");
+
+        // If the html string already starts with a tag we don't want to add extra tags
+        // as this would cause doc.DocumentNode.FirstChild.SelectNodes(".//*") to return null
+        if (Regex.IsMatch(html, @"^<[^>^<.]*>"))
+        {
+            doc.LoadHtml(html);
+        }
+        else
+        {
+            doc.LoadHtml("<p>" + html + "</p>");
+        }
 
         var targets = new List<HtmlNode>();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #12400 

### Description
The additional `<p>` tag around the html string should only be added if the string is not already starting with a tag.
If the string is already starting with an html tag and additionally is getting added another `<p>` tag the `doc.DocumentNode.FirstChild.SelectNodes(".//*")` is not finding any nodes.

### How to test
Add `@Html.StripHtml("<p>Some text<span>More text</span></p>", "p")` to a razor view and check if the string is stripped correctly.
