### PR TITLE
Add RuntimeModeValidator collection builder

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -2,6 +2,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Mappers;
+using Umbraco.Cms.Infrastructure.Runtime;
 
 namespace Umbraco.Extensions;
 
@@ -17,6 +18,10 @@ public static partial class UmbracoBuilderExtensions
     public static MapperCollectionBuilder? Mappers(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<MapperCollectionBuilder>();
 
+    /// <summary>
+    ///     Gets the NPoco mappers collection builder.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
     public static NPocoMapperCollectionBuilder? NPocoMappers(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<NPocoMapperCollectionBuilder>();
 
@@ -26,4 +31,11 @@ public static partial class UmbracoBuilderExtensions
     /// <param name="builder">The builder.</param>
     public static PackageMigrationPlanCollectionBuilder? PackageMigrationPlans(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<PackageMigrationPlanCollectionBuilder>();
+
+    /// <summary>
+    ///     Gets the runtime mode validators collection builder.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static RuntimeModeValidatorCollectionBuilder RuntimeModeValidators(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<RuntimeModeValidatorCollectionBuilder>();
 }

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -86,11 +86,12 @@ public static partial class UmbracoBuilderExtensions
 
         // Add runtime mode validation
         builder.Services.AddSingleton<IRuntimeModeValidationService, RuntimeModeValidationService>();
-        builder.Services.AddTransient<IRuntimeModeValidator, JITOptimizerValidator>();
-        builder.Services.AddTransient<IRuntimeModeValidator, UmbracoApplicationUrlValidator>();
-        builder.Services.AddTransient<IRuntimeModeValidator, UseHttpsValidator>();
-        builder.Services.AddTransient<IRuntimeModeValidator, RuntimeMinificationValidator>();
-        builder.Services.AddTransient<IRuntimeModeValidator, ModelsBuilderModeValidator>();
+        builder.RuntimeModeValidators()
+            .Add<JITOptimizerValidator>()
+            .Add<UmbracoApplicationUrlValidator>()
+            .Add<UseHttpsValidator>()
+            .Add<RuntimeMinificationValidator>()
+            .Add<ModelsBuilderModeValidator>();
 
         // composers
         builder

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidationService.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidationService.cs
@@ -29,11 +29,18 @@ internal class RuntimeModeValidationService : IRuntimeModeValidationService
         var validationMessages = new List<string>();
 
         // Runtime mode validators are registered transient, but this service is registered as singleton
-        foreach (var runtimeModeValidator in _serviceProvider.GetServices<IRuntimeModeValidator>())
+        using (var scope = _serviceProvider.CreateScope())
         {
-            if (runtimeModeValidator.Validate(runtimeMode, out var validationMessage) == false)
+            var runtimeModeValidators = scope.ServiceProvider.GetService<RuntimeModeValidatorCollection>();
+            if (runtimeModeValidators is not null)
             {
-                validationMessages.Add(validationMessage);
+                foreach (var runtimeModeValidator in runtimeModeValidators)
+                {
+                    if (runtimeModeValidator.Validate(runtimeMode, out var validationMessage) == false)
+                    {
+                        validationMessages.Add(validationMessage);
+                    }
+                }
             }
         }
 

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidatorCollection.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidatorCollection.cs
@@ -1,0 +1,10 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Infrastructure.Runtime;
+
+public class RuntimeModeValidatorCollection : BuilderCollectionBase<IRuntimeModeValidator>
+{
+    public RuntimeModeValidatorCollection(Func<IEnumerable<IRuntimeModeValidator>> items)
+        : base(items)
+    { }
+}

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidatorCollectionBuilder.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidatorCollectionBuilder.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Infrastructure.Runtime;
+
+public class RuntimeModeValidatorCollectionBuilder : SetCollectionBuilderBase<RuntimeModeValidatorCollectionBuilder, RuntimeModeValidatorCollection, IRuntimeModeValidator>
+{
+    protected override ServiceLifetime CollectionLifetime => ServiceLifetime.Transient;
+
+    protected override RuntimeModeValidatorCollectionBuilder This => this;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/12631 added `IRuntimeModeValidator`s that were directly added to the service collection, making opting-out of specific validators a bit awkward (even when assuming it's registered as generic type, so this doesn't even support factory or instance registrations):

```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Infrastructure.Runtime.RuntimeModeValidators;

public class RuntimeModeValidatorComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.RemoveAll(x => x.ImplementationType == typeof(UmbracoApplicationUrlValidator));
}
```

This PR fixes that by adding a `RuntimeModeValidatorCollection` and `RuntimeModeValidatorCollectionBuilder` that is exposed on the `IUmbracoBuilder` using a new `RuntimeModeValidators()` extension method. This allows a much nicer and fluent API for removing or adding runtime mode validators:

```c#
using System.Diagnostics.CodeAnalysis;
using Microsoft.Extensions.Options;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Configuration.Models;
using Umbraco.Cms.Infrastructure.Runtime;
using Umbraco.Cms.Infrastructure.Runtime.RuntimeModeValidators;

public class RuntimeModeValidatorComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.RuntimeModeValidators()
            .Remove<UmbracoApplicationUrlValidator>()
            .Add<DisableElectionForSingleServerValidator>();
}

public class DisableElectionForSingleServerValidator : IRuntimeModeValidator
{
    private readonly IOptionsMonitor<GlobalSettings> _globalSettings;

    public DisableElectionForSingleServerValidator(IOptionsMonitor<GlobalSettings> globalSettings) => _globalSettings = globalSettings;

    public bool Validate(RuntimeMode runtimeMode, [NotNullWhen(false)] out string? validationErrorMessage)
    {
        if (_globalSettings.CurrentValue.DisableElectionForSingleServer == false)
        {
            validationErrorMessage = "Disable primary server election (and support for load balancing) to improve startup performance.";
            return false;
        }

        validationErrorMessage = null;
        return true;
    }
}
```

I've ensured the validators are still registered as transient services, as they are only required during startup (when determining the runtime level) and we don't want/need to keep them in memory.

Testing can be done by adding breakpoints on the `Validate` methods of default validators and checking whether they are still invoked. If you then add the above composer, the `UmbracoApplicationUrlValidator` won't be invoked anymore and the custom `DisableElectionForSingleServerValidator` one will be added and validated.