### PR TITLE
Disable editing templates when using runtime mode Production

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -1630,6 +1630,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="tabRules">Editor</key>
   </area>
   <area alias="template">
+    <key alias="runtimeModeProduction"><![CDATA[Template content is not editable when using runtime mode <code>Production</code>.]]></key>
     <key alias="deleteByIdFailed">Failed to delete template with ID %0%</key>
     <key alias="edittemplate">Edit template</key>
     <key alias="insertSections">Sections</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -1683,6 +1683,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="tabRules">Rich Text Editor</key>
   </area>
   <area alias="template">
+    <key alias="runtimeModeProduction"><![CDATA[Template content is not editable when using runtime mode <code>Production</code>.]]></key>
     <key alias="deleteByIdFailed">Failed to delete template with ID %0%</key>
     <key alias="edittemplate">Edit template</key>
     <key alias="insertSections">Sections</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -1444,6 +1444,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="tabRules">Rich Text Editor</key>
   </area>
   <area alias="template">
+    <key alias="runtimeModeProduction"><![CDATA[Sjablooninhoud kan niet worden bewerkt in de runtime-modus <code>Production</code>.]]></key>
     <key alias="deleteByIdFailed">Kan sjabloon met ID %0% niet verwijderen</key>
     <key alias="edittemplate">Sjabloon aanpassen</key>
     <key alias="insertSections">Secties</key>

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -597,7 +597,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 { "assemblyVersion", _umbracoVersion.AssemblyVersion?.ToString() }
             };
 
