### PR TITLE
Fix #12770

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -797,7 +797,7 @@
     <key alias="permissionsMaybeAnIssue"><![CDATA[<strong>Vaše nastavení oprávnění může být problém!</strong>
       <br/><br />
       Můžete provozovat Umbraco bez potíží, ale nebudete smět vytvářet složky a instalovat balíčky, které jsou doporučené pro plné využívání všech možností umbraca.]]></key>
-    <key alias="permissionsNotReady"><![CDATA[<strong>Vaše nastavení oprívnění není připraveno pro umbraco!</strong>
+    <key alias="permissionsNotReady"><![CDATA[<strong>Vaše nastavení oprívnění není připraveno pro Umbraco!</strong>
           <br /><br />
           Abyste mohli Umbraco provozovat, budete muset aktualizovat Vaše nastavení oprávnění.]]></key>
     <key alias="permissionsPerfect"><![CDATA[<strong>Vaše nastavení oprávnění je dokonalé!</strong><br /><br />

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -781,8 +781,8 @@
     <key alias="databaseUpgradeDone"><![CDATA[Vaše databáze byla povýšená na konečnou verzi %0%.<br />Stiskněte <strong>Následující</strong> pro pokračování. ]]></key>
     <key alias="databaseUpToDate"><![CDATA[Vaše současná databáze je aktuální!. Klikněte na <strong>následující</strong>, pro pokračování konfiguračního průvodce]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>Heslo výchozího uživatele musí být změněno!</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>Výchozí uživatel byl deaktivován, nebo nemá přístup k umbracu!</strong></p><p>Netřeba nic dalšího dělat. Klikněte na <b>Následující</b> pro pokračování.]]></key>
-    <key alias="defaultUserPassChanged"><![CDATA[<strong>Heslo výchozího uživatele bylo úspěšně změněno od doby instalace!</strong></p><p>Netřeba nic dalšího dělat. Klikněte na <b>Následující</b> pro pokračování.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>Výchozí uživatel byl deaktivován, nebo nemá přístup k umbracu!</strong></p><p>Netřeba nic dalšího dělat. Klikněte na <strong>Následující</strong> pro pokračování.]]></key>
+    <key alias="defaultUserPassChanged"><![CDATA[<strong>Heslo výchozího uživatele bylo úspěšně změněno od doby instalace!</strong></p><p>Netřeba nic dalšího dělat. Klikněte na <strong>Následující</strong> pro pokračování.]]></key>
     <key alias="defaultUserPasswordChanged">Heslo je změněno!</key>
     <key alias="greatStart">Mějte skvělý start, sledujte naše uváděcí videa</key>
     <key alias="None">Není nainstalováno.</key>
@@ -2132,7 +2132,7 @@
     <key alias="performanceProfiling">Profilování výkonu</key>
     <key alias="performanceProfilingDescription">
       <![CDATA[
-                <p> Umbraco aktuálně běží v režimu ladění. To znamená, že můžete použít vestavěný profiler výkonu k vyhodnocení výkonu při vykreslování stránek. </p> <p> Pokud chcete aktivovat profiler pro konkrétní vykreslení stránky, jednoduše při požadavku na stránku jednoduše přidejte <b>umbDebug=true</b> do URL.</p> <p> Pokud chcete, aby byl profiler ve výchozím nastavení aktivován pro všechna vykreslení stránky, můžete použít přepínač níže. Ve vašem prohlížeči nastaví soubor cookie, který automaticky aktivuje profiler. Jinými slovy, profiler bude ve výchozím nastavení aktivní pouze ve <i> vašem </i> prohlížeči, ne v ostatních. </p>
+                <p> Umbraco aktuálně běží v režimu ladění. To znamená, že můžete použít vestavěný profiler výkonu k vyhodnocení výkonu při vykreslování stránek. </p> <p> Pokud chcete aktivovat profiler pro konkrétní vykreslení stránky, jednoduše při požadavku na stránku jednoduše přidejte <strong>umbDebug=true</strong> do URL.</p> <p> Pokud chcete, aby byl profiler ve výchozím nastavení aktivován pro všechna vykreslení stránky, můžete použít přepínač níže. Ve vašem prohlížeči nastaví soubor cookie, který automaticky aktivuje profiler. Jinými slovy, profiler bude ve výchozím nastavení aktivní pouze ve <em> vašem </em> prohlížeči, ne v ostatních. </p>
         ]]>
     </key>
     <key alias="activateByDefault">Ve výchozím stavu aktivovat profiler</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -838,7 +838,7 @@
     <key alias="step3">Krok 3/5: Ověřování oprávnění k souborům</key>
     <key alias="step4">Krok 4/5: Kontrola zabezpečení umbraca</key>
     <key alias="step5">Krok 5/5: Umbraco je připraveno a můžete začít</key>
-    <key alias="thankYou">Děkujeme, že jeste si vybrali umbraco</key>
+    <key alias="thankYou">Děkujeme, že jeste si vybrali Umbraco</key>
     <key alias="theEndBrowseSite"><![CDATA[<h3>Prohlédněte si svůj nový web</h3>
     Nainstalovali jste Runway, tak proč se nepodívat, jak Váš nový web vypadá.]]></key>
     <key alias="theEndFurtherHelp"><![CDATA[<h3>Další pomoc a informace</h3>
@@ -1379,7 +1379,7 @@
     <key alias="insertMacroDesc">
       Makro je konfigurovatelná součást, která je skvělá pro opakovaně použitelné části návrhu, kde potřebujete předat parametry, jako jsou galerie, formuláře a seznamy.
     </key>
-    <key alias="insertPageField">Vložit pole stránky umbraco</key>
+    <key alias="insertPageField">Vložit pole stránky Umbraco</key>
     <key alias="insertPageFieldDesc">Zobrazuje hodnotu pojmenovaného pole z aktuální stránky s možnostmi upravit hodnotu nebo alternativní hodnoty.</key>
     <key alias="insertPartialView">Částečná šablona</key>
     <key alias="insertPartialViewDesc">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -449,13 +449,13 @@
     <key alias="assignDomain">Gweinyddu enwau gwesteia</key>
     <key alias="closeThisWindow">Cau'r ffenestr yma</key>
     <key alias="confirmdelete">Ydych chi'n sicr eich bod eisiau dileu</key>
-    <key alias="confirmdeleteNumberOfItems"><![CDATA[Wyt ti'n siŵr fod ti eisiau dileu <b>%0%</b> yn seiliedig ar <b>%1%</b>]]></key>
+    <key alias="confirmdeleteNumberOfItems"><![CDATA[Wyt ti'n siŵr fod ti eisiau dileu <strong>%0%</strong> yn seiliedig ar <strong>%1%</strong>]]></key>
 
     <key alias="confirmdisable">Ydych chi'n sicr eich bod eisiau analluogi</key>
 
     <key alias="confirmremove">Wyt ti'n siŵr fod ti eisiau dileu</key>
-    <key alias="confirmremoveusageof"><![CDATA[Ydych chi'n siŵr bod chi am gael gwared ar y defnydd o <b>%0%</b>]]></key>
-    <key alias="confirmremovereferenceto"><![CDATA[Ydych chi'n siŵr bod chi am gael gwared ar y cyfeirnod i <b>%0%</b>]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[Ydych chi'n siŵr bod chi am gael gwared ar y defnydd o <strong>%0%</strong>]]></key>
+    <key alias="confirmremovereferenceto"><![CDATA[Ydych chi'n siŵr bod chi am gael gwared ar y cyfeirnod i <strong>%0%</strong>]]></key>
 
     <key alias="confirmlogout">Ydych chi'n sicr?</key>
     <key alias="confirmSure">Ydych chi'n sicr?</key>
@@ -546,8 +546,8 @@
     <key alias="selectEditorConfiguration">Dewiswch ffurfweddiad</key>
     <key alias="selectSnippet">Dewiswch damaid</key>
     <key alias="variantdeletewarning">Bydd hyn yn dileu'r nod a'i holl ieithoedd. Os mai dim ond un iaith yr ydych am ei dileu, ewch i'w anghyhoedd yn lle.</key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[Bydd hyn yn cael gwared ar y defnyddiwr <b>%0%</b>.]]></key>
-    <key alias="userremovewarning"><![CDATA[bydd hyn yn cael gwared ar y defnyddiwr <b>%0%</b> o'r grŵp <b>%1%</b>]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[Bydd hyn yn cael gwared ar y defnyddiwr <strong>%0%</strong>.]]></key>
+    <key alias="userremovewarning"><![CDATA[bydd hyn yn cael gwared ar y defnyddiwr <strong>%0%</strong> o'r grŵp <strong>%1%</strong>]]></key>
     <key alias="yesRemove">Ydw, dileu</key>
   </area>
   <area alias="dictionary">
@@ -965,7 +965,7 @@
     </key>
     <key alias="databaseUpToDate"><![CDATA[Mae eich cronfa ddata bresennol wedi diweddaru eisoes!. Cliciwch <strong>nesaf</strong> i barhau gyda'r dewin ffurfwedd]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>Mae angen newid cyfrinair y defnyddiwr Diofyn!</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>Mae'r defnyddiwr Diofyn wedi'u analluogi neu does dim hawliau i Umbraco!</strong></p><p>Does dim angen unrhyw weithredoedd pellach. Cliciwch <b>Nesaf</b> i barhau.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>Mae'r defnyddiwr Diofyn wedi'u analluogi neu does dim hawliau i Umbraco!</strong></p><p>Does dim angen unrhyw weithredoedd pellach. Cliciwch <strong>Nesaf</strong> i barhau.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>Mae cyfrinair y defnyddiwr Diofyn wedi'i newid yn llwyddiannus ers y gosodiad!</strong></p><p>Does dim angen unrhyw weithredoedd pellach. Cliciwch <strong>Nesaf</strong> i barhau.]]></key>
     <key alias="defaultUserPasswordChanged">Mae'r cyfrinair wedi'i newid!</key>
     <key alias="greatStart">Cewch gychwyn gwych, gwyliwch ein fideos rhaglith</key>
@@ -2695,12 +2695,12 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
                     Mae Umbraco yn rhedeg mewn modd dadfygio. Mae hyn yn golygu y gallwch chi ddefnyddio'r proffiliwr perfformiad adeiledig i asesu'r perfformiad wrth rendro tudalennau.
                 </p>
                 <p>
-                    OS ti eisiau actifadu'r proffiliwr am rendro tudalen penodol, bydd angen ychwanegu <b>umbDebug=true</b> i'r ymholiad wrth geisio am y tudalen
+                    OS ti eisiau actifadu'r proffiliwr am rendro tudalen penodol, bydd angen ychwanegu <strong>umbDebug=true</strong> i'r ymholiad wrth geisio am y tudalen
                 </p>
                 <p>
                     Os ydych chi am i'r proffiliwr gael ei actifadu yn ddiofyn am bob rendrad tudalen, gallwch chi ddefnyddio'r togl isod.
                     Bydd e'n gosod cwci yn eich porwr, sydd wedyn yn actifadu'r proffiliwr yn awtomatig.
-                    Mewn geiriau eraill, bydd y proffiliwr dim ond yn actif yn ddiofyn yn eich porwr <i>chi</i> - nid porwr pawb eraill.
+                    Mewn geiriau eraill, bydd y proffiliwr dim ond yn actif yn ddiofyn yn eich porwr <em>chi</em> - nid porwr pawb eraill.
                 </p>
         ]]>
     </key>
@@ -2709,7 +2709,7 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
     <key alias="reminderDescription">
       <![CDATA[
             <p>
-                Ni ddylech chi fyth adael i safle cynhyrchu redeg yn y modd dadfygio. Mae'r modd dadfygio yn gallu cael ei diffodd trwy ychwanegu'r gosodiad <b>debug="false"</b> ar yr elfen <b>&lt;grynhoi /&gt;</b> yn web.config.
+                Ni ddylech chi fyth adael i safle cynhyrchu redeg yn y modd dadfygio. Mae'r modd dadfygio yn gallu cael ei diffodd trwy ychwanegu'r gosodiad <strong>debug="false"</strong> ar yr elfen <strong>&lt;grynhoi /&gt;</strong> yn web.config.
             </p>
         ]]>
     </key>
@@ -2719,7 +2719,7 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
                 Mae Umbraco ddim yn rhedeg mewn modd dadfygio ar hyn o bryd, felly nid allwch chi ddefnyddio'r proffiliwer adeiledig. Dyma sut y dylai fod ar gyfer safle cynhyrchu.
             </p>
             <p>
-                Mae'r modd dadfygio yn gallu cael ei throi arno gan ychwanegu'r gosodiad <b>debug="true"</b> ar yr elfen <b>&lt;grynhoi /&gt;</b> yn web.config.
+                Mae'r modd dadfygio yn gallu cael ei throi arno gan ychwanegu'r gosodiad <strong>debug="true"</strong> ar yr elfen <strong>&lt;grynhoi /&gt;</strong> yn web.config.
             </p>
         ]]>
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -465,7 +465,7 @@
     <key alias="confirmdelete">Er du sikker på at du vil slette</key>
     <key alias="confirmdisable">Er du sikker på du vil deaktivere</key>
     <key alias="confirmremove">Er du sikker på at du vil fjerne</key>
-    <key alias="confirmremoveusageof"><![CDATA[Er du sikker på du vil fjerne brugen af <b>%0%</b>]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[Er du sikker på du vil fjerne brugen af <strong>%0%</strong>]]></key>
     <key alias="confirmlogout">Er du sikker på at du vil forlade Umbraco?</key>
     <key alias="confirmSure">Er du sikker?</key>
     <key alias="cut">Klip</key>
@@ -556,8 +556,8 @@
     <key alias="variantdeletewarning">Dette vil slette noden og alle dets sprog. Hvis du kun vil slette et sprog, så
       afpublicér det i stedet.
     </key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[Dette vil fjerne brugeren <b>%0%</b>]]></key>
-    <key alias="userremovewarning"><![CDATA[Dette vil fjerne brugeren <b>%0%</b> fra <b%1%</b> gruppen]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[Dette vil fjerne brugeren <strong>%0%</strong>]]></key>
+    <key alias="userremovewarning"><![CDATA[Dette vil fjerne brugeren <strong>%0%</strong> fra <strong>%1%</strong> gruppen]]></key>
     <key alias="yesRemove">Ja, fjern</key>
   </area>
   <area alias="dictionary">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -469,10 +469,10 @@
     <key alias="assignDomain">Manage hostnames</key>
     <key alias="closeThisWindow">Close this window</key>
     <key alias="confirmdelete">Are you sure you want to delete</key>
-    <key alias="confirmdeleteNumberOfItems"><![CDATA[Are you sure you want to delete <b>%0%</b> of <b>%1%</b> items]]></key>
+    <key alias="confirmdeleteNumberOfItems"><![CDATA[Are you sure you want to delete <strong>%0%</strong> of <strong>%1%</strong> items]]></key>
     <key alias="confirmdisable">Are you sure you want to disable</key>
     <key alias="confirmremove">Are you sure you want to remove</key>
-    <key alias="confirmremoveusageof"><![CDATA[Are you sure you want to remove the usage of <b>%0%</b>]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[Are you sure you want to remove the usage of <strong>%0%</strong>]]></key>
     <key alias="confirmlogout">Are you sure?</key>
     <key alias="confirmSure">Are you sure?</key>
     <key alias="cut">Cut</key>
@@ -564,8 +564,8 @@
     <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one
       language, you should unpublish the node in that language instead.
     </key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[This will remove the user <b>%0%</b>.]]></key>
-    <key alias="userremovewarning"><![CDATA[This will remove the user <b>%0%</b> from the <b>%1%</b> group]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[This will remove the user <strong>%0%</strong>.]]></key>
+    <key alias="userremovewarning"><![CDATA[This will remove the user <strong>%0%</strong> from the <strong>%1%</strong> group]]></key>
     <key alias="yesRemove">Yes, remove</key>
     <key alias="deleteLayout">You are deleting the layout</key>
     <key alias="deletingALayout">Modifying layout will result in loss of data for any existing content that is based on this configuration.</key>
@@ -948,7 +948,7 @@
     <key alias="defaultUserChangePass">
       <![CDATA[<strong>The Default users' password needs to be changed!</strong>]]></key>
     <key alias="defaultUserDisabled">
-      <![CDATA[<strong>The Default user has been disabled or has no access to Umbraco!</strong></p><p>No further actions needs to be taken. Click <b>Next</b> to proceed.]]></key>
+      <![CDATA[<strong>The Default user has been disabled or has no access to Umbraco!</strong></p><p>No further actions needs to be taken. Click <strong>Next</strong> to proceed.]]></key>
     <key alias="defaultUserPassChanged">
       <![CDATA[<strong>The Default user's password has been successfully changed since the installation!</strong></p><p>No further actions needs to be taken. Click <strong>Next</strong> to proceed.]]></key>
     <key alias="defaultUserPasswordChanged">The password is changed!</key>
@@ -1873,7 +1873,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
-    <key alias="historyCleanupGloballyDisabled"><![CDATA[<b>NOTE!</b> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
+    <key alias="historyCleanupGloballyDisabled"><![CDATA[<strong>NOTE!</strong> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>
@@ -2611,12 +2611,12 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
                 Umbraco currently runs in debug mode. This means you can use the built-in performance profiler to assess the performance when rendering pages.
             </p>
             <p>
-                If you want to activate the profiler for a specific page rendering, simply add <b>umbDebug=true</b> to the querystring when requesting the page.
+                If you want to activate the profiler for a specific page rendering, simply add <strong>umbDebug=true</strong> to the querystring when requesting the page.
             </p>
             <p>
                 If you want the profiler to be activated by default for all page renderings, you can use the toggle below.
                 It will set a cookie in your browser, which then activates the profiler automatically.
-                In other words, the profiler will only be active by default in <i>your</i> browser - not everyone else's.
+                In other words, the profiler will only be active by default in <em>your</em> browser - not everyone else's.
             </p>
     ]]>
     </key>
@@ -2625,7 +2625,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="reminderDescription">
       <![CDATA[
         <p>
-            You should never let a production site run in debug mode. Debug mode is turned off by setting <b>Umbraco:CMS:Hosting:Debug</b> to <b>false</b> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
+            You should never let a production site run in debug mode. Debug mode is turned off by setting <strong>Umbraco:CMS:Hosting:Debug</strong> to <strong>false</strong> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
         </p>
     ]]>
     </key>
@@ -2635,7 +2635,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
             Umbraco currently does not run in debug mode, so you can't use the built-in profiler. This is how it should be for a production site.
         </p>
         <p>
-            Debug mode is turned on by setting <b>Umbraco:CMS:Hosting:Debug</b> to <b>true</b> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
+            Debug mode is turned on by setting <strong>Umbraco:CMS:Hosting:Debug</strong> to <strong>true</strong> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
         </p>
     ]]>
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2910,12 +2910,12 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
        ]]>
     </key>
     <key alias="minimalLevelDescription">We will only send an anonymized site ID to let us know that the site exists.</key>
-    <key alias="basicLevelDescription">We will send an anonymized site ID, umbraco version, and packages installed</key>
+    <key alias="basicLevelDescription">We will send an anonymized site ID, Umbraco version, and packages installed</key>
     <key alias="detailedLevelDescription">
       <![CDATA[
           We will send:
           <ul>
-            <li>Anonymized site ID, umbraco version, and packages installed.</li>
+            <li>Anonymized site ID, Umbraco version, and packages installed.</li>
             <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.</li>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -483,10 +483,10 @@
     <key alias="anchorInsert">Name</key>
     <key alias="closeThisWindow">Close this window</key>
     <key alias="confirmdelete">Are you sure you want to delete</key>
-    <key alias="confirmdeleteNumberOfItems"><![CDATA[Are you sure you want to delete <b>%0%</b> of <b>%1%</b> items]]></key>
+    <key alias="confirmdeleteNumberOfItems"><![CDATA[Are you sure you want to delete <strong>%0%</strong> of <strong>%1%</strong> items]]></key>
     <key alias="confirmdisable">Are you sure you want to disable</key>
     <key alias="confirmremove">Are you sure you want to remove</key>
-    <key alias="confirmremoveusageof"><![CDATA[Are you sure you want to remove the usage of <b>%0%</b>]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[Are you sure you want to remove the usage of <strong>%0%</strong>]]></key>
     <key alias="confirmlogout">Are you sure?</key>
     <key alias="confirmSure">Are you sure?</key>
     <key alias="cut">Cut</key>
@@ -579,8 +579,8 @@
     <key alias="variantdeletewarning">This will delete the node and all its languages. If you only want to delete one
       language, you should unpublish the node in that language instead.
     </key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[This will remove the user <b>%0%</b>.]]></key>
-    <key alias="userremovewarning"><![CDATA[This will remove the user <b>%0%</b> from the <b>%1%</b> group]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[This will remove the user <strong>%0%</strong>.]]></key>
+    <key alias="userremovewarning"><![CDATA[This will remove the user <strong>%0%</strong> from the <strong>%1%</strong> group]]></key>
     <key alias="yesRemove">Yes, remove</key>
     <key alias="deleteLayout">You are deleting the layout</key>
     <key alias="deletingALayout">Modifying layout will result in loss of data for any existing content that is based on this configuration.</key>
@@ -975,7 +975,7 @@
     <key alias="defaultUserChangePass">
       <![CDATA[<strong>The Default users' password needs to be changed!</strong>]]></key>
     <key alias="defaultUserDisabled">
-      <![CDATA[<strong>The Default user has been disabled or has no access to Umbraco!</strong></p><p>No further actions needs to be taken. Click <b>Next</b> to proceed.]]></key>
+      <![CDATA[<strong>The Default user has been disabled or has no access to Umbraco!</strong></p><p>No further actions needs to be taken. Click <strong>Next</strong> to proceed.]]></key>
     <key alias="defaultUserPassChanged">
       <![CDATA[<strong>The Default user's password has been successfully changed since the installation!</strong></p><p>No further actions needs to be taken. Click <strong>Next</strong> to proceed.]]></key>
     <key alias="defaultUserPasswordChanged">The password is changed!</key>
@@ -1947,7 +1947,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
-    <key alias="historyCleanupGloballyDisabled"><![CDATA[<b>NOTE!</b> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
+    <key alias="historyCleanupGloballyDisabled"><![CDATA[<strong>NOTE!</strong> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
     <key alias="changeDataTypeHelpText">Changing a data type with stored values is disabled. To allow this you can change the Umbraco:CMS:DataTypes:CanBeChanged setting in appsettings.json.</key>
   </area>
   <area alias="languages">
@@ -2713,12 +2713,12 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
                     Umbraco currently runs in debug mode. This means you can use the built-in performance profiler to assess the performance when rendering pages.
                 </p>
                 <p>
-                    If you want to activate the profiler for a specific page rendering, simply add <b>umbDebug=true</b> to the querystring when requesting the page.
+                    If you want to activate the profiler for a specific page rendering, simply add <strong>umbDebug=true</strong> to the querystring when requesting the page.
                 </p>
                 <p>
                     If you want the profiler to be activated by default for all page renderings, you can use the toggle below.
                     It will set a cookie in your browser, which then activates the profiler automatically.
-                    In other words, the profiler will only be active by default in <i>your</i> browser - not everyone else's.
+                    In other words, the profiler will only be active by default in <em>your</em> browser - not everyone else's.
                 </p>
         ]]>
     </key>
@@ -2727,7 +2727,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="reminderDescription">
       <![CDATA[
             <p>
-                You should never let a production site run in debug mode. Debug mode is turned off by setting <b>Umbraco:CMS:Hosting:Debug</b> to <b>false</b> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
+                You should never let a production site run in debug mode. Debug mode is turned off by setting <strong>Umbraco:CMS:Hosting:Debug</strong> to <strong>false</strong> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
             </p>
         ]]>
     </key>
@@ -2737,7 +2737,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
                 Umbraco currently does not run in debug mode, so you can't use the built-in profiler. This is how it should be for a production site.
             </p>
             <p>
-                Debug mode is turned on by setting <b>Umbraco:CMS:Hosting:Debug</b> to <b>true</b> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
+                Debug mode is turned on by setting <strong>Umbraco:CMS:Hosting:Debug</strong> to <strong>true</strong> in appsettings.json, appsettings.{Environment}.json or via an environment variable.
             </p>
         ]]>
     </key>
@@ -2906,7 +2906,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
           <br>Aggregate data will be shared on a regular basis as well as learnings from these metrics.
           <br>Hopefully, you will help us collect some valuable data.
           <br>
-          <br>We <b>WILL NOT</b> collect any personal data such as content, code, user information, and all data will be fully anonymized.
+          <br>We <strong>WILL NOT</strong> collect any personal data such as content, code, user information, and all data will be fully anonymized.
        ]]>
     </key>
     <key alias="minimalLevelDescription">We will only send an anonymized site ID to let us know that the site exists.</key>
@@ -2920,8 +2920,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.</li>
           </ul>
-          <i>We might change what we send on the Detailed level in the future. If so, it will be listed above.
-          <br>By choosing "Detailed" you agree to current and future anonymized information being collected.</i>
+          <em>We might change what we send on the Detailed level in the future. If so, it will be listed above.
+          <br>By choosing "Detailed" you agree to current and future anonymized information being collected.</em>
        ]]>
     </key>
   </area>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
@@ -601,7 +601,7 @@
     <key alias="databaseUpgradeDone"><![CDATA[La base de datos ha sido actualizada a la versión 0%.<br />Pincha en <strong>Próximo</strong> para continuar. ]]></key>
     <key alias="databaseUpToDate"><![CDATA[La base de datos está actualizada. Pincha en <strong>próximo</strong> para continuar con el asistente de configuración]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>La contraseña del usuario por defecto debe ser cambiada</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>El usuario por defecto ha sido deshabilitado o ha perdido el acceso a Umbraco!</strong></p><p>Pincha en <b>Próximo</b> para continuar.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>El usuario por defecto ha sido deshabilitado o ha perdido el acceso a Umbraco!</strong></p><p>Pincha en <strong>Próximo</strong> para continuar.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>¡La contraseña del usuario por defecto ha sido cambiada desde que se instaló!</strong></p><p>No hay que realizar ninguna tarea más. Pulsa <strong>Siguiente</strong> para proseguir.]]></key>
     <key alias="defaultUserPasswordChanged">¡La contraseña se ha cambiado!</key>
     <key alias="greatStart">Ten un buen comienzo, visita nuestros videos de introducción</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -390,7 +390,7 @@
     <key alias="anchorInsert">Nom</key>
     <key alias="closeThisWindow">Fermer cette fenêtre</key>
     <key alias="confirmdelete">Êtes-vous certain(e) de vouloir supprimer</key>
-    <key alias="confirmdeleteNumberOfItems"><![CDATA[Êtes-vous certain(e) de vouloir supprimer <b>%0%</b> des <b>%1%</b> éléments]]></key>
+    <key alias="confirmdeleteNumberOfItems"><![CDATA[Êtes-vous certain(e) de vouloir supprimer <strong>%0%</strong> des <strong>%1%</strong> éléments]]></key>
     <key alias="confirmdisable">Êtes-vous certain(e) de vouloir désactiver</key>
     <key alias="confirmlogout">Êtes-vous certain(e)?</key>
     <key alias="confirmSure">Êtes-vous certain(e)?</key>
@@ -799,7 +799,7 @@
       poursuivre. ]]></key>
     <key alias="databaseUpToDate"><![CDATA[Votre base de données est à jour ! Cliquez sur <strong>Suivant</strong> pour poursuivre la configuration]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>Le mot de passe par défaut doit être modifié !</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>L'utilisateur par défaut a été désactivé ou n'a pas accès à Umbraco!</strong></p><p>Aucune autre action n'est requise. Cliquez sur <b>Suivant</b> pour poursuivre.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>L'utilisateur par défaut a été désactivé ou n'a pas accès à Umbraco!</strong></p><p>Aucune autre action n'est requise. Cliquez sur <strong>Suivant</strong> pour poursuivre.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>Le mot de passe par défaut a été modifié avec succès depuis l'installation!</strong></p><p>Aucune autre action n'est requise. Cliquez sur <strong>Suivant</strong> pour poursuivre.]]></key>
     <key alias="defaultUserPasswordChanged">Le mot de passe a été modifié !</key>
     <key alias="greatStart">Pour bien commencer, regardez nos vidéos d'introduction</key>
@@ -2177,12 +2177,12 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
 				   Umbraco est actuellement exécuté en mode debug. Cela signifie que vous pouvez utiliser le profileur de performances intégré pour évaluer les performance lors du rendu des pages.
                 </p>
                 <p>
-                    Si vous souhaitez activer le profileur pour le rendu d'une page spécifique, ajoutez simplement <b>umbDebug=true</b> au querystring lorsque vous demandez la page.
+                    Si vous souhaitez activer le profileur pour le rendu d'une page spécifique, ajoutez simplement <strong>umbDebug=true</strong> au querystring lorsque vous demandez la page.
                 </p>
                 <p>
                     Si vous souhaitez que le profileur soit activé par défaut pour tous les rendus de pages, vous pouvez utiliser le bouton bascule ci-dessous.
 					Cela créera un cookie dans votre browser, qui activera alors le profileur automatiquement.
-                    En d'autres termes, le profileur ne sera activé par défaut que dans <i>votre</i> browser - pas celui des autres.
+                    En d'autres termes, le profileur ne sera activé par défaut que dans <em>votre</em> browser - pas celui des autres.
                 </p>
         ]]>
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
@@ -366,7 +366,7 @@
       proceed. ]]></key>
     <key alias="databaseUpToDate"><![CDATA[Your current database is up-to-date!. Click <strong>next</strong> to continue the configuration wizard]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>The Default users’ password needs to be changed!</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>The Default user has been disabled or has no access to Umbraco!</strong></p><p>No further actions needs to be taken. Click <b>Next</b> to proceed.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>The Default user has been disabled or has no access to Umbraco!</strong></p><p>No further actions needs to be taken. Click <strong>Next</strong> to proceed.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>The Default user's password has been successfully changed since the installation!</strong></p><p>No further actions needs to be taken. Click <strong>Next</strong> to proceed.]]></key>
     <key alias="defaultUserPasswordChanged">הסיסמה שונתה!</key>
     <key alias="greatStart">התחל מכאן, צפה בסרטוני ההדרכה עבור אומברקו</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -487,8 +487,8 @@
     <key alias="confirmdelete">Sei sicuro di voler eliminare</key>
     <key alias="confirmdisable">Sei sicuro di voler disabilitare</key>
     <key alias="confirmremove">Sei sicuro di voler rimuovere</key>
-    <key alias="confirmremoveusageof"><![CDATA[Sei sicuro di voler rimuovere l'utilizzo di <b>%0%</b>]]></key>
-    <key alias="confirmremovereferenceto"><![CDATA[Sei sicuro di voler rimuovere la referenza a <b>%0%</b>]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[Sei sicuro di voler rimuovere l'utilizzo di <strong>%0%</strong>]]></key>
+    <key alias="confirmremovereferenceto"><![CDATA[Sei sicuro di voler rimuovere la referenza a <strong>%0%</strong>]]></key>
     <key alias="confirmlogout"><![CDATA[Sei sicuro?]]></key>
     <key alias="confirmSure"><![CDATA[Sei sicuro?]]></key>
     <key alias="cut">Taglia</key>
@@ -574,8 +574,8 @@
     <key alias="selectSnippet">Seleziona snippet</key>
     <key alias="variantdeletewarning">
       <![CDATA[Questo cancellerà il nodo e tutte le sue lingue. Se desideri eliminare solo una lingua, dovresti invece non pubblicare il nodo in quella lingua.]]></key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[Questo rimuoverà l'utente <b>%0%</b>.]]></key>
-    <key alias="userremovewarning"><![CDATA[Questo rimuoverà l'utente <b>%0%</b> dal gruppo <b>%1%</b>]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[Questo rimuoverà l'utente <strong>%0%</strong>.]]></key>
+    <key alias="userremovewarning"><![CDATA[Questo rimuoverà l'utente <strong>%0%</strong> dal gruppo <strong>%1%</strong>]]></key>
     <key alias="yesRemove">Si, rimuovi</key>
   </area>
   <area alias="dictionary">
@@ -2767,12 +2767,12 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
                     Umbraco attualmente funziona in modalità debug. Ciò significa che puoi utilizzare il profiler delle prestazioni integrato per valutare le prestazioni durante il rendering delle pagine.
                 </p>
                 <p>
-                    Se vuoi attivare il profiler per il rendering di una pagina specifica, aggiungi semplicemente <b>umbDebug=true</b> alla querystring quando richiedi la pagina.
+                    Se vuoi attivare il profiler per il rendering di una pagina specifica, aggiungi semplicemente <strong>umbDebug=true</strong> alla querystring quando richiedi la pagina.
                 </p>
                 <p>
                     Se vuoi che il profiler sia attivato per impostazione predefinita per tutti i rendering di pagina, puoi utilizzare l'interruttore qui sotto.
                     Verrà impostato un cookie nel tuo browser, che quindi attiverà automaticamente il profiler.
-                    In altre parole, il profiler sarà attivo per impostazione predefinita solo nel <i>tuo</i> browser, non in quello di tutti gli altri.
+                    In altre parole, il profiler sarà attivo per impostazione predefinita solo nel <em>tuo</em> browser, non in quello di tutti gli altri.
                 </p>
         ]]>
     </key>
@@ -2781,7 +2781,7 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
     <key alias="reminderDescription">
       <![CDATA[
             <p>
-                Non dovresti mai lasciare che un sito di produzione venga eseguito in modalità debug. La modalità di debug viene disattivata impostando <b>debug="false"</b> nell'elemento <b>&lt;compilation /&gt;</b> nel file web.config.
+                Non dovresti mai lasciare che un sito di produzione venga eseguito in modalità debug. La modalità di debug viene disattivata impostando <strong>debug="false"</strong> nell'elemento <strong>&lt;compilation /&gt;</strong> nel file web.config.
             </p>
         ]]>
     </key>
@@ -2791,7 +2791,7 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
                 Umbraco attualmente non viene eseguito in modalità debug, quindi non è possibile utilizzare il profiler integrato. Questo è come dovrebbe essere per un sito produttivo.
             </p>
             <p>
-                La modalità di debug viene attivata impostando <b>debug="true"</b> nell'elemento <b>&lt;compilation /&gt;</b> in web.config.
+                La modalità di debug viene attivata impostando <strong>debug="true"</strong> nell'elemento <strong>&lt;compilation /&gt;</strong> in web.config.
             </p>
         ]]>
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
@@ -555,7 +555,7 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="Version3">Umbraco Version 3</key>
     <key alias="Version4">Umbraco Version 4</key>
     <key alias="watch">見る</key>
-    <key alias="welcomeIntro"><![CDATA[このウィザードでは <strong>umbraco %0%</strong> の新規インストールまたは3.0からの更新について設定方法を案内します。
+    <key alias="welcomeIntro"><![CDATA[このウィザードでは <strong>Umbraco %0%</strong> の新規インストールまたは3.0からの更新について設定方法を案内します。
                                 <br /><br />
                                 <strong>"次へ"</strong>を押してウィザードを開始します。]]></key>
   </area>
@@ -849,9 +849,9 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="insertContentAreaPlaceHolder">コンテンツ領域プレースホルダーの挿入</key>
     <key alias="insertDictionaryItem">ディクショナリ アイテムを挿入</key>
     <key alias="insertMacro">マクロの挿入</key>
-    <key alias="insertPageField">umbraco ページフィールドの挿入</key>
+    <key alias="insertPageField">Umbraco ページフィールドの挿入</key>
     <key alias="mastertemplate">マスターテンプレート</key>
-    <key alias="quickGuide">umbraco テンプレートタグのクイックガイド</key>
+    <key alias="quickGuide">Umbraco テンプレートタグのクイックガイド</key>
     <key alias="template">テンプレート</key>
   </area>
   <area alias="grid">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
@@ -481,7 +481,7 @@
       を押して続行してください。]]></key>
     <key alias="databaseUpToDate"><![CDATA[データベースを更新しました！ <strong>次へ</strong> をクリックして設定ウィザードを進めてください。]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>デフォルトユーザーのパスワードを変更する必要があります！</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>デフォルトユーザーは無効化されているかUmbracoにアクセスできない状態になっています！</strong></p><p>これ以上のアクションは必要ありません。<b>次へ</b>をクリックして続行してください。]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>デフォルトユーザーは無効化されているかUmbracoにアクセスできない状態になっています！</strong></p><p>これ以上のアクションは必要ありません。<strong>次へ</strong>をクリックして続行してください。]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>インストール後にデフォルトユーザーのパスワードが変更されています！</strong></p><p>これ以上のアクションは必要ありません。<strong>次へ</strong>をクリックして続行してください。]]></key>
     <key alias="defaultUserPasswordChanged">パスワードは変更されました！</key>
     <key alias="greatStart">始めに、ビデオによる解説を見ましょう</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
@@ -357,7 +357,7 @@
     <key alias="databaseUpgradeDone"><![CDATA[데이터베이스가 최신 버전 %0% 로 업그레이드 되었습니다.<br />계속 진행하시려면 <strong>다음</strong> 을 누르세요. ]]></key>
     <key alias="databaseUpToDate"><![CDATA[데이터베이스가 업데이트 되었습니다. <strong>다음</strong>을 클릭하시면 설정마법사를 계속 진행합니다.]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>기본 사용자의 암호가 변경되어야 합니다!</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>기본 사용자가 비활성화되었거나 Umbraco에 접근할 수 없습니다!</strong></p><p>더 이상 과정이 필요없으시면 <b>다음</b>을 눌러주세요.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>기본 사용자가 비활성화되었거나 Umbraco에 접근할 수 없습니다!</strong></p><p>더 이상 과정이 필요없으시면 <strong>다음</strong>을 눌러주세요.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>설치후 기본사용자의 암호가 성공적으로 변경되었습니다!</strong></p><p>더 이상 과정이 필요없으시면 <strong>다음</strong>을 눌러주세요.]]></key>
     <key alias="defaultUserPasswordChanged">비밀번호가 변경되었습니다!</key>
     <key alias="greatStart">편리한 시작을 위해, 소개 Video를 시청하세요</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
@@ -420,7 +420,7 @@
     <key alias="databaseUpgradeDone"><![CDATA[Databasen din har blitt oppgradert til den siste utgaven, %0%.<br/>Trykk <strong>Neste</strong> for å fortsette.]]></key>
     <key alias="databaseUpToDate"><![CDATA[Databasen din er av nyeste versjon! Klikk <strong>neste</strong> for å fortsette konfigurasjonsveiviseren]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>Passordet til standardbrukeren må endres!]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>Standardbrukeren har blitt deaktivert eller har ingen tilgang til Umbraco!</strong></p><p>Ingen videre handling er nødvendig. Klikk <b>neste</b> for å fortsette.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>Standardbrukeren har blitt deaktivert eller har ingen tilgang til Umbraco!</strong></p><p>Ingen videre handling er nødvendig. Klikk <strong>neste</strong> for å fortsette.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>Passordet til standardbrukeren har blitt forandret etter installasjonen!</strong></p><p>Ingen videre handling er nødvendig. Klikk <strong>Neste</strong> for å fortsette.]]></key>
     <key alias="defaultUserPasswordChanged">Passordet er blitt endret!</key>
     <key alias="greatStart">Få en god start med våre introduksjonsvideoer</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -439,7 +439,7 @@
     <key alias="confirmdelete">Weet je zeker dat je dit wilt verwijderen</key>
     <key alias="confirmdisable">Weet je zeker dat je dit wilt uitschakelen</key>
     <key alias="confirmremove">Weet u zeker dat u wilt verwijderen</key>
-    <key alias="confirmremoveusageof"><![CDATA[Ben je zeker dat je het gebruik van <b>%0%</b> wil verwijderen]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[Ben je zeker dat je het gebruik van <strong>%0%</strong> wil verwijderen]]></key>
     <key alias="confirmlogout">Weet je het zeker?</key>
     <key alias="confirmSure">Weet je het zeker?</key>
     <key alias="cut">Knippen</key>
@@ -529,8 +529,8 @@
     <key alias="variantdeletewarning">Dit zal de node en al zijn talen verwijderen. Als je slechts één taal wil
       verwijderen, moet je de node in die taal depubliceren.
     </key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[Dit zal de gebruiker <b>%0%</b> verwijderen.]]></key>
-    <key alias="userremovewarning"><![CDATA[Dit zal de gebruiker <b>%0%</b> verwijderen van de <b>%1%</b> groep]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[Dit zal de gebruiker <strong>%0%</strong> verwijderen.]]></key>
+    <key alias="userremovewarning"><![CDATA[Dit zal de gebruiker <strong>%0%</strong> verwijderen van de <strong>%1%</strong> groep]]></key>
     <key alias="yesRemove">Ja, verwijderen</key>
   </area>
   <area alias="dictionary">
@@ -889,7 +889,7 @@
     <key alias="defaultUserChangePass">
       <![CDATA[<strong>Het wachtwoord van de default gebruiker dient veranderd te worden!</strong>]]></key>
     <key alias="defaultUserDisabled">
-      <![CDATA[<strong>De default gebruiker is geblokkeerd of heeft geen toegang tot Umbraco!</strong></p><p>Geen verdere actie noodzakelijk. Klik <b>Volgende</b> om verder te gaan.]]></key>
+      <![CDATA[<strong>De default gebruiker is geblokkeerd of heeft geen toegang tot Umbraco!</strong></p><p>Geen verdere actie noodzakelijk. Klik <strong>Volgende</strong> om verder te gaan.]]></key>
     <key alias="defaultUserPassChanged">
       <![CDATA[<strong>Het wachtwoord van de default gebruiker is sinds installatie met succes veranderd.</strong></p><p>Geen verdere actie noodzakelijk. Klik <strong>Volgende</strong> om verder te gaan.]]></key>
     <key alias="defaultUserPasswordChanged">Het wachtwoord is veranderd!</key>
@@ -2399,12 +2399,12 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
                   Umbraco wordt uitgevoerd in de foutopsporingsmodus. Dit betekent dat u de ingebouwde prestatieprofiler kunt gebruiken om de prestaties te beoordelen bij het renderen van pagina's.
               </p>
               <p>
-                  Als je de profiler voor een specifieke paginaweergave wilt activeren, voeg je <b>umbDebug=true</b> toe aan de querystring wanneer je de pagina opvraagt.
+                  Als je de profiler voor een specifieke paginaweergave wilt activeren, voeg je <strong>umbDebug=true</strong> toe aan de querystring wanneer je de pagina opvraagt.
               </p>
               <p>
                   Als je wil dat de profiler standaard wordt geactiveerd voor alle paginaweergaven, kun je de onderstaande schakelaar gebruiken.
                   Het plaatst een cookie in je browser, die vervolgens de profiler automatisch activeert.
-                  Met andere woorden, de profiler zal alleen voor <i>jouw</i> browser actief zijn, niet voor andere bezoekers.
+                  Met andere woorden, de profiler zal alleen voor <em>jouw</em> browser actief zijn, niet voor andere bezoekers.
               </p>
       ]]>
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
@@ -358,7 +358,7 @@
     <key alias="databaseUpgradeDone"><![CDATA[Seu banco de dados foi atualizado para última versão %0%. <br />Pressione <strong>Próximo</strong> para prosseguir.]]></key>
     <key alias="databaseUpToDate"><![CDATA[Seu banco de dados atual está desatualizado! Clique <strong>próximo</strong> para continuar com o assistente de configuração]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>A senha do usuário padrão precisa ser alterada!</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>O usuário padrão foi desabilitado ou não tem acesso à Umbraco!</strong></p><p>Nenhuma ação posterior precisa ser tomada. Clique <b>Próximo</b> para prosseguir.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>O usuário padrão foi desabilitado ou não tem acesso à Umbraco!</strong></p><p>Nenhuma ação posterior precisa ser tomada. Clique <strong>Próximo</strong> para prosseguir.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>A senha do usuário padrão foi alterada com sucesso desde a instalação!</strong></p><p>Nenhuma ação posterior é necessária. Clique <strong>Próximo</strong> para prosseguir.]]></key>
     <key alias="defaultUserPasswordChanged">Senha foi alterada!</key>
     <key alias="greatStart">Comece com o pé direito, assista nossos vídeos introdutórios</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -493,7 +493,7 @@
     <key alias="databaseUpgradeDone"><![CDATA[Din databas har nu uppgraderats till den senaste versionen %0%.<br />Tryck <strong>Nästa</strong> för att fortsätta.]]></key>
     <key alias="databaseUpToDate"><![CDATA[Din nuvarande databas behöver inte uppgraderas! Klicka <strong>Nästa</strong> för att fortsätta med konfigurationsguiden]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>Lösenordet på standardanvändaren måste bytas!</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>Standardanvändaren har avaktiverats eller har inte åtkomst till Umbraco!</strong></p><p>Du behöver inte göra något ytterligare här. Klicka <b>Next</b> för att fortsätta.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>Standardanvändaren har avaktiverats eller har inte åtkomst till Umbraco!</strong></p><p>Du behöver inte göra något ytterligare här. Klicka <strong>Next</strong> för att fortsätta.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>Standardanvändarens lösenord har ändrats sedan installationen!</strong></p><p>Du behöver inte göra något ytterligare här. Klicka <strong>Nästa</strong> för att fortsätta.]]></key>
     <key alias="defaultUserPasswordChanged">Lösenordet är ändrat!</key>
     <key alias="greatStart">Få en flygande start, kolla på våra introduktionsvideor</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -393,7 +393,7 @@
     <key alias="confirmdelete">Silmek istediğinizden emin misiniz</key>
     <key alias="confirmdisable">Devre dışı bırakmak istediğinizden emin misiniz</key>
     <key alias="confirmremove">Kaldırmak istediğinizden emin misiniz</key>
