### PR TITLE
Update richtext editor plugins in appsettings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/RichTextEditorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RichTextEditorSettings.cs
@@ -12,11 +12,7 @@ public class RichTextEditorSettings
 
     internal const string StaticInvalidElements = "font";
 
-    private static readonly string[] Default_plugins =
-    {
-        "paste", "anchor", "charmap", "table", "lists", "advlist", "hr", "autolink", "directionality", "tabfocus",
-        "searchreplace",
-    };
+    internal const string StaticPlugins = "paste,anchor,charmap,table,lists,advlist,hr,autolink,directionality,tabfocus,searchreplace";
 
     private static readonly RichTextEditorCommand[] Default_commands =
     {
@@ -124,7 +120,8 @@ public class RichTextEditorSettings
     /// <summary>
     ///     HTML RichText Editor TinyMCE Plugins
     /// </summary>
-    public IEnumerable<string> Plugins { get; set; } = Default_plugins;
+    [DefaultValue(StaticPlugins)]
+    public IEnumerable<string> Plugins { get; set; } = StaticPlugins.Split(',');
 
     /// <summary>
     ///     HTML RichText Editor TinyMCE Custom Config

--- a/src/Umbraco.Core/Configuration/Models/RichTextEditorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RichTextEditorSettings.cs
@@ -124,7 +124,7 @@ public class RichTextEditorSettings
     /// <summary>
     ///     HTML RichText Editor TinyMCE Plugins
     /// </summary>
-    public string[] Plugins { get; set; } = Default_plugins;
+    public IEnumerable<string> Plugins { get; set; } = Default_plugins;
 
     /// <summary>
     ///     HTML RichText Editor TinyMCE Custom Config


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12916

### Description

I change plugins to be `IEnumerable<string>` just like these:
https://github.com/umbraco/Umbraco-CMS/blob/v10/contrib/src/Umbraco.Core/Configuration/Models/ContentSettings.cs#L194-L203

which generates the following.

![image](https://user-images.githubusercontent.com/2919859/188178641-64981395-b3fe-4e42-a9f3-ab988b1a9441.png)

Strange enough when I delete `appsettings-schema.json`, run JsonSchema program it generates the file again, but it still seems to generate this:

```
"Plugins": {
  "description": "An array of TinyMCE Plugins to load such as 'paste', 'table'",
  "type": [
    "string"
  ]
}
```

instead of something like this:

```
"Plugins": {
  "description": "An array of TinyMCE Plugins to load such as 'paste', 'table'",
  "type": "array",
  "items": {
      "type": "string"
  }
}
```