### PR TITLE
Content modal heading fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/html/umb-group-panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/html/umb-group-panel.less
@@ -17,7 +17,8 @@
 .umb-group-panel__header h2 {
   font-size: @fontSizeMedium;
   font-weight: bold;
-  line-height: 0;
+  line-height: 1.3;
+  margin: 0;
 }
 
 .umb-group-panel__content {

--- a/src/Umbraco.Web.UI.Client/src/less/components/html/umb-group-panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/html/umb-group-panel.less
@@ -17,6 +17,7 @@
 .umb-group-panel__header h2 {
   font-size: @fontSizeMedium;
   font-weight: bold;
+  line-height: 0;
 }
 
 .umb-group-panel__content {

--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -16,7 +16,8 @@
   white-space: nowrap
 }
 
-.umb-modalcolumn-header h1 {
+.umb-modalcolumn-header h1,
+.umb-modalcolumn-header h2 {
   margin: 0;
   white-space: nowrap;
   font-size: @fontSizeMedium;

--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -16,7 +16,7 @@
   white-space: nowrap
 }
 
-.umb-modalcolumn-header h2 {
+.umb-modalcolumn-header h1 {
   margin: 0;
   white-space: nowrap;
   font-size: @fontSizeMedium;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description


After merging the above PR #12702 the styling of the headings h1 in the content and create modal were styled incorrectly:

![image](https://user-images.githubusercontent.com/8383558/183304791-f88ecd2d-9509-4e3d-a328-412311ba099c.png)

whereas the styling of h2's on the content groups had too much white space above and below.

![image](https://user-images.githubusercontent.com/8383558/183304767-7644c0d0-caa5-406d-836c-0c49c0a86ac5.png)

This occurs because of a global property for H tags that applies a default lineheight for all headings.

As a result I have:

- reset the lineheight to 0 for headings that use the class .umb-group-panel__header:

```
.umb-group-panel__header h2 {
  font-size: @fontSizeMedium;
  font-weight: bold;
  line-height: 0;
}
```

- fixed the h1 styling for modals by applying the same styling that was previously applied when the element was a div:

```
.umb-modalcolumn-header h1,
.umb-modalcolumn-header h2 {
  margin: 0;
  white-space: nowrap;
  font-size: @fontSizeMedium;
  font-weight: 400;
}
```
![image](https://user-images.githubusercontent.com/8383558/183306456-01b533c1-5773-4ead-b1a6-17d9ead6d555.png)



Therefore I have reset the lineheight to 0 on the group headings and ensured that the styling for the content modal matches the styling it used prior to the above merge - but updated to use headings instead of div.

![image](https://user-images.githubusercontent.com/8383558/183306316-817eb1d0-096a-40fc-add9-833320f501ab.png)

![image](https://user-images.githubusercontent.com/8383558/183306215-f1a97df6-4d07-4630-b69f-00d6eec9fbb9.png)



In order to test:

- open backoffice
- create a dummy site using doctypes with group sections such as 'content'
- Create a homepage from the root node by right-clicking
- The modal heading (h1) should now be the same size it was previously and not super huge.  This should be the case for all contextual modal headings across the sections such as in Media
- Right-click on the 3 dots on the root node to bring up the 'create' modal.  The heading should be the same as it was prior to the PR referenced above.
- Go to the editing section of the homepage and find the group headings normally called 'content'
- There should now be no whitespace above and below these headings


<!-- Thanks for contributing to Umbraco CMS! -->
