### PR TITLE
Upgrade CodeQL to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,8 +32,15 @@ jobs:
         languages: ${{ matrix.language }}
         config-file: ./.github/config/codeql-config.yml
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v2
+      if: ${{ matrix.language }} == 'csharp'
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: dotnet build
+      if: ${{ matrix.language }} == 'csharp'
+      run: dotnet build umbraco.sln -c SkipTests
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,12 +20,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/config/codeql-config.yml
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '6.0.x'
 
@@ -33,4 +33,4 @@ jobs:
       run: dotnet build umbraco.sln -c SkipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,29 +11,26 @@ jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'csharp', 'javascript' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
         config-file: ./.github/config/codeql-config.yml
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: dotnet build
+      run: dotnet build umbraco.sln -c SkipTests
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,11 +27,9 @@ jobs:
         config-file: ./.github/config/codeql-config.yml
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-
-    - run: dotnet clean
 
     - name: dotnet build
       run: dotnet build umbraco.sln -c SkipTests

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,15 +32,8 @@ jobs:
         languages: ${{ matrix.language }}
         config-file: ./.github/config/codeql-config.yml
 
-    - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
-      if: ${{ matrix.language }} == 'csharp'
-      with:
-        dotnet-version: '6.0.x'
-
-    - name: dotnet build
-      if: ${{ matrix.language }} == 'csharp'
-      run: dotnet build umbraco.sln -c SkipTests
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,26 +11,29 @@ jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp', 'javascript' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
+        languages: ${{ matrix.language }}
         config-file: ./.github/config/codeql-config.yml
 
-    - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '6.0.x'
-
-    - name: dotnet build
-      run: dotnet build umbraco.sln -c SkipTests
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,8 @@ jobs:
       with:
         dotnet-version: '6.0.x'
 
+    - run: dotnet clean
+
     - name: dotnet build
       run: dotnet build umbraco.sln -c SkipTests
 


### PR DESCRIPTION
### Description

Upgrade the CodeQL scanner to v2 since v1 will be deprecated [later this year](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/).
