### PR TITLE
Adds additional deploy selector.

### DIFF
--- a/src/Umbraco.Core/Constants-DeploySelector.cs
+++ b/src/Umbraco.Core/Constants-DeploySelector.cs
@@ -12,5 +12,6 @@ public static partial class Constants
         public const string ThisAndDescendants = "this-and-descendants";
         public const string ChildrenOfThis = "children";
         public const string DescendantsOfThis = "descendants";
+        public const string EntitiesOfType = "entities-of-type";
     }
 }

--- a/src/Umbraco.Core/UdiRange.cs
+++ b/src/Umbraco.Core/UdiRange.cs
@@ -34,6 +34,7 @@ public class UdiRange
             case Constants.DeploySelector.DescendantsOfThis:
             case Constants.DeploySelector.ThisAndChildren:
             case Constants.DeploySelector.ThisAndDescendants:
+            case Constants.DeploySelector.EntitiesOfType:
                 Selector = selector;
                 _uriValue = new Uri(Udi + "?" + selector);
                 break;


### PR DESCRIPTION
This adds a new selector we have added to Deploy, and means for V11 we can avoid a reflection hack needed to be able to use this when constructing a `UdiRange` (as there's an exception thrown in the constructor if the provided selector isn't known by the CMS.