### PR TITLE
Add Current Server Role to system information

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core
+namespace Umbraco.Cms.Core
 {
     public static partial class Constants
     {
@@ -27,6 +27,7 @@
             public static string AspEnvironment = "AspEnvironment";
             public static string IsDebug = "IsDebug";
             public static string DatabaseProvider = "DatabaseProvider";
+            public static string CurrentServerRole = "CurrentServerRole";
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -10,6 +7,7 @@ using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
 using Umbraco.Extensions;
@@ -25,6 +23,8 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
     private readonly ModelsBuilderSettings _modelsBuilderSettings;
     private readonly IUmbracoDatabaseFactory _umbracoDatabaseFactory;
     private readonly IUmbracoVersion _version;
+    private readonly IServerRoleAccessor _serverRoleAccessor;
+
 
     public SystemInformationTelemetryProvider(
         IUmbracoVersion version,
@@ -33,12 +33,14 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
         IOptionsMonitor<HostingSettings> hostingSettings,
         IOptionsMonitor<GlobalSettings> globalSettings,
         IHostEnvironment hostEnvironment,
-        IUmbracoDatabaseFactory umbracoDatabaseFactory)
+        IUmbracoDatabaseFactory umbracoDatabaseFactory,
+        IServerRoleAccessor serverRoleAccessor)
     {
         _version = version;
         _localizationService = localizationService;
         _hostEnvironment = hostEnvironment;
         _umbracoDatabaseFactory = umbracoDatabaseFactory;
+        _serverRoleAccessor = serverRoleAccessor;
 
         _globalSettings = globalSettings.CurrentValue;
         _hostingSettings = hostingSettings.CurrentValue;
@@ -63,6 +65,8 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
 
     private string DatabaseProvider => _umbracoDatabaseFactory.CreateDatabase().DatabaseType.GetProviderName();
 
+    private string CurrentServerRole => _serverRoleAccessor.CurrentServerRole.ToString();
+
     public IEnumerable<UsageInformation> GetInformation() =>
         new UsageInformation[]
         {
@@ -72,7 +76,8 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new(Constants.Telemetry.ModelsBuilderMode, ModelsBuilderMode),
             new(Constants.Telemetry.CustomUmbracoPath, UmbracoPathCustomized),
             new(Constants.Telemetry.AspEnvironment, AspEnvironment), new(Constants.Telemetry.IsDebug, IsDebug),
-            new(Constants.Telemetry.DatabaseProvider, DatabaseProvider)
+            new(Constants.Telemetry.DatabaseProvider, DatabaseProvider),
+            new(Constants.Telemetry.CurrentServerRole, CurrentServerRole)
         };
 
     public IEnumerable<UserData> GetUserData() =>
@@ -84,7 +89,8 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new("Current Culture", CurrentCulture),
             new("Current UI Culture", Thread.CurrentThread.CurrentUICulture.ToString()),
             new("Current Webserver", CurrentWebServer), new("Models Builder Mode", ModelsBuilderMode),
-            new("Debug Mode", IsDebug.ToString()), new("Database Provider", DatabaseProvider)
+            new("Debug Mode", IsDebug.ToString()), new("Database Provider", DatabaseProvider),
+            new("Current Server Role", CurrentServerRole)
         };
 
     private bool IsRunningInProcessIIS()

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
@@ -77,7 +77,7 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new(Constants.Telemetry.CustomUmbracoPath, UmbracoPathCustomized),
             new(Constants.Telemetry.AspEnvironment, AspEnvironment), new(Constants.Telemetry.IsDebug, IsDebug),
             new(Constants.Telemetry.DatabaseProvider, DatabaseProvider),
-            new(Constants.Telemetry.CurrentServerRole, CurrentServerRole)
+            new(Constants.Telemetry.CurrentServerRole, CurrentServerRole),
         };
 
     public IEnumerable<UserData> GetUserData() =>
@@ -90,7 +90,7 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new("Current UI Culture", Thread.CurrentThread.CurrentUICulture.ToString()),
             new("Current Webserver", CurrentWebServer), new("Models Builder Mode", ModelsBuilderMode),
             new("Debug Mode", IsDebug.ToString()), new("Database Provider", DatabaseProvider),
-            new("Current Server Role", CurrentServerRole)
+            new("Current Server Role", CurrentServerRole),
         };
 
     private bool IsRunningInProcessIIS()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -53,6 +53,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Telemetry
                 Constants.Telemetry.AspEnvironment,
                 Constants.Telemetry.IsDebug,
                 Constants.Telemetry.DatabaseProvider,
+                Constants.Telemetry.CurrentServerRole
             };
 
             MetricsConsentService.SetConsentLevel(TelemetryLevel.Detailed);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserDataServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserDataServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Semver;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Telemetry.Providers;
 
@@ -135,7 +136,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services
                 Mock.Of<IOptionsMonitor<HostingSettings>>(x => x.CurrentValue == new HostingSettings { Debug = isDebug }),
                 Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == new GlobalSettings()),
                 Mock.Of<IHostEnvironment>(),
-                Mock.Of<IUmbracoDatabaseFactory>(x=>x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y=>y.DatabaseType == DatabaseType.SQLite)));
+                Mock.Of<IUmbracoDatabaseFactory>(x=>x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y=>y.DatabaseType == DatabaseType.SQLite)),
+                Mock.Of<IServerRoleAccessor>());
         }
 
         private ILocalizationService CreateILocalizationService(string culture)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Telemetry.Providers;
 
@@ -116,7 +117,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Telemetry
                 Mock.Of<IOptionsMonitor<HostingSettings>>(x => x.CurrentValue == new HostingSettings { Debug = isDebug }),
                 Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == new GlobalSettings{ UmbracoPath = umbracoPath }),
                 hostEnvironment.Object,
-                Mock.Of<IUmbracoDatabaseFactory>(x=>x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y=>y.DatabaseType == DatabaseType.SQLite)));
+                Mock.Of<IUmbracoDatabaseFactory>(x=>x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y=>y.DatabaseType == DatabaseType.SQLite)),
+                Mock.Of<IServerRoleAccessor>());
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Added the Current Server Role to the System Information table. Not sure if this is a desired addition but in some cases it's useful to know what the current role is. 

![image](https://user-images.githubusercontent.com/7831614/176174645-817d06ff-6c94-4956-a27b-60c4a44f0121.png)

