### PR TITLE
Fixed issue with saving member groups, that was not persisted,

### DIFF
--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -794,6 +794,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)))
         {
+            anythingChanged = true;
             updateRoles = true;
         }
 


### PR DESCRIPTION
Fixed issue with saving member groups, that was not persisted, if only the member groups  was changed.

# Test
Save a member when only adding/removing groups