-
+            app.Add("runtimeMode", _runtimeSettings.Mode.ToString());
 
             //the value is the hash of the version, cdf version and the configured state
             app.Add("cacheBuster", $"{version}.{_runtimeState.Level}.{_runtimeMinifier.CacheBuster}".GenerateHash());

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -83,9 +83,7 @@
     vm.save = function (suppressNotification) {
       vm.page.saveButtonState = "busy";
 
-      if (vm.editor) {
-        vm.template.content = vm.editor.getValue();
-      }
+      vm.template.content = vm.editor.getValue();
 
       contentEditingHelper.contentEditorPerformSave({
         saveMethod: templateResource.save,
@@ -228,7 +226,10 @@
         onLoad: function (_editor) {
           vm.editor = _editor;
 
-          //Update the auto-complete method to use ctrl+alt+space
+          // Set read-only when using runtime mode Production
+          _editor.setReadOnly(vm.runtimeModeProduction);
+
+          // Update the auto-complete method to use ctrl+alt+space
           _editor.commands.bindKey("ctrl-alt-space", "startAutocomplete");
 
           // Unassigns the keybinding (That was previously auto-complete)

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.controller.js
@@ -1,723 +1,727 @@
 (function () {
-    "use strict";
+  "use strict";
 
-    function TemplatesEditController($scope, $routeParams, $timeout, templateResource, assetsService, notificationsService, editorState, navigationService, appState, macroService, treeService, contentEditingHelper, localizationService, angularHelper, templateHelper, editorService) {
+  function TemplatesEditController($scope, $routeParams, $timeout, templateResource, assetsService, notificationsService, editorState, navigationService, appState, macroService, treeService, contentEditingHelper, localizationService, angularHelper, templateHelper, editorService) {
 
-        var vm = this;
-        var oldMasterTemplateAlias = null;
-        var infiniteMode = $scope.model && $scope.model.infiniteMode;
-        var id = infiniteMode ? $scope.model.id : $routeParams.id;
-        var create = infiniteMode ? $scope.model.create : $routeParams.create;
+    var vm = this;
+    var oldMasterTemplateAlias = null;
+    var infiniteMode = $scope.model && $scope.model.infiniteMode;
+    var id = infiniteMode ? $scope.model.id : $routeParams.id;
+    var create = infiniteMode ? $scope.model.create : $routeParams.create;
 
-        vm.header = {};
-        vm.header.editorfor = "template_template";
-        vm.header.setPageTitle = true;
+    vm.runtimeModeProduction = Umbraco.Sys.ServerVariables.application.runtimeMode == 'Production';
 
-        vm.page = {};
-        vm.page.loading = true;
-        vm.templates = [];
+    vm.header = {};
+    vm.header.editorfor = "template_template";
+    vm.header.setPageTitle = true;
 
-        //menu
-        vm.page.menu = {};
-        vm.page.menu.currentSection = appState.getSectionState("currentSection");
-        vm.page.menu.currentNode = null;
+    vm.page = {};
+    vm.page.loading = true;
+    vm.templates = [];
 
-        // insert buttons
-        vm.page.insertDefaultButton = {
-            labelKey: "general_insert",
-            addEllipsis: "true",
-            handler: function () {
-                vm.openInsertOverlay();
-            }
-        };
-        vm.page.insertSubButtons = [
+    //menu
+    vm.page.menu = {};
+    vm.page.menu.currentSection = appState.getSectionState("currentSection");
+    vm.page.menu.currentNode = null;
+
+    // insert buttons
+    vm.page.insertDefaultButton = {
+      labelKey: "general_insert",
+      addEllipsis: "true",
+      handler: function () {
+        vm.openInsertOverlay();
+      }
+    };
+    vm.page.insertSubButtons = [
+      {
+        labelKey: "template_insertPageField",
+        addEllipsis: "true",
+        handler: function () {
+          vm.openPageFieldOverlay();
+        }
+      },
+      {
+        labelKey: "template_insertPartialView",
+        addEllipsis: "true",
+        handler: function () {
+          vm.openPartialOverlay();
+        }
+      },
+      {
+        labelKey: "template_insertDictionaryItem",
+        addEllipsis: "true",
+        handler: function () {
+          vm.openDictionaryItemOverlay();
+        }
+      },
+      {
+        labelKey: "template_insertMacro",
+        addEllipsis: "true",
+        handler: function () {
+          vm.openMacroOverlay()
+        }
+      }
+    ];
+
+    //Used to toggle the keyboard shortcut modal
+    //From a custom keybinding in ace editor - that conflicts with our own to show the dialog
+    vm.showKeyboardShortcut = false;
+
+    //Keyboard shortcuts for help dialog
+    vm.page.keyboardShortcutsOverview = [];
+
+    templateHelper.getGeneralShortcuts().then(function (data) {
+      vm.page.keyboardShortcutsOverview.push(data);
+    });
+    templateHelper.getEditorShortcuts().then(function (data) {
+      vm.page.keyboardShortcutsOverview.push(data);
+    });
+    templateHelper.getTemplateEditorShortcuts().then(function (data) {
+      vm.page.keyboardShortcutsOverview.push(data);
+    });
+
+    vm.save = function (suppressNotification) {
+      vm.page.saveButtonState = "busy";
+
+      if (vm.editor) {
+        vm.template.content = vm.editor.getValue();
+      }
+
+      contentEditingHelper.contentEditorPerformSave({
+        saveMethod: templateResource.save,
+        scope: $scope,
+        content: vm.template,
+        rebindCallback: function (orignal, saved) { }
+      }).then(function (saved) {
+
+        if (!suppressNotification) {
+          localizationService.localizeMany(["speechBubbles_templateSavedHeader", "speechBubbles_templateSavedText"]).then(function (data) {
+            var header = data[0];
+            var message = data[1];
+            notificationsService.success(header, message);
+          });
+        }
+
+        vm.page.saveButtonState = "success";
+        vm.template = saved;
+
+        //sync state
+        if (!infiniteMode) {
+          editorState.set(vm.template);
+        }
+
+        // sync tree
+        // if master template alias has changed move the node to it's new location
+        if (!infiniteMode && oldMasterTemplateAlias !== vm.template.masterTemplateAlias) {
+
+          // When creating a new template the id is -1. Make sure We don't remove the root node.
+          if (vm.page.menu.currentNode.id !== "-1") {
+            // move node to new location in tree
+            //first we need to remove the node that we're working on
+            treeService.removeNode(vm.page.menu.currentNode);
+          }
+
+          // update stored alias to the new one so the node won't move again unless the alias is changed again
+          oldMasterTemplateAlias = vm.template.masterTemplateAlias;
+
+          navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true, activate: true }).then(function (args) {
+            vm.page.menu.currentNode = args.node;
+          });
+
+        } else {
+
+          // normal tree sync
+          if (!infiniteMode) {
+            navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true }).then(function (syncArgs) {
+              vm.page.menu.currentNode = syncArgs.node;
+            });
+          }
+
+        }
+
+        // clear $dirty state on form
+        setFormState("pristine");
+
+        if (infiniteMode) {
+          submit();
+        }
+
+
+      }, function (err) {
+        if (suppressNotification) {
+          vm.page.saveButtonState = "error";
+
+          localizationService.localizeMany(["speechBubbles_validationFailedHeader", "speechBubbles_validationFailedMessage"]).then(function (data) {
+            var header = data[0];
+            var message = data[1];
+            notificationsService.error(header, message);
+          });
+        }
+      });
+
+    };
+
+    vm.init = function () {
+
+      // we need to load this somewhere, for now its here.
+      assetsService.loadCss("lib/ace-razor-mode/theme/razor_chrome.css", $scope);
+
+      // load templates - used in the master template picker
+      templateResource.getAll()
+        .then(function (templates) {
+          vm.templates = templates;
+        });
+
+      if (create) {
+        templateResource.getScaffold((id)).then(function (template) {
+          vm.ready(template);
+        });
+      } else {
+        templateResource.getById(id).then(function (template) {
+          vm.ready(template);
+        });
+      }
+
+    };
+
+
+    vm.ready = function (template) {
+      vm.page.loading = false;
+      vm.template = template;
+
+      // if this is a new template, bind to the blur event on the name
+      if (create) {
+        $timeout(function () {
+          var nameField = $('[data-element="editor-name-field"]');
+          if (nameField) {
+            nameField.on('blur', function (event) {
+              if (event.target.value) {
+                vm.save(true);
+              }
+            });
+          }
+        });
+      }
+
+      // sync state
+      if (!infiniteMode) {
+        editorState.set(vm.template);
+        navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true }).then(function (syncArgs) {
+          vm.page.menu.currentNode = syncArgs.node;
+        });
+      }
+
+      // save state of master template to use for comparison when syncing the tree on save
+      oldMasterTemplateAlias = Utilities.copy(template.masterTemplateAlias);
+
+      // ace configuration
+      vm.aceOption = {
+        mode: "razor",
+        theme: "chrome",
+        showPrintMargin: false,
+        advanced: {
+          fontSize: '14px',
+          enableSnippets: false, //The Razor mode snippets are awful (Need a way to override these)
+          enableBasicAutocompletion: true,
+          enableLiveAutocompletion: false
+        },
+        onLoad: function (_editor) {
+          vm.editor = _editor;
+
+          //Update the auto-complete method to use ctrl+alt+space
+          _editor.commands.bindKey("ctrl-alt-space", "startAutocomplete");
+
+          // Unassigns the keybinding (That was previously auto-complete)
+          // As conflicts with our own tree search shortcut
+          _editor.commands.bindKey("ctrl-space", null);
+
+          // Assign new keybinding
+          _editor.commands.addCommands([
+            // Disable (alt+shift+K)
+            // Conflicts with our own show shortcuts dialog - this overrides it
             {
-                labelKey: "template_insertPageField",
-                addEllipsis: "true",
-                handler: function () {
-                    vm.openPageFieldOverlay();
-                }
+              name: 'unSelectOrFindPrevious',
+              bindKey: 'Alt-Shift-K',
+              exec: function () {
+                // Toggle the show keyboard shortcuts overlay
+                $scope.$apply(function () {
+                  vm.showKeyboardShortcut = !vm.showKeyboardShortcut;
+                });
+
+              },
+              readOnly: true
             },
             {
-                labelKey: "template_insertPartialView",
-                addEllipsis: "true",
-                handler: function () {
-                    vm.openPartialOverlay();
-                }
+              name: 'insertUmbracoValue',
+              bindKey: 'Alt-Shift-V',
+              exec: function () {
+                $scope.$apply(function () {
+                  openPageFieldOverlay();
+                });
+              },
+              readOnly: true
             },
             {
-                labelKey: "template_insertDictionaryItem",
-                addEllipsis: "true",
-                handler: function () {
-                    vm.openDictionaryItemOverlay();
-                }
+              name: 'insertPartialView',
+              bindKey: 'Alt-Shift-P',
+              exec: function () {
+                $scope.$apply(function () {
+                  openPartialOverlay();
+                });
+              },
+              readOnly: true
             },
             {
-                labelKey: "template_insertMacro",
-                addEllipsis: "true",
-                handler: function () {
-                    vm.openMacroOverlay()
-                }
+              name: 'insertDictionary',
+              bindKey: 'Alt-Shift-D',
+              exec: function () {
+                $scope.$apply(function () {
+                  openDictionaryItemOverlay();
+                });
+              },
+              readOnly: true
+            },
+            {
+              name: 'insertUmbracoMacro',
+              bindKey: 'Alt-Shift-M',
+              exec: function () {
+                $scope.$apply(function () {
+                  openMacroOverlay();
+                });
+              },
+              readOnly: true
+            },
+            {
+              name: 'insertQuery',
+              bindKey: 'Alt-Shift-Q',
+              exec: function () {
+                $scope.$apply(function () {
+                  openQueryBuilderOverlay();
+                });
+              },
+              readOnly: true
+            },
+            {
+              name: 'insertSection',
+              bindKey: 'Alt-Shift-S',
+              exec: function () {
+                $scope.$apply(function () {
+                  openSectionsOverlay();
+                });
+              },
+              readOnly: true
+            },
+            {
+              name: 'chooseMasterTemplate',
+              bindKey: 'Alt-Shift-T',
+              exec: function () {
+                $scope.$apply(function () {
+                  openMasterTemplateOverlay();
+                });
+              },
+              readOnly: true
             }
-        ];
 
-        //Used to toggle the keyboard shortcut modal
-        //From a custom keybinding in ace editor - that conflicts with our own to show the dialog
-        vm.showKeyboardShortcut = false;
+          ]);
 
-        //Keyboard shortcuts for help dialog
-        vm.page.keyboardShortcutsOverview = [];
-
-        templateHelper.getGeneralShortcuts().then(function (data) {
-            vm.page.keyboardShortcutsOverview.push(data);
-        });
-        templateHelper.getEditorShortcuts().then(function (data) {
-            vm.page.keyboardShortcutsOverview.push(data);
-        });
-        templateHelper.getTemplateEditorShortcuts().then(function (data) {
-            vm.page.keyboardShortcutsOverview.push(data);
-        });
-
-        vm.save = function (suppressNotification) {
-            vm.page.saveButtonState = "busy";
-
-            vm.template.content = vm.editor.getValue();
-
-            contentEditingHelper.contentEditorPerformSave({
-                saveMethod: templateResource.save,
-                scope: $scope,
-                content: vm.template,
-                rebindCallback: function (orignal, saved) { }
-            }).then(function (saved) {
-
-                if (!suppressNotification) {
-                    localizationService.localizeMany(["speechBubbles_templateSavedHeader", "speechBubbles_templateSavedText"]).then(function (data) {
-                        var header = data[0];
-                        var message = data[1];
-                        notificationsService.success(header, message);
-                    });
-                }
-
-                vm.page.saveButtonState = "success";
-                vm.template = saved;
-
-                //sync state
-                if (!infiniteMode) {
-                    editorState.set(vm.template);
-                }
-
-                // sync tree
-                // if master template alias has changed move the node to it's new location
-                if (!infiniteMode && oldMasterTemplateAlias !== vm.template.masterTemplateAlias) {
-
-                    // When creating a new template the id is -1. Make sure We don't remove the root node.
-                    if (vm.page.menu.currentNode.id !== "-1") {
-                        // move node to new location in tree
-                        //first we need to remove the node that we're working on
-                        treeService.removeNode(vm.page.menu.currentNode);
-                    }
-
-                    // update stored alias to the new one so the node won't move again unless the alias is changed again
-                    oldMasterTemplateAlias = vm.template.masterTemplateAlias;
-
-                    navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true, activate: true }).then(function (args) {
-                        vm.page.menu.currentNode = args.node;
-                    });
-
-                } else {
-
-                    // normal tree sync
-                    if (!infiniteMode) {
-                        navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true }).then(function (syncArgs) {
-                            vm.page.menu.currentNode = syncArgs.node;
-                        });
-                    }
-
-                }
-
-                // clear $dirty state on form
-                setFormState("pristine");
-
-                if (infiniteMode) {
-                    submit();
-                }
-
-
-            }, function (err) {
-                if (suppressNotification) {
-                    vm.page.saveButtonState = "error";
-
-                    localizationService.localizeMany(["speechBubbles_validationFailedHeader", "speechBubbles_validationFailedMessage"]).then(function (data) {
-                        var header = data[0];
-                        var message = data[1];
-                        notificationsService.error(header, message);
-                    });
-                }
+          // initial cursor placement
+          // Keep cursor in name field if we are create a new template
+          // else set the cursor at the bottom of the code editor
+          if (!create) {
+            $timeout(function () {
+              vm.editor.navigateFileEnd();
+              vm.editor.focus();
+              persistCurrentLocation();
             });
+          }
 
+          // change on blur, focus
+          vm.editor.on("blur", persistCurrentLocation);
+          vm.editor.on("focus", persistCurrentLocation);
+          vm.editor.on("change", changeAceEditor);
+        }
+      }
+
+    };
+
+    vm.openPageFieldOverlay = openPageFieldOverlay;
+    vm.openDictionaryItemOverlay = openDictionaryItemOverlay;
+    vm.openQueryBuilderOverlay = openQueryBuilderOverlay;
+    vm.openMacroOverlay = openMacroOverlay;
+    vm.openInsertOverlay = openInsertOverlay;
+    vm.openSectionsOverlay = openSectionsOverlay;
+    vm.openPartialOverlay = openPartialOverlay;
+    vm.openMasterTemplateOverlay = openMasterTemplateOverlay;
+    vm.selectMasterTemplate = selectMasterTemplate;
+    vm.getMasterTemplateName = getMasterTemplateName;
+    vm.removeMasterTemplate = removeMasterTemplate;
+    vm.closeShortcuts = closeShortcuts;
+    vm.submit = submit;
+    vm.close = close;
+
+    function openInsertOverlay() {
+      var insertOverlay = {
+        allowedTypes: {
+          macro: true,
+          dictionary: true,
+          partial: true,
+          umbracoField: true
+        },
+        submit: function (model) {
+          switch (model.insert.type) {
+            case "macro":
+              var macroObject = macroService.collectValueData(model.insert.selectedMacro, model.insert.macroParams, "Mvc");
+              insert(macroObject.syntax);
+              break;
+            case "dictionary":
+              var code = templateHelper.getInsertDictionarySnippet(model.insert.node.name);
+              insert(code);
+              break;
+            case "partial":
+              var code = templateHelper.getInsertPartialSnippet(model.insert.node.parentId, model.insert.node.name);
+              insert(code);
+              break;
+            case "umbracoField":
+              insert(model.insert.umbracoField);
+              break;
+          }
+          editorService.close();
+        },
+        close: function (oldModel) {
+          // close the dialog
+          editorService.close();
+          // focus editor
+          vm.editor.focus();
+        }
+      };
+      editorService.insertCodeSnippet(insertOverlay);
+    }
+
+    function openMacroOverlay() {
+      var macroPicker = {
+        dialogData: {},
+        submit: function (model) {
+          var macroObject = macroService.collectValueData(model.selectedMacro, model.macroParams, "Mvc");
+          insert(macroObject.syntax);
+          editorService.close();
+        },
+        close: function () {
+          editorService.close();
+          vm.editor.focus();
+        }
+      };
+      editorService.macroPicker(macroPicker);
+    }
+
+    function openPageFieldOverlay() {
+      var insertFieldEditor = {
+        submit: function (model) {
+          insert(model.umbracoField);
+          editorService.close();
+        },
+        close: function () {
+          editorService.close();
+          vm.editor.focus();
+        }
+      };
+      editorService.insertField(insertFieldEditor);
+    }
+
+
+    function openDictionaryItemOverlay() {
+
+      var labelKeys = [
+        "template_insertDictionaryItem",
+        "emptyStates_emptyDictionaryTree"
+      ];
+
+      localizationService.localizeMany(labelKeys).then(function (values) {
+        var title = values[0];
+        var emptyStateMessage = values[1];
+
+        var dictionaryItem = {
+          section: "translation",
+          treeAlias: "dictionary",
+          entityType: "dictionary",
+          multiPicker: false,
+          title: title,
+          emptyStateMessage: emptyStateMessage,
+          select: function (node) {
+            var code = templateHelper.getInsertDictionarySnippet(node.name);
+            insert(code);
+            editorService.close();
+          },
+          close: function (model) {
+            // close dialog
+            editorService.close();
+            // focus editor
+            vm.editor.focus();
+          }
         };
 
-        vm.init = function () {
+        editorService.treePicker(dictionaryItem);
 
-            // we need to load this somewhere, for now its here.
-            assetsService.loadCss("lib/ace-razor-mode/theme/razor_chrome.css", $scope);
-
-            // load templates - used in the master template picker
-            templateResource.getAll()
-                .then(function (templates) {
-                    vm.templates = templates;
-                });
-
-            if (create) {
-                templateResource.getScaffold((id)).then(function (template) {
-                    vm.ready(template);
-                });
-            } else {
-                templateResource.getById(id).then(function (template) {
-                    vm.ready(template);
-                });
-            }
-
-        };
-
-
-        vm.ready = function (template) {
-            vm.page.loading = false;
-            vm.template = template;
-
-            // if this is a new template, bind to the blur event on the name
-            if (create) {
-                $timeout(function () {
-                    var nameField = $('[data-element="editor-name-field"]');
-                    if (nameField) {
-                        nameField.on('blur', function (event) {
-                            if (event.target.value) {
-                                vm.save(true);
-                            }
-                        });
-                    }
-                });
-            }
-
-            // sync state
-            if (!infiniteMode) {
-                editorState.set(vm.template);
-                navigationService.syncTree({ tree: "templates", path: vm.template.path, forceReload: true }).then(function (syncArgs) {
-                    vm.page.menu.currentNode = syncArgs.node;
-                });
-            }
-
-            // save state of master template to use for comparison when syncing the tree on save
-            oldMasterTemplateAlias = Utilities.copy(template.masterTemplateAlias);
-
-            // ace configuration
-            vm.aceOption = {
-                mode: "razor",
-                theme: "chrome",
-                showPrintMargin: false,
-                advanced: {
-                    fontSize: '14px',
-                    enableSnippets: false, //The Razor mode snippets are awful (Need a way to override these)
-                    enableBasicAutocompletion: true,
-                    enableLiveAutocompletion: false
-                },
-                onLoad: function (_editor) {
-                    vm.editor = _editor;
-
-                    //Update the auto-complete method to use ctrl+alt+space
-                    _editor.commands.bindKey("ctrl-alt-space", "startAutocomplete");
-
-                    // Unassigns the keybinding (That was previously auto-complete)
-                    // As conflicts with our own tree search shortcut
-                    _editor.commands.bindKey("ctrl-space", null);
-
-                    // Assign new keybinding
-                    _editor.commands.addCommands([
-                        // Disable (alt+shift+K)
-                        // Conflicts with our own show shortcuts dialog - this overrides it
-                        {
-                            name: 'unSelectOrFindPrevious',
-                            bindKey: 'Alt-Shift-K',
-                            exec: function () {
-                                // Toggle the show keyboard shortcuts overlay
-                                $scope.$apply(function () {
-                                    vm.showKeyboardShortcut = !vm.showKeyboardShortcut;
-                                });
-
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'insertUmbracoValue',
-                            bindKey: 'Alt-Shift-V',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openPageFieldOverlay();
-                                });
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'insertPartialView',
-                            bindKey: 'Alt-Shift-P',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openPartialOverlay();
-                                });
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'insertDictionary',
-                            bindKey: 'Alt-Shift-D',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openDictionaryItemOverlay();
-                                });
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'insertUmbracoMacro',
-                            bindKey: 'Alt-Shift-M',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openMacroOverlay();
-                                });
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'insertQuery',
-                            bindKey: 'Alt-Shift-Q',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openQueryBuilderOverlay();
-                                });
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'insertSection',
-                            bindKey: 'Alt-Shift-S',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openSectionsOverlay();
-                                });
-                            },
-                            readOnly: true
-                        },
-                        {
-                            name: 'chooseMasterTemplate',
-                            bindKey: 'Alt-Shift-T',
-                            exec: function () {
-                                $scope.$apply(function () {
-                                    openMasterTemplateOverlay();
-                                });
-                            },
-                            readOnly: true
-                        }
-
-                    ]);
-
-                    // initial cursor placement
-                    // Keep cursor in name field if we are create a new template
-                    // else set the cursor at the bottom of the code editor
-                    if (!create) {
-                        $timeout(function () {
-                            vm.editor.navigateFileEnd();
-                            vm.editor.focus();
-                            persistCurrentLocation();
-                        });
-                    }
-
-                    // change on blur, focus
-                    vm.editor.on("blur", persistCurrentLocation);
-                    vm.editor.on("focus", persistCurrentLocation);
-                    vm.editor.on("change", changeAceEditor);
-                }
-            }
-
-        };
-
-        vm.openPageFieldOverlay = openPageFieldOverlay;
-        vm.openDictionaryItemOverlay = openDictionaryItemOverlay;
-        vm.openQueryBuilderOverlay = openQueryBuilderOverlay;
-        vm.openMacroOverlay = openMacroOverlay;
-        vm.openInsertOverlay = openInsertOverlay;
-        vm.openSectionsOverlay = openSectionsOverlay;
-        vm.openPartialOverlay = openPartialOverlay;
-        vm.openMasterTemplateOverlay = openMasterTemplateOverlay;
-        vm.selectMasterTemplate = selectMasterTemplate;
-        vm.getMasterTemplateName = getMasterTemplateName;
-        vm.removeMasterTemplate = removeMasterTemplate;
-        vm.closeShortcuts = closeShortcuts;
-        vm.submit = submit;
-        vm.close = close;
-
-        function openInsertOverlay() {
-            var insertOverlay = {
-                allowedTypes: {
-                    macro: true,
-                    dictionary: true,
-                    partial: true,
-                    umbracoField: true
-                },
-                submit: function (model) {
-                    switch (model.insert.type) {
-                        case "macro":
-                            var macroObject = macroService.collectValueData(model.insert.selectedMacro, model.insert.macroParams, "Mvc");
-                            insert(macroObject.syntax);
-                            break;
-                        case "dictionary":
-                            var code = templateHelper.getInsertDictionarySnippet(model.insert.node.name);
-                            insert(code);
-                            break;
-                        case "partial":
-                            var code = templateHelper.getInsertPartialSnippet(model.insert.node.parentId, model.insert.node.name);
-                            insert(code);
-                            break;
-                        case "umbracoField":
-                            insert(model.insert.umbracoField);
-                            break;
-                    }
-                    editorService.close();
-                },
-                close: function (oldModel) {
-                    // close the dialog
-                    editorService.close();
-                    // focus editor
-                    vm.editor.focus();
-                }
-            };
-            editorService.insertCodeSnippet(insertOverlay);
-        }
-
-        function openMacroOverlay() {
-            var macroPicker = {
-                dialogData: {},
-                submit: function (model) {
-                    var macroObject = macroService.collectValueData(model.selectedMacro, model.macroParams, "Mvc");
-                    insert(macroObject.syntax);
-                    editorService.close();
-                },
-                close: function () {
-                    editorService.close();
-                    vm.editor.focus();
-                }
-            };
-            editorService.macroPicker(macroPicker);
-        }
-
-        function openPageFieldOverlay() {
-            var insertFieldEditor = {
-                submit: function (model) {
-                    insert(model.umbracoField);
-                    editorService.close();
-                },
-                close: function () {
-                    editorService.close();
-                    vm.editor.focus();
-                }
-            };
-            editorService.insertField(insertFieldEditor);
-        }
-
-
-        function openDictionaryItemOverlay() {
-
-            var labelKeys = [
-                "template_insertDictionaryItem",
-                "emptyStates_emptyDictionaryTree"
-            ];
-
-            localizationService.localizeMany(labelKeys).then(function (values) {
-                var title = values[0];
-                var emptyStateMessage = values[1];
-
-                var dictionaryItem = {
-                    section: "translation",
-                    treeAlias: "dictionary",
-                    entityType: "dictionary",
-                    multiPicker: false,
-                    title: title,
-                    emptyStateMessage: emptyStateMessage,
-                    select: function (node) {
-                        var code = templateHelper.getInsertDictionarySnippet(node.name);
-                        insert(code);
-                        editorService.close();
-                    },
-                    close: function (model) {
-                        // close dialog
-                        editorService.close();
-                        // focus editor
-                        vm.editor.focus();
-                    }
-                };
-
-                editorService.treePicker(dictionaryItem);
-
-            });
-
-        }
-
-        function openPartialOverlay() {
-
-            localizationService.localize("template_insertPartialView").then(function (value) {
-                var title = value;
-
-                var partialItem = {
-                    section: "settings",
-                    treeAlias: "partialViews",
-                    entityType: "partialView",
-                    multiPicker: false,
-                    title: title,
-                    filter: function (i) {
-                        if (i.name.indexOf(".cshtml") === -1 && i.name.indexOf(".vbhtml") === -1) {
-                            return true;
-                        }
-                    },
-                    filterCssClass: "not-allowed",
-                    select: function (node) {
-                        var code = templateHelper.getInsertPartialSnippet(node.parentId, node.name);
-                        insert(code);
-                        editorService.close();
-                    },
-                    close: function (model) {
-                        // close dialog
-                        editorService.close();
-                        // focus editor
-                        vm.editor.focus();
-                    }
-                };
-
-                editorService.treePicker(partialItem);
-            });
-        }
-
-        function openQueryBuilderOverlay() {
-            var queryBuilder = {
-                submit: function (model) {
-                    var code = templateHelper.getQuerySnippet(model.result.queryExpression);
-                    insert(code);
-                    editorService.close();
-                },
-                close: function () {
-                    editorService.close();
-                    // focus editor
-                    vm.editor.focus();
-                }
-            };
-            editorService.queryBuilder(queryBuilder);
-        }
-
-
-        function openSectionsOverlay() {
-            var templateSections = {
-                isMaster: vm.template.isMasterTemplate,
-                submit: function (model) {
-
-                    if (model.insertType === 'renderBody') {
-                        var code = templateHelper.getRenderBodySnippet();
-                        insert(code);
-                    }
-
-                    if (model.insertType === 'renderSection') {
-                        var code = templateHelper.getRenderSectionSnippet(model.renderSectionName, model.mandatoryRenderSection);
-                        insert(code);
-                    }
-
-                    if (model.insertType === 'addSection') {
-                        var code = templateHelper.getAddSectionSnippet(model.sectionName);
-                        wrap(code);
-                    }
-
-                    editorService.close();
-
-                },
-                close: function (model) {
-                    editorService.close();
-                    vm.editor.focus();
-                }
-            }
-            editorService.templateSections(templateSections);
-        }
-
-        function openMasterTemplateOverlay() {
-
-            // make collection of available master templates
-            var availableMasterTemplates = [];
-
-            // filter out the current template and the selected master template
-            vm.templates.forEach(function (template) {
-                if (template.alias !== vm.template.alias && template.alias !== vm.template.masterTemplateAlias) {
-                    var templatePathArray = template.path.split(',');
-                    // filter descendant templates of current template
-                    if (templatePathArray.indexOf(String(vm.template.id)) === -1) {
-                        availableMasterTemplates.push(template);
-                    }
-                }
-            });
-          
-            const editor = {
-                filterCssClass: 'not-allowed',
-                filter: item => !availableMasterTemplates.some(template => template.id == item.id),
-                submit: model => {
-                  const template = model.selection[0];
-                  if (template && template.alias) {
-                    vm.template.masterTemplateAlias = template.alias;
-                    setLayout(template.alias + ".cshtml");
-                  } else {
-                    vm.template.masterTemplateAlias = null;
-                    setLayout(null);
-                  }
-                  editorService.close();
-                },
-                close: () => editorService.close()
-            }
-
-            localizationService.localize("template_mastertemplate").then(title => {
-                editor.title = title;
-                
-                const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
-                if (currentTemplate) {
-                    editor.currentNode = {
-                        path: currentTemplate.path
-                    };
-                }
-
-                editorService.templatePicker(editor);
-            });
-
-        }
-
-        function selectMasterTemplate(template) {
-
-            if (template && template.alias) {
-                vm.template.masterTemplateAlias = template.alias;
-                setLayout(template.alias + ".cshtml");
-            } else {
-                vm.template.masterTemplateAlias = null;
-                setLayout(null);
-            }
-
-        }
-
-        function getMasterTemplateName(masterTemplateAlias, templates) {
-            if (masterTemplateAlias) {
-                var templateName = "";
-                templates.forEach(function (template) {
-                    if (template.alias === masterTemplateAlias) {
-                        templateName = template.name;
-                    }
-                });
-                return templateName;
-            }
-        }
-
-        function removeMasterTemplate() {
-
-            vm.template.masterTemplateAlias = null;
-
-            // call set layout with no paramters to set layout to null
-            setLayout();
-
-        }
-
-        function setLayout(templatePath) {
-
-            var templateCode = vm.editor.getValue();
-            var newValue = templatePath;
-            var layoutDefRegex = new RegExp("(@{[\\s\\S]*?Layout\\s*?=\\s*?)(\"[^\"]*?\"|null)(;[\\s\\S]*?})", "gi");
-
-            if (newValue !== undefined && newValue !== "") {
-                if (layoutDefRegex.test(templateCode)) {
-                    // Declaration exists, so just update it
-                    templateCode = templateCode.replace(layoutDefRegex, "$1\"" + newValue + "\"$3");
-                } else {
-                    // Declaration doesn't exist, so prepend to start of doc
-                    // TODO: Maybe insert at the cursor position, rather than just at the top of the doc?
-                    templateCode = "@{\n\tLayout = \"" + newValue + "\";\n}\n" + templateCode;
-                }
-            } else {
-                if (layoutDefRegex.test(templateCode)) {
-                    // Declaration exists, so just update it
-                    templateCode = templateCode.replace(layoutDefRegex, "$1null$3");
-                }
-            }
-
-            vm.editor.setValue(templateCode);
-            vm.editor.clearSelection();
-            vm.editor.navigateFileStart();
-
-            vm.editor.focus();
-            // set form state to $dirty
-            setFormState("dirty");
-
-        }
-
-
-        function insert(str) {
-            vm.editor.focus();
-            vm.editor.moveCursorToPosition(vm.currentPosition);
-            vm.editor.insert(str);
-
-            // set form state to $dirty
-            setFormState("dirty");
-        }
-
-        function wrap(str) {
-
-            var selectedContent = vm.editor.session.getTextRange(vm.editor.getSelectionRange());
-            str = str.replace("{0}", selectedContent);
-            vm.editor.insert(str);
-            vm.editor.focus();
-
-            // set form state to $dirty
-            setFormState("dirty");
-        }
-
-        function persistCurrentLocation() {
-            vm.currentPosition = vm.editor.getCursorPosition();
-        }
-
-        function changeAceEditor() {
-            setFormState("dirty");
-        }
-
-        function setFormState(state) {
-
-            // get the current form
-            var currentForm = angularHelper.getCurrentForm($scope);
-
-            // set state
-            if (state === "dirty") {
-                currentForm.$setDirty();
-            } else if (state === "pristine") {
-                currentForm.$setPristine();
-            }
-        }
-
-        function closeShortcuts() {
-            vm.showKeyboardShortcut = false;
-        }
-
-        function submit() {
-            if ($scope.model.submit) {
-                $scope.model.template = vm.template;
-                $scope.model.submit($scope.model);
-            }
-        }
-
-        function close() {
-            if ($scope.model.close) {
-                $scope.model.close();
-            }
-        }
-
-        vm.init();
+      });
 
     }
 
