### PR TITLE
Bugfix: Variant permission languages needs a clear cache to work fully for current user

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/user.service.js
@@ -8,6 +8,14 @@ angular.module('umbraco.services')
         // this is used so that we know when to go and get the user's remaining seconds directly.
         var lastServerTimeoutSet = null;
 
+        eventsService.on("editors.languages.languageSaved", () => {
+            service.refreshCurrentUser();
+        });
+
+        eventsService.on("editors.userGroups.userGroupSaved", () => {
+            service.refreshCurrentUser();
+        });
+
         function openLoginDialog(isTimedOut) {
             //broadcast a global event that the user is no longer logged in
             const args = { isTimedOut: isTimedOut };
@@ -158,7 +166,7 @@ angular.module('umbraco.services')
             }
         });
 
-        return {
+        const service = {
 
             /** Internal method to display the login dialog */
             _showLoginDialog: function () {
@@ -291,5 +299,7 @@ angular.module('umbraco.services')
                 return emailMarketingResource.postAddUserToEmailMarketing(user);
             }
         };
+
+        return service;
 
     });

--- a/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/group.controller.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
 
-  function UserGroupEditController($scope, $location, $routeParams, userGroupsResource, localizationService, contentEditingHelper, editorService, overlayService) {
+  function UserGroupEditController($scope, $location, $routeParams, userGroupsResource, localizationService, contentEditingHelper, editorService, overlayService, eventsService) {
 
     var infiniteMode = $scope.model && $scope.model.infiniteMode;
     var id = infiniteMode ? $scope.model.id : $routeParams.id;
@@ -107,6 +107,11 @@
           setSectionIcon(vm.userGroup.sections);
           makeBreadcrumbs();
           vm.page.saveButtonState = "success";
+
+          eventsService.emit("editors.userGroups.userGroupSaved", {
+            userGroup: vm.userGroup,
+            isNew: create
+          });
         }
       }, function (err) {
         vm.page.saveButtonState = "error";


### PR DESCRIPTION
When adding languages that can be edited by a user group changes in Translation do not take effect for the current user before the site is reloaded (F5) and GetCurrentUser is called.  

This PR ensures that the cache is updated when changes are made to both languages and user groups.

How to test:
* Create new languages and makes sure the permissions in the translation section reflect the changes.
* Update user group permissions and ensure the translation section reflects the changes
* Update user groups on a user and ensure the translation section reflects the changes