### PR TITLE
Update Ace code editor to v1.9.4

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -7,7 +7,7 @@
       "name": "ui",
       "dependencies": {
         "@microsoft/signalr": "6.0.4",
-        "ace-builds": "1.4.2",
+        "ace-builds": "1.9.4",
         "angular": "1.8.3",
         "angular-animate": "1.8.3",
         "angular-aria": "1.8.3",
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.2.tgz",
-      "integrity": "sha512-M1JtZctO2Zg+1qeGUFZXtYKsyaRptqQtqpVzlj80I0NzGW9MF3um0DBuizIvQlrPYUlTdm+wcOPZpZoerkxQdA=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.9.4.tgz",
+      "integrity": "sha512-17qGGPdFo3IHFhrtPQdVnWYI1IP4lNDtp3valwgIX7KyQiyt2ZmwKX+XYtvHi90NA6KNgGceZGzwuJr4PzicBA=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -18023,9 +18023,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.2.tgz",
-      "integrity": "sha512-M1JtZctO2Zg+1qeGUFZXtYKsyaRptqQtqpVzlj80I0NzGW9MF3um0DBuizIvQlrPYUlTdm+wcOPZpZoerkxQdA=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.9.4.tgz",
+      "integrity": "sha512-17qGGPdFo3IHFhrtPQdVnWYI1IP4lNDtp3valwgIX7KyQiyt2ZmwKX+XYtvHi90NA6KNgGceZGzwuJr4PzicBA=="
     },
     "acorn": {
       "version": "7.4.1",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@microsoft/signalr": "6.0.4",
-    "ace-builds": "1.4.2",
+    "ace-builds": "1.9.4",
     "angular": "1.8.3",
     "angular-animate": "1.8.3",
     "angular-aria": "1.8.3",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
It has been a while since the [Ace editor](https://github.com/ajaxorg/ace) via [Ace builds](https://github.com/ajaxorg/ace-builds) has been updated and since the JavaScript has matured.

The current version shows warnings at keywords like `let` and `const` which most modern browsers support:
https://caniuse.com/let
https://caniuse.com/const

Some modern example JS snippets: https://javascript.plainenglish.io/modern-practical-javascript-code-snippets-4002a7a4ba9c

**Before**

![image](https://user-images.githubusercontent.com/2919859/183750954-5c1cf3e1-53ad-46c0-878a-eee4aab3ca15.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/183750205-121246e7-7802-4cd2-abdf-2ec801125cef.png)

It seems it is also possible to set a specific `esversion`:
https://github.com/ajaxorg/ace/issues/3160#issuecomment-1170018316