### PR TITLE
Makes active pip text darker to contrast with non-active pips

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -139,6 +139,7 @@ For extra details about options and events take a look here: https://refreshless
             });
 
             setUpCallbacks();
+            setUpActivePipsHandling();
 
             // Refresh the scope
             $scope.$applyAsync();
@@ -299,7 +300,18 @@ For extra details about options and events take a look here: https://refreshless
                 });
             });
         }
-
+      function setUpActivePipsHandling() {
+        console.log("setUpActivePipsHandling");
+        const pips = sliderInstance.querySelectorAll('.noUi-value');
+        let activePip = [null, null];
+        sliderInstance.noUiSlider.on('update', function (values,handle) {
+          if(activePip[handle]){
+            activePip[handle].classList.remove("noUi-value-active");
+          }
+          activePip[handle] = pips[parseInt(values[handle])-1];
+          activePip[handle].classList.add("noUi-value-active");
+        });
+      }
     }
 
     angular.module('umbraco.directives').component('umbRangeSlider', umbRangeSlider);

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -301,7 +301,6 @@ For extra details about options and events take a look here: https://refreshless
             });
         }
       function setUpActivePipsHandling() {
-        console.log("setUpActivePipsHandling");
         const pips = sliderInstance.querySelectorAll('.noUi-value');
         let activePip = [null, null];
         sliderInstance.noUiSlider.on('update', function (values,handle) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -301,13 +301,12 @@ For extra details about options and events take a look here: https://refreshless
             });
         }
       function setUpActivePipsHandling() {
-        const pips = sliderInstance.querySelectorAll('.noUi-value');
         let activePip = [null, null];
         sliderInstance.noUiSlider.on('update', function (values,handle) {
           if(activePip[handle]){
             activePip[handle].classList.remove("noUi-value-active");
           }
-          activePip[handle] = pips[parseInt(values[handle])-1];
+          activePip[handle] = sliderInstance.querySelector('.noUi-value[data-value="' + parseInt(values[handle]) + '"]');
           activePip[handle].classList.add("noUi-value-active");
         });
       }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -140,6 +140,7 @@ For extra details about options and events take a look here: https://refreshless
 
             setUpCallbacks();
             setUpActivePipsHandling();
+            addPipClickHandler();
 
             // Refresh the scope
             $scope.$applyAsync();
@@ -306,9 +307,21 @@ For extra details about options and events take a look here: https://refreshless
           if(activePip[handle]){
             activePip[handle].classList.remove("noUi-value-active");
           }
-          activePip[handle] = sliderInstance.querySelector('.noUi-value[data-value="' + parseInt(values[handle]) + '"]');
+          sliderInstance.querySelectorAll('.noUi-value').forEach(pip => {
+            if (Number(values[handle]) === Number(pip.getAttribute('data-value'))) {
+              activePip[handle] = pip;
+            }
+          });
           activePip[handle].classList.add("noUi-value-active");
         });
+      }
+      function addPipClickHandler(){
+          sliderInstance.querySelectorAll('.noUi-value').forEach(function(pip){
+            pip.addEventListener('click', function () {
+              const value = pip.getAttribute('data-value');
+              sliderInstance.noUiSlider.set(value);
+            });
+          });
       }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -58,6 +58,15 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
 
       const pips = consentSlider.querySelectorAll('.noUi-value');
 
+      let activePip = null;
+      consentSlider.noUiSlider.on('update', function (values,handle) {
+        if(activePip){
+          activePip.classList.remove("noUi-value-active");
+        }
+        activePip = pips[parseInt(values[0]) -1];
+        activePip.classList.add("noUi-value-active");
+      });
+
       $(consentSlider).on('$destroy', function () {
         consentSlider.noUiSlider.off();
       });

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -58,13 +58,13 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
 
       const pips = consentSlider.querySelectorAll('.noUi-value');
 