-    <key alias="confirmremoveusageof"><![CDATA[<b>%0%</b> kullanımını kaldırmak istediğinizden emin misiniz?]]></key>
+    <key alias="confirmremoveusageof"><![CDATA[<strong>%0%</strong> kullanımını kaldırmak istediğinizden emin misiniz?]]></key>
     <key alias="confirmlogout">Emin misiniz?</key>
     <key alias="confirmSure">Emin misiniz?</key>
     <key alias="cut">Kes</key>
@@ -471,8 +471,8 @@
     <key alias="selectEditor">Düzenleyici seçin</key>
     <key alias="selectSnippet">Snippet seçin</key>
     <key alias="variantdeletewarning">Bu, düğümü ve tüm dillerini silecektir. Yalnızca bir dili silmek istiyorsanız, bunun yerine düğümü o dilde yayından kaldırmalısınız.</key>
-    <key alias="propertyuserpickerremovewarning"><![CDATA[Bu, <b>%0%</b> kullanıcısını kaldıracaktır.]]></key>
-    <key alias="userremovewarning"><![CDATA[Bu, <b>%0% </b> kullanıcısını <b>%1%</b> grubundan kaldıracak]]></key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[Bu, <strong>%0%</strong> kullanıcısını kaldıracaktır.]]></key>
+    <key alias="userremovewarning"><![CDATA[Bu, <strong>%0% </strong> kullanıcısını <strong>%1%</strong> grubundan kaldıracak]]></key>
     <key alias="yesRemove">Evet, kaldır</key>
   </area>
   <area alias="dictionary">
