### PR TITLE
Fixes alignment issue for "Saved searches" dropdown in log viewer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-avatar.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-avatar.less
@@ -11,6 +11,8 @@
     font-weight: bold;
     font-size: 16px;
     box-sizing: border-box;
+    object-fit: cover;
+    object-position: center;
 }
 
 /* Sizes */

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-logviewer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-logviewer.less
@@ -114,6 +114,16 @@
                 max-height: 250px;
                 overflow-y: scroll;
                 margin-top: -10px;
+
+                > li {
+
+                    > button {
+                        white-space: normal;
+                        flex-wrap: wrap;
+                        column-gap: 5px;
+                    }
+
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
This PR fixes the broken dropdown in "Saved searches" of log viewer in low resolution screens (screen resolution used is 1200x700).

### Before
![image](https://user-images.githubusercontent.com/5023476/177630574-71a18d00-1409-4bbc-888c-039df06588b9.png)


### After
![image](https://user-images.githubusercontent.com/5023476/177630875-4be91ad6-415b-47f2-8075-19bb97481de6.png)


<!-- Thanks for contributing to Umbraco CMS! -->
