### PR TITLE
Add support to display public access on list views

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/ContentItemBasic.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentItemBasic.cs
@@ -96,6 +96,12 @@ public class ContentItemBasic<T> : ContentItemBasic, IContentProperties<T>
         // ensure its not null
         _properties = Enumerable.Empty<T>();
 
+    /// <summary>
+    /// Indicates if the item is restricted by public access
+    /// </summary>
+    [DataMember(Name = "protected")]
+    public bool IsProtected { get; set; }
+
     [DataMember(Name = "properties")]
     public virtual IEnumerable<T> Properties
     {

--- a/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
@@ -25,6 +25,7 @@ namespace Umbraco.Cms.Web.BackOffice.Mapping;
 internal class ContentMapDefinition : IMapDefinition
 {
     private readonly AppCaches _appCaches;
+    private readonly IPublicAccessService _publicAccessService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly ContentBasicSavedStateMapper<ContentPropertyBasic> _basicStateMapper;
     private readonly CommonMapper _commonMapper;
@@ -67,7 +68,8 @@ internal class ContentMapDefinition : IMapDefinition
         IPublishedUrlProvider publishedUrlProvider,
         IEntityService entityService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
-        AppCaches appCaches)
+        AppCaches appCaches,
+        IPublicAccessService publicAccessService)
     {
         _commonMapper = commonMapper;
         _commonTreeNodeMapper = commonTreeNodeMapper;
@@ -87,6 +89,7 @@ internal class ContentMapDefinition : IMapDefinition
         _uriUtility = uriUtility;
         _publishedUrlProvider = publishedUrlProvider;
         _appCaches = appCaches;
+        _publicAccessService = publicAccessService;
 
         _tabsAndPropertiesMapper = new TabsAndPropertiesMapper<IContent>(cultureDictionary, localizedTextService, contentTypeBaseServiceProvider);
         _stateMapper = new ContentSavedStateMapper<ContentPropertyDisplay>();
@@ -332,6 +335,7 @@ internal class ContentMapDefinition : IMapDefinition
         target.UpdateDate = GetUpdateDate(source, context);
         target.Updater = _commonMapper.GetCreator(source, context);
         target.VariesByCulture = source.ContentType.VariesByCulture();
+        target.IsProtected = _publicAccessService.IsProtected(source).Success;
     }
 
     private IEnumerable<string> GetActions(IContent source, IContent? parent, MapperContext context)

--- a/src/Umbraco.Web.BackOffice/Mapping/MediaMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/MediaMapDefinition.cs
@@ -82,6 +82,10 @@ public class MediaMapDefinition : IMapDefinition
         target.Udi = Udi.Create(Constants.UdiEntityType.Media, source.Key);
         target.UpdateDate = source.UpdateDate;
         target.VariesByCulture = source.ContentType.VariesByCulture();
+
+        // Currently not possible for media to be protected
+        target.IsProtected = false;
+
     }
 
     // Umbraco.Code.MapAll -Edited -Updater -Alias
@@ -104,6 +108,9 @@ public class MediaMapDefinition : IMapDefinition
         target.Udi = Udi.Create(Constants.UdiEntityType.Media, source.Key);
         target.UpdateDate = source.UpdateDate;
         target.VariesByCulture = source.ContentType.VariesByCulture();
+
+        // Currently not possible for media to be protected
+        target.IsProtected = false;
     }
 
     private bool DetermineIsChildOfListView(IMedia source)

--- a/src/Umbraco.Web.BackOffice/Mapping/MemberMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/MemberMapDefinition.cs
@@ -60,6 +60,9 @@ public class MemberMapDefinition : IMapDefinition
         target.Udi = Udi.Create(Constants.UdiEntityType.Member, source.Key);
         target.UpdateDate = source.UpdateDate;
 
+        // Currently not possible for members to be protected
+        target.IsProtected = false;
+
         //Membership
         target.Username = source.Username;
         target.Email = source.Email;
@@ -88,6 +91,9 @@ public class MemberMapDefinition : IMapDefinition
         target.Udi = Udi.Create(Constants.UdiEntityType.Member, source.Key);
         target.UpdateDate = source.UpdateDate;
         target.Username = source.Username;
+
+        // Currently not possible for members to be protected
+        target.IsProtected = false;
     }
 
     // Umbraco.Code.MapAll -Icon -Trashed -ParentId -Alias

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/includeproperties.prevalues.controller.js
@@ -18,7 +18,8 @@ function includePropsPreValsController($rootScope, $scope, localizationService, 
         { value: "published"},
         { value: "contentTypeAlias" },
         { value: "email" },
-        { value: "username" }
+        { value: "username" },
+        { value: "protected" }
     ];
 
     $scope.getLocalizedKey = function(alias) {
@@ -44,6 +45,8 @@ function includePropsPreValsController($rootScope, $scope, localizationService, 
                 return "general_email";
             case "username":
                 return "general_username";
+            case "protected":
+                return "actions_protect";
         }
         return alias;
     }
@@ -76,6 +79,9 @@ function includePropsPreValsController($rootScope, $scope, localizationService, 
                     break;
                 case "username":
                     e.name += " (Members only)";
+                    break;
+                case "protected":
+                    e.name += " (Content only)";
                     break;
             }
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -193,6 +193,11 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                 e.alias === "contentTypeAlias";
         }
 
+        // Don't allow sorting on protected
+        if (e.isSystem && $scope.entityType === "content") {
+            e.allowSorting = e.alias !== "protected";
+        }
+
         if (e.isSystem) {
             //localize the header
             var key = getLocalizedKey(e.alias);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -784,6 +784,8 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
                 return "general_email";
             case "username":
                 return "general_username";
+            case "protected":
+                return "actions_protect";
         }
         return alias;
     }


### PR DESCRIPTION
Add a new system field for list views so that you can display the status of public access.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Currently it is impossible to see the status of public access for item inside a list view without going to the node directly, pressing "actions", selecting "restrict public access", and seeing if something has been set (a quite tedious experience for an editor)

This PR adds a new "System Field" to the list view config which allows you to add a column for public access

![image](https://user-images.githubusercontent.com/1469061/190455652-1a75ac0d-c9ba-4964-b4b4-5004fec55186.png)


Which will give you this 

![image](https://user-images.githubusercontent.com/1469061/190455832-21160552-2a6f-412e-a0d2-c62f6a2f7ebb.png)

To test:
- Update the list view data type and add the new column
- Add public access restrictions to nodes in a list view
- Verify adding public access to a parent node also updates the status