### PR TITLE
Fix regression of active pips handling with noUiSlider

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -332,7 +332,10 @@ For extra details about options and events take a look here: https://refreshless
               activePip[handle] = pip;
             }
           });
-          activePip[handle].classList.add("noUi-value-active");
+
+          if (activePip[handle]) {
+            activePip[handle].classList.add("noUi-value-active");
+          }
         });
       }
       function addPipClickHandler(){

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbrangeslider.directive.js
@@ -322,20 +322,13 @@ For extra details about options and events take a look here: https://refreshless
             });
         }
       function setUpActivePipsHandling() {
-        let activePip = [null, null];
         sliderInstance.noUiSlider.on('update', function (values,handle) {
-          if(activePip[handle]){
-            activePip[handle].classList.remove("noUi-value-active");
-          }
           sliderInstance.querySelectorAll('.noUi-value').forEach(pip => {
+            pip.classList.remove("noUi-value-active");
             if (Number(values[handle]) === Number(pip.getAttribute('data-value'))) {
-              activePip[handle] = pip;
+              pip.classList.add("noUi-value-active");
             }
           });
-
-          if (activePip[handle]) {
-            activePip[handle].classList.add("noUi-value-active");
-          }
         });
       }
       function addPipClickHandler(){

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -54,20 +54,13 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
 
       const pips = consentSlider.querySelectorAll('.noUi-value');
 
-      let activePip = [null, null];
       consentSlider.noUiSlider.on('update', function (values,handle) {
-        if(activePip[handle]){
-          activePip[handle].classList.remove("noUi-value-active");
-        }
         consentSlider.querySelectorAll('.noUi-value').forEach(pip => {
+          pip.classList.remove("noUi-value-active");
           if (Number(values[handle]) === Number(pip.getAttribute('data-value'))) {
-            activePip[handle] = pip;
+            pip.classList.add("noUi-value-active");
           }
         });
-
-        if (activePip[handle]) {
-          activePip[handle].classList.add("noUi-value-active");
-        }
       });
 
       $(consentSlider).on('$destroy', function () {

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -64,7 +64,10 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
             activePip[handle] = pip;
           }
         });
-        activePip[handle].classList.add("noUi-value-active");
+
+        if (activePip[handle]) {
+          activePip[handle].classList.add("noUi-value-active");
+        }
       });
 
       $(consentSlider).on('$destroy', function () {


### PR DESCRIPTION
Fixes #13029 
Fixes [AB#22651](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/22651)

### Description
Earlier in 10.2 we tried to make the noUiSlider (umb-range-slider) more useful by marking the active pip (if you are using pips) with an extra class so it could be styled. This implementation did not take into account that not all pips might exist and had thus a need for an extra if-check. Upon further inspection, we were able to improve the code a bit to avoid having an intermediary variable as well.

The issue was particularly noticeable with pre-configuration of the slider data type.

With this fix it will stop throwing an immediate javascript error when configuring the slider, and it will still work even with decimals with this configuration:

```js
      "pips": {
        mode: 'count',
        density: 1,
        values: 10,
        format: {
          from: value => Number(value),
          to: value => Number(value).toFixed(1)
        }
      }
```

which results in this where you can see the active pip marked with a slightly darker color:

![Screenshot 2022-09-21 at 15 36 55](https://user-images.githubusercontent.com/752371/191520197-b12a1d31-611d-4b5e-a794-f682f6033bc1.png)

<!-- Thanks for contributing to Umbraco CMS! -->
