### PR TITLE
Don't allocate new object array instances when indexing

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
@@ -16,9 +16,9 @@ namespace Umbraco.Cms.Infrastructure.Examine;
 public class ContentValueSetBuilder : BaseValueSetBuilder<IContent>, IContentValueSetBuilder,
     IPublishedContentValueSetBuilder
 {
-    private static readonly NoValue = new object[] { "n" };
-    private static readonly YesValue = new object[] { "y" };
-    
+    private static readonly object[] NoValue = new[] { "n" };
+    private static readonly object[] YesValue = new[] { "y" };
+
     private readonly IScopeProvider _scopeProvider;
 
     private readonly IShortStringHelper _shortStringHelper;

--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
@@ -75,7 +75,7 @@ public class ContentValueSetBuilder : BaseValueSetBuilder<IContent>, IContentVal
             {
                 { "icon", c.ContentType.Icon?.Yield() ?? Enumerable.Empty<string>() },
                 {
-                    UmbracoExamineFieldNames.PublishedFieldName, c.Published ? NoValue : YesValue
+                    UmbracoExamineFieldNames.PublishedFieldName, c.Published ? YesValue : NoValue
                 }, // Always add invariant published value
                 { "id", new object[] { c.Id } },
                 { UmbracoExamineFieldNames.NodeKeyFieldName, new object[] { c.Key } },

--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetBuilder.cs
@@ -16,6 +16,9 @@ namespace Umbraco.Cms.Infrastructure.Examine;
 public class ContentValueSetBuilder : BaseValueSetBuilder<IContent>, IContentValueSetBuilder,
     IPublishedContentValueSetBuilder
 {
+    private static readonly NoValue = new object[] { "n" };
+    private static readonly YesValue = new object[] { "y" };
+    
     private readonly IScopeProvider _scopeProvider;
 
     private readonly IShortStringHelper _shortStringHelper;
@@ -72,7 +75,7 @@ public class ContentValueSetBuilder : BaseValueSetBuilder<IContent>, IContentVal
             {
                 { "icon", c.ContentType.Icon?.Yield() ?? Enumerable.Empty<string>() },
                 {
-                    UmbracoExamineFieldNames.PublishedFieldName, new object[] { c.Published ? "y" : "n" }
+                    UmbracoExamineFieldNames.PublishedFieldName, c.Published ? NoValue : YesValue
                 }, // Always add invariant published value
                 { "id", new object[] { c.Id } },
                 { UmbracoExamineFieldNames.NodeKeyFieldName, new object[] { c.Key } },
@@ -102,12 +105,12 @@ public class ContentValueSetBuilder : BaseValueSetBuilder<IContent>, IContentVal
                 },
                 { "writerID", new object[] { c.WriterId } },
                 { "templateID", new object[] { c.TemplateId ?? 0 } },
-                { UmbracoExamineFieldNames.VariesByCultureFieldName, new object[] { "n" } },
+                { UmbracoExamineFieldNames.VariesByCultureFieldName, NoValue },
             };
 
             if (isVariant)
             {
-                values[UmbracoExamineFieldNames.VariesByCultureFieldName] = new object[] { "y" };
+                values[UmbracoExamineFieldNames.VariesByCultureFieldName] = YesValue;
 
                 foreach (var culture in c.AvailableCultures)
                 {


### PR DESCRIPTION
There's no reason to allocate new object[] array instances for each ValueSet created for the "y" or "n" values going into the index. This just creates a single object[] for each "y" or "n" value which will save on a ton of allocations when re indexing a bunch of content.

There's an easy way to make further allocation reductions too (prob a separate PR) since there is no reason to create new object[] allocations for: CreatorId, WriterId, Level, TemplateId, Culture. Each of these can be returned from a concurrent dictionary since these values are finite and there won't be too many of each so we can just keep an internal dictionary of these object[] instances.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
