### PR TITLE
Refactor event handler away from keyup to ng-change

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textarea/textarea.html
@@ -6,7 +6,7 @@
             rows="{{model.config.rows || 10}}"
             class="umb-property-editor umb-textarea textstring"
             val-server="value"
-            ng-keyup="change()"
+            ng-change="change()"
             ng-trim="false"
             ng-required="model.validation.mandatory"
             aria-required="{{model.validation.mandatory}}"


### PR DESCRIPTION
Addresses issue #13083 

When right-click pasting inside of a TextArea there is no `KeyUp` event fired, this PR introduces a change away from listing for keyup and listens for [ng-change](https://www.w3schools.com/angular/ng_ng-change.asp).


