### PR TITLE
Performance improvement: Reusable data editors

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -21,7 +21,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Content Picker",
     "contentpicker",
     ValueType = ValueTypes.String,
-    Group = Constants.PropertyEditors.Groups.Pickers)]
+    Group = Constants.PropertyEditors.Groups.Pickers,
+    IsReusable = true)]
 public class ContentPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "contentpicker",
     ValueType = ValueTypes.String,
     Group = Constants.PropertyEditors.Groups.Pickers,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class ContentPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class DataEditor : IDataEditor
 {
     private IDictionary<string, object>? _defaultConfiguration;
+    private IDataValueEditor? _reusableEditor;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="DataEditor" /> class.
@@ -48,6 +49,7 @@ public class DataEditor : IDataEditor
         Icon = Attribute.Icon;
         Group = Attribute.Group;
         IsDeprecated = Attribute.IsDeprecated;
+        IsReusable = Attribute.IsReusable;
     }
 
     /// <summary>
@@ -99,6 +101,9 @@ public class DataEditor : IDataEditor
     [IgnoreDataMember]
     public bool IsDeprecated { get; }
 
+    [IgnoreDataMember]
+    private bool IsReusable { get; }
+
     /// <inheritdoc />
     [DataMember(Name = "defaultConfig")]
     public IDictionary<string, object> DefaultConfiguration
@@ -129,7 +134,10 @@ public class DataEditor : IDataEditor
     ///     </para>
     /// </remarks>
     // TODO: point of that one? shouldn't we always configure?
