### PR TITLE
Allow action links to wrap

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -133,7 +133,7 @@ body.umb-drawer-is-visible #mainwrapper{
   position: absolute;
   top: 0px;
   left: 100%;
-  min-width: 250px;
+  min-width: 260px;
 }
 
 #speechbubble {

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-actions.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-actions.less
@@ -28,7 +28,6 @@
 
 .umb-action-link {
     position: relative;
-    white-space: nowrap;
     font-size: 15px;
     color: @black;
     padding: 9px 25px 9px 20px;
@@ -37,6 +36,7 @@
     display: flex;
     width: 100%;
     align-items: center;
+    text-align: left;
 
     body.touch & {
         padding: 7px 25px 7px 20px;


### PR DESCRIPTION
Preventing wrapping means that buttons can overflow their container.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Preventing text from wrapping means things can overflow their container.
Since action links have hover states / centred icons there is no need to force a single line and hide content from users.

Perhaps it's sensible to increase the minimum width of `#contextMenu` from 250px as well?

Before
![context-menu-before](https://user-images.githubusercontent.com/1469061/175139611-db661581-78cb-41fd-aff0-f95c234fbe05.png)

After
![context-menu-after](https://user-images.githubusercontent.com/1469061/175139645-41fdf73e-af90-44cb-9864-1db1636dc922.png)

