### PR TITLE
Upgrade CodeQL from v1 to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/config/codeql-config.yml
 
@@ -37,4 +37,4 @@ jobs:
       run: dotnet build umbraco.sln -c SkipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
         config-file: ./.github/config/codeql-config.yml
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '6.0.x'
 


### PR DESCRIPTION
### Description

Upgrade the CodeQL scanner to v2 since v1 will be deprecated [later this year](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/).
