### PR TITLE
Adjust label styles to allow wrapping

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -551,7 +551,7 @@ input.umb-group-builder__group-title-input:disabled:hover {
 
 
 .umb-group-builder__property-meta {
-  flex: 0 0 250px;
+  flex: 0 0 160px;
   margin-right: 20px;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -17,7 +17,6 @@ label small, .guiDialogTiny {
 }
 
 label.control-label, .control-label {
-  padding: 0 10px 0 0 !important;
   font-weight: bold;
   color: @black;
   font-size: 14px;

--- a/src/Umbraco.Web.UI.Client/src/less/forms.less
+++ b/src/Umbraco.Web.UI.Client/src/less/forms.less
@@ -758,7 +758,7 @@ input.search-query {
 
 // Margin to space out fieldsets
 .control-group {
-  margin-bottom: (@baseLineHeight / 2);
+  margin-bottom: (@baseLineHeight / 2) + 5px;
 }
 
 //modifier for control group

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -216,6 +216,8 @@ umb-property:last-of-type .umb-control-group {
 .umb-control-group .control-header {
     
     .control-label {
+        white-space: break-spaces;
+        overflow-wrap: break-word;
         float: left;
     }
 
@@ -239,13 +241,13 @@ umb-property:last-of-type .umb-control-group {
 .form-horizontal .umb-control-group .control-header {
     float: left;
     width: 160px;
-    padding-top: 5px;
     padding-bottom: 0;
     text-align: left;
     margin-bottom: 5px;
 
     .control-label {
-        width: auto;
+        width: 100%;
+        box-sizing: border-box;
         padding-top: 0;
         text-align: left;
     }

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -261,6 +261,11 @@ umb-property:last-of-type .umb-control-group {
     .form-horizontal .umb-control-group .control-header {
         float: none;
         width: 100%;
+
+        .control-label {
+            width: auto;
+        }
+
         &::after {
             content: "";
             display: table;

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -279,6 +279,11 @@ umb-property:last-of-type .umb-control-group {
             clear: both;
         }
     }
+
+    & .control-label {
+        width: auto;
+    }
+
     & > .controls {
         margin-left: 0;
     }

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -12,10 +12,7 @@
                         <localize key="contentTypeEditor_inheritedFrom">Inherited from</localize> {{vm.inheritsFrom}}
                     </small>
 
-                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory">
-                            <strong class="umb-control-required">*</strong>
-                        </span>
-                    </label>
+                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span></label>
 
                     <umb-property-actions ng-if="!vm.showInherit" actions="vm.propertyActions"></umb-property-actions>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -12,14 +12,9 @@
                         <localize key="contentTypeEditor_inheritedFrom">Inherited from</localize> {{vm.inheritsFrom}}
                     </small>
 
-                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">
-
-                        {{vm.property.label}}
-
-                        <span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory">
+                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory">
                             <strong class="umb-control-required">*</strong>
                         </span>
-
                     </label>
 
                     <umb-property-actions ng-if="!vm.showInherit" actions="vm.propertyActions"></umb-property-actions>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Improvements to the label styling to handle long words, and the mandatory asterisk not being on its own line.
Also reduced the width of the document type creation label / descriptions to match that of the content editor so you can more accurately see what your labels will look like

Before
![labels-before](https://user-images.githubusercontent.com/1469061/175136514-38c77ff9-e870-43fa-b66a-c75559a81acf.png)

After 
Note: The additional xx in the property name is due to removing some padding, so extra characters needed to be added to demonstrate the change.
![labels-after](https://user-images.githubusercontent.com/1469061/175136538-3cef8cd3-212b-415a-9698-6d5f914eead0.png)

