### PR TITLE
Set the first app to active if no active apps in block list item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockeditor/blockeditor.controller.js
@@ -35,6 +35,11 @@ angular.module("umbraco")
                     }
                 }
 
+                var activeApp = apps.filter(x => x.active);
+                if (activeApp.length === 0 && apps.length > 0) {
+                  apps[0].active = true;
+                }
+
                 vm.tabs = apps;
             }
 


### PR DESCRIPTION
Add support for a block list item which only contains settings

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If you create a block list item whereby the "Content" part of the item doesn't have any properties but you do add a "Settings" component, there are some issues.
![image](https://user-images.githubusercontent.com/1469061/188287529-c9b0c65f-c463-4696-99a7-057b18cbb5b7.png)

- You can't access the settings section unless you first create the block list item and then press the "edit settings" button
![image](https://user-images.githubusercontent.com/1469061/188287561-d73c0f8f-ab7e-4219-88dc-269354480ba4.png)

- If the settings has a mandatory field, you can't create the item at all.

This PR checks to see if there is an active app, and if there isn't, it sets the first app to be active. This handles this specific scenario, and any scenario where you have a custom content app yet no properties in the "Content" section.

Hopefully that all makes sense!


