### PR TITLE
New endpoint for web profiling dashboard

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/Controllers/Profiling/ProfilingControllerBase.cs
+++ b/src/Umbraco.Cms.ManagementApi/Controllers/Profiling/ProfilingControllerBase.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using NSwag.Annotations;
+using Umbraco.New.Cms.Web.Common.Routing;
+
+namespace Umbraco.Cms.ManagementApi.Controllers.Profiling;
+
+[ApiVersion("1.0")]
+[ApiController]
+[BackOfficeRoute("api/v{version:apiVersion}/profiling")]
+[OpenApiTag("Profiling")]
+public class ProfilingControllerBase : ManagementApiControllerBase
+{
+}

--- a/src/Umbraco.Cms.ManagementApi/Controllers/Profiling/StatusProfilingController.cs
+++ b/src/Umbraco.Cms.ManagementApi/Controllers/Profiling/StatusProfilingController.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.ManagementApi.ViewModels.Profiling;
+
+namespace Umbraco.Cms.ManagementApi.Controllers.Profiling;
+
+public class StatusProfilingController : ProfilingControllerBase
+{
+    private readonly IHostingEnvironment _hosting;
+
+    public StatusProfilingController(IHostingEnvironment hosting) => _hosting = hosting;
+
+    [HttpGet("status")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(ProfilingStatusViewModel), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ProfilingStatusViewModel>> Status()
+        => await Task.FromResult(Ok(new ProfilingStatusViewModel(_hosting.IsDebugMode)));
+}

--- a/src/Umbraco.Cms.ManagementApi/OpenApi.json
+++ b/src/Umbraco.Cms.ManagementApi/OpenApi.json
@@ -253,6 +253,26 @@
           }
         }
       }
+    },
+    "/umbraco/api/v1/profiling/status": {
+      "get": {
+        "tags": [
+          "Profiling"
+        ],
+        "operationId": "StatusProfiling_Status",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfilingStatusViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -535,6 +555,15 @@
             "type": "string"
           }
         }
+      },
+      "ProfilingStatusViewModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
       }
     }
   },
@@ -544,6 +573,9 @@
     },
     {
       "name": "Server"
+    },
+    {
+      "name": "Profiling"
     },
     {
       "name": "Install"

--- a/src/Umbraco.Cms.ManagementApi/ViewModels/Profiling/ProfilingStatusViewModel.cs
+++ b/src/Umbraco.Cms.ManagementApi/ViewModels/Profiling/ProfilingStatusViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.ManagementApi.ViewModels.Profiling;
+
+public class ProfilingStatusViewModel
+{
+    public ProfilingStatusViewModel(bool enabled) => Enabled = enabled;
+
+    public bool Enabled { get; }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds the endpoint required for the "web profiling" dashboard:

### Testing this PR

Call `https://localhost:44331/umbraco/api/v1.0/profiling/status` - when running in debug mode, the response should be:

```json
{
    "enabled": true
}
```

...while not running in debug mode should yield:

```json
{
    "enabled": false
}
```
