### PR TITLE
Remove Obsolete AddOEmbedProvider extension method

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -84,10 +84,6 @@ namespace Umbraco.Cms.Core.DependencyInjection
             return builder;
         }
 
-        [Obsolete("Use AddEmbedProvider instead. This will be removed in Umbraco 10")]
-        public static IUmbracoBuilder AddOEmbedProvider<T>(this IUmbracoBuilder builder)
-            where T : class, IEmbedProvider => AddEmbedProvider<T>(builder);
-
         /// <summary>
         /// Register a section.
         /// </summary>

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -1,4 +1,3 @@
-using System;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.Media;

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -1,3 +1,4 @@
+using System;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.Media;
@@ -83,6 +84,10 @@ namespace Umbraco.Cms.Core.DependencyInjection
             builder.EmbedProviders()?.Append<T>();
             return builder;
         }
+
+        [Obsolete("Use AddEmbedProvider instead. This will be removed in Umbraco 11")]
+        public static IUmbracoBuilder AddOEmbedProvider<T>(this IUmbracoBuilder builder)
+            where T : class, IEmbedProvider => AddEmbedProvider<T>(builder);
 
         /// <summary>
         /// Register a section.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Remove `AddOEmbedProvider` extension method because it should have been removed in v10. Not sure if this should go to v10 or  v11 branch now? 😄 
