### PR TITLE
Listview property editor: Change Prevalue placement for "Order By"

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ListViewConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ListViewConfiguration.cs
@@ -54,9 +54,6 @@ public class ListViewConfiguration
     [ConfigurationField("pageSize", "Page Size", "number", Description = "Number of items per page")]
     public int PageSize { get; set; }
 
-    [ConfigurationField("orderBy", "Order By", "views/propertyeditors/listview/sortby.prevalues.html", Description = "The default sort order for the list")]
-    public string OrderBy { get; set; }
-
     [ConfigurationField("orderDirection", "Order Direction", "views/propertyeditors/listview/orderDirection.prevalues.html")]
     public string OrderDirection { get; set; }
 
@@ -66,6 +63,9 @@ public class ListViewConfiguration
         "views/propertyeditors/listview/includeproperties.prevalues.html",
         Description = "The properties that will be displayed for each column")]
     public Property[] IncludeProperties { get; set; }
+
+    [ConfigurationField("orderBy", "Order By", "views/propertyeditors/listview/sortby.prevalues.html", Description = "The default sort order for the list")]
+    public string OrderBy { get; set; }
 
     [ConfigurationField("layouts", "Layouts", "views/propertyeditors/listview/layouts.prevalues.html")]
     public Layout[] Layouts { get; set; }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While working with list views I found it a bit odd that I would need to choose the "Order By" field, before I had selected the columns I wish to display since if I add more columns it will give me more options to choose from in the "Order By" dropdown. Therefore I propose to place the "Order By" after the "Columns Displayed" setting.

**Before**
![listview-order-by-before](https://user-images.githubusercontent.com/1932158/193680735-be3073a4-4902-4505-ae7d-f6ab3d7a0e23.gif)

**After**
![listview-order-by-after](https://user-images.githubusercontent.com/1932158/193680027-93047bdc-cd7d-457d-b908-d229dfc13ae1.gif)