-    angular.module("umbraco").controller("Umbraco.Editors.Templates.EditController", TemplatesEditController);
+    function openPartialOverlay() {
+
+      localizationService.localize("template_insertPartialView").then(function (value) {
+        var title = value;
+
+        var partialItem = {
+          section: "settings",
+          treeAlias: "partialViews",
+          entityType: "partialView",
+          multiPicker: false,
+          title: title,
+          filter: function (i) {
+            if (i.name.indexOf(".cshtml") === -1 && i.name.indexOf(".vbhtml") === -1) {
+              return true;
+            }
+          },
+          filterCssClass: "not-allowed",
+          select: function (node) {
+            var code = templateHelper.getInsertPartialSnippet(node.parentId, node.name);
+            insert(code);
+            editorService.close();
+          },
+          close: function (model) {
+            // close dialog
+            editorService.close();
+            // focus editor
+            vm.editor.focus();
+          }
+        };
+
+        editorService.treePicker(partialItem);
+      });
+    }
+
+    function openQueryBuilderOverlay() {
+      var queryBuilder = {
+        submit: function (model) {
+          var code = templateHelper.getQuerySnippet(model.result.queryExpression);
+          insert(code);
+          editorService.close();
+        },
+        close: function () {
+          editorService.close();
+          // focus editor
+          vm.editor.focus();
+        }
+      };
+      editorService.queryBuilder(queryBuilder);
+    }
+
+
+    function openSectionsOverlay() {
+      var templateSections = {
+        isMaster: vm.template.isMasterTemplate,
+        submit: function (model) {
+
+          if (model.insertType === 'renderBody') {
+            var code = templateHelper.getRenderBodySnippet();
+            insert(code);
+          }
+
+          if (model.insertType === 'renderSection') {
+            var code = templateHelper.getRenderSectionSnippet(model.renderSectionName, model.mandatoryRenderSection);
+            insert(code);
+          }
+
+          if (model.insertType === 'addSection') {
+            var code = templateHelper.getAddSectionSnippet(model.sectionName);
+            wrap(code);
+          }
+
+          editorService.close();
+
+        },
+        close: function (model) {
+          editorService.close();
+          vm.editor.focus();
+        }
+      }
+      editorService.templateSections(templateSections);
+    }
+
+    function openMasterTemplateOverlay() {
+
+      // make collection of available master templates
+      var availableMasterTemplates = [];
+
+      // filter out the current template and the selected master template
+      vm.templates.forEach(function (template) {
+        if (template.alias !== vm.template.alias && template.alias !== vm.template.masterTemplateAlias) {
+          var templatePathArray = template.path.split(',');
+          // filter descendant templates of current template
+          if (templatePathArray.indexOf(String(vm.template.id)) === -1) {
+            availableMasterTemplates.push(template);
+          }
+        }
+      });
+
+      const editor = {
+        filterCssClass: 'not-allowed',
+        filter: item => !availableMasterTemplates.some(template => template.id == item.id),
+        submit: model => {
+          const template = model.selection[0];
+          if (template && template.alias) {
+            vm.template.masterTemplateAlias = template.alias;
+            setLayout(template.alias + ".cshtml");
+          } else {
+            vm.template.masterTemplateAlias = null;
+            setLayout(null);
+          }
+          editorService.close();
+        },
+        close: () => editorService.close()
+      }
+
+      localizationService.localize("template_mastertemplate").then(title => {
+        editor.title = title;
+
+        const currentTemplate = vm.templates.find(template => template.alias == vm.template.masterTemplateAlias);
+        if (currentTemplate) {
+          editor.currentNode = {
+            path: currentTemplate.path
+          };
+        }
+
+        editorService.templatePicker(editor);
+      });
+
+    }
+
+    function selectMasterTemplate(template) {
+
+      if (template && template.alias) {
+        vm.template.masterTemplateAlias = template.alias;
+        setLayout(template.alias + ".cshtml");
+      } else {
+        vm.template.masterTemplateAlias = null;
+        setLayout(null);
+      }
+
+    }
+
+    function getMasterTemplateName(masterTemplateAlias, templates) {
+      if (masterTemplateAlias) {
+        var templateName = "";
+        templates.forEach(function (template) {
+          if (template.alias === masterTemplateAlias) {
+            templateName = template.name;
+          }
+        });
+        return templateName;
+      }
+    }
+
+    function removeMasterTemplate() {
+
+      vm.template.masterTemplateAlias = null;
+
+      // call set layout with no paramters to set layout to null
+      setLayout();
+
+    }
+
+    function setLayout(templatePath) {
+
+      var templateCode = vm.editor.getValue();
+      var newValue = templatePath;
+      var layoutDefRegex = new RegExp("(@{[\\s\\S]*?Layout\\s*?=\\s*?)(\"[^\"]*?\"|null)(;[\\s\\S]*?})", "gi");
+
+      if (newValue !== undefined && newValue !== "") {
+        if (layoutDefRegex.test(templateCode)) {
+          // Declaration exists, so just update it
+          templateCode = templateCode.replace(layoutDefRegex, "$1\"" + newValue + "\"$3");
+        } else {
+          // Declaration doesn't exist, so prepend to start of doc
+          // TODO: Maybe insert at the cursor position, rather than just at the top of the doc?
+          templateCode = "@{\n\tLayout = \"" + newValue + "\";\n}\n" + templateCode;
+        }
+      } else {
+        if (layoutDefRegex.test(templateCode)) {
+          // Declaration exists, so just update it
+          templateCode = templateCode.replace(layoutDefRegex, "$1null$3");
+        }
+      }
+
+      vm.editor.setValue(templateCode);
+      vm.editor.clearSelection();
+      vm.editor.navigateFileStart();
+
+      vm.editor.focus();
+      // set form state to $dirty
+      setFormState("dirty");
+
+    }
+
+
+    function insert(str) {
+      vm.editor.focus();
+      vm.editor.moveCursorToPosition(vm.currentPosition);
+      vm.editor.insert(str);
+
+      // set form state to $dirty
+      setFormState("dirty");
+    }
+
+    function wrap(str) {
+
+      var selectedContent = vm.editor.session.getTextRange(vm.editor.getSelectionRange());
+      str = str.replace("{0}", selectedContent);
+      vm.editor.insert(str);
+      vm.editor.focus();
+
+      // set form state to $dirty
+      setFormState("dirty");
+    }
+
+    function persistCurrentLocation() {
+      vm.currentPosition = vm.editor.getCursorPosition();
+    }
+
+    function changeAceEditor() {
+      setFormState("dirty");
+    }
+
+    function setFormState(state) {
+
+      // get the current form
+      var currentForm = angularHelper.getCurrentForm($scope);
+
+      // set state
+      if (state === "dirty") {
+        currentForm.$setDirty();
+      } else if (state === "pristine") {
+        currentForm.$setPristine();
+      }
+    }
+
+    function closeShortcuts() {
+      vm.showKeyboardShortcut = false;
+    }
+
+    function submit() {
+      if ($scope.model.submit) {
+        $scope.model.template = vm.template;
+        $scope.model.submit($scope.model);
+      }
+    }
+
+    function close() {
+      if ($scope.model.close) {
+        $scope.model.close();
+      }
+    }
+
+    vm.init();
+
+  }
+
+  angular.module("umbraco").controller("Umbraco.Editors.Templates.EditController", TemplatesEditController);
 })();

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.html
@@ -23,15 +23,13 @@
 
             <umb-editor-container>
                 <umb-box>
