### PR TITLE
v10: Avoid password policy in server response

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -151,7 +151,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl", "previewHubUrl", "iconApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "minimumPasswordLength", "minimumPasswordNonAlphaNum", "hideBackofficeLogo", "disableDeleteWhenReferenced", "disableUnpublishWhenReferenced"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "hideBackofficeLogo", "disableDeleteWhenReferenced", "disableUnpublishWhenReferenced"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}


### PR DESCRIPTION
# Notes
- Right now in Umbraco, we expose more than we should, namely the `minimumPasswordLength`, `minimumPasswordNonAlphaNum`
- These are displayed just when making an unauthenticated request to Umbraco, they can be found in the view
![image](https://user-images.githubusercontent.com/70372949/181466439-b4e76b68-d722-4963-8697-3173f761cc98.png)
- This PR remedies that, by removing them.

# How to test
- Create an empty umbraco install
- Install Umbraco
- Log out
- Go to the login page and assert `minimumPasswordLength` and `minimumPasswordNonAlphaNum` are now removed from the view.
- Assert that you can login
- Setup a local smtp server like Papercut
- Configure your appsettings.Development.json with something like this Under Umbraco -> CMS:
```
"Umbraco": {
    "CMS": {
        "Smtp": {
          "From": "nge@umbraco.dk",
          "Host": "localhost",
           "Port": "25"
        }
    }
}
```
- Try and invite a user
- Assert that user can create a new password and login