### PR TITLE
Only expose the filename when uploading content types

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -571,7 +571,7 @@ public class ContentTypeController : ContentTypeControllerBase<IContentType>
     [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
     public IActionResult Import(string file)
     {
-        var filePath = Path.Combine(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.Data), file);
+        var filePath = Path.Combine(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads), file);
         if (string.IsNullOrEmpty(file) || !System.IO.File.Exists(filePath))
         {
             return NotFound();
@@ -623,10 +623,10 @@ public class ContentTypeController : ContentTypeControllerBase<IContentType>
 
                 if (ext.InvariantEquals("udt"))
                 {
-                    model.TempFileName = Path.Combine(root, fileName);
+                    model.TempFileName = fileName;
 
                     var xd = new XmlDocument { XmlResolver = null };
-                    xd.Load(model.TempFileName);
+                    xd.Load(Path.Combine(root,  fileName));
 
                     model.Alias = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Alias")?.FirstChild?.Value;
                     model.Name = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Name")?.FirstChild?.Value;


### PR DESCRIPTION
This PR changes so the temp folder location is not exposed in API.