### PR TITLE
Prevent overflowing property values

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -38,7 +38,6 @@
 
 .umb-node-preview__content {
     flex: 1 1 auto;
-    margin-right: 25px;
     overflow: hidden;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-node-preview.less
@@ -7,7 +7,8 @@
 }
 
 .umb-editor-wrapper .umb-node-preview {
-    .umb-property-editor--limit-width();
+  word-break: break-word;
+  .umb-property-editor--limit-width();
 }
 
 .umb-node-preview:last-of-type {

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-readonlyvalue.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-readonlyvalue.less
@@ -1,4 +1,5 @@
 .umb-readonlyvalue {
   position: relative;
+  word-break: break-word;
   .umb-property-editor--limit-width();
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-readonlyvalue.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-readonlyvalue.less
@@ -1,3 +1,4 @@
-.umb-readonlyvalue  {
-    position:relative;
+.umb-readonlyvalue {
+  position: relative;
+  .umb-property-editor--limit-width();
 }

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -421,7 +421,6 @@
 // Limit width of specific property editors
 .umb-property-editor--limit-width {
     max-width: @propertyEditorLimitedWidth;
-    word-break: break-all;
 }
 
 // Horizontal dividers

--- a/src/Umbraco.Web.UI.Client/src/less/mixins.less
+++ b/src/Umbraco.Web.UI.Client/src/less/mixins.less
@@ -421,6 +421,7 @@
 // Limit width of specific property editors
 .umb-property-editor--limit-width {
     max-width: @propertyEditorLimitedWidth;
+    word-break: break-all;
 }
 
 // Horizontal dividers


### PR DESCRIPTION
[PR 12608](https://github.com/umbraco/Umbraco-CMS/pull/12608), but with the scope of the CSS to be restricted to elements which actually need the change. Also changed from `break-all` to `break-word` which will work much better with real world data.
