### PR TITLE
Fix: Infinite Editor creates each save action a new version when cont…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/contenteditinghelper.service.js
@@ -142,6 +142,9 @@ function contentEditingHelper(fileManager, $q, $location, $routeParams, editorSt
                         //update editor state to what is current
                         editorState.set(args.content);
 
+                        //needs to be manually set for infinite editing mode
+                        args.scope.isNew = args.content.id === 0 && args.scope.isNew;
+
                         return $q.reject(err);
                     });
             }


### PR DESCRIPTION
…ent is invalid (#12713)

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#12713](https://github.com/umbraco/Umbraco-CMS/issues/12713)

### Description

When a node is created with the infinite editor and a required field is not filled in, every save action creates a new node.

Cause:
Because the save action contains invalid content the status code 400 is returned, but it has created a content node.
This is ok, but as result of the status code 400 the code below in the edit.controller.js file is not excecuted. 

```
// must be set manually for infinite edit mode
$scope.page.isNew = false;
```

Solution:
If an error occurs and there is a content node created then the content id is set. At that point, the scope.isNew must also be adjusted to false