### PR TITLE
Fix docfx generation

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -225,7 +225,7 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
             return dbType.EscapeSqlIdentifier(columnName);
         }
 
-        return base.GetColumn(dbType, tableName, columnName, columnAlias, referenceName, forInsert);
+        return base.GetColumn(dbType, tableName, columnName, columnAlias!, referenceName, forInsert);
     }
 
     public override string FormatPrimaryKey(TableDefinition table)

--- a/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
@@ -33,9 +33,8 @@ public abstract class MigrationExpressionBase : IMigrationExpression
     public List<IMigrationExpression> Expressions => _expressions ??= new List<IMigrationExpression>();
 
     /// <summary>
-    ///     This might be useful in the future if we add it to the interface, but for now it's used to hack the DeleteAppTables
-    ///     & DeleteForeignKeyExpression
-    ///     to ensure they are not executed twice.
+    /// This might be useful in the future if we add it to the interface, but for now it's used to hack the DeleteAppTables & DeleteForeignKeyExpression
+    /// to ensure they are not executed twice.
     /// </summary>
     internal string? Name { get; set; }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -145,8 +145,7 @@ internal class UserRepository : EntityRepositoryBase<int, IUser>, IUserRepositor
     /// </summary>
     /// <param name="username"></param>
     /// <param name="includeSecurityData">
-    ///     Can be used for slightly faster user lookups if the result doesn't require security data (i.e. groups, apps & start
-    ///     nodes).
+    ///     Can be used for slightly faster user lookups if the result doesn't require security data (i.e. groups, apps & start nodes).
     ///     This is really only used for a shim in order to upgrade to 7.6.
     /// </param>
     /// <returns>
@@ -164,7 +163,7 @@ internal class UserRepository : EntityRepositoryBase<int, IUser>, IUserRepositor
     ///     for slightly faster user lookups if the result doesn't require security data (i.e. groups, apps & start nodes)
     /// </param>
     /// <returns>
-    ///     A non cached <see cref="IUser" /> instance
+    ///     A non cached <see cref="IUser"/> instance
     /// </returns>
     public IUser? Get(int? id, bool includeSecurityData) =>
         GetWith(sql => sql.Where<UserDto>(x => x.Id == id), includeSecurityData);

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -1,3 +1,5 @@
+// Don't remove the unused System using, for some reason this breaks docfx, and I have no clue why.
+using System;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -35,10 +37,10 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
             FormatConstraint,
             FormatDefaultValue,
             FormatPrimaryKey,
-            FormatIdentity,
+            FormatIdentity
         };
 
-        // defaults for all providers
+        //defaults for all providers
         StringLengthColumnDefinitionFormat = StringLengthUnicodeColumnDefinitionFormat;
         StringColumnDefinition = string.Format(StringLengthColumnDefinitionFormat, DefaultStringLength);
         DecimalColumnDefinition =
@@ -48,7 +50,6 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         // ok to call virtual GetQuotedXxxName here - they don't depend on any state
         var col = Regex.Escape(GetQuotedColumnName("column")).Replace("column", @"\w+");
         var fld = Regex.Escape(GetQuotedTableName("table") + ".").Replace("table", @"\w+") + col;
-
         // ReSharper restore VirtualMemberCallInConstructor
         AliasRegex = new Regex(
             "(" + fld + @")\s+AS\s+(" + col + ")",
@@ -71,7 +72,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public int DefaultDecimalScale { get; } = 9;
 
-    // Set by Constructor
+    //Set by Constructor
     public virtual string StringColumnDefinition { get; }
 
     public string StringLengthColumnDefinitionFormat { get; }
@@ -98,35 +99,31 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public string TimeColumnDefinition { get; protected set; } = "DATETIME";
 
-    public virtual string CreateForeignKeyConstraint =>
-        "ALTER TABLE {0} ADD CONSTRAINT {1} FOREIGN KEY ({2}) REFERENCES {3} ({4}){5}{6}";
-
     protected IList<Func<ColumnDefinition, string>> ClauseOrder { get; }
 
     protected DbTypes DbTypeMap => _dbTypes.Value;
+
+    public virtual string CreateForeignKeyConstraint =>
+        "ALTER TABLE {0} ADD CONSTRAINT {1} FOREIGN KEY ({2}) REFERENCES {3} ({4}){5}{6}";
 
     public virtual string CreateDefaultConstraint => "ALTER TABLE {0} ADD CONSTRAINT {1} DEFAULT ({2}) FOR {3}";
 
     public Regex AliasRegex { get; }
 
-    public abstract string ProviderName { get; }
-
-    public abstract IsolationLevel DefaultIsolationLevel { get; }
-
     public string GetWildcardPlaceholder() => "%";
 
     public virtual DatabaseType GetUpdatedDatabaseType(DatabaseType current, string? connectionString) => current;
 
+    public abstract string ProviderName { get; }
+
     public virtual string EscapeString(string val) => NPocoDatabaseExtensions.EscapeAtSymbols(val.Replace("'", "''"));
 
     public virtual string GetStringColumnEqualComparison(string column, int paramIndex, TextColumnType columnType) =>
-
-        // use the 'upper' method to always ensure strings are matched without case sensitivity no matter what the db setting.
+        //use the 'upper' method to always ensure strings are matched without case sensitivity no matter what the db setting.
         $"upper({column}) = upper(@{paramIndex})";
 
     public virtual string GetStringColumnWildcardComparison(string column, int paramIndex, TextColumnType columnType) =>
-
-        // use the 'upper' method to always ensure strings are matched without case sensitivity no matter what the db setting.
+        //use the 'upper' method to always ensure strings are matched without case sensitivity no matter what the db setting.
         $"upper({column}) LIKE upper(@{paramIndex})";
 
     public virtual string GetConcat(params string[] args) => "concat(" + string.Join(",", args) + ")";
@@ -177,7 +174,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         return "NVARCHAR";
     }
 
