### PR TITLE
Use Sytem.Text.Json for ColorPickers

### DIFF
--- a/src/Umbraco.Core/Extensions/JsonExtensions.cs
+++ b/src/Umbraco.Core/Extensions/JsonExtensions.cs
@@ -23,8 +23,6 @@ namespace Umbraco.Cms.Core.Extensions
             }
         }
 
-        public static bool TryParse(object json, out JsonNode? node) => TryParse(json.ToString()!, out node);
-
         public static bool TryParse(string json, out JsonArray? array)
         {
             try
@@ -39,8 +37,6 @@ namespace Umbraco.Cms.Core.Extensions
             }
         }
 
-        public static bool TryParse(object json, out JsonArray? array) => TryParse(json.ToString()!, out array);
-
         public static bool TryParse(string json, out JsonObject? obj)
         {
             try
@@ -54,7 +50,5 @@ namespace Umbraco.Cms.Core.Extensions
                 return false;
             }
         }
-
-        public static bool TryParse(object json, out JsonObject? obj) => TryParse(json.ToString()!, out obj);
     }
 }

--- a/src/Umbraco.Core/Extensions/JsonExtensions.cs
+++ b/src/Umbraco.Core/Extensions/JsonExtensions.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace Umbraco.Cms.Core.Extensions
+{
+    public static class JsonExtensions
+    {
+        public static bool TryParse(string json, out JsonNode? node)
+        {
+            try
+            {
+                node = JsonNode.Parse(json);
+                return true;
+            }
+            catch (Exception)
+            {
+                node = null;
+                return false;
+            }
+        }
+
+        public static bool TryParse(object json, out JsonNode? node) => TryParse(json.ToString()!, out node);
+
+        public static bool TryParse(string json, out JsonArray? array)
+        {
+            try
+            {
+                array = JsonArray.Parse(json)!.AsArray();
+                return true;
+            }
+            catch (Exception)
+            {
+                array = null;
+                return false;
+            }
+        }
+
+        public static bool TryParse(object json, out JsonArray? array) => TryParse(json.ToString()!, out array);
+
+        public static bool TryParse(string json, out JsonObject? obj)
+        {
+            try
+            {
+                obj = JsonNode.Parse(json)!.AsObject();
+                return true;
+            }
+            catch (Exception)
+            {
+                obj = null;
+                return false;
+            }
+        }
+
+        public static bool TryParse(object json, out JsonObject? obj) => TryParse(json.ToString()!, out obj);
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
@@ -69,7 +69,7 @@ internal class ColorPickerConfigurationEditor : ConfigurationEditor<ColorPickerC
             return output; // oops
         }
 
-        if(!JsonExtensions.TryParse(jjj!, out JsonArray? jItems) || jItems is null)
+        if(!JsonExtensions.TryParse(jjj!.ToString()!, out JsonArray? jItems) || jItems is null)
         {
             return output;
         }
@@ -171,7 +171,7 @@ internal class ColorPickerConfigurationEditor : ConfigurationEditor<ColorPickerC
                 yield break;
             }
 
-            if (!JsonExtensions.TryParse(value!, out JsonArray? json) || json is null)
+            if (!JsonExtensions.TryParse(value.ToString()!, out JsonArray? json) || json is null)
             {
                 yield break;
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
@@ -34,13 +34,19 @@ public class ColorPickerValueConverter : PropertyValueConverterBase
         {
             try
             {
-                JObject? jo = JsonConvert.DeserializeObject<JObject>(ssource);
-                if (useLabel)
+                JsonObject json = JsonNode.Parse(ssource)!.AsObject();
+                if (json.ContainsKey("value"))
                 {
-                    return new PickedColor(jo!["value"]!.ToString(), jo["label"]!.ToString());
-                }
+                    if (useLabel)
+                    {
+                        if (json.ContainsKey("value"))
+                        {
+                            return new PickedColor(json["value"]?.GetValue<string>()!, json["label"]?.GetValue<string>()!);
+                        }
+                    }
 
-                return jo!["value"]!.ToString();
+                    return json["value"]?.GetValue<string>();
+                }
             }
             catch
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Replacing the current implementation which is using Newtonsoft with a System.Text.Json implementation as it is more perfomant.

### How to test
- On a content type create a property using the ColorPicker editor and make sure that the configuration gets saved correctly
- Call this property in a template and make sure the values are getting displayed correctly
