### PR TITLE
set isInfoTab to true if active tab is info tab

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js
@@ -1,4 +1,4 @@
-﻿(function () {
+(function () {
     'use strict';
 
     function ContentNodeInfoDirective($timeout, logResource, eventsService, userService, localizationService, dateHelper, editorService, redirectUrlsResource, overlayService, entityResource) {
@@ -105,6 +105,7 @@
                 if (activeApp.alias === "umbInfo") {
                     loadRedirectUrls();
                     loadAuditTrail();
+                    isInfoTab = true;
                 }
 
                 // never show templates for element types (if they happen to have been created in the content tree)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
#12596 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I Updated the umbraco content info directive in javascript to set the `isInfoTab` flag to true onInit if the currently active app is the info tab.

Steps to test:
1. Log in to backoffice
2. Create new document (use a document type without any properties!)
3. Save & Publish
4. Notice that the date property is properly updated now, whereas it wouldn't be without the change.

<!-- Thanks for contributing to Umbraco CMS! -->
