### PR TITLE
Use array instead of list when rebuilding mediacache

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -486,7 +486,7 @@ WHERE cmsContentNu.nodeId IN (
         Guid mediaObjectType = Constants.ObjectTypes.Media;
 
         // remove all - if anything fails the transaction will rollback
-        if (contentTypeIds == null || contentTypeIds.Count == 0)
+        if (contentTypeIds is null || contentTypeIds.Count == 0)
         {
             // must support SQL-CE
             Database.Execute(
@@ -513,7 +513,7 @@ WHERE cmsContentNu.nodeId IN (
 
         // insert back - if anything fails the transaction will rollback
         IQuery<IMedia> query = SqlContext.Query<IMedia>();
-        if (contentTypeIds != null && contentTypeIds.Count > 0)
+        if (contentTypeIds is not null && contentTypeIds.Count > 0)
         {
             query = query.WhereIn(x => x.ContentTypeId, contentTypeIds); // assume number of ctypes won't blow IN(...)
         }
@@ -526,9 +526,9 @@ WHERE cmsContentNu.nodeId IN (
             // the tree is locked, counting and comparing to total is safe
             IEnumerable<IMedia> descendants =
                 _mediaRepository.GetPage(query, pageIndex++, groupSize, out total, null, Ordering.By("Path"));
-            var items = descendants.Select(m => GetDto(m, false, serializer)).ToList();
+            var items = descendants.Select(m => GetDto(m, false, serializer)).ToArray();
             Database.BulkInsertRecords(items);
-            processed += items.Count;
+            processed += items.Length;
         }
         while (processed < total);
     }

--- a/tests/Umbraco.Tests.Benchmarks/CollectionBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/CollectionBenchmarks.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Umbraco.Tests.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class CollectionBenchmarks
+    {
+        private static readonly IEnumerable<int> _enumerable = Enumerable.Range(0, 1000);
+        private static readonly int[] _array = _enumerable.ToArray();
+        private static readonly List<int> _list = _enumerable.ToList();
+
+        [Benchmark]
+        public int[] ToArray()
+        {
+            return _enumerable.ToArray();
+        }
+
+        [Benchmark]
+        public List<int> ToList()
+        {
+            return _enumerable.ToList();
+        }
+
+        [Benchmark]
+        public void IterateArray()
+        {
+            foreach (int item in _array)
+            {
+
+            }
+        }
+
+        [Benchmark]
+        public void IterateList()
+        {
+            foreach (int item in _list)
+            {
+            }
+        }
+
+        //BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
+        //Intel Core i9-10885H CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
+        //.NET SDK= 6.0.401
+        //  [Host]     : .NET 6.0.9 (6.0.922.41905), X64 RyuJIT
+        //  DefaultJob : .NET 6.0.9 (6.0.922.41905), X64 RyuJIT
+        //
+        //
+        //|       Method |       Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
+        //|------------- |-----------:|---------:|---------:|-------:|-------:|----------:|
+        //|      ToArray |   503.8 ns |  5.11 ns |  4.53 ns | 0.4807 | 0.0067 |   4,024 B |
+        //|       ToList | 1,369.0 ns | 25.38 ns | 49.50 ns | 0.4845 | 0.0134 |   4,056 B |
+        //| IterateArray |   244.9 ns |  3.29 ns |  2.75 ns |      - |      - |         - |
+        //|  IterateList |   620.5 ns |  4.45 ns |  3.95 ns |      - |      - |         - |
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
It would be better to use `.ToArray` instead of `.ToList` as first of all it is faster, as you can see in the benchmarks, and secondly if you go further down the line in `Database.BulkInsertRecords(items)` it would be converted to an array anyways.

### How to test
- Upload some images in the backoffice
- Go to the Settings sections
- Open the _Published Status_ dashboard
- Check if in the _Published Cache Status_ the  _MediaStore_ items count matches the amount of images uploaded
