### PR TITLE
Trap lightbox, and fix and bug in umbfocuslock found under test

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -152,7 +152,7 @@
 
                     // When an element is remove or become not focusable, but focus is on it,
                     // we need to ensure a now focus inside the trap, else the focus can escape the trap.
-                    if (focusableElements.indexOf(document.activeElement) === -1) {
+                    if (focusableElements.includes(document.activeElement) === false) {
                         setElementFocus();
                     }
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -152,7 +152,7 @@
 
                     // When an element is remove or become not focusable, but focus is on it,
                     // we need to ensure a now focus inside the trap, else the focus can escape the trap.
-                    if (focusableElements.filter(elm => elm == document.activeElement).length === 0) {
+                    if (focusableElements.indexOf(document.activeElement) === -1) {
                         setElementFocus();
                     }
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -149,6 +149,12 @@
                 // Whenever the DOM changes ensure the list of focused elements is updated
                 function domChange() {
                     getFocusableElements();
+
+                    // When an element is remove or become not focusable, but focus is on it,
+                    // we need to ensure a now focus inside the trap, else the focus can escape the trap.
+                    if (focusableElements.filter(elm => elm == document.activeElement).length === 0) {
+                        setElementFocus();
+                    }
                 }
 
                 // Start observing the target node for configured mutations

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -187,6 +187,7 @@
                         ng-if="vm.lightbox.show"
                         items="vm.lightbox.items"
                         active-item-index="vm.lightbox.activeIndex"
+                        ng-attr-umb-focus-lock="true"
                         on-close="vm.closeLightbox">
                     </umb-lightbox>
 

--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -187,7 +187,7 @@
                         ng-if="vm.lightbox.show"
                         items="vm.lightbox.items"
                         active-item-index="vm.lightbox.activeIndex"
-                        ng-attr-umb-focus-lock="true"
+                        umb-focus-lock="true"
                         on-close="vm.closeLightbox">
                     </umb-lightbox>
 


### PR DESCRIPTION
### Prerequisites
https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/61

### Description

Steps to replicate:
1) Go To packages tab
2) Open a package (e.g. Umbraco forms)
3) Scroll to bottom of the page and open the image modal

At the package details, can you at the bottom view some images, where if you tabbed around you ended outside of the ligthbox.
I have added the umb-focus-lock to the ligthbox, and now focus is trapped.

Doing my test I saw if you opened up the lightbox, go next on the images until the last (so the next arrow disappere) and tab to move focus, the focus esacpe the trap. So I extended the directive. So whenever the DOM changes inside the trap, we are getting the focusableelement, but also see if current focus still is on a trapped focusabled element, if not we set the focus at new.
