### PR TITLE
Added configuration to allow RTL cultures to opt-in to reverse the url hierarchy

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -33,6 +33,7 @@ public class GlobalSettings
     internal const string StaticDistributedLockingWriteLockDefaultTimeout = "00:00:05";
     internal const bool StaticSanitizeTinyMce = false;
     internal const int StaticMainDomReleaseSignalPollingInterval = 2000;
+    private const bool StaticForceCombineUrlPathLeftToRight = true;
 
     /// <summary>
     ///     Gets or sets a value for the reserved URLs (must end with a comma).
@@ -226,7 +227,25 @@ public class GlobalSettings
         TimeSpan.Parse(StaticDistributedLockingWriteLockDefaultTimeout);
 
     /// <summary>
-    ///     Gets or sets a value representing the DistributedLockingMechanism to use.
+    /// Gets or sets a value representing the DistributedLockingMechanism to use.
     /// </summary>
     public string DistributedLockingMechanism { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Force url paths to be left to right, even when the culture has right to left text
+    /// </summary>
+    /// <example>
+    /// For the following hierarchy
+    /// - Root (/ar)
+    ///   - 1 (/ar/1)
+    ///     - 2 (/ar/1/2)
+    ///       - 3 (/ar/1/2/3)
+    ///         - 3 (/ar/1/2/3/4)
+    /// When forced
+    /// - https://www.umbraco.com/ar/1/2/3/4
+    /// when not
+    /// - https://www.umbraco.com/ar/4/3/2/1
+    /// </example>
+    [DefaultValue(StaticForceCombineUrlPathLeftToRight)]
+    public bool ForceCombineUrlPathLeftToRight { get; set; }  = StaticForceCombineUrlPathLeftToRight;
 }

--- a/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
@@ -87,7 +87,11 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
 
         IPublishedContent? content;
 
-        if (startNodeId > 0)
+        if ((!_globalSettings.ForceCombineUrlPathLeftToRight
+             && CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
+            {
+                parts.Reverse();
+            }if (startNodeId > 0)
         {
             // if in a domain then start with the root node of the domain
             // and follow the path
@@ -190,8 +194,11 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
             ApplyHideTopLevelNodeFromPath(node, pathParts, preview);
         }
 
-        // assemble the route
-        pathParts.Reverse();
+        // assemble the route- We only have to reverse for left to right languages
+            if ((_globalSettings.ForceCombineUrlPathLeftToRight
+                 || !CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
+            {
+        pathParts.Reverse();}
         var path = "/" + string.Join("/", pathParts); // will be "/" or "/foo" or "/foo/bar" etc
 
         // prefix the root node id containing the domain if it exists (this is a standard way of creating route paths)

--- a/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
@@ -90,7 +90,7 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
         if ((!_globalSettings.ForceCombineUrlPathLeftToRight
              && CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
             {
-                parts.Reverse();
+                parts = parts.Reverse().ToArray();
             }if (startNodeId > 0)
         {
             // if in a domain then start with the root node of the domain
@@ -198,7 +198,8 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
             if ((_globalSettings.ForceCombineUrlPathLeftToRight
                  || !CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
             {
-        pathParts.Reverse();}
+                pathParts.Reverse();
+            }
         var path = "/" + string.Join("/", pathParts); // will be "/" or "/foo" or "/foo/bar" etc
 
         // prefix the root node id containing the domain if it exists (this is a standard way of creating route paths)

--- a/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
@@ -89,9 +89,11 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
 
         if ((!_globalSettings.ForceCombineUrlPathLeftToRight
              && CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
-            {
-                parts = parts.Reverse().ToArray();
-            }if (startNodeId > 0)
+        {
+            parts = parts.Reverse().ToArray();
+        }
+
+        if (startNodeId > 0)
         {
             // if in a domain then start with the root node of the domain
             // and follow the path
@@ -195,11 +197,12 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
         }
 
         // assemble the route- We only have to reverse for left to right languages
-            if ((_globalSettings.ForceCombineUrlPathLeftToRight
-                 || !CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
-            {
-                pathParts.Reverse();
-            }
+        if ((_globalSettings.ForceCombineUrlPathLeftToRight
+             || !CultureInfo.GetCultureInfo(culture ?? _globalSettings.DefaultUILanguage).TextInfo.IsRightToLeft))
+        {
+            pathParts.Reverse();
+        }
+
         var path = "/" + string.Join("/", pathParts); // will be "/" or "/foo" or "/foo/bar" etc
 
         // prefix the root node id containing the domain if it exists (this is a standard way of creating route paths)


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/12621

Added configuration to avoid a behavioral breaking changes

# Test
- Set the new `Umbraco:CMS:Global:ForceCombineUrlPathLeftToRight` setting to `false`
- Create urls and add a RTL culture..
- Ensure the URL is RTL for the RTL cultures and still LTR for LTR cultures.