### PR TITLE
V10: Fix AutoMoq for unit tests

### DIFF
--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -64,28 +64,18 @@ namespace Umbraco.Cms.Infrastructure.Install
             ICookieManager cookieManager,
             IUserAgentProvider userAgentProvider,
             IUmbracoDatabaseFactory umbracoDatabaseFactory)
-        : this(
-            databaseBuilder,
-            logger,
-            umbracoVersion,
-            connectionStrings,
-            installationService,
-            cookieManager,
-            userAgentProvider,
-            umbracoDatabaseFactory,
-            StaticServiceProvider.Instance.GetRequiredService<IFireAndForgetRunner>())
+            : this(
+                databaseBuilder,
+                logger,
+                umbracoVersion,
+                connectionStrings,
+                installationService,
+                cookieManager,
+                userAgentProvider,
+                umbracoDatabaseFactory,
+                StaticServiceProvider.Instance.GetRequiredService<IFireAndForgetRunner>())
         {
-            _logger = logger;
-            _umbracoVersion = umbracoVersion;
-            _databaseBuilder = databaseBuilder;
-            _connectionStrings = connectionStrings;
-            _installationService = installationService;
-            _cookieManager = cookieManager;
-            _userAgentProvider = userAgentProvider;
-            _umbracoDatabaseFactory = umbracoDatabaseFactory;
 
-            // We need to initialize the type already, as we can't detect later, if the connection string is added on the fly.
-            GetInstallationType();
         }
 
         public InstallationType GetInstallationType() => _installationType ??= IsBrandNewInstall ? InstallationType.NewInstall : InstallationType.Upgrade;

--- a/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
+++ b/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.BackOffice.Install;
@@ -37,7 +38,8 @@ internal class UmbracoCustomizations : ICustomization
             .Customize(new ConstructorCustomization(typeof(BackOfficeUserManager), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(MemberManager), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(DatabaseSchemaCreatorFactory), new GreedyConstructorQuery()))
-            .Customize(new ConstructorCustomization(typeof(BackOfficeServerVariables), new GreedyConstructorQuery()));
+            .Customize(new ConstructorCustomization(typeof(BackOfficeServerVariables), new GreedyConstructorQuery()))
+            .Customize(new ConstructorCustomization(typeof(InstallHelper), new GreedyConstructorQuery()));
 
         // When requesting an IUserStore ensure we actually uses a IUserLockoutStore
         fixture.Customize<IUserStore<BackOfficeIdentityUser>>(cc =>


### PR DESCRIPTION
After https://github.com/umbraco/Umbraco-CMS/commit/be38fb41adf201991456844c810bddfff8a6adcc the unit tests would fail.

This was because Automoq tried to use the obsolete constructor which requires a static service provider, however this does not exist in unit tests. 

This PR fixes this by make the constructor invocation greedy.

It also removes the unnecessary body of the obsolete constructor