### PR TITLE
V11: fix more unstable acceptance tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.5",
+        "@umbraco/playwright-testhelpers": "^1.0.6",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.5.tgz",
-      "integrity": "sha512-OGV83Clpj3OQgPks3uczcL1JSVW8eF16nRtTKcBSNeg4QaN/021DbluqoVOYtlFYAw3NtOoorAVIGCDhxKECOw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.6.tgz",
+      "integrity": "sha512-KHc56WSsyLhqBcdaxSKYwjVkTuE9dgIVoc7ixwYUMLxxP2wlPxcn/gcYA7xa+mLVKgXmQYaP2zoA317j7oBz/Q==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -1064,9 +1064,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.5.tgz",
-      "integrity": "sha512-OGV83Clpj3OQgPks3uczcL1JSVW8eF16nRtTKcBSNeg4QaN/021DbluqoVOYtlFYAw3NtOoorAVIGCDhxKECOw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.6.tgz",
+      "integrity": "sha512-KHc56WSsyLhqBcdaxSKYwjVkTuE9dgIVoc7ixwYUMLxxP2wlPxcn/gcYA7xa+mLVKgXmQYaP2zoA317j7oBz/Q==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.4",
+        "@umbraco/playwright-testhelpers": "^1.0.5",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.4.tgz",
-      "integrity": "sha512-OBAUzscj+v1w0TwUcWAUeUou6t1wz/7ZXDhMPq6gL8jzAXSFobWRShfC4zqCiWoGLZ8721UN55Q01WFyWiuOSg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.5.tgz",
+      "integrity": "sha512-OGV83Clpj3OQgPks3uczcL1JSVW8eF16nRtTKcBSNeg4QaN/021DbluqoVOYtlFYAw3NtOoorAVIGCDhxKECOw==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -906,9 +906,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.4.tgz",
-      "integrity": "sha512-OBAUzscj+v1w0TwUcWAUeUou6t1wz/7ZXDhMPq6gL8jzAXSFobWRShfC4zqCiWoGLZ8721UN55Q01WFyWiuOSg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.5.tgz",
+      "integrity": "sha512-OGV83Clpj3OQgPks3uczcL1JSVW8eF16nRtTKcBSNeg4QaN/021DbluqoVOYtlFYAw3NtOoorAVIGCDhxKECOw==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.8",
+        "@umbraco/playwright-testhelpers": "^1.0.9",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.8.tgz",
-      "integrity": "sha512-zzwxgJGmQQckF3pi4EQPeeUxGfXRDMefK2LjfDfQHesaRMBoTf4ah73w4nAOKuoREuE1yZIDwf7bzz3pNOEXiw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.9.tgz",
+      "integrity": "sha512-+w0jisYmKWfBojTZ6UJeIGub9N67x+j/atA1vVjABv2+69KDMZ+lby7ZfA51gitOpFGZpt4w6DvYiO85+93kvA==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -1064,9 +1064,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.8.tgz",
-      "integrity": "sha512-zzwxgJGmQQckF3pi4EQPeeUxGfXRDMefK2LjfDfQHesaRMBoTf4ah73w4nAOKuoREuE1yZIDwf7bzz3pNOEXiw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.9.tgz",
+      "integrity": "sha512-+w0jisYmKWfBojTZ6UJeIGub9N67x+j/atA1vVjABv2+69KDMZ+lby7ZfA51gitOpFGZpt4w6DvYiO85+93kvA==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.9",
+        "@umbraco/playwright-testhelpers": "^1.0.10",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.9.tgz",
-      "integrity": "sha512-+w0jisYmKWfBojTZ6UJeIGub9N67x+j/atA1vVjABv2+69KDMZ+lby7ZfA51gitOpFGZpt4w6DvYiO85+93kvA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.10.tgz",
+      "integrity": "sha512-4NTuMbbNWGcawZIuYnDdPUGN4W2F9iw0EvsyJ2Pr5rYj8Rg1PCu2MXW77r27fGhfr31PYDEL6RSL9zp8SyxfJg==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -1064,9 +1064,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.9.tgz",
-      "integrity": "sha512-+w0jisYmKWfBojTZ6UJeIGub9N67x+j/atA1vVjABv2+69KDMZ+lby7ZfA51gitOpFGZpt4w6DvYiO85+93kvA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.10.tgz",
+      "integrity": "sha512-4NTuMbbNWGcawZIuYnDdPUGN4W2F9iw0EvsyJ2Pr5rYj8Rg1PCu2MXW77r27fGhfr31PYDEL6RSL9zp8SyxfJg==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.7",
+        "@umbraco/playwright-testhelpers": "^1.0.8",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.7.tgz",
-      "integrity": "sha512-6kv4w5cshC2WjcD6+WS/c6OETC7nM1G6W2oopl7oHE/JUWGqftulDsq9ZDFYDVn+4q+Edcf6griu7Y1vdhiKtQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.8.tgz",
+      "integrity": "sha512-zzwxgJGmQQckF3pi4EQPeeUxGfXRDMefK2LjfDfQHesaRMBoTf4ah73w4nAOKuoREuE1yZIDwf7bzz3pNOEXiw==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -1064,9 +1064,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.7.tgz",
-      "integrity": "sha512-6kv4w5cshC2WjcD6+WS/c6OETC7nM1G6W2oopl7oHE/JUWGqftulDsq9ZDFYDVn+4q+Edcf6griu7Y1vdhiKtQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.8.tgz",
+      "integrity": "sha512-zzwxgJGmQQckF3pi4EQPeeUxGfXRDMefK2LjfDfQHesaRMBoTf4ah73w4nAOKuoREuE1yZIDwf7bzz3pNOEXiw==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
-        "@umbraco/playwright-testhelpers": "^1.0.6",
+        "@umbraco/playwright-testhelpers": "^1.0.7",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.6.tgz",
-      "integrity": "sha512-KHc56WSsyLhqBcdaxSKYwjVkTuE9dgIVoc7ixwYUMLxxP2wlPxcn/gcYA7xa+mLVKgXmQYaP2zoA317j7oBz/Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.7.tgz",
+      "integrity": "sha512-6kv4w5cshC2WjcD6+WS/c6OETC7nM1G6W2oopl7oHE/JUWGqftulDsq9ZDFYDVn+4q+Edcf6griu7Y1vdhiKtQ==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",
@@ -1064,9 +1064,9 @@
       }
     },
     "@umbraco/playwright-testhelpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.6.tgz",
