### PR TITLE
Fix FOREIGN KEY constraint error on cmsMember2MemberGroup

### DIFF
--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -785,7 +785,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             member.SecurityStamp = identityUser.SecurityStamp;
         }
 
-        if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)))
+        if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)) && member.HasIdentity)
         {
             anythingChanged = true;
 


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/12853

It's possible that `_memberService.ReplaceRoles` can be executed while the member is not persisted yet. So the member id could be 0 which can cause the FOREIGN KEY constraint error.

Old code:
```
if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)))
{
    anythingChanged = true;

    var identityUserRoles = identityUser.Roles.Select(x => x.RoleId).ToArray();
    _memberService.ReplaceRoles(new[] { member.Id }, identityUserRoles);
}
```

New code:
```
if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)) && member.HasIdentity)
{
    anythingChanged = true;

    var identityUserRoles = identityUser.Roles.Select(x => x.RoleId).ToArray();
    _memberService.ReplaceRoles(new[] { member.Id }, identityUserRoles);
}
```