-    public IDataValueEditor GetValueEditor() => ExplicitValueEditor ?? CreateValueEditor();
+    public IDataValueEditor GetValueEditor() => ExplicitValueEditor
+                                                ?? (IsReusable
+                                                    ? _reusableEditor ??= CreateValueEditor()
+                                                    : CreateValueEditor());
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
@@ -178,4 +178,10 @@ public sealed class DataEditorAttribute : Attribute
     /// </summary>
     /// <remarks>A deprecated editor is still supported but not proposed in the UI.</remarks>
     public bool IsDeprecated { get; set; }
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the value editor can be reused (cached).
+    /// </summary>
+    /// <remarks>While most value editors can be reused, complex editors (e.g. block based editors) might not be applicable for reuse.</remarks>
+    public bool IsReusable { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditorAttribute.cs
@@ -183,5 +183,5 @@ public sealed class DataEditorAttribute : Attribute
     ///     Gets or sets a value indicating whether the value editor can be reused (cached).
     /// </summary>
     /// <remarks>While most value editors can be reused, complex editors (e.g. block based editors) might not be applicable for reuse.</remarks>
-    public bool IsReusable { get; set; }
+    public bool ValueEditorIsReusable { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Decimal",
     "decimal",
     ValueType = ValueTypes.Decimal,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class DecimalPropertyEditor : DataEditor
 {
     /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -11,7 +11,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     EditorType.PropertyValue | EditorType.MacroParameter,
     "Decimal",
     "decimal",
-    ValueType = ValueTypes.Decimal)]
+    ValueType = ValueTypes.Decimal,
+    IsReusable = true)]
 public class DecimalPropertyEditor : DataEditor
 {
     /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "eyedropper",
     Icon = "icon-colorpicker",
     Group = Constants.PropertyEditors.Groups.Pickers,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class EyeDropperColorPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/EyeDropperColorPickerPropertyEditor.cs
@@ -11,7 +11,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Eye Dropper Color Picker",
     "eyedropper",
     Icon = "icon-colorpicker",
-    Group = Constants.PropertyEditors.Groups.Pickers)]
+    Group = Constants.PropertyEditors.Groups.Pickers,
+    IsReusable = true)]
 public class EyeDropperColorPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Numeric",
     "integer",
     ValueType = ValueTypes.Integer,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class IntegerPropertyEditor : DataEditor
 {
     public IntegerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
@@ -11,7 +11,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     EditorType.PropertyValue | EditorType.MacroParameter,
     "Numeric",
     "integer",
-    ValueType = ValueTypes.Integer)]
+    ValueType = ValueTypes.Integer,
+    IsReusable = true)]
 public class IntegerPropertyEditor : DataEditor
 {
     public IntegerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
@@ -18,7 +18,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Constants.PropertyEditors.Aliases.Label,
     "Label",
     "readonlyvalue",
-    Icon = "icon-readonly")]
+    Icon = "icon-readonly",
+    IsReusable = true)]
 public class LabelPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Label",
     "readonlyvalue",
     Icon = "icon-readonly",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class LabelPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/MarkdownPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MarkdownPropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "markdowneditor",
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.RichContent,
-    Icon = "icon-code")]
+    Icon = "icon-code",
+    IsReusable = true)]
 public class MarkdownPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/MarkdownPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MarkdownPropertyEditor.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.RichContent,
     Icon = "icon-code",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MarkdownPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Core/PropertyEditors/MemberGroupPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MemberGroupPickerPropertyEditor.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.People,
     Icon = Constants.Icons.MemberGroup,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MemberGroupPickerPropertyEditor : DataEditor
 {
     public MemberGroupPickerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/MemberGroupPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MemberGroupPickerPropertyEditor.cs
@@ -6,7 +6,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "membergrouppicker",
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.People,
-    Icon = Constants.Icons.MemberGroup)]
+    Icon = Constants.Icons.MemberGroup,
+    IsReusable = true)]
 public class MemberGroupPickerPropertyEditor : DataEditor
 {
     public MemberGroupPickerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/MemberPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MemberPickerPropertyEditor.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.String,
     Group = Constants.PropertyEditors.Groups.People,
     Icon = Constants.Icons.Member,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MemberPickerPropertyEditor : DataEditor
 {
     public MemberPickerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/MemberPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MemberPickerPropertyEditor.cs
@@ -6,7 +6,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "memberpicker",
     ValueType = ValueTypes.String,
     Group = Constants.PropertyEditors.Groups.People,
-    Icon = Constants.Icons.Member)]
+    Icon = Constants.Icons.Member,
+    IsReusable = true)]
 public class MemberPickerPropertyEditor : DataEditor
 {
     public MemberPickerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Integer,
     Group = Constants.PropertyEditors.Groups.People,
     Icon = Constants.Icons.User,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class UserPickerPropertyEditor : DataEditor
 {
     public UserPickerPropertyEditor(

--- a/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
@@ -6,7 +6,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "userpicker",
     ValueType = ValueTypes.Integer,
     Group = Constants.PropertyEditors.Groups.People,
-    Icon = Constants.Icons.User)]
+    Icon = Constants.Icons.User,
+    IsReusable = true)]
 public class UserPickerPropertyEditor : DataEditor
 {
     public UserPickerPropertyEditor(

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -57,7 +57,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddTransient<IExamineIndexCountService, ExamineIndexCountService>();
         builder.Services.AddUnique<IUserDataService, SystemInformationTelemetryProvider>();
         builder.Services.AddTransient<IUsageInformationService, UsageInformationService>();
-        builder.Services.AddTransient<IEditorConfigurationParser, EditorConfigurationParser>();
+        builder.Services.AddSingleton<IEditorConfigurationParser, EditorConfigurationParser>();
 
         return builder;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Lists,
     Icon = "icon-thumbnail-list",
-    IsReusable = false)]
+    ValueEditorIsReusable = false)]
 public class BlockListPropertyEditor : BlockEditorPropertyEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "blocklist",
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Lists,
-    Icon = "icon-thumbnail-list")]
+    Icon = "icon-thumbnail-list",
+    IsReusable = false)]
 public class BlockListPropertyEditor : BlockEditorPropertyEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/CheckBoxListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/CheckBoxListPropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Checkbox list",
     "checkboxlist",
     Icon = "icon-bulleted-list",
