### PR TITLE
Fixes and updates JSONSchema settings for Forms and Deploy configuration.

### DIFF
--- a/src/JsonSchema/AppSettings.cs
+++ b/src/JsonSchema/AppSettings.cs
@@ -120,6 +120,8 @@ namespace JsonSchema
                     public Recaptcha2Settings? Recaptcha2 { get; set; }
 
                     public Recaptcha3Settings? Recaptcha3 { get; set; }
+
+                    public RichTextSettings? RichText { get; set; }
                 }
             }
 

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -11,10 +11,8 @@
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="NJsonSchema" Version="10.7.2" />
       <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-      <PackageReference Include="Umbraco.Deploy.Core" Version="9.3.1" />
-      <PackageReference Include="Umbraco.Forms.Core" Version="10.0.0-rc1" />
-      <PackageReference Include="Umbraco.Deploy.Core" Version="9.4.0" />
-      <PackageReference Include="Umbraco.Forms.Core" Version="9.4.0" />
+      <PackageReference Include="Umbraco.Deploy.Core" Version="10.0.0" />
+      <PackageReference Include="Umbraco.Forms.Core" Version="10.1.0" />
       <PackageReference Update="Nerdbank.GitVersioning">
         <Version>3.5.107</Version>
       </PackageReference>


### PR DESCRIPTION
This adds an extra setting introduced in Forms 10.1 and also fixes up what looks like a merge issue with duplicate references to Forms and Deploy.

Forms 10.1 is currently only on MyGet, but it'll be on NuGet next Tuesday.