### PR TITLE
Fix #12748: Make sure to set `writerId` for `MediaService.Thrashed` event

### DIFF
--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -728,6 +728,8 @@ namespace Umbraco.Cms.Core.Services
                     media.CreatorId = userId;
                 }
 
+                media.WriterId = userId;
+
                 _mediaRepository.Save(media);
                 scope.Notifications.Publish(new MediaSavedNotification(media, eventMessages).WithStateFrom(savingNotification));
                 // TODO: See note about suppressing events in content service


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12748 (after a save of the media item)

Tested with this piece of code:
```
public class TestCode : INotificationHandler<MediaMovedToRecycleBinNotification>
    {
        public void Handle(MediaMovedToRecycleBinNotification notification)
        {
            foreach (var media in notification.MoveInfoCollection)
            {
                var test = media.Entity.WriterId;
            }
        }
    }

    public class TestComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.AddNotificationHandler<MediaMovedToRecycleBinNotification, TestCode>();
        }
    }
```

I took a look at how the ContentService did this and copied the piece of code from there.