### PR TITLE
V10: fix for editable tabs in Firefox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-tab.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-tab.html
@@ -28,9 +28,9 @@
                       ng-if="vm.tab.inherited">
             </umb-icon>
             <ng-form name="tabNameForm" data-element="tab-name">
-                <div class="umb-group-builder__tab-name" ng-if="vm.tab.inherited" title="{{vm.tab.alias}}">{{ vm.tab.name }}</div>
+                <div class="umb-group-builder__tab-name" ng-if="vm.tab.inherited || !vm.isOpen" title="{{vm.tab.alias}}">{{ vm.tab.name }}</div>
                 <input
-                    ng-if="!vm.tab.inherited"
+                    ng-if="!vm.tab.inherited && vm.isOpen"
                     class="umb-group-builder__group-title-input"
                     data-element="tab-name-field"
                     type="text"
@@ -40,7 +40,7 @@
                     title="{{vm.tab.alias}}"
                     ng-model="vm.tab.name"
                     ng-class="{'-placeholder': vm.tab.name == ''}"
-                    ng-disabled="!vm.isOpen || vm.allowChangeName === false"
+                    ng-disabled="vm.allowChangeName === false"
                     ng-change="vm.changeName()"
                     umb-auto-focus
                     umb-auto-resize


### PR DESCRIPTION
Possible fix for #12603

Would like for this to be tested in multiple browsers!

### Description

This fix prevents Firefox (and possibly others) from preventing the click event, which now bubbles up as it should. I have not looked into why the input field might be stopping events from bubbling, because it seems to me that a better solution would be to simply not show any input fields in the DOM before a tab is actually active (i.e. the `is-open` property is set to true).

Firefox 102 on MacOS:
![Jul-25-2022 15-32-54](https://user-images.githubusercontent.com/752371/180792155-b15d4513-85b8-43ff-a24b-892351ff5e64.gif)


<!-- Thanks for contributing to Umbraco CMS! -->
