### PR TITLE
Remove temporary workaround from schema generator

### DIFF
--- a/src/JsonSchema/UmbracoJsonSchemaGenerator.cs
+++ b/src/JsonSchema/UmbracoJsonSchemaGenerator.cs
@@ -46,9 +46,6 @@ namespace JsonSchema
 
             JObject schema = JsonConvert.DeserializeObject<JObject>(result)!;
 
-            // TODO: when "UmbracoPath" is removed from the from the official schema store, remove this line as well
-            (schema.Root["definitions"]?["umbracoGlobal"]?["properties"] as JObject)?.Remove(nameof(GlobalSettings.UmbracoPath));
-
             return schema;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The online appsettings schema https://json.schemastore.org/appsettings.json no longer has any notion of the removed `UmbracoPath` config, so we no longer need the workaround that removes it when generating our local schema.

The workaround was introduced here: https://github.com/umbraco/Umbraco-CMS/pull/13032

The completed PR for the online schema store is here: https://github.com/SchemaStore/schemastore/pull/2492

