### PR TITLE
Fix issue 13017 - BeginUmbracoForm doesn't work with custom umbraco routes

### DIFF
--- a/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoPipelineFilter.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoPipelineFilter.cs
@@ -35,5 +35,11 @@ public interface IUmbracoPipelineFilter
     ///     Executes after <see cref="OnPostPipeline(IApplicationBuilder)" /> just before any Umbraco endpoints are declared.
     /// </summary>
     /// <param name="app"></param>
-    void OnEndpoints(IApplicationBuilder app);
+    void OnPreEndpoints(IApplicationBuilder app);
+
+    /// <summary>
+    ///     Executes after <see cref="OnPostPipeline(IApplicationBuilder)" /> after any Umbraco endpoints are declared.
+    /// </summary>
+    /// <param name="app"></param>
+    void OnPostEndpoints(IApplicationBuilder app);
 }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -161,13 +161,23 @@ public class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoEnd
                     ApplicationServices, AppBuilder, endpoints);
             configureUmbraco(umbAppBuilder);
         });
+
+        RunPostEndpointsPipeline();
     }
 
     private void RunPreEndpointsPipeline()
     {
         foreach (IUmbracoPipelineFilter filter in _umbracoPipelineStartupOptions.Value.PipelineFilters)
         {
-            filter.OnEndpoints(AppBuilder);
+            filter.OnPreEndpoints(AppBuilder);
+        }
+    }
+
+    private void RunPostEndpointsPipeline()
+    {
+        foreach (IUmbracoPipelineFilter filter in _umbracoPipelineStartupOptions.Value.PipelineFilters)
+        {
+            filter.OnPostEndpoints(AppBuilder);
         }
     }
 }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoPipelineFilter.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoPipelineFilter.cs
@@ -20,19 +20,37 @@ public class UmbracoPipelineFilter : IUmbracoPipelineFilter
         string name,
         Action<IApplicationBuilder>? prePipeline,
         Action<IApplicationBuilder>? postPipeline,
-        Action<IApplicationBuilder>? endpointCallback)
+        Action<IApplicationBuilder>? preEndpointCallback,
+        Action<IApplicationBuilder>? postEndpointCallback = null)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         PrePipeline = prePipeline;
         PostPipeline = postPipeline;
-        Endpoints = endpointCallback;
+        PreEndpoints = preEndpointCallback;
+        PostEndpoints = postEndpointCallback;
     }
 
     public Action<IApplicationBuilder>? PrePipeline { get; set; }
 
     public Action<IApplicationBuilder>? PostPipeline { get; set; }
 
-    public Action<IApplicationBuilder>? Endpoints { get; set; }
+    // This has been retained for backward compatability
+    [Obsolete("Use PreEndpoints for adding endpoints before the Umbraco endpoints and PostEndpoints for endpoints after the Umbraco endpoints")]
+    public Action<IApplicationBuilder>? Endpoints
+    {
+        get
+        {
+            return PreEndpoints;
+        }
+        set
+        {
+            PreEndpoints = value;
+        }
+    }
+
+    public Action<IApplicationBuilder>? PreEndpoints { get; set; }
+
+    public Action<IApplicationBuilder>? PostEndpoints { get; set; }
 
     public string Name { get; }
 
@@ -40,5 +58,7 @@ public class UmbracoPipelineFilter : IUmbracoPipelineFilter
 
     public void OnPostPipeline(IApplicationBuilder app) => PostPipeline?.Invoke(app);
 
-    public void OnEndpoints(IApplicationBuilder app) => Endpoints?.Invoke(app);
+    public void OnPreEndpoints(IApplicationBuilder app) => PreEndpoints?.Invoke(app);
+
+    public void OnPostEndpoints(IApplicationBuilder app) => PostEndpoints?.Invoke(app);
 }


### PR DESCRIPTION
This fixes #13017 where a surface controller is not called when a form is submitted using a custom Umbraco route and a virtual page controller.  The order the custom endpoint is added using the composer means the endpoint is added before the surface controller endpoints are added so the custom route is being called on postback after the form is submitted rather than the surface controller (as per the example in the issue).

Interestingly, if we change it so the custom route is added in the Configure method in Startup.cs after UseWebsiteEndpoints() is called (where the surface controller routes are added) the issue goes away, but this does not help anyone using a composer (i.e. package devs or people wanting to keep their code out of Startup.cs).

