### PR TITLE
Use System.Text.Json to improve ImageCropperTemplateExtensions

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateExtensions.cs
@@ -1,6 +1,5 @@
-using System.Globalization;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
@@ -11,10 +10,9 @@ namespace Umbraco.Extensions;
 /// </summary>
 public static class ImageCropperTemplateExtensions
 {
-    private static readonly JsonSerializerSettings ImageCropperValueJsonSerializerSettings = new()
+    private static readonly JsonSerializerOptions _imageCropperValueJsonSerializerSettings = new()
     {
-        Culture = CultureInfo.InvariantCulture,
-        FloatParseHandling = FloatParseHandling.Decimal,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
     internal static ImageCropperValue DeserializeImageCropperValue(this string json)
@@ -26,7 +24,7 @@ public static class ImageCropperTemplateExtensions
             try
             {
                 imageCrops =
-                    JsonConvert.DeserializeObject<ImageCropperValue>(json, ImageCropperValueJsonSerializerSettings);
+                    JsonSerializer.Deserialize<ImageCropperValue>(json, _imageCropperValueJsonSerializerSettings);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Making use of System.Text.Json in the ImageCropperTemplateExtensions in order to make the function faster and use less memory

### How to test
Make sure the tests are green
