### PR TITLE
Improve system information/telemetry

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core;
+namespace Umbraco.Cms.Core;
 
 public static partial class Constants
 {
@@ -28,5 +28,6 @@ public static partial class Constants
         public static string IsDebug = "IsDebug";
         public static string DatabaseProvider = "DatabaseProvider";
         public static string CurrentServerRole = "CurrentServerRole";
+        public static string RuntimeMode = "RuntimeMode";
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -52,12 +52,11 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
         _hostEnvironment = hostEnvironment;
         _umbracoDatabaseFactory = umbracoDatabaseFactory;
         _serverRoleAccessor = serverRoleAccessor;
-
         _hostingSettings = hostingSettings.CurrentValue;
         _modelsBuilderSettings = modelsBuilderSettings.CurrentValue;
     }
 
-    private string CurrentWebServer => IsRunningInProcessIIS() ? "IIS" : "Kestrel";
+    private string CurrentWebServer => GetWebServerName();
 
     private string ServerFramework => RuntimeInformation.FrameworkDescription;
 
@@ -100,14 +99,20 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new("Current Server Role", CurrentServerRole),
         };
 
-    private bool IsRunningInProcessIIS()
+    private string GetWebServerName()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        var processName = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
+
+        if (processName.Contains("w3wp"))
         {
-            return false;
+            return "IIS";
         }
 
-        var processName = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
-        return processName.Contains("w3wp") || processName.Contains("iisexpress");
+        if (processName.Contains("iisexpress"))
+        {
+            return "IIS Express";
+        }
+
+        return "Kestrel";
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemInformationTelemetryProvider.cs
@@ -23,6 +23,7 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
     private readonly IUmbracoDatabaseFactory _umbracoDatabaseFactory;
     private readonly IUmbracoVersion _version;
     private readonly IServerRoleAccessor _serverRoleAccessor;
+    private readonly RuntimeSettings _runtimeSettings;
 
     [Obsolete($"Use the constructor that does not take an IOptionsMonitor<GlobalSettings> parameter, scheduled for removal in V12")]
     public SystemInformationTelemetryProvider(
@@ -33,8 +34,9 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
         IOptionsMonitor<GlobalSettings> globalSettings,
         IHostEnvironment hostEnvironment,
         IUmbracoDatabaseFactory umbracoDatabaseFactory,
-        IServerRoleAccessor serverRoleAccessor)
-        : this(version, localizationService, modelsBuilderSettings, hostingSettings, hostEnvironment, umbracoDatabaseFactory, serverRoleAccessor)
+        IServerRoleAccessor serverRoleAccessor,
+        IOptionsMonitor<RuntimeSettings> runtimeSettings)
+        : this(version, localizationService, modelsBuilderSettings, hostingSettings, hostEnvironment, umbracoDatabaseFactory, serverRoleAccessor, runtimeSettings)
     {
     }
 
@@ -45,13 +47,15 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
         IOptionsMonitor<HostingSettings> hostingSettings,
         IHostEnvironment hostEnvironment,
         IUmbracoDatabaseFactory umbracoDatabaseFactory,
-        IServerRoleAccessor serverRoleAccessor)
+        IServerRoleAccessor serverRoleAccessor,
+        IOptionsMonitor<RuntimeSettings> runtimeSettings)
     {
         _version = version;
         _localizationService = localizationService;
         _hostEnvironment = hostEnvironment;
         _umbracoDatabaseFactory = umbracoDatabaseFactory;
         _serverRoleAccessor = serverRoleAccessor;
+        _runtimeSettings = runtimeSettings.CurrentValue;
         _hostingSettings = hostingSettings.CurrentValue;
         _modelsBuilderSettings = modelsBuilderSettings.CurrentValue;
     }
@@ -61,6 +65,8 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
     private string ServerFramework => RuntimeInformation.FrameworkDescription;
 
     private string ModelsBuilderMode => _modelsBuilderSettings.ModelsMode.ToString();
+
+    private string RuntimeMode => _runtimeSettings.Mode.ToString();
 
     private string CurrentCulture => Thread.CurrentThread.CurrentCulture.ToString();
 
@@ -81,6 +87,7 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new(Constants.Telemetry.OsLanguage, CurrentCulture),
             new(Constants.Telemetry.WebServer, CurrentWebServer),
             new(Constants.Telemetry.ModelsBuilderMode, ModelsBuilderMode),
+            new(Constants.Telemetry.RuntimeMode, RuntimeMode),
             new(Constants.Telemetry.AspEnvironment, AspEnvironment), new(Constants.Telemetry.IsDebug, IsDebug),
             new(Constants.Telemetry.DatabaseProvider, DatabaseProvider),
             new(Constants.Telemetry.CurrentServerRole, CurrentServerRole),
@@ -94,8 +101,11 @@ internal class SystemInformationTelemetryProvider : IDetailedTelemetryProvider, 
             new("Umbraco Version", _version.SemanticVersion.ToSemanticStringWithoutBuild()),
             new("Current Culture", CurrentCulture),
             new("Current UI Culture", Thread.CurrentThread.CurrentUICulture.ToString()),
