### PR TITLE
V8: Replace usage of Random().Next with RNGCryptoServiceProvider

### DIFF
--- a/src/Umbraco.Core/CryptoServiceProviderExtensions.cs
+++ b/src/Umbraco.Core/CryptoServiceProviderExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Security.Cryptography;
+
+namespace Umbraco.Core
+{
+    public static class CryptoServiceProviderExtensions
+    {
+        /// <summary>
+        /// Generates a random int withing a specified range.
+        /// </summary>
+        /// <param name="provider">Random bytes provider.</param>
+        /// <param name="minValue">The minimum value of the resulting int.</param>
+        /// <param name="maxValue">The maximum value of the resulting int.</param>
+        /// <returns>A random integer that falls withing the specified range.</returns>
+        public static int GetInt32(this RNGCryptoServiceProvider provider, int minValue, int maxValue)
+        {
+            var randomBytes = new byte[4];
+            provider.GetBytes(randomBytes);
+
+            var randomInt = Math.Abs(BitConverter.ToInt32(randomBytes, 0));
+            // We call do mod to ensure that the value is within the specified range.
+            return randomInt % (maxValue - minValue + 1) + minValue;
+        }
+    }
+}
+
+

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Collections\EventClearingObservableCollection.cs" />
     <Compile Include="Constants-Sql.cs" />
     <Compile Include="Constants-SqlTemplates.cs" />
+    <Compile Include="CryptoServiceProviderExtensions.cs" />
     <Compile Include="Events\UnattendedInstallEventArgs.cs" />
     <Compile Include="Help\HelpPageSettings.cs" />
     <Compile Include="Help\IHelpPageSettings.cs" />

--- a/src/Umbraco.Web/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web/Security/BackOfficeUserManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Security;
@@ -294,21 +295,22 @@ namespace Umbraco.Web.Security
                 passwordValidator.RequiredLength,
                 passwordValidator.RequireNonLetterOrDigit ? 2 : 0);
 
-            var random = new Random();
-
             var passwordChars = password.ToCharArray();
 
-            if (passwordValidator.RequireDigit && passwordChars.ContainsAny(Enumerable.Range(48, 58).Select(x => (char)x)))
-                password += Convert.ToChar(random.Next(48, 58));  // 0-9
+            using (var numberGenerator = new RNGCryptoServiceProvider())
+            {
+                if (passwordValidator.RequireDigit && passwordChars.ContainsAny(Enumerable.Range(48, 58).Select(x => (char)x)))
+                    password += Convert.ToChar(numberGenerator.GetInt32(48, 58));  // 0-9
 
-            if (passwordValidator.RequireLowercase && passwordChars.ContainsAny(Enumerable.Range(97, 123).Select(x => (char)x)))
-                password += Convert.ToChar(random.Next(97, 123));  // a-z
+                if (passwordValidator.RequireLowercase && passwordChars.ContainsAny(Enumerable.Range(97, 123).Select(x => (char)x)))
+                    password += Convert.ToChar(numberGenerator.GetInt32(97, 123));  // a-z
 
-            if (passwordValidator.RequireUppercase && passwordChars.ContainsAny(Enumerable.Range(65, 91).Select(x => (char)x)))
-                password += Convert.ToChar(random.Next(65, 91));  // A-Z
+                if (passwordValidator.RequireUppercase && passwordChars.ContainsAny(Enumerable.Range(65, 91).Select(x => (char)x)))
+                    password += Convert.ToChar(numberGenerator.GetInt32(65, 91));  // A-Z
 
-            if (passwordValidator.RequireNonLetterOrDigit && passwordChars.ContainsAny(Enumerable.Range(33, 48).Select(x => (char)x)))
-                password += Convert.ToChar(random.Next(33, 48));  // symbols !"#$%&'()*+,-./
+                if (passwordValidator.RequireNonLetterOrDigit && passwordChars.ContainsAny(Enumerable.Range(33, 48).Select(x => (char)x)))
+                    password += Convert.ToChar(numberGenerator.GetInt32(33, 48));  // symbols !"#$%&'()*+,-./
+            }
 
             return password;
         }


### PR DESCRIPTION
Migrates #12759 to V8.

Unfortunately `RandomNumberGenerator.GetInt32` does not exists for framwork, so instead I've had to use the `RNGCryptoServiceProvider` to generate random bytes and turn that into an int 32 within the specified range.


## Testing
Ensure that you can still create a user, and that user gets a password with the required configuration 