### PR TITLE
Replace help drawer to dialog.

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -1,4 +1,4 @@
-﻿@using Microsoft.Extensions.Options;
+@using Microsoft.Extensions.Options;
 @using System.Globalization
 @using Umbraco.Cms.Core
 @using Umbraco.Cms.Core.Configuration
@@ -88,7 +88,7 @@
         <!-- help dialog controller by the help button - this also forces the backoffice UI to shift 400px  -->
         <umb-drawer data-element="drawer" ng-if="drawer.show" model="drawer.model" view="drawer.view"></umb-drawer>
 
-        <umb-search ng-if="search.show" on-close="closeSearch()"></umb-search>
+        <umb-search ng-attr-umb-focus-lock="true" ng-if="search.show" on-close="closeSearch()"></umb-search>
 
     </div>
 

--- a/src/Umbraco.Web.BackOffice/Controllers/DashboardController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DashboardController.cs
@@ -203,7 +203,7 @@ public class DashboardController : UmbracoApiController
 
         // This is used in place of the old feedproxy.config
         // Which was used to grab data from our.umbraco.com, umbraco.com or umbraco.tv
-        // for certain dashboards or the help drawer
+        // for certain dashboards or the help dialog
         var urlPrefix = string.Empty;
         switch (site.ToUpper())
         {

--- a/src/Umbraco.Web.BackOffice/EmbeddedResources/Tours/getting-started.json
+++ b/src/Umbraco.Web.BackOffice/EmbeddedResources/Tours/getting-started.json
@@ -97,19 +97,19 @@
       {
         "element": "[data-element='global-help']",
         "title": "Help",
-        "content": "If you ever find yourself in trouble click here to open the Help drawer.",
+        "content": "If you ever find yourself in trouble click here to open the Help dialog.",
         "event": "click",
         "backdropOpacity": 0.6
       },
       {
-        "element": "[data-element='drawer']",
+        "element": "[data-element='overlay-help']",
         "elementPreventClick": true,
         "title": "Help",
         "content": "<p>In the help drawer you will find articles and videos related to the section you are using.</p><p>This is also where you will find the next tour on how to get started with Umbraco.</p>",
         "backdropOpacity": 0.6
       },
       {
-        "element": "[data-element='drawer'] [data-element='help-tours']",
+        "element": "[data-element='overlay-help'] [data-element='help-tours']",
         "title": "Tours",
         "content": "To continue your journey on getting started with Umbraco, you can find more tours right here."
       }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
@@ -63,7 +63,7 @@
                 appState.setSearchState("show", !showSearch);
             };
 
