### PR TITLE
Umbraco avatar component image fit fixed

### DIFF
--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeAntiforgery.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeAntiforgery.cs
@@ -37,6 +37,7 @@ namespace Umbraco.Cms.Web.BackOffice.Security
             {
                 x.HeaderName = Constants.Web.AngularHeadername;
                 x.Cookie.Name = Constants.Web.CsrfValidationCookieName;
+                x.Cookie.SecurePolicy = globalSettings.Value.UseHttps ? CookieSecurePolicy.Always : CookieSecurePolicy.SameAsRequest;
             });
             ServiceProvider container = services.BuildServiceProvider();
             _internalAntiForgery = container.GetRequiredService<IAntiforgery>();

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-avatar.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-avatar.less
@@ -11,6 +11,8 @@
     font-weight: bold;
     font-size: 16px;
     box-sizing: border-box;
+    object-fit: cover;
+    object-position: center;
 }
 
 /* Sizes */


### PR DESCRIPTION
### Description
This PR changes the object-fit & object-position properties for umb-avatar component in backoffice to fix the avatar fit issue.

### Before
![image](https://user-images.githubusercontent.com/5023476/176396472-65c196fe-e471-4053-9e58-d4763b6a3855.png)

### After
![image](https://user-images.githubusercontent.com/5023476/176396573-8d2ff111-d1f1-466d-9470-9f65c091b528.png)


<!-- Thanks for contributing to Umbraco CMS! -->
