### PR TITLE
Bypass the redirect to login page if the current page is the login page.

### DIFF
--- a/src/Umbraco.Web.Website/Routing/PublicAccessRequestHandler.cs
+++ b/src/Umbraco.Web.Website/Routing/PublicAccessRequestHandler.cs
@@ -84,12 +84,20 @@ namespace Umbraco.Cms.Web.Website.Routing
                     switch (publicAccessStatus)
                     {
                         case PublicAccessStatus.NotLoggedIn:
-                            _logger.LogDebug("EnsurePublishedContentAccess: Not logged in, redirect to login page");
-                            routeValues = await SetPublishedContentAsOtherPageAsync(httpContext, routeValues.PublishedRequest, publicAccessAttempt.Result.LoginNodeId);
+                            // redirect if this is not the login page
+                            if (publicAccessAttempt.Result.LoginNodeId != publishedContent.Id)
+                            {
+                                _logger.LogDebug("EnsurePublishedContentAccess: Not logged in, redirect to login page");
+                                routeValues = await SetPublishedContentAsOtherPageAsync(httpContext, routeValues.PublishedRequest, publicAccessAttempt.Result.LoginNodeId);
+                            }
                             break;
                         case PublicAccessStatus.AccessDenied:
-                            _logger.LogDebug("EnsurePublishedContentAccess: Current member has not access, redirect to error page");
-                            routeValues = await SetPublishedContentAsOtherPageAsync(httpContext, routeValues.PublishedRequest, publicAccessAttempt.Result.NoAccessNodeId);
+                            // Redirect if this is not the access denied page
+                            if (publicAccessAttempt.Result.NoAccessNodeId != publishedContent.Id)
+                            {
+                                _logger.LogDebug("EnsurePublishedContentAccess: Current member has not access, redirect to error page");
+                                routeValues = await SetPublishedContentAsOtherPageAsync(httpContext, routeValues.PublishedRequest, publicAccessAttempt.Result.NoAccessNodeId);
+                            }
                             break;
                         case PublicAccessStatus.LockedOut:
                             _logger.LogDebug("Current member is locked out, redirect to error page");


### PR DESCRIPTION
Bypass the redirect to login page if the current page is the login page. 
Same for access denied page.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/12007
