### PR TITLE
replace newtonsoft with system.text in MultiUrlPickerValueEditor

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -24,7 +25,7 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference
     private static readonly JsonSerializerOptions _linkDisplayJsonSerializerSettings = new()
     {
         WriteIndented = false,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     private static readonly JsonSerializerOptions _deserializeOptions = new()

--- a/src/Umbraco.Infrastructure/Serialization/UdiConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/UdiConverter.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Serialization
+{
+    public class UdiConverter : JsonConverter<Udi>
+    {
+        public override bool CanConvert(Type typeToConvert) => typeof(Udi).IsAssignableFrom(typeToConvert);
+
+        public override Udi? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            try
+            {
+                JsonElement json = JsonElement.ParseValue(ref reader);
+                Udi udi = UdiParser.Parse(json.GetString()!);
+                return udi;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, Udi value, JsonSerializerOptions options) => throw new NotImplementedException();
+    }
+}

--- a/src/Umbraco.Infrastructure/Serialization/UdiConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/UdiConverter.cs
@@ -22,6 +22,7 @@ namespace Umbraco.Cms.Infrastructure.Serialization
             }
         }
 
-        public override void Write(Utf8JsonWriter writer, Udi value, JsonSerializerOptions options) => throw new NotImplementedException();
+        public override void Write(Utf8JsonWriter writer, Udi value, JsonSerializerOptions options)
+                => writer.WriteStringValue(value?.ToString());
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Replaced Newtonsoft with System.Text.Json to make the MultiUrlPicker more performant.

### How to test
- Create a content type with a multiurlpicker, make sure that the configuration gets saved correctly
- Create a page based on this content type and try to access properties of the Multiurlpicker