@@ -818,7 +818,7 @@
     </key>
     <key alias="databaseUpToDate"><![CDATA[Mevcut veritabanınız güncel !. Yapılandırma sihirbazına devam etmek için <strong> ileri </strong> 'yi tıklayın]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong> Varsayılan kullanıcıların şifresinin değiştirilmesi gerekiyor! </strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong> Varsayılan kullanıcı devre dışı bırakıldı veya Umbraco'ya erişimi yok! </strong> </p> <p> Başka işlem yapılmasına gerek yok. Devam etmek için <b> İleri </b> 'yi tıklayın.]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong> Varsayılan kullanıcı devre dışı bırakıldı veya Umbraco'ya erişimi yok! </strong> </p> <p> Başka işlem yapılmasına gerek yok. Devam etmek için <strong> İleri </strong> 'yi tıklayın.]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong> Varsayılan kullanıcının şifresi kurulumdan bu yana başarıyla değiştirildi! </strong> </p> <p> Başka işlem yapılmasına gerek yok. Devam etmek için <strong> İleri </strong> 'yi tıklayın.]]></key>
     <key alias="defaultUserPasswordChanged">Şifre değiştirildi!</key>
     <key alias="greatStart">Harika bir başlangıç ​​yapın, tanıtım videolarımızı izleyin</key>
