### PR TITLE
implement flag on notification

### DIFF
--- a/src/Umbraco.Core/Notifications/ContentPublishedNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentPublishedNotification.cs
@@ -17,6 +17,10 @@ public sealed class ContentPublishedNotification : EnumerableObjectNotification<
         : base(target, messages)
     {
     }
-
+    public ContentPublishedNotification(IEnumerable<IContent> target, EventMessages messages, bool includeDescandants) : base(target, messages)
+    {
+        includeDescandants = includeDescandants;
+    }
     public IEnumerable<IContent> PublishedEntities => Target;
+    public bool IncludeDescendants { get; set; }
 }

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2162,7 +2162,7 @@ public class ContentService : RepositoryService, IContentService
             // (SaveAndPublishBranchOne does *not* do it)
             scope.Notifications.Publish(
                 new ContentTreeChangeNotification(document, TreeChangeTypes.RefreshBranch, eventMessages));
-            scope.Notifications.Publish(new ContentPublishedNotification(publishedDocuments, eventMessages));
+            scope.Notifications.Publish(new ContentPublishedNotification(publishedDocuments, eventMessages, true));
 
             scope.Complete();
         }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
If descendants are already published and do not require refreshing, Umbraco will not return information about sub nodes that should be republished as well, which causes an interesting issue as then if custom action has to happen on all subtree, we can't detect if we should do it.

<!-- Thanks for contributing to Umbraco CMS! -->
