### PR TITLE
Fixes: listitem: `<li>` elements must be contained in a `<ul>` or `<ol>`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,4 +1,4 @@
-<ul role="tablist" class="umb-tabs-nav here">
+<ul role="tablist" class="umb-tabs-nav">
     <li role="tab" aria-selected="{{tab.active}}" class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
         <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" ng-disabled="tab.disabled" type="button">
             {{ tab.label }}

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,6 +1,6 @@
-<ul role="tablist" class="umb-tabs-nav">
-    <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
-        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" role="tab" ng-disabled="tab.disabled" aria-selected="{{tab.active}}" type="button">
+<ul role="tablist" class="umb-tabs-nav here">
+    <li role="tab" aria-selected="{{tab.active}}" class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
+        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" ng-disabled="tab.disabled" type="button">
             {{ tab.label }}
             <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,4 +1,4 @@
-<ul role="tablist" class="umb-tabs-nav">
+<ul role="tablist" class="umb-tabs-nav"> 
     <li role="tab" aria-selected="{{tab.active}}" class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
         <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" ng-disabled="tab.disabled" type="button">
             {{ tab.label }}

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,4 +1,4 @@
-<ul role="tablist" class="umb-tabs-nav"> 
+<ul role="tablist" class="umb-tabs-nav">
     <li role="tab" aria-selected="{{tab.active}}" class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
         <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" ng-disabled="tab.disabled" type="button">
             {{ tab.label }}


### PR DESCRIPTION
### Prerequisites

https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/27

### Description
Moved the role and aria-selected from the buttons to the child listitem elements to conform with the expectation that tablist child elements have a role of tab. This change will apply to all of the section tab navigation items.


<!-- Thanks for contributing to Umbraco CMS! -->
