### PR TITLE
Bump Smidge up to v4.1.1

### DIFF
--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -41,8 +41,8 @@
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.2" />
-    <PackageReference Include="Smidge.InMemory" Version="4.1.0" />
-    <PackageReference Include="Smidge.Nuglify" Version="4.1.0" />
+    <PackageReference Include="Smidge.InMemory" Version="4.1.1" />
+    <PackageReference Include="Smidge.Nuglify" Version="4.1.1" />
     <PackageReference Include="Umbraco.Code" Version="2.0.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Smidge v4.1.1 updates Nuglify from v1.13.12 to v1.20.2 with tons of bug fixes for many issues some are detailed in this forum thread https://our.umbraco.com/forum/using-umbraco-and-getting-started/108469-backofficeadmin-css-smidgenuglify-error-breaking-package-styling