### PR TITLE
Fix issue with autolinking external accounts. User should be automatically approved during autolink steps.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -230,6 +230,12 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
 
         autoLinkUser = BackOfficeIdentityUser.CreateNew(_globalSettings, email, email, autoLinkOptions.GetUserAutoLinkCulture(_globalSettings), name);
 
+        // Enable the user if not approved - user cannot sign in otherwise.
+        if (!autoLinkUser.IsApproved)
+        {
+            autoLinkUser.IsApproved = true;
+        }
+
         foreach (var userGroup in autoLinkOptions.DefaultUserGroups)
         {
             autoLinkUser.AddRole(userGroup);


### PR DESCRIPTION

### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes: https://github.com/umbraco/Umbraco-CMS/issues/12670

### Description
There is an issue when using the 'auto-linking' feature for external accounts.
https://our.umbraco.com/documentation/reference/security/auto-linking/

Newly linked accounts are created in an unapproved state e.g. `IsApproved = false` so they will hit 401 errors when redirected back to umbraco from the configured external login provider.

![image](https://user-images.githubusercontent.com/59481722/183144872-84d4d6fc-f805-4d73-8412-3c504affc6ac.png)

![image](https://user-images.githubusercontent.com/59481722/183147476-e0bcd5b6-18c8-4ad4-b84a-517a40c06a76.png)

I believe accounts created through the autolinking process should be created with the `IsApproved` flag set to true.

My proposed change is simple adding this check to `Umbraco.Cms.Web.BackOffice.Security.BackOfficeSignInManager` 

```
// Enable the user if not approved - user cannot sign in otherwise.
if (!autoLinkUser.IsApproved)
{
    autoLinkUser.IsApproved = true;
}
```
Just after the call to `BackOfficeIdentityUser.CreateNew`.
https://github.com/umbraco/Umbraco-CMS/blob/c0c9c50e2110a88afab800abbf0e4a6b6a08c62d/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs#L235


### Testing
You can test these changes by configuring an external login provider, e.g. `Microsoft.AspNetCore.Authentication.OpenIdConnect` and following the documentation for setting up autolinking, found here:
 https://our.umbraco.com/documentation/reference/security/auto-linking/

As an aside, the documentation around autolinking could also be updated to reflect the proper name and role claim type mappings, e.g:

```
 // map claims
 options.TokenValidationParameters.NameClaimType = "name";
 options.TokenValidationParameters.RoleClaimType = "role";
```

Should actually be:

```
 // map claims
 options.TokenValidationParameters.NameClaimType = ClaimTypes.Name;
 options.TokenValidationParameters.RoleClaimType = ClaimTypes.Role;
```

As the example given is for OpenIdConnect. The provider wont know how to find the name or role claims using those dummy values, this caught me and others out.
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