-      let activePip = null;
+      let activePip = [null, null];
       consentSlider.noUiSlider.on('update', function (values,handle) {
-        if(activePip){
-          activePip.classList.remove("noUi-value-active");
+        if(activePip[handle]){
+          activePip[handle].classList.remove("noUi-value-active");
         }
-        activePip = pips[parseInt(values[0]) -1];
-        activePip.classList.add("noUi-value-active");
+        activePip[handle] = pips[parseInt(values[handle])-1];
+        activePip[handle].classList.add("noUi-value-active");
       });
 
       $(consentSlider).on('$destroy', function () {

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -63,7 +63,11 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
         if(activePip[handle]){
           activePip[handle].classList.remove("noUi-value-active");
         }
-        activePip[handle] = pips[parseInt(values[handle])-1];
+        consentSlider.querySelectorAll('.noUi-value').forEach(pip => {
+          if (Number(values[handle]) === Number(pip.getAttribute('data-value'))) {
+            activePip[handle] = pip;
+          }
+        });
         activePip[handle].classList.add("noUi-value-active");
       });
 

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -47,7 +47,7 @@
             <label class="control-label">Telemetry</label>
             <div class="controls">
               <div id="consentSliderWrapper">
-                <div id="consentSlider"></div>
+                <div id="consentSlider" class="umb-range-slider"></div>
 
                 <umb-tooltip ng-if="consentTooltip.show" event="consentTooltip.event">
                   <div ng-bind-html="consentTooltip.description"></div>

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-range-slider.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-range-slider.less
@@ -53,6 +53,9 @@
     width: 1px;
 }
 
-.umb-range-slider .noUi-value-active {
-  color: @black;
+.noUi-value {
+  cursor: pointer;
+  &-active{
+    color: @black;
+  }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-range-slider.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-range-slider.less
@@ -52,3 +52,7 @@
 .umb-range-slider .noUi-marker.noUi-marker-horizontal {
     width: 1px;
 }
+
+.umb-range-slider .noUi-value-active {
+  color: @black;
+}

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -18,6 +18,7 @@
 // Umbraco Components
 @import "components/umb-loader.less";
 @import "components/tooltip/umb-tooltip.less";
+@import "components/umb-range-slider.less";
 
 
 [ng\:cloak],
@@ -285,48 +286,3 @@ select {
   margin-bottom: 40px;
 }
 
-#consentSlider {
-  .noUi-target {
-    background: linear-gradient(to bottom, @grayLighter 0%, @grayLighter 100%);
-    box-shadow: none;
-    border-radius: 20px;
-    height: 8px;
-    border: 1px solid @inputBorder;
-
-    &:focus,
-    &:focus-within {
-      border-color: @inputBorderFocus;
-    }
-  }
-
-  .noUi-handle {
-    cursor: grab;
-    border-radius: 100px;
-    border: none;
-    box-shadow: none;
-    width: 20px !important;
-    height: 20px !important;
-    right: -10px !important; // half the handle width
-    top: -1px;
-    background-color: @blueExtraDark;
-  }
-
-  .noUi-handle::before {
-    display: none;
-  }
-
-  .noUi-handle::after {
-    display: none;
-  }
-
-  .noUi-value {
-    cursor: pointer;
-    &-active{
-      color: @black;
-    }
-  }
-
-  .noUi-pips-horizontal {
-    height: 40px;
-  }
-}

--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -321,6 +321,9 @@ select {
 
   .noUi-value {
     cursor: pointer;
+    &-active{
+      color: @black;
+    }
   }
 
   .noUi-pips-horizontal {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [12773](https://github.com/umbraco/Umbraco-CMS/issues/12773)

### Description
Adds a class to the active pip (slider on the install screen) that makes it darker to contrast with the non-active pips.
To test build and start an installation, choose a new telemetry "level" and observe that the active class moves to the selected value.


<!-- Thanks for contributing to Umbraco CMS! -->
