### PR TITLE
Add OEmbed property editor

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -132,6 +132,11 @@ namespace Umbraco.Cms.Core
                 public const string MultipleTextstring = "Umbraco.MultipleTextstring";
 
                 /// <summary>
+                /// OEmbed Picker.
+                /// </summary>
+                public const string OEmbedPicker = "Umbraco.OEmbedPicker";
+
+                /// <summary>
                 /// Label.
                 /// </summary>
                 public const string Label = "Umbraco.Label";

--- a/src/Umbraco.Core/Models/NumberRange.cs
+++ b/src/Umbraco.Core/Models/NumberRange.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Models
+{
+    [DataContract]
+    public class NumberRange
+    {
+        [DataMember(Name = "min")]
+        public int? Min { get; set; }
+
+        [DataMember(Name = "max")]
+        public int? Max { get; set; }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
@@ -1,6 +1,5 @@
 using System.Runtime.Serialization;
 
-
 namespace Umbraco.Cms.Core.PropertyEditors
 {
     /// <summary>
@@ -16,8 +15,10 @@ namespace Umbraco.Cms.Core.PropertyEditors
         public bool Multiple { get; set; }
 
         [ConfigurationField("validationLimit", "Amount", "numberrange", Description = "Set a required range of medias")]
-        public NumberRange ValidationLimit { get; set; } = new NumberRange();
+        public Models.NumberRange ValidationLimit { get; set; } = new Models.NumberRange();
 
+        // TODO: Remove this in V12
+        [Obsolete("Use NumberRange in Umbraco.Cms.Core.Models namespace")]
         [DataContract]
         public class NumberRange
         {

--- a/src/Umbraco.Core/PropertyEditors/OEmbedPickerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/OEmbedPickerConfiguration.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.PropertyEditors
 {
@@ -12,5 +12,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
         /// </summary>
         [ConfigurationField("multiple", "Allow picking of multiple items", "boolean")]
         public bool Multiple { get; set; }
+
+        [ConfigurationField("validationLimit", "Amount", "numberrange", Description = "Set a required range of medias")]
+        public NumberRange ValidationLimit { get; set; } = new NumberRange();
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/OEmbedPickerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/OEmbedPickerConfiguration.cs
@@ -1,0 +1,16 @@
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Core.PropertyEditors
+{
+    /// <summary>
+    /// Represents the configuration for the OEmbed picker.
+    /// </summary>
+    public class OEmbedPickerConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether multiple items are allowed to be picked.
+        /// </summary>
+        [ConfigurationField("multiple", "Allow picking of multiple items", "boolean")]
+        public bool Multiple { get; set; }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/OEmbedPickerConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/OEmbedPickerConfigurationEditor.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.PropertyEditors
+{
+    /// <summary>
+    /// Represents the configuration editor for the OEmbed picker editor.
+    /// </summary>
+    public class OEmbedPickerConfigurationEditor : ConfigurationEditor<OEmbedPickerConfiguration>
+    {
+        public OEmbedPickerConfigurationEditor(IIOHelper ioHelper, IEditorConfigurationParser editorConfigurationParser)
+            : base(ioHelper, editorConfigurationParser)
+        {
+
+        }
+
+        /// <summary>
+        /// Gets the default configuration object.
+        /// </summary>
+        public override object DefaultConfigurationObject { get; } = new OEmbedPickerConfiguration { Multiple = false };
+    }
+}

--- a/src/Umbraco.Infrastructure/Models/OEmbedItem.cs
+++ b/src/Umbraco.Infrastructure/Models/OEmbedItem.cs
@@ -1,0 +1,44 @@
+using Newtonsoft.Json;
+//using Microsoft.AspNetCore.Html;
+
+namespace Umbraco.Cms.Core.Models
+{
+    /// <summary>
+    /// Represents a item picked in the editor.
+    /// </summary>
+    public class OEmbedItem
+    {
+        /// <summary>
+        /// Gets or sets the URL.
+        /// </summary>
+        [JsonProperty(PropertyName = "url")]
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width.
+        /// </summary>
+        [JsonProperty(PropertyName = "width")]
+        public int Width { get; set; }
+
+        /// <summary>
+        /// Gets or sets the height.
+        /// </summary>
+        [JsonProperty(PropertyName = "height")]
+        public int Height { get; set; }
+
+        /// <summary>
+        /// Gets the embed code.
+        /// </summary>
+        //[JsonIgnore]
+        //public IHtmlContent EmbedCode => new HtmlString(this.Preview);
+
+        /// <summary>
+        /// Gets or sets the preview.
+        /// </summary>
+        [JsonProperty(PropertyName = "preview")]
+        internal string? Preview { get; set; }
+
+        /// <inheritdoc />
+        public override string? ToString() => Preview;
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +51,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         }
 
         /// <inheritdoc />
-        protected override IConfigurationEditor CreateConfigurationEditor() => new DateTimeConfigurationEditor(_ioHelper, _editorConfigurationParser);
+        protected override IConfigurationEditor CreateConfigurationEditor()
+            => new DateTimeConfigurationEditor(_ioHelper, _editorConfigurationParser);
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 return base.FromEditor(editorValue, currentValue);
             }
 
-            ///<remarks>
+            /// <remarks>
             /// Note: no FromEditor() and ToEditor() methods
             /// We do not want to transform the way the data is stored in the DB and would like to keep a raw JSON string
             /// </remarks>

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -68,8 +68,12 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
                 var udiPaths = asString!.Split(',');
                 foreach (var udiPath in udiPaths)
+                {
                     if (UdiParser.TryParse(udiPath, out var udi))
+                    {
                         yield return new UmbracoEntityReference(udi);
+                    }
+                }
             }
         }
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/OEmbedPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/OEmbedPickerPropertyEditor.cs
@@ -1,21 +1,11 @@
-using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
-using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
-using Newtonsoft.Json;
-using System;
-using System.Linq;
-using System.Runtime.Serialization;
-using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Web.Common.DependencyInjection;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors
 {
@@ -67,7 +57,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         protected override IDataValueEditor CreateValueEditor() =>
             DataValueEditorFactory.Create<OEmbedPickerPropertyValueEditor>(Attribute!);
 
-        internal class OEmbedPickerPropertyValueEditor : DataValueEditor, IDataValueReference
+        internal class OEmbedPickerPropertyValueEditor : DataValueEditor
         {
             private readonly IJsonSerializer _jsonSerializer;
             private readonly IDataTypeService _dataTypeService;
@@ -84,9 +74,6 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 _jsonSerializer = jsonSerializer;
                 _dataTypeService = dataTypeService;
             }
-
-            public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
-                => throw new NotImplementedException();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/OEmbedPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/OEmbedPickerPropertyEditor.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Runtime.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Web.Common.DependencyInjection;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors
+{
+    /// <summary>
+    /// Represents a OEmbed picker property editor.
+    /// </summary>
+    [DataEditor(
+        Constants.PropertyEditors.Aliases.OEmbedPicker,
+        EditorType.PropertyValue,
+        "OEmbed Picker",
+        "oembedpicker",
+        ValueType = ValueTypes.Json,
+        Group = Constants.PropertyEditors.Groups.Media,
+        Icon = Constants.Icons.MediaVideo)]
+    public class OEmbedPickerPropertyEditor : DataEditor
+    {
+        private readonly IIOHelper _ioHelper;
+        private readonly IEditorConfigurationParser _editorConfigurationParser;
+
+        // Scheduled for removal in v12
+        [Obsolete("Please use constructor that takes an IEditorConfigurationParser instead")]
+        public OEmbedPickerPropertyEditor(
+            IDataValueEditorFactory dataValueEditorFactory,
+            IIOHelper ioHelper,
+            EditorType type = EditorType.PropertyValue)
+            : this(dataValueEditorFactory, ioHelper, StaticServiceProvider.Instance.GetRequiredService<IEditorConfigurationParser>(), type)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OEmbedPickerPropertyEditor" /> class.
+        /// </summary>
+        public OEmbedPickerPropertyEditor(
+            IDataValueEditorFactory dataValueEditorFactory,
+            IIOHelper ioHelper,
+            IEditorConfigurationParser editorConfigurationParser,
+            EditorType type = EditorType.PropertyValue)
+            : base(dataValueEditorFactory, type)
+        {
+            _ioHelper = ioHelper;
+            _editorConfigurationParser = editorConfigurationParser;
+        }
+
+        /// <inheritdoc />
+        protected override IConfigurationEditor CreateConfigurationEditor() =>
+            new OEmbedPickerConfigurationEditor(_ioHelper, _editorConfigurationParser);
+
+        /// <inheritdoc />
+        protected override IDataValueEditor CreateValueEditor() =>
+            DataValueEditorFactory.Create<OEmbedPickerPropertyValueEditor>(Attribute!);
+
+        internal class OEmbedPickerPropertyValueEditor : DataValueEditor, IDataValueReference
+        {
+            private readonly IJsonSerializer _jsonSerializer;
+            private readonly IDataTypeService _dataTypeService;
+
+            public OEmbedPickerPropertyValueEditor(
+                ILocalizedTextService localizedTextService,
+                IShortStringHelper shortStringHelper,
+                IJsonSerializer jsonSerializer,
+                IIOHelper ioHelper,
+                DataEditorAttribute attribute,
+                IDataTypeService dataTypeService)
+                : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
+            {
+                _jsonSerializer = jsonSerializer;
+                _dataTypeService = dataTypeService;
+            }
+
+            public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
+                => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System;
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
 {
     /// <summary>
-    /// The default converter for all property editors that expose a JSON value type
+    /// The default converter for all property editors that expose a JSON value type.
     /// </summary>
     /// <remarks>
     /// Since this is a default (umbraco) converter it will be ignored if another converter found conflicts with this one.
@@ -23,7 +23,11 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
         private readonly PropertyEditorCollection _propertyEditors;
         private readonly ILogger<JsonValueConverter> _logger;
 
-        string[] ExcludedPropertyEditors = new string[] { Constants.PropertyEditors.Aliases.MediaPicker3 };
+        private readonly string[] _excludedPropertyEditors = new string[]
+        {
+            Constants.PropertyEditors.Aliases.MediaPicker3,
+            Constants.PropertyEditors.Aliases.OEmbedPicker
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonValueConverter"/> class.
@@ -45,7 +49,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
         {
             return _propertyEditors.TryGet(propertyType.EditorAlias, out var editor)
                    && editor.GetValueEditor().ValueType.InvariantEquals(ValueTypes.Json)
-                   && ExcludedPropertyEditors.Contains(propertyType.EditorAlias) == false;
+                   && _excludedPropertyEditors.Contains(propertyType.EditorAlias) == false;
         }
 
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/OEmbedPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/OEmbedPickerValueConverter.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
     [DefaultPropertyValueConverter]
     public class OEmbedPickerValueConverter : PropertyValueConverterBase
     {
+        /// <inheritdoc/>
         public override bool IsConverter(IPublishedPropertyType propertyType)
             => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.OEmbedPicker);
 
@@ -15,8 +16,11 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
             => IsMultipleDataType(propertyType.DataType)
                 ? typeof(IEnumerable<OEmbedItem>)
                 : typeof(OEmbedItem);
+
+        /// <inheritdoc/>
         public override bool? IsValue(object? value, PropertyValueLevel level) => value?.ToString() != "[]";
 
+        /// <inheritdoc/>
         public override object? ConvertSourceToIntermediate(
             IPublishedElement owner,
             IPublishedPropertyType propertyType,
@@ -24,6 +28,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
             bool preview) =>
             source?.ToString();
 
+        /// <inheritdoc/>
         public override object? ConvertIntermediateToObject(
             IPublishedElement owner,
             IPublishedPropertyType propertyType,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/OEmbedPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/OEmbedPickerValueConverter.cs
@@ -43,7 +43,16 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                 return isMultiple ? Enumerable.Empty<OEmbedItem>() : null;
             }
 
-            var items = JsonConvert.DeserializeObject<List<OEmbedItem>>(inter.ToString() ?? string.Empty);
+            List<OEmbedItem>? items = new();
+
+            try
+            {
+                items = JsonConvert.DeserializeObject<List<OEmbedItem>>(inter.ToString() ?? string.Empty);
+            }
+            catch
+            {
+
+            }
 
             return isMultiple ? items : items?.FirstOrDefault();
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/OEmbedPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/OEmbedPickerValueConverter.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
+{
+    [DefaultPropertyValueConverter]
+    public class OEmbedPickerValueConverter : PropertyValueConverterBase
+    {
+        public override bool IsConverter(IPublishedPropertyType propertyType)
+            => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.OEmbedPicker);
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+            => IsMultipleDataType(propertyType.DataType)
+                ? typeof(IEnumerable<OEmbedItem>)
+                : typeof(OEmbedItem);
+        public override bool? IsValue(object? value, PropertyValueLevel level) => value?.ToString() != "[]";
+
+        public override object? ConvertSourceToIntermediate(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            object? source,
+            bool preview) =>
+            source?.ToString();
+
+        public override object? ConvertIntermediateToObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview)
+        {
+            var isMultiple = IsMultipleDataType(propertyType.DataType);
+
+            if (string.IsNullOrWhiteSpace(inter?.ToString()))
+            {
+                return isMultiple ? Enumerable.Empty<OEmbedItem>() : null;
+            }
+
+            var items = JsonConvert.DeserializeObject<List<OEmbedItem>>(inter.ToString() ?? string.Empty);
+
+            return isMultiple ? items : items?.FirstOrDefault();
+        }
+
+        private bool IsMultipleDataType(PublishedDataType dataType) => dataType.ConfigurationAs<OEmbedPickerConfiguration>()?.Multiple ?? false;
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -227,7 +227,7 @@
 @import "../views/propertyeditors/mediapicker3/prevalue/mediapicker3.crops.less";
 @import "../views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.less";
 @import "../views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.less";
-
+@import "../views/propertyeditors/oembedpicker/oembed-picker.less";
 
 // Utilities
 @import "utilities/layout/_display.less";

--- a/src/Umbraco.Web.UI.Client/src/views/components/mediacard/umb-media-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/mediacard/umb-media-card.less
@@ -3,12 +3,9 @@ umb-media-card {
     position: relative;
     display: inline-block;
     width: 100%;
-    //background-color: white;
     border-radius: @baseBorderRadius;
-    //box-shadow: 0 1px 2px rgba(0,0,0,.2);
     overflow: hidden;
     transition: box-shadow 120ms;
-    cursor: pointer;
     .umb-outline();
 
     &:hover {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -58,10 +58,12 @@
         vm.$onInit = function() {
 
             vm.validationLimit = vm.model.config.validationLimit || {};
+            
             // If single-mode we only allow 1 item as the maximum:
-            if(vm.model.config.multiple === false) {
+            if (vm.model.config.multiple === false) {
                 vm.validationLimit.max = 1;
             }
+            
             vm.model.config.crops = vm.model.config.crops || [];
             vm.singleMode = vm.validationLimit.max === 1;
             vm.allowedTypes = vm.model.config.filter ? vm.model.config.filter.split(",") : null;
@@ -83,9 +85,9 @@
                 isDisabled: true,
                 useLegacyIcon: false
             };
-
-            var propertyActions = [];
-            if(vm.supportCopy) {
+            
+            let propertyActions = [];
+            if (vm.supportCopy) {
                 propertyActions.push(copyAllMediasAction);
             }
             propertyActions.push(removeAllMediasAction);
@@ -94,7 +96,7 @@
                 vm.umbProperty.setPropertyActions(propertyActions);
             }
 
-            if(vm.model.value === null || !Array.isArray(vm.model.value)) {
+            if (vm.model.value === null || !Array.isArray(vm.model.value)) {
                 vm.model.value = [];
             }
 
@@ -127,7 +129,7 @@
         };
 
         function onServerValueChanged(newVal, oldVal) {
-            if(newVal === null || !Array.isArray(newVal)) {
+            if (newVal === null || !Array.isArray(newVal)) {
                 newVal = [];
                 vm.model.value = newVal;
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -30,7 +30,7 @@
 
     function MediaPicker3Controller($scope, editorService, clipboardService, localizationService, overlayService, userService, entityResource) {
 
-        var unsubscribe = [];
+        let unsubscribe = [];
 
         // Property actions:
         let copyAllMediasAction = null;
@@ -59,7 +59,7 @@
 
             vm.validationLimit = vm.model.config.validationLimit || {};
             
-            // If single-mode we only allow 1 item as the maximum:
+            // If single-mode we only allow 1 item as the maximum.
             if (vm.model.config.multiple === false) {
                 vm.validationLimit.max = 1;
             }
@@ -95,7 +95,7 @@
             if (vm.umbProperty) {
                 vm.umbProperty.setPropertyActions(propertyActions);
             }
-
+            
             if (vm.model.value === null || !Array.isArray(vm.model.value)) {
                 vm.model.value = [];
             }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembed-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembed-picker.less
@@ -11,21 +11,32 @@
     }
   }
 
+  .__actions {
+    z-index: 2;
+  }
+
+  .__overlay {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+  }
+
   .preview-item {
-      position: relative;
+    position: relative;
 
-      &::before {
-        content: "";
-        display: block;
-        position: absolute;
-        width: 100%;
-        height: 100%;
-      }
+    &::before {
+      content: "";
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
 
-      iframe,
-      span {
-        display: inline-block;
-        height: 100%;
-      }
+    iframe,
+    span {
+      display: inline-block;
+      height: 100%;
+    }
   }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembed-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembed-picker.less
@@ -1,0 +1,22 @@
+.umb-oembedpicker {
+  .umb-property-editor--limit-width();
+
+  .umb-media-card-grid {
+    padding: 20px;
+    border: 1px solid @inputBorder;
+    box-sizing: border-box;
+
+    &.--singleMode {
+      max-width: 202px;
+    }
+  }
+
+  .preview-item {
+      position: relative;
+
+      iframe,
+      span {
+          height: 100%;
+      }
+  }
+}

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembed-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembed-picker.less
@@ -14,9 +14,18 @@
   .preview-item {
       position: relative;
 
+      &::before {
+        content: "";
+        display: block;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+      }
+
       iframe,
       span {
-          height: 100%;
+        display: inline-block;
+        height: 100%;
       }
   }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
@@ -1,0 +1,120 @@
+(function () {
+  "use strict";
+
+  angular
+    .module("umbraco")
+    .controller("Umbraco.PropertyEditors.OEmbedPickerController",
+      function Controller($scope) {
+
+        const vm = this;
+
+        vm.allowMultiple = $scope.model.config.allowmultiple;
+
+        vm.items = Array.isArray($scope.model.value) ? $scope.model.value : [];
+
+        function openEmbedDialog(embed, onSubmit) {
+
+          // Pass in a clone of embed object to embed infinite editor.
+          // We set both "orignal" and "modify" properties as it changed in Umbraco v8.2
+          const clone = Utilities.copy(embed);
+
+          const embedDialog = {
+            modify: clone,
+            original: clone,
+            submit: model => {
+              onSubmit(model.embed);
+              editorService.close();
+            },
+            close: () => {
+              editorService.close();
+            }
+          };
+
+          editorService.embed(embedDialog);
+        }
+
+        function trustHtml(html) {
+          return $sce.trustAsHtml(html);
+        }
+
+        function addEmbed(evt) {
+          evt.preventDefault();
+
+          openEmbedDialog({},
+            (newEmbed) => {
+              vm.items.push({
+                'url': newEmbed.url,
+                'width': newEmbed.width,
+                'height': newEmbed.height,
+                'preview': newEmbed.preview
+              });
+              updateModelValue();
+            });
+        }
+
+        function editEmbed(index, evt) {
+          evt.preventDefault();
+
+          var embed = vm.items[index];
+
+          openEmbedDialog(embed,
+            (newEmbed) => {
+
+              vm.items[index] = {
+                'url': newEmbed.url,
+                'width': newEmbed.width,
+                'height': newEmbed.height,
+                'preview': newEmbed.preview
+              };
+
+              updateModelValue();
+            });
+        }
+
+        function removeEmbed(index, evt) {
+          evt.preventDefault();
+
+          vm.items.splice(index, 1);
+
+          updateModelValue();
+        }
+
+        function updateModelValue() {
+          $scope.model.value = vm.items;
+          if (vm.oembedform && vm.oembedform.itemCount) {
+            vm.oembedform.itemCount.$setViewValue(vm.items.length);
+          }
+        }
+
+        function validate() {
+          var isValid = true;
+
+          if ($scope.model.validation.mandatory && (Array.isArray(vm.items) === false || vm.items.length === 0)) {
+            isValid = false;
+          }
+
+          return {
+            isValid: isValid,
+            errorMsg: "Value cannot be empty",
+            errorKey: "required"
+          };
+        }
+
+        vm.add = addEmbed;
+        vm.edit = editEmbed;
+        vm.remove = removeEmbed;
+        vm.trustHtml = trustHtml;
+        vm.validateMandatory = validate;
+
+        vm.sortableOptions = {
+          axis: 'y',
+          containment: 'parent',
+          cursor: 'move',
+          items: '> .umb-table-row',
+          handle: '.handle',
+          tolerance: 'pointer'
+        };
+
+      });
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
@@ -4,23 +4,36 @@
   angular
     .module("umbraco")
     .controller("Umbraco.PropertyEditors.OEmbedPickerController",
-      function Controller($scope) {
+      function Controller($scope, $sce, editorService) {
 
         const vm = this;
+
+        vm.add = addEmbed;
+        vm.edit = editEmbed;
+        vm.remove = removeEmbed;
+        vm.trustHtml = trustHtml;
+        vm.validateMandatory = validateMandatory;
 
         vm.allowMultiple = $scope.model.config.allowmultiple;
 
         vm.items = Array.isArray($scope.model.value) ? $scope.model.value : [];
 
+        vm.sortableOptions = {
+          axis: 'y',
+          containment: 'parent',
+          cursor: 'move',
+          items: '> .umb-table-row',
+          handle: '.handle',
+          tolerance: 'pointer'
+        };
+
         function openEmbedDialog(embed, onSubmit) {
 
           // Pass in a clone of embed object to embed infinite editor.
-          // We set both "orignal" and "modify" properties as it changed in Umbraco v8.2
           const clone = Utilities.copy(embed);
 
           const embedDialog = {
             modify: clone,
-            original: clone,
             submit: model => {
               onSubmit(model.embed);
               editorService.close();
@@ -81,12 +94,13 @@
 
         function updateModelValue() {
           $scope.model.value = vm.items;
+
           if (vm.oembedform && vm.oembedform.itemCount) {
             vm.oembedform.itemCount.$setViewValue(vm.items.length);
           }
         }
 
-        function validate() {
+        function validateMandatory() {
           var isValid = true;
 
           if ($scope.model.validation.mandatory && (Array.isArray(vm.items) === false || vm.items.length === 0)) {
@@ -99,21 +113,6 @@
             errorKey: "required"
           };
         }
-
-        vm.add = addEmbed;
-        vm.edit = editEmbed;
-        vm.remove = removeEmbed;
-        vm.trustHtml = trustHtml;
-        vm.validateMandatory = validate;
-
-        vm.sortableOptions = {
-          axis: 'y',
-          containment: 'parent',
-          cursor: 'move',
-          items: '> .umb-table-row',
-          handle: '.handle',
-          tolerance: 'pointer'
-        };
 
       });
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
@@ -19,13 +19,23 @@
         vm.items = Array.isArray($scope.model.value) ? $scope.model.value : [];
 
         vm.sortableOptions = {
-          axis: 'y',
-          containment: 'parent',
-          cursor: 'move',
-          items: '> .umb-table-row',
-          handle: '.handle',
-          tolerance: 'pointer'
+          containment: "parent",
+          cursor: "grabbing",
+          handle: ".umb-media-card",
+          cancel: "input,textarea,select,option",
+          classes: ".umb-media-card--dragging",
+          distance: 5,
+          tolerance: "pointer",
+          update: function (ev, ui) {
+            setDirty();
+          }
         };
+
+        function setDirty() {
+          if (vm.oembedForm) {
+            vm.oembedForm.$setDirty();
+          }
+        }
 
         function openEmbedDialog(embed, onSubmit) {
 
@@ -95,8 +105,8 @@
         function updateModelValue() {
           $scope.model.value = vm.items;
 
-          if (vm.oembedform && vm.oembedform.itemCount) {
-            vm.oembedform.itemCount.$setViewValue(vm.items.length);
+          if (vm.oembedForm && vm.oembedForm.itemCount) {
+            vm.oembedForm.itemCount.$setViewValue(vm.items.length);
           }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.controller.js
@@ -14,7 +14,7 @@
         vm.trustHtml = trustHtml;
         vm.validateMandatory = validateMandatory;
 
-        vm.allowMultiple = $scope.model.config.allowmultiple;
+        vm.allowMultiple = $scope.model.config.multiple;
 
         vm.items = Array.isArray($scope.model.value) ? $scope.model.value : [];
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
@@ -1,0 +1,28 @@
+<div ng-controller="Umbraco.PropertyEditors.OEmbedPickerController as vm" class="umb-property-editor umb-mediapicker umb-mediapicker-multiple">
+  <ng-form name="vm.oembedform">
+    <div ui-sortable="sortableOptions" ng-model="vm.items" class="items-container" ng-hide="!model.value">
+      <div class="umb-sortable-thumbnails umb-table-row" ng-repeat="embed in vm.items track by $index">
+        <div class="sort-icon" ng-if="vm.allowMultiple === true && vm.items.length > 1">
+          <i class="icon icon-navigation handle" aria-hidden="true"></i>
+        </div>
+        <div class="preview-item">
+          <span ng-bind-html="vm.trustHtml(embed.preview)"></span>
+        </div>
+        <div class="umb-sortable-thumbnails__actions">
+          <button type="button" class="umb-node-preview__action" ng-click="vm.edit($index, $event)">
+            <i class="icon icon-edit" aria-hidden="true"></i>
+          </button>
+          <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove($index, $event)">
+            <i class="icon icon-delete" aria-hidden="true"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="picker-btn" ng-hide="vm.allowMultiple === false && vm.items.length == 1">
+      <button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)">
+        <i class="icon icon-add large" aria-hidden="true"></i>
+      </button>
+    </div>
+    <input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
+  </ng-form>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
@@ -1,12 +1,13 @@
 <div ng-controller="Umbraco.PropertyEditors.OEmbedPickerController as vm" class="umb-property-editor umb-oembedpicker">
 
   <ng-form name="vm.oembedForm">
-    <div class="umb-media-card-grid" ng-class="{'--singleMode': vm.allowMultiple === false}">
+    <div class="umb-media-card-grid" ng-class="{'--singleMode': vm.singleMode }">
       <div style="display:contents;" ui-sortable="vm.sortableOptions" ng-model="vm.items" ng-hide="!model.value">
 
         <div ng-repeat="embed in vm.items track by $index" class="umb-media-card-grid__cell">
 
           <div class="umb-media-card">
+            <div class="__overlay handle"></div>
             <div class="__showcase">
               <div class="preview-item">
                 <span ng-bind-html="vm.trustHtml(embed.preview)"></span>
@@ -26,11 +27,10 @@
 
       </div>
 
-      <button 
-          type="button"
-          ng-if="(vm.allowMultiple === false && vm.items.length === 0) || vm.allowMultiple === true"
-          class="btn-reset umb-media-card-grid__create-button umb-outline"
-          ng-click="vm.add($event)">
+      <button type="button"
+              ng-if="(vm.singleMode === true && vm.items.length === 0) || vm.singleMode !== true"
+              class="btn-reset umb-media-card-grid__create-button umb-outline"
+              ng-click="vm.add($event)">
         <div>
           <umb-icon icon="icon-add" class="icon large"></umb-icon>
           <localize key="general_add">Add</localize>
@@ -42,5 +42,21 @@
     {{model.value | json}}
 
     <input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
+    <input type="hidden" name="minCount" ng-model="vm.items.length" val-server="minCount" />
+    <input type="hidden" name="maxCount" ng-model="vm.items.length" val-server="maxCount" />
+
+    <div ng-messages="vm.oembedForm.minCount.$error">
+      <div class="help text-error" ng-message="minCount">
+        <localize key="validation_entriesShort" tokens="[vm.validationLimit.min, vm.validationLimit.min - vm.items.length]" watch-tokens="true">Minimum %0% entries, needs <strong>%1%</strong> more.</localize>
+      </div>
+      <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.minCount.errorMsg">></span>
+    </div>
+    <div ng-messages="vm.oembedForm.maxCount.$error">
+      <div class="help text-error" ng-message="maxCount">
+        <localize key="validation_entriesExceed" tokens="[vm.validationLimit.max, vm.items.length - vm.validationLimit.max]" watch-tokens="true">Maximum %0% entries, <strong>%1%</strong> too many.</localize>
+      </div>
+      <span class="help-inline" ng-message="valServer" ng-bind-html="vm.propertyForm.maxCount.errorMsg"></span>
+    </div>
+
   </ng-form>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
@@ -1,7 +1,32 @@
-<div ng-controller="Umbraco.PropertyEditors.OEmbedPickerController as vm" class="umb-property-editor umb-mediapicker umb-mediapicker-multiple">
+<div ng-controller="Umbraco.PropertyEditors.OEmbedPickerController as vm" class="umb-property-editor umb-oembedpicker">
+
   <ng-form name="vm.oembedform">
-    <div ui-sortable="sortableOptions" ng-model="vm.items" class="items-container" ng-hide="!model.value">
-      <div class="umb-sortable-thumbnails umb-table-row" ng-repeat="embed in vm.items track by $index">
+    <div class="umb-media-card-grid">
+      <div style="display:contents;" ui-sortable="vm.sortableOptions" ng-model="vm.items" ng-hide="!model.value">
+
+        <div ng-repeat="embed in vm.items track by $index" class="umb-media-card-grid__cell">
+
+          <div class="umb-media-card">
+            <div class="__showcase">
+              <div class="preview-item">
+                <span ng-bind-html="vm.trustHtml(embed.preview)"></span>
+              </div>
+            </div>
+            <div class="__actions">
+              <button type="button" class="btn-reset __action umb-outline" localize="title" title="general_edit" ng-click="vm.edit($index, $event)">
+                <umb-icon icon="icon-edit" class="icon"></umb-icon>
+              </button>
+              <button type="button" class="btn-reset __action umb-outline" localize="title" title="general_remove" ng-click="vm.remove($index, $event)">
+                <umb-icon icon="icon-trash" class="icon"></umb-icon>
+              </button>
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+      <!--<div class="umb-sortable-thumbnails umb-table-row" ng-repeat="embed in vm.items track by $index">
         <div class="sort-icon" ng-if="vm.allowMultiple === true && vm.items.length > 1">
           <i class="icon icon-navigation handle" aria-hidden="true"></i>
         </div>
@@ -16,13 +41,30 @@
             <i class="icon icon-delete" aria-hidden="true"></i>
           </button>
         </div>
-      </div>
+      </div>-->
+
+      <!--ng-if="vm.allowMultiple === false && vm.items.length == 1"-->
+      <button 
+          type="button"
+          class="btn-reset umb-media-card-grid__create-button umb-outline"
+          ng-click="vm.add($event)">
+        <div>
+          <umb-icon icon="icon-add" class="icon large"></umb-icon>
+          <localize key="general_add">Add</localize>
+        </div>
+      </button>
+
     </div>
-    <div class="picker-btn" ng-hide="vm.allowMultiple === false && vm.items.length == 1">
+
+    {{model.value | json}}
+    
+
+    <!--<div class="picker-btn" ng-hide="vm.allowMultiple === false && vm.items.length == 1">
       <button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)">
         <i class="icon icon-add large" aria-hidden="true"></i>
       </button>
-    </div>
+    </div>-->
+
     <input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
   </ng-form>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/oembedpicker/oembedpicker.html
@@ -1,7 +1,7 @@
 <div ng-controller="Umbraco.PropertyEditors.OEmbedPickerController as vm" class="umb-property-editor umb-oembedpicker">
 
-  <ng-form name="vm.oembedform">
-    <div class="umb-media-card-grid">
+  <ng-form name="vm.oembedForm">
+    <div class="umb-media-card-grid" ng-class="{'--singleMode': vm.allowMultiple === false}">
       <div style="display:contents;" ui-sortable="vm.sortableOptions" ng-model="vm.items" ng-hide="!model.value">
 
         <div ng-repeat="embed in vm.items track by $index" class="umb-media-card-grid__cell">
@@ -26,26 +26,9 @@
 
       </div>
 
-      <!--<div class="umb-sortable-thumbnails umb-table-row" ng-repeat="embed in vm.items track by $index">
-        <div class="sort-icon" ng-if="vm.allowMultiple === true && vm.items.length > 1">
-          <i class="icon icon-navigation handle" aria-hidden="true"></i>
-        </div>
-        <div class="preview-item">
-          <span ng-bind-html="vm.trustHtml(embed.preview)"></span>
-        </div>
-        <div class="umb-sortable-thumbnails__actions">
-          <button type="button" class="umb-node-preview__action" ng-click="vm.edit($index, $event)">
-            <i class="icon icon-edit" aria-hidden="true"></i>
-          </button>
-          <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove($index, $event)">
-            <i class="icon icon-delete" aria-hidden="true"></i>
-          </button>
-        </div>
-      </div>-->
-
-      <!--ng-if="vm.allowMultiple === false && vm.items.length == 1"-->
       <button 
           type="button"
+          ng-if="(vm.allowMultiple === false && vm.items.length === 0) || vm.allowMultiple === true"
           class="btn-reset umb-media-card-grid__create-button umb-outline"
           ng-click="vm.add($event)">
         <div>
@@ -57,13 +40,6 @@
     </div>
 
     {{model.value | json}}
-    
-
-    <!--<div class="picker-btn" ng-hide="vm.allowMultiple === false && vm.items.length == 1">
-      <button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)">
-        <i class="icon icon-add large" aria-hidden="true"></i>
-      </button>
-    </div>-->
 
     <input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
   </ng-form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently Umbraco core doesn't have a property editor for OEmbed although it is supported in the Grid editor using the OEmbed inifinite editor. For many projects on Umbraco v7, v8 and v9 we have used the excellent package from @dawoe creaing a custom property editor, but using the existing `embed` infinite editor: https://github.com/dawoe/OEmbed-Picker-Property-Editor

I think this would be great to include in core as it introduces minimal code, but it useful in many projects on page/document level or on block/element level.

For example selecting an YouTube or Vimeo video has background hero video. In some projects we have enhanced this with [plyr.io](https://plyr.io/) to extract the YouTube/Vimeo ID and used Plyr to render the hero video player.

I have tried to keep to consistent with Media Picker 3. Based on the various OEmbed providers and the preview of these, it may not look nice in the current media cards, e.g. a Tweet.

![image](https://user-images.githubusercontent.com/2919859/175813156-de1ff0a7-2532-4a22-8b5a-84d5c531f286.png)

https://user-images.githubusercontent.com/2919859/175814461-3c644fb8-fd48-4d14-94b4-35d08dbe58e5.mp4

Something which could be nice to have, is and configuration option to filter by providers (core and custom added). For example only videos from YouTube and Vimeo. However I am not sure if we have any logic in place to get a list of all registered OEmbed providers.

Something I noticed if element wrapping the iframe, e.g. `.umb-media-card` act as sortable handle, it refreshed the iframe. Instead I added an overlay - it still reload the iframe, but first on drop, when the element is moved in DOM tree.