### PR TITLE
v10: ensure blocklist supports dynamic label expressions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/blockHtmlCompile.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/blockHtmlCompile.js
@@ -1,0 +1,62 @@
+/**
+* @ngdoc directive
+* @name umbraco.directives.directive:blockHtmlCompile
+* @element ANY
+* @restrict A
+* @function
+* @description
+* Compiles any HTML into the provided scope, e.g. for use with the label field of blocks
+
+* @example
+* <example module="umbraco.directives">
+*    <file name="index.html">
+*        <div block-html-compile="block.label" block-html-scope="block"></div>
+*    </file>
+* </example>
+**/
+
+angular
+  .module("umbraco.directives")
+  .directive("blockHtmlCompile", function ($compile) {
+    return {
+      restrict: "A",
+      link: function (scope, element, attrs) {
+        function compileBlock(value, blockObject) {
+          // In case value is a TrustedValueHolderType, sometimes it
+          // needs to be explicitly called into a string in order to
+          // get the HTML string.
+          element.html(value && value.toString());
+
+          var labelVars = Object.assign(
+            blockObject.interpolatableData,
+            blockObject.data
+          );
+
+          var compileScope = scope.$new(true);
+          compileScope = Object.assign(compileScope, labelVars);
+
+          $compile(element.contents())(compileScope);
+        }
+
+        // Watch for changes to the isolated block scope
+        scope.$watchCollection(function () {
+          return scope.$eval(attrs.blockHtmlScope);
+        }, function (value) {
+          compileBlock(scope.$eval(attrs.blockHtmlCompile), value);
+        });
+
+        // Compile the block on initial load
+        var ensureCompileRunsOnce = scope.$watch(
+          function () {
+            return scope.$eval(attrs.blockHtmlCompile);
+          },
+          function (value) {
+            compileBlock(value, scope.$eval(attrs.blockHtmlScope));
+
+            // Use un-watch feature to ensure compilation happens only once.
+            ensureCompileRunsOnce();
+          }
+        );
+      }
+    };
+  });

