### PR TITLE
Ensure to reset padding and border as well for textarea in richtext

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.html
@@ -3,7 +3,7 @@
 
     <ng-form name="rteForm">
         <div class="umb-rte-editor-con">
-            <input type="text" id="{{model.alias}}" ng-focus="focus()" name="modelValue" ng-model="model.value" style="position:absolute;top:0;width:0;height:0;" />
+            <input type="text" id="{{model.alias}}" ng-focus="focus()" name="modelValue" ng-model="model.value" style="position:absolute;top:0;width:0;height:0;padding:0;border:none;" />
             <div disable-hotkeys id="{{textAreaHtmlId}}" class="umb-rte-editor" ng-style="{ width: containerWidth, height: containerHeight, overflow: containerOverflow}"></div>
         </div>
     </ng-form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed on some Umbraco 10 project that password managers in some cases focused the "hidden" textarea in richtext editor.
Not sure if there's specific reason it can't use `display:none` or `visually:hidden`.

However even width and height is set to 0 the textarea still has a size because of padding and border.


https://user-images.githubusercontent.com/2919859/190515247-b5c14576-9aaa-48b1-a4fe-c6526d211477.mp4


