### PR TITLE
Use the actual save function for saving the copy

### DIFF
--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -462,7 +462,8 @@ namespace Umbraco.Cms.Core.Services.Implement
 
                     copy.Name += " (copy)"; // might not be unique
                     copy.ParentId = containerId;
-                    _dataTypeRepository.Save(copy);
+
+                    Save(copy);
                     scope.Complete();
                 }
                 catch (DataOperationException<MoveOperationStatusType> ex)

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Umbraco.Cms.Core.Services.Implement
 {
@@ -441,35 +442,31 @@ namespace Umbraco.Cms.Core.Services.Implement
             return OperationResult.Attempt.Succeed(MoveOperationStatusType.Success, evtMsgs);
         }
 
-        public Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId)
+        public Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId, int userId = Constants.Security.SuperUserId)
         {
             var evtMsgs = EventMessagesFactory.Get();
 
             IDataType copy;
-            using (var scope = ScopeProvider.CreateCoreScope())
+            try
             {
-                try
+                if (containerId > 0)
                 {
-                    if (containerId > 0)
+                    var container = GetContainer(containerId);
+                    if (container is null)
                     {
-                        var container = _dataTypeContainerRepository.Get(containerId);
-                        if (container is null)
-                        {
-                            throw new DataOperationException<MoveOperationStatusType>(MoveOperationStatusType.FailedParentNotFound); // causes rollback
-                        }
+                        throw new DataOperationException<MoveOperationStatusType>(MoveOperationStatusType.FailedParentNotFound); // causes rollback
                     }
-                    copy = copying.DeepCloneWithResetIdentities();
-
-                    copy.Name += " (copy)"; // might not be unique
-                    copy.ParentId = containerId;
-
-                    Save(copy);
-                    scope.Complete();
                 }
-                catch (DataOperationException<MoveOperationStatusType> ex)
-                {
-                    return OperationResult.Attempt.Fail<MoveOperationStatusType, IDataType>(ex.Operation, evtMsgs); // causes rollback
-                }
+                copy = copying.DeepCloneWithResetIdentities();
+
+                copy.Name += " (copy)"; // might not be unique
+                copy.ParentId = containerId;
+
+                Save(copy, userId);
+            }
+            catch (DataOperationException<MoveOperationStatusType> ex)
+            {
+                return OperationResult.Attempt.Fail<MoveOperationStatusType, IDataType>(ex.Operation, evtMsgs); // causes rollback
             }
 
             return OperationResult.Attempt.Succeed(MoveOperationStatusType.Success, evtMsgs, copy);

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -107,8 +107,9 @@ public interface IDataTypeService : IService
     /// </summary>
     /// <param name="copying">The data type that will be copied</param>
     /// <param name="containerId">The container ID under where the data type will be copied</param>
+    /// <param name="userId">The user that did the Copy action</param>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
-    Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId) => throw new NotImplementedException();
+    Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId, int userId = Constants.Security.SuperUserId) => throw new NotImplementedException();
 
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Mapping;
@@ -391,7 +392,8 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 return NotFound();
             }
 
-            Attempt<OperationResult<MoveOperationStatusType, IDataType>?> result = _dataTypeService.Copy(toCopy, copy.ParentId);
+            var currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+            Attempt<OperationResult<MoveOperationStatusType, IDataType>?> result = _dataTypeService.Copy(toCopy, copy.ParentId, currentUser?.Id ?? Constants.Security.SuperUserId);
             if (result.Success)
             {
                 return Content(toCopy.Path, MediaTypeNames.Text.Plain, Encoding.UTF8);


### PR DESCRIPTION
Based on the feedback of @KevinJump in https://github.com/umbraco/Umbraco-CMS/pull/11867#issuecomment-1259178819

By using the actual Save function of the service, it'll go through all the needed notifications.