### PR TITLE
Missing methods from IMemberService

### DIFF
--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -99,12 +99,60 @@ public interface IMemberService : IMembershipMemberService
     /// </remarks>
     /// <param name="username">Username of the Member to create</param>
     /// <param name="email">Email of the Member to create</param>
+    /// <param name="memberTypeAlias">Alias of the MemberType the Member should be based on</param>
+    /// <returns>
+    ///     <see cref="IMember" />
+    /// </returns>
+    IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias);
+
+    /// <summary>
+    ///     Creates and persists a Member
+    /// </summary>
+    /// <remarks>
+    ///     Using this method will persist the Member object before its returned
+    ///     meaning that it will have an Id available (unlike the CreateMember method)
+    /// </remarks>
+    /// <param name="username">Username of the Member to create</param>
+    /// <param name="email">Email of the Member to create</param>
+    /// <param name="memberTypeAlias">Alias of the MemberType the Member should be based on</param>
+    /// <param name="isApproved">Whether the member is approved or not</param>
+    /// <returns>
+    ///     <see cref="IMember" />
+    /// </returns>
+    IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias, bool isApproved);
+
+    /// <summary>
+    ///     Creates and persists a Member
+    /// </summary>
+    /// <remarks>
+    ///     Using this method will persist the Member object before its returned
+    ///     meaning that it will have an Id available (unlike the CreateMember method)
+    /// </remarks>
+    /// <param name="username">Username of the Member to create</param>
+    /// <param name="email">Email of the Member to create</param>
     /// <param name="name">Name of the Member to create</param>
     /// <param name="memberTypeAlias">Alias of the MemberType the Member should be based on</param>
     /// <returns>
     ///     <see cref="IMember" />
     /// </returns>
     IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias);
+
+    /// <summary>
+    ///     Creates and persists a Member
+    /// </summary>
+    /// <remarks>
+    ///     Using this method will persist the Member object before its returned
+    ///     meaning that it will have an Id available (unlike the CreateMember method)
+    /// </remarks>
+    /// <param name="username">Username of the Member to create</param>
+    /// <param name="email">Email of the Member to create</param>
+    /// <param name="name">Name of the Member to create</param>
+    /// <param name="memberTypeAlias">Alias of the MemberType the Member should be based on</param>
+    /// <param name="isApproved">Whether the member is approved or not</param>
+    /// <returns>
+    ///     <see cref="IMember" />
+    /// </returns>
+    IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias, bool isApproved);
 
     /// <summary>
     ///     Creates and persists a Member

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -103,7 +103,8 @@ public interface IMemberService : IMembershipMemberService
     /// <returns>
     ///     <see cref="IMember" />
     /// </returns>
-    IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias);
+    IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias) =>
+        throw new NotImplementedException();
 
     /// <summary>
     ///     Creates and persists a Member
@@ -119,7 +120,8 @@ public interface IMemberService : IMembershipMemberService
     /// <returns>
     ///     <see cref="IMember" />
     /// </returns>
-    IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias, bool isApproved);
+    IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias, bool isApproved) =>
+        throw new NotImplementedException();
 
     /// <summary>
     ///     Creates and persists a Member
@@ -152,7 +154,8 @@ public interface IMemberService : IMembershipMemberService
     /// <returns>
     ///     <see cref="IMember" />
     /// </returns>
-    IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias, bool isApproved);
+    IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias, bool isApproved)
+        => throw new NotImplementedException();
 
     /// <summary>
     ///     Creates and persists a Member

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -177,7 +177,7 @@ namespace Umbraco.Cms.Core.Services
             => CreateMemberWithIdentity(username, email, username, string.Empty, memberTypeAlias);
 
         public IMember CreateMemberWithIdentity(string username, string email, string memberTypeAlias, bool isApproved)
-            => CreateMemberWithIdentity(username, email, string.Empty, string.Empty, memberTypeAlias, isApproved);
+            => CreateMemberWithIdentity(username, email, username, string.Empty, memberTypeAlias, isApproved);
 
         public IMember CreateMemberWithIdentity(string username, string email, string name, string memberTypeAlias)
             => CreateMemberWithIdentity(username, email, name, string.Empty, memberTypeAlias);


### PR DESCRIPTION
# Notes
- This is an extension of this PR: https://github.com/umbraco/Umbraco-CMS/pull/13020
- As @bjarnef pointed out, we missed a method, where a name was still passed as `string.Empty` and thus would throw exceptions. This has now been change to pass the username instead 💪
- There where several methods missing from the `IMemberService` interface, these has now been added with default implementations to avoid breaking changes

# How to test
- I tested this by calling the method from a NotificationHandler, here is the code snippet:

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

public class NotificationTest : INotificationHandler<ContentTypeSavedNotification>
{
    private readonly IMemberService _memberService;

    public NotificationTest(IMemberService memberService)
    {
        _memberService = memberService;
    }
    public void Handle(ContentTypeSavedNotification notification)
    {
        _memberService.CreateMemberWithIdentity("Nikolaj", "test@test.dk", "Member", true);
    }
}

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentTypeSavedNotification, NotificationTest>();
    }
}

```