### PR TITLE
Add missing text node before asterisk in mandatory properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -12,7 +12,9 @@
                         <localize key="contentTypeEditor_inheritedFrom">Inherited from</localize> {{vm.inheritsFrom}}
                     </small>
 
-                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span></label>
+                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}
+                      <span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span>
+                    </label>
 
                     <umb-property-actions ng-if="!vm.showInherit" actions="vm.propertyActions"></umb-property-actions>
 

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
@@ -28,24 +28,23 @@
                             <span ng-bind="variant.displayName"></span>
                             <strong class="umb-control-required" ng-if="variant.isMandatory">*</strong>
                         </span>
-            <span class="umb-variant-selector-entry__title" ng-if="variant.segment && variant.language">
+                        <span class="umb-variant-selector-entry__title" ng-if="variant.segment && variant.language">
                             <span ng-bind="variant.segment"></span>
                             <span class="__secondarytitle"> — {{variant.language.name}}</span>
                             <strong class="umb-control-required" ng-if="variant.isMandatory">*</strong>
                         </span>
-            <span class="umb-variant-selector-entry__description"
-                  ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
+                        <span class="umb-variant-selector-entry__description"
+                              ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
                             <umb-variant-state variant="variant"></umb-variant-state>
                             <span ng-if="variant.isMandatory"> - </span>
                             <span ng-class="{'text-error': (variant.publish === false) }" ng-if="variant.isMandatory"><localize
                               key="general_mandatory">Mandatory</localize></span>
                         </span>
-            <span class="umb-variant-selector-entry__description"
-                  ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
+                        <span class="umb-variant-selector-entry__description"
+                              ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
                             <span class="text-error"
                                   ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
                         </span>
-
           </umb-checkbox>
 
           <umb-variant-notification-list notifications="variant.notifications"></umb-variant-notification-list>
@@ -78,20 +77,20 @@
                     <span ng-bind="variant.displayName"></span>
                     <strong class="umb-control-required" ng-if="variant.isMandatory">*</strong>
                 </span>
-        <span class="umb-variant-selector-entry__title" ng-if="variant.segment && variant.language">
+                <span class="umb-variant-selector-entry__title" ng-if="variant.segment && variant.language">
                     <span ng-bind="variant.segment"></span>
                     <span class="__secondarytitle"> — {{variant.language.name}}</span>
                     <strong class="umb-control-required" ng-if="variant.isMandatory">*</strong>
                 </span>
-        <span class="umb-variant-selector-entry__description"
-              ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
+                <span class="umb-variant-selector-entry__description"
+                      ng-if="!publishVariantSelectorForm.publishVariantSelector.$invalid && !(variant.notifications && variant.notifications.length > 0)">
                     <umb-variant-state variant="variant"></umb-variant-state>
                     <span ng-if="variant.isMandatory"> - </span>
                     <span ng-class="{'text-error': (variant.publish === false) }" ng-if="variant.isMandatory"><localize
                       key="languages_mandatoryLanguage">Mandatory language</localize></span>
                 </span>
-        <span class="umb-variant-selector-entry__description"
-              ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
+                <span class="umb-variant-selector-entry__description"
+                      ng-messages="publishVariantSelectorForm.publishVariantSelector.$error" show-validation-on-submit>
                     <span class="text-error"
                           ng-message="valServerField">{{publishVariantSelectorForm.publishVariantSelector.errorMsg}}</span>
                 </span>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Previous mandatory properties has a text node before in asterisk in DOM, but now there is none, meaning the asterisk is close the the property label.

**Before**

![image](https://user-images.githubusercontent.com/2919859/182468318-80f7de26-8333-4723-81a2-5742eafb11d7.png)


**After**

![image](https://user-images.githubusercontent.com/2919859/182468122-87e54c04-f5ec-4d8f-8bff-c11ab7841397.png)


It seems it was affected by this PR which removed the text nodes: https://github.com/umbraco/Umbraco-CMS/pull/12610