### PR TITLE
V10: Use FireAndForget when logging install

### DIFF
--- a/src/Umbraco.Core/FireAndForgetRunner.cs
+++ b/src/Umbraco.Core/FireAndForgetRunner.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Umbraco.Cms.Core;
+
+
+public class FireAndForgetRunner : IFireAndForgetRunner
+{
+    private readonly ILogger<FireAndForgetRunner> _logger;
+
+    public FireAndForgetRunner(ILogger<FireAndForgetRunner> logger) => _logger = logger;
+
+    public void RunFireAndForget(Func<Task> task) => ExecuteBackgroundTask(task);
+
+    private Task ExecuteBackgroundTask(Func<Task> fn)
+    {
+        // it is also possible to use UnsafeQueueUserWorkItem which does not flow the execution context,
+        // however that seems more difficult to use for async operations.
+
+        // Do not flow AsyncLocal to the child thread
+        using (ExecutionContext.SuppressFlow())
+        {
+            // NOTE: ConfigureAwait(false) is irrelevant here, it is not needed because this is not being
+            // awaited. ConfigureAwait(false) is only relevant when awaiting to prevent the SynchronizationContext
+            // (very different from the ExecutionContext!) from running the continuation on the calling thread.
+            return Task.Run(LoggingWrapper(fn));
+        }
+    }
+
+    private Func<Task> LoggingWrapper(Func<Task> fn) =>
+        async () =>
+        {
+            try
+            {
+                await fn();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Exception thrown in a background thread");
+            }
+        };
+}

--- a/src/Umbraco.Core/IFireAndForgetRunner.cs
+++ b/src/Umbraco.Core/IFireAndForgetRunner.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Core;
+
+public interface IFireAndForgetRunner
+{
+    void RunFireAndForget(Func<Task> task);
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -219,6 +219,8 @@ public static partial class UmbracoBuilderExtensions
 
         // Services required to run background jobs (with out the handler)
         builder.Services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
+
+        builder.Services.AddTransient<IFireAndForgetRunner, FireAndForgetRunner>();
         return builder;
     }
 

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 using Constants = Umbraco.Cms.Core.Constants;
 
@@ -47,6 +49,40 @@ namespace Umbraco.Cms.Infrastructure.Install
             _userAgentProvider = userAgentProvider;
             _umbracoDatabaseFactory = umbracoDatabaseFactory;
             _fireAndForgetRunner = fireAndForgetRunner;
+
+            // We need to initialize the type already, as we can't detect later, if the connection string is added on the fly.
+            GetInstallationType();
+        }
+
+        [Obsolete("Please use constructor that takes an IFireAndForgetRunner instead, scheduled for removal in Umbraco 12")]
+        public InstallHelper(
+            DatabaseBuilder databaseBuilder,
+            ILogger<InstallHelper> logger,
+            IUmbracoVersion umbracoVersion,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
+            IInstallationService installationService,
+            ICookieManager cookieManager,
+            IUserAgentProvider userAgentProvider,
+            IUmbracoDatabaseFactory umbracoDatabaseFactory)
+        : this(
+            databaseBuilder,
+            logger,
+            umbracoVersion,
+            connectionStrings,
+            installationService,
+            cookieManager,
+            userAgentProvider,
+            umbracoDatabaseFactory,
+            StaticServiceProvider.Instance.GetRequiredService<IFireAndForgetRunner>())
+        {
+            _logger = logger;
+            _umbracoVersion = umbracoVersion;
+            _databaseBuilder = databaseBuilder;
+            _connectionStrings = connectionStrings;
+            _installationService = installationService;
+            _cookieManager = cookieManager;
+            _userAgentProvider = userAgentProvider;
+            _umbracoDatabaseFactory = umbracoDatabaseFactory;
 
             // We need to initialize the type already, as we can't detect later, if the connection string is added on the fly.
             GetInstallationType();

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -24,6 +24,7 @@ namespace Umbraco.Cms.Infrastructure.Install
         private readonly ICookieManager _cookieManager;
         private readonly IUserAgentProvider _userAgentProvider;
         private readonly IUmbracoDatabaseFactory _umbracoDatabaseFactory;
+        private readonly IFireAndForgetRunner _fireAndForgetRunner;
         private InstallationType? _installationType;
 
         public InstallHelper(
@@ -34,7 +35,8 @@ namespace Umbraco.Cms.Infrastructure.Install
             IInstallationService installationService,
             ICookieManager cookieManager,
             IUserAgentProvider userAgentProvider,
-            IUmbracoDatabaseFactory umbracoDatabaseFactory)
+            IUmbracoDatabaseFactory umbracoDatabaseFactory,
+            IFireAndForgetRunner fireAndForgetRunner)
         {
             _logger = logger;
             _umbracoVersion = umbracoVersion;
@@ -44,6 +46,7 @@ namespace Umbraco.Cms.Infrastructure.Install
             _cookieManager = cookieManager;
             _userAgentProvider = userAgentProvider;
             _umbracoDatabaseFactory = umbracoDatabaseFactory;
+            _fireAndForgetRunner = fireAndForgetRunner;
 
             // We need to initialize the type already, as we can't detect later, if the connection string is added on the fly.
             GetInstallationType();
@@ -87,7 +90,7 @@ namespace Umbraco.Cms.Infrastructure.Install
                     userAgent: userAgent,
                     dbProvider: dbProvider);
 
-                await _installationService.LogInstall(installLog);
+                _fireAndForgetRunner.RunFireAndForget(() => _installationService.LogInstall(installLog));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes #12583

When intializing and completing the installer a request is sent off, in some circumstances this can take up to 100 seconds, however, this request is not required to finish for the installer to continue, so I've put it in a fire and forget task. 


## Testing 
Installer and Upgrader should still run.

Testing that it no longer hangs is a bit more tricky, however you can test it by changing the URL in `InstallationRepository`, to a local server that responds slowly, there is a python one here: 


```python
import json
import time

from flask import Flask, app
from flask.globals import request

app = Flask("JsonDumpServer")


@app.route("/installs/", methods=['POST'])
def dump_json():
    print("Received request\n\n")
    print(f"{json.dumps(request.get_json(), indent=2)}\n\n")
    print("Waiting 10 seconds...")
    time.sleep(10)
    return "Request received"


app.config['ENV'] = 'development'
# app.config['DEBUG'] = True
app.config['TESTING'] = True
app.run()

```