### PR TITLE
Separate dotnet pack command to use DotNetCoreCLI task

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -101,6 +101,7 @@ stages:
               command: pack
               packagesToPack: umbraco.sln
               packDirectory: $(Build.ArtifactStagingDirectory)/nupkg
+              verbosityPack: 'normal'
               arguments: '--no-restore --configuration $(buildConfiguration)'
           - script: |
               sha="$(Build.SourceVersion)"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -72,16 +72,16 @@ stages:
               arguments: '--configuration $(buildConfiguration)'
           - script: |
               version="$(Build.BuildNumber)"
-              echo "varsion: $version"
+              echo "Version: $version"
 
               major="$(echo $version | cut -d '.' -f 1)"
-              echo "major version: $major"
+              echo "Major version: $major"
 
               echo "##vso[task.setvariable variable=majorVersion;isOutput=true]$major"
             displayName: Set major version
             name: determineMajorVersion
           - task: PowerShell@2
-            displayName: Prepare nupkg
+            displayName: Update UmbracoVersion in templates
             inputs:
               targetType: inline
               script: |
@@ -95,8 +95,14 @@ stages:
                     $a | ConvertTo-Json -Depth 32 | Set-Content $templatePath
                   }
                 }
-
-                dotnet pack --configuration $(buildConfiguration) umbraco.sln -o $(Build.ArtifactStagingDirectory)/nupkg
+          - task: DotNetCoreCLI@2
+            displayName: Run dotnet pack
+            inputs:
+              command: pack
+              projects: umbraco.sln
+              packDirectory: $(Build.ArtifactStagingDirectory)/nupkg
+              nobuild: true
+              arguments: '--no-restore --configuration $(buildConfiguration)'
           - script: |
               sha="$(Build.SourceVersion)"
               sha=${sha:0:7}
@@ -237,7 +243,8 @@ stages:
             inputs:
               command: test
               projects: '**/*.Tests.UnitTests.csproj'
-              arguments: '--no-build --configuration $(buildConfiguration)'
+              nobuild: true
+              arguments: '--configuration $(buildConfiguration)'
               testRunTitle: Unit Tests - $(Agent.OS)
 
   - stage: Integration
@@ -273,7 +280,8 @@ stages:
             inputs:
               command: test
               projects: '**/*.Tests.Integration.csproj'
-              arguments: '--no-build --configuration $(buildConfiguration)'
+              nobuild: true
+              arguments: '--configuration $(buildConfiguration)'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
             env:
               Tests__Database__DatabaseType: 'Sqlite'
@@ -313,7 +321,8 @@ stages:
             inputs:
               command: test
               projects: '**/*.Tests.Integration.csproj'
-              arguments: '--no-build --configuration $(buildConfiguration)'
+              nobuild: true
+              arguments: '--configuration $(buildConfiguration)'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
             env:
               Tests__Database__DatabaseType: $(testDb)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -99,7 +99,7 @@ stages:
             displayName: Run dotnet pack
             inputs:
               command: pack
-              projects: umbraco.sln
+              packagesToPack: umbraco.sln
               packDirectory: $(Build.ArtifactStagingDirectory)/nupkg
               nobuild: true
               arguments: '--no-restore --configuration $(buildConfiguration)'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -101,7 +101,6 @@ stages:
               command: pack
               packagesToPack: umbraco.sln
               packDirectory: $(Build.ArtifactStagingDirectory)/nupkg
-              nobuild: true
               arguments: '--no-restore --configuration $(buildConfiguration)'
           - script: |
               sha="$(Build.SourceVersion)"

--- a/src/Umbraco.Core/Persistence/Repositories/IRedirectUrlRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRedirectUrlRepository.cs
@@ -46,7 +46,7 @@ public interface IRedirectUrlRepository : IReadWriteQueryRepository<Guid, IRedir
     /// </summary>
     /// <param name="url">The Umbraco redirect URL route.</param>
     /// <returns>The most recent redirect URL corresponding to the route.</returns>
-    Task<IRedirectUrl?> GetMostRecentUrlAsync(string url) => Task.FromResult(GetMostRecentUrl(url));
+    Task<IRedirectUrl?> GetMostRecentUrlAsync(string url);
 
     /// <summary>
     /// Gets the most recent redirect URL corresponding to an Umbraco redirect URL route.
@@ -62,7 +62,7 @@ public interface IRedirectUrlRepository : IReadWriteQueryRepository<Guid, IRedir
     /// <param name="url">The Umbraco redirect URL route.</param>
     /// <param name="culture">The culture the domain is associated with</param>
     /// <returns>The most recent redirect URL corresponding to the route.</returns>
-    Task<IRedirectUrl?> GetMostRecentUrlAsync(string url, string culture) => Task.FromResult(GetMostRecentUrl(url, culture));
+    Task<IRedirectUrl?> GetMostRecentUrlAsync(string url, string culture);
 
     /// <summary>
     ///     Gets all redirect URLs for a content item.

