### PR TITLE
Bump ImageSharp to latest version

### DIFF
--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -48,7 +48,7 @@
       <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
       <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
       <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" /> <!-- Explicit updated this nested dependency due to this https://github.com/dotnet/announcements/issues/178-->
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.2" />
     <PackageReference Include="Smidge.InMemory" Version="4.0.4" />
     <PackageReference Include="Smidge.Nuglify" Version="4.0.4" />
     <PackageReference Include="Umbraco.Code" Version="2.0.0" PrivateAssets="all" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes issues with image names containing special characters (diacritics, umlauts, ...) in conjunction with ImageSharp operations such as resizing and cropping. Should fix https://github.com/umbraco/Umbraco-CMS/issues/12598 and perhaps https://github.com/umbraco/Umbraco-CMS/issues/12559 and I guess this one can be closed as well https://github.com/umbraco/Umbraco-CMS/issues/12300.

### Description
After upgrading to ImageSharp 2.0.0 image filenames containing non-ascii characters (myöimage.jpg, somé-othèr.jpg) fail to resolve on the file system causing image crops to fail silently in Umbraco. [This PR over at ImageSharp](https://github.com/SixLabors/ImageSharp.Web/pull/279) should fix that.

Test by uploading an image with a filename containing characters such as è or á or å, ä, ö (eg somé-imagè.jpg) and then try to display a crop of it, or browse to the image directly adding ?width=100 to the url.
