### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/add-issues-to-review-project.yml
+++ b/.github/workflows/add-issues-to-review-project.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   get-user-type:
     runs-on: ubuntu-latest
@@ -43,6 +46,8 @@ jobs:
             core.setOutput("ignored", isIgnoredUser);
             console.log("Ignored is", isIgnoredUser);
   add-to-project:
+    permissions:
+      repository-projects: write # for actions/add-to-project
     if: needs.get-user-type.outputs.ignored == 'false'
     runs-on: ubuntu-latest
     needs: [get-user-type]


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.