### PR TITLE
V11: Fix SourceCode modelsbuilder

### DIFF
--- a/src/Umbraco.Core/Constants-Configuration.cs
+++ b/src/Umbraco.Core/Constants-Configuration.cs
@@ -41,6 +41,7 @@ public static partial class Constants
         public const string ConfigLogging = ConfigPrefix + "Logging";
         public const string ConfigMemberPassword = ConfigPrefix + "Security:MemberPassword";
         public const string ConfigModelsBuilder = ConfigPrefix + "ModelsBuilder";
+        public const string ConfigModelsMode = ConfigModelsBuilder + ":ModelsMode";
         public const string ConfigNuCache = ConfigPrefix + "NuCache";
         public const string ConfigPlugins = ConfigPrefix + "Plugins";
         public const string ConfigRequestHandler = ConfigPrefix + "RequestHandler";

--- a/src/Umbraco.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Extensions;
@@ -101,4 +102,7 @@ public static class ConfigurationExtensions
     /// </returns>
     public static RuntimeMode GetRuntimeMode(this IConfiguration configuration)
         => configuration.GetValue<RuntimeMode>(Constants.Configuration.ConfigRuntimeMode);
+
+    public static ModelsMode GetModelsMode(this IConfiguration configuration) =>
+        configuration.GetValue<ModelsMode>(Constants.Configuration.ConfigModelsMode);
 }


### PR DESCRIPTION
#13107 Accidentally broke SourceCode memory models. 

The reason for this is that we would replace the ViewCompiler regardless of ModelsMode, this meant that it would break when using SourceCodeAuto because the `CollectibleRuntimeViewCompiler` directly creates a reference to the `InMemoryAuto` models assembly, but since we're not in InMemoryAuto mode, this does not work. 

Now if we really wanted to we could make a workaround and only add a reference if there is an `InMemoryAuto` models assembly, however I don't think this is is the best solution, since we really only want to replace these services when in `InMemoryAuto`, so I think it's nice that it fails if this is not the case 😄 

So the fix was to add a check and only register the services when we're in `InMemoryAuto`. 

## Testing
Ensure that `SourceCodeAuto` and `InMemoryAuto` can render to the frontend.  