### PR TITLE
Removes bottom margin from template select box in content node info

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-content-node-info.html
@@ -163,7 +163,7 @@
                 <umb-control-group ng-if="disableTemplates == false" data-element="node-info-template" label="@template_template" alias="template">
 
                     <div class="flex items-center">
-                        <select class="input-block-level"
+                        <select class="input-block-level mb0"
                                 id="template"
                                 ng-model="node.template"
                                 ng-options="key as value for (key, value) in availableTemplates"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed the template picker in the info tab on a content node is slightly off center. This is because the select box has a bottom margin. I've removed it with this PR.

Before:
![2022-07-15-12-53-31-908__1MqH5dbiCL](https://user-images.githubusercontent.com/3726467/179214461-21023218-8f07-4906-b604-16170f306f34.png)

After:
![2022-07-15-12-53-41-119__FZHt9b6s6b](https://user-images.githubusercontent.com/3726467/179214470-96534cb7-6e68-4eba-9c33-0359ae7bbe01.png)


<!-- Thanks for contributing to Umbraco CMS! -->
