### PR TITLE
Bump version to 7.15.10

### DIFF
--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -11,5 +11,5 @@ using System.Resources;
 
 [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyFileVersion("7.15.9")]
-[assembly: AssemblyInformationalVersion("7.15.9")]
+[assembly: AssemblyFileVersion("7.15.10")]
+[assembly: AssemblyInformationalVersion("7.15.10")]

--- a/src/Umbraco.Core/Configuration/UmbracoVersion.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoVersion.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Core.Configuration
 {
     public class UmbracoVersion
     {
-        private static readonly Version Version = new Version("7.15.9");
+        private static readonly Version Version = new Version("7.15.10");
 
         /// <summary>
         /// Gets the current version of Umbraco.

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -1030,9 +1030,9 @@ xcopy "$(ProjectDir)"..\packages\SqlServerCE.4.0.0.1\x86\*.* "$(TargetDir)x86\" 
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>7159</DevelopmentServerPort>
+          <DevelopmentServerPort>71510</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:7159</IISUrl>
+          <IISUrl>http://localhost:71510</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In the release 7.15.9, Umbraco version was not bumped in src\Umbraco.Core\Configuration\UmbracoVersion.cs.
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/13053

**Steps to reproduce**
Install Umbraco v7.15.9

The public 7.15.9 release does not update the Umbraco version in web.config to 7.15.9
With my fix, the Umbraco version in web.config is correctly updated to 7.15.9

