### PR TITLE
feat: adding item templates from old template package

### DIFF
--- a/templates/ItemTemplates/ContentApp/.template.config/template.json
+++ b/templates/ItemTemplates/ContentApp/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "UmbracoPackageTeam",
+    "classifications": [
+        "Web",
+        "Umbraco",
+        "ContentApp"
+    ],
+    "tags": {
+        "language": "JavaScript",
+        "type": "item"
+    },
+
+    "identity": "Umbraco.Templates.Items.ContentApp",
+    "groupIdentity": "Umbraco.Templates.Items.ContentApp",
+
+    "name": "Umbraco Content App",
+    "shortName": "umbraco-contentapp",
+    "description": "Files to add a content app to an Umbraco v10 project",
+    
+    "sourceName": "UmbracoPackage.1"
+}

--- a/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
+++ b/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="UmbracoPackage.1">
+		<key alias="contentAppHeader">UmbracoPackage.1 super content app</key>
+		<key alias="contentAppDesc">My super awesome content app</key>
+	</area>
+</language>

--- a/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
+++ b/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
@@ -1,0 +1,32 @@
+/**
+ * @ngdoc
+ * 
+ * @name: contentAppController
+ * @description: code for a content app in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function contentAppController() {
+
+        var vm = this;
+        vm.loading = true;
+        vm.message = "";
+
+        function init() {
+            getInfo();
+        }
+
+        function getInfo() {
+            vm.message = "Content App init() has run";
+            vm.loading = false;
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1ContentAppController', contentAppController);
+})();

--- a/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
+++ b/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
@@ -1,0 +1,17 @@
+<div ng-controller="umbracopackage__1ContentAppController as vm">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-if="!vm.loading">
+        <umb-box>
+            <umb-box-header title-key="UmbracoPackage.1_contentAppHeader"
+                            description-key="UmbracoPackage.1_contentAppDesc">
+            </umb-box-header>
+            <umb-box-content>
+                <h4>{{vm.message}}</h4>
+            </umb-box-content>
+
+        </umb-box>
+    </div>
+
+</div>

--- a/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
+++ b/templates/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
@@ -1,0 +1,17 @@
+{
+    "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js"
+  ],
+  "contentApps": [
+    {
+        "name": "My App", // required - the name that appears under the icon
+        "alias": "umbracopackage._1-contentapp", // required - unique alias for your app
+        "weight": 0, // optional, default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps
+        "icon": "icon-cupcake", // required - the icon to use
+        "view": "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html", // required - the location of the view file
+		"show": [
+			"+content/*" // show app for all content types
+		]
+    }
+  ]
+}

--- a/templates/ItemTemplates/Dashboard/.template.config/template.json
+++ b/templates/ItemTemplates/Dashboard/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "UmbracoPackageTeam",
+    "classifications": [
+        "Web",
+        "Umbraco",
+        "Dashboard"
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+
+    "identity": "Umbraco.Templates.Items.Dashboard",
+    "groupIdentity": "Umbraco.Templates.Items.Dashboard",
+
+    "name": "Umbraco Dashboard Item",
+    "shortName": "umbraco-dashboard",
+    "description": "Umbraco dashboard files",
+    
+    "sourceName": "UmbracoPackage.1"
+}

--- a/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/Lang/en.xml
+++ b/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/Lang/en.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="UmbracoPackage.1">
+		<key alias="dashboardHeader">UmbracoPackage.1 super dashboard</key>
+		<key alias="dashboardDesc">My super awesome dashboard</key>
+	</area>
+	<area alias="dashboardTabs"> 
+		<key alias="umbracopackage._1-dashboard">UmbracoPackage.1</key>
+	</area>
+
+</language>

--- a/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.controller.js
+++ b/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.controller.js
@@ -1,0 +1,41 @@
+/**
+ * @ngdoc
+ * 
+ * @name: dashboardController
+ * @description: code for a dashboard in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function dashboardController($scope,
+        notificationsService,
+        umbracopackage__1DashboardService) {
+
+        var vm = this;
+        vm.loading = true;
+        vm.info = {};
+
+        function init() {
+            getServerInfo();
+        }
+
+        // ask the server what version it is and what time it things it is.
+        function getServerInfo() {
+            umbracopackage__1DashboardService.getServerInfo()
+                .then(function (result) {
+                    vm.info = result.data;
+                    vm.loading = false; 
+                }, function (error) {
+                    console.warn(error);
+                    notificationsService.error('Error', 'Unable to get the server info');
+                });
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1DashboardController', dashboardController);
+})();

--- a/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.html
+++ b/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.html
@@ -1,0 +1,17 @@
+<div ng-controller="umbracoproject1DashboardController as vm">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-if="!vm.loading">
+        <umb-box>
+            <umb-box-header title-key="UmbracoProject1_dashboardHeader"
+                            description-key="UmbracoProject1_dashboardDesc">
+            </umb-box-header>
+            <umb-box-content>
+                <h4>Server Time : {{vm.info | date:'medium'}}</h4>
+            </umb-box-content>
+
+        </umb-box>
+    </div>
+
+</div>

--- a/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.service.js
+++ b/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/dashboard.service.js
@@ -1,0 +1,28 @@
+/**
+ * @ngdoc
+ * 
+ * @name: dashboardService
+ * @description: provides an interface between the javascript dashboard and our 
+ *               backoffice api.
+ */
+(function () {
+    'use strict';
+
+    function dashboardService($http) {
+
+        var serviceRoot = Umbraco.Sys.ServerVariables.umbracopackage__1.dashboardController;
+
+        return {
+            getServerInfo: getServerInfo
+        }
+
+        /////
+
+        function getServerInfo() {
+            return $http.get(serviceRoot + "GetServerInfo");
+        }
+    };
+
+    angular.module('umbraco')
+        .factory('umbracopackage__1DashboardService', dashboardService);
+})();

