### PR TITLE
Use Spans in UriExtensions

### DIFF
--- a/src/Umbraco.Core/Extensions/UriExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UriExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System;
 using System.Net;
 using System.Web;
 using Umbraco.Cms.Core;
@@ -75,14 +76,14 @@ public static class UriExtensions
         }
 
         // cannot get .AbsolutePath on relative uri (InvalidOperation)
-        var s = uri.OriginalString;
+        var s = uri.OriginalString.AsSpan();
 
         // TODO: Shouldn't this just use Uri.GetLeftPart?
-        var posq = s.IndexOf("?", StringComparison.Ordinal);
-        var posf = s.IndexOf("#", StringComparison.Ordinal);
+        var posq = s.IndexOf('?');
+        var posf = s.IndexOf('#');
         var pos = posq > 0 ? posq : posf > 0 ? posf : 0;
-        var path = pos > 0 ? s.Substring(0, pos) : s;
-        return path;
+        var path = pos > 0 ? s[..pos] : s;
+        return new string(path);
     }
 
     /// <summary>
@@ -188,12 +189,12 @@ public static class UriExtensions
         }
 
         // cannot get .Query on relative uri (InvalidOperation)
-        var s = uri.OriginalString;
-        var posq = s.IndexOf("?", StringComparison.Ordinal);
-        var posf = s.IndexOf("#", StringComparison.Ordinal);
-        var query = posq < 0 ? null : (posf < 0 ? s.Substring(posq) : s.Substring(posq, posf - posq));
+        var s = uri.OriginalString.AsSpan();
+        var posq = s.IndexOf('?');
+        var posf = s.IndexOf('#');
+        var query = posq < 0 ? null : (posf < 0 ? s[posq..] : s.Slice(posq, posf - posq));
 
-        return query;
+        return new string(query);
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Benchmark for GetSafeAbsolutePath
|              Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------- |---------:|---------:|---------:|-------:|----------:|
|                 Old | 40.75 ns | 0.859 ns | 1.990 ns | 0.0048 |      40 B |
|                 New | 17.92 ns | 0.420 ns | 0.747 ns | 0.0048 |      40 B |

Benchmark for GetSafeQuery
|              Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------- |---------:|---------:|---------:|-------:|----------:|
|                 Old | 37.01 ns | 0.750 ns | 0.702 ns | 0.0038 |      32 B |
|                 New | 16.26 ns | 0.359 ns | 0.336 ns | 0.0038 |      32 B |

### How to test
- Make sure all tests are passing