-    public virtual string GetColumn(DatabaseType dbType, string tableName, string columnName, string? columnAlias, string? referenceName = null, bool forInsert = false)
+    public virtual string GetColumn(DatabaseType dbType, string tableName, string columnName, string columnAlias, string? referenceName = null, bool forInsert = false)
     {
         tableName = GetQuotedTableName(tableName);
         columnName = GetQuotedColumnName(columnName);
@@ -193,12 +190,10 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         return column;
     }
 
+
+    public abstract IsolationLevel DefaultIsolationLevel { get; }
+
     public abstract string DbProvider { get; }
-
-    public virtual IDictionary<Type, IScalarMapper>? ScalarMappers => null;
-
-    public virtual string DeleteDefaultConstraint =>
-        throw new NotSupportedException("Default constraints are not supported");
 
     public virtual IEnumerable<string> GetTablesInSchema(IDatabase db) => new List<string>();
 
@@ -222,7 +217,12 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public virtual Sql<ISqlContext> AppendForUpdateHint(Sql<ISqlContext> sql) => sql;
 
-    public abstract Sql<ISqlContext>.SqlJoinClause<ISqlContext> LeftJoinWithNestedJoin<TDto>(Sql<ISqlContext> sql, Func<Sql<ISqlContext>, Sql<ISqlContext>> nestedJoin, string? alias = null);
+    public abstract Sql<ISqlContext>.SqlJoinClause<ISqlContext> LeftJoinWithNestedJoin<TDto>(
+        Sql<ISqlContext> sql,
+        Func<Sql<ISqlContext>, Sql<ISqlContext>> nestedJoin,
+        string? alias = null);
+
+    public virtual IDictionary<Type, IScalarMapper>? ScalarMappers => null;
 
     public virtual bool DoesTableExist(IDatabase db, string tableName) => GetTablesInSchema(db).Contains(tableName);
 
@@ -241,7 +241,6 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     ///     YYYYMMDD HH:mm:ss
     /// </remarks>
     public virtual string FormatDateTime(DateTime date, bool includeTime = true) =>
-
         // need CultureInfo.InvariantCulture because ":" here is the "time separator" and
         // may be converted to something else in different cultures (eg "." in DK).
         date.ToString(includeTime ? "yyyyMMdd HH:mm:ss" : "yyyyMMdd", CultureInfo.InvariantCulture);
@@ -265,7 +264,13 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
             ? string.Join(",", index.Columns.Select(x => GetQuotedColumnName(x.Name)))
             : GetQuotedColumnName(index.ColumnName);
 
-        return string.Format(CreateIndex, GetIndexType(index.IndexType), " ", GetQuotedName(name), GetQuotedTableName(index.TableName), columns);
+        return string.Format(
+            CreateIndex,
+            GetIndexType(index.IndexType),
+            " ",
+            GetQuotedName(name),
+            GetQuotedTableName(index.TableName),
+            columns);
     }
 
     public virtual List<string> Format(IEnumerable<ForeignKeyDefinition> foreignKeys) =>
@@ -321,22 +326,23 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         sql.Append(" ");
         sql.Append(FormatIdentity(column));
 
-        // var isNullable = column.IsNullable;
+        //var isNullable = column.IsNullable;
 
