### PR TITLE
Support localization for content search (backoffice)

### DIFF
--- a/src/Umbraco.Core/Trees/ISearchableTree.cs
+++ b/src/Umbraco.Core/Trees/ISearchableTree.cs
@@ -25,4 +25,23 @@ namespace Umbraco.Cms.Core.Trees
         /// <returns></returns>
         Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null);
     }
+
+    // TODO: eventually this interface should be merged into ISearchableTree by adding the culture parameter to
+    //       ISearchableTree.SearchAsync. however, this is a breaking change, so we have to wait until that is allowed.
+    [Obsolete("This interface will be merged into ISearchableTree")]
+    public interface ISearchableTreeWithCulture : ISearchableTree
+    {
+        /// <summary>
+        /// Searches for results based on the entity type
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="pageSize"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="searchFrom">
+        ///     A starting point for the search, generally a node id, but for members this is a member type alias
+        /// </param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null, string? culture = null);
+    }
 }

--- a/src/Umbraco.Core/Trees/ISearchableTreeWithCulture.cs
+++ b/src/Umbraco.Core/Trees/ISearchableTreeWithCulture.cs
@@ -1,28 +1,21 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models.ContentEditing;
 
 namespace Umbraco.Cms.Core.Trees
 {
-    public interface ISearchableTree : IDiscoverable
+    [Obsolete("This interface will be merged into ISearchableTree in Umbraco 12")]
+    public interface ISearchableTreeWithCulture : ISearchableTree
     {
-        /// <summary>
-        /// The alias of the tree that the <see cref="ISearchableTree"/> belongs to
-        /// </summary>
-        string TreeAlias { get; }
-
         /// <summary>
         /// Searches for results based on the entity type
         /// </summary>
         /// <param name="query"></param>
         /// <param name="pageSize"></param>
         /// <param name="pageIndex"></param>
-        /// <param name="totalFound"></param>
         /// <param name="searchFrom">
         ///     A starting point for the search, generally a node id, but for members this is a member type alias
         /// </param>
+        /// <param name="culture"></param>
         /// <returns></returns>
-        Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null);
+        Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null, string? culture = null);
     }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -243,8 +243,8 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IEnumerable<SearchResultEntity> results = (
                 searcher is ISearchableTreeWithCulture searcherWithCulture
                     ? await searcherWithCulture.SearchAsync(query, pageSize, 0, culture: culture)
-                    : await searcher.SearchAsync(query, pageSize, 0)
-            ).WhereNotNull();
+                    : await searcher.SearchAsync(query, pageSize, 0))
+            .WhereNotNull();
 
             var searchResult = new TreeSearchResult
             {

--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -204,6 +204,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 return result;
             }
 
+            var culture = ClientCulture();
             var allowedSections = _backofficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.AllowedSections.ToArray();
 
             var searchTasks = new List<Task>();
@@ -221,7 +222,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                     var rootNodeDisplayName = Tree.GetRootNodeDisplayName(tree, _localizedTextService);
                     if (rootNodeDisplayName is not null)
                     {
-                        searchTasks.Add(ExecuteSearchAsync(query, searchableTree, rootNodeDisplayName,result));
+                        searchTasks.Add(ExecuteSearchAsync(query, culture, searchableTree, rootNodeDisplayName,result));
                     }
                 }
             }
@@ -232,13 +233,22 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
         private static async Task ExecuteSearchAsync(
             string query,
+            string? culture,
             KeyValuePair<string, SearchableApplicationTree> searchableTree,
             string rootNodeDisplayName,
             ConcurrentDictionary<string, TreeSearchResult> result)
         {
+            ISearchableTree searcher = searchableTree.Value.SearchableTree;
+            const int pageSize = 200;
+            IEnumerable<SearchResultEntity> results = (
+                searcher is ISearchableTreeWithCulture searcherWithCulture
+                    ? await searcherWithCulture.SearchAsync(query, pageSize, 0, culture: culture)
+                    : await searcher.SearchAsync(query, pageSize, 0)
+            ).WhereNotNull();
+
             var searchResult = new TreeSearchResult
             {
-                Results = (await searchableTree.Value.SearchableTree.SearchAsync(query, 200, 0)).WhereNotNull(),
+                Results = results,
                 TreeAlias = searchableTree.Key,
                 AppAlias = searchableTree.Value.AppAlias,
                 JsFormatterService = searchableTree.Value.FormatterService,

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
     [PluginController(Constants.Web.Mvc.BackOfficeTreeArea)]
     [CoreTree]
     [SearchableTree("searchResultFormatter", "configureContentResult", 10)]
-    public class ContentTreeController : ContentTreeControllerBase, ISearchableTree
+    public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeWithCulture
     {
         private readonly UmbracoTreeSearcher _treeSearcher;
         private readonly ActionCollection _actions;
@@ -369,8 +369,11 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         }
 
         public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null)
+            => await SearchAsync(query, pageSize, pageIndex, searchFrom);
+
+        public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null, string? culture = null)
         {
-            var results = _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out long totalFound, searchFrom);
+            var results = _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out long totalFound, culture: culture, searchFrom: searchFrom);
             return new EntitySearchResults(results, totalFound);
         }
     }

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -369,7 +369,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
         }
 
         public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null)
-            => await SearchAsync(query, pageSize, pageIndex, searchFrom);
+            => await SearchAsync(query, pageSize, pageIndex, searchFrom, null);
 
         public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null, string? culture = null)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The backoffice search doesn't support localization, which is a shame because the underlying search implementation does.

As shown in the screencast below, backoffice searches always yield content results in the default culture, no matter which main culture is selected by the editor. The content results even list with URLs from the default culture:

![localized-search-before](https://user-images.githubusercontent.com/7405322/175492724-4756392b-0014-4956-8b72-14f5d28fb36f.gif)

This PR ensures that localization is present in the search results:

![localized-search-after](https://user-images.githubusercontent.com/7405322/175493043-35e6fc70-750b-46c4-8bdf-890da9053c00.gif)

#### To break, or not to break?

Backoffice tree search is performed by implementations of `ISearchableTree`. This interface has no culture support, so fixing the issue in the right way would mean extending the interface, which would be a breaking change.

To avoid breakage, I have chosen to fix the issue in a somewhat cumbersome way. I have introduced a specialized interface `ISearchableTreeWithCulture`, which does support culture for searching. `ISearchableTreeWithCulture` has been marked as obsolete straight away, as it should be merged into `ISearchableTree` at a later stage, when breaking changes are allowed. Although it goes against almost every developer bone in my body, I have also put `ISearchableTreeWithCulture` in the same file as `ISearchableTree` to make it more visible, in the hope that it will indeed be cleaned up down the road. 




---
_This item has been added to our backlog [AB#20463](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/20463)_