### PR TITLE
Issue 12551 search bug

### DIFF
--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -26,8 +26,8 @@ namespace Umbraco.Cms.Infrastructure
         private readonly IPublishedSnapshot _publishedSnapshot;
         private readonly IVariationContextAccessor _variationContextAccessor;
 
-        private static readonly HashSet<string> s_itemIdFieldNameHashSet =
-            new HashSet<string>() { ExamineFieldNames.ItemIdFieldName };
+        private static readonly HashSet<string> s_returnedQueryFields =
+            new() { ExamineFieldNames.ItemIdFieldName, ExamineFieldNames.CategoryFieldName };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PublishedContentQuery" /> class.
@@ -272,8 +272,8 @@ namespace Umbraco.Cms.Infrastructure
                 ordering = query.ManagedQuery(term, fields);
             }
 
-            // Only select item ID field, because results are loaded from the published snapshot based on this single value
-            var queryExecutor = ordering.SelectFields(s_itemIdFieldNameHashSet);
+            // Filter selected fields because results are loaded from the published snapshot based on these
+            var queryExecutor = ordering.SelectFields(s_returnedQueryFields);
 
 
             var results = skip == 0 && take == 0
@@ -304,8 +304,8 @@ namespace Umbraco.Cms.Infrastructure
 
             if (query is IOrdering ordering)
             {
-                // Only select item ID field, because results are loaded from the published snapshot based on this single value
-                query = ordering.SelectFields(s_itemIdFieldNameHashSet);
+                // Filter selected fields because results are loaded from the published snapshot based on these
+                query = ordering.SelectFields(s_returnedQueryFields);
             }
 
             var results = skip == 0 && take == 0


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes reported bug introduced in PR #11950

Fixes #12551 

To replicate create a document type, and add a property.
In this case I used `Test Document` with a property `Test Property`.
I created a page, and populated the property with the word `yes`.

This code is used in the view for ease:
```
@inject IPublishedContentQuery PublishedContentQuery;
@inject IExamineManager ExamineManager;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.TestDocument>
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@using Umbraco.Cms.Core
@using Examine
@using Umbraco.Cms.Infrastructure.Examine


@{
    if (!ExamineManager.TryGetIndex(Constants.UmbracoIndexes.ExternalIndexName, out var index) || index is not IUmbracoIndex umbIndex)
    {
        throw new Exception("Index not found");
    }

    var query = index.Searcher.CreateQuery(IndexTypes.Content);
    var operation = query.Field("testProperty", "yes");


    var results = PublishedContentQuery.Search(operation, 0, 12, out var totalResults).ToList();
    var results2 = PublishedContentQuery.Search("yes", 0, 12, out var totalResults2).ToList();
}

Results: @results.Count
<br/>
Total Results Value: @totalResults

<br/>
<br/>
Results 2: @results2.Count
<br/>
Total Results 2 Value: @totalResults2
```

Before, as described in the bug report, the first set of results wouldn't have any documents even though the total results would say there were some. This is because the `CategoryFieldName` was missing from the returned index fields, so the content was never retrieved

