### PR TITLE
Added support for disabling tabs in <umbTabsNav /> elements

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-tabs.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-tabs.less
@@ -57,6 +57,11 @@
         text-decoration: none;
     }
 
+    &:disabled {
+        color: @ui-option-disabled-type;
+        text-decoration: none;
+    }
+
     &::after {
         content: "";
         height: 0px;

--- a/src/Umbraco.Web.UI.Client/src/less/navs.less
+++ b/src/Umbraco.Web.UI.Client/src/less/navs.less
@@ -290,6 +290,12 @@
     background: @ui-option-hover;
 }
 
+.dropdown-menu > li > button:disabled, 
+.dropdown-submenu:hover > button:disabled {
+    color: @ui-option-disabled-type;
+    background: transparent;
+}
+
 .nav-tabs .dropdown-menu {
   .border-radius(0 0 3px 3px); // remove the top rounded corners here since there is a hard edge above the menu
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,6 +1,6 @@
 <ul role="tablist" class="umb-tabs-nav">
     <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
-        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" aria-selected="{{tab.active}}" type="button">
+        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" ng-disabled="tab.disabled" aria-selected="{{tab.active}}" type="button">
             {{ tab.label }}
             <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
         </button>
@@ -23,6 +23,7 @@
                     ng-class="{'dropdown-menu--active': tab.active}"
                     ng-click="vm.clickTab($event, tab)"
                     role="tab"
+                    ng-disabled="tab.disabled"
                     aria-selected="{{tab.active}}" >
                     {{ tab.label }}
                     <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I came across a scenario where it would make sense that individual tabs in an `<umb-tabs-nav />` element can be in a disabled state.

As the tabs are essentially buttons, this PR adds `ng-disabled="tab.disabled"` to the tabs, and a bit of LESS styling so the tabs also looks disabled in the UI (text color is dimmed down and no background on hover).

I set up a quick dashboard to test my changes. The dashboard may be replicated with the following files:


**/src/Umbraco.Web.UI/App_Plugins/Hello/package.manifest**
```json
{
    "$schema": "https://json.schemastore.org/package.manifest",
    "javascript": [
	"/App_Plugins/Hello/Dashboard.js"
    ],
    "dashboards":  [
        {
            "alias": "hello",
            "view":  "/App_Plugins/Hello/Dashboard.html",
            "sections":  [ "content" ],
            "weight": -10
        }
    ]
}
```

**/src/Umbraco.Web.UI/App_Plugins/Hello/Dashboard.js**
```javascript
(function () {
    "use strict";
 
    function Controller(eventsService) {
 
        var vm = this;
 
        vm.changeTab = changeTab;
 
        vm.tabs = [
            {
                "alias": "tabOne",
                "label": "Tab 1",
                "active": true
            },
            {
                "alias": "tabTwo",
                "label": "Tab 2"
            },
            {
                "alias": "tabThree",
                "label": "Tab 3",
                "disabled": true
            },
            {
                "alias": "tabFour",
                "label": "Tab 4",
                "disabled": true
            },
            {
                "alias": "tabFive",
                "label": "Tab 5"
            }
        ];
 
        function changeTab(selectedTab) {
            vm.tabs.forEach(function(tab) {
                tab.active = false;
            });
            selectedTab.active = true;
        };
 
    }
 
    angular.module("umbraco").controller("Hello.Dashboard", Controller);
 
})();
```

**/src/Umbraco.Web.UI/App_Plugins/Hello/Dashboard.html**
```html
<div ng-controller="Hello.Dashboard as vm" style="min-height: 350px;">
    <ng-form name="tabsForm" val-form-manager>
        <umb-tabs-nav
            tabs="vm.tabs"
            on-tab-change="vm.changeTab(tab)">
        </umb-tabs-nav>
        <umb-tab-content
            ng-repeat="tab in vm.tabs"
            ng-show="tab.active"
            tab="tab">
            <div ng-if="tab.alias === 'tabOne'">
                <div>Content of tab 1</div>
            </div>
            <div ng-if="tab.alias === 'tabTwo'">
                <div>Content of tab 2</div>
            </div>
        </umb-tab-content>
    </ng-form>
</div>
```

My demo dashboard has five tabs, where Tab 3 and Tab 4 are disabled. When there is enough space for the tabs, it look like this:

![image](https://user-images.githubusercontent.com/3634580/183294749-3a3015ce-0f8d-4006-8435-6859a365f600.png)

When there is not enough space, the last few tabs are placed in a dropdown menu instead. This will look something like:

![image](https://user-images.githubusercontent.com/3634580/183294445-c7641dcf-587a-4c3f-8df7-0be177b28a65.png)

Dropdown menu items normally have a hover effect for both the text color and the background. My additions to the `navs.less` file ensures that the hover effect on disabled tabs/buttons are removed.

<hr />

The disabled text color uses the `@ui-option-disabled-type` LESS variable, which is equal to `@gray-6`, which again is equal to `#A2A1A6`.

IMO it could help emphasize the disabled state if the text color was a bit lighter - eg. `@gray-7` (`#BBBABF`) or perhaps even `@gray-8` (`#D8D7D9`). But at least for now, I've went with `@ui-option-disabled-type` (`@gray-6`) as this appears to be the default throughout the backoffice.

Here is a quick illustration of the colors:

![image](https://user-images.githubusercontent.com/3634580/183294888-8057d354-29fc-4704-a950-2e0082ecdb65.png)



<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
