### PR TITLE
Added nullable helper for IfNullOrWhiteSpace

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -419,8 +419,7 @@ public static class StringExtensions
     ///     returns <see langword="false" />.
     /// </returns>
     public static bool IsNullOrWhiteSpace(this string? value) => string.IsNullOrWhiteSpace(value);
-
-    [return: NotNullIfNotNull("str")]
+    
     [return: NotNullIfNotNull("defaultValue")]
     public static string? IfNullOrWhiteSpace(this string? str, string? defaultValue) =>
         str.IsNullOrWhiteSpace() ? defaultValue : str;

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -420,6 +420,8 @@ public static class StringExtensions
     /// </returns>
     public static bool IsNullOrWhiteSpace(this string? value) => string.IsNullOrWhiteSpace(value);
 
+    [return: NotNullIfNotNull("str")]
+    [return: NotNullIfNotNull("defaultValue")]
     public static string? IfNullOrWhiteSpace(this string? str, string? defaultValue) =>
         str.IsNullOrWhiteSpace() ? defaultValue : str;
 


### PR DESCRIPTION
I noticed while working on a project that IsNullOrWhiteSpace always demanded that you null check the result even if you are 100% sure that result cannot be NULL. This is because there were no helper classes on it that could help with this. If `defaultValue` is not null, then we can be sure that the return value is not null. So I've added the helpers to the function.

Take the following code:

```
public void Test()
        {
            string? testNullString = null;
            string testString = "Hello";

            string test = testNullString.IfNullOrWhiteSpace("Hello")!;
            string? test2 = testNullString.IfNullOrWhiteSpace(null);
            string test3 = testString.IfNullOrWhiteSpace(null)!;
        }
```
		
This is how you would have to write it now. Even though we know test cannot be null, we still have to add the `!` to the end of the statement to force it to accept a normal string.

However with the changes of the PR, you will be able to write it like this:
```
public void Test()
        {
            string? testNullString = null;
            string testString = "Hello";

            string test = testNullString.IfNullOrWhiteSpace("Hello");
            string? test2 = testNullString.IfNullOrWhiteSpace(null);
            string test3 = testString.IfNullOrWhiteSpace(null)!;
            string? test4 = testNullString.IfNullOrWhiteSpace(null);
        }
```

So now we don't have to add the ! after test as we already know that it will never return null.