### PR TITLE
Fix JS error when clicking a reset password link twice

### DIFF
--- a/src/Umbraco.Web.BackOffice/Extensions/HtmlHelperBackOfficeExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/Extensions/HtmlHelperBackOfficeExtensions.cs
@@ -104,7 +104,7 @@ public static class HtmlHelperBackOfficeExtensions
     /// <param name="html"></param>
     /// <param name="val"></param>
     /// <returns></returns>
-    public static IHtmlContent AngularValueResetPasswordCodeInfoScript(this IHtmlHelper html, object val)
+    public static IHtmlContent AngularValueResetPasswordCodeInfoScript(this IHtmlHelper html, object? val)
     {
         var sb = new StringBuilder();
         sb.AppendLine();
@@ -116,6 +116,8 @@ public static class HtmlHelperBackOfficeExtensions
             {
                 sb.AppendFormat(@"errors.push(""{0}"");", error).AppendLine();
             }
+
+            val = null;
         }
 
         sb.AppendLine(@"app.value(""resetPasswordCodeInfo"", {");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

If you attempt to reset your backoffice user password twice using the same password reset link, the backoffice goes blank with a JS error:

<img width="713" alt="image" src="https://user-images.githubusercontent.com/7405322/184803951-1bb0347d-9720-4b95-a1ab-544920700512.png">

This PR restores the expected behavior:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/7405322/184803695-9e87a2a3-1594-4978-95a3-80965113de45.png">

Steps:

1. Configure SMTP settings (to enable password reset) - perhaps something like this: <img width="431" alt="image" src="https://user-images.githubusercontent.com/7405322/184804213-e87efeef-7f76-48b3-97c3-4db747cf37ed.png">
2. Go to /umbraco and request a password reset.
3. Click the link in the mail and perform a password reset.
4. Click the link in the mail again - backoffice goes blank.
