### PR TITLE
Prevent overflowing property values

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -38,7 +38,6 @@
 
 .umb-node-preview__content {
     flex: 1 1 auto;
-    margin-right: 25px;
     overflow: hidden;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-readonlyvalue.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-readonlyvalue.less
@@ -1,3 +1,4 @@
-.umb-readonlyvalue  {
-    position:relative;
+.umb-readonlyvalue {
+  position: relative;
+  .umb-property-editor--limit-width();
 }

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -421,6 +421,7 @@
 // Limit width of specific property editors
 .umb-property-editor--limit-width {
     max-width: @propertyEditorLimitedWidth;
+    word-break: break-all;
 }
 
 // Horizontal dividers


### PR DESCRIPTION
Add break word to avoid overflowing content / account for label values which are often used to store random data

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When storing certain data in labels (in this case base64 strings), the content overflows.
Similarly with url pickers, sometimes you will paste a long url which also can overflow.

Adjusted the styling so that content wraps more elegantly.

To replicate, add some long strings / urls to relevant properties.

Before
![break-word-before](https://user-images.githubusercontent.com/1469061/175120327-00ffd48d-7f75-46e8-a12d-bd01e7da9a3e.png)

After
![break-word-after](https://user-images.githubusercontent.com/1469061/175120332-b9e0bda7-8ccf-462a-8bba-efe22f0e5a0e.png)

