### PR TITLE
Display package version in Installed Packages

### DIFF
--- a/src/Umbraco.Core/Packaging/InstalledPackage.cs
+++ b/src/Umbraco.Core/Packaging/InstalledPackage.cs
@@ -14,6 +14,9 @@ public class InstalledPackage
     [DataMember(Name = "packageView")]
     public string? PackageView { get; set; }
 
+    [DataMember(Name = "version")]
+    public string? Version { get; set; }
+
     [DataMember(Name = "plans")]
     public IEnumerable<InstalledPackageMigrationPlans> PackageMigrationPlans { get; set; } =
         Enumerable.Empty<InstalledPackageMigrationPlans>();

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -157,7 +157,10 @@ public class PackagingService : IPackagingService
 
             if (!installedPackages.TryGetValue(package.PackageName, out InstalledPackage? installedPackage))
             {
-                installedPackage = new InstalledPackage { PackageName = package.PackageName };
+                installedPackage = new InstalledPackage {
+                    PackageName = package.PackageName,
+                    Version = string.IsNullOrEmpty(package.Version) ? "Unknown" : package.Version,
+                };
 
                 installedPackages.Add(package.PackageName, installedPackage);
             }

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
@@ -17,7 +17,7 @@
                             </div>
                             <div class="umb-package-list__item-content">
                                 <div class="umb-package-list__item-name">{{ installedPackage.name }}</div>
-                                <div class="umb-package-list__item-description">{{ installedPackage.version }}</div>
+                                <div class="umb-package-list__item-description">Version: {{ installedPackage.version }}</div>
                                 <div class="umb-package-list__item-description">
                                     <localize ng-if="installedPackage.hasMigrations && !installedPackage.hasPendingMigrations"
                                               key="packager_packageMigrationsNonePending">No pending migrations</localize>

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/installed.html
@@ -16,11 +16,12 @@
                                 <img ng-if="installedPackage.iconUrl" ng-src="{{installedPackage.iconUrl}}" />
                             </div>
                             <div class="umb-package-list__item-content">
-                              <div class="umb-package-list__item-name">{{ installedPackage.name }}</div>
-                              <div class="umb-package-list__item-description">
-                                <localize ng-if="installedPackage.hasMigrations && !installedPackage.hasPendingMigrations"
-                                          key="packager_packageMigrationsNonePending">No pending migrations</localize>
-                              </div>
+                                <div class="umb-package-list__item-name">{{ installedPackage.name }}</div>
+                                <div class="umb-package-list__item-description">{{ installedPackage.version }}</div>
+                                <div class="umb-package-list__item-description">
+                                    <localize ng-if="installedPackage.hasMigrations && !installedPackage.hasPendingMigrations"
+                                              key="packager_packageMigrationsNonePending">No pending migrations</localize>
+                                </div>
                             </div>
                           <!-- TODO: Show migrations up to date if they are -->
                         </td>


### PR DESCRIPTION
## What
Adds the package version from Package Manifest JSON file or C# ManifestFilter approach in the list of installed packages in the Umbraco backoffice.

![image](https://user-images.githubusercontent.com/1389894/182854781-84aa5e69-4798-4b3c-8a4b-e3e16f1475d2.png)


## Why
* Makes it clear to end users which version of a package they have installed.
* For package developers it will make them aware of the Version property if they have not set the value already.
* Package Version is used in the anonymous Telemetry data so its helpful to know what version of a package is installed/used

## Testing
* Create a package.manifest file with no 'version' property set
  * Should display `Version Unknown`
* Create a package.manifest JSON file with version property set
  * Verify correct information is displayed
* Use ManifestFilter with C# to register a package
  * Verify correct version shown

## Example ManifestFilter
```csharp
public class PackageManifestComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.ManifestFilters().Append<TagHelperManifestFilter>();
    }
}

public class TagHelperManifestFilter : IManifestFilter
{
    public void Filter(List<PackageManifest> manifests)
        {
        // Use reflection to get the version from the Assembly/DLL
        // Saves manually updating the version every release
        var version = typeof(TagHelperManifestFilter).Assembly?.GetName()?.Version?.ToString() ?? "Unknown";

        manifests.Add(new PackageManifest
        {
            PackageName = "Our Umbraco TagHelpers",
            AllowPackageTelemetry = true,
            Version = version
        });
    }
}
```



