### PR TITLE
Only display action controls to user if they can use them on a single block list

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -1,5 +1,4 @@
 <div class="umb-block-list">
-
     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
     <div class="umb-block-list__wrapper" ng-style="vm.listWrapperStyles">
@@ -19,7 +18,7 @@
                     </div>
                 </button>
 
-                <umb-block-list-row 
+                <umb-block-list-row
                     block-editor-api="vm.blockEditorApi"
                     layout="layout"
                     index="$index">
@@ -28,7 +27,7 @@
             </div>
         </div>
 
-        <div class="umb-block-list__actions" ng-if="vm.loading !== true">
+        <div class="umb-block-list__actions" ng-if="vm.loading !== true" ng-hide="vm.validationLimit.max === 1 && vm.layout.length === 1">
             <button
                     id="{{vm.model.alias}}"
                     type="button"


### PR DESCRIPTION
When limiting a block list to only allowing one element, the UI to add more still shows but allows the editor to continue editing with only help text. This PR removes the editors ability to do so, but keeps all the functionality intact

There was some discussion #12927

To test:

- Create a doctype with a block list property editor
- Limit said property editor to only allow 0 to 1 blocks
- View in content and add a block


![chrome_WKAxur4sqc](https://user-images.githubusercontent.com/29239704/192009409-5aac8314-12bb-4b42-a77c-e1343e2d2271.gif)

