### PR TITLE
UmbracoPath should no longer be configurable

### DIFF
--- a/src/JsonSchema/UmbracoJsonSchemaGenerator.cs
+++ b/src/JsonSchema/UmbracoJsonSchemaGenerator.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NJsonSchema.Generation;
+using Umbraco.Cms.Core.Configuration.Models;
 
 namespace JsonSchema
 {
@@ -43,12 +44,20 @@ namespace JsonSchema
 
             var result = await response.Content.ReadAsStringAsync();
 
-            return JsonConvert.DeserializeObject<JObject>(result)!;
+            JObject schema = JsonConvert.DeserializeObject<JObject>(result)!;
+
+            // TODO: when "UmbracoPath" is removed from the from the official schema store, remove this line as well
+            (schema.Root["definitions"]?["umbracoGlobal"]?["properties"] as JObject)?.Remove(nameof(GlobalSettings.UmbracoPath));
+
+            return schema;
         }
 
         private JObject GenerateUmbracoSchema()
         {
             NJsonSchema.JsonSchema schema = _innerGenerator.Generate(typeof(AppSettings));
+
+            // TODO: when the "UmbracoPath" setter is removed from "GlobalSettings" (scheduled for V12), remove this line as well
+            schema.Definitions["UmbracoCmsCoreConfigurationModelsGlobalSettings"]?.Properties?.Remove(nameof(GlobalSettings.UmbracoPath));
 
             return JsonConvert.DeserializeObject<JObject>(schema.ToJson())!;
         }

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -21,7 +21,6 @@ public class GlobalSettings
     internal const bool StaticHideTopLevelNodeFromPath = true;
     internal const bool StaticUseHttps = false;
     internal const int StaticVersionCheckPeriod = 7;
-    internal const string StaticUmbracoPath = Constants.System.DefaultUmbracoPath;
     internal const string StaticIconsPath = "umbraco/assets/icons";
     internal const string StaticUmbracoCssPath = "~/css";
     internal const string StaticUmbracoScriptsPath = "~/scripts";
@@ -80,8 +79,13 @@ public class GlobalSettings
     /// <summary>
     ///     Gets or sets a value for the Umbraco back-office path.
     /// </summary>
-    [DefaultValue(StaticUmbracoPath)]
-    public string UmbracoPath { get; set; } = StaticUmbracoPath;
+    public string UmbracoPath
+    {
+        get => Constants.System.DefaultUmbracoPath;
+        [Obsolete($"{nameof(UmbracoPath)}  is no longer configurable, property setter is scheduled for removal in V12")]
+        // NOTE: when removing this, also clean up the hardcoded removal of UmbracoPath in UmbracoJsonSchemaGenerator
+        set { }
+    }
 
     /// <summary>
     ///     Gets or sets a value for the Umbraco icons path.

--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -22,6 +22,7 @@ public static partial class Constants
         public static string OsLanguage = "OsLanguage";
         public static string WebServer = "WebServer";
         public static string ModelsBuilderMode = "ModelBuilderMode";
+        [Obsolete($"UmbracoPath is no longer configurable, scheduled for removal in V12")]
         public static string CustomUmbracoPath = "CustomUmbracoPath";
         public static string AspEnvironment = "AspEnvironment";
         public static string IsDebug = "IsDebug";

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
@@ -16,7 +16,6 @@ namespace Umbraco.Cms.Infrastructure.Telemetry.Providers;
 
 internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, IUserDataService
 {
-    private readonly GlobalSettings _globalSettings;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly HostingSettings _hostingSettings;
     private readonly ILocalizationService _localizationService;
@@ -25,13 +24,25 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
     private readonly IUmbracoVersion _version;
     private readonly IServerRoleAccessor _serverRoleAccessor;
 
-
+    [Obsolete($"Use the constructor that does not take an IOptionsMonitor<GlobalSettings> parameter, scheduled for removal in V12")]
     public SystemInformationTelemetryProvider(
         IUmbracoVersion version,
         ILocalizationService localizationService,
         IOptionsMonitor<ModelsBuilderSettings> modelsBuilderSettings,
         IOptionsMonitor<HostingSettings> hostingSettings,
         IOptionsMonitor<GlobalSettings> globalSettings,
+        IHostEnvironment hostEnvironment,
+        IUmbracoDatabaseFactory umbracoDatabaseFactory,
+        IServerRoleAccessor serverRoleAccessor)
+        : this(version, localizationService, modelsBuilderSettings, hostingSettings, hostEnvironment, umbracoDatabaseFactory, serverRoleAccessor)
+    {
+    }
+
+    public SystemInformationTelemetryProvider(
+        IUmbracoVersion version,
+        ILocalizationService localizationService,
+        IOptionsMonitor<ModelsBuilderSettings> modelsBuilderSettings,
+        IOptionsMonitor<HostingSettings> hostingSettings,
         IHostEnvironment hostEnvironment,
         IUmbracoDatabaseFactory umbracoDatabaseFactory,
         IServerRoleAccessor serverRoleAccessor)
@@ -42,7 +53,6 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
         _umbracoDatabaseFactory = umbracoDatabaseFactory;
         _serverRoleAccessor = serverRoleAccessor;
 
-        _globalSettings = globalSettings.CurrentValue;
         _hostingSettings = hostingSettings.CurrentValue;
         _modelsBuilderSettings = modelsBuilderSettings.CurrentValue;
     }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
