### PR TITLE
Update description for `maxPropertyWidth`

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
@@ -19,7 +19,7 @@ public class BlockListConfiguration
     [ConfigurationField("useInlineEditingAsDefault", "Inline editing mode", "boolean", Description = "Use the inline editor as the default block view.")]
     public bool UseInlineEditingAsDefault { get; set; }
 
-    [ConfigurationField("maxPropertyWidth", "Property editor width", "textstring", Description = "optional css overwrite, example: 800px or 100%")]
+    [ConfigurationField("maxPropertyWidth", "Property editor width", "textstring", Description = "Optional CSS override, example: 800px or 100%")]
     public string? MaxPropertyWidth { get; set; }
 
     [DataContract]


### PR DESCRIPTION
- Consistent casing for first word of description (all others start with a capital letter)
- css => CSS
- Use "override" instead of "overwrite" (if this isn't what's intended here let me know and I'll update the PR free of charge)

(Did not feel like tackling the discrepancy of descriptions ending with or without a period this time 😅)