### PR TITLE
Make the error message friendlier when attempting to use unsupported sorting in listviews

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -304,11 +304,11 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                     navigationService.reloadSection(section);
                 }
             }
-        }, function(error){
+        }).catch(function(error){
           // if someone attempts to add mix listviews across sections (i.e. use a members list view on content types),
           // a not-supported exception will be most likely be thrown, at least for the default list views - lets be
           // helpful and show a meaningful error message directly in content/content type UI
-          if(error.data.ExceptionType && error.data.ExceptionType.indexOf("System.NotSupportedException") > -1) {
+          if(error.data && error.data.ExceptionType && error.data.ExceptionType.indexOf("System.NotSupportedException") > -1) {
             $scope.viewLoadedError = error.errorMsg + ": " + error.data.ExceptionMessage;
           }
           $scope.viewLoaded = true;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -44,8 +44,8 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             return selected.id;
         };
         createEditUrlCallback = function (item) {
-            return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.id 
-                + "?list=" + $routeParams.id + "&page=" + $scope.options.pageNumber + "&filter=" + $scope.options.filter 
+            return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.id
+                + "?list=" + $routeParams.id + "&page=" + $scope.options.pageNumber + "&filter=" + $scope.options.filter
                 + "&orderBy=" + $scope.options.orderBy + "&orderDirection=" + $scope.options.orderDirection;
         };
     }
@@ -126,7 +126,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     var listParamsForCurrent = $routeParams.id == $routeParams.list;
-    
+
     $scope.options = {
         useInfiniteEditor: $scope.model.config.useInfiniteEditor === true,
         pageSize: $scope.model.config.pageSize ? $scope.model.config.pageSize : 10,
@@ -152,7 +152,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
         cultureName: $routeParams.cculture ? $routeParams.cculture : $routeParams.mculture,
         readonly: $scope.readonly
     };
-    
+
     _.each($scope.options.includeProperties, function (property) {
         property.nameExp = !!property.nameTemplate
             ? $interpolate(property.nameTemplate)
@@ -258,7 +258,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
         if (!id) {
             return;
         }
-        
+
         $scope.viewLoaded = false;
         $scope.folders = [];
 
@@ -292,7 +292,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                 //reload!
                 $scope.reloadView(id, reloadActiveNode);
             }
-            // in the media section, the list view items are by default also shown in the tree, so we need 
+            // in the media section, the list view items are by default also shown in the tree, so we need
             // to refresh the current tree node when changing the folder contents (adding and removing)
             else if (reloadActiveNode && section === "media") {
                 var activeNode = appState.getTreeState("selectedNode");
@@ -304,6 +304,14 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                     navigationService.reloadSection(section);
                 }
             }
+        }, function(error){
+          // if someone attempts to add mix listviews across sections (i.e. use a members list view on content types),
+          // a not-supported exception will be most likely be thrown, at least for the default list views - lets be
+          // helpful and show a meaningful error message directly in content/content type UI
+          if(error.data.ExceptionType && error.data.ExceptionType.indexOf("System.NotSupportedException") > -1) {
+            $scope.viewLoadedError = error.errorMsg + ": " + error.data.ExceptionMessage;
+          }
+          $scope.viewLoaded = true;
         });
     };
 
@@ -444,7 +452,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             }
         };
 
-        // if any of the selected nodes has variants we want to 
+        // if any of the selected nodes has variants we want to
         // show a dialog where the languages can be chosen
         if (selectionHasVariants()) {
             languageResource.getAll()
@@ -500,7 +508,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             }
         };
 
