### PR TITLE
Fix the authzitation problem, when startnodes is not choosen.

### DIFF
--- a/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
+++ b/src/Umbraco.Core/Security/UmbracoBackOfficeIdentity.cs
@@ -120,8 +120,14 @@ namespace Umbraco.Core.Security
             ClaimTypes.NameIdentifier, //id
             ClaimTypes.Name,  //username
             ClaimTypes.GivenName,
-            Constants.Security.StartContentNodeIdClaimType,
-            Constants.Security.StartMediaNodeIdClaimType,
+
+            // Comment out the Startnodes due to this bug https://github.com/umbraco/Umbraco-CMS/issues/12809
+            // But also in Umbraco 9 and 10 theis properties outcomment.
+            // The properties can be null or not exiting in the claims and therefor
+            // the authization will not be successed.
+            //Constants.Security.StartContentNodeIdClaimType,
+            //Constants.Security.StartMediaNodeIdClaimType,
+
             ClaimTypes.Locality,
             Constants.Security.SessionIdClaimType,
             Microsoft.AspNet.Identity.Constants.DefaultSecurityStampClaimType


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #12809 

### Description
The excpedted result:
1) Create a user group with content root and media root properties is correct set.
2) Invite a new user and assign the group from step 1
3) Receive the invitation and click on the link
4) Now you´re able to finish up the creation of your user.

With bug:
1) Create a user group without content root and media root properties is correct set.
2) Invite a new user and assign the group from step 1
3) Receive the invitation and click on the link
4) No option to finish up, before gets redirect to login page

Here I would have excpeted that I was able to finish up the creation of my user.

I teste the same bug in Umbraco 10 with followed teste above and everything worked as expeteded. 

The reason it happens is that the user is not correct login, and therefor the invitationVerify flow get an 401 from the API calls, make the flow invalid. In Umbraco 10 it is already been taking care of: https://github.com/umbraco/Umbraco-CMS/blob/v10/contrib/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs#L27

So we don´t execpet the startnodes properties to be set in the Claims of the ClaimsIdentity, becouse they can be null and missing, therefor invalid authentication can happen.