-    Group = Constants.PropertyEditors.Groups.Lists)]
+    Group = Constants.PropertyEditors.Groups.Lists,
+    IsReusable = true)]
 public class CheckBoxListPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/CheckBoxListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/CheckBoxListPropertyEditor.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "checkboxlist",
     Icon = "icon-bulleted-list",
     Group = Constants.PropertyEditors.Groups.Lists,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class CheckBoxListPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerPropertyEditor.cs
@@ -14,7 +14,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Color Picker",
     "colorpicker",
     Icon = "icon-colorpicker",
-    Group = Constants.PropertyEditors.Groups.Pickers)]
+    Group = Constants.PropertyEditors.Groups.Pickers,
+    IsReusable = true)]
 public class ColorPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerPropertyEditor.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "colorpicker",
     Icon = "icon-colorpicker",
     Group = Constants.PropertyEditors.Groups.Pickers,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class ColorPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditor.cs
@@ -18,7 +18,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Date/Time",
     "datepicker",
     ValueType = ValueTypes.DateTime,
-    Icon = "icon-time")]
+    Icon = "icon-time",
+    IsReusable = true)]
 public class DateTimePropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditor.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "datepicker",
     ValueType = ValueTypes.DateTime,
     Icon = "icon-time",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class DateTimePropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/DropDownFlexiblePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DropDownFlexiblePropertyEditor.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "dropdownFlexible",
     Group = Constants.PropertyEditors.Groups.Lists,
     Icon = "icon-indent",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class DropDownFlexiblePropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/DropDownFlexiblePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DropDownFlexiblePropertyEditor.cs
@@ -14,7 +14,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Dropdown",
     "dropdownFlexible",
     Group = Constants.PropertyEditors.Groups.Lists,
-    Icon = "icon-indent")]
+    Icon = "icon-indent",
+    IsReusable = true)]
 public class DropDownFlexiblePropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/EmailAddressPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/EmailAddressPropertyEditor.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Email address",
     "email",
     Icon = "icon-message",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class EmailAddressPropertyEditor : DataEditor
 {
     private readonly IIOHelper _ioHelper;

--- a/src/Umbraco.Infrastructure/PropertyEditors/EmailAddressPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/EmailAddressPropertyEditor.cs
@@ -12,7 +12,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     EditorType.PropertyValue | EditorType.MacroParameter,
     "Email address",
     "email",
-    Icon = "icon-message")]
+    Icon = "icon-message",
+    IsReusable = true)]
 public class EmailAddressPropertyEditor : DataEditor
 {
     private readonly IIOHelper _ioHelper;

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
@@ -21,7 +21,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "File upload",
     "fileupload",
     Group = Constants.PropertyEditors.Groups.Media,
-    Icon = "icon-download-alt")]
+    Icon = "icon-download-alt",
+    // TODO: test if file upload can be made reusable
+    IsReusable = false)]
 public class FileUploadPropertyEditor : DataEditor, IMediaUrlGenerator,
     INotificationHandler<ContentCopiedNotification>, INotificationHandler<ContentDeletedNotification>,
     INotificationHandler<MediaDeletedNotification>, INotificationHandler<MediaSavingNotification>,

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = "icon-download-alt",
     // TODO: test if file upload can be made reusable
-    IsReusable = false)]
+    ValueEditorIsReusable = false)]
 public class FileUploadPropertyEditor : DataEditor, IMediaUrlGenerator,
     INotificationHandler<ContentCopiedNotification>, INotificationHandler<ContentDeletedNotification>,
     INotificationHandler<MediaDeletedNotification>, INotificationHandler<MediaSavingNotification>,

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyEditor.cs
@@ -22,8 +22,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "fileupload",
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = "icon-download-alt",
-    // TODO: test if file upload can be made reusable
-    ValueEditorIsReusable = false)]
+    ValueEditorIsReusable = true)]
 public class FileUploadPropertyEditor : DataEditor, IMediaUrlGenerator,
     INotificationHandler<ContentCopiedNotification>, INotificationHandler<ContentDeletedNotification>,
     INotificationHandler<MediaDeletedNotification>, INotificationHandler<MediaSavingNotification>,

