### PR TITLE
Add "View" to context menu

### DIFF
--- a/src/Umbraco.Core/Models/Trees/View.cs
+++ b/src/Umbraco.Core/Models/Trees/View.cs
@@ -1,0 +1,29 @@
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.Models.Trees;
+
+/// <inheritdoc />
+/// <summary>
+///     Represents the view page node item
+/// </summary>
+public sealed class View : ActionMenuItem
+{
+    private const string icon = "icon-application-window-alt";
+
+    public View(string name, bool separatorBefore = false) : base("view", name)
+    {
+        Icon = icon;
+        SeparatorBefore = separatorBefore;
+        UseLegacyIcon = false;
+    }
+
+    public View(ILocalizedTextService textService, bool separatorBefore = false)
+        : base("view", textService)
+    {
+        Icon = icon;
+        SeparatorBefore = separatorBefore;
+        UseLegacyIcon = false;
+    }
+
+    public override string AngularServiceName => "umbracoMenuActions";
+}

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -321,6 +321,10 @@ public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeW
             });
         }
 
+
+        menu.Items.Add(new View(LocalizedTextService, true));
+
+
         if ((item is DocumentEntitySlim documentEntity && documentEntity.IsContainer) == false)
         {
             menu.Items.Add(new RefreshNode(LocalizedTextService, true));

--- a/src/Umbraco.Web.UI.Client/src/common/services/menuactions.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/menuactions.service.js
@@ -8,7 +8,7 @@
  * @description
  * Defines the methods that are called when menu items declare only an action to execute
  */
-function umbracoMenuActions(treeService, $location, navigationService, appState, localizationService, usersResource, umbRequestHelper, notificationsService) {
+function umbracoMenuActions(treeService, entityResource, $location, navigationService, appState, localizationService, usersResource, umbRequestHelper, notificationsService) {
     
     return {
 
@@ -78,6 +78,14 @@ function umbracoMenuActions(treeService, $location, navigationService, appState,
             }
 
             
+        },
+
+        "View" : function(args) {
+            const culture = $location.search().culture || null;
+            entityResource.getUrl(args.entity.id, "Document", culture).then(resp => {
+                window.open(window.location.origin + resp, "_blank");
+                navigationService.hideMenu();
+            });
         },
         
         /**


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


Sometimes you want to view a page whilst you are editing another page.
You're then faced with the choice of opening a new tab, navigating to the site, then finding the page you wanted to view, or saving your current edits, going to the node, and following the link on the info tab.

This PR adds a "View" option to a node's context menu so that you can avoid that.

I'm not sure if it would be prefered to have the option in a different position in the menu, or if the wording "View" is a bit ambiguous (I was trying to use something pre-existing in the language resources to avoid a translation task).

Let me know what you think.


