### PR TITLE
Revert incorrect change in Property.PublishValues

### DIFF
--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -291,8 +291,8 @@ namespace Umbraco.Cms.Core.Models
             // and match the specified culture and segment (or anything when '*').
             var pvalues = _vvalues.Where(x =>
                     PropertyType.SupportsVariation(x.Value.Culture, x.Value.Segment, true) && // the value variation is ok
-                    (culture == "*" || (x.Value.Culture?.InvariantEquals(culture) ?? false)) && // the culture matches
-                    (segment == "*" || (x.Value.Segment?.InvariantEquals(segment) ?? false))) // the segment matches
+                    (culture == "*" || x.Value.Culture.InvariantEquals(culture)) && // the culture matches
+                    (segment == "*" || x.Value.Segment.InvariantEquals(segment))) // the segment matches
                 .Select(x => x.Value);
 
             foreach (var pvalue in pvalues)


### PR DESCRIPTION
Fixes #12679

Fix incorrect change made for nullability support which changes the result of the updated expression to `false` instead of `true` when both inputs are `null`.
That is, `null?.InvariantEquals(null) ?? false` becomes `false` but in the previous version it was `true` since the `InvariantEquals` extension method simply calls `string.Equals(v1, v2)` which will return `true` when both inputs are `null`. Due to the `?` operator the `InvariantEquals` method is not called anymore and `?? false` turns the expression to `false`.

Because of this segment support in Umbraco 10 is broken.