-      "integrity": "sha512-KHc56WSsyLhqBcdaxSKYwjVkTuE9dgIVoc7ixwYUMLxxP2wlPxcn/gcYA7xa+mLVKgXmQYaP2zoA317j7oBz/Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.7.tgz",
+      "integrity": "sha512-6kv4w5cshC2WjcD6+WS/c6OETC7nM1G6W2oopl7oHE/JUWGqftulDsq9ZDFYDVn+4q+Edcf6griu7Y1vdhiKtQ==",
       "requires": {
         "@umbraco/json-models-builders": "^1.0.0",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.6",
+    "@umbraco/playwright-testhelpers": "^1.0.7",
     "camelize": "^1.0.0",
     "dotenv": "^16.0.2",
     "faker": "^4.1.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.4",
+    "@umbraco/playwright-testhelpers": "^1.0.5",
     "camelize": "^1.0.0",
     "faker": "^4.1.0",
     "form-data": "^4.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.5",
+    "@umbraco/playwright-testhelpers": "^1.0.6",
     "camelize": "^1.0.0",
     "dotenv": "^16.0.2",
     "faker": "^4.1.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.7",
+    "@umbraco/playwright-testhelpers": "^1.0.8",
     "camelize": "^1.0.0",
     "dotenv": "^16.0.2",
     "faker": "^4.1.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.9",
+    "@umbraco/playwright-testhelpers": "^1.0.10",
     "camelize": "^1.0.0",
     "dotenv": "^16.0.2",
     "faker": "^4.1.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.0",
-    "@umbraco/playwright-testhelpers": "^1.0.8",
+    "@umbraco/playwright-testhelpers": "^1.0.9",
     "camelize": "^1.0.0",
     "dotenv": "^16.0.2",
     "faker": "^4.1.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
@@ -10,7 +10,7 @@ dotenv.config();
 const config: PlaywrightTestConfig = {
   testDir: './tests/',
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 120 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
@@ -10,7 +10,7 @@ dotenv.config();
 const config: PlaywrightTestConfig = {
   testDir: './tests/',
   /* Maximum time one test can run for. */
-  timeout: 120 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
@@ -21,7 +21,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 5 : 0,
+  retries: process.env.CI ? 5 : 2,
   // We don't want to run parallel, as tests might differ in state
   workers:  1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
@@ -21,7 +21,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 5 : 2,
+  retries: process.env.CI ? 5 : 0,
   // We don't want to run parallel, as tests might differ in state
   workers:  1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
@@ -295,7 +295,9 @@ test.describe('Content tests', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.rollback));
     // Not a very nice selector, but there's sadly no alternative :(
     await page.locator('.-selectable.cursor-pointer').first().click();
-    // Sadly can't use the button by label key here since there's another one in the DOM 
+    // Sadly can't use the button by label key here since there's another one in the DOM
+    const helpText = await page.locator('[key="rollback_diffHelp"]');
+    await expect(helpText).toBeVisible();
     await page.locator('[action="vm.rollback()"]').click();
 
     await umbracoUi.refreshContentTree();
@@ -664,10 +666,10 @@ test.describe('Content tests', () => {
       .build();
 
     const alias = AliasHelper.toAlias(name);
-    
+
     // Save grid and get the ID
     const dataType = await umbracoApi.dataTypes.save(grid)
-    
+
     // Create a document type using the data type
     const docType = new DocumentTypeBuilder()
       .withName(name)
@@ -691,7 +693,7 @@ test.describe('Content tests', () => {
       .build();
 
     await umbracoApi.content.save(contentNode);
-    
+
     // Ugly wait but we have to wait for cache to rebuild
     await page.waitForTimeout(1000);
 
@@ -720,7 +722,7 @@ test.describe('Content tests', () => {
     // Save and publish
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
-    
+
     const expected = `
     <div class="umb-grid">
       <div class="grid-section">

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
@@ -290,6 +290,7 @@ test.describe('Content tests', () => {
     await umbracoUi.setEditorHeaderName(newNodeName);
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
+    await page.locator('span:has-text("×")').click();
 
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.rollback));
     // Not a very nice selector, but there's sadly no alternative :(

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
@@ -65,7 +65,7 @@ test.describe('DataTypes', () => {
 
     // Assert
     const expected2 = '<p style="color:FF0000">Lorem ipsum dolor sit amet</p>';
-    await expect(await umbracoApi.content.verifyRenderedContent('/', expected2)).toBeTruthy();
+    await expect(await umbracoApi.content.verifyRenderedContent('/', expected2, true)).toBeTruthy();
 
     // Clean
     await umbracoApi.documentTypes.ensureNameNotExists(name);
@@ -176,7 +176,7 @@ test.describe('DataTypes', () => {
     
     // Testing if the edits match the expected results
     const expected = '<a href="/">UrlPickerContent</a>';
-    await expect(await umbracoApi.content.verifyRenderedContent('/', expected)).toBeTruthy();
+    await expect(await umbracoApi.content.verifyRenderedContent('/', expected, true)).toBeTruthy();
 
     // Clean
     await umbracoApi.documentTypes.ensureNameNotExists(urlPickerDocTypeName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
@@ -159,6 +159,7 @@ test.describe('DataTypes', () => {
     await umbracoUi.setEditorHeaderName('UrlPickerContent');
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
+    await page.locator('span:has-text("×")').click();
     await page.locator('.umb-node-preview-add').click();
 
     // Should really try and find a better way to do this, but umbracoTreeItem tries to click the content pane in the background

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
@@ -65,7 +65,7 @@ test.describe('DataTypes', () => {
 
     // Assert
     const expected2 = '<p style="color:FF0000">Lorem ipsum dolor sit amet</p>';
-    await expect(await umbracoApi.content.verifyRenderedContent('/', expected2, true)).toBeTruthy();
+    await expect(await umbracoApi.content.verifyRenderedContent('/', expected2)).toBeTruthy();
 
     // Clean
     await umbracoApi.documentTypes.ensureNameNotExists(name);
@@ -176,7 +176,7 @@ test.describe('DataTypes', () => {
     
     // Testing if the edits match the expected results
     const expected = '<a href="/">UrlPickerContent</a>';
-    await expect(await umbracoApi.content.verifyRenderedContent('/', expected, true)).toBeTruthy();
+    await expect(await umbracoApi.content.verifyRenderedContent('/', expected)).toBeTruthy();
 
     // Clean
     await umbracoApi.documentTypes.ensureNameNotExists(urlPickerDocTypeName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
@@ -48,6 +48,7 @@ test.describe('DataTypes', () => {
     // Save
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
+    await page.locator('span:has-text("×")').click();
 
     // Assert
     const expected = `<p style="color:000000" > Lorem ipsum dolor sit amet </p>`;

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
@@ -50,7 +50,7 @@ test.describe('Modelsbuilder tests', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
     // Ensure that we can render it on the frontend = we can compile the models and views
-    await umbracoApi.content.verifyRenderedContent("/", "<h1>Hello world!</h1>");
+    await umbracoApi.content.verifyRenderedContent("/", "<h1>Hello world!</h1>", true);
 
     await umbracoApi.content.deleteAllContent();
     await umbracoApi.documentTypes.ensureNameNotExists(docTypeName);
@@ -243,6 +243,7 @@ test.describe('Modelsbuilder tests', () => {
 
     await umbracoApi.content.save(content);
 
+    await page.pause();
     // Navigate to the document type
     await umbracoUi.goToSection(ConstantHelper.sections.settings);
     await umbracoUi.clickElement(umbracoUi.getTreeItem("settings", ["Document Types", docTypeName]));
@@ -272,6 +273,7 @@ test.describe('Modelsbuilder tests', () => {
     await umbracoUi.refreshContentTree();
     await umbracoUi.clickElement(umbracoUi.getTreeItem("content", [contentName]));
     await page.locator("#bod").type("Fancy body text");
+    await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish))
 
     await umbracoApi.content.verifyRenderedContent("/", "<h1>" + propertyValue + "</h1><p>Fancy body text</p>", true);
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
@@ -255,6 +255,7 @@ test.describe('Modelsbuilder tests', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.submit));
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
     await umbracoUi.isSuccessNotificationVisible();
+    await page.locator('span:has-text("×")').click();
 
     // Update the template
     await umbracoUi.clickElement(umbracoUi.getTreeItem("settings", ["templates", docTypeName]));
@@ -264,6 +265,7 @@ test.describe('Modelsbuilder tests', () => {
     await editor.type("<p>@Model.Bod")
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save))
     await umbracoUi.isSuccessNotificationVisible();
+    await page.locator('span:has-text("×")').click();
 
     // Navigate to the content section and update the content
     await umbracoUi.goToSection(ConstantHelper.sections.content);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
@@ -50,7 +50,7 @@ test.describe('Modelsbuilder tests', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
     // Ensure that we can render it on the frontend = we can compile the models and views
-    await umbracoApi.content.verifyRenderedContent("/", "<h1>Hello world!</h1>", true);
+    await umbracoApi.content.verifyRenderedContent("/", "<h1>Hello world!</h1>");
 
     await umbracoApi.content.deleteAllContent();
     await umbracoApi.documentTypes.ensureNameNotExists(docTypeName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
@@ -243,7 +243,6 @@ test.describe('Modelsbuilder tests', () => {
 
     await umbracoApi.content.save(content);
 
-    await page.pause();
     // Navigate to the document type
     await umbracoUi.goToSection(ConstantHelper.sections.settings);
     await umbracoUi.clickElement(umbracoUi.getTreeItem("settings", ["Document Types", docTypeName]));

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/packages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/packages.spec.ts
@@ -88,7 +88,8 @@ test.describe('Packages', () => {
     
     // Navigate pack to packages and Assert the file is created
     // Waits until the button download is visible
-    await page.locator('[label-key="general_download"]').isVisible();
+    await expect(await page.locator('[label-key="general_download"]')).toBeVisible({timeout: 60000});
+    
     // Checks if the packages was created
     const doesExist = await umbracoApi.packages.doesNameExist(packageName);
     await expect(doesExist).toBe(true);


### PR DESCRIPTION
Seems like some of the tests where still flaky on the pipelines, turns out its a timing issue, because the success notifications still display, if we're going to fast.

The changes in this PR makes it so we will just close the success notification after we've asserted it is there.