### PR TITLE
Temp 12709 dashboard loading fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -76,14 +76,13 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
 
         /** execute code on each successful route */
         $rootScope.$on('$routeChangeSuccess', function (event, current, previous) {
-            var toRetain = currentRouteParams ? navigationService.retainQueryStrings(currentRouteParams, current.params) : null;
+            var toRetain = currentRouteParams ? navigationService.retainQueryStrings(currentRouteParams.params, current.params) : null;
+            currentRouteParams = Utilities.copy(current);
 
             //if toRetain is not null it means that there are missing query strings and we need to update the current params
             if (toRetain) {
                 $route.updateParams(toRetain);
-                currentRouteParams = toRetain;
-            } else {
-                currentRouteParams = Utilities.copy(current.params);
+                currentRouteParams ? currentRouteParams.params = toRetain : currentRouteParams = { params: toRetain };
             }
 
             var deployConfig = Umbraco.Sys.ServerVariables.deploy;
@@ -134,31 +133,31 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
         //global state query strings without force re-loading views.
         //We can then detect if it's a location change that should force a route or not programatically.
         $rootScope.$on('$routeUpdate', function (event, next) {
-            if (!currentRouteParams) {
+            if (!currentRouteParams?.params) {
                 //if there is no current route then always route which is done with reload
                 $route.reload();
             } else {
-                var toRetain = navigationService.retainQueryStrings(currentRouteParams, next.params);
+                var toRetain = navigationService.retainQueryStrings(currentRouteParams.params, next.params);
                 //if toRetain is not null it means that there are missing query strings and we need to update the current params.
                 if (toRetain) {
                     $route.updateParams(toRetain);
                 }
                 //check if the location being changed is only due to global/state query strings which means the location change
                 //isn't actually going to cause a route change.
-                if (navigationService.isRouteChangingNavigation(currentRouteParams, next.params)) {
+                if (navigationService.isRouteChangingNavigation(currentRouteParams.pathParams, next.pathParams)) {
                     //The location change will cause a route change, continue the route if the query strings haven't been updated.
                     $route.reload();
                 } else {
                     //navigation is not changing but we should update the currentRouteParams to include all current parameters
                     if (toRetain) {
-                        currentRouteParams = toRetain;
+                        currentRouteParams.params = toRetain;
                     } else {
-                        currentRouteParams = Utilities.copy(next.params);
+                        currentRouteParams.params = Utilities.copy(next.params);
                     }
                     //always clear the 'sr' query string (soft redirect) if it exists
-                    if (currentRouteParams.sr) {
-                        currentRouteParams.sr = null;
-                        $route.updateParams(currentRouteParams);
+                    if (currentRouteParams.params.sr) {
+                        currentRouteParams.params.sr = null;
+                        $route.updateParams(currentRouteParams.params);
                     }
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -172,4 +172,3 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
         appState.setGlobalState("touchDevice", touchDevice);
 
     }]);
-    

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -172,3 +172,4 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
         appState.setGlobalState("touchDevice", touchDevice);
 
     }]);
+    

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -133,7 +133,7 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
         //global state query strings without force re-loading views.
         //We can then detect if it's a location change that should force a route or not programatically.
         $rootScope.$on('$routeUpdate', function (event, next) {
-            if (!currentRouteParams?.params) {
+            if (!currentRouteParams || !currentRouteParams.params) {
                 //if there is no current route then always route which is done with reload
                 $route.reload();
             } else {

--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -133,18 +133,20 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
         //global state query strings without force re-loading views.
         //We can then detect if it's a location change that should force a route or not programatically.
         $rootScope.$on('$routeUpdate', function (event, next) {
+            let pathParamsKeys = Object.keys(next.pathParams);
+            let nextParams = Object.fromEntries(Object.entries(next.params).filter(([key, value]) => pathParamsKeys.includes(key)));
             if (!currentRouteParams || !currentRouteParams.params) {
                 //if there is no current route then always route which is done with reload
                 $route.reload();
             } else {
-                var toRetain = navigationService.retainQueryStrings(currentRouteParams.params, next.params);
+                var toRetain = navigationService.retainQueryStrings(currentRouteParams.params, nextParams);
                 //if toRetain is not null it means that there are missing query strings and we need to update the current params.
                 if (toRetain) {
                     $route.updateParams(toRetain);
                 }
                 //check if the location being changed is only due to global/state query strings which means the location change
                 //isn't actually going to cause a route change.
-                if (navigationService.isRouteChangingNavigation(currentRouteParams.pathParams, next.pathParams)) {
+                if (navigationService.isRouteChangingNavigation(currentRouteParams.pathParams, nextParams)) {
                     //The location change will cause a route change, continue the route if the query strings haven't been updated.
                     $route.reload();
                 } else {
@@ -152,7 +154,7 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
                     if (toRetain) {
                         currentRouteParams.params = toRetain;
                     } else {
-                        currentRouteParams.params = Utilities.copy(next.params);
+                        currentRouteParams.params = Utilities.copy(nextParams);
                     }
                     //always clear the 'sr' query string (soft redirect) if it exists
                     if (currentRouteParams.params.sr) {
@@ -170,3 +172,4 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
         appState.setGlobalState("touchDevice", touchDevice);
 
     }]);
+    


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes: #12709

### Description

After investigation, found out that `isRouteChangingNavigation` method in `navigation.service.js` also compares query strings (though shouldn't based on comment on 195 line).

![image](https://user-images.githubusercontent.com/44713059/180661553-7e666ea8-a3d0-426d-b6f8-2bcfccd1a06e.png)

It happens because `current.params` during `$routeChangeSuccess` event (in init.js) returns also query strings parameters, while it should be `current.pathParams` which returns only routing parameters.

![image](https://user-images.githubusercontent.com/44713059/180661694-b8e2760e-e339-4a21-aae1-2dc36f8e49ee.png)

I changed initialization of `currentRouteParams` variable so it now stores entire `current` parameter and passes to `isRouteChangingNavigation` method only `pathParams` routing parameters.

**Before**

![image](https://user-images.githubusercontent.com/44713059/180661355-8293f45b-c6fb-49c3-8d45-6cbedfc0ebe1.png)

**After**

![image](https://user-images.githubusercontent.com/44713059/180661362-063d900f-a712-4399-b3fe-80a127e81ec8.png)

Also switching  between tabs is smooth again.

**Testing**
Steps for reproducing are available in the issue.