### PR TITLE
V11: Using IFileProvider to access assets added from packages

### DIFF
--- a/src/Umbraco.Core/Configuration/Grid/GridConfig.cs
+++ b/src/Umbraco.Core/Configuration/Grid/GridConfig.cs
@@ -1,8 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Core.Configuration.Grid;
 
@@ -13,9 +16,27 @@ public class GridConfig : IGridConfig
         IManifestParser manifestParser,
         IJsonSerializer jsonSerializer,
         IHostingEnvironment hostingEnvironment,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IGridEditorsConfigFileProviderFactory gridEditorsConfigFileProviderFactory)
         => EditorsConfig =
-        new GridEditorsConfig(appCaches, hostingEnvironment, manifestParser, jsonSerializer, loggerFactory.CreateLogger<GridEditorsConfig>());
+            new GridEditorsConfig(appCaches, hostingEnvironment, manifestParser, jsonSerializer, loggerFactory.CreateLogger<GridEditorsConfig>(), gridEditorsConfigFileProviderFactory);
+
+    [Obsolete("Use other ctor - Will be removed in Umbraco 13")]
+    public GridConfig(
+        AppCaches appCaches,
+        IManifestParser manifestParser,
+        IJsonSerializer jsonSerializer,
+        IHostingEnvironment hostingEnvironment,
+        ILoggerFactory loggerFactory)
+        : this(
+              appCaches,
+              manifestParser,
+              jsonSerializer,
+              hostingEnvironment,
+              loggerFactory,
+              StaticServiceProvider.Instance.GetRequiredService<IGridEditorsConfigFileProviderFactory>())
+    {
+    }
 
     public IGridEditorsConfig EditorsConfig { get; }
 }

--- a/src/Umbraco.Core/IO/IGridEditorsConfigFileProviderFactory.cs
+++ b/src/Umbraco.Core/IO/IGridEditorsConfigFileProviderFactory.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Umbraco.Cms.Core.IO;
+
+/// <summary>
+///     Factory for creating <see cref="IFileProvider" /> instances for providing the grid.editors.config.js file.
+/// </summary>
+public interface IGridEditorsConfigFileProviderFactory : IFileProviderFactory
+{
+}

--- a/src/Umbraco.Core/IO/IManifestFileProviderFactory.cs
+++ b/src/Umbraco.Core/IO/IManifestFileProviderFactory.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Umbraco.Cms.Core.IO;
+
+/// <summary>
+///     Factory for creating <see cref="IFileProvider" /> instances for providing the package.manifest file.
+/// </summary>
+public interface IManifestFileProviderFactory : IFileProviderFactory
+{
+}

--- a/src/Umbraco.Web.BackOffice/Controllers/TourController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TourController.cs
@@ -1,16 +1,21 @@
 using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Tour;
 using Umbraco.Cms.Web.Common.Attributes;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Web.BackOffice.Controllers;
 
@@ -21,21 +26,41 @@ public class TourController : UmbracoAuthorizedJsonController
     private readonly IContentTypeService _contentTypeService;
     private readonly TourFilterCollection _filters;
     private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly IWebHostEnvironment _webHostEnvironment;
     private readonly TourSettings _tourSettings;
 
+    [ActivatorUtilitiesConstructor]
+    public TourController(
+        TourFilterCollection filters,
+        IHostingEnvironment hostingEnvironment,
+        IOptionsSnapshot<TourSettings> tourSettings,
+        IBackOfficeSecurityAccessor backofficeSecurityAccessor,
+        IContentTypeService contentTypeService,
+        IWebHostEnvironment webHostEnvironment)
+    {
+        _filters = filters;
+        _hostingEnvironment = hostingEnvironment;
+        _tourSettings = tourSettings.Value;
+        _backofficeSecurityAccessor = backofficeSecurityAccessor;
+        _contentTypeService = contentTypeService;
+        _webHostEnvironment = webHostEnvironment;
+    }
+
+    [Obsolete("Use other ctor - Will be removed in Umbraco 13")]
     public TourController(
         TourFilterCollection filters,
         IHostingEnvironment hostingEnvironment,
         IOptionsSnapshot<TourSettings> tourSettings,
         IBackOfficeSecurityAccessor backofficeSecurityAccessor,
         IContentTypeService contentTypeService)
