### PR TITLE
V10: Fix external login token table

### DIFF
--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -440,14 +440,15 @@ public class BackOfficeUserStore : UmbracoUserStore<BackOfficeIdentityUser, Iden
 
         IIdentityUserToken? token = user.LoginTokens.FirstOrDefault(x =>
             x.LoginProvider.InvariantEquals(loginProvider) && x.Name.InvariantEquals(name));
-        if (token == null)
+
+        // We have to remove token and then re-add to ensure that LoginTokens are dirty, which is required for them to save
+        // This is because we're using an observable collection, which only cares about added/removed items.
+        if (token is not null)
         {
-            user.LoginTokens.Add(new IdentityUserToken(loginProvider, name, value, user.Id));
+            user.LoginTokens.Remove(token);
         }
-        else
-        {
-            token.Value = value;
-        }
+
+        user.LoginTokens.Add(new IdentityUserToken(loginProvider, name, value, user.Id));
 
         return Task.CompletedTask;
     }

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -445,6 +445,12 @@ public class BackOfficeUserStore : UmbracoUserStore<BackOfficeIdentityUser, Iden
         // This is because we're using an observable collection, which only cares about added/removed items.
         if (token is not null)
         {
+            // The token hasn't changed, so there's no reason for us to re-add it.
+            if (token.Value == value)
+            {
+                return Task.CompletedTask;
+            }
+
             user.LoginTokens.Remove(token);
         }
 

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -585,6 +585,12 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
         // This is because we're using an observable collection, which only cares about added/removed items.
         if (token is not null)
         {
+            // The token hasn't changed, so there's no reason for us to re-add it.
+            if (token.Value == value)
+            {
+                return Task.CompletedTask;
+            }
+
             user.LoginTokens.Remove(token);
         }
 

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -580,14 +580,15 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
 
         IIdentityUserToken? token = user.LoginTokens.FirstOrDefault(x =>
             x.LoginProvider.InvariantEquals(loginProvider) && x.Name.InvariantEquals(name));
-        if (token == null)
+
+        // We have to remove token and then re-add to ensure that LoginTokens are dirty, which is required for them to save
+        // This is because we're using an observable collection, which only cares about added/removed items.
+        if (token is not null)
         {
-            user.LoginTokens.Add(new IdentityUserToken(loginProvider, name, value, user.Id));
+            user.LoginTokens.Remove(token);
         }
-        else
-        {
-            token.Value = value;
-        }
+
+        user.LoginTokens.Add(new IdentityUserToken(loginProvider, name, value, user.Id));
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
Fixes: #12749

The problem is that the umbracoExternalLoginToken does not get updated when a new login token is issued.

This was due to a misunderstanding with the observable collection, essentially an observable collection will only raise its event if an item is added or removed, and we use this event to determine if the login tokens are dirty. 

This meant that the tokens would never be dirty, and would therefore never be updated.  