### PR TITLE
add setDirty() logic to remove actions on mediaPicker3 property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -243,6 +243,8 @@
                     if (onSuccess) {
                         onSuccess();
                     }
+
+                    setDirty();
                 },
                 close: function () {
                     editorService.close();
@@ -291,12 +293,15 @@
             if (index !== -1) {
                 vm.model.value.splice(index, 1);
             }
+
+            setDirty();
         }
 
         function deleteAllMedias() {
             if (!vm.allowRemoveMedia) return;
 
             vm.model.value = [];
+            setDirty();
         }
 
         function setActiveMedia(mediaEntryOrNull) {


### PR DESCRIPTION
Addresses issue #13009 

the `setDirty()` logic was missing from remove-able actions, this PR adds them