--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -3,79 +3,78 @@
 
 // Cache for node names so we don't make a ton of requests
 var ncNodeNameCache = {
-    id: "",
-    keys: {}
+  id: "",
+  keys: {}
 };
 
 angular.module("umbraco.filters").filter("ncNodeName", function (editorState, entityResource) {
 
-    function formatLabel(firstNodeName, totalNodes) {
-        return totalNodes <= 1
-            ? firstNodeName
-            // If there is more than one item selected, append the additional number of items selected to hint that
-            : firstNodeName + " (+" + (totalNodes - 1) + ")";
+  function formatLabel(firstNodeName, totalNodes) {
+    return totalNodes <= 1
+      ? firstNodeName
+      // If there is more than one item selected, append the additional number of items selected to hint that
+      : firstNodeName + " (+" + (totalNodes - 1) + ")";
+  }
+
+  nodeNameFilter.$stateful = true;
+  function nodeNameFilter(input) {
+
+    // Check we have a value at all
+    if (typeof input === 'undefined' || input === "" || input.toString() === "0" || input === null) {
+      return "";
     }
 
-    nodeNameFilter.$stateful = true;
-    function nodeNameFilter(input) {
+    var currentNode = editorState.getCurrent();
 
-        // Check we have a value at all
-        if (typeof input === 'undefined' || input === "" || input.toString() === "0" || input === null) {
-            return "";
-        }
-
-        var currentNode = editorState.getCurrent();
-
-        // Ensure a unique cache per editor instance
-        var key = "ncNodeName_" + currentNode.key;
-        if (ncNodeNameCache.id !== key) {
-            ncNodeNameCache.id = key;
-            ncNodeNameCache.keys = {};
-        }
-
-        // MNTP values are comma separated IDs. We'll only fetch the first one for the NC header.
-        var ids = input.split(',');
-        var lookupId = ids[0];
-        var serviceInvoked = false;
-
-        // See if there is a value in the cache and use that
-        if (ncNodeNameCache.keys[lookupId]) {
-            return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
-        }
-
-        // No value, so go fetch one
-        // We'll put a temp value in the cache though so we don't
-        // make a load of requests while we wait for a response
-        ncNodeNameCache.keys[lookupId] = "Loading...";
-
-        // If the service has already been invoked, don't do it again
-        if (serviceInvoked) {
-            return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
-        }
-
-        serviceInvoked = true;
-
-        var type = lookupId.indexOf("umb://media/") === 0
-            ? "Media"
-            : lookupId.indexOf("umb://member/") === 0
-                ? "Member"
-                : "Document";
-        entityResource.getById(lookupId, type)
-            .then(
-                function (ent) {
-                  console.log('returned with response',ent.name, lookupId);
-                  ncNodeNameCache.keys[lookupId] = ent.name;
-                }
-            );
-
-        // Return the current value for now
-        return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
+    // Ensure a unique cache per editor instance
+    var key = "ncNodeName_" + currentNode.key;
+    if (ncNodeNameCache.id !== key) {
+      ncNodeNameCache.id = key;
+      ncNodeNameCache.keys = {};
     }
 
-    return nodeNameFilter;
+    // MNTP values are comma separated IDs. We'll only fetch the first one for the NC header.
+    var ids = input.split(',');
+    var lookupId = ids[0];
+    var serviceInvoked = false;
+
+    // See if there is a value in the cache and use that
+    if (ncNodeNameCache.keys[lookupId]) {
+      return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
+    }
+
+    // No value, so go fetch one
+    // We'll put a temp value in the cache though so we don't
+    // make a load of requests while we wait for a response
+    ncNodeNameCache.keys[lookupId] = "Loading...";
+
+    // If the service has already been invoked, don't do it again
+    if (serviceInvoked) {
+      return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
+    }
+
+    serviceInvoked = true;
+
+    var type = lookupId.indexOf("umb://media/") === 0
+      ? "Media"
+      : lookupId.indexOf("umb://member/") === 0
+        ? "Member"
+        : "Document";
+    entityResource.getById(lookupId, type)
+      .then(
+        function (ent) {
+          ncNodeNameCache.keys[lookupId] = ent.name;
+        }
+      );
+
+    // Return the current value for now
+    return formatLabel(ncNodeNameCache.keys[lookupId], ids.length);
+  }
+
+  return nodeNameFilter;
 
 }).filter("ncRichText", function () {
-    return function(input) {
-        return $("<div/>").html(input).text();
-    };
+  return function (input) {
+    return $("<div/>").html(input).text();
+  };
 });

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.html
@@ -6,7 +6,7 @@
             ng-focus="block.focus">
         <span class="caret"></span>
         <umb-icon icon="{{block.content.icon}}" class="icon"></umb-icon>
-        <span class="name">{{block.label}}</span>
+        <span class="name" block-html-compile="block.label" block-html-scope="block"></span>
     </button>
     <div class="blockelement-inlineblock-editor__inner" ng-class="{'--singleGroup':block.content.variants[0].tabs.length === 1}" ng-if="block.active === true">
         <umb-element-editor-content model="block.content"></umb-element-editor-content>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/labelblock/labelblock.editor.html
@@ -1,8 +1,11 @@
-<button type="button" class="btn-reset umb-outline blockelement-labelblock-editor blockelement__draggable-element"
-        ng-click="block.edit()"
-        ng-focus="block.focus"
-        ng-class="{ '--active': block.active, '--error': parentForm.$invalid && valFormManager.isShowingValidation() }"
-        val-server-property-class="">
-    <umb-icon icon="{{block.content.icon}}" class="icon"></umb-icon>
-    <span>{{block.label}}</span>
+<button
+  type="button"
+  class="btn-reset umb-outline blockelement-labelblock-editor blockelement__draggable-element"
+  ng-click="block.edit()"
+  ng-focus="block.focus"
+  ng-class="{ '--active': block.active, '--error': parentForm.$invalid && valFormManager.isShowingValidation() }"
+  val-server-property-class=""
+>
+  <umb-icon icon="{{block.content.icon}}" class="icon"></umb-icon>
+  <span block-html-compile="block.label" block-html-scope="block"></span>
 </button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/unsupportedblock/unsupportedblock.editor.html
@@ -1,7 +1,7 @@
 <div class="blockelement-unsupportedblock-editor blockelement__draggable-element" ng-focus="block.focus">
     <div class="__header">
         <umb-icon icon="icon-alert" class="icon"></umb-icon>
-        <span>{{block.label}}</span>
+        <span block-html-compile="block.label" block-html-scope="block"></span>
     </div>
     <div class="__body">
         This content is no longer supported in this context.<br/>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -28,7 +28,7 @@
             }
         });
 
