### PR TITLE
added fix for ncNodeName filter in list view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-content-grid.html
@@ -23,7 +23,7 @@
             </li>
             <li class="umb-content-grid__details-item" ng-repeat="property in contentProperties">
                 <div class="umb-content-grid__details-label">{{ property.header }}:</div>
-                <div class="umb-content-grid__details-value">{{ item[property.alias] }}</div>
+                <div class="umb-content-grid__details-value">{{ item[property.alias].expression ? item[property.alias].expression({value: item[property.alias].value}) : item[property.alias] }}</div>
             </li>
         </ul>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -57,10 +57,10 @@
                     </umb-variant-state>
                 </div>
                 <div class="umb-table-cell" ng-repeat="column in vm.itemProperties track by column.alias">
-                    <span title="{{column.header}}: {{item[column.alias]}}">
+                    <span title="{{column.header}}: {{item[column.alias].expression ? item[column.alias].expression({value: item[column.alias].value}) : item[column.alias]}}">
 
                         <div ng-if="!column.isSensitive">
-                            {{item[column.alias]}}
+                            {{item[column.alias].expression ? item[column.alias].expression({value: item[column.alias].value}) : item[column.alias]}}
                         </div>
 
                         <em ng-show="column.isSensitive" class="muted">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -682,7 +682,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             }
 
             if (e.nameExp) {
-                if (e.nameTemplate.indexOf('|') > -1) {
+                if (/{{\s*\w+\|\w+\s*}}/.test(e.nameTemplate)) {
                     value = {
                       value,
                       expression: e.nameExp

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -682,7 +682,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             }
 
             if (e.nameExp) {
-                if (/{{\s*\w+\|\w+\s*}}/.test(e.nameTemplate)) {
+                if (/{{.*\s*\w+\s*\|\s*\w+\s*.*}}/.test(e.nameTemplate)) { //check whether the name template has a filter
                     value = {
                       value,
                       expression: e.nameExp

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -691,11 +691,16 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
     function resolveExpression(e, result, value, alias, retestCount) {
         var newValue = e.nameExp({ value });
-        if (newValue && newValue.startsWith('Loading...') && retestCount < 5) {
-            retestCount++;
-            $timeout(function () {
-              resolveExpression(e, result, value, alias, retestCount);
-            }, retestCount * 1000);
+        if (newValue && newValue.startsWith('Loading...')) {
+            if (retestCount === 5) {
+                newValue = "Failed to load.";
+            }
+            else {
+                retestCount++;
+                $timeout(function () {
+                  resolveExpression(e, result, value, alias, retestCount);
+                }, retestCount * 1000);
+            }
         }
         if (newValue && (newValue = newValue.trim())) {
             result[alias] = newValue;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -680,27 +680,26 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             if (isDate(value)) {
                 value = value.substring(0, value.length - 3);
             }
+
             if (e.nameExp) {
-                value = resolveExpression(e, result, value, alias, 0);
+                if (e.nameTemplate.indexOf('|') > -1) {
+                    value = {
+                      value,
+                      expression: e.nameExp
+                    };
+                }
+                else {
+                    var newValue = e.nameExp({ value });
+
+                    if (newValue && (newValue = newValue.trim())) {
+                      value = newValue;
+                    }
+                }
             }
 
             // set what we've got on the result
             result[alias] = value;
         });
-    }
-
-    function resolveExpression(e, result, value, alias, retestCount) {
-        var newValue = e.nameExp({ value });
-        if (newValue && newValue.startsWith('Loading...') && retestCount < 5) {
-            retestCount++;
-            $timeout(function () {
-              resolveExpression(e, result, value, alias, retestCount);
-            }, retestCount * 1000);
-        }
-        if (newValue && (newValue = newValue.trim())) {
-            result[alias] = newValue;
-        }
-        return newValue;
     }
 
     function isDate(val) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -680,17 +680,27 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
             if (isDate(value)) {
                 value = value.substring(0, value.length - 3);
             }
-
             if (e.nameExp) {
-                var newValue = e.nameExp({ value });
-                if (newValue && (newValue = newValue.trim())) {
-                    value = newValue;
-                }
+                value = resolveExpression(e, result, value, alias, 0);
             }
 
             // set what we've got on the result
             result[alias] = value;
         });
+    }
+
+    function resolveExpression(e, result, value, alias, retestCount) {
+        var newValue = e.nameExp({ value });
+        if (newValue && newValue.startsWith('Loading...') && retestCount < 5) {
+            retestCount++;
+            $timeout(function () {
+              resolveExpression(e, result, value, alias, retestCount);
+            }, retestCount * 1000);
+        }
+        if (newValue && (newValue = newValue.trim())) {
+            result[alias] = newValue;
+        }
+        return newValue;
     }
 
     function isDate(val) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -691,16 +691,11 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
 
     function resolveExpression(e, result, value, alias, retestCount) {
         var newValue = e.nameExp({ value });
-        if (newValue && newValue.startsWith('Loading...')) {
-            if (retestCount === 5) {
-                newValue = "Failed to load.";
-            }
-            else {
-                retestCount++;
-                $timeout(function () {
-                  resolveExpression(e, result, value, alias, retestCount);
-                }, retestCount * 1000);
-            }
+        if (newValue && newValue.startsWith('Loading...') && retestCount < 5) {
+            retestCount++;
+            $timeout(function () {
+              resolveExpression(e, result, value, alias, retestCount);
+            }, retestCount * 1000);
         }
         if (newValue && (newValue = newValue.trim())) {
             result[alias] = newValue;


### PR DESCRIPTION
### Prerequisites

- [ ] Create a doc type with a content picker property.
- [ ] Create another doc type that allows the previously created doc type as a child.
- [ ] Update parent doc type to display children in a custom list view.
- [ ] Update custom list view to display the child node's content picker data with {{value|ncNodeName}}.
- [ ] Create the parent node and a couple child nodes beneath it, making sure to set values for the content picker on the child nodes.

This fixes #9145.

### Description
The issue is that the view list doesn't replace "Loading..." with the actual value. This happens because angular filters don't work with data that is loaded asynchronously. It will show the correct values if the user leaves the page and goes back to it, since **ncNodeName** caches the data, but it doesn't help for that first visit.

To work around this problem, a timer is set to check the result of the angular expression until it changes from "Loading..." or hits the check limit (currently set to 5). Once it detects the change, it replaces the loading text with the actual value.

This is definitely a hack, but I'm not sure there is a better way to handle this. Thought about tweaking it to only apply to expressions with "ncNodeName," but I do have a couple custom asynchronous filters I use in my internal project that would also benefit from this, so I decided not to do that.

Note that the original solution for this comes from the pull request [here](https://github.com/umbraco/Umbraco-CMS/pull/11072). Only difference at the moment is that this one is implemented in an umbraco 10 environment, while the original pull request is for umbraco 8 (was asked by support team to pull it into umbraco 10 so that it could be processed).
