### PR TITLE
Remove context from IScopeProvider.cs

### DIFF
--- a/src/Umbraco.Infrastructure/Scoping/IScopeProvider.cs
+++ b/src/Umbraco.Infrastructure/Scoping/IScopeProvider.cs
@@ -11,11 +11,6 @@ namespace Umbraco.Cms.Infrastructure.Scoping;
 /// </summary>
 public interface IScopeProvider : ICoreScopeProvider
 {
-    /// <summary>
-    ///     Gets the scope context.
-    /// </summary>
-    IScopeContext? Context { get; }
-
     /// <inheritdoc />
     ICoreScope ICoreScopeProvider.CreateCoreScope(
         IsolationLevel isolationLevel,


### PR DESCRIPTION
# Notes
- Fixes breaking change in IScopeProvider by removing Context property