### PR TITLE
Fix Nucache rebuilding more type caches than necessary

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
+++ b/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
@@ -61,6 +61,25 @@ public interface IPublishedSnapshotService : IDisposable
         IReadOnlyCollection<int>? mediaTypeIds = null,
         IReadOnlyCollection<int>? memberTypeIds = null);
 
+
+    /// <summary>
+    ///     Rebuilds all internal database caches (but does not reload).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Forces the snapshot service to rebuild its internal database caches. For instance, some caches
+    ///         may rely on a database table to store pre-serialized version of documents.
+    ///     </para>
+    ///     <para>
+    ///         This does *not* reload the caches. Caches need to be reloaded, for instance via
+    ///         <see cref="DistributedCache" /> RefreshAllPublishedSnapshot method.
+    ///     </para>
+    /// </remarks>
+    void RebuildAll()
+    {
+        Rebuild(Array.Empty<int>(),Array.Empty<int>(), Array.Empty<int>());
+    }
+
     /* An IPublishedCachesService implementation can rely on transaction-level events to update
      * its internal, database-level data, as these events are purely internal. However, it cannot
      * rely on cache refreshers CacheUpdated events to update itself, as these events are external

--- a/src/Umbraco.Infrastructure/Migrations/PostMigrations/PublishedSnapshotRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PostMigrations/PublishedSnapshotRebuilder.cs
@@ -26,7 +26,7 @@ public class PublishedSnapshotRebuilder : IPublishedSnapshotRebuilder
     /// <inheritdoc />
     public void Rebuild()
     {
-        _publishedSnapshotService.Rebuild();
+        _publishedSnapshotService.RebuildAll();
         _distributedCache.RefreshAllPublishedSnapshot();
     }
 }

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -97,6 +97,7 @@ public class NuCacheContentRepository : RepositoryBase, INuCacheContentRepositor
         OnRepositoryRefreshed(serializer, member, false);
     }
 
+    /// <inheritdoc/>
     public void Rebuild(
         IReadOnlyCollection<int>? contentTypeIds = null,
         IReadOnlyCollection<int>? mediaTypeIds = null,
@@ -107,9 +108,18 @@ public class NuCacheContentRepository : RepositoryBase, INuCacheContentRepositor
             | ContentCacheDataSerializerEntityType.Media
             | ContentCacheDataSerializerEntityType.Member);
 
-        RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds);
-        RebuildMediaDbCache(serializer, _nucacheSettings.Value.SqlPageSize, mediaTypeIds);
-        RebuildMemberDbCache(serializer, _nucacheSettings.Value.SqlPageSize, memberTypeIds);
+        if(contentTypeIds != null)
+        {
+            RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds);
+        }
+        if (mediaTypeIds != null)
+        {
+            RebuildMediaDbCache(serializer, _nucacheSettings.Value.SqlPageSize, mediaTypeIds);
+        }
+        if (memberTypeIds != null)
+        {
+            RebuildMemberDbCache(serializer, _nucacheSettings.Value.SqlPageSize, memberTypeIds);
+        }
     }
 
     // assumes content tree lock

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentService.cs
@@ -51,7 +51,7 @@ public class NuCacheContentService : RepositoryService, INuCacheContentService
             using (_profilingLogger.TraceDuration<NuCacheContentService>(
                        $"Rebuilding NuCache database with {serializer} serializer"))
             {
-                Rebuild();
+                RebuildAll();
                 _keyValueService.SetValue(NuCacheSerializerKey, serializer.ToString());
             }
         }
@@ -114,10 +114,16 @@ public class NuCacheContentService : RepositoryService, INuCacheContentService
         => _repository.RefreshMember(member);
 
     /// <inheritdoc />
+    public void RebuildAll()
+    {
+        Rebuild(Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>());
+    }
+
+    /// <inheritdoc />
     public void Rebuild(
-        IReadOnlyCollection<int>? contentTypeIds = null,
-        IReadOnlyCollection<int>? mediaTypeIds = null,
-        IReadOnlyCollection<int>? memberTypeIds = null)
+    IReadOnlyCollection<int>? contentTypeIds = null,
+    IReadOnlyCollection<int>? mediaTypeIds = null,
+    IReadOnlyCollection<int>? memberTypeIds = null)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(repositoryCacheMode: RepositoryCacheMode.Scoped))
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/PublishedSnapshotCacheStatusController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PublishedSnapshotCacheStatusController.cs
@@ -34,7 +34,8 @@ public class PublishedSnapshotCacheStatusController : UmbracoAuthorizedApiContro
     [HttpPost]
     public string RebuildDbCache()
     {
-        _publishedSnapshotService.Rebuild();
+        //Rebuild All
+        _publishedSnapshotService.RebuildAll();
         return _publishedSnapshotStatus.GetStatus();
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/NuCacheRebuildTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/NuCacheRebuildTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.PublishedCache;
@@ -59,7 +60,7 @@ public class NuCacheRebuildTests : UmbracoIntegrationTest
 
         Assert.AreEqual("hello", segment);
 
-        PublishedSnapshotService.Rebuild();
+        PublishedSnapshotService.RebuildAll();
 
         cachedContent = ContentService.GetById(content.Id);
         segment = urlSegmentProvider.GetUrlSegment(cachedContent);
@@ -76,7 +77,7 @@ public class NuCacheRebuildTests : UmbracoIntegrationTest
         // The page has now been published, so we should see the new url segment
         Assert.AreEqual("goodbye", segment);
 
-        PublishedSnapshotService.Rebuild();
+        PublishedSnapshotService.RebuildAll();
         cachedContent = ContentService.GetById(content.Id);
         segment = urlSegmentProvider.GetUrlSegment(cachedContent);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Fix Nucache rebuilding more type caches than necessary. The Rebuild method is intended per it's existing docs to not rebuild the cache when the typeids are null, however this behavior has been broken. This results in slow cache rebuilds when rebuilding a limited number of types. For example `Rebuild(new int[] {1234},null,null)` results in cache rebuilds for content with content type 1234 having it's nucache rebuilt, as well as all media and members in the cache, which occurs if modifying content type 1234 via the backoffice ui and can be incredibly slow.

This pr fixes the issue by correcting the implementation of Rebuild, and adding a RebuildAll() to make it clearer to implementers how to rebuild all types vs a limited set of types.

<!-- Thanks for contributing to Umbraco CMS! -->