-        // if any of the selected nodes has variants we want to 
+        // if any of the selected nodes has variants we want to
         // show a dialog where the languages can be chosen
         if (selectionHasVariants()) {
             languageResource.getAll()
@@ -693,13 +701,13 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     function initView() {
-        
+
         var id = $routeParams.id;
         if (id === undefined) {
             // no ID found in route params - don't list anything as we don't know for sure where we are
             return;
         }
-        
+
         // Get current id for node to load it's children
         $scope.contentId = editorState.current ? editorState.current.id : id;
         $scope.isTrashed = editorState.current ? editorState.current.trashed : id === "-20" || id === "-21";
@@ -791,7 +799,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
     function createBlank(entityType, docTypeAlias) {
         if ($scope.options.useInfiniteEditor) {
-            
+
             var editorModel = {
                 create: true,
                 submit: function(model) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -44,8 +44,8 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             return selected.id;
         };
         createEditUrlCallback = function (item) {
-            return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.id
-                + "?list=" + $routeParams.id + "&page=" + $scope.options.pageNumber + "&filter=" + $scope.options.filter
+            return "/" + $scope.entityType + "/" + $scope.entityType + "/edit/" + item.id 
+                + "?list=" + $routeParams.id + "&page=" + $scope.options.pageNumber + "&filter=" + $scope.options.filter 
                 + "&orderBy=" + $scope.options.orderBy + "&orderDirection=" + $scope.options.orderDirection;
         };
     }
@@ -126,7 +126,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     var listParamsForCurrent = $routeParams.id == $routeParams.list;
-
+    
     $scope.options = {
         useInfiniteEditor: $scope.model.config.useInfiniteEditor === true,
         pageSize: $scope.model.config.pageSize ? $scope.model.config.pageSize : 10,
@@ -152,7 +152,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
         cultureName: $routeParams.cculture ? $routeParams.cculture : $routeParams.mculture,
         readonly: $scope.readonly
     };
-
+    
     _.each($scope.options.includeProperties, function (property) {
         property.nameExp = !!property.nameTemplate
             ? $interpolate(property.nameTemplate)
@@ -258,7 +258,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
         if (!id) {
             return;
         }
-
+        
         $scope.viewLoaded = false;
         $scope.folders = [];
 
@@ -292,7 +292,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                 //reload!
                 $scope.reloadView(id, reloadActiveNode);
             }
-            // in the media section, the list view items are by default also shown in the tree, so we need
+            // in the media section, the list view items are by default also shown in the tree, so we need 
             // to refresh the current tree node when changing the folder contents (adding and removing)
             else if (reloadActiveNode && section === "media") {
                 var activeNode = appState.getTreeState("selectedNode");
@@ -452,7 +452,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             }
         };
 
-        // if any of the selected nodes has variants we want to
+        // if any of the selected nodes has variants we want to 
         // show a dialog where the languages can be chosen
         if (selectionHasVariants()) {
             languageResource.getAll()
@@ -508,7 +508,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             }
         };
 
-        // if any of the selected nodes has variants we want to
+        // if any of the selected nodes has variants we want to 
         // show a dialog where the languages can be chosen
         if (selectionHasVariants()) {
             languageResource.getAll()
@@ -701,13 +701,13 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
     }
 
     function initView() {
-
+        
         var id = $routeParams.id;
         if (id === undefined) {
             // no ID found in route params - don't list anything as we don't know for sure where we are
             return;
         }
-
+        
         // Get current id for node to load it's children
         $scope.contentId = editorState.current ? editorState.current.id : id;
         $scope.isTrashed = editorState.current ? editorState.current.trashed : id === "-20" || id === "-21";
@@ -799,7 +799,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
     function createBlank(entityType, docTypeAlias) {
         if ($scope.options.useInfiniteEditor) {
-
+            
             var editorModel = {
                 create: true,
                 submit: function(model) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.html
@@ -202,7 +202,7 @@
        </umb-editor-sub-header>
 
        <umb-list-view-layout
-         ng-if="viewLoaded"
+         ng-if="viewLoaded && !viewLoadedError"
          content-id="contentId"
          folders="folders"
          items="listViewResultSet.items"
@@ -213,6 +213,8 @@
       </umb-list-view-layout>
 
       <umb-load-indicator ng-show="!viewLoaded"></umb-load-indicator>
+
+      <div ng-if="viewLoaded && viewLoadedError" class="umb-alert umb-alert--warning">{{viewLoadedError}}</div>
 
       <div class="flex justify-center">
           <umb-pagination


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12743

### Description

At the moment you can't use the members list views in content types. List views are built with the assumption that they are supposed to list items based on their current context, i.e. a list view on a content type will attempt to list content (specifically children of the currently edited content).

This PR does not make it possible to use the members list view on content types, but it does aim to make the error message a little friendlier, or at least easier to decipher:

![issue-12743](https://user-images.githubusercontent.com/7405322/184852077-bbbfa1e4-6022-48ea-8215-f7820a3ae2ff.gif)
