### PR TITLE
Only contain style instead of full layout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-editor.less
@@ -1,6 +1,6 @@
 .umb-property-editor {
   position: relative;
-  contain: layout;
+  contain: style;
 }
 
 .umb-property-editor--preview {


### PR DESCRIPTION
This PR fixes problems with umb-overlay not rendering after a property-editor was changed to contain layout.

fixes #12989
