### PR TITLE
Add input id to args in toggleValue event

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js
@@ -82,7 +82,7 @@
                 // Must wait until the current digest cycle is finished before we emit this event on init, 
                 // otherwise other property editors might not yet be ready to receive the event
                 $timeout(function () {
-                    eventsService.emit("toggleValue", { value: scope.checked });
+                    eventsService.emit("toggleValue", { value: scope.checked, inputId: scope.inputId });
                 }, 100);
             }
 
@@ -122,7 +122,7 @@
                 }
 
                 if (scope.onClick) {
-                    eventsService.emit("toggleValue", { value: !scope.checked });
+                    eventsService.emit("toggleValue", { value: !scope.checked, inputId: scope.inputId });
                     scope.onClick();
                 }
             };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js
@@ -1,7 +1,7 @@
-﻿angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiColorPickerController",
+angular.module("umbraco").controller("Umbraco.PrevalueEditors.MultiColorPickerController",
     function ($scope, angularHelper, $element, eventsService) {
 
-        var vm = this;
+        const vm = this;
 
         vm.add = add;
         vm.remove = remove;
@@ -15,10 +15,10 @@
         vm.labelEnabled = false;
         vm.editItem = null;
 
-        //NOTE: We need to make each color an object, not just a string because you cannot 2-way bind to a primitive.
-        var defaultColor = "000000";
-        var defaultLabel = null;
-
+        // NOTE: We need to make each color an object, not just a string because you cannot 2-way bind to a primitive.
+        const defaultColor = "000000";
+        const defaultLabel = null;
+        
         $scope.newColor = defaultColor;
         $scope.newLabel = defaultLabel;
         $scope.hasError = false;
@@ -48,15 +48,18 @@
                 }
             });
         }
+        
         var evts = [];
         evts.push(eventsService.on("toggleValue", function (e, args) {
             vm.labelEnabled = args.value;
         }));
+        
         $scope.$on('$destroy', function () {
             for (var e in evts) {
                 eventsService.unsubscribe(evts[e]);
             }
         });
+        
         if (!Utilities.isArray($scope.model.value)) {
             //make an array from the dictionary
             var items = [];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I was working on a project where I added a custom Button Picker property editor, which had two boolean config properties: "Multiple" and "Show Icons". When toggle this the event `toggleValue` is triggered, which also is used on core Color Picker to show/hide labels.
https://github.com/umbraco/Umbraco-CMS/blob/v10/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors/colorpicker/multicolorpicker.controller.js#L52-L54

This is fine when one only have a single toggle, but with multiple toggles in configuration, there didn't seem to be an easy way to act on the specific toggle triggering the event.

As test I added a "Multiple" property to the existing `ColorPickerConfiguration`:

```
public class ColorPickerConfiguration : ValueListConfiguration
{
    [ConfigurationField(
        "useLabel",
        "Include labels?",
        "boolean",
        Description = "Stores colors as a Json object containing both the color hex string and label, rather than just the hex string.")]
    public bool UseLabel { get; set; }

    [ConfigurationField(
        "multiple",
        "Multiple",
        "boolean",
        Description = "Test.")]
    public bool Multiple { get; set; }
}
```

As seen here both toggles show the labels in the other Colors config property.

https://user-images.githubusercontent.com/2919859/193789858-b39dc432-eb86-43fe-8e84-557290b092f5.mp4