@@ -2289,12 +2289,12 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
                 Umbraco şu anda hata ayıklama modunda çalışıyor. Bu, sayfaları işlerken performansı değerlendirmek için yerleşik performans profilleyicisini kullanabileceğiniz anlamına gelir.
             </p>
             <p>
-                Profil oluşturucuyu belirli bir sayfa oluşturma için etkinleştirmek istiyorsanız, sayfayı talep ederken sorgu dizesine <b> umbDebug=true </b> eklemeniz yeterlidir.
+                Profil oluşturucuyu belirli bir sayfa oluşturma için etkinleştirmek istiyorsanız, sayfayı talep ederken sorgu dizesine <strong> umbDebug=true </strong> eklemeniz yeterlidir.
             </p>
             <p>
                 Profilcinin tüm sayfa görüntülemeleri için varsayılan olarak etkinleştirilmesini istiyorsanız, aşağıdaki geçişi kullanabilirsiniz.
                 Tarayıcınızda, profil oluşturucuyu otomatik olarak etkinleştiren bir çerez ayarlayacaktır.
-                Başka bir deyişle, profil oluşturucu yalnızca <i>tarayıcınızda</i> varsayılan olarak etkin olacaktır - diğer herkesin değil.
+                Başka bir deyişle, profil oluşturucu yalnızca <em>tarayıcınızda</em> varsayılan olarak etkin olacaktır - diğer herkesin değil.
             </p>
     ]]>
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
@@ -501,7 +501,7 @@
     <key alias="databaseUpgradeDone"><![CDATA[数据库已更新到版本 %0%。<br />点击<strong>下一步</strong>继续。]]></key>
     <key alias="databaseUpToDate"><![CDATA[您的数据库已安装！点击<strong>下一步</strong>继续]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>需要修改默认密码！</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>默认账户已禁用或无权访问系统！</strong></p><p>点击<b>下一步</b>继续。]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>默认账户已禁用或无权访问系统！</strong></p><p>点击<strong>下一步</strong>继续。]]></key>
     <key alias="defaultUserPassChanged"><![CDATA[<strong>安装过程中默认用户密码已更改</strong></p><p>点击<strong>下一步</strong>继续。]]></key>
     <key alias="defaultUserPasswordChanged">密码已更改</key>
     <key alias="greatStart">作为入门者，从视频教程开始吧！</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
