### PR TITLE
Added nullability attribute to IsNullOrWhitespace

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -417,7 +417,7 @@ public static class StringExtensions
     ///     empty, or consists only of white-space characters, otherwise
     ///     returns <see langword="false" />.
     /// </returns>
-    public static bool IsNullOrWhiteSpace(this string? value) => string.IsNullOrWhiteSpace(value);
+    public static bool IsNullOrWhiteSpace([NotNullWhen(false)] this string? value) => string.IsNullOrWhiteSpace(value);
     
     [return: NotNullIfNotNull("defaultValue")]
     public static string? IfNullOrWhiteSpace(this string? str, string? defaultValue) =>


### PR DESCRIPTION
The following code:
```
public void Test()
        {
            string? nullableString = null;

            if (!nullableString.IsNullOrWhiteSpace())
            {
                string test = nullableString;
            }
        }
```

Throws an error because it cannot convert `nullableString` to a `string` because it could be null. But the system should know that the string isn't null due to the `IsNullOrWhiteSpace`.

This PR fixes that. When IsNullOrWhiteSpace returns false, it will tell the system that the string cannot be null.