### PR TITLE
Fix index updating when culture gets unpublished

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
@@ -416,7 +416,7 @@ public class UmbracoContentValueSetValidatorTests
         Assert.IsTrue(valueSet.Values.ContainsKey("title_es-ES"));
 
         result = validator.Validate(valueSet);
-        Assert.AreEqual(ValueSetValidationStatus.Filtered, result.Status);
+        Assert.AreEqual(ValueSetValidationStatus.Valid, result.Status);
 
         Assert.AreEqual(7, result.ValueSet.Values.Count()); // filtered to 7 values (removes es-es values)
         Assert.IsFalse(result.ValueSet.Values.ContainsKey($"{UmbracoExamineFieldNames.PublishedFieldName}_es-es"));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #12964 

### Description
Currently if one culture of a node gets unpublished the whole ValueSet gets marked as filtered and will then later be removed from the index even if there are other cultures which are still published.
This PR changes this as it does not set the ValueSets as filtered but as valid and thus will update the index accordingly.

### How to test
- Setup two languages (English and French)
- Create a homepage document type with vary by cultures selected
- Create a homepage node
- Set the hostnames and domains for each culture
- Publish the homepage in both cultures
- Go to Settings and query the external index using `*:*` you should note the homepage node in there and the fields in both cultures
- Go back to the homepage node an unpublish the French version of the homepage
- Return to the Settings page and query the external index using `*:*` and make sure that the node is still there but without the content of the unpublished culture