### PR TITLE
Umbraco-CMS.Accessibility.Issues#61

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -1,4 +1,4 @@
-﻿@using Microsoft.Extensions.Options;
+@using Microsoft.Extensions.Options;
 @using System.Globalization
 @using Umbraco.Cms.Core
 @using Umbraco.Cms.Core.Configuration
@@ -88,7 +88,7 @@
         <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
         <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
 
-        <umb-search ng-if="search.show" on-close="closeSearch()"></umb-search>
+        <umb-search ng-attr-umb-focus-lock="true" ng-if="search.show" on-close="closeSearch()"></umb-search>
 
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -148,7 +148,14 @@
 
                 // Whenever the DOM changes ensure the list of focused elements is updated
                 function domChange() {
-                    getFocusableElements();
+                  getFocusableElements();
+
+                  // When an element is remove or become not focusable, but focus is on it,
+                  // we need to ensure a now focus inside the trap, else the focus can escape the trap.
+                  if (focusableElements.filter(elm => elm == document.activeElement).length == 0)
+                  {
+                    setElementFocus();
+                  }
                 }
 
                 // Start observing the target node for configured mutations

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -187,6 +187,7 @@
                         ng-if="vm.lightbox.show"
                         items="vm.lightbox.items"
                         active-item-index="vm.lightbox.activeIndex"
+                        ng-attr-umb-focus-lock="true"
                         on-close="vm.closeLightbox">
                     </umb-lightbox>
 


### PR DESCRIPTION
### Prerequisites
https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/61

### Description
At the package details, can you at the bottom view some images, where if you tabbed around you ended outside of the ligthbox.
I have added the `umb-focus-lock` to the ligthbox, and now focus is trapped. 

Doing my test I saw if you opened up the lightbox, go next on the images until the last (so the next arrow disappere) and tab to move focus, the focus esacpe the trap. So I extended the directive. So whenever the DOM changes inside the trap, we are getting the focusableelement, but also see if current focus still is on a trapped focusabled element, if not we set the focus at new.
