### PR TITLE
Feature: UmbracoBuilder extensions  - SetTreeSearcherFields

### DIFF
--- a/src/Umbraco.Web.Website/Extensions/WebsiteUmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/WebsiteUmbracoBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Infrastructure.Examine;
 
 namespace Umbraco.Extensions;
 
@@ -81,6 +82,42 @@ public static class WebsiteUmbracoBuilderExtensions
     public static IUmbracoBuilder SetSiteDomainHelper(this IUmbracoBuilder builder, ISiteDomainMapper helper)
     {
         builder.Services.AddUnique(helper);
+        return builder;
+    }
+
+    /// <summary>
+    ///     Sets the UmbracoTreeSearcherFields to change fields that can be searched in the backoffice.
+    /// </summary>
+    /// <typeparam name="T">The type of the Umbraco tree searcher fields.</typeparam>
+    /// <param name="builder">The builder.</param>
+    public static IUmbracoBuilder SetTreeSearcherFields<T>(this IUmbracoBuilder builder)
+        where T : class, IUmbracoTreeSearcherFields
+    {
+        builder.Services.AddUnique<IUmbracoTreeSearcherFields, T>();
+        return builder;
+    }
+
+    /// <summary>
+    ///     Sets the UmbracoTreeSearcherFields to change fields that can be searched in the backoffice.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="factory">A function creating a TreeSearcherFields</param>
+    public static IUmbracoBuilder SetTreeSearcherFields(
+        this IUmbracoBuilder builder,
+        Func<IServiceProvider, IUmbracoTreeSearcherFields> factory)
+    {
+        builder.Services.AddUnique(factory);
+        return builder;
+    }
+
+    /// <summary>
+    ///     Sets the UmbracoTreeSearcherFields to change fields that can be searched in the backoffice.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="treeSearcherFields">An UmbracoTreeSearcherFields.</param>
+    public static IUmbracoBuilder SetTreeSearcherFields(this IUmbracoBuilder builder, IUmbracoTreeSearcherFields treeSearcherFields)
+    {
+        builder.Services.AddUnique(treeSearcherFields);
         return builder;
     }
 


### PR DESCRIPTION
When giving a workshop this week on some more of the hidden features & customisations in Umbraco, I discovered `IUmbracoTreeSearcherFields` from our docs.

https://our.umbraco.com/documentation/Extending/Backoffice-Search/#adding-custom-properties-to-backoffice-search

I always think we should be having extension methods for DX to help with discoverability by exploring the UmbracoBuilder. As you would not find out about this unless you stumble over it in our docs.

## Testing steps
* Install the starter kit
* In backoffice search for the word `codegarden` - note no results shown
* On the blog content nodes we have a property called categories that contains tags that we want to search on
* Add example class below
* Update Startup.cs or create an IComposer to call `.SetTreeSearcherFields<AddTagsTreeSearcherFields>()`
* Search for `codegarden` or `cg16` and note the correct blog post node is displayed with the tag

```csharp
public class AddTagsTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields
{
    public AddTagsTreeSearcherFields(ILocalizationService localizationService) : base(localizationService)
    {
    }

    public new IEnumerable<string> GetBackOfficeDocumentFields()
    {
        return new List<string>(base.GetBackOfficeDocumentFields()) { "categories" };
    }
}
```