### PR TITLE
Check if content has an identity before attempting to get it's ancestors

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1797,7 +1797,7 @@ public class ContentController : ContentControllerBase
 
     private IEnumerable<string> GetPublishedCulturesFromAncestors(IContent? content)
     {
-        if (content?.HasIdentity == false)
+        if (content?.HasIdentity == false && content.ParentId != -1)
         {
             content = _contentService.GetById(content.ParentId);
         }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1797,6 +1797,11 @@ public class ContentController : ContentControllerBase
 
     private IEnumerable<string> GetPublishedCulturesFromAncestors(IContent? content)
     {
+        if (content?.HasIdentity == false)
+        {
+            content = _contentService.GetById(content.ParentId);
+        }
+
         if (content?.ParentId == -1)
         {
             return content.PublishedCultures;

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1797,7 +1797,7 @@ public class ContentController : ContentControllerBase
 
     private IEnumerable<string> GetPublishedCulturesFromAncestors(IContent? content)
     {
-        if (content?.HasIdentity == false && content.ParentId != -1)
+        if (content?.ParentId != -1 && content?.HasIdentity == false)
         {
             content = _contentService.GetById(content.ParentId);
         }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1797,7 +1797,7 @@ public class ContentController : ContentControllerBase
 
     private IEnumerable<string> GetPublishedCulturesFromAncestors(IContent? content)
     {
-        if (content?.ParentId != -1 && content?.HasIdentity == false)
+        if (content?.ParentId is not -1 && content?.HasIdentity is false)
         {
             content = _contentService.GetById(content.ParentId);
         }


### PR DESCRIPTION
This fixes #12732 

I'm not entirely sure if this is the correct fix, but it prevents the `OverflowOrFormatException` and it still gets all the cultures from the ancestors. 
The other fix I tried was to add `StringSplitOptions.RemoveEmptyEntries` in `GetAncestorIds`:

```csharp
 public static IEnumerable<int>? GetAncestorIds(this IContent content) =>
        content.Path?.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
```

This works, but it would just return an empty collection. The fix in this PR still gets the cultures of the ancestors.