### PR TITLE
Don't use legacy icon for action delete

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/TemplatesTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TemplatesTreeController.cs
@@ -143,7 +143,7 @@ public class TemplatesTreeController : TreeController, ISearchableTree
         if (template.IsMasterTemplate == false)
         {
             //add delete option if it doesn't have children
-            menu.Items.Add<ActionDelete>(LocalizedTextService, hasSeparator: true, opensDialog: true);
+            menu.Items.Add<ActionDelete>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
         }
 
             //add refresh


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed from time to time when opening the action delete, the icon was sometimes missing. It seems it required `icon-icon-delete` because `useLegacyIcon` wasn't set.

In https://github.com/umbraco/Umbraco-CMS/pull/12403 this was changes so full icon name should be specified and core icons updated to use full icon name, but to be backward compatible it added the `useLecacyIcon` which is `true` by default, which mean it always requested an icon with `icon-` prefix + specified icon name.

However this was fixed here https://github.com/umbraco/Umbraco-CMS/pull/12403/files#diff-5233dfc5cb8dcc04b74ba67fc13b7c8833c80b63a76ed965e4d0d89cc7f04dcaR134 but somehow is reverted in core. I guess it has been a merge conflict somewhere, which discarded this change.

**Before**

https://user-images.githubusercontent.com/2919859/193425020-5704a441-e299-4658-81fc-56de34ecf1f4.mp4


**After**

https://user-images.githubusercontent.com/2919859/193424872-707172aa-5b93-48c5-8db3-8dbee338e274.mp4