@@ -57,8 +57,6 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
 
     private bool IsDebug => _hostingSettings.Debug;
 
-    private bool UmbracoPathCustomized => _globalSettings.UmbracoPath != Constants.System.DefaultUmbracoPath;
-
     private string AspEnvironment => _hostEnvironment.EnvironmentName;
 
     private string ServerOs => RuntimeInformation.OSDescription;
@@ -74,7 +72,6 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new(Constants.Telemetry.OsLanguage, CurrentCulture),
             new(Constants.Telemetry.WebServer, CurrentWebServer),
             new(Constants.Telemetry.ModelsBuilderMode, ModelsBuilderMode),
-            new(Constants.Telemetry.CustomUmbracoPath, UmbracoPathCustomized),
             new(Constants.Telemetry.AspEnvironment, AspEnvironment), new(Constants.Telemetry.IsDebug, IsDebug),
             new(Constants.Telemetry.DatabaseProvider, DatabaseProvider),
             new(Constants.Telemetry.CurrentServerRole, CurrentServerRole),

--- a/src/Umbraco.Web.UI/appsettings.template.json
+++ b/src/Umbraco.Web.UI/appsettings.template.json
@@ -24,7 +24,6 @@
       "Global": {
         "DefaultUILanguage": "en-us",
         "HideTopLevelNodeFromPath": true,
-        "UmbracoPath": "~/umbraco",
         "TimeOutInMinutes": 20,
         "UseHttps": false
       },

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -46,7 +46,6 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.OsLanguage,
             Constants.Telemetry.WebServer,
             Constants.Telemetry.ModelsBuilderMode,
-            Constants.Telemetry.CustomUmbracoPath,
             Constants.Telemetry.AspEnvironment,
             Constants.Telemetry.IsDebug,
             Constants.Telemetry.DatabaseProvider,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/GlobalSettingsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/GlobalSettingsTests.cs
@@ -16,9 +16,9 @@ public class GlobalSettingsTests
 {
     [InlineAutoMoqData("~/umbraco", "/", "umbraco")]
     [InlineAutoMoqData("~/umbraco", "/MyVirtualDir", "umbraco")]
-    [InlineAutoMoqData("~/customPath", "/MyVirtualDir/", "custompath")]
-    [InlineAutoMoqData("~/some-wacky/nestedPath", "/MyVirtualDir", "some-wacky-nestedpath")]
-    [InlineAutoMoqData("~/some-wacky/nestedPath", "/MyVirtualDir/NestedVDir/", "some-wacky-nestedpath")]
+    [InlineAutoMoqData("~/customPath", "/MyVirtualDir/", "umbraco")]
+    [InlineAutoMoqData("~/some-wacky/nestedPath", "/MyVirtualDir", "umbraco")]
+    [InlineAutoMoqData("~/some-wacky/nestedPath", "/MyVirtualDir/NestedVDir/", "umbraco")]
     public void Umbraco_Mvc_Area(
         string path,
         string rootPath,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserDataServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserDataServiceTests.cs
@@ -136,7 +136,6 @@ public class UserDataServiceTests
             localizationService,
             Mock.Of<IOptionsMonitor<ModelsBuilderSettings>>(x => x.CurrentValue == new ModelsBuilderSettings { ModelsMode = modelsMode }),
             Mock.Of<IOptionsMonitor<HostingSettings>>(x => x.CurrentValue == new HostingSettings { Debug = isDebug }),
-            Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == new GlobalSettings()),
             Mock.Of<IHostEnvironment>(),
             Mock.Of<IUmbracoDatabaseFactory>(x => x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y => y.DatabaseType == DatabaseType.SQLite)),
             Mock.Of<IServerRoleAccessor>());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
@@ -65,23 +65,6 @@ public class SystemInformationTelemetryProviderTests
     }
 
     [Test]
