### PR TITLE
Redirect to a return URL if one is present on the querystring when lo…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/init.js
+++ b/src/Umbraco.Web.UI.Client/src/init.js
@@ -119,8 +119,15 @@ app.run(['$rootScope', '$route', '$location', '$cookies', 'urlHelper', 'appState
                 event.preventDefault();
                 var returnPath = null;
                 if (rejection.path == "/login" || rejection.path.startsWith("/login/")) {
+                  // Check if a ReturnUrl is present on the querystring and redirect to it if set
+                  var queryStrings = urlHelper.getQueryStringParams();
+                  if (typeof queryStrings.ReturnUrl !== 'undefined' && queryStrings.ReturnUrl.length > 0) {
+                    returnPath = queryStrings.ReturnUrl;
+                  }
+                  else {
                     //Set the current path before redirecting so we know where to redirect back to
-                    returnPath = encodeURIComponent(window.location.href.replace(window.location.origin,''));
+                    returnPath = encodeURIComponent(window.location.href.replace(window.location.origin, ''));                    
+                  }
                 }
                 $location.path(rejection.path)
                 if (returnPath) {


### PR DESCRIPTION
Fixes issue:

https://github.com/umbraco/Umbraco-CMS/issues/13011

this fixes #13011

Added logic to $routeChangeError handler in init.js to check for a ReturnURL on the querystring and if present, sets the returnRath to the ReturnURL.  This allows back office logins to redirect correctly if a ReturnURL is present which was previously being ignored.  Existing logic used when no ReturnURL is present.

Testing:

Tested that the back office login redirects to an UmbracoAuthorizedApiController controller action after login and also checked that existing back office URLs are redirected correctly after login when no RedirectURL is present.

All tests checked and passed.

See issue 13011 for more details.