### PR TITLE
Fixes #12972 for validating legacy member passwords

### DIFF
--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -263,9 +263,7 @@ public abstract class UmbracoUserManager<TUser, TPasswordConfig> : UserManager<T
             throw new NotSupportedException("The current user store does not implement " +
                                             typeof(IUserPasswordStore<>));
         }
-
-        await userPasswordStore.GetPasswordHashAsync(user, CancellationToken.None);
-
+        
         var result = await VerifyPasswordAsync(userPasswordStore, user, password);
 
         return result == PasswordVerificationResult.Success || result == PasswordVerificationResult.SuccessRehashNeeded;

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -264,7 +264,7 @@ public abstract class UmbracoUserManager<TUser, TPasswordConfig> : UserManager<T
                                             typeof(IUserPasswordStore<>));
         }
 
-        var hash = await userPasswordStore.GetPasswordHashAsync(user, CancellationToken.None);
+        await userPasswordStore.GetPasswordHashAsync(user, CancellationToken.None);
 
         var result = await VerifyPasswordAsync(userPasswordStore, user, password);
 

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -252,6 +252,7 @@ public abstract class UmbracoUserManager<TUser, TPasswordConfig> : UserManager<T
     public async Task<bool> ValidateCredentialsAsync(string username, string password)
     {
         TUser user = await FindByNameAsync(username);
+        
         if (user == null)
         {
             return false;
@@ -265,7 +266,9 @@ public abstract class UmbracoUserManager<TUser, TPasswordConfig> : UserManager<T
 
         var hash = await userPasswordStore.GetPasswordHashAsync(user, CancellationToken.None);
 
-        return await VerifyPasswordAsync(userPasswordStore, user, password) == PasswordVerificationResult.Success;
+        var result = await VerifyPasswordAsync(userPasswordStore, user, password);
+
+        return result == PasswordVerificationResult.Success || result == PasswordVerificationResult.SuccessRehashNeeded;
     }
 
     public virtual async Task<IList<string>> GetValidTwoFactorProvidersAsync(TUser user)


### PR DESCRIPTION
Umbraco has the `MemberPasswordHasher` which then calls `LegacyPasswordSecurity`.

This successfully validates the correct legacy password hash and returns true.

As it's a legacy password the `MemberPasswordHasher` returns `PasswordVerificationResult.SuccessRehashNeeded` which seems helpful because it allows you to perform different logic.

But `UmbracoUserManager` checks this method returns `PasswordVerificationResult.Success` to determine if the password is valid. Therefore it's always false for every legacy password.

The `MemberManager` should check both `Success` or `SuccessRehashNeeded` states when validating a password.

If this isn't suitable perhaps there should be a config that allows this check (off by default).