### PR TITLE
Fix GetBackOfficeUrl extension method

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -13,32 +13,25 @@ namespace Umbraco.Extensions;
 public static class LinkGeneratorExtensions
 {
     /// <summary>
-    ///     Return the back office url if the back office is installed
+    /// Gets the backoffice URL (if the back office is installed).
     /// </summary>
-    public static string? GetBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
-    {
-        Type? backOfficeControllerType;
-        try
-        {
-            backOfficeControllerType = Assembly.Load("Umbraco.Web.BackOffice")
-                .GetType("Umbraco.Web.BackOffice.Controllers.BackOfficeController");
-            if (backOfficeControllerType == null)
-            {
-                return "/"; // this would indicate that the installer is installed without the back office
-            }
-        }
-        catch
-        {
-            return
-                hostingEnvironment
-                    .ApplicationVirtualPath; // this would indicate that the installer is installed without the back office
-        }
+    /// <param name="linkGenerator">The link generator.</param>
+    /// <returns>
+    /// The backoffice URL.
+    /// </returns>
+    public static string? GetBackOfficeUrl(this LinkGenerator linkGenerator)
+        => linkGenerator.GetPathByAction("Default", "BackOffice", new { area = Constants.Web.Mvc.BackOfficeArea });
 
-        return linkGenerator.GetPathByAction(
-            "Default",
-            ControllerExtensions.GetControllerName(backOfficeControllerType),
-            new { area = Constants.Web.Mvc.BackOfficeApiArea });
-    }
+    /// <summary>
+    /// Gets the backoffice URL (if the back office is installed) or application virtual path (in most cases just <c>"/"</c>).
+    /// </summary>
+    /// <param name="linkGenerator">The link generator.</param>
+    /// <param name="hostingEnvironment">The hosting environment.</param>
+    /// <returns>
+    /// The backoffice URL.
+    /// </returns>
+    public static string GetBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
+         => GetBackOfficeUrl(linkGenerator) ?? hostingEnvironment.ApplicationVirtualPath;
 
     /// <summary>
     ///     Return the Url for a Web Api service

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/InstallAreaRoutesTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/InstallAreaRoutesTests.cs
@@ -21,6 +21,7 @@ public class InstallAreaRoutesTests
     [TestCase(RuntimeLevel.BootFailed)]
     [TestCase(RuntimeLevel.Unknown)]
     [TestCase(RuntimeLevel.Boot)]
+    [TestCase(RuntimeLevel.Run)]
     public void RuntimeState_No_Routes(RuntimeLevel level)
     {
         var routes = GetInstallAreaRoutes(level);
@@ -68,20 +69,6 @@ public class InstallAreaRoutesTests
         Assert.AreEqual(1, fallbackRoute.Endpoints.Count);
 
         Assert.AreEqual("Fallback {*path:nonfile}", fallbackRoute.Endpoints[0].ToString());
-    }
-
-    [Test]
-    public void RuntimeState_Run()
-    {
-        var routes = GetInstallAreaRoutes(RuntimeLevel.Run);
-        var endpoints = new TestRouteBuilder();
-        routes.CreateRoutes(endpoints);
-
-        Assert.AreEqual(1, endpoints.DataSources.Count);
-        var route = endpoints.DataSources.First();
-        Assert.AreEqual(1, route.Endpoints.Count);
-
-        Assert.AreEqual("install/{controller?}/{action?} HTTP: GET", route.Endpoints[0].ToString());
     }
 
     private InstallAreaRoutes GetInstallAreaRoutes(RuntimeLevel level) =>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The `GetBackOfficeUrl()` extension method contains two bugs, causing it to always return `/`:
1. The hardcoded namespace wasn't updated (from `Umbraco.Web.BackOffice.Controllers` to `Umbraco.Cms.Web.BackOffice.Controllers`);
2. The path was using the wrong MVC area (`BackOfficeApiArea` instead of `BackOfficeArea`).

You can test this by adding the following composer to a site and checking the log:

```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;
using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;

public class BackOfficeUrlLoggerComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.AddNotificationHandler<UmbracoApplicationStartedNotification, BackOfficeUrlLoggerNotificationHandler>();

    private class BackOfficeUrlLoggerNotificationHandler : INotificationHandler<UmbracoApplicationStartedNotification>
    {
        private readonly ILogger<BackOfficeUrlLoggerNotificationHandler> _logger;
        private readonly LinkGenerator _linkGenerator;
        private readonly IHostingEnvironment _hostingEnvironment;

        public BackOfficeUrlLoggerNotificationHandler(ILogger<BackOfficeUrlLoggerNotificationHandler> logger, LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
        {
            _logger = logger;
            _linkGenerator = linkGenerator;
            _hostingEnvironment = hostingEnvironment;
        }

        public void Handle(UmbracoApplicationStartedNotification notification)
            => _logger.LogInformation("Backoffice URL: {Url}", _linkGenerator.GetBackOfficeUrl(_hostingEnvironment));
    }
}
```

Before applying this PR, it will log `Backoffice URL: /`, but with this fix it will log `Backoffice URL: /umbraco`.

This probably wasn't discovered earlier because the codebase only uses this extension method when the installer endpoints are replaced with a redirect. This change will therefore change the redirect on `/install` from `/` to `/umbraco`. This will expose the actual Umbraco backoffice path by simply going to `/install`, so we should either change this redirect to always use the application root URL (almost always `/`) or remove the redirects entirely: any thoughts on this? _Note: I've added a commit that removes the redirect (as that seems the most sensible thing to do)._