### PR TITLE
Fixes: Grid property editors not loading after Umbraco 10.2.0 update

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -190,8 +190,8 @@
                 }
 
                 var contentLanguage = $scope.content.language;
-
-                var otherCreatedVariants = $scope.contentNodeModel.variants.filter(x => x.compositeId !== $scope.content.compositeId && (x.state !== "NotCreated" || x.name !== null)).length === 0;
+                var variants = $scope.contentNodeModel && $scope.contentNodeModel.variants || [];
+                var otherCreatedVariants = variants.filter(x => x.compositeId !== $scope.content.compositeId && (x.state !== "NotCreated" || x.name !== null)).length === 0;
 
                 var canEditCulture = !contentLanguage ||
                     // If the property culture equals the content culture it can be edited


### PR DESCRIPTION
Fixes #12994

Find details and testing instructions in issue description