### PR TITLE
Removing can connect to database check so that Umbraco errors out on …

### DIFF
--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -348,5 +348,10 @@ public static partial class Constants
 
             // TODO: return a list of built in types so we can use that to prevent deletion in the uI
         }
+
+        public static class Udi
+        {
+            public const string Prefix = "umb://";
+        }
     }
 }

--- a/src/Umbraco.Core/StringUdi.cs
+++ b/src/Umbraco.Core/StringUdi.cs
@@ -14,7 +14,7 @@ public class StringUdi : Udi
     /// <param name="entityType">The entity type part of the udi.</param>
     /// <param name="id">The string id part of the udi.</param>
     public StringUdi(string entityType, string id)
-        : base(entityType, "umb://" + entityType + "/" + EscapeUriString(id)) =>
+        : base(entityType, Constants.Conventions.Udi.Prefix + entityType + "/" + EscapeUriString(id)) =>
         Id = id;
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -133,7 +133,6 @@ namespace Umbraco.Cms.Infrastructure.Install
         private bool IsBrandNewInstall =>
             _connectionStrings.CurrentValue.IsConnectionStringConfigured() == false ||
             _databaseBuilder.IsDatabaseConfigured == false ||
-            _databaseBuilder.CanConnectToDatabase == false ||
             _databaseBuilder.IsUmbracoInstalled() == false;
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -80,12 +80,6 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         public bool IsDatabaseConfigured => _databaseFactory.Configured;
 
         /// <summary>
-        /// Gets a value indicating whether it is possible to connect to the configured database.
-        /// It does not necessarily mean that Umbraco is installed, nor up-to-date.
-        /// </summary>
-        public bool CanConnectToDatabase => _databaseFactory.CanConnect;
-
-        /// <summary>
         /// Verifies whether a it is possible to connect to a database.
         /// </summary>
         public bool CanConnect(string? connectionString, string providerName)
@@ -96,7 +90,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
 
         public bool HasSomeNonDefaultUser()
         {
-            using (var scope = _scopeProvider.CreateCoreScope())
+            using (ICoreScope scope = _scopeProvider.CreateCoreScope())
             {
                 // look for the super user with default password
                 var sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql()
@@ -119,7 +113,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
 
         internal bool IsUmbracoInstalled()
         {
-            using (var scope = _scopeProvider.CreateCoreScope(autoComplete: true))
+            using (ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true))
             {
                 return _scopeAccessor.AmbientScope?.Database.IsUmbracoInstalled() ?? false;
             }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -80,6 +80,12 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         public bool IsDatabaseConfigured => _databaseFactory.Configured;
 
         /// <summary>
+        /// Gets a value indicating whether it is possible to connect to the configured database.
+        /// It does not necessarily mean that Umbraco is installed, nor up-to-date.
+        /// </summary>
+        public bool CanConnectToDatabase => _databaseFactory.CanConnect;
+
+        /// <summary>
         /// Verifies whether a it is possible to connect to a database.
         /// </summary>
         public bool CanConnect(string? connectionString, string providerName)

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -80,12 +80,6 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         public bool IsDatabaseConfigured => _databaseFactory.Configured;
 
         /// <summary>
-        /// Gets a value indicating whether it is possible to connect to the configured database.
-        /// It does not necessarily mean that Umbraco is installed, nor up-to-date.
-        /// </summary>
-        public bool CanConnectToDatabase => _databaseFactory.CanConnect;
-
-        /// <summary>
         /// Verifies whether a it is possible to connect to a database.
         /// </summary>
         public bool CanConnect(string? connectionString, string providerName)

--- a/tests/Umbraco.Tests.Benchmarks/GuidUdiBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/GuidUdiBenchmarks.cs
@@ -1,0 +1,88 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Umbraco.Cms.Core;
+using Umbraco.Tests.Benchmarks.Config;
+
+namespace Umbraco.Tests.Benchmarks
+{
+    [QuickRunWithMemoryDiagnoserConfig]
+    public class GuidUdiBenchmarks
+    {
+        private readonly Guid _guid = Guid.NewGuid();
+        private readonly string _entityType = Constants.UdiEntityType.DocumentType;
+
+        [Benchmark(Baseline = true)]
+        public Udi CurrentInit()
+        {
+            return new OldGuidUdi(_entityType, _guid);
+        }
+
+        [Benchmark()]
+        public Udi StringPolationInit()
+        {
+            return new StringPolationGuidUdi(_entityType, _guid);
+        }
+
+        [Benchmark]
+        public Udi NewInit()
+        {
+            return new NewGuidUdi(_entityType, _guid);
+        }
+
+        public class OldGuidUdi : Udi
+        {
+            public Guid Guid { get; }
+
+            public override bool IsRoot => throw new NotImplementedException();
+
+            public OldGuidUdi(string entityType, Guid guid)
+            : base(entityType, "umb://" + entityType + "/" + guid.ToString("N")) =>
+            Guid = guid;
+        }
+
+        public class StringPolationGuidUdi : Udi
+        {
+            public Guid Guid { get; }
+
+            public override bool IsRoot => throw new NotImplementedException();
+
+            public StringPolationGuidUdi(string entityType, Guid guid)
+            : base(entityType, $"umb://{entityType}/{guid:N}") =>
+            Guid = guid;
+        }
+
+        public class NewGuidUdi : Udi
+        {
+            public Guid Guid { get; }
+
+            public override bool IsRoot => throw new NotImplementedException();
+
+            public NewGuidUdi(string entityType, Guid guid) : base(entityType, GetStringValue(entityType, guid))
+            {
+                Guid = guid;
+            }
+
+            public static string GetStringValue(ReadOnlySpan<char> entityType, Guid guid)
+            {
+                var startUdiLength = Constants.Conventions.Udi.Prefix.Length;
+                var outputSize = entityType.Length + startUdiLength + 32 + 1;
+                Span<char> output = stackalloc char[outputSize];
+
+                Constants.Conventions.Udi.Prefix.CopyTo(output[..startUdiLength]);
+                entityType.CopyTo(output.Slice(startUdiLength, entityType.Length));
+                output[startUdiLength + entityType.Length] = '/';
+                guid.TryFormat(output.Slice(outputSize - 32, 32), out _, "N");
+
+                return new string(output);
+            }
+        }
+
+        // I think we are currently bottlenecked by the 'new Udi(string)' not accepting a span. If it did, then we wouldn't have to create a string mid creation and we would be able to cut back on the allocated data
+        //
+        //|             Method |     Mean |     Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
+        //|------------------- |---------:|----------:|---------:|------:|--------:|-------:|----------:|
+        //|        CurrentInit | 562.2 ns | 242.84 ns | 13.31 ns |  1.00 |    0.00 | 0.1113 |     352 B |
+        //| StringPolationInit | 589.3 ns | 530.08 ns | 29.06 ns |  1.05 |    0.07 | 0.0811 |     264 B |
+        //|            NewInit | 533.6 ns |  40.55 ns |  2.22 ns |  0.95 |    0.03 | 0.0808 |     264 B |
+    }
+}


### PR DESCRIPTION
…startup rather than trying to re-install when unable to connect to database.

### Prerequisites

https://github.com/umbraco/Umbraco-CMS/issues/13042
https://github.com/umbraco/Umbraco-CMS/issues/12949

### Description

A bug was reported that when an existing database string is present for a previously installed database, but the database is unreachable (in this case the firewall was blocking all connections), then the install screen is shown rather than a startup error.