### PR TITLE
Use `umb-icon` component in tracked references to support custom SVG icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/references/umb-tracked-references-table.html
@@ -15,7 +15,7 @@
         </div>
         <div class="umb-table-body">
             <div class="umb-table-row" ng-repeat="reference in vm.items">
-                <div class="umb-table-cell"><i class="umb-table-body__icon {{reference.icon}}"></i></div>
+                <div class="umb-table-cell"><umb-icon icon="{{reference.icon}}" class="umb-table-body__icon"></umb-icon></div>
                 <div class="umb-table-cell umb-table__name"><a ng-href="{{vm.getUrl(reference.udi, reference.id)}}" ng-click="vm.referenceAnchorClicked($event, reference)">{{::reference.name}}</a></div>
                 <div ng-if="vm.showTypeName" class="umb-table-cell"><span title="{{::reference.contentTypeName}}">{{::reference.contentTypeName}}</span></div>
                 <div ng-if="vm.showType" class="umb-table-cell"><span title="{{::reference.type}}">{{::reference.type}}</span></div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The tracked references table is showing icons like inside `<umb-table>` and other parts of backoffice UI.
This work for core font icons, but not custom SVG icons.

![chrome_c9daUF8u6X](https://user-images.githubusercontent.com/2919859/182258776-ddb55115-7ed6-4ed3-8376-44b599cb7e47.png)

**Before**

![chrome_FXAl0hMZqy](https://user-images.githubusercontent.com/2919859/182258804-36fe9605-405a-45a9-8cd2-e1fa35760adb.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/182258840-288b0f0c-e4b6-4f8a-8fe5-7a29796ed6cb.png)
