### PR TITLE
Only expose the filename when uploading content types

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -552,7 +552,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
         public IActionResult Import(string file)
         {
-            var filePath = Path.Combine(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.Data), file);
+            var filePath = Path.Combine(_hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads), file);
             if (string.IsNullOrEmpty(file) || !System.IO.File.Exists(filePath))
             {
                 return NotFound();
@@ -601,13 +601,13 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
 
                     if (ext.InvariantEquals("udt"))
                     {
-                        model.TempFileName = Path.Combine(root, fileName);
+                        model.TempFileName = fileName;
 
                         var xd = new XmlDocument
                         {
                             XmlResolver = null
                         };
-                        xd.Load(model.TempFileName);
+                        xd.Load(Path.Combine(root,  fileName));
 
                         model.Alias = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Alias")?.FirstChild.Value;
                         model.Name = xd.DocumentElement?.SelectSingleNode("//DocumentType/Info/Name")?.FirstChild.Value;


### PR DESCRIPTION
Only expose filename when uploading content types, and not the entire temp folder