### PR TITLE
Tweaks the composition dialog in the content type editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-checkbox-list.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-checkbox-list.less
@@ -47,6 +47,7 @@
 
 .umb-checkbox-list__item-icon-wrapper {
   position: relative;
+  display: flex;
 
   .umb-button__progress {
     width: 10px;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -16,45 +16,52 @@
             <umb-box>
                 <umb-box-content>
 
-                    <div class="umb-control-group">
+                  <div ng-if="model.availableCompositeContentTypes.length !== 0">
 
-                        <umb-search-filter
-                            input-id="composition-search"
-                            model="searchTerm"
-                            label-key="placeholders_filter"
-                            text="Type to filter..."
-                            css-class="w-100"
-                            auto-focus="true">
-                        </umb-search-filter>
-
+                    <div class="mb2">
+                      <localize key="contentTypeEditor_compositionsDescription">
+                        Inherit tabs and properties from an existing Document Type. New tabs will be added to the current Document Type or
+                        merged if a tab with an identical name exists.
+                      </localize>
                     </div>
 
                     <div class="umb-control-group">
-                        <localize key="contentTypeEditor_compositionsDescription">Inherit tabs and properties from an existing Document Type. New tabs will be added to the current Document Type or
-                        merged if a tab with an identical name exists.</localize>
+
+                      <umb-search-filter input-id="composition-search"
+                                         model="searchTerm"
+                                         label-key="placeholders_filter"
+                                         text="Type to filter..."
+                                         css-class="w-100"
+                                         auto-focus="true">
+                      </umb-search-filter>
+
                     </div>
 
-                    <umb-empty-state ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes <= 1"
-                                     position="center">
+                  </div>
+
+                    <div ng-if="model.availableCompositeContentTypes.length === 0">
+
+                      <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes <= 1">
                         <localize key="contentTypeEditor_noAvailableCompositions">There are no Content Types available to use as a composition.</localize>
-                    </umb-empty-state>
+                      </div>
 
-                    <umb-empty-state ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1">
+                      <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1">
                         <localize key="contentTypeEditor_compositionInUse">This Content Type is used in a composition, and therefore cannot be composed itself.</localize>
-                    </umb-empty-state>
+                      </div>
 
-                    <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1 && model.whereCompositionUsed.length > 0">
+                      <div ng-if="model.availableCompositeContentTypes.length === 0 && model.totalContentTypes > 1 && model.whereCompositionUsed.length > 0">
                         <h5><localize key="contentTypeEditor_compositionUsageHeading">Where is this composition used?</localize></h5>
                         <p><localize key="contentTypeEditor_compositionUsageSpecification">This composition is currently used in the composition of the following Content Types:</localize></p>
                         <ul class="umb-checkbox-list">
-                            <li class="umb-checkbox-list__item"
-                                ng-repeat="contentTypeEntity in model.whereCompositionUsed">
-                                <a ng-click="vm.openContentType(contentTypeEntity.contentType, model.section)">
-                                    <umb-icon icon="{{contentTypeEntity.contentType.icon}}"></umb-icon>
-                                    &nbsp;{{contentTypeEntity.contentType.name}}
-                                </a>
-                            </li>
+                          <li class="umb-checkbox-list__item"
+                              ng-repeat="contentTypeEntity in model.whereCompositionUsed">
+                            <a ng-click="vm.openContentType(contentTypeEntity.contentType, model.section)">
+                              <umb-icon icon="{{contentTypeEntity.contentType.icon}}"></umb-icon>
+                              &nbsp;{{contentTypeEntity.contentType.name}}
+                            </a>
+                          </li>
                         </ul>
+                      </div>
                     </div>
 
                     <div class="umb-control-group -no-border" ng-if="vm.availableGroups.length > 0">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/compositions/compositions.html
@@ -28,7 +28,7 @@
                     <div class="umb-control-group">
 
                       <umb-search-filter input-id="composition-search"
-                                         model="searchTerm"
+                                         model="vm.searchTerm"
                                          label-key="placeholders_filter"
                                          text="Type to filter..."
                                          css-class="w-100"
@@ -65,13 +65,13 @@
                     </div>
 
                     <div class="umb-control-group -no-border" ng-if="vm.availableGroups.length > 0">
-                        <ul class="umb-checkbox-list" ng-repeat="group in vm.availableGroups | filter:searchTerm">
+                        <ul class="umb-checkbox-list" ng-repeat="group in vm.availableGroups | filter:vm.searchTerm">
                             <li ng-show="vm.availableGroups.length > 1">
                                 <umb-icon icon="icon-folder" class="umb-checkbox-list__item-icon"></umb-icon>
                                 {{group.containerPath}}
                             </li>
                             <li class="umb-checkbox-list__item"
-                                ng-repeat="compositeContentType in group.compositeContentTypes | orderBy:'contentType.name' | filter:searchTerm"
+                                ng-repeat="compositeContentType in group.compositeContentTypes | orderBy:'contentType.name' | filter:vm.searchTerm"
                                 ng-class="{'-disabled': (compositeContentType.allowed === false && !compositeContentType.selected) || compositeContentType.inherited, '-selected': compositeContentType.selected}">
 
                                 <div class="umb-checkbox-list__item-checkbox" ng-class="{'-selected': compositeContentType.selected }">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This ones tweaks the compositions dialog a little, in order to make it look prettier.


- removes the search field if no content types is available
- change the styling on the info text regarding missing content types
- moves the search field closer to the content type list

Before:
![2022-07-15-13-05-09-890__kDP9J2Jq1J](https://user-images.githubusercontent.com/3726467/179213328-a3a6326c-649e-4f3b-adc3-ab1836674481.png)


After:
![2022-07-15-13-10-11-293__UZ6cum0bXQ](https://user-images.githubusercontent.com/3726467/179213364-8b146d41-e11f-4ca9-b607-d88695d5aefb.png)
![2022-07-15-13-09-59-007__OK4hfitiS2](https://user-images.githubusercontent.com/3726467/179213372-fdf3c997-be79-4513-b2f7-f8868a327fd7.png)


### To test:
Verify that the composition dialog looks like the screenshots above, and that the necessary information/UI is available.
