### PR TITLE
Add sortorder to configuration field

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System.Reflection;
@@ -125,7 +125,8 @@ public abstract class ConfigurationEditor<TConfiguration> : ConfigurationEditor
                     PropertyType = property.PropertyType,
                     Description = attribute.Description,
                     HideLabel = attribute.HideLabel,
-                    View = attributeView,
+                    SortOrder = attribute.SortOrder ?? 0,
+                    View = attributeView
                 };
 
                 fields.Add(field);
@@ -176,12 +177,17 @@ public abstract class ConfigurationEditor<TConfiguration> : ConfigurationEditor
                 field.Description = attribute.Description;
             }
 
+            if (attribute.SortOrder.HasValue)
+            {
+                field.SortOrder = attribute.SortOrder.Value;
+            }
+
             if (attribute.HideLabelSettable.HasValue)
             {
                 field.HideLabel = attribute.HideLabel;
             }
         }
 
-        return fields;
+        return fields.OrderBy(x => x.SortOrder).ToList();
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationField.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationField.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
+using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
@@ -47,6 +48,7 @@ public class ConfigurationField
         HideLabel = attribute.HideLabel;
         Key = attribute.Key;
         View = attribute.View;
+        SortOrder = attribute.SortOrder ?? 0;
     }
 
     /// <summary>
@@ -76,6 +78,12 @@ public class ConfigurationField
     /// </summary>
     [DataMember(Name = "description")]
     public string? Description { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the sort order of the field.
+    /// </summary>
+    [DataMember(Name = "sortOrder")]
+    public int SortOrder { get; set; }
 
     /// <summary>
     ///     Gets or sets a value indicating whether to hide the label of the field.

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationFieldAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationFieldAttribute.cs
@@ -120,9 +120,14 @@ public class ConfigurationFieldAttribute : Attribute
     public string? Name { get; }
 
     /// <summary>
-    ///     Gets or sets the view to use to render the field editor.
+    ///     Gets the view to use to render the field editor.
     /// </summary>
     public string? View { get; }
+
+    /// <summary>
+    ///     Gets the sort order to use to render the field editor.
+    /// </summary>
+    public int? SortOrder { get; }
 
     /// <summary>
     ///     Gets or sets the description of the field.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/discussions/13065

### Description
Added `SortOrder` property to `ConfigurationField` attribute and field.