### PR TITLE
Fix issue 13023 - Cannot read properties of undefined (reading 'allow…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/apps/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/apps/listview/listview.controller.js
@@ -9,7 +9,7 @@
 
     function propertyEditorReadonly () {
       // check for permission to update
-      return !$scope.variantContent.allowedActions.includes('A');
+      return !(typeof $scope.variantContent !== 'undefined' && $scope.variantContent.allowedActions.includes('A'));
     }
       
   }


### PR DESCRIPTION
this fixes #13023

Added check to propertyEditorReadonly() function in listview.controller.js to ensure $scope.variantContent is defined before accessing $scope.variantContent.allowedActions.

See issue 13023 for more details.

All tests checked and passed.