### PR TITLE
Ensuring that MemberManager.ConfirmEmailAsync persists.

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -790,6 +790,11 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 changedCols.Add("passwordConfig");
             }
 
+            if (entity.IsPropertyDirty("EmailConfirmedDate"))
+            {
+                changedCols.Add("emailConfirmedDate");
+            }
+
             // If userlogin or the email has changed then need to reset security stamp
             if (changedCols.Contains("Email") || changedCols.Contains("LoginName"))
             {


### PR DESCRIPTION
### Prerequisites

https://github.com/umbraco/Umbraco-CMS/issues/12227

### Description

These changes ensures that a member's `EmailConfirmed` property changes persists when using `ConfirmEmailAsync()` located in the `IMemberManager` interface. Before these changes, the property would be set to true temporarily in memory, but then never actually saved to the database, continuing to read false for all following requests/calls. This was happening because the `emailConfirmedDate` is only added to the list of changed columns if the member's login name or email had also been changed, resulting in `emailConfirmedDate` always being null and `EmailConfirmed` not being set.

To test, do the following:
- Create a new member in Umbraco
- Use `IMemberManager` to generate a string token
- Without these changes, use `IMemberManager` to confirm the email with the string token using `ConfirmEmailAsync()` while debugging to see that the `IdentityResult` succeeded and that `EmailConfirmed` has been set to true for that member
- Reload either the site or page executing the code to see that `EmailConfirmed` is still set to false instead of true
- Repeat the previous two steps with the pull request's changes to see that `EmailConfirmed` is now being set to true in the database


---
_This item has been added to our backlog [AB#20458](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/20458)_