### PR TITLE
Fix up contextmenu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree-root.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree-root.less
@@ -10,7 +10,7 @@
     height: @editorHeaderHeight;
   }
 
-  h1 {
+  h1, h2 {
     font-size: 18.75px;
     font-weight: 600;
     margin: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
@@ -2,7 +2,7 @@
     aria-labelledby="contextmenu-title" aria-describedby="contextmenu-description" on-outside-click="outSideClick()">
     <div>
         <div class="umb-modalcolumn-header">
-            <h1 id="contextmenu-title">{{menuDialogTitle}}</h1>
+            <h2 id="contextmenu-title">{{menuDialogTitle}}</h2>
             <p id="contextmenu-description" class="sr-only">
                 <localize key="visuallyHiddenTexts_contextMenuDescription">Select one of the options to edit the node.</localize>
             </p>


### PR DESCRIPTION
# Notes
- Fixed an issue where the context menu title didn't have proper css

# How to test
- Go to the settings section
- Right click document types
- Document types title should now have proper css