### PR TITLE
V10: Include app plugins in csproj

### DIFF
--- a/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
+++ b/src/Umbraco.Cms/buildTransitive/Umbraco.Cms.targets
@@ -17,7 +17,6 @@
   <Target Name="IncludeAppPluginsContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;">
     <ItemGroup>
       <_AppPluginsFiles Include="App_Plugins\**" />
-
       <ContentWithTargetPath
         Include="@(_AppPluginsFiles)"
         Exclude="@(ContentWithTargetPath)"
@@ -38,4 +37,7 @@
       <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
+  <ItemGroup>
+    <Content Include="App_Plugins\**" CopyToPublishDirectory="PreserveNewest"/>
+  </ItemGroup>
 </Project>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <Import Project="..\Umbraco.Cms\buildTransitive\Umbraco.Cms.props" />
+  <Import Project="..\Umbraco.Cms\buildTransitive\Umbraco.Cms.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Cms\Umbraco.Cms.csproj" />
   </ItemGroup>


### PR DESCRIPTION
# Notes
- Added include for App_Plugins in Umbraco.Cms.Targets, this should mean the App_Plugins folder should now always be visible in your solution and be copied on publishing by default 👍 
- Added reference to the Umbraco.Cms.Targets file in the Web.UI project

# How to test
- Create the App_Plugins folder in the root of the Web.UI project
- Throw some files in there
- Assert they get copied when publishing