### PR TITLE
CodeQL should not scan compiled assets

### DIFF
--- a/.github/config/codeql-config.yml
+++ b/.github/config/codeql-config.yml
@@ -6,4 +6,4 @@ paths:
 paths-ignore:
   - '**/node_modules'
   - 'src/Umbraco.Web.UI/wwwroot'
-  - 'src/Umbraco.Cms.StaticAssets'
+  - 'src/Umbraco.Cms.StaticAssets/wwwroot'

--- a/.github/config/codeql-config.yml
+++ b/.github/config/codeql-config.yml
@@ -6,3 +6,4 @@ paths:
 paths-ignore:
   - '**/node_modules'
   - 'src/Umbraco.Web.UI/wwwroot'
+  - 'src/Umbraco.Cms.StaticAssets'


### PR DESCRIPTION
### Description

Add the Umbraco.Cms.StaticAssets folder to ignored paths for the CodeQL scanner so it doesn't pick up compiled assets which are generated after build.