+        : this(
+              filters,
+              hostingEnvironment,
+              tourSettings,
+              backofficeSecurityAccessor,
+              contentTypeService,
+              StaticServiceProvider.Instance.GetRequiredService<IWebHostEnvironment>())
     {
-        _filters = filters;
-        _hostingEnvironment = hostingEnvironment;
-
-        _tourSettings = tourSettings.Value;
-        _backofficeSecurityAccessor = backofficeSecurityAccessor;
-        _contentTypeService = contentTypeService;
     }
 
     public async Task<IEnumerable<BackOfficeTourFile>> GetTours()
@@ -53,69 +78,55 @@ public class TourController : UmbracoAuthorizedJsonController
             return result;
         }
 
-        //get all filters that will be applied to all tour aliases
+        // Get all filters that will be applied to all tour aliases
         var aliasOnlyFilters = _filters.Where(x => x.PluginName == null && x.TourFileName == null).ToList();
 
-        //don't pass in any filters for core tours that have a plugin name assigned
+        // Don't pass in any filters for core tours that have a plugin name assigned
         var nonPluginFilters = _filters.Where(x => x.PluginName == null).ToList();
 
-        //add core tour files
-        IEnumerable<string> embeddedTourNames = GetType()
-            .Assembly
-            .GetManifestResourceNames()
-            .Where(x => x.StartsWith("Umbraco.Cms.Web.BackOffice.EmbeddedResources.Tours."));
 
-        foreach (var embeddedTourName in embeddedTourNames)
+        // Get core tour files
+        IFileProvider toursProvider = new EmbeddedFileProvider(GetType().Assembly, "Umbraco.Cms.Web.BackOffice.EmbeddedResources.Tours");
+
+        IEnumerable<IFileInfo> embeddedTourFiles = toursProvider.GetDirectoryContents(string.Empty)
+                                    .Where(x => !x.IsDirectory && x.Name.EndsWith(".json"));
+
+        foreach (var embeddedTour in embeddedTourFiles)
         {
-            await TryParseTourFile(embeddedTourName, result, nonPluginFilters, aliasOnlyFilters, async x => await GetContentFromEmbeddedResource(x));
+            using Stream stream = embeddedTour.CreateReadStream();
+            await TryParseTourFile(embeddedTour.Name, result, nonPluginFilters, aliasOnlyFilters, stream);
         }
 
+        // Collect all tour files from packages - /App_Plugins physical or virtual locations
+        IEnumerable<Tuple<IFileInfo, string>> toursFromPackages = GetTourFiles(_webHostEnvironment.WebRootFileProvider, Constants.SystemDirectories.AppPlugins);
 
-        //collect all tour files in packages
-        var appPlugins = _hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.AppPlugins);
-        if (Directory.Exists(appPlugins))
+        foreach (var tuple in toursFromPackages)
         {
-            foreach (var plugin in Directory.EnumerateDirectories(appPlugins))
+            string pluginName = tuple.Item2;
+            var pluginFilters = _filters.Where(x => x.PluginName != null && x.PluginName.IsMatch(pluginName)).ToList();
+
+            // Combine matched package filters with filters not specific to a package
+            var combinedFilters = nonPluginFilters.Concat(pluginFilters).ToList();
+
+            IFileInfo tourFile = tuple.Item1;
+            using (Stream stream = tourFile.CreateReadStream())
             {
-                var pluginName = Path.GetFileName(plugin.TrimEnd(Constants.CharArrays.Backslash));
-                var pluginFilters = _filters.Where(x => x.PluginName != null && x.PluginName.IsMatch(pluginName))
-                    .ToList();
-
-                //If there is any filter applied to match the plugin only (no file or tour alias) then ignore the plugin entirely
-                var isPluginFiltered = pluginFilters.Any(x => x.TourFileName == null && x.TourAlias == null);
-                if (isPluginFiltered)
-                {
-                    continue;
-                }
-
-                //combine matched package filters with filters not specific to a package
-                var combinedFilters = nonPluginFilters.Concat(pluginFilters).ToList();
-
-                foreach (var backofficeDir in Directory.EnumerateDirectories(plugin, "backoffice"))
-                {
-                    foreach (var tourDir in Directory.EnumerateDirectories(backofficeDir, "tours"))
-                    {
-                        foreach (var tourFile in Directory.EnumerateFiles(tourDir, "*.json"))
-                        {
-                            await TryParseTourFile(
-                                tourFile,
-                                result,
-                                combinedFilters,
-                                aliasOnlyFilters,
-                                async x => await System.IO.File.ReadAllTextAsync(x),
-                                pluginName);
-                        }
-                    }
-                }
+                await TryParseTourFile(
+                    tourFile.Name,
+                    result,
+                    combinedFilters,
+                    aliasOnlyFilters,
+                    stream,
+                    pluginName);
             }
         }
 
