### PR TITLE
Add separator before reload node in Media Types tree

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -112,7 +112,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
 
             // root actions
             menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
-            menu.Items.Add(new RefreshNode(LocalizedTextService));
+            menu.Items.Add(new RefreshNode(LocalizedTextService, true));
             return menu;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed in Forms the separator before reload action was a bit inconsistent https://github.com/umbraco/Umbraco.Forms.Issues/issues/869

I had a look at Umbraco core as well and found reload action in root of Media Types tree to be different as well. 

![image](https://user-images.githubusercontent.com/2919859/190333885-5b40e287-82fc-47f1-b791-7e15569348da.png)
