### PR TITLE
fix: remove unnesessary focus states from users list and card view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
@@ -12,16 +12,8 @@
     user-select: none;
 }
 
-.umb-user-card:hover,
-.umb-user-card:focus {
-    outline: none;
-    text-decoration: none !important;
-}
 
-.umb-user-card.-selectable {
-    cursor: pointer;
-}
-.umb-user-card.-selected, .umb-user-card.-selectable:hover {
+.umb-user-card__select {
     &::before {
         content: "";
         position: absolute;
@@ -31,17 +23,25 @@
         right: -2px;
         bottom: -2px;
         border-radius: 5px;
-        pointer-events: none;
         border: 2px solid @ui-selected-border;
         box-shadow: 0 0 4px 0 darken(@ui-selected-border, 20), inset 0 0 2px 0 darken(@ui-selected-border, 20);
+        opacity: 0;
     }
 }
-.umb-user-card.-selectable:hover {
+
+.umb-user-card__select:hover {
     &::before {
         opacity: .33;
     }
 }
-.umb-user-card.-selected:hover {
+
+.umb-user-card__select.-selected {
+    &::before {
+        opacity: 1;
+    }
+}
+
+.umb-user-card__select.-selected:hover {
     &::before {
         opacity: .75;
     }
@@ -61,6 +61,9 @@
 }
 
 .umb-user-card__goToUser {
+    position: relative;
+    z-index: 3;
+
     &:hover, &:focus {
         text-decoration: none;
 

--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-table.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-table.less
@@ -14,6 +14,8 @@
     }
 
     .umb-table-cell a {
+      position: relative;
+      z-index: 3;
 
         &:hover, &:focus {
             .umb-avatar {
@@ -24,7 +26,7 @@
     
     .umb-table-body .umb-table-cell.umb-table__name {
         a {
-            display: flex;
+          position: relative;
         }
     }
     .umb-table-cell.umb-table__name a {
@@ -33,32 +35,7 @@
         }
     }
     
-    .umb-user-table-row {
-        .umb-checkmark {
-            visibility: hidden;
-        }
-    }
-    
-    &.-has-selection {
-        .umb-user-table-row.-selectable {
-            .umb-checkmark {
-                visibility: visible;
-            }
-        }
-    }
-    
-    .umb-user-table-row.-selectable:hover {
-        .umb-checkmark {
-            visibility: visible;
-        }
-    }
-    
-    .umb-user-table-row.-selected {
-        
-        .umb-checkmark {
-            visibility: visible;
-        }
-        
+    .umb-user-table-row__select {
         &::before {
             content: "";
             position: absolute;
@@ -69,8 +46,25 @@
             bottom: 1px;
             border: 2px solid @ui-selected-border;
             box-shadow: 0 0 2px 0 fade(@ui-selected-border, 80%);
-            pointer-events: none;
+            opacity: 0;
+        }
+
+        &:hover {
+            &::before {
+                opacity:.33;
+            }
         }
     }
-    
+
+    .umb-user-table-row__select.-selected {
+        &::before {
+          opacity: 1;
+        }
+
+          &:hover {
+            &::before {
+              opacity: .66;
+            }
+        }
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -186,7 +186,7 @@
 
         <!-- Layout: Cards -->
         <div class="umb-user-cards" ng-if="vm.activeLayout.path === '1' && vm.loading === false">
-            <div class="umb-user-card umb-outline umb-outline--surrounding" ng-class="{'-selected': user.selected, '-selectable': vm.isSelectable(user)}" ng-repeat="user in vm.users track by user.key" ng-click="vm.selectUser(user, $event)">
+            <div class="umb-user-card" ng-repeat="user in vm.users track by user.key">
                 <div class="umb-user-card__content">
                     <umb-badge class="umb-user-card__badge" size="xs" ng-if="user.userDisplayState.key !== 'Active'" color="{{user.userDisplayState.color}}">
                         {{ user.userDisplayState.name }}
@@ -215,6 +215,9 @@
                         </div>
                     </div>
                 </div>
+                <button type="button" class="btn-reset umb-user-card__select umb-outline umb-outline--surrounding" ng-class="{'-selected': user.selected}" ng-if="vm.isSelectable(user)"  ng-click="vm.selectUser(user, $event)">
+                  <span class="sr-only">Select {{user.name}}</span>
+                </button>
             </div>
         </div>
 
@@ -237,11 +240,9 @@
                 </div>
                 <div class="umb-table-body">
                     <div ng-repeat="user in vm.users track by user.key"
-                        ng-click="vm.selectUser(user, vm.selection, $event)"
-                        ng-class="{'-selected': user.selected, '-selectable': vm.isSelectable(user)}"
-                        class="umb-table-row umb-user-table-row umb-outline umb-outline--surrounding">
+                        class="umb-table-row umb-user-table-row">
                         <div class="umb-table-cell umb-user-table-col-avatar not-fixed" scope="row" style="width: 70px; padding:10px 15px;">
-                            <a ng-click="vm.clickUser(user, $event)" ng-href="#{{::vm.getEditPath(user)}}">
+                            <a ng-click="vm.clickUser(user, $event)" ng-href="#{{::vm.getEditPath(user)}}" tabindex="-1">
                                 <umb-avatar
                                     size="xs"
                                     color="secondary"
@@ -268,6 +269,9 @@
                                 {{ user.userDisplayState.name }}
                             </umb-badge>
                         </div>
+                        <button type="button" class="btn-reset umb-user-table-row__select umb-outline umb-outline--surrounding" ng-class="{'-selected': user.selected}" ng-if="vm.isSelectable(user)" ng-click="vm.selectUser(user, vm.selection, $event)">
+                          <span class="sr-only">Select {{user.name}}</span>
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
This PR fixes https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/65 

## Before

When using keyboard navigating to select a user card (or row when in list view), an redundant tab focus exists for the card associated with the current logged in user. It is not possible to select your own user in this way, so there should be a focus state for it.

Card View
![user-focus-state-before](https://user-images.githubusercontent.com/6573613/194373578-226527e5-9819-4403-8647-242303b332c7.gif)

List View
![user-row-focus-state-before](https://user-images.githubusercontent.com/6573613/194373609-cd3b2466-9bce-4861-a283-dad079e8ade3.gif)

## After

I have updated the cards and the table rows to use a concept as describe in this article https://inclusive-components.design/cards/

This creates an actual button for the focus functionality and uses a pseudo element to expand the focus / click area. In addition for the table row row I have disabled the ability to focus on the first available link in the row (the avatar icon) so that there is only one link accessibly via the keyboard, and it has an accessible name. This helps to reduce duplication when using keyboard navigation, but doesn't affect the mouse experience. I have also updated the hover state to make it clearer when a person is going to select a card / table row, and when they will be linked to the users profile page.

Card View
![user-focus-state-after](https://user-images.githubusercontent.com/6573613/194373657-f427ee31-c92c-4933-abd7-b348b256aafb.gif)

List View
![user-row-focus-state-after](https://user-images.githubusercontent.com/6573613/194373698-cf7ebe4f-2027-4980-a2ac-69923aadfb98.gif)

## Extra
It was out of the remit of the PR, but I did notice some UX quirks where it isn't quite clear that you're not able to select your own user. @nielslyngsoe I wonder if this is something that needs a little UX treatment, such as updated the `Selected x or y` value to not include the logged in user, and also maybe have something displayed on the logged in users card / table row to make is clear that they can't select themselves.