-        //Get all allowed sections for the current user
+        // Get all allowed sections for the current user
         var allowedSections = user.AllowedSections.ToList();
 
         var toursToBeRemoved = new List<BackOfficeTourFile>();
 
-        //Checking to see if the user has access to the required tour sections, else we remove the tour
+        // Checking to see if the user has access to the required tour sections, else we remove the tour
         foreach (BackOfficeTourFile backOfficeTourFile in result)
         {
             if (backOfficeTourFile.Tours != null)
@@ -140,21 +151,63 @@ public class TourController : UmbracoAuthorizedJsonController
         return result.Except(toursToBeRemoved).OrderBy(x => x.FileName, StringComparer.InvariantCultureIgnoreCase);
     }
 
-    private async Task<string> GetContentFromEmbeddedResource(string fileName)
+    private IEnumerable<Tuple<IFileInfo, string>> GetTourFiles(IFileProvider fileProvider, string folder)
     {
-        Stream? resourceStream = GetType().Assembly.GetManifestResourceStream(fileName);
+        IEnumerable<IFileInfo> pluginFolders = fileProvider.GetDirectoryContents(folder).Where(x => x.IsDirectory);
 
-        if (resourceStream is null)
+        foreach (IFileInfo pluginFolder in pluginFolders)
         {
-            return string.Empty;
-        }
+            var pluginFilters = _filters.Where(x => x.PluginName != null && x.PluginName.IsMatch(pluginFolder.Name)).ToList();
 
-        using var reader = new StreamReader(resourceStream, Encoding.UTF8);
-        return await reader.ReadToEndAsync();
+            // If there is any filter applied to match the plugin only (no file or tour alias) then ignore the plugin entirely
+            var isPluginFiltered = pluginFilters.Any(x => x.TourFileName == null && x.TourAlias == null);
+            if (isPluginFiltered)
+            {
+                continue;
+            }
+
+            // get the full virtual path for the plugin folder
+            var pluginFolderPath = WebPath.Combine(folder, pluginFolder.Name);
+
+            // loop through the folder(s) in order to find tours
+            //  - there could be multiple on case sensitive file system
+            foreach (var subDir in GetToursFolderPaths(fileProvider, pluginFolderPath))
+            {
+                IEnumerable<IFileInfo> tourFiles = fileProvider
+                    .GetDirectoryContents(subDir)
+                    .Where(x => !string.IsNullOrEmpty(x.PhysicalPath))
+                    .Where(x => x.Name.InvariantEndsWith(".json"));
+
+                foreach (IFileInfo file in tourFiles)
+                {
+                    yield return new Tuple<IFileInfo, string>(file, pluginFolder.Name);
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetToursFolderPaths(IFileProvider fileProvider, string path)
+    {
+        IEnumerable<IFileInfo> directories = fileProvider.GetDirectoryContents(path).Where(x => x.IsDirectory);
+
+        foreach (IFileInfo directory in directories)
+        {
+            var virtualPath = WebPath.Combine(path, directory.Name);
+
+            if (directory.Name.InvariantEquals("tours"))
+            {
+                yield return virtualPath;
+            }
+
+            foreach (var nested in GetToursFolderPaths(fileProvider, virtualPath))
+            {
+                yield return nested;
+            }
+        }
     }
 
     /// <summary>
-    ///     Gets a tours for a specific doctype
+    ///     Gets a tours for a specific doctype.
     /// </summary>
     /// <param name="doctypeAlias">The documenttype alias</param>
     /// <returns>A <see cref="BackOfficeTour" /></returns>
@@ -190,7 +243,7 @@ public class TourController : UmbracoAuthorizedJsonController
         ICollection<BackOfficeTourFile> result,
         List<BackOfficeTourFilter> filters,
         List<BackOfficeTourFilter> aliasOnlyFilters,
-        Func<string, Task<string>> fileNameToFileContent,
+        Stream fileStream,
         string? pluginName = null)
     {
         var fileName = Path.GetFileNameWithoutExtension(tourFile);
@@ -199,24 +252,25 @@ public class TourController : UmbracoAuthorizedJsonController
             return;
         }
 
-        //get the filters specific to this file
+        // Get the filters specific to this file
         var fileFilters = filters.Where(x => x.TourFileName != null && x.TourFileName.IsMatch(fileName)).ToList();
 
-        //If there is any filter applied to match the file only (no tour alias) then ignore the file entirely
+        // If there is any filter applied to match the file only (no tour alias) then ignore the file entirely
         var isFileFiltered = fileFilters.Any(x => x.TourAlias == null);
         if (isFileFiltered)
         {
             return;
         }
 
-        //now combine all aliases to filter below
+        // Now combine all aliases to filter below
         var aliasFilters = aliasOnlyFilters.Concat(filters.Where(x => x.TourAlias != null))
             .Select(x => x.TourAlias)
             .ToList();
 
         try
         {
-            var contents = await fileNameToFileContent(tourFile);
+            using var reader = new StreamReader(fileStream, Encoding.UTF8);
+            var contents = reader.ReadToEnd();
             BackOfficeTour[]? tours = JsonConvert.DeserializeObject<BackOfficeTour[]>(contents);
 
             IEnumerable<BackOfficeTour>? backOfficeTours = tours?.Where(x =>
@@ -234,7 +288,7 @@ public class TourController : UmbracoAuthorizedJsonController
                 Tours = localizedTours ?? new List<BackOfficeTour>()
             };
 
-            //don't add if all of the tours are filtered
+            // Don't add if all of the tours are filtered
             if (tour.Tours.Any())
             {
                 result.Add(tour);

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Infrastructure.DependencyInjection;
 using Umbraco.Cms.Infrastructure.Examine.DependencyInjection;
 using Umbraco.Cms.Infrastructure.WebAssets;
 using Umbraco.Cms.Web.BackOffice.Controllers;
+using Umbraco.Cms.Web.BackOffice.FileProviders;
 using Umbraco.Cms.Web.BackOffice.Filters;
 using Umbraco.Cms.Web.BackOffice.Install;
 using Umbraco.Cms.Web.BackOffice.Middleware;
@@ -112,6 +113,10 @@ public static partial class UmbracoBuilderExtensions
                 hostingEnvironment.ToAbsolute(path)
             );
         });
+
+        builder.Services.AddSingleton<WebRootFileProviderFactory>();
+        builder.Services.AddSingleton<IManifestFileProviderFactory>(factory => factory.GetRequiredService<WebRootFileProviderFactory>());
+        builder.Services.AddSingleton<IGridEditorsConfigFileProviderFactory>(factory => factory.GetRequiredService<WebRootFileProviderFactory>());
 
         builder.Services.AddUnique<IIconService, IconService>();
         builder.Services.AddUnique<IConflictingRouteService, ConflictingRouteService>();

--- a/src/Umbraco.Web.BackOffice/FileProviders/WebRootFileProviderFactory.cs
+++ b/src/Umbraco.Web.BackOffice/FileProviders/WebRootFileProviderFactory.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Web.BackOffice.FileProviders;
+
+public class WebRootFileProviderFactory : IManifestFileProviderFactory, IGridEditorsConfigFileProviderFactory
+{
+    private readonly IWebHostEnvironment _webHostEnvironment;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebRootFileProviderFactory"/> class.
+    /// </summary>
+    /// <param name="webHostEnvironment">The web hosting environment an application is running in.</param>
+    public WebRootFileProviderFactory(IWebHostEnvironment webHostEnvironment)
+    {
+        _webHostEnvironment = webHostEnvironment;
+    }
+
+    /// <summary>
+    ///     Creates a new <see cref="IFileProvider" /> instance, pointing at <see cref="WebRootPath"/>.
+    /// </summary>
+    /// <returns>
+    ///     The newly created <see cref="IFileProvider" /> instance.
+    /// </returns>
+    public IFileProvider Create() => _webHostEnvironment.WebRootFileProvider;
+}

--- a/src/Umbraco.Web.BackOffice/Services/IconService.cs
+++ b/src/Umbraco.Web.BackOffice/Services/IconService.cs
@@ -165,7 +165,8 @@ public class IconService : IIconService
         foreach (IFileInfo pluginDirectory in fileProvider.GetDirectoryContents(path).Where(x => x.IsDirectory))
         {
             // Iterate through the sub directories of each plugin folder
-            foreach (IFileInfo subDir1 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}").Where(x => x.IsDirectory))
+            // Hard-coding the "backoffice" directory name to gain a better performance when traversing the pluginDirectory directories
+            foreach (IFileInfo subDir1 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}").Where(x => x.IsDirectory && x.Name.InvariantEquals("backoffice")))
             {
                 // Iterate through second level sub directories
                 foreach (IFileInfo subDir2 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}/{subDir1.Name}").Where(x => x.IsDirectory))

--- a/src/Umbraco.Web.BackOffice/Services/IconService.cs
+++ b/src/Umbraco.Web.BackOffice/Services/IconService.cs
@@ -34,7 +34,6 @@ public class IconService : IIconService
     {
     }
 
-    [Obsolete("Use other ctor - Will be removed in Umbraco 12")]
     public IconService(
         IOptionsMonitor<GlobalSettings> globalSettings,
         IHostingEnvironment hostingEnvironment,
@@ -163,32 +162,14 @@ public class IconService : IIconService
     {
         // Iterate through all plugin folders, this is necessary because on Linux we'll get casing issues when
         // we directly try to access {path}/{pluginDirectory.Name}/{Constants.SystemDirectories.PluginIcons}
-        foreach (IFileInfo pluginDirectory in fileProvider.GetDirectoryContents(path))
+        foreach (IFileInfo pluginDirectory in fileProvider.GetDirectoryContents(path).Where(x => x.IsDirectory))
         {
-            // Ideally there shouldn't be any files, but we'd better check to be sure
-            if (!pluginDirectory.IsDirectory)
-            {
-                continue;
-            }
-
             // Iterate through the sub directories of each plugin folder
-            foreach (IFileInfo subDir1 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}"))
+            foreach (IFileInfo subDir1 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}").Where(x => x.IsDirectory))
             {
-                // Skip files again
-                if (!subDir1.IsDirectory)
-                {
-                    continue;
-                }
-
                 // Iterate through second level sub directories
-                foreach (IFileInfo subDir2 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}/{subDir1.Name}"))
+                foreach (IFileInfo subDir2 in fileProvider.GetDirectoryContents($"{path}/{pluginDirectory.Name}/{subDir1.Name}").Where(x => x.IsDirectory))
                 {
-                    // Skip files again
-                    if (!subDir2.IsDirectory)
-                    {
-                        continue;
-                    }
-
                     // Does the directory match the plugin icons folder? (case insensitive for legacy support)
                     if (!$"/{subDir1.Name}/{subDir2.Name}".InvariantEquals(Constants.SystemDirectories.PluginIcons))
                     {

--- a/src/Umbraco.Web.BackOffice/Trees/MemberGroupTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberGroupTreeController.cs
@@ -20,8 +20,7 @@ public class MemberGroupTreeController : MemberTypeAndGroupTreeControllerBase
 {
     private readonly IMemberGroupService _memberGroupService;
 
-    [
-        ActivatorUtilitiesConstructor]
+    [ActivatorUtilitiesConstructor]
     public MemberGroupTreeController(
         ILocalizedTextService localizedTextService,
         UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/ManifestParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/ManifestParserTests.cs
@@ -47,7 +47,8 @@ public class ManifestParserTests
             new JsonNetSerializer(),
             Mock.Of<ILocalizedTextService>(),
             Mock.Of<IShortStringHelper>(),
-            Mock.Of<IDataValueEditorFactory>());
+            Mock.Of<IDataValueEditorFactory>(),
+            Mock.Of<IManifestFileProviderFactory>());
     }
 
     private ManifestParser _parser;


### PR DESCRIPTION
## Details
- In this PR, tours, icons, _package.manifest_ and _grid.editors.config.js_ files are considered;

## Test