### PR TITLE
Fixes #12127 - sets z-index on block list actions element

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -353,6 +353,7 @@
 // Try to avoid customizing these :)
 @zIndexEditor: 100;
 @zIndexTree: 100;
+@zIndexBlockActions: 500;
 @zindexDropdown: 1000;
 @zindexPopover: 1010;
 @zindexTooltip: 1030;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
@@ -86,7 +86,7 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
     border-radius: 16px;
     padding-left: 5px;
     padding-right: 5px;
-    z-index: 500;
+    z-index: @zIndexBlockActions;
     .action {
         position: relative;
         display: inline-block;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.less
@@ -86,6 +86,7 @@ ng-form.ng-invalid-val-server-match-settings > .umb-block-list__block > .umb-blo
     border-radius: 16px;
     padding-left: 5px;
     padding-right: 5px;
+    z-index: 500;
     .action {
         position: relative;
         display: inline-block;


### PR DESCRIPTION
Should solve [#12127](https://github.com/umbraco/Umbraco-CMS/issues/12127)

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12127

### Description
As described in the issue, this fix helps to ensure that actions for a block list editor remain visible, even if a custom view uses z-index (as long as the custom view doesn't go above z-index: 500, I guess).
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
