### PR TITLE
Replaced usage of new Random().Next(..) with RandomNumberGenerator.Ge…

### DIFF
--- a/src/Umbraco.Core/Security/PasswordGenerator.cs
+++ b/src/Umbraco.Core/Security/PasswordGenerator.cs
@@ -23,32 +23,30 @@ public class PasswordGenerator
             _passwordConfiguration.RequiredLength,
             _passwordConfiguration.GetMinNonAlphaNumericChars());
 
-        var random = new Random();
-
         var passwordChars = password.ToCharArray();
 
         if (_passwordConfiguration.RequireDigit &&
             passwordChars.ContainsAny(Enumerable.Range(48, 58).Select(x => (char)x)))
         {
-            password += Convert.ToChar(random.Next(48, 58)); // 0-9
+            password += Convert.ToChar(RandomNumberGenerator.GetInt32(48, 58)); // 0-9
         }
 
         if (_passwordConfiguration.RequireLowercase &&
             passwordChars.ContainsAny(Enumerable.Range(97, 123).Select(x => (char)x)))
         {
-            password += Convert.ToChar(random.Next(97, 123)); // a-z
+            password += Convert.ToChar(RandomNumberGenerator.GetInt32(97, 123)); // a-z
         }
 
         if (_passwordConfiguration.RequireUppercase &&
             passwordChars.ContainsAny(Enumerable.Range(65, 91).Select(x => (char)x)))
         {
-            password += Convert.ToChar(random.Next(65, 91)); // A-Z
+            password += Convert.ToChar(RandomNumberGenerator.GetInt32(65, 91)); // A-Z
         }
 
         if (_passwordConfiguration.RequireNonLetterOrDigit &&
             passwordChars.ContainsAny(Enumerable.Range(33, 48).Select(x => (char)x)))
         {
-            password += Convert.ToChar(random.Next(33, 48)); // symbols !"#$%&'()*+,-./
+            password += Convert.ToChar(RandomNumberGenerator.GetInt32(33, 48)); // symbols !"#$%&'()*+,-./
         }
 
         return password;
@@ -101,6 +99,7 @@ public class PasswordGenerator
                 var chArray = new char[length];
                 var num1 = 0;
                 new RNGCryptoServiceProvider().GetBytes(data);
+
                 for (var index = 0; index < length; ++index)
                 {
                     var num2 = data[index] % 87;
@@ -125,17 +124,17 @@ public class PasswordGenerator
 
                 if (num1 < numberOfNonAlphanumericCharacters)
                 {
-                    var random = new Random();
+
                     for (var index1 = 0; index1 < numberOfNonAlphanumericCharacters - num1; ++index1)
                     {
                         int index2;
                         do
                         {
-                            index2 = random.Next(0, length);
+                            index2 = RandomNumberGenerator.GetInt32(0, length);
                         }
                         while (!char.IsLetterOrDigit(chArray[index2]));
 
-                        chArray[index2] = Punctuations[random.Next(0, Punctuations.Length)];
+                        chArray[index2] = Punctuations[RandomNumberGenerator.GetInt32(0, Punctuations.Length)];
                     }
                 }
 


### PR DESCRIPTION
Even that the password generation should already be safe, due to the usage of `RNGCryptoServiceProvider` it is considered best practice never to use `new Random()`, when generating passwords. 

So this PR updates to use `RandomNumberGenerator` instead.


---
_This item has been added to our backlog [AB#21039](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/21039)_