-            // toggle the help dialog by raising the global app state to toggle the help drawer
+            // toggle the help dialog by raising the global app state to toggle the help dialog
             scope.helpClick = function () {
                 const helpEditor = {
                   size: "small",

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
@@ -65,10 +65,15 @@
 
             // toggle the help dialog by raising the global app state to toggle the help drawer
             scope.helpClick = function () {
-                var showDrawer = appState.getDrawerState("showDrawer");
-                var drawer = { view: "help", show: !showDrawer };
-                appState.setDrawerState("view", drawer.view);
-                appState.setDrawerState("showDrawer", drawer.show);
+                const helpEditor = {
+                  size: "small",
+                  view: "views/common/infiniteeditors/help/help.html",
+                  close: function() {
+                    editorService.close();
+                  }
+                };
+
+                editorService.open(helpEditor);
             };
 
             scope.avatarClick = function () {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour.directive.js
@@ -6,14 +6,14 @@
 
 @description
 <b>Added in Umbraco 7.8</b>. The tour component is a global component and is already added to the umbraco markup.
-In the Umbraco UI the tours live in the "Help drawer" which opens when you click the Help-icon in the bottom left corner of Umbraco.
-You can easily add you own tours to the Help-drawer or show and start tours from
+In the Umbraco UI the tours live in the "Help dialog" which opens when you click the Help-icon in the bottom left corner of Umbraco.
+You can easily add you own tours to the Help-dialog or show and start tours from
 anywhere in the Umbraco backoffice. To see a real world example of a custom tour implementation, install <a href="https://our.umbraco.com/projects/starter-kits/the-starter-kit/">The Starter Kit</a> in Umbraco 7.8
 
-<h1><b>Extending the help drawer with custom tours</b></h1>
-The easiet way to add new tours to Umbraco is through the Help-drawer. All it requires is a my-tour.json file.
+<h1><b>Extending the help dialog with custom tours</b></h1>
+The easiet way to add new tours to Umbraco is through the Help-dialog. All it requires is a my-tour.json file.
 Place the file in <i>App_Plugins/{MyPackage}/backoffice/tours/{my-tour}.json</i> and it will automatically be
-picked up by Umbraco and shown in the Help-drawer.
+picked up by Umbraco and shown in the Help-dialog.
 
 <h3><b>The tour object</b></h3>
 The tour object consist of two parts - The overall tour configuration and a list of tour steps. We have split up the tour object for a better overview.
@@ -22,7 +22,7 @@ The tour object consist of two parts - The overall tour configuration and a list
 {
     "name": "My Custom Tour", // (required)
     "alias": "myCustomTour", // A unique tour alias (required)
-    "group": "My Custom Group" // Used to group tours in the help drawer
+    "group": "My Custom Group" // Used to group tours in the help dialog
     "groupOrder": 200 // Control the order of tour groups
     "allowDisable": // Adds a "Don't" show this tour again"-button to the intro step
     "culture" : // From v7.11+. Specifies the culture of the tour (eg. en-US), if set the tour will only be shown to users with this culture set on their profile. If omitted or left empty the tour will be visible to all users

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -149,6 +149,12 @@
                 // Whenever the DOM changes ensure the list of focused elements is updated
                 function domChange() {
                     getFocusableElements();
+
+                    // When an element is remove or become not focusable, but focus is on it,
+                    // we need to ensure a now focus inside the trap, else the focus can escape the trap.
+                    if (focusableElements.filter(elm => elm === document.activeElement).length === 0) {
+                      setElementFocus();
+                  }
                 }
 
                 // Start observing the target node for configured mutations

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/help/help.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/help/help.controller.js
@@ -2,7 +2,7 @@
 (function () {
     "use strict";
 
-    function HelpDrawerController($scope, $routeParams, $timeout, dashboardResource, localizationService, userService, eventsService, helpService, appState, tourService, $filter, editorState, notificationsService, currentUserResource, platformService) {
+    function HelpController($scope, $routeParams, $timeout, dashboardResource, localizationService, userService, eventsService, helpService, appState, tourService, $filter, editorState, notificationsService, currentUserResource, platformService) {
 
         var vm = this;
         var evts = [];
@@ -21,7 +21,7 @@
         vm.labels.copyErrorStatus = "";
 
 
-        vm.closeDrawer = closeDrawer;
+        vm.close = close;
         vm.startTour = startTour;
         vm.getTourGroupCompletedPercentage = getTourGroupCompletedPercentage;
         vm.showTourButton = showTourButton;
@@ -34,7 +34,7 @@
 
         function startTour(tour) {
             tourService.startTour(tour);
-            closeDrawer();
+            close();
         }
 
         function oninit() {
@@ -116,8 +116,10 @@
 
         }
 
-        function closeDrawer() {
-            appState.setDrawerState("showDrawer", false);
+        function close() {
+          if ($scope.model.close) {
+            $scope.model.close();
+          }
         }
 
         function handleSectionChange() {
@@ -277,6 +279,6 @@
         oninit();
     }
 
-    angular.module("umbraco").controller("Umbraco.Drawers.Help", HelpDrawerController);
+    angular.module("umbraco").controller("Umbraco.Editors.HelpController", HelpController);
 
 })();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/help/help.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/help/help.html
@@ -1,12 +1,15 @@
-<div style="height: 100%" ng-controller="Umbraco.Drawers.Help as vm">
-    <umb-drawer-view>
+<div ng-controller="Umbraco.Editors.HelpController as vm">
+    <umb-editor-view data-element="overlay-help">
+      <umb-editor-header
+        name="vm.title"
+        name-locked="true"
+        description="vm.subtitle"
+        description-locked="true"
+        hide-alias="true"
+        hide-icon="true"
+      ></umb-editor-header>
 
-        <umb-drawer-header
-            title="{{vm.title}}"
-            description="{{vm.subtitle}}">
-        </umb-drawer-header>
-
-        <umb-drawer-content>
+        <umb-editor-container>
 
             <!-- Doctype Tours -->
             <div class="umb-help-section" ng-if="vm.showDocTypeTour" data-element="doctype-tour">
@@ -190,23 +193,21 @@
                 </div>
               </div>
           </div>
-        </umb-drawer-content>
+        </umb-editor-container>
 
-        <umb-drawer-footer>
+        <umb-editor-footer>
+          <umb-editor-footer-content-right>
+            <umb-button
+                alias="close"
+                type="button"
+                shortcut="esc"
+                button-style="link"
+                label-key="general_close"
+                action="vm.close()">
+            </umb-button>
+          </umb-editor-footer-content-right>
+        </umb-editor-footer>
 
-            <div class="flex justify-end">
-                <umb-button
-                    alias="close"
-                    type="button"
-                    shortcut="esc"
-                    button-style="link"
-                    label-key="general_close"
-                    action="vm.closeDrawer()">
-                </umb-button>
-            </div>
-
-        </umb-drawer-footer>
-
-    </umb-drawer-view>
+    </umb-editor-view>
 
 </div>


### PR DESCRIPTION
### Prerequisites
- [Y] I have added steps to test this contribution in the description below

### Description
When playing around with accessibility I discover the the help icon open up a completely new way then others as ex "Users dialog". When opining the drawer the focus not turned into the area or neither trapped.  Search through Umbraco code, the only place the "Drawer" is used is for the "Help", so the is a ton of angular code just for a small part of the Umbraco.

I challenge this area, with this PR.
I have replace the "Help drawer" with a "Help dialog". So if you open User dialog "as done in the tour" and afterwards open "help dialog" you´ll see the same behavior, a more clean experience, with more focus on the content in that area and a focus trap in order to help with accessibility.

For test. 1
Follow the tour guide that appear in the Umbraco first time going to Backoffice. Ensure that the tour still works as attendee, but with a dialog for the help part.

For test 2.
Hotkeys CTRL+SHIFT+H and see Dialog opens.

For test 3
Click on the "Help icon" and see Dialog opens.

For test 4
Open help dialog and test tab and esc for accessibility. 

---
With this PR, the code to "Drawer" can be removed. But the decision and discussion will I you guys make, that is know, by removing the "Drawer" and it is a breaking changes, and maybe a candidate for Umbraco 11. 