### PR TITLE
fix: focus state for search and help icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -75,6 +75,10 @@
     align-items: center;
     height: @appHeaderHeight;
     outline: none;
+
+    .umb-icon {
+      display: block;
+    }
     
     &:focus {
         .tabbing-active & {

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -54,10 +54,9 @@
                                 >Open backoffice search</localize
                             >...
                         </span>
-                        <umb-icon
-                            icon="icon-search"
-                            class="umb-app-header__action-icon"
-                        ></umb-icon>
+                        <span class="umb-app-header__action-icon">
+                            <umb-icon icon="icon-search"></umb-icon>
+                        </span>
                     </button>
                 </li>
                 <li data-element="global-help" class="umb-app-header__action">
@@ -75,10 +74,9 @@
                                 >Open/Close backoffice help</localize
                             >...
                         </span>
-                        <umb-icon
-                            icon="icon-help-alt"
-                            class="umb-app-header__action-icon"
-                        ></umb-icon>
+                        <span class="umb-app-header__action-icon">
+                            <umb-icon icon="icon-help-alt"></umb-icon>
+                        </span>
                     </button>
                 </li>
                 <li data-element="global-user" class="umb-app-header__action">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes [Accessibility Issue 16](https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/16)

### Description
This fix required moving the icons for the search and help buttons in the main navigation into a span element. 

Steps to replicate:

Navigate to top navigation using a keyboard
Focus on the Search or Help icon  (should have the same focus state as the profile icon now)

