### PR TITLE
V10: Show more telemetry info on the installer

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoInstall/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoInstall/Index.cshtml
@@ -26,7 +26,7 @@
 
     <div id="overlay" ng-cloak ng-animate="'fade'" ng-show="installer.done"></div>
 
-    <div id="installer" class="absolute-center clearfix"
+    <div id="installer"
          ng-cloak
          ng-animate="'fade'"
          ng-show="installer.configuring">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2528,7 +2528,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="settingsPublishedStatus">Published Status</key>
     <key alias="settingsModelsBuilder">Models Builder</key>
     <key alias="settingsHealthCheck">Health Check</key>
-    <key alias="settingsAnalytics">Analytics</key>
+    <key alias="settingsAnalytics">Telemetry data</key>
     <key alias="settingsProfiler">Profiling</key>
     <key alias="memberIntro">Getting Started</key>
     <key alias="formsInstall">Install Umbraco Forms</key>
@@ -2886,8 +2886,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="searchResults">items returned</key>
   </area>
   <area alias="analytics">
-    <key alias="consentForAnalytics">Consent for analytics</key>
-    <key alias="analyticsLevelSavedSuccess">Analytics level saved!</key>
+    <key alias="consentForAnalytics">Consent for telemetry data</key>
+    <key alias="analyticsLevelSavedSuccess">Telemetry level saved!</key>
     <key alias="analyticsDescription">
       <![CDATA[
       In order to improve Umbraco and add new functionality based on as relevant information as possible,

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2903,12 +2903,13 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="detailedLevelDescription">
       <![CDATA[
           We will send:
-          <br>- Anonymized site ID, umbraco version, and packages installed.
-          <br>- Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, and Property Editors in use.
-          <br>- System information: Webserver, server OS, server framework, server OS language, and database provider.
-          <br>- Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.
-          <br>
-          <br><i>We might change what we send on the Detailed level in the future. If so, it will be listed above.
+          <ul>
+            <li>Anonymized site ID, umbraco version, and packages installed.</li>
+            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, and Property Editors in use.</li>
+            <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
+            <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.</li>
+          </ul>
+          <i>We might change what we send on the Detailed level in the future. If so, it will be listed above.
           <br>By choosing "Detailed" you agree to current and future anonymized information being collected.</i>
        ]]>
     </key>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
@@ -1,144 +1,188 @@
 <div ng-controller="Umbraco.Installer.DataBaseController">
+  <h1>Configure your database</h1>
+  <p>
+    Enter connection and authentication details for the database you want to
+    install Umbraco on
+  </p>
 
-    <h1>Configure your database</h1>
-    <p>
-        Enter connection and authentication details for the database you want to install Umbraco on
-    </p>
+  <form
+    name="myForm"
+    class="form-horizontal -no-margin-bottom"
+    novalidate
+    ng-submit="validateAndForward();"
+  >
+    <div class="control-group">
+      <legend>What type of database do you use?</legend>
+      <label class="control-label" for="dbType">Database type</label>
+      <div class="controls">
+        <select
+          id="dbType"
+          ng-options="db as db.displayName for db in dbs"
+          required
+          ng-model="selectedDbMeta"
+        ></select>
+      </div>
+    </div>
 
-    <form name="myForm" class="form-horizontal" novalidate ng-submit="validateAndForward();">
-        <div class="control-group">
-            <legend>What type of database do you use?</legend>
-            <label class="control-label" for="dbType">Database type</label>
+    <div ng-if="isCustom()">
+      <legend>What is the exact connection string we should use?</legend>
+      <div class="control-group">
+        <label class="control-label" for="Custom_connectionString"
+          >Connection string</label
+        >
+        <div class="controls">
+          <textarea
+            id="Custom_connectionString"
+            class="input-block-level"
+            required
+            ng-model="installer.current.model.connectionString"
+            rows="5"
+          ></textarea>
+          <small class="inline-help"
+            >Enter a valid database connection string.</small
+          >
+        </div>
+      </div>
+
+      <div class="control-group">
+        <label class="control-label" for="Custom_providerName"
+          >Provider Name</label
+        >
+        <div class="controls">
+          <select
+            id="dbType"
+            ng-options="providerName for providerName in providerNames"
+            required
+            ng-model="installer.current.model.providerName"
+          ></select>
+        </div>
+      </div>
+    </div>
+
+    <div ng-if="!isCustom()">
+      <div class="row">
+        <legend>Where do we find your database?</legend>
+
+        <div ng-if="selectedDbMeta.requiresServer">
+          <div class="span6">
+            <div class="control-group">
+              <label class="control-label" for="Sql_Server">Server</label>
+              <div class="controls">
+                <input
+                  type="text"
+                  id="Sql_Server"
+                  placeholder="{{selectedDbMeta.serverPlaceholder}}"
+                  required
+                  ng-model="installer.current.model.server"
+                />
+                <small class="inline-help">Enter server domain or IP</small>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="span6">
+          <div class="control-group">
+            <label class="control-label" for="Sql_databaseName"
+              >Database name</label
+            >
             <div class="controls">
-                <select id="dbType"
-                        ng-options="db as db.displayName for db in dbs"
-                        required
-                        ng-model="selectedDbMeta">
-                </select>
+              <input
+                type="text"
+                id="Sql_databaseName"
+                placeholder="umbraco-cms"
+                required
+                ng-model="installer.current.model.databaseName"
+              />
+              <small class="inline-help">Enter the name of the database</small>
             </div>
+          </div>
         </div>
+      </div>
 
-        <div ng-if="isCustom()">
-            <legend>What is the exact connection string we should use?</legend>
-            <div class="control-group">
-                <label class="control-label" for="Custom_connectionString">Connection string</label>
-                  <div class="controls">
-                    <textarea id="Custom_connectionString"
-                              class="input-block-level"
-                              required
-                              ng-model="installer.current.model.connectionString"
-                              rows="5"></textarea>
-                    <small class="inline-help">Enter a valid database connection string.</small>
-                </div>
-            </div>
-
-           <div class="control-group">
-                <label class="control-label" for="Custom_providerName">Provider Name</label>
-                  <div class="controls">
-                       <select id="dbType"
-                               ng-options="providerName for providerName in providerNames"
-                               required
-                               ng-model="installer.current.model.providerName">
-                        </select>
-                </div>
-            </div>
-        </div>
-
-
-
-        <div ng-if="!isCustom()">
-            <div class="row">
-                <legend>Where do we find your database?</legend>
-
-                <div ng-if="selectedDbMeta.requiresServer">
-                    <div class="span6">
-                        <div class="control-group">
-                            <label class="control-label" for="Sql_Server">Server</label>
-                            <div class="controls">
-                                <input type="text" id="Sql_Server"
-                                       placeholder="{{selectedDbMeta.serverPlaceholder}}"
-                                       required
-                                       ng-model="installer.current.model.server" />
-                                <small class="inline-help">Enter server domain or IP</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="span6">
-                    <div class="control-group">
-                        <label class="control-label" for="Sql_databaseName">Database name</label>
-                        <div class="controls">
-                            <input type="text" id="Sql_databaseName"
-                                   placeholder="umbraco-cms"
-                                   required
-                                   ng-model="installer.current.model.databaseName" />
-                            <small class="inline-help">Enter the name of the database</small>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div ng-if="selectedDbMeta.requiresCredentials">
-                <div class="row">
-                    <legend>What credentials are used to access the database?</legend>
-                    <div class="span6">
-                        <div class="control-group" ng-if="!installer.current.model.integratedAuth">
-                            <label class="control-label" for="Sql_login">Login</label>
-                            <div class="controls">
-                                <input type="text" id="Sql_login"
-                                       placeholder="umbraco-db-user"
-                                       required
-                                       ng-model="installer.current.model.login" />
-                                <small class="inline-help">Enter the database user name</small>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="span6">
-                        <div class="control-group" ng-if="!installer.current.model.integratedAuth">
-                        <label class="control-label" for="Sql_password">Password</label>
-                            <div class="controls">
-                                <input type="password" id="Sql_password"
-                                       placeholder="umbraco-db-password"
-                                       required
-                                       ng-model="installer.current.model.password" />
-                                <small class="inline-help">Enter the database password</small>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="span12 control-group" ng-if="selectedDbMeta.supportsIntegratedAuthentication">
-                        <div class="controls">
-                            <label class="checkbox">
-                                <input type="checkbox" ng-model="installer.current.model.integratedAuth" />
-                                Use integrated authentication
-                            </label>
-                        </div>
-                    </div>
-                </div>
-            </div>
-       </div>
-
-
+      <div ng-if="selectedDbMeta.requiresCredentials">
         <div class="row">
-            <div class="control-group">
-                <div class="controls">
-                    <input type="submit" value="Install" class="btn btn-success"
-                           ng-disabled="myForm.$invalid || checking"
-                           ng-class="{disabled:myForm.$invalid}" />
-
-                    <button class="btn btn-info" ng-click="restart()">Go back</button>
-
-                    <span class="inline-help" ng-if="checking" ng-animate="'fade'">
-                        Validating your database connection...
-                    </span>
-
-                    <span class="inline-help error" ng-if="invalidDbDns" ng-animate="'fade'">
-                        Could not connect to database
-                    </span>
-                </div>
+          <legend>What credentials are used to access the database?</legend>
+          <div class="span6">
+            <div
+              class="control-group"
+              ng-if="!installer.current.model.integratedAuth"
+            >
+              <label class="control-label" for="Sql_login">Login</label>
+              <div class="controls">
+                <input
+                  type="text"
+                  id="Sql_login"
+                  placeholder="umbraco-db-user"
+                  required
+                  ng-model="installer.current.model.login"
+                />
+                <small class="inline-help">Enter the database user name</small>
+              </div>
             </div>
+          </div>
+
+          <div class="span6">
+            <div
+              class="control-group"
+              ng-if="!installer.current.model.integratedAuth"
+            >
+              <label class="control-label" for="Sql_password">Password</label>
+              <div class="controls">
+                <input
+                  type="password"
+                  id="Sql_password"
+                  placeholder="umbraco-db-password"
+                  required
+                  ng-model="installer.current.model.password"
+                />
+                <small class="inline-help">Enter the database password</small>
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="span12 control-group"
+            ng-if="selectedDbMeta.supportsIntegratedAuthentication"
+          >
+            <div class="controls">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  ng-model="installer.current.model.integratedAuth"
+                />
+                Use integrated authentication
+              </label>
+            </div>
+          </div>
         </div>
-    </form>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="control-actions controls-space-between">
+        <button class="btn btn-info" ng-click="restart()">Go back</button>
+        <button
+          class="btn btn-success"
+          ng-disabled="myForm.$invalid || checking"
+          ng-class="{disabled:myForm.$invalid}"
+        >
+          Install
+        </button>
+      </div>
+      <div>
+        <span ng-if="checking" class="inline-help" ng-animate="'fade'">
+          Validating your database connection...
+        </span>
+
+        <span
+          ng-if="invalidDbDns"
+          class="inline-help error"
+          ng-animate="'fade'"
+        >
+          Could not connect to database
+        </span>
+      </div>
+    </div>
+  </form>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -3,7 +3,7 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
   $scope.majorVersion = Umbraco.Sys.ServerVariables.application.version;
   $scope.passwordPattern = /.*/;
   $scope.installer.current.model.subscribeToNewsLetter = $scope.installer.current.model.subscribeToNewsLetter || false;
-  $scope.installer.current.model.telemetryLevel = $scope.installer.current.model.telemetryLevel || $scope.installer.current.model.consentLevels[1].level;
+  setTelemetryLevelAndDescription($scope.installer.current.model.telemetryIndex ?? 1);
 
   if ($scope.installer.current.model.minNonAlphaNumericLength > 0) {
     var exp = "";
@@ -14,11 +14,6 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
     exp = exp.replace(".*.*", ".*");
     $scope.passwordPattern = new RegExp(exp);
   }
-
-  $scope.consentTooltip = {
-    show: false,
-    event: null
-  };
 
   if ('noUiSlider' in window) {
     let consentSliderStartLevel = 2;
@@ -63,22 +58,6 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
       });
 
       pips.forEach(function (pip) {
-        pip.addEventListener('mouseenter', function (e) {
-          $scope.$apply(function () {
-            const value = pip.getAttribute('data-value');
-            $scope.consentTooltip.show = true;
-            $scope.consentTooltip.event = e;
-            $scope.consentTooltip.description = $sce.trustAsHtml($scope.installer.current.model.consentLevels[value - 1].description);
-          });
-        });
-
-        pip.addEventListener('mouseleave', function () {
-          $scope.$apply(function () {
-            $scope.consentTooltip.show = false;
-            $scope.consentTooltip.event = null;
-            $scope.consentTooltip.description = '';
-          });
-        });
 
         pip.addEventListener('click', function () {
           const value = pip.getAttribute('data-value');
@@ -99,8 +78,16 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
   };
 
   function onChangeConsent(values) {
-    const result = Number(values[0]);
-    $scope.installer.current.model.telemetryLevel = $scope.installer.current.model.consentLevels[result - 1].level;
+    const result = Number(values[0]) - 1;
+    $scope.$apply(() => {
+      setTelemetryLevelAndDescription(result);
+    });
   };
+
+  function setTelemetryLevelAndDescription(idx) {
+    $scope.telemetryDescription = $sce.trustAsHtml($scope.installer.current.model.consentLevels[idx].description);
+    $scope.installer.current.model.telemetryIndex = idx;
+    $scope.installer.current.model.telemetryLevel = $scope.installer.current.model.consentLevels[idx].level;
+  }
 
 });

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -31,6 +31,7 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
         "min": 1,
         "max": 3
       },
+      behaviour: 'smooth-steps-tap',
       pips: {
         mode: 'values',
         density: 50,

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -121,11 +121,7 @@
             </div>
           </div>
 
-          <div>
-            <b>{{installer.current.model.telemetryLevel}}</b>
-            <br />
-            <div ng-bind-html="telemetryDescription"></div>
-          </div>
+          <div ng-bind-html="telemetryDescription"></div>
         </div>
       </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -121,7 +121,7 @@
             </div>
           </div>
 
-          <div ng-bind-html="telemetryDescription"></div>
+          <small ng-bind-html="telemetryDescription"></small>
         </div>
       </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -113,15 +113,18 @@
 
       <div class="installer-col telemetry-col">
         <div class="control-group">
-          <label class="control-label">Consent for telemetry data</label>
+          <label class="control-label">
+            Consent for telemetry data
+            <br /><small>
+              This can be changed later in the Settings panel.
+            </small>
+          </label>
           <div class="controls">
             <div id="consentSliderWrapper">
               <div id="consentSlider"></div>
             </div>
           </div>
-
-          <small ng-bind-html="telemetryDescription"></small>
-          <p><small>This can be changed later in the Settings panel.</small></p>
+          <p><small ng-bind-html="telemetryDescription"></small></p>
         </div>
       </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -95,7 +95,6 @@
 
         <div
           ng-if="installer.current.model.quickInstallSettings"
-          ng-style="{'opacity': myForm.$invalid ? '0.4' : ''}"
           style="margin-top: auto"
         >
           <div class="control-group">

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -3,8 +3,7 @@
 
   <p>
     Enter your name, email and password to install Umbraco with its default
-    settings, alternatively you can customize your installation TODO: Kan
-    felterne blive helt brede?
+    settings, alternatively you can customize your installation
   </p>
 
   <form

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -100,7 +100,7 @@
         >
           <div class="control-group">
             <label class="control-label" for="dbType">Database</label>
-            <div class="controls">
+            <div class="controls -with-border">
               <div class="input-readonly-text">
                 <strong>Provider:</strong>
                 {{installer.current.model.quickInstallSettings.displayName}}

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -124,6 +124,13 @@
               <div id="consentSlider"></div>
             </div>
           </div>
+          <p>
+            <small>
+              In order to improve Umbraco and add new functionality based on as
+              relevant information as possible, we would like to collect system-
+              and usage information from your installation.
+            </small>
+          </p>
           <p><small ng-bind-html="telemetryDescription"></small></p>
         </div>
       </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -1,102 +1,163 @@
 <div ng-controller="Umbraco.Install.UserController">
   <h1>Install Umbraco</h1>
 
-  <p>Enter your name, email and password to install Umbraco with its default settings, alternatively you can customize
-    your installation</p>
+  <p>
+    Enter your name, email and password to install Umbraco with its default
+    settings, alternatively you can customize your installation TODO: Kan
+    felterne blive helt brede?
+  </p>
 
-  <form name="myForm" class="form-horizontal" novalidate ng-submit="validateAndInstall();">
-
-    <div class="row">
-      <div class="span8">
-        <div class="pull-right">
-          <div class="control-group">
-            <label class="control-label" for="name">Name</label>
-            <div class="controls">
-              <input type="text" id="name" name="name" placeholder="Full name" required
-                ng-model="installer.current.model.name" />
-            </div>
+  <form
+    class="-no-margin-bottom"
+    name="myForm"
+    novalidate
+    ng-submit="validateAndInstall();"
+  >
+    <div class="installer-cols">
+      <div class="installer-col user-col">
+        <div class="control-group">
+          <label class="control-label" for="name">Name</label>
+          <div class="controls">
+            <input
+              type="text"
+              id="name"
+              name="name"
+              placeholder="Full name"
+              required
+              ng-model="installer.current.model.name"
+            />
           </div>
+        </div>
 
-          <div class="control-group">
-            <label class="control-label" for="email">Email</label>
-            <div class="controls">
-              <input type="email" id="email" name="email" placeholder="you@example.com" val-email required
-                ng-model="installer.current.model.email" />
-              <small class="inline-help">Your email will be used as your login</small>
-            </div>
+        <div class="control-group">
+          <label class="control-label" for="email">Email</label>
+          <div class="controls">
+            <input
+              type="email"
+              id="email"
+              name="email"
+              placeholder="you@example.com"
+              val-email
+              required
+              ng-model="installer.current.model.email"
+            />
+            <small class="inline-help"
+              >Your email will be used as your login</small
+            >
           </div>
+        </div>
 
-          <div class="control-group">
-            <label class="control-label" for="password">Password</label>
-            <div class="controls">
-              <!-- why isn't this masked: https://www.nngroup.com/articles/stop-password-masking/ -->
-              <input type="text" name="installer.current.model.password"
-                ng-minlength="{{installer.current.model.minCharLength}}" ng-pattern="passwordPattern" autocorrect="off"
-                autocapitalize="off" autocomplete="off" required ng-model="installer.current.model.password"
-                id="password" />
-              <small class="inline-help">At least {{installer.current.model.minCharLength}} characters long</small>
+        <div class="control-group">
+          <label class="control-label" for="password">Password</label>
+          <div class="controls">
+            <!-- why isn't this masked: https://www.nngroup.com/articles/stop-password-masking/ -->
+            <input
+              type="text"
+              name="installer.current.model.password"
+              ng-minlength="{{installer.current.model.minCharLength}}"
+              ng-pattern="passwordPattern"
+              autocorrect="off"
+              autocapitalize="off"
+              autocomplete="off"
+              required
+              ng-model="installer.current.model.password"
+              id="password"
+            />
+            <small class="inline-help"
+              >At least {{installer.current.model.minCharLength}} characters
+              long</small
+            >
 
-              <small ng-if="installer.current.model.minNonAlphaNumericLength > 0" class="inline-help">
-                At least {{installer.current.model.minNonAlphaNumericLength}}
-                symbol{{installer.current.model.minNonAlphaNumericLength > 1 ? 's' : ''}}
-              </small>
-            </div>
+            <small
+              ng-if="installer.current.model.minNonAlphaNumericLength > 0"
+              class="inline-help"
+            >
+              At least {{installer.current.model.minNonAlphaNumericLength}}
+              symbol{{installer.current.model.minNonAlphaNumericLength > 1 ? 's'
+              : ''}}
+            </small>
           </div>
+        </div>
 
+        <div class="control-group">
+          <div class="controls">
+            <label>
+              <input
+                type="checkbox"
+                id="subscribeToNewsLetter"
+                name="subscribeToNewsLetter"
+                ng-model="installer.current.model.subscribeToNewsLetter"
+              />
+              Keep me updated on Umbraco Versions, Security Bulletins and
+              Community News
+            </label>
+          </div>
+        </div>
+
+        <div
+          ng-if="installer.current.model.quickInstallSettings"
+          ng-style="{'opacity': myForm.$invalid ? '0.4' : ''}"
+          style="margin-top: auto"
+        >
           <div class="control-group">
-            <label class="control-label">Telemetry</label>
+            <label class="control-label" for="dbType">Database</label>
             <div class="controls">
-              <div id="consentSliderWrapper">
-                <div id="consentSlider"></div>
-
-                <umb-tooltip ng-if="consentTooltip.show" event="consentTooltip.event">
-                  <div ng-bind-html="consentTooltip.description"></div>
-                </umb-tooltip>
+              <div class="input-readonly-text">
+                <strong>Provider:</strong>
+                {{installer.current.model.quickInstallSettings.displayName}}
+                <br /><strong>Name:</strong>
+                {{installer.current.model.quickInstallSettings.defaultDatabaseName}}
               </div>
             </div>
           </div>
+        </div>
+      </div>
 
-          <div class="control-group">
-            <div class="controls">
-              <label>
-                <input type="checkbox" id="subscribeToNewsLetter" name="subscribeToNewsLetter"
-                  ng-model="installer.current.model.subscribeToNewsLetter" />
-                Keep me updated on Umbraco Versions, Security Bulletins and Community News
-              </label>
+      <div class="installer-col telemetry-col">
+        <div class="control-group">
+          <label class="control-label">Telemetry</label>
+          <div class="controls">
+            <div id="consentSliderWrapper">
+              <div id="consentSlider"></div>
             </div>
           </div>
 
-          <div ng-if="installer.current.model.quickInstallSettings" ng-style="{'opacity': myForm.$invalid ? '0.4' : ''}">
-            <div class="control-group">
-              <label class="control-label" for="dbType">Database</label>
-              <div class="controls">
-                <div class="input-readonly-text">
-                  <strong>Provider:</strong> {{installer.current.model.quickInstallSettings.displayName}}
-                  <br /><strong>Name:</strong> {{installer.current.model.quickInstallSettings.defaultDatabaseName}}</div>
-              </div>
-            </div>
+          <div>
+            <b>{{installer.current.model.telemetryLevel}}</b>
+            <br />
+            <div ng-bind-html="telemetryDescription"></div>
           </div>
-
-          <div class="control-group" ng-class="{disabled:myForm.$invalid}">
-            <div class="controls">
-              <div ng-if="installer.current.model.quickInstallSettings">
-                <button ng-disabled="myForm.$invalid" class="btn btn-success">
-                  Install
-                </button>
-                <button
-                  ng-if="installer.current.model.quickInstallSettings && installer.current.model.customInstallAvailable"
-                  class="btn btn-info control-customize" ng-disabled="myForm.$invalid"
-                  ng-click="validateAndForward()">Change Database</button>
-              </div>
-
-              <button ng-if="!installer.current.model.quickInstallSettings" class="btn btn-primary control-customize"
-                ng-disabled="myForm.$invalid" ng-click="validateAndForward()">Next</button>
-            </div>
-          </div>
-
         </div>
       </div>
     </div>
-  </form>
 
+    <div class="control-actions" ng-class="{disabled:myForm.$invalid}">
+      <div
+        class="controls-space-between"
+        ng-if="installer.current.model.quickInstallSettings"
+      >
+        <button
+          ng-if="installer.current.model.quickInstallSettings && installer.current.model.customInstallAvailable"
+          class="btn btn-info control-customize"
+          ng-disabled="myForm.$invalid"
+          ng-click="validateAndForward()"
+        >
+          Change Database
+        </button>
+
+        <button ng-disabled="myForm.$invalid" class="btn btn-success">
+          Install
+        </button>
+      </div>
+
+      <button
+        ng-if="!installer.current.model.quickInstallSettings"
+        class="btn btn-primary control-customize"
+        ng-disabled="myForm.$invalid"
+        ng-click="validateAndForward()"
+      >
+        Next
+      </button>
+    </div>
+  </form>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -2,8 +2,8 @@
   <h1>Install Umbraco</h1>
 
   <p>
-    Enter your name, email and password to install Umbraco with its default
-    settings, alternatively you can customize your installation
+    Enter credentials for the default administrator user and choose the level of
+    consent for telemetry data of your Umbraco installation.
   </p>
 
   <form
@@ -113,7 +113,7 @@
 
       <div class="installer-col telemetry-col">
         <div class="control-group">
-          <label class="control-label">Telemetry</label>
+          <label class="control-label">Consent for telemetry data</label>
           <div class="controls">
             <div id="consentSliderWrapper">
               <div id="consentSlider"></div>
@@ -121,6 +121,7 @@
           </div>
 
           <small ng-bind-html="telemetryDescription"></small>
+          <p><small>This can be changed later in the Settings panel.</small></p>
         </div>
       </div>
     </div>

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -1,4 +1,4 @@
-﻿// Core variables and mixins
+// Core variables and mixins
 @import "fonts.less"; // Loading fonts
 @import "variables.less"; // Modify this for custom colors, font-sizes, etc
 @import "colors.less";
@@ -29,27 +29,25 @@
   display: none !important;
 }
 
-
-html {
+body {
   background: url('../img/installer.svg') no-repeat center center fixed;
   background-size: cover;
-}
-
-body {
   margin: 0;
   padding: 0;
-  height: 100%;
+  height: 100vh;
   width: 100%;
   font-family: @baseFontFamily;
   font-size: @baseFontSize;
   line-height: @baseLineHeight;
   color: @textColor;
-  vertical-align: middle;
   text-align: center;
   // better font rendering
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  // center items
+  display: grid;
+  place-items: center center;
 }
 
 #logo {
@@ -61,16 +59,13 @@ body {
 }
 
 #installer {
-  margin: auto;
   background: @white;
-  width: 80%;
-  max-width: 750px;
-  height: 640px;
+  width: min-content;
   text-align: left;
-  padding: 30px;
+  padding: 3rem;
   z-index: 667;
   border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 0 2px 4px rgba(0, 0, 0, 0.16);
 }
 
 #overlay {
@@ -174,15 +169,6 @@ input.ng-dirty.ng-invalid {
 
 #installer legend {
   clear: both;
-}
-
-.absolute-center {
-  margin: auto;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
 }
 
 .fade-hide,

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -61,6 +61,7 @@ body {
 #installer {
   background: @white;
   width: min-content;
+  min-width: 500px;
   text-align: left;
   padding: 3rem;
   z-index: 667;

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -160,7 +160,7 @@ input.ng-dirty.ng-invalid {
 .installer-cols {
   display: grid;
   grid-template-columns: repeat(2, minmax(300px, 1fr));
-  gap: 75px;
+  gap: 120px;
 }
 
 .user-col {
@@ -184,6 +184,10 @@ input.ng-dirty.ng-invalid {
   small {
     display: block;
     color: @gray-3;
+  }
+
+  &.-with-border {
+    border: 1px solid @inputBorder;
   }
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -1,4 +1,4 @@
-// Core variables and mixins
+﻿// Core variables and mixins
 @import "fonts.less"; // Loading fonts
 @import "variables.less"; // Modify this for custom colors, font-sizes, etc
 @import "colors.less";
@@ -139,6 +139,14 @@ legend {
   font-weight: bold
 }
 
+#installer input {
+  width: 100%;
+
+  &[type=checkbox] {
+    width: auto;
+  }
+}
+
 input.ng-dirty.ng-invalid {
   border-color: @pink;
   color: @pink;
@@ -176,6 +184,15 @@ input.ng-dirty.ng-invalid {
     display: block;
     color: @gray-3;
   }
+}
+
+.control-actions {
+  margin-top: 2rem;
+}
+
+.controls-space-between {
+  display: flex;
+  justify-content: space-between;;
 }
 
 #installer .input-readonly-text {
@@ -283,10 +300,12 @@ select {
 }
 
 #consentSliderWrapper {
-  margin-bottom: 40px;
+  margin-bottom: 60px;
 }
 
 #consentSlider {
+  width: 300px;
+
   .noUi-target {
     background: linear-gradient(to bottom, @grayLighter 0%, @grayLighter 100%);
     box-shadow: none;

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -148,6 +148,21 @@ input.ng-dirty.ng-invalid {
   opacity: 0.6;
 }
 
+.installer-cols {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(300px, 1fr));
+  gap: 75px;
+}
+
+.user-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.telemetry-col {
+  min-height: 500px
+}
+
 
 #installer label.control-label,
 #installer .constrol-label {

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.controller.js
@@ -24,6 +24,7 @@
           "min": 1,
           "max": 3
         },
+        behaviour: 'smooth-steps-tap',
         pips: {
           mode: 'values',
           density: 50,

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.html
@@ -39,13 +39,14 @@
           <b>{{vm.sliderVal}}</b>
           <br>
           <localize key="analytics_detailedLevelDescription">
-                  We will send:
-            <br>- Anonymized site ID, umbraco version, and packages installed.
-            <br>- Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, and Property Editors in use.
-            <br>- System information: Webserver, server OS, server framework, server OS language, and database provider.
-            <br>- Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.
-            <br>
-            <br><i>We might change what we send on the Detailed level in the future. If so, it will be listed above.
+            We will send:
+            <ul>
+              <li>Anonymized site ID, umbraco version, and packages installed.</li>
+              <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, and Property Editors in use.</li>
+              <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
+              <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.</li>
+            </ul>
+            <i>We might change what we send on the Detailed level in the future. If so, it will be listed above.
             <br>By choosing "Detailed" you agree to current and future anonymized information being collected.</i>
           </localize>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.html
@@ -2,7 +2,7 @@
   <umb-box>
     <umb-box-content>
       <h3 class="bold">
-        <localize key="analytics_consentForAnalytics">Consent for analytics</localize>
+        <localize key="analytics_consentForAnalytics">Consent for telemetry data</localize>
       </h3>
       <div class="umb-healthcheck-help-text">
         <localize key="analytics_analyticsDescription">
@@ -23,21 +23,15 @@
         </div>
 
         <div ng-if="vm.sliderVal === 'Minimal'">
-          <b>{{vm.sliderVal}}</b>
-          <br>
           <localize key="analytics_minimalLevelDescription">We'll only send an anonymous site ID to let us know that the
             site exists.
           </localize>
         </div>
         <div ng-if="vm.sliderVal === 'Basic'">
-          <b>{{vm.sliderVal}}</b>
-          <br>
           <localize key="analytics_basicLevelDescription">We'll send site ID, umbraco version and packages installed
           </localize>
         </div>
         <div ng-if="vm.sliderVal === 'Detailed'">
-          <b>{{vm.sliderVal}}</b>
-          <br>
           <localize key="analytics_detailedLevelDescription">
             We will send:
             <ul>


### PR DESCRIPTION
This fixes #12738 

### Description
I have experimented a bit with the installer with the help of @JesmoDev to look into the UX issue of #12738. We are proposing to extend the installer into two columns to be able to show the telemetry slider in its entirety - just like it is being shown inside the backoffice.

Installer screen
![image](https://user-images.githubusercontent.com/752371/182338854-53cd6838-5607-4e92-8c54-62c334583439.png)

Backoffice settings telemetry:
![image](https://user-images.githubusercontent.com/752371/182338293-ae757329-ae50-44d7-aba0-9512caab6c4f.png)



Among other changes, we also managed to:
- Make the installer screen a bit more responsive; removing the absolute positioning of the box and making sure the installer supports reacting to various types of content on small monitors
- Convert input[type=submit] to actual buttons
- Place the buttons in the same way and order as the rest of the system
- Get rid of the invisible tooltips
