### PR TITLE
Pass cache level defined in value converters

### DIFF
--- a/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
+++ b/src/Umbraco.Web/PublishedCache/NuCache/PublishedContent.cs
@@ -40,7 +40,7 @@ namespace Umbraco.Web.PublishedCache.NuCache
                 // add one property per property type - this is required, for the indexing to work
                 // if contentData supplies pdatas, use them, else use null
                 contentData.Properties.TryGetValue(propertyType.Alias, out var pdatas); // else will be null
-                properties[i++] =new Property(propertyType, this, pdatas, _publishedSnapshotAccessor);
+                properties[i++] =new Property(propertyType, this, pdatas, _publishedSnapshotAccessor, propertyType.CacheLevel);
             }
             PropertiesArray = properties;
         }


### PR DESCRIPTION


### Prerequisites

- Create an implementation of ie `NestedContentSingleValueConverter`
- Override `GetPropertyCacheLevel`
- Check that your overridden property cache level is respected

### Description

We, on the heartcore saw, that our custom ValueConverters wasn't respected. This caused a few headaches, where when content containing nestedcontent had been copied, sometimes the key would be copied - causing incorrect data to be returned from the cache.

Investigation showed that our cache level wasn't being respected, hence we came up with this fix.

A more proper fix would be to ensure that nested content keys isn't copied when content is, we will discuss a potential fix for this.
