### PR TITLE
Enforce passing tree alias to tree api requests

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ApplicationTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ApplicationTreeController.cs
@@ -208,15 +208,20 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             {
                 throw new ArgumentNullException(nameof(tree));
             }
+            
+            // Force tree querystring param
+            Dictionary<string, StringValues>? d = querystring?.ToDictionary(x => x.Key, x => x.Value) ?? new Dictionary<string, StringValues>();
+            d["tree"] = tree.TreeAlias;
+            var qs = new FormCollection(d);
 
-            var childrenResult = await GetChildren(tree, id, querystring);
+            var childrenResult = await GetChildren(tree, id, qs);
             if (!(childrenResult?.Result is null))
             {
                 return new ActionResult<TreeRootNode>(childrenResult.Result);
             }
 
             var children = childrenResult?.Value;
-            var rootNodeResult = await GetRootNode(tree, querystring);
+            var rootNodeResult = await GetRootNode(tree, qs);
             if (!(rootNodeResult?.Result is null))
             {
                 return rootNodeResult.Result;
@@ -256,7 +261,12 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
                 throw new ArgumentNullException(nameof(tree));
             }
 
-            var result = await GetApiControllerProxy(tree.TreeControllerType, "GetRootNode", querystring);
+            // Force tree querystring param
+            Dictionary<string, StringValues>? d = querystring?.ToDictionary(x => x.Key, x => x.Value) ?? new Dictionary<string, StringValues>();
+            d["tree"] = tree.TreeAlias;
+            var qs = new FormCollection(d);
+
+            var result = await GetApiControllerProxy(tree.TreeControllerType, "GetRootNode", qs);
 
             // return null if the user isn't authorized to view that tree
             if (!((ForbidResult?)result.Result is null))
@@ -268,7 +278,7 @@ namespace Umbraco.Cms.Web.BackOffice.Trees
             TreeNode? rootNode = null;
             if (controller is not null)
             {
-                var rootNodeResult = await controller.GetRootNode(querystring);
+                var rootNodeResult = await controller.GetRootNode(qs);
                 if (!(rootNodeResult.Result is null))
                 {
                     return rootNodeResult.Result;


### PR DESCRIPTION
I'm looking at adding a feature to Konstrukt that allows injecting a konstrukt tree into an existing section root. I can make it do the injection, but the problem is that we re-use the same tree controller multiple times and we want to use the `tree` querystring parameter to know which tree is actually being rendered and so we know which configuration to use.

Within all the tree API calls there is a `tree` querystring parameter but this is nearly always empty. I believe this is only used by `GetApplicationTrees` to decide whether to render all trees or just a single tree and it being passed to the tree API's is just a byproduct of it not being removed from the original querystring.

This PR then ensures that whenever a root node request is made to a tree that the `tree` querystring parameter is always set to the alias of the tree definition for the tree being proxied. I believe this should be fine at this point to enforce as the decision by `GetApplicationTrees` has already been made and the tree being rendered is known at this point and so passing a filled in tree parameter shouldn't pose any problems from what I can tell.