### PR TITLE
Collect new .xml language files from different sources

### DIFF
--- a/src/Umbraco.Core/Services/LocalizedTextServiceFileSources.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceFileSources.cs
@@ -167,7 +167,7 @@ public class LocalizedTextServiceFileSources
     }
 
     /// <summary>
-    ///     returns all xml sources for all culture files found in the folder
+    ///     Returns all xml sources for all culture files found in the folder.
     /// </summary>
     /// <returns></returns>
     public IDictionary<CultureInfo, Lazy<XDocument>> GetXmlSources() => _xmlSources.Value;
@@ -186,12 +186,9 @@ public class LocalizedTextServiceFileSources
         if (_supplementFileSources is not null)
         {
             // Get only the .xml files and filter out the user defined language files (*.user.xml) that overwrite the default
-            var newLangFiles = _supplementFileSources.Where(x => !x.FileInfo.Name.Contains("user") && x.FileInfo.Name.EndsWith(".xml"));
-
-            foreach (var item in newLangFiles)
-            {
-                result.Add(item.FileInfo);
-            }
+            result.AddRange(_supplementFileSources
+                .Where(x => !x.FileInfo.Name.Contains("user") && x.FileInfo.Name.EndsWith(".xml"))
+                .Select(x => x.FileInfo));
         }
 
         if (_directoryContents.Exists)
