### PR TITLE
Fix sections wording

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/users/umb-user-group-preview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/umb-user-group-preview.html
@@ -9,7 +9,7 @@
             <span>
                 <span class="bold"><localize key="main_sections">Sections</localize>:</span>
                 <span ng-repeat="section in sections" class="umb-user-group-preview__permission">{{ section.name }}</span>
-                <span ng-if="sections.length === 0">All sections</span>
+                <span ng-if="sections.length === 0">No sections</span>
             </span>
         </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/groups/groups.html
@@ -96,7 +96,7 @@
                 <div class="umb-table-cell">
                     <div>
                         <span ng-repeat="section in group.sections">{{ section.name }}<span ng-if="!$last">, </span></span>
-                        <span ng-if="group.sections.length === 0">All sections</span>
+                        <span ng-if="group.sections.length === 0">No sections</span>
                     </div>
                 </div>
                 <div class="umb-table-cell umb-table-cell--small">


### PR DESCRIPTION
# Notes
- In sections right now, if no sections are selected, it displays as you have access to "All sections", while this means exactly the opposite, this PR remedies that

![image](https://user-images.githubusercontent.com/70372949/179502283-e7c5b317-0440-45be-8dde-1e30782067ab.png)
![image](https://user-images.githubusercontent.com/70372949/179504295-7adfe1db-957a-4ffe-b5f3-8838c900f5a1.png)

# How to test
- Run umbraco
- Navigate to Users > Groups
- Assert that it now says "No sections" instead of "All Sections"
