### PR TITLE
Adjustment of telemetry data slider

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -72,7 +72,6 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
       });
 
       pips.forEach(function (pip) {
-
         pip.addEventListener('click', function () {
           const value = pip.getAttribute('data-value');
           consentSlider.noUiSlider.set(value);
@@ -92,7 +91,8 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
   };
 
   function onChangeConsent(values) {
-    const result = Number(values[0]) - 1;
+    const result = Math.round(Number(values[0]) - 1);
+
     $scope.$apply(() => {
       setTelemetryLevelAndDescription(result);
     });

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.controller.js
@@ -1,11 +1,11 @@
-﻿(function () {
+(function () {
   "use strict";
 
   function AnalyticsController($q, analyticResource, localizationService, notificationsService) {
 
     let sliderRef = null;
 
-    var vm = this;
+    const vm = this;
     vm.getConsentLevel = getConsentLevel;
     vm.getAllConsentLevels = getAllConsentLevels;
     vm.saveConsentLevel = saveConsentLevel;
@@ -61,6 +61,7 @@
       }
 
     });
+
     function setup(slider) {
       sliderRef = slider;
     }
@@ -70,11 +71,13 @@
         vm.consentLevel = response;
       })
     }
+
     function getAllConsentLevels(){
       return analyticResource.getAllConsentLevels().then(function (response) {
         vm.consentLevels = response;
       })
     }
+
     function saveConsentLevel(){
       analyticResource.saveConsentLevel(vm.sliderVal);
       localizationService.localize("analytics_analyticsLevelSavedSuccess").then(function(value) {
@@ -83,14 +86,14 @@
     }
 
     function sliderChange(values) {
-      const result = Number(values[0]);
-      vm.sliderVal = vm.consentLevels[result - 1];
+      const result = Math.round(Number(values[0]) - 1);
+      vm.sliderVal = vm.consentLevels[result];
     }
 
     function calculateStartPositionForSlider(){
       let startPosition = vm.consentLevels.indexOf(vm.consentLevel) + 1;
-      if(startPosition === 0){
-        return 2;// Default start value
+      if (startPosition === 0) {
+         return 2;// Default start value
       }
       return startPosition;
     }

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/analytics.html
@@ -13,7 +13,7 @@
           <br>
           <br>We <b>WILL NOT</b> collect any personal data such as content, code, user information, and all data will be fully anonymized.
         </localize>
-        <div ng-if="!vm.loading" style="padding-left: 12px;padding-top: 50px; padding-bottom: 50px; width: 25%">
+        <div ng-if="!vm.loading" style="padding-left: 12px; padding-top: 50px; padding-bottom: 50px; width: 280px;">
           <umb-range-slider
             ng-model="vm.val"
             on-setup="vm.setup(slider)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR fixes a few issues with the telemetry data slider.

1. In settings dashboard when switching between the levels, the browser may add scrollbar due the length of the description, which made the slider flickering a bit between the different levels as the container width was in percentage.

2. As the slider is using smooth behaviour the value in update function returned a decimal value and therefore only showed the descriptions on the exact numeric values, but not all decimal values between, which wasn't useful when dragging the slider handle.

 