### PR TITLE
Implement new backoffice upgrader

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/Controllers/UpgradeController.cs
+++ b/src/Umbraco.Cms.ManagementApi/Controllers/UpgradeController.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.ManagementApi.Filters;
+using Umbraco.Cms.ManagementApi.ViewModels.Installer;
+using Umbraco.New.Cms.Core.Factories;
+using Umbraco.New.Cms.Core.Models.Installer;
+using Umbraco.New.Cms.Web.Common.Routing;
+
+namespace Umbraco.Cms.ManagementApi.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[BackofficeRoute("api/v{version:apiVersion}/upgrade")]
+public class UpgradeController : Controller
+{
+    private readonly IUpgradeSettingsFactory _upgradeSettingsFactory;
+    private readonly IUmbracoMapper _mapper;
+
+    public UpgradeController(
+        IUpgradeSettingsFactory upgradeSettingsFactory,
+        IUmbracoMapper mapper)
+    {
+        _upgradeSettingsFactory = upgradeSettingsFactory;
+        _mapper = mapper;
+    }
+
+    [HttpGet("settings")]
+    [MapToApiVersion("1.0")]
+    [RequireRuntimeLevel(RuntimeLevel.Upgrade)]
+    [ProducesResponseType(typeof(UpgradeSettingsViewModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status428PreconditionRequired)]
+    public async Task<ActionResult<UpgradeSettingsViewModel>> Settings()
+    {
+        UpgradeSettingsModel upgradeSettings = _upgradeSettingsFactory.GetUpgradeSettings();
+        UpgradeSettingsViewModel viewModel = _mapper.Map<UpgradeSettingsViewModel>(upgradeSettings)!;
+
+        return viewModel;
+    }
+}

--- a/src/Umbraco.Cms.ManagementApi/Controllers/UpgradeController.cs
+++ b/src/Umbraco.Cms.ManagementApi/Controllers/UpgradeController.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.ManagementApi.Filters;
 using Umbraco.Cms.ManagementApi.ViewModels.Installer;
 using Umbraco.New.Cms.Core.Factories;
 using Umbraco.New.Cms.Core.Models.Installer;
+using Umbraco.New.Cms.Core.Services.Installer;
 using Umbraco.New.Cms.Web.Common.Routing;
 
 namespace Umbraco.Cms.ManagementApi.Controllers;
@@ -16,14 +17,29 @@ namespace Umbraco.Cms.ManagementApi.Controllers;
 public class UpgradeController : Controller
 {
     private readonly IUpgradeSettingsFactory _upgradeSettingsFactory;
+    private readonly IUpgradeService _upgradeService;
     private readonly IUmbracoMapper _mapper;
 
     public UpgradeController(
         IUpgradeSettingsFactory upgradeSettingsFactory,
+        IUpgradeService upgradeService,
         IUmbracoMapper mapper)
     {
         _upgradeSettingsFactory = upgradeSettingsFactory;
+        _upgradeService = upgradeService;
         _mapper = mapper;
+    }
+
+    [HttpPost("authorize")]
+    [MapToApiVersion("1.0")]
+    [RequireRuntimeLevel(RuntimeLevel.Upgrade)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status428PreconditionRequired)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Authorize()
+    {
+        await _upgradeService.Upgrade();
+        return Ok();
     }
 
     [HttpGet("settings")]

--- a/src/Umbraco.Cms.ManagementApi/DependencyInjection/InstallerBuilderExtensions.cs
+++ b/src/Umbraco.Cms.ManagementApi/DependencyInjection/InstallerBuilderExtensions.cs
@@ -31,6 +31,15 @@ public static class InstallerBuilderExtensions
         return builder;
     }
 
+    internal static IUmbracoBuilder AddNewUpgrader(this IUmbracoBuilder builder)
+    {
+        IServiceCollection services = builder.Services;
+
+        services.AddTransient<IUpgradeSettingsFactory, UpgradeSettingsFactory>();
+
+        return builder;
+    }
+
     internal static IUmbracoBuilder AddInstallSteps(this IUmbracoBuilder builder)
     {
         builder.InstallSteps()

--- a/src/Umbraco.Cms.ManagementApi/DependencyInjection/InstallerBuilderExtensions.cs
+++ b/src/Umbraco.Cms.ManagementApi/DependencyInjection/InstallerBuilderExtensions.cs
@@ -31,11 +31,13 @@ public static class InstallerBuilderExtensions
         return builder;
     }
 
-    internal static IUmbracoBuilder AddNewUpgrader(this IUmbracoBuilder builder)
+    internal static IUmbracoBuilder AddUpgrader(this IUmbracoBuilder builder)
     {
         IServiceCollection services = builder.Services;
 
         services.AddTransient<IUpgradeSettingsFactory, UpgradeSettingsFactory>();
+
+        builder.AddUpgradeSteps();
 
         return builder;
     }
@@ -58,4 +60,20 @@ public static class InstallerBuilderExtensions
 
     public static NewInstallStepCollectionBuilder InstallSteps(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<NewInstallStepCollectionBuilder>();
+
+    internal static IUmbracoBuilder AddUpgradeSteps(this IUmbracoBuilder builder)
+    {
+        builder.UpgradeSteps()
+            .Append<FilePermissionsStep>()
+            .Append<TelemetryIdentifierStep>()
+            .Append<DatabaseInstallStep>()
+            .Append<DatabaseUpgradeStep>()
+            .Append<RegisterInstallCompleteStep>()
+            .Append<RestartRuntimeStep>();
+
+        return builder;
+    }
+
+    public static UpgradeStepCollectionBuilder UpgradeSteps(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<UpgradeStepCollectionBuilder>();
 }

--- a/src/Umbraco.Cms.ManagementApi/DependencyInjection/InstallerBuilderExtensions.cs
+++ b/src/Umbraco.Cms.ManagementApi/DependencyInjection/InstallerBuilderExtensions.cs
@@ -36,8 +36,8 @@ public static class InstallerBuilderExtensions
         IServiceCollection services = builder.Services;
 
         services.AddTransient<IUpgradeSettingsFactory, UpgradeSettingsFactory>();
-
         builder.AddUpgradeSteps();
+        services.AddScoped<IUpgradeService, UpgradeService>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
+++ b/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
@@ -31,7 +31,7 @@ public class ManagementApiComposer : IComposer
 
         builder
             .AddNewInstaller()
-            .AddNewUpgrader();
+            .AddUpgrader();
 
         services.AddApiVersioning(options =>
         {

--- a/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
+++ b/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
@@ -29,7 +29,9 @@ public class ManagementApiComposer : IComposer
     {
         IServiceCollection services = builder.Services;
 
-        builder.AddNewInstaller();
+        builder
+            .AddNewInstaller()
+            .AddNewUpgrader();
 
         services.AddApiVersioning(options =>
         {

--- a/src/Umbraco.Cms.ManagementApi/Mapping/Installer/InstallerViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.ManagementApi/Mapping/Installer/InstallerViewModelsMapDefinition.cs
@@ -20,6 +20,16 @@ public class InstallerViewModelsMapDefinition : IMapDefinition
         mapper.Define<IDatabaseProviderMetadata, DatabaseSettingsModel>((source, context) => new DatabaseSettingsModel(), Map);
         mapper.Define<DatabaseSettingsModel, DatabaseSettingsViewModel>((source, context) => new DatabaseSettingsViewModel(), Map);
         mapper.Define<ConsentLevelModel, ConsentLevelViewModel>((source, context) => new ConsentLevelViewModel(), Map);
+        mapper.Define<UpgradeSettingsModel, UpgradeSettingsViewModel>((source, context) => new UpgradeSettingsViewModel(), Map);
+    }
+
+    // Umbraco.Code.MapAll
+    private void Map(UpgradeSettingsModel source, UpgradeSettingsViewModel target, MapperContext context)
+    {
+        target.CurrentState = source.CurrentState;
+        target.NewState = source.NewState;
+        target.NewVersion = source.NewVersion.ToString();
+        target.OldVersion = source.OldVersion.ToString();
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.ManagementApi/ViewModels/Installer/UpgradeSettingsViewModel.cs
+++ b/src/Umbraco.Cms.ManagementApi/ViewModels/Installer/UpgradeSettingsViewModel.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.ManagementApi.ViewModels.Installer;
+
+[DataContract(Name = "upgradeSettingsViewModel")]
+public class UpgradeSettingsViewModel
+{
+    [DataMember(Name = "currentState")]
+    public string CurrentState { get; set; } = string.Empty;
+
+    [DataMember(Name = "newState")]
+    public string NewState { get; set; } = string.Empty;
+
+    [DataMember(Name = "newVersion")]
+    public string NewVersion { get; set; } = string.Empty;
+
+    [DataMember(Name = "oldVersion")]
+    public string OldVersion { get; set; } = string.Empty;
+
+    [DataMember(Name = "reportUrl")]
+    public string ReportUrl =>
+        $"https://our.umbraco.com/contribute/releases/compare?from={OldVersion}&to={NewVersion}&notes=1";
+}

--- a/src/Umbraco.New.Cms.Core/Factories/IUpgradeSettingsFactory.cs
+++ b/src/Umbraco.New.Cms.Core/Factories/IUpgradeSettingsFactory.cs
@@ -1,0 +1,8 @@
+﻿using Umbraco.New.Cms.Core.Models.Installer;
+
+namespace Umbraco.New.Cms.Core.Factories;
+
+public interface IUpgradeSettingsFactory
+{
+    public UpgradeSettingsModel GetUpgradeSettings();
+}

--- a/src/Umbraco.New.Cms.Core/Factories/IUpgradeSettingsFactory.cs
+++ b/src/Umbraco.New.Cms.Core/Factories/IUpgradeSettingsFactory.cs
@@ -4,5 +4,5 @@ namespace Umbraco.New.Cms.Core.Factories;
 
 public interface IUpgradeSettingsFactory
 {
-    public UpgradeSettingsModel GetUpgradeSettings();
+    UpgradeSettingsModel GetUpgradeSettings();
 }

--- a/src/Umbraco.New.Cms.Core/Factories/UpgradeSettingsFactory.cs
+++ b/src/Umbraco.New.Cms.Core/Factories/UpgradeSettingsFactory.cs
@@ -1,0 +1,34 @@
+﻿using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Services;
+using Umbraco.New.Cms.Core.Models.Installer;
+
+namespace Umbraco.New.Cms.Core.Factories;
+
+public class UpgradeSettingsFactory : IUpgradeSettingsFactory
+{
+    private readonly IRuntimeState _runtimeState;
+    private readonly IUmbracoVersion _umbracoVersion;
+
+    public UpgradeSettingsFactory(
+        IRuntimeState runtimeState,
+        IUmbracoVersion umbracoVersion)
+    {
+        _runtimeState = runtimeState;
+        _umbracoVersion = umbracoVersion;
+    }
+
+
+    public UpgradeSettingsModel GetUpgradeSettings()
+    {
+        var model = new UpgradeSettingsModel
+        {
+            CurrentState = _runtimeState.CurrentMigrationState ?? string.Empty,
+            NewState = _runtimeState.FinalMigrationState ?? string.Empty,
+            NewVersion = _umbracoVersion.SemanticVersion,
+            OldVersion = new SemVersion(_umbracoVersion.SemanticVersion.Major),
+        };
+
+        return model;
+    }
+}

--- a/src/Umbraco.New.Cms.Core/Installer/IInstallStep.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/IInstallStep.cs
@@ -3,7 +3,7 @@
 namespace Umbraco.New.Cms.Core.Installer;
 
 /// <summary>
-/// Defines a step that's needed to install Umbraco.
+/// Defines a step that's required to install Umbraco.
 /// </summary>
 public interface IInstallStep
 {
@@ -18,6 +18,6 @@ public interface IInstallStep
     /// Determines if the step is required to execute.
     /// </summary>
     /// <param name="model">InstallData model containing the data provided by the installer UI.</param>
-    /// <returns></returns>
+    /// <returns>True if the step should execute, otherwise false.</returns>
     Task<bool> RequiresExecutionAsync(InstallData model);
 }

--- a/src/Umbraco.New.Cms.Core/Installer/IUpgradeStep.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/IUpgradeStep.cs
@@ -1,0 +1,18 @@
+﻿namespace Umbraco.New.Cms.Core.Installer;
+
+/// <summary>
+/// Defines a step that's required to upgrade Umbraco.
+/// </summary>
+public interface IUpgradeStep
+{
+    /// <summary>
+    /// Executes the upgrade step.
+    /// </summary>
+    Task ExecuteAsync();
+
+    /// <summary>
+    /// Determines if the step is required to execute.
+    /// </summary>
+    /// <returns>True if the step should execute, otherwise false.</returns>
+    Task<bool> RequiresExecutionAsync();
+}

--- a/src/Umbraco.New.Cms.Core/Installer/Steps/FilePermissionsStep.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/Steps/FilePermissionsStep.cs
@@ -1,12 +1,11 @@
 ﻿using Umbraco.Cms.Core.Install;
-using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 using Umbraco.New.Cms.Core.Models.Installer;
 
 namespace Umbraco.New.Cms.Core.Installer.Steps;
 
-public class FilePermissionsStep : IInstallStep
+public class FilePermissionsStep : IInstallStep, IUpgradeStep
 {
     private readonly IFilePermissionHelper _filePermissionHelper;
     private readonly ILocalizedTextService _localizedTextService;
@@ -19,7 +18,11 @@ public class FilePermissionsStep : IInstallStep
         _localizedTextService = localizedTextService;
     }
 
-    public Task ExecuteAsync(InstallData model)
+    public Task ExecuteAsync(InstallData _) => Execute();
+
+    public Task ExecuteAsync() => Execute();
+
+    private Task Execute()
     {
         // validate file permissions
         var permissionsOk =
@@ -36,5 +39,9 @@ public class FilePermissionsStep : IInstallStep
         return Task.CompletedTask;
     }
 
-    public Task<bool> RequiresExecutionAsync(InstallData model) => Task.FromResult(true);
+    public Task<bool> RequiresExecutionAsync(InstallData model) => ShouldExecute();
+
+    public Task<bool> RequiresExecutionAsync() => ShouldExecute();
+
+    private static Task<bool> ShouldExecute() => Task.FromResult(true);
 }

--- a/src/Umbraco.New.Cms.Core/Installer/Steps/RestartRuntimeStep.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/Steps/RestartRuntimeStep.cs
@@ -3,13 +3,21 @@ using Umbraco.New.Cms.Core.Models.Installer;
 
 namespace Umbraco.New.Cms.Core.Installer.Steps;
 
-public class RestartRuntimeStep : IInstallStep
+public class RestartRuntimeStep : IInstallStep, IUpgradeStep
 {
     private readonly IRuntime _runtime;
 
     public RestartRuntimeStep(IRuntime runtime) => _runtime = runtime;
 
-    public async Task ExecuteAsync(InstallData model) => await _runtime.RestartAsync();
+    public async Task ExecuteAsync(InstallData _) => await Execute();
 
-    public Task<bool> RequiresExecutionAsync(InstallData model) => Task.FromResult(true);
+    public async Task ExecuteAsync() => await Execute();
+
+    private async Task Execute() => await _runtime.RestartAsync();
+
+    public Task<bool> RequiresExecutionAsync(InstallData _) => ShouldExecute();
+
+    public Task<bool> RequiresExecutionAsync() => ShouldExecute();
+
+    private Task<bool> ShouldExecute() => Task.FromResult(true);
 }

--- a/src/Umbraco.New.Cms.Core/Installer/Steps/TelemetryIdentifierStep.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/Steps/TelemetryIdentifierStep.cs
@@ -6,7 +6,7 @@ using Umbraco.New.Cms.Core.Models.Installer;
 
 namespace Umbraco.New.Cms.Core.Installer.Steps;
 
-public class TelemetryIdentifierStep : IInstallStep
+public class TelemetryIdentifierStep : IInstallStep, IUpgradeStep
 {
     private readonly IOptions<GlobalSettings> _globalSettings;
     private readonly ISiteIdentifierService _siteIdentifierService;
@@ -19,13 +19,21 @@ public class TelemetryIdentifierStep : IInstallStep
         _siteIdentifierService = siteIdentifierService;
     }
 
-    public Task ExecuteAsync(InstallData model)
+    public Task ExecuteAsync(InstallData _) => Execute();
+
+    public Task ExecuteAsync() => Execute();
+
+    private Task Execute()
     {
         _siteIdentifierService.TryCreateSiteIdentifier(out _);
         return Task.CompletedTask;
     }
 
-    public Task<bool> RequiresExecutionAsync(InstallData model)
+    public Task<bool> RequiresExecutionAsync(InstallData _) => ShouldExecute();
+
+    public Task<bool> RequiresExecutionAsync() => ShouldExecute();
+
+    private Task<bool> ShouldExecute()
     {
         // Verify that Json value is not empty string
         // Try & get a value stored in appSettings.json

--- a/src/Umbraco.New.Cms.Core/Installer/UpgradeStepCollection.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/UpgradeStepCollection.cs
@@ -1,0 +1,11 @@
+﻿using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.New.Cms.Core.Installer;
+
+public class UpgradeStepCollection : BuilderCollectionBase<IUpgradeStep>
+{
+    public UpgradeStepCollection(Func<IEnumerable<IUpgradeStep>> items)
+        : base(items)
+    {
+    }
+}

--- a/src/Umbraco.New.Cms.Core/Installer/UpgradeStepCollectionBuilder.cs
+++ b/src/Umbraco.New.Cms.Core/Installer/UpgradeStepCollectionBuilder.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.New.Cms.Core.Installer;
+
+public class UpgradeStepCollectionBuilder : OrderedCollectionBuilderBase<UpgradeStepCollectionBuilder, UpgradeStepCollection, IUpgradeStep>
+{
+    protected override UpgradeStepCollectionBuilder This => this;
+
+    protected override ServiceLifetime CollectionLifetime => ServiceLifetime.Scoped;
+}

--- a/src/Umbraco.New.Cms.Core/Models/Installer/UpgradeSettingsModel.cs
+++ b/src/Umbraco.New.Cms.Core/Models/Installer/UpgradeSettingsModel.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Cms.Core.Semver;
+using Umbraco.Extensions;
+
+namespace Umbraco.New.Cms.Core.Models.Installer;
+
+public class UpgradeSettingsModel
+{
+    public string CurrentState { get; set; } = string.Empty;
+
+    public string NewState { get; set; } = string.Empty;
+
+    public SemVersion NewVersion { get; set; } = null!;
+
+    public SemVersion OldVersion { get; set; } = null!;
+}

--- a/src/Umbraco.New.Cms.Core/Services/Installer/IUpgradeService.cs
+++ b/src/Umbraco.New.Cms.Core/Services/Installer/IUpgradeService.cs
@@ -1,0 +1,11 @@
+﻿using Umbraco.New.Cms.Core.Installer;
+
+namespace Umbraco.New.Cms.Core.Services.Installer;
+
+public interface IUpgradeService
+{
+    /// <summary>
+    /// Runs all the steps in the <see cref="UpgradeStepCollection"/>, upgrading Umbraco.
+    /// </summary>
+    Task Upgrade();
+}

--- a/src/Umbraco.New.Cms.Core/Services/Installer/InstallService.cs
+++ b/src/Umbraco.New.Cms.Core/Services/Installer/InstallService.cs
@@ -47,6 +47,7 @@ public class InstallService : IInstallService
 
             _logger.LogInformation("Running {StepName}", stepName);
             await step.ExecuteAsync(model);
+            _logger.LogInformation("Finished {StepName}", stepName);
         }
     }
 }

--- a/src/Umbraco.New.Cms.Core/Services/Installer/UpgradeService.cs
+++ b/src/Umbraco.New.Cms.Core/Services/Installer/UpgradeService.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.New.Cms.Core.Installer;
+
+namespace Umbraco.New.Cms.Core.Services.Installer;
+
+public class UpgradeService : IUpgradeService
+{
+    private readonly UpgradeStepCollection _upgradeSteps;
+    private readonly IRuntimeState _runtimeState;
+    private readonly ILogger<UpgradeService> _logger;
+
+    public UpgradeService(
+        UpgradeStepCollection upgradeSteps,
+        IRuntimeState runtimeState,
+        ILogger<UpgradeService> logger)
+    {
+        _upgradeSteps = upgradeSteps;
+        _runtimeState = runtimeState;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task Upgrade()
+    {
+        if (_runtimeState.Level != RuntimeLevel.Upgrade)
+        {
+            throw new InvalidOperationException(
+                $"Runtime level must be Upgrade to upgrade but was: {_runtimeState.Level}");
+        }
+
+        foreach (IUpgradeStep step in _upgradeSteps)
+        {
+            var stepName = step.GetType().Name;
+            _logger.LogInformation("Checking if {StepName} requires execution", stepName);
+            if (await step.RequiresExecutionAsync() is false)
+            {
+                _logger.LogInformation("Skipping {StepName}", stepName);
+                continue;
+            }
+
+            _logger.LogInformation("Running {StepName}", stepName);
+            await step.ExecuteAsync();
+            _logger.LogInformation("Finished {StepName}", stepName);
+        }
+    }
+}

--- a/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/DatabaseInstallStep.cs
+++ b/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/DatabaseInstallStep.cs
@@ -1,6 +1,5 @@
 ﻿using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Install;
-using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.New.Cms.Core.Installer;
@@ -8,7 +7,7 @@ using Umbraco.New.Cms.Core.Models.Installer;
 
 namespace Umbraco.New.Cms.Infrastructure.Installer.Steps;
 
-public class DatabaseInstallStep : IInstallStep
+public class DatabaseInstallStep : IInstallStep, IUpgradeStep
 {
     private readonly IRuntimeState _runtime;
     private readonly DatabaseBuilder _databaseBuilder;
@@ -19,7 +18,11 @@ public class DatabaseInstallStep : IInstallStep
         _databaseBuilder = databaseBuilder;
     }
 
-    public Task ExecuteAsync(InstallData model)
+    public Task ExecuteAsync(InstallData _) => Execute();
+
+    public Task ExecuteAsync() => Execute();
+
+    private Task Execute()
     {
         if (_runtime.Level == RuntimeLevel.Run)
         {
@@ -41,5 +44,10 @@ public class DatabaseInstallStep : IInstallStep
         return Task.CompletedTask;
     }
 
-    public Task<bool> RequiresExecutionAsync(InstallData model) => Task.FromResult(true);
+    public Task<bool> RequiresExecutionAsync(InstallData _) => ShouldExecute();
+
+    public Task<bool> RequiresExecutionAsync() => ShouldExecute();
+
+    private Task<bool> ShouldExecute()
+        => Task.FromResult(true);
 }

--- a/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/DatabaseUpgradeStep.cs
+++ b/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/DatabaseUpgradeStep.cs
@@ -2,7 +2,6 @@
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Install;
-using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Migrations.PostMigrations;
@@ -12,7 +11,7 @@ using Umbraco.New.Cms.Core.Models.Installer;
 
 namespace Umbraco.New.Cms.Infrastructure.Installer.Steps;
 
-public class DatabaseUpgradeStep : IInstallStep
+public class DatabaseUpgradeStep : IInstallStep, IUpgradeStep
 {
     private readonly DatabaseBuilder _databaseBuilder;
     private readonly IRuntimeState _runtime;
@@ -34,7 +33,11 @@ public class DatabaseUpgradeStep : IInstallStep
         _keyValueService = keyValueService;
     }
 
-    public Task ExecuteAsync(InstallData model)
+    public Task ExecuteAsync(InstallData _) => Execute();
+
+    public Task ExecuteAsync() => Execute();
+
+    private Task Execute()
     {
         _logger.LogInformation("Running 'Upgrade' service");
 
@@ -51,7 +54,11 @@ public class DatabaseUpgradeStep : IInstallStep
         return Task.CompletedTask;
     }
 
-    public Task<bool> RequiresExecutionAsync(InstallData model)
+    public Task<bool> RequiresExecutionAsync(InstallData model) => ShouldExecute();
+
+    public Task<bool> RequiresExecutionAsync() => ShouldExecute();
+
+    private Task<bool> ShouldExecute()
     {
         // Don't do anything if RunTimeLevel is not Install/Upgrade
         if (_runtime.Level == RuntimeLevel.Run)

--- a/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/RegisterInstallCompleteStep.cs
+++ b/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/RegisterInstallCompleteStep.cs
@@ -1,17 +1,24 @@
-using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.New.Cms.Core.Installer;
 using Umbraco.New.Cms.Core.Models.Installer;
 
 namespace Umbraco.New.Cms.Infrastructure.Installer.Steps;
 
-public class RegisterInstallCompleteStep : IInstallStep
+public class RegisterInstallCompleteStep : IInstallStep, IUpgradeStep
 {
     private readonly InstallHelper _installHelper;
 
     public RegisterInstallCompleteStep(InstallHelper installHelper) => _installHelper = installHelper;
 
-    public Task ExecuteAsync(InstallData model) => _installHelper.SetInstallStatusAsync(true, string.Empty);
+    public Task ExecuteAsync(InstallData _) => Execute();
 
-    public Task<bool> RequiresExecutionAsync(InstallData model) => Task.FromResult(true);
+    public Task ExecuteAsync() => Execute();
+
+    private Task Execute() => _installHelper.SetInstallStatusAsync(true, string.Empty);
+
+    public Task<bool> RequiresExecutionAsync(InstallData _) => ShouldExecute();
+
+    public Task<bool> RequiresExecutionAsync() => ShouldExecute();
+
+    private static Task<bool> ShouldExecute() => Task.FromResult(true);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.New.Cms.Core/Services/UpgradeServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.New.Cms.Core/Services/UpgradeServiceTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.New.Cms.Core.Installer;
+using UpgradeService = Umbraco.New.Cms.Core.Services.Installer.UpgradeService;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.New.Cms.Core.Services;
+
+[TestFixture]
+public class UpgradeServiceTests
+{
+
+    [Test]
+    [TestCase(RuntimeLevel.Install)]
+    [TestCase(RuntimeLevel.Boot)]
+    [TestCase(RuntimeLevel.Run)]
+    [TestCase(RuntimeLevel.Unknown)]
+    public void RequiresUpgradeRuntimeToUpgrade(RuntimeLevel level)
+    {
+        var sut = CreateUpgradeService(Enumerable.Empty<IUpgradeStep>(), level);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.Upgrade());
+    }
+
+    [Test]
+    public async Task OnlyRunsStepsThatRequireExecution()
+    {
+        var steps = new[]
+        {
+            new TestUpgradeStep { ShouldRun = true },
+            new TestUpgradeStep { ShouldRun = false },
+            new TestUpgradeStep { ShouldRun = true },
+        };
+
+        var sut = CreateUpgradeService(steps);
+
+        await sut.Upgrade();
+
+        foreach (var step in steps)
+        {
+            Assert.AreEqual(step.ShouldRun, step.HasRun);
+        }
+    }
+
+    [Test]
+    public async Task StepsRunInCollectionOrder()
+    {
+        List<TestUpgradeStep> runOrder = new List<TestUpgradeStep>();
+
+        var steps = new[]
+        {
+            new TestUpgradeStep { Id = 1 },
+            new TestUpgradeStep { Id = 2 },
+            new TestUpgradeStep { Id = 3 },
+        };
+
+        // Add an method delegate that will add the step itself, that way we can know the executed order.
+        foreach (var step in steps)
+        {
+            step.AdditionalExecution = () => runOrder.Add(step);
+        }
+
+        var sut = CreateUpgradeService(steps);
+        await sut.Upgrade();
+
+        // The ID's are strictly not necessary, but it makes potential debugging easier.
+        var expectedRunOrder = steps.Select(x => x.Id);
+        var actualRunOrder = runOrder.Select(x => x.Id);
+        Assert.AreEqual(expectedRunOrder, actualRunOrder);
+    }
+
+    private UpgradeService CreateUpgradeService(IEnumerable<IUpgradeStep> steps, RuntimeLevel runtimeLevel = RuntimeLevel.Upgrade)
+    {
+        var logger = Mock.Of<ILogger<UpgradeService>>();
+        var stepCollection = new UpgradeStepCollection(() => steps);
+        var runtimeStateMock = new Mock<IRuntimeState>();
+        runtimeStateMock.Setup(x => x.Level).Returns(runtimeLevel);
+
+        return new UpgradeService(stepCollection, runtimeStateMock.Object, logger);
+    }
+
+    private class TestUpgradeStep : IUpgradeStep
+    {
+        public bool HasRun;
+
+        public bool ShouldRun = true;
+
+        public int Id;
+
+        public Action AdditionalExecution;
+
+        public Task ExecuteAsync()
+        {
+            HasRun = true;
+
+            AdditionalExecution?.Invoke();
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RequiresExecutionAsync() => Task.FromResult(ShouldRun);
+    }
+}


### PR DESCRIPTION
This is a continuation of #12790.

This implements the versions upgrades, there's not an awful lot to mention here that's not already mentioned in #12790, so read that for more information. 

The only thing really worth mentioning is that authorizing (starting) the upgrade used to be part of the `InstallApiController`, this is now its own controller `UpgradeController`

## Testing

Just like #12790, you must add this to Umbraco.Cms.csproj and Umbraco.Web.BackOffice.csproj

```XML
<ProjectReference Include="..\Umbraco.Cms.ManagementApi\Umbraco.Cms.ManagementApi.csproj" />
```

Other than that add a migration to enter the upgrade runtime state, and test away. 

## Todo
Auth is still not implemented, so currently the upgrade endpoint is not secured.