### PR TITLE
Fix up system information test

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/HelpPanel/systemInformation.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/cypress/integration/HelpPanel/systemInformation.ts
@@ -20,7 +20,22 @@ context('System Information', () => {
 
     it('Check System Info Displays', () => {
         openSystemInformation();
-        cy.get('.table').find('tr').should('have.length', 13);
+        
+        // Assert
+        cy.get('.table').find('tr').should('contain', 'Server OS');
+        cy.get('.table').find('tr').should('contain', 'Server Framework');
+        cy.get('.table').find('tr').should('contain', 'Default Language');
+        cy.get('.table').find('tr').should('contain', 'Umbraco Version');
+        cy.get('.table').find('tr').should('contain', 'Current Culture');
+        cy.get('.table').find('tr').should('contain', 'Current UI Culture');
+        cy.get('.table').find('tr').should('contain', 'Current Webserver');
+        cy.get('.table').find('tr').should('contain', 'Models Builder Mode');
+        cy.get('.table').find('tr').should('contain', 'Debug Mode');
+        cy.get('.table').find('tr').should('contain', 'Database Provider');
+        cy.get('.table').find('tr').should('contain', 'Current Server Role');
+        cy.get('.table').find('tr').should('contain', 'Browser');
+        cy.get('.table').find('tr').should('contain', 'Browser OS');
+        cy.contains('Default Language').parent().should('contain', 'en-US');
         cy.contains('Current Culture').parent().should('contain', 'en-US');
         cy.contains('Current UI Culture').parent().should('contain', 'en-US');
     });


### PR DESCRIPTION
# Notes
- System information test broke with https://github.com/umbraco/Umbraco-CMS/pull/12630
- This is because we were asserting that there where 13 rows in the system information table, which means whenever we add something to the table, this test breaks.
- I have fixed it up so now we assert that all the known rows are there, this means instead that if we add a new row to the table, it will no longer break 🎉 
- Do note that this test will still break if we remove a row from the table, but I think that should be expected, same as removing something else in the ui, you expect your test to break 👍 