### PR TITLE
Changed healthcheck collection configuration to use a concrete type to ensure configuration settings are bound.

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/HealthChecksNotificationSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/HealthChecksNotificationSettings.cs
@@ -39,6 +39,6 @@ public class HealthChecksNotificationSettings
     /// <summary>
     ///     Gets or sets a value for the collection of health checks that are disabled for notifications.
     /// </summary>
-    public IEnumerable<DisabledHealthCheckSettings> DisabledChecks { get; set; } =
-        Enumerable.Empty<DisabledHealthCheckSettings>();
+    public List<DisabledHealthCheckSettings> DisabledChecks { get; set; } =
+        new List<DisabledHealthCheckSettings>();
 }

--- a/src/Umbraco.Core/Configuration/Models/HealthChecksSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/HealthChecksSettings.cs
@@ -12,8 +12,8 @@ public class HealthChecksSettings
     /// <summary>
     ///     Gets or sets a value for the collection of healthchecks that are disabled.
     /// </summary>
-    public IEnumerable<DisabledHealthCheckSettings> DisabledChecks { get; set; } =
-        Enumerable.Empty<DisabledHealthCheckSettings>();
+    public List<DisabledHealthCheckSettings> DisabledChecks { get; set; } =
+        new List<DisabledHealthCheckSettings>();
 
     /// <summary>
     ///     Gets or sets a value for the healthcheck notification settings.


### PR DESCRIPTION
I came across this issue when trying to add similar configuration, finding that configuration properties defined with `IEnumerable` don't get bound.  They do with `List` which is what I've updated these two examples to.

To Test:
 - Prior to applying these code changes, set up the configuration documented [here](https://our.umbraco.com/Documentation/Reference/Configuration/HealthChecks/#health-checks) or as below:

```
"Umbraco": {
    "CMS": {      
      "HealthChecks": {
        "DisabledChecks": [
          {
            "Id": "D0F7599E-9B2A-4D9E-9883-81C7EDC5616F"
          }
        ]
      }
```

- This should disable the _Configuration > Macro Errors_ healthcheck, but you'll see it's still available
- Apply the code changes and you should see it's no longer available.