### PR TITLE
Use char instead of string for DetectJson

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -129,8 +129,7 @@ public static class StringExtensions
         }
 
         input = input.Trim();
-        return (input.StartsWith('{') && input.EndsWith('}'))
-               || (input.StartsWith('[') && input.EndsWith(']'));
+        return input[0] is '{' or '[' || input[^1] is '}' or ']';
     }
 
     public static bool DetectIsEmptyJson(this string input) =>

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -129,8 +129,8 @@ public static class StringExtensions
         }
 
         input = input.Trim();
-        return (input.StartsWith("{") && input.EndsWith("}"))
-               || (input.StartsWith("[") && input.EndsWith("]"));
+        return (input.StartsWith('{') && input.EndsWith('}'))
+               || (input.StartsWith('[') && input.EndsWith(']'));
     }
 
     public static bool DetectIsEmptyJson(this string input) =>

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -129,7 +129,7 @@ public static class StringExtensions
         }
 
         input = input.Trim();
-        return input[0] is '{' or '[' || input[^1] is '}' or ']';
+        return (input[0] is '[' && input[^1] is ']') || (input[0] is '{' && input[^1] is '}');
     }
 
     public static bool DetectIsEmptyJson(this string input) =>

--- a/tests/Umbraco.Tests.Benchmarks/DetectJsonBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/DetectJsonBenchmarks.cs
@@ -35,6 +35,21 @@ public class DetectJsonBenchmarks
                || (input.StartsWith('[') && input.EndsWith(']'));
     }
 
+    [Benchmark]
+    public bool CharRangeIndexDetectJson()
+    {
+        var input = Input.Trim();
+        return (input[0] is '[' && input[^1] is ']') || (input[0] is '{' && input[^1] is '}');
+    }
+
+    [Benchmark]
+    public bool CharRangeIndexDetectJsonBad()
+    {
+        var input = Input;
+        return input[0] is '{' or '[' || input[^1] is '}' or ']';
+    }
+
+
     //|           Method |      Mean |      Error |     StdDev | Ratio | RatioSD | Allocated |
     //|----------------- |----------:|-----------:|-----------:|------:|--------:|----------:|
     //| StringDetectJson | 96.580 ns | 285.565 ns | 15.6528 ns |  1.00 |    0.00 |         - |

--- a/tests/Umbraco.Tests.Benchmarks/DetectJsonBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/DetectJsonBenchmarks.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Umbraco.Tests.Benchmarks.Config;
+
+namespace Umbraco.Tests.Benchmarks;
+
+[QuickRunWithMemoryDiagnoserConfig]
+public class DetectJsonBenchmarks
+{
+    private string Input { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Input = "[{test: true},{test:false}]";
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool StringDetectJson()
+    {
+        var input = Input.Trim();
+        return (input.StartsWith("{") && input.EndsWith("}"))
+               || (input.StartsWith("[") && input.EndsWith("]"));
+    }
+
+    [Benchmark]
+    public bool CharDetectJson()
+    {
+        var input = Input.Trim();
+        return (input.StartsWith('{') && input.EndsWith('}'))
+               || (input.StartsWith('[') && input.EndsWith(']'));
+    }
+
+    //|           Method |      Mean |      Error |     StdDev | Ratio | RatioSD | Allocated |
+    //|----------------- |----------:|-----------:|-----------:|------:|--------:|----------:|
+    //| StringDetectJson | 96.580 ns | 285.565 ns | 15.6528 ns |  1.00 |    0.00 |         - |
+    //|   CharDetectJson |  8.846 ns |   1.220 ns |  0.0669 ns |  0.09 |    0.02 |         - |
+}

--- a/tests/Umbraco.Tests.Benchmarks/DetectJsonBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/DetectJsonBenchmarks.cs
@@ -42,6 +42,8 @@ public class DetectJsonBenchmarks
         return (input[0] is '[' && input[^1] is ']') || (input[0] is '{' && input[^1] is '}');
     }
 
+
+    //This is the fastest, however we the check will be less good than before as it'll return true on things like this: [test or {test]
     [Benchmark]
     public bool CharRangeIndexDetectJsonBad()
     {
@@ -49,9 +51,21 @@ public class DetectJsonBenchmarks
         return input[0] is '{' or '[' || input[^1] is '}' or ']';
     }
 
+    [Benchmark]
+    public bool CharDetectJsonTwoLookups()
+    {
+        var input = Input.Trim();
+        var firstChar = input[0];
+        var lastChar = input[^1];
+        return (firstChar is '[' && lastChar is ']') || (firstChar is '{' && lastChar is '}');
+    }
 
-    //|           Method |      Mean |      Error |     StdDev | Ratio | RatioSD | Allocated |
-    //|----------------- |----------:|-----------:|-----------:|------:|--------:|----------:|
-    //| StringDetectJson | 96.580 ns | 285.565 ns | 15.6528 ns |  1.00 |    0.00 |         - |
-    //|   CharDetectJson |  8.846 ns |   1.220 ns |  0.0669 ns |  0.09 |    0.02 |         - |
+
+//|                      Method |        Mean |     Error |    StdDev | Ratio | Allocated |
+//|---------------------------- |------------:|----------:|----------:|------:|----------:|
+//|            StringDetectJson | 103.7203 ns | 1.5370 ns | 0.0842 ns | 1.000 |         - |
+//|              CharDetectJson |   8.8119 ns | 1.0330 ns | 0.0566 ns | 0.085 |         - |
+//|    CharRangeIndexDetectJson |   7.8054 ns | 1.2396 ns | 0.0679 ns | 0.075 |         - |
+//| CharRangeIndexDetectJsonBad |   0.4597 ns | 0.1882 ns | 0.0103 ns | 0.004 |         - |
+//|    CharDetectJsonTwoLookups |   7.8292 ns | 1.7397 ns | 0.0954 ns | 0.075 |         - |
 }


### PR DESCRIPTION
Using chars instead of strings in the DetectJson improves the performance of the function, which will probably add up due to all the value converters using it.
```
|           Method |      Mean |      Error |     StdDev | Ratio | RatioSD | Allocated |
|----------------- |----------:|-----------:|-----------:|------:|--------:|----------:|
| StringDetectJson | 96.580 ns | 285.565 ns | 15.6528 ns |  1.00 |    0.00 |         - |
|   CharDetectJson |  8.846 ns |   1.220 ns |  0.0669 ns |  0.09 |    0.02 |         - |
```

How to test: Make sure that the value converters still work, but I don't see a reason why this would break anything.