### PR TITLE
https://github.com/umbraco/Umbraco-CMS/issues/12844

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -105,7 +105,7 @@ function dateTimePickerController($scope, angularHelper, dateHelper, validationM
                 setDate(momentDate);
             }
             setDatePickerVal();
-            flatPickr.setDate($scope.model.value, false);
+            flatPickr.setDate($scope.model.datetimePickerValue, false);
         }
     }
     

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.html
@@ -5,7 +5,7 @@
         <div id="datepicker{{model.alias}}">
 
             <umb-date-time-picker
-                ng-model="model.value"
+                ng-model="model.datetimePickerValue"
                 options="datePickerConfig"
                 on-setup="datePickerSetup(fpItem)"
                 on-change="datePickerChange(dateStr)">
@@ -38,7 +38,7 @@
             <p class="help-inline" ng-message="pickerError"><localize key="validation_invalidDate">Invalid date</localize></p>
         </div>
 
-        <p ng-if="model.config.offsetTime === '1' && serverTimeNeedsOffsetting && model.value" class="muted">
+        <p xng-if="model.config.offsetTime === '1' && serverTimeNeedsOffsetting && model.value" class="muted">
             <small><localize key="content_scheduledPublishServerTime">This translates to the following time on the server:</localize> {{serverTime}}</small><br />
             <small><localize key="content_scheduledPublishDocumentation">What does this mean?</localize></small>
         </p>


### PR DESCRIPTION
### Prerequisites
If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/12844)

### Description
Start the test before the fix:
Clean Umbraco solution testede in Umbraco v 10.1
Create a doctype with a date time picker. The datetime picker should have the Offset time enabled.

Set the timeserveroffset to +00:00 or 0 mininuts in the umbracovariable for test.
Pick a time ex. 10:00 and close it saveAndPublishe and the reopen the picker. 

Now you see the input field sayes 10:00 a clock but the flatuipickr say 08:00 due to +02:00 for my local machine.
We have tested it on a Umbraco 8.18.3 where it is the same problem.

In my disvocery the bug has been prestiges since Umbraco 8 or since this commit https://github.com/umbraco/Umbraco-CMS/commit/e84cbc7e19a053556c5730de2402db607092f0f6.

So this PR is also a fix for Umbraco 10, 9 and 8.

Start the test after this fix.
The same as above but everything say 10:00 and never change as you would except.