--- a/src/Umbraco.Core/Services/IRedirectUrlService.cs
+++ b/src/Umbraco.Core/Services/IRedirectUrlService.cs
@@ -60,7 +60,7 @@ public interface IRedirectUrlService : IService
     /// <param name="url">The Umbraco redirect URL route.</param>
     /// <param name="culture">The culture of the request.</param>
     /// <returns>The most recent redirect URLs corresponding to the route.</returns>
-    Task<IRedirectUrl?> GetMostRecentRedirectUrlAsync(string url, string? culture) => Task.FromResult(GetMostRecentRedirectUrl(url, culture));
+    Task<IRedirectUrl?> GetMostRecentRedirectUrlAsync(string url, string? culture);
 
         /// <summary>
     ///     Gets all redirect URLs for a content item.

--- a/umbraco.sln
+++ b/umbraco.sln
@@ -7,21 +7,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{2849E9D4-3B4E-40A3-A309-F3CB4F0E125F}"
 	ProjectSection(SolutionItems) = preProject
 		build\azure-pipelines.yml = build\azure-pipelines.yml
-		build\build-bootstrap.ps1 = build\build-bootstrap.ps1
-		build\build.ps1 = build\build.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{FD962632-184C-4005-A5F3-E705D92FC645}"
 	ProjectSection(SolutionItems) = preProject
 		.github\BUILD.md = .github\BUILD.md
-		.github\CLEAR.md = .github\CLEAR.md
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
-		.github\CONTRIBUTING_DETAILED.md = .github\CONTRIBUTING_DETAILED.md
-		.github\CONTRIBUTION_GUIDELINES.md = .github\CONTRIBUTION_GUIDELINES.md
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 		.github\README.md = .github\README.md
-		.github\REVIEW_PROCESS.md = .github\REVIEW_PROCESS.md
-		.github\V8_GETTING_STARTED.md = .github\V8_GETTING_STARTED.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{B5BD12C1-A454-435E-8A46-FF4A364C0382}"
@@ -72,24 +65,7 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Umbraco.Tests.AcceptanceTes
 		StartServerOnDebug = "false"
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DocTools", "DocTools", "{53594E5B-64A2-4545-8367-E3627D266AE8}"
-	ProjectSection(SolutionItems) = preProject
-		src\ApiDocs\docfx.filter.yml = src\ApiDocs\docfx.filter.yml
-		src\ApiDocs\docfx.json = src\ApiDocs\docfx.json
-		src\ApiDocs\index.md = src\ApiDocs\index.md
-		src\ApiDocs\toc.yml = src\ApiDocs\toc.yml
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Tests.Benchmarks", "tests\Umbraco.Tests.Benchmarks\Umbraco.Tests.Benchmarks.csproj", "{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IssueTemplates", "IssueTemplates", "{C7311C00-2184-409B-B506-52A5FAEA8736}"
-	ProjectSection(SolutionItems) = preProject
-		.github\ISSUE_TEMPLATE\1_Bug.md = .github\ISSUE_TEMPLATE\1_Bug.md
-		.github\ISSUE_TEMPLATE\2_Feature_request.md = .github\ISSUE_TEMPLATE\2_Feature_request.md
-		.github\ISSUE_TEMPLATE\3_Support_question.md = .github\ISSUE_TEMPLATE\3_Support_question.md
-		.github\ISSUE_TEMPLATE\4_Documentation_issue.md = .github\ISSUE_TEMPLATE\4_Documentation_issue.md
-		.github\ISSUE_TEMPLATE\5_Security_issue.md = .github\ISSUE_TEMPLATE\5_Security_issue.md
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Core", "src\Umbraco.Core\Umbraco.Core.csproj", "{29AA69D9-B597-4395-8D42-43B1263C240A}"
 EndProject
@@ -255,9 +231,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9E4C8A12-FBE0-4673-8CE2-DF99D5D57817} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
-		{53594E5B-64A2-4545-8367-E3627D266AE8} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{3A33ADC9-C6C0-4DB1-A613-A9AF0210DF3D} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
-		{C7311C00-2184-409B-B506-52A5FAEA8736} = {FD962632-184C-4005-A5F3-E705D92FC645}
 		{FB5676ED-7A69-492C-B802-E7B24144C0FC} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{D6319409-777A-4BD0-93ED-B2DFD805B32C} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 		{A499779C-1B3B-48A8-B551-458E582E6E96} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With PR https://github.com/umbraco/Umbraco-CMS/pull/12769 now merged, any breaking changes will be automatically detected during packaging, but that resulted in a non-descriptive `PowerShell exited with code '1'.` error. This separates the dotnet pack command to use the DotNetCoreCLI task that _should_ report better error messages...

I'll revert commit https://github.com/umbraco/Umbraco-CMS/commit/6ce91eff4e449f8e9388e717c9384fcb6bd0998d to reintroduce the error, so we can test whether it now produces a better message.