-        // var constraint = FormatConstraint(column)?.TrimStart("CONSTRAINT ");
-        // var hasConstraint = !string.IsNullOrWhiteSpace(constraint);
+        //var constraint = FormatConstraint(column)?.TrimStart("CONSTRAINT ");
+        //var hasConstraint = !string.IsNullOrWhiteSpace(constraint);
 
-        // var defaultValue = FormatDefaultValue(column);
-        // var hasDefaultValue = !string.IsNullOrWhiteSpace(defaultValue);
+        //var defaultValue = FormatDefaultValue(column);
+        //var hasDefaultValue = !string.IsNullOrWhiteSpace(defaultValue);
 
         // TODO: This used to exit if nullable but that means this would never work
         // to return SQL if the column was nullable?!? I don't get it. This was here
         // 4 years ago, I've removed it so that this works for nullable columns.
-        // if (isNullable /*&& !hasConstraint && !hasDefaultValue*/)
-        // {
+        //if (isNullable /*&& !hasConstraint && !hasDefaultValue*/)
+        //{
         //    sqls = Enumerable.Empty<string>();
         //    return sql.ToString();
-        // }
+        //}
+
         var msql = new List<string>();
         sqls = msql;
 
@@ -346,21 +352,21 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         alterSql.Append(FormatType(column));
         alterSql.Append(" ");
         alterSql.Append(FormatNullable(column));
-
-        // alterSql.Append(" ");
-        // alterSql.Append(FormatPrimaryKey(column));
-        // alterSql.Append(" ");
-        // alterSql.Append(FormatIdentity(column));
+        //alterSql.Append(" ");
+        //alterSql.Append(FormatPrimaryKey(column));
+        //alterSql.Append(" ");
+        //alterSql.Append(FormatIdentity(column));
         msql.Add(string.Format(AlterColumn, tableName, alterSql));
 
-        // if (hasConstraint)
-        // {
+        //if (hasConstraint)
+        //{
         //    var dropConstraintSql = string.Format(DeleteConstraint, tableName, constraint);
         //    msql.Add(dropConstraintSql);
         //    var constraintType = hasDefaultValue ? defaultValue : "";
         //    var createConstraintSql = string.Format(CreateConstraint, tableName, constraint, constraintType, FormatString(column));
         //    msql.Add(createConstraintSql);
-        // }
+        //}
+
         return sql.ToString();
     }
 
@@ -382,7 +388,8 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
                 .Split(Constants.CharArrays.CommaSpace, StringSplitOptions.RemoveEmptyEntries)
                 .Select(GetQuotedColumnName));
 
