### PR TITLE
V10: Fix request accessor memory leak

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlRequestBeginNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlRequestBeginNotificationHandler.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore;
 /// Notification handler which will listen to the <see cref="UmbracoRequestBeginNotification"/>, and ensure that
 /// the applicationUrl is set on the first request.
 /// </summary>
-public class ApplicationUrlRequestBeginNotificationHandler : INotificationHandler<UmbracoRequestBeginNotification>
+internal class ApplicationUrlRequestBeginNotificationHandler : INotificationHandler<UmbracoRequestBeginNotification>
 {
     private readonly IRequestAccessor _requestAccessor;
 

--- a/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlRequestBeginNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlRequestBeginNotificationHandler.cs
@@ -1,0 +1,26 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Web.Common.AspNetCore;
+
+/// <summary>
+/// Notification handler which will listen to the <see cref="UmbracoRequestBeginNotification"/>, and ensure that
+/// the applicationUrl is set on the first request.
+/// </summary>
+public class ApplicationUrlRequestBeginNotificationHandler : INotificationHandler<UmbracoRequestBeginNotification>
+{
+    private readonly IRequestAccessor _requestAccessor;
+
+    public ApplicationUrlRequestBeginNotificationHandler(IRequestAccessor requestAccessor) =>
+        _requestAccessor = requestAccessor;
+
+    public void Handle(UmbracoRequestBeginNotification notification)
+    {
+        // If someone has replaced the AspNetCoreRequestAccessor we'll do nothing and assume they handle it themselves.
+        if (_requestAccessor is AspNetCoreRequestAccessor accessor)
+        {
+            accessor.EnsureApplicationUrl();
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
@@ -58,7 +58,7 @@ public class AspNetCoreRequestAccessor : IRequestAccessor, INotificationHandler<
     /// Ensure that the ApplicationUrl is set on the first request, this is using a LazyInitializer, so the code will only be run the first time
     /// </summary>
     /// TODO: This doesn't belong here, the GetApplicationUrl doesn't belong to IRequestAccessor
-    public void EnsureApplicationUrl() =>
+    internal void EnsureApplicationUrl() =>
         LazyInitializer.EnsureInitialized(ref _hasAppUrl, ref _isInit, ref _initLocker, () =>
         {
             GetApplicationUrl();

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
@@ -33,16 +33,15 @@ public class AspNetCoreRequestAccessor : IRequestAccessor, INotificationHandler<
     }
 
     /// <summary>
-    ///     This just initializes the application URL on first request attempt
-    ///     TODO: This doesn't belong here, the GetApplicationUrl doesn't belong to IRequestAccessor
-    ///     this should be part of middleware not a lazy init based on an INotification
+    /// <para>
+    /// This is now a NoOp, and is no longer used, instead ApplicationUrlRequestBeginNotificationHandler is used
+    /// </para>
     /// </summary>
+    [Obsolete("This is no longer used, AspNetCoreRequestAccessor will no longer implement INotificationHandler in V12, see ApplicationUrlRequestBeginNotificationHandler instead.")]
     public void Handle(UmbracoRequestBeginNotification notification)
-        => LazyInitializer.EnsureInitialized(ref _hasAppUrl, ref _isInit, ref _initLocker, () =>
-        {
-            GetApplicationUrl();
-            return true;
-        });
+    {
+        // NoOP
+    }
 
     /// <inheritdoc />
     public string GetRequestValue(string name) => GetFormValue(name) ?? GetQueryStringValue(name);
@@ -54,6 +53,17 @@ public class AspNetCoreRequestAccessor : IRequestAccessor, INotificationHandler<
     public Uri? GetRequestUrl() => _httpContextAccessor.HttpContext != null
         ? new Uri(_httpContextAccessor.HttpContext.Request.GetEncodedUrl())
         : null;
+
+    /// <summary>
+    /// Ensure that the ApplicationUrl is set on the first request, this is using a LazyInitializer, so the code will only be run the first time
+    /// </summary>
+    /// TODO: This doesn't belong here, the GetApplicationUrl doesn't belong to IRequestAccessor
+    public void EnsureApplicationUrl() =>
+        LazyInitializer.EnsureInitialized(ref _hasAppUrl, ref _isInit, ref _initLocker, () =>
+        {
+            GetApplicationUrl();
+            return true;
+        });
 
     public Uri? GetApplicationUrl()
     {

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -298,6 +298,7 @@ public static partial class UmbracoBuilderExtensions
         // AspNetCore specific services
         builder.Services.AddUnique<IRequestAccessor, AspNetCoreRequestAccessor>();
         builder.AddNotificationHandler<UmbracoRequestBeginNotification, AspNetCoreRequestAccessor>();
+        builder.AddNotificationHandler<UmbracoRequestBeginNotification, ApplicationUrlRequestBeginNotificationHandler>();
 
         // Password hasher
         builder.Services.AddUnique<IPasswordHasher, AspNetCorePasswordHasher>();


### PR DESCRIPTION
This PR fixes #13098.

As described in the issue there was a memory leak in `AspNetCoreRequestAccessor`

The reason for this memory leak was that it was set up as a notification handler, which is transient. This meant that every time a request was sent, a new`AspNetCoreRequestAccessor` was initialized, and an OnChange even registered on the `IOptionsMonitor`, this meant that the `AspNetCoreRequestAccessor` alongside its delegate in the `IOptionsMonitor` would never be GC'ed. 

To add insult to injury, since the notification handler is transient, the `_isInit` and `_hasAppUrl` would re-default to false each time, meaning that `GetApplicationUrl` is called unnecessarily on *every* request.

Unfortunately, this is not that simple to fix in a nice way without breaking changes. What I've done is implement `IDisposable` on the `AspNetCoreRequestAccessor`,  this allows us to unregister our `OnChange` when disposing notification handler, meaning no more hanging references 🎉.

Additionally to fix the initializer issue I've created a new class `ApplicationUrlRequestBeginNotificationHandler` which then calls the `EnsureApplicationUrl`, making sure we're using the singleton instance of `AspNetCoreRequestAccessor`.


### Testing
I've tested in this way, and everything seems to be working great.

1. Send a lot of requests to the frontend, and take a memory snapshot, and ensure that there's not a bunch of `AspNetCoreRequestAccessors` in memory
2. Set a breakpoint and ensure that `GetApplicationUrl` is only called once, not on every request. 

These was my results:

v10/dev dev after sending ~32k requests:
![Pasted image 20221010134124](https://user-images.githubusercontent.com/16456704/194875063-f8c7a699-4d7b-4320-896d-c0f7763ab4cb.png)

This branch after sending ~34K requests:

![Pasted image 20221010134615](https://user-images.githubusercontent.com/16456704/194875232-4b00df22-7f8c-4922-9047-d82fdfd206ab.png)


As you can see, prior to this branch we'd have ~32K instances of `AspNetCoreRequestAccessor` in memory, on this branch, there are none. 
