### PR TITLE
Fix tags with CSV storage type

### DIFF
--- a/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
+++ b/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
@@ -33,7 +33,7 @@ public static class PropertyTagsExtensions
             : dataTypeService.GetDataType(property.PropertyType.DataTypeId)?.Configuration;
         TagConfiguration? configuration = ConfigurationEditor.ConfigurationAs<TagConfiguration>(configurationObject);
 
-        if (configuration?.Delimiter == default && configuration?.Delimiter is not null)
+        if (configuration is not null && configuration.Delimiter == default)
         {
             configuration.Delimiter = tagAttribute.Delimiter;
         }


### PR DESCRIPTION
## Details
Fixes #13132

The problem is related to how tags, configured with CSV storage type, are saved in the database. As mentioned in the issue, the UI behaves correctly, ex: splitting up tags that include comma-separated values when the storage type is CSV, while allowing those to be a single tag when the choice is JSON. _Check [docs](https://our.umbraco.com/Documentation/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Tags/#storage-type) for more info on the storage type differences._

The bug is present since Umbraco 10.0 when we introduced NRT. When the storage type format is CSV, we are splitting the tags based on a delimiter that we have to set in case it is the default "`\0`" value for the char type. But with the old check in place, `configuration?.Delimiter == default` was evaluating to `false` because it is the null value for a nullable value type. And therefore we were never setting the delimiter. All tags were combined as a single tag that was saved in the database.

I've added some tests to verify that the tags are saved correctly depending on the tags' storage type.

## Test
- Create a document type with a tags property where the storage type is set to CSV;
- Create a content node and add a few different tags - `a,b,c`, `d`, `e`;
- Save & Publish;
  - Verify that each comma-separated value results in its own tag in the UI, as well as **in the database** (they all have individual ids);
- Switch to JSON storage type and add the same tags as before;
  - This time the tag `a,b,c` is allowed and it has its own entry in the database;
- Lastly, the new tags tests should suceed. 