### PR TITLE
Make sure swagger tags and operations are sorted alphabetically

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
+++ b/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
@@ -52,6 +52,10 @@ public class ManagementApiComposer : IComposer
             options.Version = ApiAllName;
             options.DocumentName = ApiAllName;
             options.Description = "This shows all APIs available in this version of Umbraco - Including all the legacy apis that is available for backward compatibility";
+            options.PostProcess = document =>
+            {
+                document.Tags = document.Tags.OrderBy(tag => tag.Name).ToList();
+            };
         });
 
         services.AddVersionedApiExplorer(options =>
@@ -113,6 +117,8 @@ public class ManagementApiComposer : IComposer
                             config.SwaggerRoutes.Clear();
                             var swaggerPath = $"{officePath}/swagger/{ApiAllName}/swagger.json";
                             config.SwaggerRoutes.Add(new SwaggerUi3Route(ApiAllName, swaggerPath));
+                            config.OperationsSorter = "alpha";
+                            config.TagsSorter = "alpha";
                         });
                     }
                 },

--- a/src/Umbraco.Cms.ManagementApi/OpenApi.json
+++ b/src/Umbraco.Cms.ManagementApi/OpenApi.json
@@ -569,16 +569,16 @@
   },
   "tags": [
     {
-      "name": "Upgrade"
-    },
-    {
-      "name": "Server"
+      "name": "Install"
     },
     {
       "name": "Profiling"
     },
     {
-      "name": "Install"
+      "name": "Server"
+    },
+    {
+      "name": "Upgrade"
     }
   ]
 }

--- a/src/Umbraco.Cms.ManagementApi/OpenApi.json
+++ b/src/Umbraco.Cms.ManagementApi/OpenApi.json
@@ -273,6 +273,65 @@
           }
         }
       }
+    },
+    "/umbraco/api/v1/published-cache/collect": {
+      "post": {
+        "tags": [
+          "PublishedCache"
+        ],
+        "operationId": "CollectPublishedCache_Collect",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/umbraco/api/v1/published-cache/rebuild": {
+      "post": {
+        "tags": [
+          "PublishedCache"
+        ],
+        "operationId": "RebuildPublishedCache_Collect",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/umbraco/api/v1/published-cache/reload": {
+      "post": {
+        "tags": [
+          "PublishedCache"
+        ],
+        "operationId": "ReloadPublishedCache_Reload",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/umbraco/api/v1/published-cache/status": {
+      "get": {
+        "tags": [
+          "PublishedCache"
+        ],
+        "operationId": "StatusPublishedCache_Status",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The paths and tags in the Swagger UI are currently unsorted. It's fine now, but as the API grows it'll be harder to find things:

![image](https://user-images.githubusercontent.com/7405322/191957848-4624b696-9b06-4f8c-9853-03778d6533eb.png)

This PR adds explicit sorting to Swagger UI and also explicit sorting to the tags of the OpenApi JSON output (unfortunately it is no longer possible so sort the paths in the OpenApi JSON output):

![image](https://user-images.githubusercontent.com/7405322/191957793-31b31b23-97d7-499f-921e-5549e85f43e4.png)

