### PR TITLE
Bug fix for images just upload, before selected media ContentType

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -91,9 +91,6 @@ angular.module("umbraco.directives")
                             scope.contentTypeAlias = "umbracoAutoSelect";
                         }
 
-                        // Add the processed length, as we might be uploading in stages
-                        scope.totalQueued = scope.queue.length + scope.processed.length;
-
                         _processQueueItems();                        
                     }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -79,8 +79,15 @@ angular.module("umbraco.directives")
                             });
                         }
 
+                        // Add the processed length, as we might be uploading in stages
+                        scope.totalQueued = scope.queue.length + scope.processed.length;
+
                         // If we have Accepted Media Types, we will ask to choose Media Type, if Choose Media Type returns false, it only had one choice and therefor no reason to
-                        if (scope.acceptedMediatypes && _requestChooseMediaTypeDialog() === false) {
+                        if (scope.acceptedMediatypes) {
+                            if (_requestChooseMediaTypeDialog()) {
+                                return;
+                            }
+
                             scope.contentTypeAlias = "umbracoAutoSelect";
                         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

[If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/13210)

### Description
Fix the issue with media upload before pick a media contentType.
[screen-capture (1).webm](https://user-images.githubusercontent.com/5937899/195828494-941c393e-f531-460e-8e69-643fa94a4481.webm)

The media was allways allowed to execute "_processQueueItems", witch lead it to upload the media before the modal witch closed, witch also on submit run the _processQueueItems therefore if _requestChooseMediaTypeDialog is true witch means an modal is opening then we return so the _processQueueItems isn´t runned as the close and submit events on modal is now the state we should listen to
