### PR TITLE
Disable spellcheck on password inputs

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tests/css-tests.html
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tests/css-tests.html
@@ -940,7 +940,7 @@
   <div class="span12">
     <form class="form-inline">
       <input type="text" class="span3" placeholder="Email">
-      <input type="password" class="span3" placeholder="Password">
+      <input type="password" class="span3" placeholder="Password" spellcheck="false">
       <label class="checkbox">
         <input type="checkbox"> Remember me
       </label>

--- a/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tests/forms.html
+++ b/src/Umbraco.Web.UI.Client/lib/bootstrap/less/tests/forms.html
@@ -61,7 +61,7 @@
           <hr>
 
           <label>password</label>
-          <input type="password" value="Password input">
+          <input type="password" value="Password input" spellcheck="false">
 
           <hr>
 

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
@@ -135,6 +135,7 @@
                   placeholder="umbraco-db-password"
                   required
                   ng-model="installer.current.model.password"
+                  spellcheck="false"
                 />
                 <small class="inline-help">Enter the database password</small>
               </div>

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -61,6 +61,7 @@
               required
               ng-model="installer.current.model.password"
               id="password"
+              spellcheck="false"
             />
             <small class="inline-help"
               >At least {{installer.current.model.minCharLength}} characters

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -22,7 +22,7 @@
                             <localize key="user_newPassword">New password</localize>
                             <small style="font-size: 13px;">{{vm.invitedUserPasswordModel.passwordPolicyText}}</small>
                         </label>
-                        <input type="password" ng-model="vm.invitedUserPasswordModel.password" name="password" id="umb-passwordOne" class="-full-width-input" umb-auto-focus required val-server-field="value" ng-minlength="{{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}}" />
+                        <input type="password" ng-model="vm.invitedUserPasswordModel.password" name="password" id="umb-passwordOne" class="-full-width-input" umb-auto-focus required val-server-field="value" ng-minlength="{{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}}" spellcheck="false" />
                         <span ng-messages="inviteUserPasswordForm.password.$error" show-validation-on-submit>
                             <span class="help-inline" ng-message="required"><localize key="user_passwordIsBlank">Your new password cannot be blank!</localize></span>
                             <span class="help-inline" ng-message="minlength">Minimum {{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}} characters</span>
@@ -32,7 +32,7 @@
 
                     <div class="control-group" ng-class="{error: vm.setPasswordForm.confirmPassword.$invalid}">
                         <label for="umb-confirmPasswordOne"><localize key="user_confirmNewPassword">Confirm new password</localize></label>
-                        <input type="password" ng-model="vm.invitedUserPasswordModel.confirmPassword" name="confirmPassword" id="umb-confirmPasswordOne" class="-full-width-input" required val-compare="password" />
+                        <input type="password" ng-model="vm.invitedUserPasswordModel.confirmPassword" name="confirmPassword" id="umb-confirmPasswordOne" class="-full-width-input" required val-compare="password" spellcheck="false"/>
                         <span ng-messages="inviteUserPasswordForm.confirmPassword.$error" show-validation-on-submit>
                             <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
                             <span class="help-inline" ng-message="valCompare"><localize key="user_passwordMismatch">The confirmed password doesn't match the new password!</localize></span>
@@ -156,7 +156,7 @@
 
                         <div class="control-group" ng-class="{error: vm.loginForm.password.$invalid}">
                             <label for="umb-passwordTwo"><localize key="general_password">Password</localize></label>
-                            <input type="password" ng-model="vm.password" name="password" id="umb-passwordTwo" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" aria-required="true" />
+                            <input type="password" ng-model="vm.password" name="password" id="umb-passwordTwo" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" aria-required="true" spellcheck="false"/>
                             <div class="password-toggle">
                                 <button type="button" class="btn-reset" ng-click="vm.togglePassword()">
                                     <span class="password-text show"><localize key="login_showPassword">Show password</localize></span>
@@ -226,13 +226,13 @@
 
                         <div ng-hide="vm.resetComplete" class="control-group" ng-class="{error: vm.setPasswordForm.password.$invalid}">
                             <label for="umb-passwordThree"><localize key="user_newPassword">New password</localize></label>
-                            <input type="password" ng-model="vm.password" name="password" id="umb-passwordThree" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" focus-when="{{vm.view === 'set-password'}}" ng-keyup="vm.newPasswordKeyUp($event)" />
+                            <input type="password" ng-model="vm.password" name="password" id="umb-passwordThree" class="-full-width-input" localize="placeholder" placeholder="@placeholders_password" focus-when="{{vm.view === 'set-password'}}" ng-keyup="vm.newPasswordKeyUp($event)" spellcheck="false" />
                             <umb-password-tip password-val="vm.passwordVal"></umb-password-tip>
                         </div>
 
                         <div ng-hide="vm.resetComplete" class="control-group" ng-class="{error: vm.setPasswordForm.confirmPassword.$invalid}">
                             <label for="umb-confirmPasswordThree"><localize key="user_confirmNewPassword">Confirm new password</localize></label>
-                            <input type="password" ng-model="vm.confirmPassword" name="confirmPassword" id="umb-confirmPasswordThree" class="-full-width-input" localize="placeholder" placeholder="@placeholders_confirmPassword" />
+                            <input type="password" ng-model="vm.confirmPassword" name="confirmPassword" id="umb-confirmPasswordThree" class="-full-width-input" localize="placeholder" placeholder="@placeholders_confirmPassword" spellcheck="false" />
                         </div>
 
                         <div ng-messages="vm.setPasswordForm.$error" class="control-group" ng-show="vm.setPasswordForm.$invalid">

--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -21,7 +21,9 @@
                            autocomplete="current-password"
                            required
                            val-server-field="oldPassword"
-                           no-dirty-check />
+                           no-dirty-check
+                           spellcheck="false"
+                    />
                     <span ng-messages="changePasswordForm.oldPassword.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="required">Required</span>
                         <span class="help-inline" ng-message="valServerField">{{changePasswordForm.oldPassword.errorMsg}}</span>
@@ -37,7 +39,9 @@
                            ng-model="vm.passwordValues.newPassword"
                            ng-minlength="{{vm.config.minPasswordLength}}"
                            no-dirty-check
-                           ng-keyup="vm.newPasswordKeyUp($event)" />
+                           ng-keyup="vm.newPasswordKeyUp($event)"
+                           spellcheck="false"
+                    />
                     <span ng-messages="changePasswordForm.password.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="required">Required</span>
                         <span class="help-inline" ng-message="minlength">Minimum {{vm.config.minPasswordLength}} characters</span>
@@ -51,7 +55,9 @@
                            class="input-block-level umb-textstring textstring"
                            autocomplete="new-password"
                            val-compare="newPassword"
-                           no-dirty-check />
+                           no-dirty-check
+                           spellcheck="false"
+                    />
                     <span ng-messages="changePasswordForm.confirmPassword.$error" show-validation-on-submit>
                         <span class="help-inline" ng-message="valCompare"><localize key="user_passwordMismatch">The confirmed password doesn't match the new password!</localize></span>
                     </span>


### PR DESCRIPTION
Disables spellchecking on password inputs.

## Testing

1. Run `npm build`
2. Check that spellchecking is disabled when:
	1. Creating your user in the install screen
	2. Loggin in to the CMS