### PR TITLE
fix: name discared causing exception

### DIFF
--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -180,10 +180,10 @@ namespace Umbraco.Cms.Core.Services
             => CreateMemberWithIdentity(username, email, string.Empty, string.Empty, memberTypeAlias, isApproved);
 
         public IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias)
-            => CreateMemberWithIdentity(username, email, string.Empty, string.Empty, memberTypeAlias);
+            => CreateMemberWithIdentity(username, email, name, string.Empty, memberTypeAlias);
 
         public IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias, bool isApproved)
-            => CreateMemberWithIdentity(username, string.Empty, name, string.Empty, memberTypeAlias, isApproved);
+            => CreateMemberWithIdentity(username, email, name, string.Empty, memberTypeAlias, isApproved);
 
         /// <summary>
         /// Creates and persists a Member


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [<!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/12822)

### Description

Steps to reproduce:

The code below fails even though a valid name is passed.
```
Services.MemberService.CreateMemberWithIdentity(
username: "someUsername",
email: "some@email.com",
name: "Mandatory name",
memberTypeAlias: "Member");
```