--- a/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/package.manifest
+++ b/templates/ItemTemplates/Dashboard/App_Plugins/UmbracoPackage.1/dashboard/package.manifest
@@ -1,0 +1,15 @@
+{
+  "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/dashboard/dashboard.service.js",
+    "~/App_Plugins/UmbracoPackage.1/dashboard/dashboard.controller.js"
+  ],
+  "dashboards": [
+    {
+      "alias": "umbracopackage._1-dashboard",
+      "sections": [
+        "content"
+      ],
+      "view": "~/App_Plugins/UmbracoPackage.1/dashboard/dashboard.html"
+    }
+  ]
+}

--- a/templates/ItemTemplates/Dashboard/Controllers/DashboardApiController.cs
+++ b/templates/ItemTemplates/Dashboard/Controllers/DashboardApiController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Web.BackOffice.Controllers;
+
+namespace UmbracoPackage._1.Controllers;
+
+public class DashboardApiController : UmbracoAuthorizedApiController
+{
+    /// <summary>
+    ///  GetApi - Called in our ServerVariablesParser.Parsing event handler
+    ///  this gets the URL of this API, so we don't have to hardwire it anywhere
+    /// </summary>
+    [HttpGet]
+    public bool GetApi() => true; 
+
+    /// <summary>
+    ///  Simple call return the time,
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet]
+    public DateTime GetServerInfo() => DateTime.UtcNow;
+}