@@ -258,7 +255,7 @@ public class LocalizedTextServiceFileSources
 
             foreach (LocalizedTextServiceSupplementaryFileSource supplementaryFile in found)
             {
-                using (var stream = supplementaryFile.FileInfo.CreateReadStream())
+                using (Stream stream = supplementaryFile.FileInfo.CreateReadStream())
                 {
                     XDocument xChildDoc;
                     try

--- a/src/Umbraco.Core/Services/LocalizedTextServiceSupplementaryFileSource.cs
+++ b/src/Umbraco.Core/Services/LocalizedTextServiceSupplementaryFileSource.cs
@@ -1,14 +1,27 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+
 namespace Umbraco.Cms.Core.Services;
 
 public class LocalizedTextServiceSupplementaryFileSource
 {
+    [Obsolete("Use other ctor. Will be removed in Umbraco 12")]
     public LocalizedTextServiceSupplementaryFileSource(FileInfo file, bool overwriteCoreKeys)
+        : this(new PhysicalFileInfo(file), overwriteCoreKeys)
     {
-        File = file ?? throw new ArgumentNullException("file");
+    }
+
+    public LocalizedTextServiceSupplementaryFileSource(IFileInfo file, bool overwriteCoreKeys)
+    {
+        FileInfo = file ?? throw new ArgumentNullException(nameof(file));
+        File = file is PhysicalFileInfo ? new FileInfo(file.PhysicalPath) : null!;
         OverwriteCoreKeys = overwriteCoreKeys;
     }
 
+    [Obsolete("Use FileInfo instead. Will be removed in Umbraco 12")]
     public FileInfo File { get; }
+
+    public IFileInfo FileInfo { get; }
 
     public bool OverwriteCoreKeys { get; }
 }

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -102,7 +102,14 @@ public static partial class UmbracoBuilderExtensions
         IServiceProvider container)
     {
         IHostingEnvironment hostingEnvironment = container.GetRequiredService<IHostingEnvironment>();
+
+        // TODO: (for >= v13) Rethink whether all language files (.xml and .user.xml) should be located in ~/config/lang
+        // instead of ~/umbraco/config/lang and ~/config/lang.
+        // Currently when extending Umbraco, a new language file that the backoffice will be available in, should be placed
+        // in ~/umbraco/config/lang, while 'user' translation files for overrides are in ~/config/lang (according to our docs).
+        // Such change will be breaking and we would need to document this clearly.
         var subPath = WebPath.Combine(Constants.SystemDirectories.Umbraco, "config", "lang");
+
         var mainLangFolder = new DirectoryInfo(hostingEnvironment.MapPathContentRoot(subPath));
 
         return new LocalizedTextServiceFileSources(

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -50,11 +50,17 @@ namespace Umbraco.Extensions
 
             var configLangFileSources = new List<LocalizedTextServiceSupplementaryFileSource>();
 
-            foreach (IFileInfo langFileSource in contentFileProvider.GetDirectoryContents(userConfigLangFolder).Where(x => x.IsDirectory && x.Name.InvariantEquals("lang")))
+            foreach (IFileInfo langFileSource in contentFileProvider.GetDirectoryContents(userConfigLangFolder))
             {
-                foreach (IFileInfo langFile in contentFileProvider.GetDirectoryContents($"{userConfigLangFolder}/{langFileSource.Name}").Where(x => x.Name.InvariantEndsWith(".xml") && x.PhysicalPath != null))
+                if (langFileSource.IsDirectory && langFileSource.Name.InvariantEquals("lang"))
                 {
-                    configLangFileSources.Add(new LocalizedTextServiceSupplementaryFileSource(langFile, true));
+                    foreach (IFileInfo langFile in contentFileProvider.GetDirectoryContents($"{userConfigLangFolder}/{langFileSource.Name}"))
+                    {
+                        if (langFile.Name.InvariantEndsWith(".xml") && langFile.PhysicalPath is not null)
+                        {
+                            configLangFileSources.Add(new LocalizedTextServiceSupplementaryFileSource(langFile, true));
+                        }
+                    }
                 }
             }
 

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.LocalizedText.cs
@@ -1,6 +1,8 @@
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
@@ -42,20 +44,24 @@ namespace Umbraco.Extensions
             // gets all langs files in /app_plugins real or virtual locations
             IEnumerable<LocalizedTextServiceSupplementaryFileSource> pluginLangFileSources = GetPluginLanguageFileSources(webFileProvider, Cms.Core.Constants.SystemDirectories.AppPlugins, false);
 
-            // user defined langs that overwrite the default, these should not be used by plugin creators
+            // user defined language files that overwrite the default, these should not be used by plugin creators
             var userConfigLangFolder = Cms.Core.Constants.SystemDirectories.Config
                                             .TrimStart(Cms.Core.Constants.CharArrays.Tilde);
 
-            IEnumerable<LocalizedTextServiceSupplementaryFileSource> userLangFileSources = contentFileProvider.GetDirectoryContents(userConfigLangFolder)
-                    .Where(x => x.IsDirectory && x.Name.InvariantEquals("lang"))
-                    .Select(x => new DirectoryInfo(x.PhysicalPath))
-                    .SelectMany(x => x.GetFiles("*.user.xml", SearchOption.TopDirectoryOnly))
-                    .Select(x => new LocalizedTextServiceSupplementaryFileSource(x, true));
+            var configLangFileSources = new List<LocalizedTextServiceSupplementaryFileSource>();
+
+            foreach (IFileInfo langFileSource in contentFileProvider.GetDirectoryContents(userConfigLangFolder).Where(x => x.IsDirectory && x.Name.InvariantEquals("lang")))
+            {
+                foreach (IFileInfo langFile in contentFileProvider.GetDirectoryContents($"{userConfigLangFolder}/{langFileSource.Name}").Where(x => x.Name.InvariantEndsWith(".xml") && x.PhysicalPath != null))
+                {
+                    configLangFileSources.Add(new LocalizedTextServiceSupplementaryFileSource(langFile, true));
+                }
+            }
 
             return
                 localPluginFileSources
                 .Concat(pluginLangFileSources)
-                .Concat(userLangFileSources);
+                .Concat(configLangFileSources);
         }
 
 
@@ -83,13 +89,12 @@ namespace Umbraco.Extensions
                 foreach (var langFolder in GetLangFolderPaths(fileProvider, pluginFolderPath))
                 {
                     // request all the files out of the path, these will have physicalPath set.
-                    IEnumerable<FileInfo> localizationFiles = fileProvider
+                    IEnumerable<IFileInfo> localizationFiles = fileProvider
                         .GetDirectoryContents(langFolder)
                         .Where(x => !string.IsNullOrEmpty(x.PhysicalPath))
-                        .Where(x => x.Name.InvariantEndsWith(".xml"))
-                        .Select(x => new FileInfo(x.PhysicalPath));
+                        .Where(x => x.Name.InvariantEndsWith(".xml"));
 
-                    foreach (FileInfo file in localizationFiles)
+                    foreach (IFileInfo file in localizationFiles)
                     {
                         yield return new LocalizedTextServiceSupplementaryFileSource(file, overwriteCoreKeys);
                     }


### PR DESCRIPTION
## Details
- Gets .xml files for new languages (languages that [Umbraco doesn't support](https://our.umbraco.com/documentation/extending/language-files/#supported-languages)) from other sources than `umbraco/config/lang/`, like:
  - _/App_Plugins/mypackage/Lang/_ - physical files or from RCLs
  - _config/lang/_ - physical files

## Test
- Pick a language from [the list](https://learn.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes);
  - For the example, I chose Bulgarian (`bg`);
- Create the following `bg.xml` file:
```xml
<?xml version="1.0" encoding="utf-8"?>
<language alias="bg" intName="Bulgarian" localName="български" lcid="" culture="bg-BG">
  <area alias="login">
    <key alias="greeting0">(BG) Happy super Sunday</key>
    <key alias="greeting1">(BG) Happy marvelous Monday</key>
    <key alias="greeting2">(BG) Happy tubular Tuesday</key>
    <key alias="greeting3">(BG) Happy wonderful Wednesday</key>
    <key alias="greeting4">(BG) Happy thunderous Thursday</key>
    <key alias="greeting5">(BG) Happy funky Friday</key>
    <key alias="greeting6">(BG) Happy Caturday</key>
	</area>
  <area alias="sections">
    <key alias="translation">(BG) Translation</key>
  </area>
</language>
```

- Place it in _different places_** and verify that Bulgarian comes as an option in the list of Languages that you can select the menus and dialogues to be translated to, like here:
![image](https://user-images.githubusercontent.com/21998037/195855590-048b03f4-e384-4d20-a776-ca70514d9bac.png)

-----------
** _Different places like_:
- **Umbraco.Cms.StaticAssets\wwwroot\App_Plugins\MyPackage\Lang**;
- **Umbraco.Web.UI\App_Plugins\UIPackage\Lang**;  
- **Umbraco.Web.UI\config\lang**;  
- **Umbraco.Web.UI\umbraco\config\lang**;	

-----------

- Switch the language to Bulgarian and verify that the name of the Translation section changes to "_(BG) Translation_";
- Try setting the default backoffice language in appsettings by setting the `Umbraco.CMS.Global.DefaultUILanguage` key and verify that the login screen greetings changed to the ones we specified in the `bg.xml` file;
```json
  "Umbraco": {
    "CMS": {
      "Global": {
        "DefaultUILanguage": "bg-BG", // or just "bg"
      }
   }
}
```

</br>

- Delete the "packages" key from the "sections" area in `en_us.xml` file located in `Umbraco.Core/EmbeddedResources/Lang/`;
```xml
  <area alias="sections">
    <key alias="packages">Packages</key>
  </area>
```
and add the following new `en_us.xml` to either **Umbraco.Cms.StaticAssets\wwwroot\App_Plugins\MyPackage\Lang** or **Umbraco.Web.UI\App_Plugins\UIPackage\Lang**:
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<language alias="en_us" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
    <area alias="sections">
        <key alias="packages">Packages</key>
    </area>
</language>
```
- Verify that we can [add new language keys for packages](https://our.umbraco.com/documentation/extending/Packages/Language-Files-For-Packages/#including-new-language-keys) - basically check that we get a name for the packages section, instead of the `[packages]` key ;

</br>

- Verify that you can still override existing language translation keys - [follow the Greeting section](https://our.umbraco.com/documentation/Fundamentals/Backoffice/Login/#greeting):
  -  NB ❗ : Remember to change back the `"DefaultUILanguage": "en-us"`.