```
            app.UseUmbraco()
                .WithMiddleware(u =>
                {
                    u.UseBackOffice();
                    u.UseWebsite();
                })
                .WithEndpoints(u =>
                {
                    u.UseInstallerEndpoints();
                    u.UseBackOfficeEndpoints();
                    u.UseWebsiteEndpoints();

                    u.EndpointRouteBuilder.MapControllerRoute(
                        "DemoPageController",
                        "demo",
                        new { Controller = "DemoPage", Action = "Index" });
                });
```

The problem is that the custom endpoints are being added before the Umbraco endpoints during startup in the UmbracoApplicationBuilder where RunPreEndpointsPipeline() is being called.  The fix is to create a new action for adding endpoints **after** the Umbraco endpoints so I have added two new endpoint actions in UmbracoPipelineFilter called PreEndpoints and PostEndpoints.  PreEndpoints runs before Umbraco (as it does now) and PostEndpoints runs after Umbraco, allowing routes to be added using a composer in the correct order.

The original Endpoints action in UmbracoPipelineFilter and the existing constructor have been retained to allow for backward compatibility as there is likely to be lots of existing code that will break otherwise.  The original Endpoints action just refers to PreEndpoints (which is what it was doing before running before the Umbraco endpoints are added).

You can test this by creating a home page node (no extra properties needed) with the following template:

```
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.HomePage>
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@{
	Layout = null;
}

<h1>@Model.Name</h1>

@using (Html.BeginUmbracoForm<DemoSurfaceController>("Handle"))
{
    @Html.TextBox("name")
    <input type="submit" />
}
```

Then add the following virtual page controller using a custom route which is added to the UmbracoPipelineFilter using the PostEndpoints property:

```
using Microsoft.AspNetCore.Mvc.Filters;
using Microsoft.AspNetCore.Mvc.ViewEngines;
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Cache;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Logging;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Routing;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Infrastructure.Persistence;
using Umbraco.Cms.Web.Common.ApplicationBuilder;
using Umbraco.Cms.Web.Common.Controllers;
using Umbraco.Cms.Web.Common;
using Umbraco.Cms.Web.Website.Controllers;
using Umbraco.Cms.ManagementApi.Filters;
using Umbraco.Cms.Core;

namespace Umbraco.Cms.Web.UI
{
    public class DemoComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.Services.Configure<UmbracoPipelineOptions>(options =>
            {
                options.AddFilter(new UmbracoPipelineFilter(nameof(DemoPageController))
                {
                    PostEndpoints = app => app.UseEndpoints(endpoints =>
                    {
                        endpoints.MapControllerRoute(
                            "DemoPageController",
                            "demo",
                            new { Controller = "DemoPage", Action = "Index" });
                    })
                });
            });
        }
    }

    public class DemoPageController : UmbracoPageController, IVirtualPageController
    {
        private readonly UmbracoHelper _umbracoHelper;

        public DemoPageController(
            ILogger<UmbracoPageController> logger,
            ICompositeViewEngine compositeViewEngine,
            UmbracoHelper umbracoHelper) : base(logger, compositeViewEngine) =>
            _umbracoHelper = umbracoHelper;

        public IPublishedContent? FindContent(ActionExecutingContext actionExecutingContext) =>
            _umbracoHelper.ContentAtRoot().First();

        public IActionResult Index() =>
            View("~/Views/HomePage.cshtml", CurrentPage);
    }

    public class DemoSurfaceController : SurfaceController
    {
        public DemoSurfaceController(
            IUmbracoContextAccessor umbracoContextAccessor,
            IUmbracoDatabaseFactory databaseFactory,
            ServiceContext services,
            AppCaches appCaches,
            IProfilingLogger profilingLogger,
            IPublishedUrlProvider publishedUrlProvider)
            : base(umbracoContextAccessor, databaseFactory, services, appCaches, profilingLogger, publishedUrlProvider)
        { }

        public IActionResult Handle(string name) =>
            Ok(new { name });
    }
}
```

Run Umbraco and create a home node and navigate to home, the form will show and submit to the surface controller using the normal Umbraco routing.

Now, navigate to `/demo` which is the virtual page and submit the form, it will also submit to the surface controller where as before it would just refresh the page and show the form again without executing the surface controller.

If you change the filter to run using the PreEndpoints (or the older Endpoints) the form does not submit to the surface controller:

```
    public class DemoComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.Services.Configure<UmbracoPipelineOptions>(options =>
            {
                options.AddFilter(new UmbracoPipelineFilter(nameof(DemoPageController))
                {
                    Endpoints = app => app.UseEndpoints(endpoints =>
                    {
                        endpoints.MapControllerRoute(
                            "DemoPageController",
                            "demo",
                            new { Controller = "DemoPage", Action = "Index" });
                    })
                });
            });
        }
    }
```

All tests have been run and pass.


