### PR TITLE
Hide colors from icon picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -1,6 +1,6 @@
 .umb-iconpicker {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
     gap: 0.25rem;
     margin: 0;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -1,7 +1,7 @@
 .umb-iconpicker {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+    gap: 0.25rem;
     margin: 0;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -8,7 +8,6 @@
 .umb-iconpicker-item {
     display: flex;
     flex-direction: row;
-    flex: 0 0 14.28%;
     justify-content: center;
     align-items: center;
     margin-bottom: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-iconpicker.less
@@ -13,6 +13,7 @@
     align-items: center;
     margin-bottom: 0;
     overflow: hidden;
+    border: 1px solid transparent;
 }
 
 .umb-iconpicker-item button {
@@ -41,7 +42,7 @@
 
 .umb-iconpicker-item.-selected {
     background: @gray-10;
-    border: solid 1px @ui-active;
+    border-color: @ui-active;
     border-radius: @baseBorderRadius;
     box-sizing: border-box;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.controller.js
@@ -65,10 +65,9 @@ function IconPickerController($scope, localizationService, iconHelper) {
                         vm.loading = false;
                     });
             });
-
+        
         // set a default color if nothing is passed in
         vm.color = $scope.model.color ? findColor($scope.model.color) : vm.colors.find(x => x.default);
-
 
         // if an icon is passed in - preselect it
         vm.icon = $scope.model.icon ? $scope.model.icon : undefined;
@@ -76,10 +75,9 @@ function IconPickerController($scope, localizationService, iconHelper) {
 
     function setTitle() {
         if (!$scope.model.title) {
-            localizationService.localize("defaultdialogs_selectIcon")
-                .then(function(data){
-                    $scope.model.title = data;
-                });
+            localizationService.localize("defaultdialogs_selectIcon").then(data => {
+                $scope.model.title = data;
+            });
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/iconpicker/iconpicker.html
@@ -28,7 +28,7 @@
                     </umb-search-filter>
                 </div>
 
-                <div class="umb-control-group mt3">
+                <div class="umb-control-group mt3" ng-if="model.hideColors !== true">
                     <umb-color-swatches
                         use-color-class="true"
                         colors="vm.colors"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed it wasn't possible to hide colors from icon picker infinite editor. Sometimes when using this in custom property editors etc. one may not need the colors, just a icon to select.

I also noticed it "jumped" a bit on icon selection, because it add a 1px border (so it need to 1px transparent border by default - or something else to compensate the 1px solid border on selection.

Furthermore it seems the icons didn't align well for different sizes of overlay. While it may work in small overlay, it would be difficult to adjust correct for medium and large overlays also.

I have replaced this with CSS grid instead with fill the icons to its container, a bit gap between and minimum ~~70px~~ 60px width for each icon. `auto-fill` fill the container, while I noticed `auto-fit` would stretch the icon to full width when filtering for instance "umbraco".


https://user-images.githubusercontent.com/2919859/193059031-d790cc16-f079-4357-9b61-73dd73954654.mp4

I have attached the dashboard from the video above: [MyDashboard.zip](https://github.com/umbraco/Umbraco-CMS/files/9675546/MyDashboard.zip)