-                    <umb-box-content ng-if="vm.runtimeModeProduction">
-                      <div class="umb-alert umb-alert--info">
-                        <localize key="template_runtimeModeProduction">Template content is not editable when using runtime mode <code>Production</code>.</localize>
-                      </div>
-                    </umb-box-content>
+        
+                    <umb-box-content>
+                        <div class="umb-alert umb-alert--info mb3" ng-if="vm.runtimeModeProduction">
+                          <localize key="template_runtimeModeProduction">Template content is not editable when using runtime mode <code>Production</code>.</localize>
+                        </div>
 
-                    <umb-box-content ng-if="!vm.runtimeModeProduction">
-
-                        <div class="flex" style="margin-bottom: 30px;">
+                        <div class="flex mb3" ng-if="!vm.runtimeModeProduction">
 
                             <div class="flex">
 
@@ -99,7 +97,7 @@
 
                         <div
                             data-element="code-editor"
-                            auto-scale="85"
+                            auto-scale="90"
                             umb-ace-editor="vm.aceOption"
                             model="vm.template.content">
                         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/templates/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/templates/edit.html
@@ -12,6 +12,7 @@
             <umb-editor-header
                 name="vm.template.name"
                 alias="vm.template.alias"
+                alias-locked="vm.runtimeModeProduction"
                 key="vm.template.key"
                 description="vm.template.virtualPath"
                 description-locked="true"