-    function BlockListController($scope, $timeout, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper, eventsService, $attrs) {
+    function BlockListController($scope, $timeout, $interpolate, editorService, clipboardService, localizationService, overlayService, blockEditorService, udiService, serverValidationManager, angularHelper, eventsService, $attrs) {
 
         var unsubscribe = [];
         var modelObject;
@@ -442,7 +442,7 @@
                 openSettings: openSettings === true,
                 createFlow: options.createFlow === true,
                 liveEditing: liveEditing,
-                title: blockObject.label,
+                title: $interpolate(blockObject.label)(blockObject.interpolatableData),
                 view: "views/common/infiniteeditors/blockeditor/blockeditor.html",
                 size: blockObject.config.editorSize || "medium",
                 hideSubmitButton: vm.readonly,

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -82,7 +82,9 @@
         $scope.index = index;
 
         // let the Block know about the current index:
-        $scope.block.index = $scope.block.interpolatableData.$index = index + 1;
+        if ($scope.block) {
+          $scope.block.index = $scope.block.interpolatableData.$index = index + 1;
+        }
       }
     };
   }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbblocklistblock.component.js
@@ -1,85 +1,91 @@
 (function () {
-    "use strict";
+  "use strict";
 
-    /**
-     * @ngdoc directive
-     * @name umbraco.directives.directive:umbBlockListBlock
-     * @description
-     * The component to render the view for a block.
-     * If a stylesheet is used then this uses a ShadowDom to make a scoped element.
-     * This way the backoffice styling does not collide with the block style.
-     */
+  /**
+   * @ngdoc directive
+   * @name umbraco.directives.directive:umbBlockListBlock
+   * @description
+   * The component to render the view for a block.
+   * If a stylesheet is used then this uses a ShadowDom to make a scoped element.
+   * This way the backoffice styling does not collide with the block style.
+   */
 
-    angular
-        .module("umbraco")
-        .component("umbBlockListBlock", {
-            controller: BlockListBlockController,
-            controllerAs: "model",
-            bindings: {
-                stylesheet: "@",
-                view: "@",
-                block: "=",
-                api: "<",
-                index: "<",
-                parentForm: "<"
-            },
-            require: {
-                valFormManager: "^^valFormManager"
-            }
-        }
+  angular
+    .module("umbraco")
+    .component("umbBlockListBlock", {
+      controller: BlockListBlockController,
+      controllerAs: "model",
+      bindings: {
+        stylesheet: "@",
+        view: "@",
+        block: "=",
+        api: "<",
+        index: "<",
+        parentForm: "<"
+      },
+      require: {
+        valFormManager: "^^valFormManager"
+      }
+    }
     );
 
-    function BlockListBlockController($scope, $compile, $element) {
-        var model = this;
+  function BlockListBlockController($scope, $compile, $element) {
+    var model = this;
 
-        model.$onInit = function () {
-            // This is ugly and is only necessary because we are not using components and instead
-            // relying on ng-include. It is definitely possible to compile the contents
-            // of the view into the DOM using $templateCache and $http instead of using
-            // ng - include which means that the controllerAs flows directly to the view.
-            // This would mean that any custom components would need to be updated instead of relying on $scope.
-            // Guess we'll leave it for now but means all things need to be copied to the $scope and then all
-            // primitives need to be watched.
+    model.$onInit = function () {
+      // This is ugly and is only necessary because we are not using components and instead
+      // relying on ng-include. It is definitely possible to compile the contents
+      // of the view into the DOM using $templateCache and $http instead of using
+      // ng - include which means that the controllerAs flows directly to the view.
+      // This would mean that any custom components would need to be updated instead of relying on $scope.
+      // Guess we'll leave it for now but means all things need to be copied to the $scope and then all
+      // primitives need to be watched.
 
-            // let the Block know about its form
-            model.block.setParentForm(model.parentForm);
+      // let the Block know about its form
+      model.block.setParentForm(model.parentForm);
 
-            // let the Block know about the current index
-            model.block.index = model.index;
+      // let the Block know about the current index
+      model.block.interpolatableData.$index = model.index + 1;
 
-            $scope.block = model.block;
-            $scope.api = model.api;
-            $scope.index = model.index;
-            $scope.parentForm = model.parentForm;
-            $scope.valFormManager = model.valFormManager;
+      $scope.block = model.block;
+      $scope.api = model.api;
+      $scope.index = model.index;
+      $scope.parentForm = model.parentForm;
+      $scope.valFormManager = model.valFormManager;
 
-            if (model.stylesheet) {
-                var shadowRoot = $element[0].attachShadow({ mode: 'open' });
-                shadowRoot.innerHTML = `
+      if (model.stylesheet) {
+        var shadowRoot = $element[0].attachShadow({ mode: 'open' });
+        shadowRoot.innerHTML = `
                     <style>
                     @import "${model.stylesheet}"
                     </style>
                     <div class="umb-block-list__block--view" ng-include="'${model.view}'"></div>
                 `;
-                $compile(shadowRoot)($scope);
-            }
-            else {
-                $element.append($compile('<div class="umb-block-list__block--view" ng-include="model.view"></div>')($scope));
-            }
-        };
+        $compile(shadowRoot)($scope);
+      }
+      else {
+        $element.append($compile('<div class="umb-block-list__block--view" ng-include="model.view"></div>')($scope));
+      }
+    };
 
-        // We need to watch for changes on primitive types and upate the $scope values.
-        model.$onChanges = function (changes) {
-            if (changes.index) {
-                var index = changes.index.currentValue;
-                $scope.index = index;
+    // React to changes to the block data and reset the scope data to force a digest cycle
+    $scope.$watchCollection(function () {
+      return model.block.data;
+    }, function () {
+      $scope.block.data = Object.assign({}, model.block.data);
+    });
 
-                // let the Block know about the current index:
-                model.block.index = index;
-                model.block.updateLabel();
-            }
-        };
-    }
+    // We need to watch for changes on primitive types and upate the $scope values.
+    model.$onChanges = function (changes) {
+      if (changes.index) {
+        var index = changes.index.currentValue;
+        $scope.index = index;
+
+        // let the Block know about the current index:
+        $scope.block.index = $scope.block.interpolatableData.$index = index + 1;
+      }
+    };
+  }
 
 
 })();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #10127 

### Description

We have the ability to set a custom label expression for blocks in the block list editor. This expression can even point to the element type itself and extract values from whatever is in the block, e.g. `{{ description }}` if the element type has a "description" property.

Sometimes, you might want to extract more data from your properties. Say you have an MNTP with articles and you wanted to display the name of that article. This was possible in the Nested Content editor, but it has had its ups and downs in the block list. Nominally you do this by adding the `ncNodeName` filter to your expression like this: `{{ article | ncNodeName }}`. The thing is that this filter requires an async operation in most cases unless you have the article picked several places.

The first change proposed in this PR is to mark that filter as `$stateful` and add some checks on fallthrough cases where the same node is requested twice in a row before the async operation completes, null-ish node IDs, etc.

The next change is to remove the `$interpolate` logic for custom labels and make sure that the template for blocks always compiles the label instead, which in turn ensures that stateful filters are being updated ($interpolate seems to ignore filters that are stateful, even though other direct values are updated just fine).

To make the second change work, this PR introduces a new directive called `blockHtmlCompile` which you can input any custom expression and it will compile that against the former interpolatable values of each block, including some values that are set dynamically such as $index. We can then use it like this for example in labelblock.editor.html:

```html
<span block-html-compile="block.label" block-html-scope="block"></span>
```

[See this Plunker](https://plnkr.co/edit/Bc3xzETZChRLE9Sj) for what works and what does not.

If desired this new compile directive could be abstracted into a generic one and used elsewhere in the future.

Everything put together works like this:

![block-ncnodename](https://user-images.githubusercontent.com/752371/185422462-6e37db23-6a35-4ee0-9fa0-4695011d920a.gif)

### Steps to reproduce
Create a document type with a block list editor property.
The block list editor contains one block with a multinode treepicker on the content model with alias = article.
The block has the label expression `{{ article | ncNodeName }}`

Create / publish the above then add multiple items to the block list editor.


<!-- Thanks for contributing to Umbraco CMS! -->


---
_This item has been added to our backlog [AB#21874](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/21874)_