--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
         ValueType = ValueTypes.Json,
         Icon = "icon-layout",
         Group = Constants.PropertyEditors.Groups.RichContent,
-        IsReusable = false)]
+        ValueEditorIsReusable = false)]
     public class GridPropertyEditor : DataEditor
     {
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
@@ -28,7 +28,8 @@ namespace Umbraco.Cms.Core.PropertyEditors
         HideLabel = true,
         ValueType = ValueTypes.Json,
         Icon = "icon-layout",
-        Group = Constants.PropertyEditors.Groups.RichContent)]
+        Group = Constants.PropertyEditors.Groups.RichContent,
+        IsReusable = false)]
     public class GridPropertyEditor : DataEditor
     {
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = "icon-crop",
     // TODO: test if media cropper can be made reusable
-    IsReusable = false)]
+    ValueEditorIsReusable = false)]
 public class ImageCropperPropertyEditor : DataEditor, IMediaUrlGenerator,
     INotificationHandler<ContentCopiedNotification>, INotificationHandler<ContentDeletedNotification>,
     INotificationHandler<MediaDeletedNotification>, INotificationHandler<MediaSavingNotification>,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -29,8 +29,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     HideLabel = false,
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = "icon-crop",
-    // TODO: test if media cropper can be made reusable
-    ValueEditorIsReusable = false)]
+    ValueEditorIsReusable = true)]
 public class ImageCropperPropertyEditor : DataEditor, IMediaUrlGenerator,
     INotificationHandler<ContentCopiedNotification>, INotificationHandler<ContentDeletedNotification>,
     INotificationHandler<MediaDeletedNotification>, INotificationHandler<MediaSavingNotification>,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -28,7 +28,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Json,
     HideLabel = false,
     Group = Constants.PropertyEditors.Groups.Media,
-    Icon = "icon-crop")]
+    Icon = "icon-crop",
+    // TODO: test if media cropper can be made reusable
+    IsReusable = false)]
 public class ImageCropperPropertyEditor : DataEditor, IMediaUrlGenerator,
     INotificationHandler<ContentCopiedNotification>, INotificationHandler<ContentDeletedNotification>,
     INotificationHandler<MediaDeletedNotification>, INotificationHandler<MediaSavingNotification>,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ListViewPropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "listview",
     HideLabel = true,
     Group = Constants.PropertyEditors.Groups.Lists,
-    Icon = Constants.Icons.ListView)]
+    Icon = Constants.Icons.ListView,
+    IsReusable = true)]
 public class ListViewPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ListViewPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ListViewPropertyEditor.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     HideLabel = true,
     Group = Constants.PropertyEditors.Groups.Lists,
     Icon = Constants.Icons.ListView,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class ListViewPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = Constants.Icons.MediaImage,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MediaPicker3PropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -24,7 +24,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "mediapicker3",
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Media,
-    Icon = Constants.Icons.MediaImage)]
+    Icon = Constants.Icons.MediaImage,
+    IsReusable = true)]
 public class MediaPicker3PropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -26,7 +26,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = Constants.Icons.MediaImage,