--- a/templates/ItemTemplates/Dashboard/Controllers/DashboardComposer.cs
+++ b/templates/ItemTemplates/Dashboard/Controllers/DashboardComposer.cs
@@ -1,0 +1,34 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+namespace UmbracoPackage._1.Controllers;
+
+public class DashboardComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder
+            .AddNotificationHandler<ServerVariablesParsingNotification,
+                DashboardServerVariablesParserNotificationHandler>();
+    }
+}
+
+public class DashboardServerVariablesParserNotificationHandler : INotificationHandler<ServerVariablesParsingNotification>
+{
+    private readonly LinkGenerator _linkGenerator;
+
+    public DashboardServerVariablesParserNotificationHandler(LinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+    public void Handle(ServerVariablesParsingNotification notification)
+    {
+        notification.ServerVariables.Add("umbracopackage__1", new Dictionary<string, object>
+        {
+            { "dashboardController", _linkGenerator.GetUmbracoApiServiceBaseUrl<DashboardApiController>(controller => controller.GetApi()) }
+        });
+    }
+}

--- a/templates/ItemTemplates/PropertyEditor/.template.config/template.json
+++ b/templates/ItemTemplates/PropertyEditor/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "UmbracoPackageTeam",
+  "classifications": [
+    "Web",
+    "Umbraco",
+    "PropertyEditor"
+  ],
+  "tags": {
+    "language": "JavaScript",
+    "type": "item"
+  },
+
+  "identity": "Umbraco.Templates.Items.PropertyEditor",
+  "groupIdentity": "Umbraco.Templates.Items.PropertyEditor",
+
+  "name": "Umbraco Property Editor Item",
+  "shortName": "umbraco-property-editor",
+  "description": "Umbraco property editor files",
+
+  "sourceName": "UmbracoPackage.1"
+}

--- a/templates/ItemTemplates/PropertyEditor/App_Plugins/UmbracoPackage.1/PropertyEditor/editor.controller.js
+++ b/templates/ItemTemplates/PropertyEditor/App_Plugins/UmbracoPackage.1/PropertyEditor/editor.controller.js
@@ -1,0 +1,24 @@
+﻿/**
+ * @ngdoc
+ * 
+ * @name: editorController
+ * @description: code for a property editor in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function editorController() {
+
+        var vm = this;
+
+        function init() {
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1EditorController', editorController);
+})();

--- a/templates/ItemTemplates/PropertyEditor/App_Plugins/UmbracoPackage.1/PropertyEditor/editor.html
+++ b/templates/ItemTemplates/PropertyEditor/App_Plugins/UmbracoPackage.1/PropertyEditor/editor.html
@@ -1,0 +1,3 @@
+﻿<div ng-controller="umbracopackage__1EditorController">
+    <p>Add your markup here</p>
+</div>

--- a/templates/ItemTemplates/PropertyEditor/App_Plugins/UmbracoPackage.1/PropertyEditor/package.manifest
+++ b/templates/ItemTemplates/PropertyEditor/App_Plugins/UmbracoPackage.1/PropertyEditor/package.manifest
@@ -1,0 +1,21 @@
+﻿{
+  "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/PropertyEditor/editor.controller.js"
+  ],
+  "propertyEditors": [
+    {
+      /*this must be a unique alias*/
+      "alias": "umbracopackage._1-editor",
+      /*the name*/
+      "name": "My editor",
+      /*the icon*/
+      "icon": "icon-code",
+      /*grouping for "Select editor" dialog*/
+      "group": "Rich Content",
+      /*the HTML file we will load for the editor*/
+      "editor": {
+        "view": "~/App_Plugins/UmbracoPackage.1/PropertyEditor/editor.html"
+      }
+    }
+  ]
+}

--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<Compile Remove="ItemTemplates\**" />
     <Content Include="icon.png" Visible="false" />
 	<Content Include="ItemTemplates\**" Exclude="bin;obj" />
     <Content Include="UmbracoPackage\**" Exclude="bin;obj" />

--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Content Include="icon.png" Visible="false" />
+	<Content Include="ItemTemplates\**" Exclude="bin;obj" />
     <Content Include="UmbracoPackage\**" Exclude="bin;obj" />
     <Content Include="UmbracoProject\**" Exclude="bin;obj" />
     <Content Include="..\src\Umbraco.Web.UI\Program.cs">


### PR DESCRIPTION
Integrating item templates from the v8 template package

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

For v8 we had item templates provided by the Packages.Templates templates pack.
These templates were provided by the Package Team. As with v9 Umbraco HQ provides general Dotnet templates for project/package, the team decided that we should move the item templates to the offical umbraco repo and be part of the official templates pack.

How to test:
- Pack the templates locally
- Install the templates from the local nuget package
- Use the item templates to install them into an exisitng umbraco project
