### PR TITLE
Fix comment of view property in `ConfigurationFieldAttribute`

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ConfigurationFieldAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationFieldAttribute.cs
@@ -106,7 +106,7 @@ public class ConfigurationFieldAttribute : Attribute
     }
 
     /// <summary>
-    ///     Gets or sets the key of the field.
+    ///     Gets the key of the field.
     /// </summary>
     /// <remarks>
     ///     When null or empty, the <see cref="ConfigurationEditor" /> should derive a key

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationFieldAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationFieldAttribute.cs
@@ -120,7 +120,7 @@ public class ConfigurationFieldAttribute : Attribute
     public string? Name { get; }
 
     /// <summary>
-    ///     Gets or sets the view to use to render the field editor.
+    ///     Gets the view to use to render the field editor.
     /// </summary>
     public string? View { get; }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Just a minor a incorrect comment I noticed when working on https://github.com/umbraco/Umbraco-CMS/pull/13075 as the `View` property is readonly.