-    IsDeprecated = false)]
+    IsDeprecated = false,
+    IsReusable = true)]
 public class MediaPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPickerPropertyEditor.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Group = Constants.PropertyEditors.Groups.Media,
     Icon = Constants.Icons.MediaImage,
     IsDeprecated = false,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MediaPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -18,7 +18,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "contentpicker",
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.Pickers,
-    Icon = "icon-page-add")]
+    Icon = "icon-page-add",
+    IsReusable = true)]
 public class MultiNodeTreePickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.Pickers,
     Icon = "icon-page-add",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MultiNodeTreePickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -16,7 +16,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "multiurlpicker",
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Pickers,
-    Icon = "icon-link")]
+    Icon = "icon-link",
+    IsReusable = true)]
 public class MultiUrlPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Pickers,
     Icon = "icon-link",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MultiUrlPickerPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -25,7 +25,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "multipletextbox",
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.Lists,
-    Icon = "icon-ordered-list")]
+    Icon = "icon-ordered-list",
+    IsReusable = true)]
 public class MultipleTextStringPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Text,
     Group = Constants.PropertyEditors.Groups.Lists,
     Icon = "icon-ordered-list",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class MultipleTextStringPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -25,7 +25,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "nestedcontent",
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Lists,
-    Icon = "icon-thumbnail-list")]
+    Icon = "icon-thumbnail-list",
+    IsReusable = false)]
 public class NestedContentPropertyEditor : DataEditor
 {
     public const string ContentTypeAliasPropertyKey = "ncContentTypeAlias";

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Json,
     Group = Constants.PropertyEditors.Groups.Lists,
     Icon = "icon-thumbnail-list",
-    IsReusable = false)]
+    ValueEditorIsReusable = false)]
 public class NestedContentPropertyEditor : DataEditor
 {
     public const string ContentTypeAliasPropertyKey = "ncContentTypeAlias";

--- a/src/Umbraco.Infrastructure/PropertyEditors/RadioButtonsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RadioButtonsPropertyEditor.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.String,
     Group = Constants.PropertyEditors.Groups.Lists,
     Icon = "icon-target",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class RadioButtonsPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RadioButtonsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RadioButtonsPropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "radiobuttons",
     ValueType = ValueTypes.String,
     Group = Constants.PropertyEditors.Groups.Lists,
-    Icon = "icon-target")]
+    Icon = "icon-target",
+    IsReusable = true)]
 public class RadioButtonsPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -29,7 +29,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Text,
     HideLabel = false,
     Group = Constants.PropertyEditors.Groups.RichContent,
-    Icon = "icon-browser-window")]
+    Icon = "icon-browser-window",
+    // TODO: verify that RTE can be reused
+    IsReusable = true)]
 public class RichTextPropertyEditor : DataEditor
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     HideLabel = false,
     Group = Constants.PropertyEditors.Groups.RichContent,
     Icon = "icon-browser-window",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class RichTextPropertyEditor : DataEditor
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -30,7 +30,6 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     HideLabel = false,
     Group = Constants.PropertyEditors.Groups.RichContent,
     Icon = "icon-browser-window",
-    // TODO: verify that RTE can be reused
     IsReusable = true)]
 public class RichTextPropertyEditor : DataEditor
 {

--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Slider",
     "slider",
     Icon = "icon-navigation-horizontal",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class SliderPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -15,7 +15,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Constants.PropertyEditors.Aliases.Slider,
     "Slider",
     "slider",
-    Icon = "icon-navigation-horizontal")]
+    Icon = "icon-navigation-horizontal",
+    IsReusable = true)]
 public class SliderPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -23,7 +23,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Constants.PropertyEditors.Aliases.Tags,
     "Tags",
     "tags",
-    Icon = "icon-tags")]
+    Icon = "icon-tags",
+    IsReusable = true)]
 public class TagsPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Tags",
     "tags",
     Icon = "icon-tags",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class TagsPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TextAreaPropertyEditor.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "textarea",
     ValueType = ValueTypes.Text,
     Icon = "icon-application-window-alt",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class TextAreaPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TextAreaPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TextAreaPropertyEditor.cs
@@ -18,7 +18,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Textarea",
     "textarea",
     ValueType = ValueTypes.Text,