-    [TestCase(GlobalSettings.StaticUmbracoPath, false)]
-    [TestCase("mycustompath", true)]
-    [TestCase("~/notUmbraco", true)]
-    [TestCase("/umbraco", true)]
-    [TestCase("umbraco", true)]
-    public void ReportsCustomUmbracoPathCorrectly(string path, bool isCustom)
-    {
-        var telemetryProvider = CreateProvider(umbracoPath: path);
-
-        var usageInformation = telemetryProvider.GetInformation().ToArray();
-        var actual = usageInformation.FirstOrDefault(x => x.Name == Constants.Telemetry.CustomUmbracoPath);
-
-        Assert.NotNull(actual?.Data);
-        Assert.AreEqual(isCustom, actual.Data);
-    }
-
-    [Test]
     [TestCase("Development")]
     [TestCase("Staging")]
     [TestCase("Production")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
@@ -82,7 +82,6 @@ public class SystemInformationTelemetryProviderTests
     private SystemInformationTelemetryProvider CreateProvider(
         ModelsMode modelsMode = ModelsMode.InMemoryAuto,
         bool isDebug = true,
-        string umbracoPath = "",
         string environment = "")
     {
         var hostEnvironment = new Mock<IHostEnvironment>();
@@ -96,7 +95,6 @@ public class SystemInformationTelemetryProviderTests
             Mock.Of<ILocalizationService>(),
             Mock.Of<IOptionsMonitor<ModelsBuilderSettings>>(x => x.CurrentValue == new ModelsBuilderSettings{ ModelsMode = modelsMode }),
             Mock.Of<IOptionsMonitor<HostingSettings>>(x => x.CurrentValue == new HostingSettings { Debug = isDebug }),
-            Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == new GlobalSettings { UmbracoPath = umbracoPath }),
             hostEnvironment.Object,
             Mock.Of<IUmbracoDatabaseFactory>(x => x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y => y.DatabaseType == DatabaseType.SQLite)),
             Mock.Of<IServerRoleAccessor>());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/FileNameTests.cs
@@ -60,12 +60,8 @@ internal class FileNameTests
 
     [Test]
     [AutoMoqData]
-    public void PreviewViewExists(
-        [Frozen] IOptions<GlobalSettings> globalSettings,
-        PreviewController sut)
+    public void PreviewViewExists(PreviewController sut)
     {
-        globalSettings.Value.UmbracoPath = "/";
-
         var viewResult = sut.Index() as ViewResult;
         var fileName = GetViewName(viewResult);
 
@@ -77,13 +73,11 @@ internal class FileNameTests
     [Test]
     [AutoMoqData]
     public async Task BackOfficeDefaultExists(
-        [Frozen] IOptions<GlobalSettings> globalSettings,
         [Frozen] IHostingEnvironment hostingEnvironment,
         [Frozen] ITempDataDictionary tempDataDictionary,
         [Frozen] IRuntimeState runtimeState,
         BackOfficeController sut)
     {
-        globalSettings.Value.UmbracoPath = "/";
         Mock.Get(hostingEnvironment).Setup(x => x.ToAbsolute("/")).Returns("http://localhost/");
         Mock.Get(hostingEnvironment).SetupGet(x => x.ApplicationVirtualPath).Returns("/");
         Mock.Get(runtimeState).Setup(x => x.Level).Returns(RuntimeLevel.Run);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/RenderNoContentControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/RenderNoContentControllerTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Web.Website.Controllers;
 using Umbraco.Cms.Web.Website.Models;
+using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
 
@@ -37,7 +38,7 @@ public class RenderNoContentControllerTests
     [Test]
     public void Renders_View_When_No_Content_Published()
     {
-        const string umbracoPathSetting = "~/umbraco";
+        const string umbracoPathSetting = Constants.System.DefaultUmbracoPath;
         const string umbracoPath = "/umbraco";
         const string viewPath = "~/config/splashes/NoNodes.cshtml";
         var mockUmbracoContext = new Mock<IUmbracoContext>();
@@ -50,7 +51,6 @@ public class RenderNoContentControllerTests
 
         var globalSettings = new TestOptionsSnapshot<GlobalSettings>(new GlobalSettings
         {
-            UmbracoPath = umbracoPathSetting,
             NoNodesViewPath = viewPath,
         });
         var controller = new RenderNoContentController(new TestUmbracoContextAccessor(mockUmbracoContext.Object), globalSettings, mockHostingEnvironment.Object);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12593

### Description

This PR removes the option to configure `UmbracoPath`. 

It is a behavioural breaking change, but as the feature does not work as-is and will not be fixed, we have accepted this change.

The code changes however have been made non-breakable with a few TODOs for cleaning up obsoletes in V12.