### PR TITLE
Change delete action back to move

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
@@ -180,10 +180,10 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
 
             menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
 
-                //no move action if this is a child doc type
+            // No move action if this is a child doc type
             if (parent == null)
             {
-                menu.Items.Add<ActionDelete>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
+                menu.Items.Add<ActionMove>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
             }
 
             menu.Items.Add<ActionCopy>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);


### PR DESCRIPTION
# Notes
- When right-clicking a document type, you no longer see a "move action", but instead 2 delete actions:
![image](https://user-images.githubusercontent.com/70372949/178709182-5a24c6ee-59da-45c5-8063-95245f9a3e4b.png)

- This PR reinstates the move action
![image](https://user-images.githubusercontent.com/70372949/178709399-64c88135-da16-463e-92bd-a7d27323e79f.png)

