### PR TITLE
Changed to make svg media urls link to the media file directly

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -69,15 +69,16 @@
                 editorService.mediaTypeEditor(editor);
             };
 
-            scope.openSVG = () => {
-                var popup = window.open('', '_blank');
-                var html = '<!DOCTYPE html><body><img src="' + scope.nodeUrl + '"/>' +
-                    '<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
+            //Why? What's this for? What does it achieve?
+            //scope.openSVG = () => {
+            //    var popup = window.open('', '_blank');
+            //    var html = '<!DOCTYPE html><body><img src="' + scope.nodeUrl + '"/>' +
+            //        '<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
                 
-                popup.document.open();
-                popup.document.write(html);
-                popup.document.close();
-            }
+            //    popup.document.open();
+            //    popup.document.write(html);
+            //    popup.document.close();
+            //}
 
             // watch for content updates - reload content when node is saved, published etc.
             scope.$watch('node.updateDate', function(newValue, oldValue){

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -17,7 +17,7 @@
 
                 <ul ng-if="nodeUrl" class="nav nav-stacked mb0">
                     <li>
-                        <a href="" ng-attr-href="{{node.extension !== 'svg' ? nodeUrl : undefined}}" ng-click="node.extension === 'svg' && openSVG()" target="_blank" rel="noopener" class="umb-outline">
+                        <a href="" ng-attr-href="{{nodeUrl}}" target="_blank" rel="noopener" class="umb-outline">
                             <umb-icon icon="icon-out" class="icon"></umb-icon>
                             <span>{{nodeFileName}}</span>
                         </a>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12654

### Description
This fixes the URL for SVG media items on the Info Tab in the backoffice so that it links directly to the media file.

It now works in the same way as if you click on the image on the Content tab.

I have commented out the code rather than remove it, as I'm not sure why it was added or what it was trying to achieve.
