### PR TITLE
V11: fix failing acceptance tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.2",
+        "@umbraco/playwright-testhelpers": "^1.0.4",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.2.tgz",
-      "integrity": "sha512-j1y6YRq2Rg5AXyYk/304P2rTrDCLU7Sz67/MMfkPBHSvadjdof7EW8649Aio29xGAg1YAR4y+Zeyw6XnM35ZkA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.4.tgz",
+      "integrity": "sha512-OBAUzscj+v1w0TwUcWAUeUou6t1wz/7ZXDhMPq6gL8jzAXSFobWRShfC4zqCiWoGLZ8721UN55Q01WFyWiuOSg==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -906,9 +906,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.2.tgz",
-      "integrity": "sha512-j1y6YRq2Rg5AXyYk/304P2rTrDCLU7Sz67/MMfkPBHSvadjdof7EW8649Aio29xGAg1YAR4y+Zeyw6XnM35ZkA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.4.tgz",
+      "integrity": "sha512-OBAUzscj+v1w0TwUcWAUeUou6t1wz/7ZXDhMPq6gL8jzAXSFobWRShfC4zqCiWoGLZ8721UN55Q01WFyWiuOSg==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.2",
+    "@umbraco/playwright-testhelpers": "^1.0.4",
     "camelize": "^1.0.0",
     "faker": "^4.1.0",
     "form-data": "^4.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
@@ -624,7 +624,7 @@ test.describe('Content tests', () => {
     await umbracoUi.clickElement(umbracoUi.getTreeItem("content", [viewMacroName]));
 
     // Insert macro
-    await page.locator('#mceu_13-button').click();
+    await page.locator('[title="Insert macro"]').click();
     await page.locator('.umb-card-grid-item', {hasText: viewMacroName}).click();
     // cy.get('.umb-card-grid-item').contains(viewMacroName).click();
 
@@ -633,7 +633,7 @@ test.describe('Content tests', () => {
     await umbracoUi.isSuccessNotificationVisible();
 
     // Ensure that the view gets rendered correctly
-    const expected = `<h1>Acceptance test</h1><p> </p>`;
+    const expected = `<p> </p><h1>Acceptance test</h1><p> </p>`;
     await expect(await umbracoApi.content.verifyRenderedContent('/', expected, true)).toBeTruthy();
 
     // Cleanup


### PR DESCRIPTION
# Notes
- Bumbed version of `playwright-testhelpers` as it used a removed endpoint
- Fixed up selector in macro, as the selector no longer existed