### PR TITLE
Add documentation for default block grid partial views in the rendering extension methods

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/BlockGridTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/BlockGridTemplateExtensions.cs
@@ -17,6 +17,19 @@ public static class BlockGridTemplateExtensions
 
     #region Async
 
+    /// <summary>
+    /// Renders a block grid model into a grid layout
+    /// </summary>
+    /// <remarks>
+    /// By default this method uses a set of built-in partial views for rendering the blocks and areas in the grid model.
+    /// These partial views are embedded in the static assets (Umbraco.Cms.StaticAssets), so they won't show up in the
+    /// Views folder on your local disk.
+    ///
+    /// If you need to tweak the grid rendering output, you can copy the partial views from GitHub to your local disk.
+    /// The partial views are found in "/src/Umbraco.Cms.StaticAssets/Views/Partials/blockgrid/" on GitHub and should
+    /// be copied to "Views/Partials/BlockGrid/" on your local disk.
+    /// </remarks>
+    /// <seealso href="https://our.umbraco.com/documentation/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Block-Editor/Block-Grid-Editor/#1-default-rendering"/>
     public static async Task<IHtmlContent> GetBlockGridHtmlAsync(this IHtmlHelper html, BlockGridModel? model, string template = DefaultTemplate)
     {
         if (model?.Count == 0)
@@ -27,9 +40,11 @@ public static class BlockGridTemplateExtensions
         return await html.PartialAsync(DefaultFolderTemplate(template), model);
     }
 
+    /// <inheritdoc cref="GetBlockGridHtmlAsync(Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper,Umbraco.Cms.Core.Models.Blocks.BlockGridModel?,string)"/>
     public static async Task<IHtmlContent> GetBlockGridHtmlAsync(this IHtmlHelper html, IPublishedProperty property, string template = DefaultTemplate)
         => await GetBlockGridHtmlAsync(html, property.GetValue() as BlockGridModel, template);
 
+    /// <inheritdoc cref="GetBlockGridHtmlAsync(Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper,Umbraco.Cms.Core.Models.Blocks.BlockGridModel?,string)"/>
     public static async Task<IHtmlContent> GetBlockGridHtmlAsync(this IHtmlHelper html, IPublishedContent contentItem, string propertyAlias)
         => await GetBlockGridHtmlAsync(html, contentItem, propertyAlias, DefaultTemplate);
 
@@ -49,6 +64,7 @@ public static class BlockGridTemplateExtensions
 
     #region Sync
 
+    /// <inheritdoc cref="GetBlockGridHtmlAsync(Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper,Umbraco.Cms.Core.Models.Blocks.BlockGridModel?,string)"/>
     public static IHtmlContent GetBlockGridHtml(this IHtmlHelper html, BlockGridModel? model, string template = DefaultTemplate)
     {
         if (model?.Count == 0)
@@ -59,9 +75,11 @@ public static class BlockGridTemplateExtensions
         return html.Partial(DefaultFolderTemplate(template), model);
     }
 
+    /// <inheritdoc cref="GetBlockGridHtmlAsync(Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper,Umbraco.Cms.Core.Models.Blocks.BlockGridModel?,string)"/>
     public static IHtmlContent GetBlockGridHtml(this IHtmlHelper html, IPublishedProperty property, string template = DefaultTemplate)
         => GetBlockGridHtml(html, property.GetValue() as BlockGridModel, template);
 
+    /// <inheritdoc cref="GetBlockGridHtmlAsync(Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper,Umbraco.Cms.Core.Models.Blocks.BlockGridModel?,string)"/>
     public static IHtmlContent GetBlockGridHtml(this IHtmlHelper html, IPublishedContent contentItem, string propertyAlias)
         => GetBlockGridHtml(html, contentItem, propertyAlias, DefaultTemplate);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Unlike block list, the default rendering for block grid utilizes built-in views within the `Umbraco.Cms.StaticAssets` class library to construct the rendered grid output. 

Some have reported this as being strange and bad for DX and discoverability. 

Unfortunately, due to limitations on package formats we cannot move the files to a more easily discovered location, so this PR adds additional notes to the appropriate block grid rendering extensions about where to find these built-in views, in case one wants to change them (or simply want to figure out what's going on).

### Testing this PR

The docs should show up if you hover over the rendering extension in a template:

```cshtml
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@{
    Layout = null;
}
<html>
<body>
@await Html.GetBlockGridHtmlAsync(Model, "grid")
</body>
</html>
```

![image](https://user-images.githubusercontent.com/7405322/195307789-d4a75973-1371-4393-b843-e9d6ea455d8a.png)

### Remarks

For whatever reason, Rider won't display the `<seealso ...` section for external links (it works for internal links), so the method remarks are somewhat more verbose than would be strictly necessary if the `<seealso ...` docs worked. Maybe they work in VS 😄 