### PR TITLE
Bypass model validation for rendering models

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/TypeExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/TypeExtensions.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Extensions;
+
+internal static class TypeExtensions
+{
+    public static bool IsRenderingModel(this Type type)
+        => typeof(ContentModel).IsAssignableFrom(type) || typeof(IPublishedContent).IsAssignableFrom(type);
+}

--- a/src/Umbraco.Web.Common/Mvc/UmbracoMvcConfigureOptions.cs
+++ b/src/Umbraco.Web.Common/Mvc/UmbracoMvcConfigureOptions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Cms.Web.Common.ModelBinders;
+using Umbraco.Cms.Web.Common.Validators;
 
 namespace Umbraco.Cms.Web.Common.Mvc;
 
@@ -18,6 +19,8 @@ public class UmbracoMvcConfigureOptions : IConfigureOptions<MvcOptions>
     public void Configure(MvcOptions options)
     {
         options.ModelBinderProviders.Insert(0, new ContentModelBinderProvider());
+        options.ModelValidatorProviders.Insert(0, new BypassRenderingModelValidatorProvider());
+        options.ModelMetadataDetailsProviders.Add(new BypassRenderingModelValidationMetadataProvider());
         options.Filters.Insert(0, new EnsurePartialViewMacroViewContextFilterAttribute());
     }
 }

--- a/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidationMetadataProvider.cs
+++ b/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidationMetadataProvider.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Web.Common.Validators;
+
+/// <summary>
+/// Ensures we bypass object graph validation for rendering models.
+/// </summary>
+internal class BypassRenderingModelValidationMetadataProvider : IValidationMetadataProvider
+{
+    public void CreateValidationMetadata(ValidationMetadataProviderContext context)
+    {
+        if (context.Key.ModelType.IsRenderingModel())
+        {
+            context.ValidationMetadata.ValidateChildren = false;
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidatorProvider.cs
+++ b/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidatorProvider.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Web.Common.Validators;
+
+/// <summary>
+/// Ensures we bypass property validation for rendering models.
+/// </summary>
+internal class BypassRenderingModelValidatorProvider : IModelValidatorProvider
+{
+    public void CreateValidators(ModelValidatorProviderContext context)
+    {
+        if (context.ModelMetadata.ModelType.IsRenderingModel())
+        {
+            context.Results.Clear();
+            context.Results.Add(new ValidatorItem
+            {
+                Validator = null,
+                IsReusable = true
+            });
+        }
+    }
+}
+
+


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12579

### Description

The slow rendering described in the linked issue is tied to how ASP.NET Core performs validation; specifically validation of object graphs. The more content items exist in near vicinity (parent, children, siblings) of the item being rendered, the larger object graph is traversed.

The only reasonable fix is to disable validation of rendering models, namely models built upon `ContentModel` or `IPublishedContent` (ModelsBuilder models).

As this is a behavioral breaking change, we cannot target V10, so the target of this PR is V11.

### Testing this fix

The files needed for testing is attached in [this ZIP file](https://github.com/umbraco/Umbraco-CMS/files/9566646/12579.zip).

1. Use the attached DB to get the required content and templates for testing - login with _test@test.test_ / _SuperSecret_
2. Copy the attached Razor templates to _/views_
3. Use ModelsBuilder mode `SourceCodeAuto` or `SourceCodeManual` to generate the Article model (required by the next step)
4. Include the attached `ArticleController` in the project
5. Verify that the five different controller actions render equally fast. The controller actions are triggered by the different templates using route hijacking on the following routes:
    - /articlealtone/ (use the rendering time of this action as benchmark for the rest of the actions)
    - /articlealttwo/
    - /articlealtthree/
    - /articlealtfour/
    - /articlealtfive/
6. Verify explicitly that model state validation works for non rendering models in the last controller action; supplying a value to the action should make the model state valid:
![image](https://user-images.githubusercontent.com/7405322/190165109-8c87af1d-e31e-4a60-b9b8-82776ed49327.png)
![image](https://user-images.githubusercontent.com/7405322/190165185-79d13232-98d9-4146-a712-ea2e19ddd588.png)

It is probably a good idea to enable the mini profiler by default when measuring the rendering times:

![image](https://user-images.githubusercontent.com/7405322/190164713-fd8cf940-d5fb-4e92-bc47-e575d20a596a.png)