-            new("Current Webserver", CurrentWebServer), new("Models Builder Mode", ModelsBuilderMode),
-            new("Debug Mode", IsDebug.ToString()), new("Database Provider", DatabaseProvider),
+            new("Current Webserver", CurrentWebServer),
+            new("Models Builder Mode", ModelsBuilderMode),
+            new("Runtime Mode", RuntimeMode),
+            new("Debug Mode", IsDebug.ToString()),
+            new("Database Provider", DatabaseProvider),
             new("Current Server Role", CurrentServerRole),
         };
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -49,7 +49,8 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.AspEnvironment,
             Constants.Telemetry.IsDebug,
             Constants.Telemetry.DatabaseProvider,
-            Constants.Telemetry.CurrentServerRole
+            Constants.Telemetry.CurrentServerRole,
+            Constants.Telemetry.RuntimeMode,
         };
 
         MetricsConsentService.SetConsentLevel(TelemetryLevel.Detailed);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/SystemInformationTelemetryProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Hosting;
@@ -32,6 +32,21 @@ public class SystemInformationTelemetryProviderTests
         var actual = usageInformation.FirstOrDefault(x => x.Name == Constants.Telemetry.ModelsBuilderMode);
         Assert.IsNotNull(actual?.Data);
         Assert.AreEqual(modelsMode.ToString(), actual.Data);
+    }
+
+    [Test]
+    [TestCase(RuntimeMode.BackofficeDevelopment)]
+    [TestCase(RuntimeMode.BackofficeDevelopment)]
+    [TestCase(RuntimeMode.BackofficeDevelopment)]
+
+    public void ReportsRuntimeModeCorrectly(RuntimeMode runtimeMode)
+    {
+        var telemetryProvider = CreateProvider(runtimeMode: runtimeMode);
+        var usageInformation = telemetryProvider.GetInformation().ToArray();
+
+        var actual = usageInformation.FirstOrDefault(x => x.Name == Constants.Telemetry.RuntimeMode);
+        Assert.IsNotNull(actual?.Data);
+        Assert.AreEqual(runtimeMode.ToString(), actual.Data);
     }
 
     [Test]
@@ -82,7 +97,8 @@ public class SystemInformationTelemetryProviderTests
     private SystemInformationTelemetryProvider CreateProvider(
         ModelsMode modelsMode = ModelsMode.InMemoryAuto,
         bool isDebug = true,
-        string environment = "")
+        string environment = "",
+        RuntimeMode runtimeMode = RuntimeMode.BackofficeDevelopment)
     {
         var hostEnvironment = new Mock<IHostEnvironment>();
         hostEnvironment.Setup(x => x.EnvironmentName).Returns(environment);
@@ -93,10 +109,11 @@ public class SystemInformationTelemetryProviderTests
         return new SystemInformationTelemetryProvider(
             Mock.Of<IUmbracoVersion>(),
             Mock.Of<ILocalizationService>(),
-            Mock.Of<IOptionsMonitor<ModelsBuilderSettings>>(x => x.CurrentValue == new ModelsBuilderSettings{ ModelsMode = modelsMode }),
+            Mock.Of<IOptionsMonitor<ModelsBuilderSettings>>(x => x.CurrentValue == new ModelsBuilderSettings { ModelsMode = modelsMode }),
             Mock.Of<IOptionsMonitor<HostingSettings>>(x => x.CurrentValue == new HostingSettings { Debug = isDebug }),
             hostEnvironment.Object,
             Mock.Of<IUmbracoDatabaseFactory>(x => x.CreateDatabase() == Mock.Of<IUmbracoDatabase>(y => y.DatabaseType == DatabaseType.SQLite)),
-            Mock.Of<IServerRoleAccessor>());
+            Mock.Of<IServerRoleAccessor>(),
+            Mock.Of<IOptionsMonitor<RuntimeSettings>>(x => x.CurrentValue == new RuntimeSettings { Mode = runtimeMode }));
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Differentiate between IIS & IIS Express
I noticed that the system information in the backoffice help menu doesn't differentiate between IIS and IIS Express. I think it probably should, so this adds that distinction.

To test: Open the help menu, then system information, while running in IIS Express and it will tell you that you're using IIS Express.

#### I'm not convinced by the Kestrel detection...

The IIS & IIS Express check makes sense, as the point of those servers is that they host the site in process. Kestrel is a little different as it's bootstrapped _inside_ of ASP.NET. Kestrel is the default, but presumably the web server _could_ be HTTP.sys or some other IServer implementation.

I think the only way to know for sure is to inject IServer and get the name of the class implementing it, but that adds a dependency on [Microsoft.AspNetCore.Hosting.Server](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.server?view=aspnetcore-6.0) to Umbraco.Infrastructure.

### Add runtime mode

As per the suggestion in #12631, this adds the runtime mode to the system information/telemetry.

To test: Open the help menu, then system information, and you'll see the runtime mode reflected in the system information.

