### PR TITLE
Improvement ReplaceFirst function

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -1039,14 +1039,15 @@ public static class StringExtensions
             throw new ArgumentNullException(nameof(text));
         }
 
-        var pos = text.IndexOf(search, StringComparison.InvariantCulture);
+        ReadOnlySpan<char> spanText = text.AsSpan();
+        var pos = spanText.IndexOf(search, StringComparison.InvariantCulture);
 
         if (pos < 0)
         {
             return text;
         }
 
-        return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
+        return string.Concat(spanText[..pos], replace.AsSpan(), spanText[(pos + search.Length)..]);
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.Benchmarks/StringReplaceFirstBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/StringReplaceFirstBenchmarks.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Umbraco.Tests.Benchmarks.Config;
+
+namespace Umbraco.Tests.Benchmarks;
+
+[QuickRunWithMemoryDiagnoserConfig]
+public class StringReplaceFirstBenchmarks
+{
+    [Params("Test string",
+        "This is a test string that contains multiple test entries",
+        "This is a string where the searched value is very far back. The system needs to go through all of this code before it reaches the test")]
+    public string Text { get; set; }
+    public string Search { get; set; }
+    public string Replace { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Search = "test";
+        Replace = "release";
+    }
+
+    [Benchmark(Baseline = true, Description = "Replace first w/ substring")]
+    public string SubstringReplaceFirst()
+    {
+        var pos = Text.IndexOf(Search, StringComparison.InvariantCulture);
+
+        if (pos < 0)
+        {
+            return Text;
+        }
+
+        return Text.Substring(0, pos) + Replace + Text.Substring(pos + Search.Length);
+    }
+
+    [Benchmark(Description = "Replace first w/ span")]
+    public string SpanReplaceFirst()
+    {
+        var spanText = Text.AsSpan();
+        var pos = spanText.IndexOf(Search, StringComparison.InvariantCulture);
+
+        if (pos < 0)
+        {
+            return Text;
+        }
+
+        return string.Concat(spanText[..pos], Replace.AsSpan(), spanText[(pos + Search.Length)..]);
+    }
+
+    //|                       Method |                 Text |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
+    //|----------------------------- |--------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
+    //| 'Replace first w/ substring' |          Test string |  46.08 ns | 25.83 ns | 1.416 ns |  1.00 |    0.00 |      - |         - |
+    //|      'Replace first w/ span' |          Test string |  38.59 ns | 19.46 ns | 1.067 ns |  0.84 |    0.05 |      - |         - |
+    //|                              |                      |           |          |          |       |         |        |           |
+    //| 'Replace first w/ substring' |  This(...)test[134] | 407.89 ns | 52.08 ns | 2.855 ns |  1.00 |    0.00 | 0.1833 |     584 B |
+    //|      'Replace first w/ span' |  This(...)test[134] | 372.99 ns | 58.38 ns | 3.200 ns |  0.91 |    0.01 | 0.0941 |     296 B |
+    //|                              |                      |           |          |          |       |         |        |           |
+    //| 'Replace first w/ substring' | This(...)tries[57] | 113.16 ns | 27.95 ns | 1.532 ns |  1.00 |    0.00 | 0.0961 |     304 B |
+    //|      'Replace first w/ span' | This(...)tries[57] |  76.57 ns | 17.86 ns | 0.979 ns |  0.68 |    0.01 | 0.0455 |     144 B |
+}

--- a/tests/Umbraco.Tests.Benchmarks/StringReplaceManyBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/StringReplaceManyBenchmarks.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Umbraco.Tests.Benchmarks.Config;
 
@@ -13,25 +15,25 @@ public class StringReplaceManyBenchmarks
         // pick what you want to benchmark
 
         // short
-        Text = "1,2.3:4&5#6";
+        //Text = "1,2.3:4&5#6";
 
         // long
