### PR TITLE
Only expose server vars for password policy rules and max file size for authenticated users

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -1,5 +1,6 @@
 using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -52,6 +53,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IEmailSender _emailSender;
         private MemberPasswordConfigurationSettings _memberPasswordConfigurationSettings;
         private DataTypesSettings _dataTypesSettings;
+        private readonly ITempDataDictionaryFactory _tempDataDictionaryFactory;
 
         [Obsolete("Use constructor that takes IOptionsMontior<DataTypeSettings>, scheduled for removal in V12")]
         public BackOfficeServerVariables(
@@ -94,6 +96,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         {
         }
 
+        [Obsolete("Use constructor that takes ITempDataDictionaryFactory, scheduled for removal in V12")]
         public BackOfficeServerVariables(
             LinkGenerator linkGenerator,
             IRuntimeState runtimeState,
@@ -113,6 +116,49 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IEmailSender emailSender,
             IOptionsMonitor<MemberPasswordConfigurationSettings> memberPasswordConfigurationSettings,
             IOptionsMonitor<DataTypesSettings> dataTypesSettings)
+        : this(
+            linkGenerator,
+            runtimeState,
+            features,
+            globalSettings,
+            umbracoVersion,
+            contentSettings,
+            httpContextAccessor,
+            treeCollection,
+            hostingEnvironment,
+            runtimeSettings,
+            securitySettings,
+            runtimeMinifier,
+            externalLogins,
+            imageUrlGenerator,
+            previewRoutes,
+            emailSender,
+            memberPasswordConfigurationSettings,
+            dataTypesSettings,
+            StaticServiceProvider.Instance.GetRequiredService<ITempDataDictionaryFactory>())
+        {
+        }
+
+        public BackOfficeServerVariables(
+            LinkGenerator linkGenerator,
+            IRuntimeState runtimeState,
+            UmbracoFeatures features,
+            IOptionsMonitor<GlobalSettings> globalSettings,
+            IUmbracoVersion umbracoVersion,
+            IOptionsMonitor<ContentSettings> contentSettings,
+            IHttpContextAccessor httpContextAccessor,
+            TreeCollection treeCollection,
+            IHostingEnvironment hostingEnvironment,
+            IOptionsMonitor<RuntimeSettings> runtimeSettings,
+            IOptionsMonitor<SecuritySettings> securitySettings,
+            IRuntimeMinifier runtimeMinifier,
+            IBackOfficeExternalLoginProviders externalLogins,
+            IImageUrlGenerator imageUrlGenerator,
+            PreviewRoutes previewRoutes,
+            IEmailSender emailSender,
+            IOptionsMonitor<MemberPasswordConfigurationSettings> memberPasswordConfigurationSettings,
+            IOptionsMonitor<DataTypesSettings> dataTypesSettings,
+            ITempDataDictionaryFactory tempDataDictionaryFactory)
         {
             _linkGenerator = linkGenerator;
             _runtimeState = runtimeState;
@@ -130,6 +176,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _imageUrlGenerator = imageUrlGenerator;
             _previewRoutes = previewRoutes;
             _emailSender = emailSender;
+            _tempDataDictionaryFactory = tempDataDictionaryFactory;
             _memberPasswordConfigurationSettings = memberPasswordConfigurationSettings.CurrentValue;
             _dataTypesSettings = dataTypesSettings.CurrentValue;
 
@@ -147,8 +194,23 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <returns></returns>
         internal async Task<Dictionary<string, object>> BareMinimumServerVariablesAsync()
         {
+            // figure out if we are executing in context of a backoffice user
             HttpContext? context = _httpContextAccessor.HttpContext;
-            var isBackofficeUser = context != null && (await context.AuthenticateBackOfficeAsync()).Succeeded;
+            var isBackofficeUser = false;
+            if (context != null)
+            {
+                // first look for an authorized user (this covers both logged in and invited users)
+                isBackofficeUser = (await context.AuthenticateBackOfficeAsync()).Succeeded;
+                if (isBackofficeUser == false)
+                {
+                    // here's where things get a little ugly:
+                    // when a backoffice user is about to reset their password, TempData[ViewDataExtensions.TokenPasswordResetCode]
+                    // contains a JSON object with the current user ID and a password reset code - see ValidatePasswordResetCodeModel
+                    ITempDataDictionary tempData = _tempDataDictionaryFactory.GetTempData(context);
+                    var passwordResetCode = tempData[ViewDataExtensions.TokenPasswordResetCode];
+                    isBackofficeUser = passwordResetCode is string passwordResetCodeString && passwordResetCodeString.InvariantContains("userId");
+                }
+            }
 
             //this is the filter for the keys that we'll keep based on the full version of the server vars
             var umbracoSettings = new List<string> {
@@ -163,7 +225,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 "disableUnpublishWhenReferenced"
             };
 
-            // add a few extras for authenticated backoffice users (server vars we don't want floating around for anonymous users)
+            // add a few extras for backoffice users (server vars we don't want floating around for anonymous users)
             if (isBackofficeUser)
             {
                 umbracoSettings.AddRange(new[] { "maxFileSize", "minimumPasswordLength", "minimumPasswordNonAlphaNum" });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The server variables "maxFileSize", "minimumPasswordLength" and "minimumPasswordNonAlphaNum" should not be exposed to unauthenticated users.

Test that:

- The page source does not contain the server variables when accessing /umbraco as unauthenticated.
- The page source *does* contain the server variables after logging in.
- The page source *does* contain the server variables when accepting an invitation to the backoffice (the invite user flow).
  - _Note: It seems the "upload avatar" step of the invite user flow is broken; it just flashes briefly into view before skipping straight to the backoffice. This behaviour is also seen on v10/dev, so it's not something introduced by this PR._ 
- The reset password flow displays the "Minimum XX character(s) to go!" message:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/7405322/184800762-87afbae0-b178-4e92-9417-3deaef5b67ca.png">
 
