### PR TITLE
Make DB Provider names case insensitive where possible

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -39,7 +39,7 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
     /// <inheritdoc />
     public bool Enabled => _connectionStrings.CurrentValue.IsConnectionStringConfigured() &&
-                           _connectionStrings.CurrentValue.ProviderName == Constants.ProviderName;
+                           string.Equals(_connectionStrings.CurrentValue.ProviderName,Constants.ProviderName, StringComparison.InvariantCultureIgnoreCase);
 
     /// <inheritdoc />
     public IDistributedLock ReadLock(int lockId, TimeSpan? obtainLockTimeout = null)

--- a/src/Umbraco.Cms.Persistence.Sqlite/Constants.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Constants.cs
@@ -8,5 +8,8 @@ public static class Constants
     /// <summary>
     /// SQLite provider name.
     /// </summary>
-    public const string ProviderName = "Microsoft.Data.SQLite";
+    public const string ProviderName = "Microsoft.Data.Sqlite";
+
+    [Obsolete("This will be removed in Umbraco 12. Use Constants.ProviderName instead")]
+    public const string ProviderNameLegacy = "Microsoft.Data.SQLite";
 }

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDistributedLockingMechanism.cs
@@ -36,7 +36,7 @@ public class SqliteDistributedLockingMechanism : IDistributedLockingMechanism
 
     /// <inheritdoc />
     public bool Enabled => _connectionStrings.CurrentValue.IsConnectionStringConfigured() &&
-                           _connectionStrings.CurrentValue.ProviderName == Constants.ProviderName;
+                           string.Equals(_connectionStrings.CurrentValue.ProviderName, Constants.ProviderName, StringComparison.InvariantCultureIgnoreCase);
 
     // With journal_mode=wal we can always read a snapshot.
     public IDistributedLock ReadLock(int lockId, TimeSpan? obtainLockTimeout = null)

--- a/src/Umbraco.Cms.Persistence.Sqlite/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/UmbracoBuilderExtensions.cs
@@ -39,11 +39,14 @@ public static class UmbracoBuilderExtensions
         DbProviderFactories.UnregisterFactory(Constants.ProviderName);
         DbProviderFactories.RegisterFactory(Constants.ProviderName, Microsoft.Data.Sqlite.SqliteFactory.Instance);
 
+        DbProviderFactories.UnregisterFactory(Constants.ProviderNameLegacy);
+        DbProviderFactories.RegisterFactory(Constants.ProviderNameLegacy, Microsoft.Data.Sqlite.SqliteFactory.Instance);
+
         // Prevent accidental creation of SQLite database files
         builder.Services.PostConfigureAll<ConnectionStrings>(options =>
         {
             // Skip empty connection string and other providers
-            if (!options.IsConnectionStringConfigured() || options.ProviderName != Constants.ProviderName)
+            if (!options.IsConnectionStringConfigured() || (options.ProviderName != Constants.ProviderName && options.ProviderName != Constants.ProviderNameLegacy))
             {
                 return;
             }

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
@@ -27,7 +27,7 @@ public static class DatabaseProviderMetadataExtensions
     ///   <c>true</c> if a database can be created for the specified provider name; otherwise, <c>false</c>.
     /// </returns>
     public static bool CanForceCreateDatabase(this IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata, string? providerName)
-        => databaseProviderMetadata.FirstOrDefault(x => x.ProviderName == providerName)?.ForceCreateDatabase == true;
+        => databaseProviderMetadata.FirstOrDefault(x => string.Equals(x.ProviderName, providerName, StringComparison.InvariantCultureIgnoreCase))?.ForceCreateDatabase == true;
 
     /// <summary>
     /// Generates the connection string.

--- a/src/Umbraco.Infrastructure/Persistence/DbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DbProviderFactoryCreator.cs
@@ -44,10 +44,10 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         {
             _getFactory = getFactory;
             _providerSpecificInterceptors = providerSpecificInterceptors;
-            _databaseCreators = databaseCreators.ToDictionary(x => x.ProviderName);
-            _syntaxProviders = syntaxProviders.ToDictionary(x => x.ProviderName);
-            _bulkSqlInsertProviders = bulkSqlInsertProviders.ToDictionary(x => x.ProviderName);
-            _providerSpecificMapperFactories = providerSpecificMapperFactories.ToDictionary(x => x.ProviderName);
+            _databaseCreators = databaseCreators.ToDictionary(x => x.ProviderName, StringComparer.InvariantCultureIgnoreCase);
+            _syntaxProviders = syntaxProviders.ToDictionary(x => x.ProviderName, StringComparer.InvariantCultureIgnoreCase);
+            _bulkSqlInsertProviders = bulkSqlInsertProviders.ToDictionary(x => x.ProviderName, StringComparer.InvariantCultureIgnoreCase);
+            _providerSpecificMapperFactories = providerSpecificMapperFactories.ToDictionary(x => x.ProviderName, StringComparer.InvariantCultureIgnoreCase);
         }
 
         public DbProviderFactory? CreateFactory(string? providerName)
@@ -98,6 +98,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence
         }
 
         public IEnumerable<IProviderSpecificInterceptor> GetProviderSpecificInterceptors(string providerName)
-            => _providerSpecificInterceptors.Where(x => x.ProviderName == providerName);
+            => _providerSpecificInterceptors.Where(x => x.ProviderName.Equals(providerName, StringComparison.InvariantCultureIgnoreCase));
     }
 }


### PR DESCRIPTION
Changed const to return "Microsoft.Data.Sqlite" instead of "Microsoft.Data.SQLite" and made our checks case insensitive where possible. Sadly DbProviderFactories is still case sensitive so for that we support both strings.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/12604