### PR TITLE
Add label-key to prevent cleanup button

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -1873,6 +1873,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
+    <key alias="historyCleanupEnableCleanup">Enable cleanup</key>
     <key alias="historyCleanupGloballyDisabled"><![CDATA[<strong>NOTE!</strong> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
   </area>
   <area alias="languages">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -1947,6 +1947,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Keep all versions newer than days</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Keep latest version per day for days</key>
     <key alias="historyCleanupPreventCleanup">Prevent cleanup</key>
+    <key alias="historyCleanupEnableCleanup">Enable cleanup</key>
     <key alias="historyCleanupGloballyDisabled"><![CDATA[<strong>NOTE!</strong> The cleanup of historically content versions are disabled globally. These settings will not take effect before it is enabled.]]></key>
     <key alias="changeDataTypeHelpText">Changing a data type with stored values is disabled. To allow this you can change the Umbraco:CMS:DataTypes:CanBeChanged setting in appsettings.json.</key>
   </area>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -1693,6 +1693,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="historyCleanupKeepAllVersionsNewerThanDays">Bewaar alle versies nieuwer dan dagen</key>
     <key alias="historyCleanupKeepLatestVersionPerDayForDays">Bewaar de laatste versie per dag voor dagen</key>
     <key alias="historyCleanupPreventCleanup">Voorkom opschonen</key>
+    <key alias="historyCleanupEnableCleanup">Opschonen aanzetten</key>
     <key alias="historyCleanupGloballyDisabled">Geschiedenis opschonen is globaal uitgeschakeld. Deze instellingen worden pas van kracht nadat ze zijn ingeschakeld.</key>
   </area>
   <area alias="languages">

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/rollback/rollback.html
@@ -73,7 +73,8 @@
                                                 size="xxs"
                                                 state="version.pinningState"
                                                 action="vm.pinVersion(version, $event)"
-                                                label="{{ version.preventCleanup ? 'Enable cleanup' : 'Prevent cleanup' }}">
+                                                label="{{ version.preventCleanup ? 'Enable cleanup' : 'Prevent cleanup' }}"
+                                                label-key="{{version.preventCleanup ? 'contentTypeEditor_historyCleanupEnableCleanup' : 'contentTypeEditor_historyCleanupPreventCleanup' }}">
                                             </umb-button>
                                         </div>
                                     </div>


### PR DESCRIPTION
Add label key to prevent/enable cleanup button so it can be translated. 

- [x] Add label-key
- [x] Add 'historyCleanupEnableCleanup' to English and Dutch file

**English:**
![image](https://user-images.githubusercontent.com/7831614/189921794-0a9a4063-0311-4cd5-ab91-567d040f190b.png)

**Dutch:**
![image](https://user-images.githubusercontent.com/7831614/189922436-bfc3946a-f275-4d08-862a-e8cfa31932b3.png)