@@ -22,7 +23,13 @@
 
             <umb-editor-container>
                 <umb-box>
-                    <umb-box-content>
+                    <umb-box-content ng-if="vm.runtimeModeProduction">
+                      <div class="umb-alert umb-alert--info">
+                        <localize key="template_runtimeModeProduction">Template content is not editable when using runtime mode <code>Production</code>.</localize>
+                      </div>
+                    </umb-box-content>
+
+                    <umb-box-content ng-if="!vm.runtimeModeProduction">
 
                         <div class="flex" style="margin-bottom: 30px;">
 
@@ -106,6 +113,7 @@
                 <umb-editor-footer-content-left>
 
                     <umb-keyboard-shortcuts-overview
+                        ng-if="!vm.runtimeModeProduction"
                         model="vm.page.keyboardShortcutsOverview"
                         show-overlay="vm.showKeyboardShortcut"
                         on-close="vm.closeShortcuts()">

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -84,7 +86,8 @@ public class ContentTypeRepositoryTest : UmbracoIntegrationTest
                 FileSystems,
                 IOHelper,
                 ShortStringHelper,
-                Mock.Of<IViewHelper>());
+                Mock.Of<IViewHelper>(),
+                Mock.Of<IOptionsMonitor<RuntimeSettings>>());
             var repository = ContentTypeRepository;
             Template[] templates =
             {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -111,7 +111,7 @@ public class DocumentRepositoryTest : UmbracoIntegrationTest
     {
         appCaches ??= AppCaches;
 
-        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, Mock.Of<IViewHelper>());
+        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, Mock.Of<IViewHelper>(), Mock.Of<IOptionsMonitor<RuntimeSettings>>());
         var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>());
         var commonRepository =
             new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
