### PR TITLE
Fix save package with folder-media throws an error

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CreatedPackageSchemaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CreatedPackageSchemaRepository.cs
@@ -652,10 +652,13 @@ public class CreatedPackageSchemaRepository : ICreatedPackagesRepository
             // the media file path is different from the URL and is specifically
             // extracted using the property editor for this media file and the current media file system.
             Stream mediaStream = _mediaFileManager.GetFile(media, out var mediaFilePath);
-            xmlMedia.Add(new XAttribute("mediaFilePath", mediaFilePath!));
+            if (mediaFilePath is not null)
+            {
+                xmlMedia.Add(new XAttribute("mediaFilePath", mediaFilePath));
 
-            // add the stream to our outgoing stream
-            mediaStreams.Add(mediaFilePath!, mediaStream);
+                // add the stream to our outgoing stream
+                mediaStreams.Add(mediaFilePath, mediaStream);
+            }
         }
 
         IEnumerable<IMedia> medias = _mediaService.GetByIds(definition.MediaUdis);


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12672

# Notes
- Adds missing null check in CreatedPackageSchemaRepository.cs
- Do note that while this will no longer throw an error, it will still not save your images in that folder, this is also the behavior in 9.5.2

# How to test
- Follow steps in original issue