### PR TITLE
Left aligned message - "This index cannot be rebuilt because it has no assigned IIndexPopulator"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -420,7 +420,7 @@
 
                                             </ng-form>
 
-                                            <div class="umb-panel-group__details-status-action-description" ng-show="!vm.selectedIndex.canRebuild">
+                                            <div class="umb-panel-group__details-status-action-description pl0" ng-show="!vm.selectedIndex.canRebuild">
                                                 <localize key="examineManagement_indexCannotRebuild">This index cannot be rebuilt because it has no assigned </localize>
                                                 <code><localize key="examineManagement_iIndexPopulator">IIndexPopulator</localize></code>
                                             </div>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

Left aligned message about no index populator

**Before**
![image](https://user-images.githubusercontent.com/3941753/195863138-388e853e-1a7c-430c-af3e-58ae268ca7fc.png)


**After**
![image](https://user-images.githubusercontent.com/3941753/195863263-c979a269-e8b4-4816-97d0-fe83ae72edb0.png)


You can see this in action if you create a index without a populator 