@@ -59,7 +60,7 @@ public class TemplateRepositoryTest : UmbracoIntegrationTest
     private IViewHelper ViewHelper => GetRequiredService<IViewHelper>();
 
     private ITemplateRepository CreateRepository(IScopeProvider provider) =>
-        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, ViewHelper);
+        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, ViewHelper, Mock.Of<IOptionsMonitor<RuntimeSettings>>());
 
     [Test]
     public void Can_Instantiate_Repository()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When using runtime mode `Production`, all Razor views/templates need to be compiled at build/publish time, because Razor runtime compilation is disabled in this mode. This wasn't apparent in the backoffice and you could still edit templates, possibly causing confusion why changes wouldn't get picked up...

This PR makes contents and filename in the code editor (and template repository) read-only and adds a warning when the runtime mode is set to `Production`:

![Template editing when using runtime mode Production](https://user-images.githubusercontent.com/1051287/179091115-e5351f87-d1e6-40e1-9379-6924f344897d.png)

To quickly test this, add the following class (after you've created some document types and templates) to configure Production runtime mode without running any of the validators:
```c#
using Microsoft.Extensions.DependencyInjection.Extensions;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Configuration.Models;
using Umbraco.Cms.Infrastructure.Runtime;

public class RuntimeModeComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.Configure<RuntimeSettings>(x => x.Mode = RuntimeMode.Production).RemoveAll<IRuntimeModeValidator>();
}
```

PR https://github.com/umbraco/Umbraco-CMS/pull/12631 mentions also removing the `CopyRazorGenerateFilesToPublishDirectory` property from the project file, but we can now keep this, so the template contents is still available (as read-only) on a published application. We might also require the template files to exist for Umbraco Deploy to generate correct template signatures, as you could otherwise get schema mismatches (I haven't tested this assumption though).