### PR TITLE
Fix equality check on property group

### DIFF
--- a/src/Umbraco.Core/Models/PropertyGroup.cs
+++ b/src/Umbraco.Core/Models/PropertyGroup.cs
@@ -133,7 +133,7 @@ public class PropertyGroup : EntityBase, IEquatable<PropertyGroup>
     }
 
     public bool Equals(PropertyGroup? other) =>
-        base.Equals(other) && (other != null && Type == other.Type && Alias == other.Alias);
+        base.Equals(other) || (other != null && Type == other.Type && Alias == other.Alias && Id == other.Id);
 
     public override int GetHashCode() => (base.GetHashCode(), Type, Alias).GetHashCode();
 

--- a/src/Umbraco.Core/Models/PropertyGroup.cs
+++ b/src/Umbraco.Core/Models/PropertyGroup.cs
@@ -2,6 +2,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+
 using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Models;
@@ -132,7 +133,7 @@ public class PropertyGroup : EntityBase, IEquatable<PropertyGroup>
     }
 
     public bool Equals(PropertyGroup? other) =>
-        base.Equals(other) || (other != null && Type == other.Type && Alias == other.Alias);
+        base.Equals(other) && (other != null && Type == other.Type && Alias == other.Alias);
 
     public override int GetHashCode() => (base.GetHashCode(), Type, Alias).GetHashCode();
 

--- a/src/Umbraco.Core/Models/PropertyTypeCollection.cs
+++ b/src/Umbraco.Core/Models/PropertyTypeCollection.cs
@@ -30,7 +30,7 @@ public class PropertyTypeCollection : KeyedCollection<string, IPropertyType>, IN
     // This baseclass calling is needed, else compiler will complain about nullability
 
     /// <inheritdoc />
-    public bool IsReadOnly => ((ICollection<IPropertyType>)this).IsReadOnly;
+    public bool IsReadOnly => false;
 
     // 'new' keyword is required! we can explicitly implement ICollection<IPropertyType>.Add BUT since normally a concrete PropertyType type
     // is passed in, the explicit implementation doesn't get called, this ensures it does get called.


### PR DESCRIPTION
Also fix circular reference on PropertyTypeCollection

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #12945 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This change should fix equality checks on the PropertyGroup model. The check was insufficient, causing changes in the backoffice to get lost on occasion. While debugging, I also stumbled upon what seemed like a circular reference (visual studio crashed while attempting to read the property), so I fixed that as well.

Steps to test:
 - Create a document type with a property group "Content" and a property "My property" and Save
 - Refresh the browser and notice that the property has properly saved
 - Now delete the property group and add a new one with the name "Content" and a property "My other property" and save
 - Refresh the browser and notice that the property has properly saved whereas it previously wouldn't have been.

<!-- Thanks for contributing to Umbraco CMS! -->
