### PR TITLE
Added "loading" parameter to "umbEditorHeader" directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js
@@ -206,6 +206,7 @@ Use this directive to construct a header inside the main editor window.
 @param {boolean=} hideDescription Set to <code>true</code> to hide description.
 @param {boolean=} setpagetitle If true the page title will be set to reflect the type of data the header is working with
 @param {string=} editorfor The localization to use to aid accessibility on the edit and create screen
+@param {boolean=} loading Whether a loading indicator should be shown as part of the header.
 **/
 
 (function () {
@@ -217,8 +218,8 @@ Use this directive to construct a header inside the main editor window.
 
             scope.vm = {};
             scope.vm.dropdownOpen = false;
-            scope.vm.currentVariant = ""; 
-            scope.loading = true;
+            scope.vm.currentVariant = "";
+            scope.initializing = true;
             scope.accessibility = {};
             scope.accessibility.a11yMessage = "";
             scope.accessibility.a11yName = "";
@@ -237,12 +238,12 @@ Use this directive to construct a header inside the main editor window.
                 // to do make it work for user group create/ edit
                 // to make it work for language edit/create
                 setAccessibilityForEditorState();
-                scope.loading = false;
+                scope.initializing = false;
             } else if (scope.name) {
                 setAccessibilityForName();
-                scope.loading = false;
+                scope.initializing = false;
             } else {
-                scope.loading = false;
+                scope.initializing = false;
             }
             scope.goBack = function () {
                 if (scope.onBack) {
@@ -402,7 +403,8 @@ Use this directive to construct a header inside the main editor window.
                 onBack: "&?",
                 showBackButton: "<?",
                 editorfor: "=",
-                setpagetitle:"="
+                setpagetitle: "=",
+                loading: "="
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -1,6 +1,6 @@
-﻿<div data-element="editor-header" class="umb-editor-header" ng-class="{'-split-view-active': splitViewOpen === true}">
-    <umb-loader ng-show="loading"></umb-loader>
-    <div class="flex items-center" style="height: 100%;" ng-hide="loading">
+<div data-element="editor-header" class="umb-editor-header" ng-class="{'-split-view-active': splitViewOpen === true}">
+    <umb-loader ng-show="initializing || loading"></umb-loader>
+    <div class="flex items-center" style="height: 100%;" ng-hide="initializing">
 
         <div ng-if="showBackButton === true && splitViewOpen !== true" style="margin-right: 15px;">
             <button type="button" class="umb-editor-header__back" ng-click="goBack()">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description

![image](https://user-images.githubusercontent.com/3634580/193889570-618706e1-cd45-4881-a70b-320d8b72729b.png)

The `<umb-editor-header />` directive already contains a load indicator, but it can't really be controlled from outside of the directive. 

Showing a load indicator in the header could be useful when content within the parent `<umb-editor-view />`, so this PR adds a new `loading` parameter to the `<umb-editor-header />` .

In the current codebase, the `<umb-editor-header />` directive already defines a `loading` variable in the scope of the directive. While this is only used when the header component is being initialized, I've taken the liberty to rename the `loading` variable to `initializing` (it's not used outside of the directive). This then makes room for naming the new parameter `loading`.

### Testing

To test this PR, I've set up a small dashboard to test the new parameter. As the loading state of the header may change over time, the dashboard contains a button for enabling the loading state, and another for disabling it again.

When enabled, a blue load indicator line is shown as part of the header as shown in my screenshot earlier in this PR.

**/src/Umbraco.Web.UI/App_Plugins/Hello/package.manifest**
```json
{
    "$schema": "https://json.schemastore.org/package.manifest",
    "javascript": [
	"/App_Plugins/Hello/Dashboard.js"
    ],
    "dashboards":  [
        {
            "alias": "hello",
            "view":  "/App_Plugins/Hello/Dashboard.html",
            "sections":  [ "content" ],
            "weight": -10
        }
    ]
}
```

**/src/Umbraco.Web.UI/App_Plugins/Hello/Dashboard.js**
```javascript
(function () {
  "use strict";

  function Controller() {

    const vm = this;

    vm.title = "Hello there!";
    vm.loading = false;

  }

  angular.module("umbraco").controller("Hello.Dashboard", Controller);

})();

```

**/src/Umbraco.Web.UI/App_Plugins/Hello/Dashboard.html**
```html
<div ng-controller="Hello.Dashboard as vm" style="min-height: 350px;">
  <div style="margin: 50px; position: relative; height: 450px;">
    <umb-editor-view>
      <umb-editor-header name="vm.title"
                         name-locked="true"
                         hide-alias="true"
                         hide-description="true"
                         hide-icon="true"
                         loading="vm.loading">
      </umb-editor-header>

      <umb-editor-container>
        <p>
          <button type="button" ng-click="vm.loading = true;" ng-disabled="vm.loading === true">Enable</button>
          <button type="button" ng-click="vm.loading = false;" ng-disabled="vm.loading === false">Disable</button>
        </p>
        <p>
          Loading: {{vm.loading}}
        </p>
      </umb-editor-container>

      <umb-editor-footer>
        // footer content here
      </umb-editor-footer>
    </umb-editor-view>
  </div>
</div>
```