-    Icon = "icon-application-window-alt")]
+    Icon = "icon-application-window-alt",
+    IsReusable = true)]
 public class TextAreaPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TextboxPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TextboxPropertyEditor.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Textbox",
     "textbox",
     Group = Constants.PropertyEditors.Groups.Common,
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class TextboxPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TextboxPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TextboxPropertyEditor.cs
@@ -17,7 +17,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     EditorType.PropertyValue | EditorType.MacroParameter,
     "Textbox",
     "textbox",
-    Group = Constants.PropertyEditors.Groups.Common)]
+    Group = Constants.PropertyEditors.Groups.Common,
+    IsReusable = true)]
 public class TextboxPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -18,7 +18,8 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "boolean",
     ValueType = ValueTypes.Integer,
     Group = Constants.PropertyEditors.Groups.Common,
-    Icon = "icon-checkbox")]
+    Icon = "icon-checkbox",
+    IsReusable = true)]
 public class TrueFalsePropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueType = ValueTypes.Integer,
     Group = Constants.PropertyEditors.Groups.Common,
     Icon = "icon-checkbox",
-    IsReusable = true)]
+    ValueEditorIsReusable = true)]
 public class TrueFalsePropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -1,0 +1,132 @@
+﻿using System.Linq;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
+
+[TestFixture]
+public class DataValueEditorReuseTests
+{
+    private Mock<IDataValueEditorFactory> _dataValueEditorFactoryMock;
+    private PropertyEditorCollection _propertyEditorCollection;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dataValueEditorFactoryMock = new Mock<IDataValueEditorFactory>();
+
+        _dataValueEditorFactoryMock
+            .Setup(m => m.Create<TextOnlyValueEditor>(It.IsAny<DataEditorAttribute>()))
+            .Returns(() => new TextOnlyValueEditor(
+                new DataEditorAttribute("a", "b", "c"),
+                Mock.Of<ILocalizedTextService>(),
+                Mock.Of<IShortStringHelper>(),
+                Mock.Of<IJsonSerializer>(),
+                Mock.Of<IIOHelper>()));
+
+        _propertyEditorCollection = new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>));
+
+        _dataValueEditorFactoryMock
+            .Setup(m =>
+                m.Create<BlockEditorPropertyEditor.BlockEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()))
+            .Returns(() => new BlockEditorPropertyEditor.BlockEditorPropertyValueEditor(
+                new DataEditorAttribute("a", "b", "c"),
+                _propertyEditorCollection,
+                Mock.Of<IDataTypeService>(),
+                Mock.Of<IContentTypeService>(),
+                Mock.Of<ILocalizedTextService>(),
+                Mock.Of<ILogger<BlockEditorPropertyEditor.BlockEditorPropertyValueEditor>>(),
+                Mock.Of<IShortStringHelper>(),
+                Mock.Of<IJsonSerializer>(),
+                Mock.Of<IIOHelper>(),
+                Mock.Of<IPropertyValidationService>()));
+    }
+
+    [Test]
+    public void GetValueEditor_Reusable_Value_Editor_Is_Reused_When_Created_Without_Configuration()
+    {
+        var textboxPropertyEditor = new TextboxPropertyEditor(
+            _dataValueEditorFactoryMock.Object,
+            Mock.Of<IIOHelper>(),
+            Mock.Of<IEditorConfigurationParser>());
+
+        // textbox is set to reuse its data value editor when created *without* configuration
+        var dataValueEditor1 = textboxPropertyEditor.GetValueEditor();
+        Assert.NotNull(dataValueEditor1);
+        var dataValueEditor2 = textboxPropertyEditor.GetValueEditor();
+        Assert.NotNull(dataValueEditor2);
+        Assert.AreSame(dataValueEditor1, dataValueEditor2);
+        _dataValueEditorFactoryMock.Verify(
+            m => m.Create<TextOnlyValueEditor>(It.IsAny<DataEditorAttribute>()), 
+            Times.Once);
+    }
+
+    [Test]
+    public void GetValueEditor_Reusable_Value_Editor_Is_Not_Reused_When_Created_With_Configuration()
+    {
+        var textboxPropertyEditor = new TextboxPropertyEditor(
+            _dataValueEditorFactoryMock.Object,
+            Mock.Of<IIOHelper>(),
+            Mock.Of<IEditorConfigurationParser>());
+
+        // no matter what, a property editor should never reuse its data value editor when created *with* configuration
+        var dataValueEditor1 = textboxPropertyEditor.GetValueEditor("config");
+        Assert.NotNull(dataValueEditor1);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor1).Configuration);
+        var dataValueEditor2 = textboxPropertyEditor.GetValueEditor("config");
+        Assert.NotNull(dataValueEditor2);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).Configuration);
+        Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
+        _dataValueEditorFactoryMock.Verify(
+            m => m.Create<TextOnlyValueEditor>(It.IsAny<DataEditorAttribute>()), 
+            Times.Exactly(2));
+    }
+
+    [Test]
+    public void GetValueEditor_Not_Reusable_Value_Editor_Is_Not_Reused_When_Created_Without_Configuration()
+    {
+        var blockListPropertyEditor = new BlockListPropertyEditor(
+            _dataValueEditorFactoryMock.Object,
+            new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>)),
+            Mock.Of<IIOHelper>(),
+            Mock.Of<IEditorConfigurationParser>());
+
+        // block list is *not* set to reuse its data value editor
+        var dataValueEditor1 = blockListPropertyEditor.GetValueEditor();
+        Assert.NotNull(dataValueEditor1);
+        var dataValueEditor2 = blockListPropertyEditor.GetValueEditor();
+        Assert.NotNull(dataValueEditor2);
+        Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
+        _dataValueEditorFactoryMock.Verify(
+            m => m.Create<BlockEditorPropertyEditor.BlockEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()),
+            Times.Exactly(2));
+    }
+
+    [Test]
+    public void GetValueEditor_Not_Reusable_Value_Editor_Is_Not_Reused_When_Created_With_Configuration()
+    {
+        var blockListPropertyEditor = new BlockListPropertyEditor(
+            _dataValueEditorFactoryMock.Object,
+            new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>)),
+            Mock.Of<IIOHelper>(),
+            Mock.Of<IEditorConfigurationParser>());
+
+        // no matter what, a property editor should never reuse its data value editor when created *with* configuration
+        var dataValueEditor1 = blockListPropertyEditor.GetValueEditor("config");
+        Assert.NotNull(dataValueEditor1);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor1).Configuration);
+        var dataValueEditor2 = blockListPropertyEditor.GetValueEditor("config");
+        Assert.NotNull(dataValueEditor2);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).Configuration);
+        Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
+        _dataValueEditorFactoryMock.Verify(
+            m => m.Create<BlockEditorPropertyEditor.BlockEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()),
+            Times.Exactly(2));
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This re-introduces the performance improvements we were forced to roll back in https://github.com/umbraco/Umbraco-CMS/pull/10938

This version makes it opt-in for property editors to reuse their data value editors. Opt-in is done by setting `ValueEditorIsReusable` in `DataEditorAttribute` to `true`. To be on the safe side, the property value is `false` by default. 

All core property editors except Block List and Nested Content opt in for data value editor reuse.

`IEditorConfigurationParser` is consumed by pretty much every single property editor in the core, among other things to create data value editors with configuration. I have opted to change its registration in the DI to singleton, as:
 
1. This is the case for all other services consumed by property editors, and
2. The implementation `EditorConfigurationParser` holds no state.

### Testing this PR

1. Create some content, save and reload - verify that property values are persisted as expected.
2. Create a Block List editor with one or more element types, and:
     - Create some content with this editor.
     - Go to settings and change one of the element types (i.e. add a new property).
     - Go back to the previously created content - verify that the element type change takes effect in the Block List elements.
     - Edit an element of the changed element type, save and reload - verify that the changed element type data is persisted.