### PR TITLE
V10: Fix foreign key constraints when using external login provider for members

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -490,8 +490,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         GetBaseQuery(isCount ? QueryType.Count : QueryType.Single);
 
     protected override string GetBaseWhereClause() // TODO: can we kill / refactor this?
-        =>
-            "umbracoNode.id = @id";
+        => "umbracoNode.id = @id";
 
     // TODO: document/understand that one
     protected Sql<ISqlContext> GetNodeIdQueryWithPropertyData() =>
@@ -526,6 +525,8 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             "DELETE FROM " + Constants.DatabaseSchema.Tables.PropertyData +
             " WHERE versionId IN (SELECT id FROM " + Constants.DatabaseSchema.Tables.ContentVersion +
             " WHERE nodeId = @id)",
+            $"DELETE FROM {Constants.DatabaseSchema.Tables.ExternalLoginToken} WHERE externalLoginId = (SELECT id FROM {Constants.DatabaseSchema.Tables.ExternalLogin} WHERE userOrMemberKey = (SELECT uniqueId from {Constants.DatabaseSchema.Tables.Node} where id = @id))",
+            $"DELETE FROM {Constants.DatabaseSchema.Tables.ExternalLogin} WHERE userOrMemberKey = (SELECT uniqueId from {Constants.DatabaseSchema.Tables.Node} where id = @id)",
             "DELETE FROM cmsMember2MemberGroup WHERE Member = @id",
             "DELETE FROM cmsMember WHERE nodeId = @id",
             "DELETE FROM " + Constants.DatabaseSchema.Tables.ContentVersion + " WHERE nodeId = @id",

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -107,7 +107,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
                     ? Constants.Security.DefaultMemberTypeAlias
                     : user.MemberTypeAlias!);
 
-            UpdateMemberProperties(memberEntity, user);
+            UpdateMemberProperties(memberEntity, user, out bool _);
 
             // create the member
             _memberService.Save(memberEntity);
@@ -188,9 +188,15 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
                 var isLoginsPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.Logins));
                 var isTokensPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.LoginTokens));
 
-                if (UpdateMemberProperties(found, user))
+                if (UpdateMemberProperties(found, user, out var updateRoles))
                 {
                     _memberService.Save(found);
+
+                    if (updateRoles)
+                    {
+                        var identityUserRoles = user.Roles.Select(x => x.RoleId).ToArray();
+                        _memberService.ReplaceRoles(new[] { found.Id }, identityUserRoles);
+                    }
                 }
 
                 if (isLoginsPropertyDirty)
@@ -673,9 +679,10 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
         return user;
     }
 
-    private bool UpdateMemberProperties(IMember member, MemberIdentityUser identityUser)
+    private bool UpdateMemberProperties(IMember member, MemberIdentityUser identityUser, out bool updateRoles)
     {
         var anythingChanged = false;
+        updateRoles = false;
 
         // don't assign anything if nothing has changed as this will trigger the track changes of the model
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.LastLoginDateUtc))
@@ -787,10 +794,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)))
         {
-            anythingChanged = true;
-
-            var identityUserRoles = identityUser.Roles.Select(x => x.RoleId).ToArray();
-            _memberService.ReplaceRoles(new[] { member.Id }, identityUserRoles);
+            updateRoles = true;
         }
 
         // reset all changes


### PR DESCRIPTION
This PR fixes #12864 and #12853


#12853 Was correctly diagnosed and fixed in #12868 by @jbreuer, however, looking at it, the code was a bit weird, since MemberUserStore` would call a service in the `UpdateMemberProperties` method. This method was otherwise just used to "map" from `MemberIdentityUser` to `IMember`, so instead of the check proposed in #12868 I've moved the service call out of `MemberUserStore` instead putting the responsibility on the caller of `UpdateMemberProperties`

#12864 was caused by some missing delete causing not correctly cleaning up the external login table and token table. 

