### PR TITLE
Allow dashboards to also be the "last accessed item"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/history.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/history.service.js
@@ -130,7 +130,7 @@ angular.module('umbraco.services')
         getLastAccessedItemForSection: function (sectionAlias) {
             for (var i = 0, len = nArray.length; i < len; i++) {
                 var item = nArray[i];
-                if (item.link == sectionAlias || item.link.indexOf(sectionAlias + "/") === 0) {
+                if (item.link === sectionAlias || item.link.indexOf(sectionAlias + "/") === 0) {
                     return item;
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/common/services/history.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/history.service.js
@@ -130,7 +130,7 @@ angular.module('umbraco.services')
         getLastAccessedItemForSection: function (sectionAlias) {
             for (var i = 0, len = nArray.length; i < len; i++) {
                 var item = nArray[i];
-                if (item.link.indexOf(sectionAlias + "/") === 0) {
+                if (item.link == sectionAlias || item.link.indexOf(sectionAlias + "/") === 0) {
                     return item;
                 }
             }


### PR DESCRIPTION
If within a section you navigate to a node and select it in the tree, but then click the section tree heading to view the section dashboard, if you then navigate away to a new section and then navigate back, it sends you back to the last node you selected, evern though the last thing you viewed in that section was the dashboard.

The PR allows dashboards to also be resolved from the navigationServices `getLastAccessedItemForSection` by allowing exact matches on the item link, as well as just sub paths of the section.

This way, when changing sections, Umbraco will actually send you back to the last thing you viewed in a section, rather than just "the last NODE you viewed".