### PR TITLE
V11: Make MemberValueSetValidator ctor parameters nullable

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/MemberValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/MemberValueSetValidator.cs
@@ -18,12 +18,12 @@ public class MemberValueSetValidator : ValueSetValidator
     {
     }
 
-    public MemberValueSetValidator(IEnumerable<string> includeItemTypes, IEnumerable<string> excludeItemTypes)
+    public MemberValueSetValidator(IEnumerable<string>? includeItemTypes, IEnumerable<string>? excludeItemTypes)
         : base(includeItemTypes, excludeItemTypes, DefaultMemberIndexFields, null)
     {
     }
 
-    public MemberValueSetValidator(IEnumerable<string> includeItemTypes, IEnumerable<string> excludeItemTypes, IEnumerable<string> includeFields, IEnumerable<string> excludeFields)
+    public MemberValueSetValidator(IEnumerable<string>? includeItemTypes, IEnumerable<string>? excludeItemTypes, IEnumerable<string>? includeFields, IEnumerable<string>? excludeFields)
         : base(includeItemTypes, excludeItemTypes, includeFields, excludeFields)
     {
     }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13036

# Notes
- Made constructor parameters nullable, as these directly pass them to `base()`, which is the `ValueSetValidator` constructor, which has all the parameters as nullable 😅 Therefore i think it makes good sense, to also have the `MemberValueSetValidator` parameters as nullable, as also described in the issue 👍 
