### PR TITLE
v8: Avoid password policy in server response

### DIFF
--- a/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web/Editors/BackOfficeServerVariables.cs
@@ -57,7 +57,7 @@ namespace Umbraco.Web.Editors
             var keepOnlyKeys = new Dictionary<string, string[]>
             {
                 {"umbracoUrls", new[] {"authenticationApiBaseUrl", "serverVarsJs", "externalLoginsUrl", "currentUserApiBaseUrl", "iconApiBaseUrl"}},
-                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "maxFileSize", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "minimumPasswordLength", "minimumPasswordNonAlphaNum", "hideBackofficeLogo"}},
+                {"umbracoSettings", new[] {"allowPasswordReset", "imageFileTypes", "loginBackgroundImage", "loginLogoImage", "canSendRequiredEmail", "usernameIsEmail", "hideBackofficeLogo"}},
                 {"application", new[] {"applicationPath", "cacheBuster"}},
                 {"isDebuggingEnabled", new string[] { }},
                 {"features", new [] {"disabledFeatures"}}


### PR DESCRIPTION
# Notes 
- Same fix as in https://github.com/umbraco/Umbraco-CMS/pull/12745 but for v8

# How to test
- Follow the same testing procedure
- As v8 does not use `appsettings.json`, use the `Web.Config` file instead and have something like this:
```
<system.net>
        <mailSettings>
            <smtp from="nge@umbraco.dk">
                <network host="localhost" port="25" userName="" password="" />
            </smtp>
        </mailSettings>
</system.net>
```