-        var primaryKeyPart = string.Concat("PRIMARY KEY", columnDefinition.IsIndexed ? " CLUSTERED" : " NONCLUSTERED");
+        var primaryKeyPart =
+            string.Concat("PRIMARY KEY", columnDefinition.IsIndexed ? " CLUSTERED" : " NONCLUSTERED");
 
         return string.Format(
             CreateConstraint,
@@ -404,7 +411,13 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public abstract Sql<ISqlContext> SelectTop(Sql<ISqlContext> sql, int top);
 
-    public abstract void HandleCreateTable(IDatabase database, TableDefinition tableDefinition, bool skipKeysAndIndexes = false);
+    public abstract void HandleCreateTable(
+        IDatabase database,
+        TableDefinition tableDefinition,
+        bool skipKeysAndIndexes = false);
+
+    public virtual string DeleteDefaultConstraint =>
+        throw new NotSupportedException("Default constraints are not supported");
 
     public virtual string CreateTable => "CREATE TABLE {0} ({1})";
 
@@ -447,9 +460,6 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     public virtual string ConvertDateToOrderableString => "CONVERT(nvarchar, {0}, 120)";
 
     public virtual string ConvertDecimalToOrderableString => "REPLACE(STR({0}, 20, 9), SPACE(1), '0')";
-
-    public virtual string GetSpecialDbType(SpecialDbType dbType, int customSize) =>
-        $"{GetSpecialDbType(dbType)}({customSize})";
 
     private DbTypes InitColumnTypeMap()
     {
@@ -499,6 +509,9 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
         return dbTypeMap.Create();
     }
+
+    public virtual string GetSpecialDbType(SpecialDbType dbType, int customSize) =>
+        $"{GetSpecialDbType(dbType)}({customSize})";
 
     protected virtual string FormatCascade(string onWhat, Rule rule)
     {
@@ -561,8 +574,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         var dbTypeDefinition = column.Size != default
             ? $"{definition}({column.Size})"
             : definition;
-
-        // NOTE Precision is left out
+        //NOTE Precision is left out
         return dbTypeDefinition;
     }
 

--- a/src/Umbraco.Infrastructure/Security/BackOfficeClaimsPrincipalFactory.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeClaimsPrincipalFactory.cs
@@ -6,7 +6,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Security;
 
 /// <summary>
-///     A <see cref="UserClaimsPrincipalFactory{TUser}" for the back office />
+///     A <see cref="UserClaimsPrincipalFactory{TUser}"/> for the back office
 /// </summary>
 public class BackOfficeClaimsPrincipalFactory : UserClaimsPrincipalFactory<BackOfficeIdentityUser>
 {

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -331,6 +331,7 @@ namespace Umbraco.Cms
             /// <param name="processed">
             ///     Tracks which instructions have already been processed to avoid duplicates
             /// </param>
+            /// <returns>
             /// Returns true if all instructions in the batch were processed, otherwise false if they could not be due to the app being shut down
             /// </returns>
             private bool ProcessDatabaseInstructions(

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -258,8 +258,7 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
         return InitializeColdBootState();
     }
 
-    // <summary>
-
+    /// <summary>
     /// Initializes a server that has never synchronized before.
     /// </summary>
     /// <remarks>

--- a/src/Umbraco.Infrastructure/Sync/ServerMessengerBase.cs
+++ b/src/Umbraco.Infrastructure/Sync/ServerMessengerBase.cs
@@ -22,7 +22,6 @@ public abstract class ServerMessengerBase : IServerMessenger
     /// <summary>
     ///     Determines whether to make distributed calls when messaging a cache refresher.
     /// </summary>
-    /// <param name="servers">The registered servers.</param>
     /// <param name="refresher">The cache refresher.</param>
     /// <param name="messageType">The message type.</param>
     /// <returns>true if distributed calls are required; otherwise, false, all we have is the local server.</returns>

--- a/src/Umbraco.Infrastructure/WebAssets/Resources.Designer.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Umbraco.Cms.Infrastructure.WebAssets {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Umbraco.Cms.Infrastructure.WebAssets {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,10 +59,10 @@ namespace Umbraco.Cms.Infrastructure.WebAssets {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [
-        ///    
+        ///
         ///    &apos;lib/jquery/jquery.min.js&apos;,
         ///    &apos;lib/jquery-ui/jquery-ui.min.js&apos;,
         ///    &apos;lib/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js&apos;,
@@ -86,7 +86,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets {
                 return ResourceManager.GetString("JsInitialize", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to LazyLoad.js(&quot;##JsInitialize##&quot;, function () {
         ///    //we need to set the legacy UmbClientMgr path
@@ -107,7 +107,7 @@ namespace Umbraco.Cms.Infrastructure.WebAssets {
                 return ResourceManager.GetString("Main", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [
         ///    &apos;lib/jquery/jquery.min.js&apos;,
@@ -130,24 +130,24 @@ namespace Umbraco.Cms.Infrastructure.WebAssets {
                 return ResourceManager.GetString("PreviewInitialize", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to // TODO: This would be nicer as an angular module so it can be injected into stuff... that&apos;d be heaps nicer, but
-        ///// how to do that when this is not a regular JS file, it is a server side JS file and RequireJS seems to only want
-        ///// to force load JS files ?
+        /// Looks up a localized string similar to // TODO: This would be nicer as an angular module so it can be injected into stuff... that&apos;d be heaps nicer, but
+        /// how to do that when this is not a regular JS file, it is a server side JS file and RequireJS seems to only want
+        /// to force load JS files ?
         ///
-        /////create the namespace (NOTE: This loads before any dependencies so we don&apos;t have a namespace mgr so we just create it manually)
-        ///var Umbraco = {};
-        ///Umbraco.Sys = {};
-        /////define a global static object
-        ///Umbraco.Sys.ServerVariables = ##Variables## ;.
+        /// create the namespace (NOTE: This loads before any dependencies so we don&apos;t have a namespace mgr so we just create it manually)
+        /// var Umbraco = {};
+        /// Umbraco.Sys = {};
+        /// define a global static object
+        /// Umbraco.Sys.ServerVariables = ##Variables## ;.
         /// </summary>
         internal static string ServerVariables {
             get {
                 return ResourceManager.GetString("ServerVariables", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [
         ///    &apos;lib/tinymce/tinymce.min.js&apos;,


### PR DESCRIPTION
For some reason the Docfx generation broke when we did the clean up of warnings.

I honestly still have no idea what broke, but it seems like the fix was to re-add an unused using statement for System to SqlSyntaxProviderBase, I have 0 idea why this is nececary, but it seems to be 🤷 


I did also find a couple of other malformed XML docs which I have fixed.