### PR TITLE
v10: Add data-element to umb property so we can find it

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -9,7 +9,7 @@
 
                 <div class="control-header" ng-hide="vm.property.hideLabel === true">
 
-                    <label class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span></label>
+                    <label data-element="property-label-{{vm.property.alias}}" class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span></label>
 
                     <umb-property-actions actions="vm.propertyActions"></umb-property-actions>
 
@@ -41,11 +41,11 @@
                         <span ng-if="vm.property.variations === 'Culture' || vm.property.variations === 'CultureAndSegment'" class="umb-property-variant-label">
                             {{ vm.property.culture }}
                         </span>
-                        
+
                         <span ng-if="vm.property.variations === 'Culture' && vm.node.documentType.variations === 'CultureAndSegment'" class="umb-property-variant-label">
                             <localize key="languages_invariantSegmentProperty"></localize>
                         </span>
-                        
+
                         <span ng-if="vm.property.variations === 'Segment' || vm.property.variations === 'CultureAndSegment'" class="umb-property-variant-label">
                             <span>{{ vm.property.segment }}</span>
                             <span ng-if="!vm.property.segment">Default</span>

--- a/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/macros/views/settings.html
@@ -21,6 +21,7 @@
                         <input type="hidden" name="partialView" ng-model="mandatoryViewValidator" ng-required="!model.macro.node" />
 
                         <button type="button"
+                                id="{{vm.macroPartialViewPickerProperty.alias}}"
                                 class="umb-node-preview-add"
                                 ng-show="!model.macro.node"
                                 ng-click="model.openViewPicker()">

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/macro.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/macro.spec.ts
@@ -30,7 +30,7 @@ test.describe('Macros', () => {
     await form.locator(".btn-primary").click();
     
     // Adds partial view to macro
-    await page.locator('[label="Macro partial view"]').click();
+    await page.locator('[data-element="property-label-macroPartialViewPickerProperty"]').click();
     await page.locator('[data-element="tree-item-' + partialViewName + '.cshtml"]').click();
     
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));


### PR DESCRIPTION
# Notes
- Adds ``data-element` to the umb-properties so we can find them in our acceptance tests.
- Changes the acceptance-test locator to look up the new data-element