@@ -493,8 +493,8 @@
     <key alias="databaseUpgradeDone"><![CDATA[您的資料庫已經升級至最新版本%0%。<br />點選<strong>下一步</strong>繼續。]]></key>
     <key alias="databaseUpToDate"><![CDATA[目前資料庫是最新的！點選<strong>下一步</strong>繼續設定精靈。]]></key>
     <key alias="defaultUserChangePass"><![CDATA[<strong>預設使用者的密碼必須更改！</strong>]]></key>
-    <key alias="defaultUserDisabled"><![CDATA[<strong>預設使用者已經被暫停或沒有Umbraco的使用權！</strong></p><p>不需更多的操作步驟。點選<b>下一步</b>繼續。]]></key>
-    <key alias="defaultUserPassChanged"><![CDATA[<strong>安裝後預設使用者的密碼已經成功修改！</strong></p><p>不需更多的操作步驟。點選<b>下一步</b>繼續。]]></key>
+    <key alias="defaultUserDisabled"><![CDATA[<strong>預設使用者已經被暫停或沒有Umbraco的使用權！</strong></p><p>不需更多的操作步驟。點選<strong>下一步</strong>繼續。]]></key>
+    <key alias="defaultUserPassChanged"><![CDATA[<strong>安裝後預設使用者的密碼已經成功修改！</strong></p><p>不需更多的操作步驟。點選<strong>下一步</strong>繼續。]]></key>
     <key alias="defaultUserPasswordChanged">密碼已更改</key>
     <key alias="greatStart">作為入門者，從視頻教程開始吧！</key>
     <key alias="None">安裝失敗。</key>


### PR DESCRIPTION
Fix #12770 

1. Replace "umbraco" with "Umbraco" in all Translation Files
2. Replace `<i>` and `<b>` tag with `<em>` and `<strong>` in all Translation Files

<!-- Thanks for contributing to Umbraco CMS! -->
