### PR TITLE
Test configuration throwing errors

### DIFF
--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -104,7 +105,7 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
                 context.HostingEnvironment = TestHelper.GetWebHostEnvironment();
                 configBuilder.Sources.Clear();
                 configBuilder.AddInMemoryCollection(InMemoryConfiguration);
-                configBuilder.AddConfiguration(GlobalSetupTeardown.TestConfiguration);
+                SetUpTestConfiguration(configBuilder);
 
                 Configuration = configBuilder.Build();
             })
@@ -193,4 +194,12 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
     }
 
     protected virtual T GetRequiredService<T>() => Services.GetRequiredService<T>();
+
+    protected virtual void SetUpTestConfiguration(IConfigurationBuilder configBuilder)
+    {
+        if (GlobalSetupTeardown.TestConfiguration is not null)
+        {
+            configBuilder.AddConfiguration(GlobalSetupTeardown.TestConfiguration);
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12911

# Notes
- Having your test class deriving from `UmbracoIntegrationTest` was throwing errors, due to `GlobalSetupTeardown` not running, as it would only run, if you are in the `Umbraco.Tests.Integration` assembly  
- Added new virtual SetUpTestConfiguration method, that can be overridden in your own code, if you wish to change the Test configurations

# How to test
- Create your own NUnit test project
- Create a class deriving from `UmbracoIntegrationTest` with a sample test
- Run your sample test

Code snippet for NUnit class:

```
using Umbraco.Cms.Tests.Integration.Testing;

namespace NUnitTestProject;

public class Tests : UmbracoIntegrationTest
{
    [SetUp]
    public void Setup()
    {
    }

    [Test]
    public void Test1()
    {
        Assert.Pass();
    }
}
```