-        //Text = "Sed ut perspiciatis unde omnis iste natus &error sit voluptatem accusantium doloremque l:audantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et &quasi architecto beatae vitae ::dicta sunt explicabo. Nemo enim ipsam volupta:tem quia voluptas sit aspernatur aut o&dit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciun&t. Neque porro quisquam est, qui dolorem: ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut e:nim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi co&&nsequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse: quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?";
+        Text = "Sed ut perspiciatis unde omnis iste natus &error sit voluptatem accusantium doloremque l:audantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et &quasi architecto beatae vitae ::dicta sunt explicabo. Nemo enim ipsam volupta:tem quia voluptas sit aspernatur aut o&dit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciun&t. Neque porro quisquam est, qui dolorem: ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut e:nim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi co&&nsequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse: quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?";
 
         // short
-        Replacements = new Dictionary<string, string>
+        /*Replacements = new Dictionary<string, string>
         {
             {",", "*"},
             {".", "*"},
             {":", "*"},
             {"&", "*"},
             {"#", "*"}
-        };
+        };*/
 
         // long
-        //Replacements = new Dictionary<string, string>();
-        //for (var i = 2; i < 100; i++)
-        //    Replacements[Convert.ToChar(i).ToString()] = "*";
+        Replacements = new Dictionary<string, string>();
+        for (var i = 2; i < 500; i++)
+            Replacements[Convert.ToChar(i).ToString()] = "*";
     }
 
     // this is what v7 originally did
@@ -74,6 +76,23 @@ public class StringReplaceManyBenchmarks
 
         return result;
     }
+
+    [Benchmark(Description = "String.ReplaceMany w/chars + span")]
+    public string ReplaceManyWithSpanForLoop()
+    {
+        var result = Text;
+        var replacedCharsAsSpan = new Span<char>(ReplacedChars, 0, ReplacedChars.Length);
+
+        // ReSharper disable once LoopCanBeConvertedToQuery
+        // ReSharper disable once ForCanBeConvertedToForeach
+        for (var i = 0; i < replacedCharsAsSpan.Length; i++)
+        {
+            result = result.Replace(replacedCharsAsSpan[i], ReplacementChar);
+        }
+
+        return result;
+    }
+
     /*
 
     short text, short replacement:

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -323,4 +323,12 @@ public class StringExtensionsTests
         var output = input.ReplaceMany(toReplace.ToArray(), replacement);
         Assert.AreEqual(expected, output);
     }
+
+    [TestCase("test to test", "test", "release", "release to test")]
+    [TestCase("nothing to do", "test", "release", "nothing to do")]
+    public void ReplaceFirst(string input, string search, string replacement, string expected)
+    {
+        var output = input.ReplaceFirst(search, replacement);
+        Assert.AreEqual(expected, output);
+    }
 }


### PR DESCRIPTION
Noticed that we could decrease the amount of memory used for the ReplaceFirst function by using spans. Wrote a benchmark to confirm the findings and also wrote a test to make sure that the logic was still working as expected.

Benchmark results:
```
 |                       Method |                 Text |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
    |----------------------------- |--------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
    | 'Replace first w/ substring' |          Test string |  46.08 ns | 25.83 ns | 1.416 ns |  1.00 |    0.00 |      - |         - |
    |      'Replace first w/ span' |          Test string |  38.59 ns | 19.46 ns | 1.067 ns |  0.84 |    0.05 |      - |         - |
    |                              |                      |           |          |          |       |         |        |           |
    | 'Replace first w/ substring' |  This(...)test[134] | 407.89 ns | 52.08 ns | 2.855 ns |  1.00 |    0.00 | 0.1833 |     584 B |
    |      'Replace first w/ span' |  This(...)test[134] | 372.99 ns | 58.38 ns | 3.200 ns |  0.91 |    0.01 | 0.0941 |     296 B |
    |                              |                      |           |          |          |       |         |        |           |
    | 'Replace first w/ substring' | This(...)tries[57] | 113.16 ns | 27.95 ns | 1.532 ns |  1.00 |    0.00 | 0.0961 |     304 B |
    |      'Replace first w/ span' | This(...)tries[57] |  76.57 ns | 17.86 ns | 0.979 ns |  0.68 |    0.01 | 0.0455 |     144 B |
```