### PR TITLE
Add AddManifestFilter extension method to UmbracoBuilder.CollectionBuilders.cs

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -66,7 +66,7 @@ public static partial class UmbracoBuilderExtensions
     /// </summary>
     /// <typeparam name="T">The type of the manifest filter.</typeparam>
     /// <param name="builder">The Builder.</param>
-    public static IUmbracoBuilder AddManifestFilters<T>(this IUmbracoBuilder builder)
+    public static IUmbracoBuilder AddManifestFilter<T>(this IUmbracoBuilder builder)
         where T : class, IManifestFilter
     {
         builder.ManifestFilters().Append<T>();

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Dashboards;
+using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Routing;
@@ -57,6 +58,18 @@ public static partial class UmbracoBuilderExtensions
         where T : class, IDashboard
     {
         builder.Dashboards().Add<T>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a manifest filter
+    /// </summary>
+    /// <typeparam name="T">The type of the manifest filter.</typeparam>
+    /// <param name="builder">The Builder.</param>
+    public static IUmbracoBuilder AddManifestFilters<T>(this IUmbracoBuilder builder)
+        where T : class, IManifestFilter
+    {
+        builder.ManifestFilters().Append<T>();
         return builder;
     }
 


### PR DESCRIPTION
In addition to: https://github.com/umbraco/Umbraco-CMS/pull/11691 . It would be nice to add a `ManifestFilter` directly from the `Startup.cs` class. 