### PR TITLE
Added const ActionLetter and ActionAlias to IAction

### DIFF
--- a/src/Umbraco.Core/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Core/Actions/ActionAssignDomain.cs
@@ -14,6 +14,12 @@ public class ActionAssignDomain : IAction
     /// <inheritdoc cref="IAction.ActionAlias" />
     public const string ActionAlias = "assigndomain";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
 

--- a/src/Umbraco.Core/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Core/Actions/ActionAssignDomain.cs
@@ -8,17 +8,11 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionAssignDomain : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter" />
     public const char ActionLetter = 'I';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    // This is all lower-case because of case sensitive filesystems, see issue: https://github.com/umbraco/Umbraco-CMS/issues/11670
-    public string Alias => "assigndomain";
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "assigndomain";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;

--- a/src/Umbraco.Core/Actions/ActionBrowse.cs
+++ b/src/Umbraco.Core/Actions/ActionBrowse.cs
@@ -16,13 +16,11 @@ namespace Umbraco.Cms.Core.Actions;
 /// </remarks>
 public class ActionBrowse : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter" />
     public const char ActionLetter = 'F';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "browse";
 
     /// <inheritdoc />
     public bool ShowInNotifier => false;
@@ -33,8 +31,6 @@ public class ActionBrowse : IAction
     /// <inheritdoc />
     public string Icon => string.Empty;
 
-    /// <inheritdoc />
-    public string Alias => "browse";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionBrowse.cs
+++ b/src/Umbraco.Core/Actions/ActionBrowse.cs
@@ -22,6 +22,12 @@ public class ActionBrowse : IAction
     /// <inheritdoc cref="IAction.ActionAlias" />
     public const string ActionAlias = "browse";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public bool ShowInNotifier => false;
 

--- a/src/Umbraco.Core/Actions/ActionCopy.cs
+++ b/src/Umbraco.Core/Actions/ActionCopy.cs
@@ -14,6 +14,12 @@ public class ActionCopy : IAction
     /// <inheritdoc cref="IAction.ActionAlias" />
     public const string ActionAlias = "copy";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;
 

--- a/src/Umbraco.Core/Actions/ActionCopy.cs
+++ b/src/Umbraco.Core/Actions/ActionCopy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
@@ -8,16 +8,11 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionCopy : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter" />
     public const char ActionLetter = 'O';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "copy";
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "copy";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;

--- a/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
+++ b/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
@@ -8,8 +8,11 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionCreateBlueprintFromContent : IAction
 {
-    /// <inheritdoc />
-    public char Letter => 'ï';
+    /// <inheritdoc cref="IAction.ActionLetter"/>
+    public const char ActionLetter = 'ï';
+
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "createblueprint";
 
     /// <inheritdoc />
     public bool ShowInNotifier => false;
@@ -19,9 +22,6 @@ public class ActionCreateBlueprintFromContent : IAction
 
     /// <inheritdoc />
     public string Icon => Constants.Icons.Blueprint;
-
-    /// <inheritdoc />
-    public string Alias => "createblueprint";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
+++ b/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
@@ -14,6 +14,12 @@ public class ActionCreateBlueprintFromContent : IAction
     /// <inheritdoc cref="IAction.ActionAlias" />
     public const string ActionAlias = "createblueprint";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public bool ShowInNotifier => false;
 

--- a/src/Umbraco.Core/Actions/ActionDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionDelete.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
@@ -8,21 +8,11 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionDelete : IAction
 {
-    /// <summary>
-    /// The unique action alias
-    /// </summary>
-    public const string ActionAlias = "delete";
-
-    /// <summary>
-    /// The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'D';
 
-    /// <inheritdoc/>
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc/>
-    public string Alias => ActionAlias;
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "delete";
 
     /// <inheritdoc/>
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionDelete.cs
@@ -15,6 +15,12 @@ public class ActionDelete : IAction
     public const string ActionAlias = "delete";
 
     /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
+    /// <inheritdoc/>
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
 
     /// <inheritdoc/>

--- a/src/Umbraco.Core/Actions/ActionMove.cs
+++ b/src/Umbraco.Core/Actions/ActionMove.cs
@@ -14,6 +14,12 @@ public class ActionMove : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "move";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;
 

--- a/src/Umbraco.Core/Actions/ActionMove.cs
+++ b/src/Umbraco.Core/Actions/ActionMove.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked upon creation of a document, media, member
+///     This action is invoked upon creation of a document, media, member.
 /// </summary>
 public class ActionMove : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'M';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "move";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "move";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;

--- a/src/Umbraco.Core/Actions/ActionNew.cs
+++ b/src/Umbraco.Core/Actions/ActionNew.cs
@@ -14,6 +14,12 @@ public class ActionNew : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "create";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Icon => "icon-add";
 

--- a/src/Umbraco.Core/Actions/ActionNew.cs
+++ b/src/Umbraco.Core/Actions/ActionNew.cs
@@ -1,28 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked upon creation of a document
+///     This action is invoked upon creation of a document.
 /// </summary>
 public class ActionNew : IAction
 {
-    /// <summary>
-    ///     The unique action alias
-    /// </summary>
-    public const string ActionAlias = "create";
-
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'C';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => ActionAlias;
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "create";
 
     /// <inheritdoc />
     public string Icon => "icon-add";

--- a/src/Umbraco.Core/Actions/ActionNotify.cs
+++ b/src/Umbraco.Core/Actions/ActionNotify.cs
@@ -14,6 +14,12 @@ public class ActionNotify : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "notify";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public bool ShowInNotifier => false;
 

--- a/src/Umbraco.Core/Actions/ActionNotify.cs
+++ b/src/Umbraco.Core/Actions/ActionNotify.cs
@@ -1,15 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked upon modifying the notification of a content
+///     This action is invoked upon modifying the notification of a content.
 /// </summary>
 public class ActionNotify : IAction
 {
-    /// <inheritdoc />
-    public char Letter => 'N';
+    /// <inheritdoc cref="IAction.ActionLetter"/>
+    public const char ActionLetter = 'N';
+
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "notify";
 
     /// <inheritdoc />
     public bool ShowInNotifier => false;
@@ -19,9 +22,6 @@ public class ActionNotify : IAction
 
     /// <inheritdoc />
     public string Icon => "icon-megaphone";
-
-    /// <inheritdoc />
-    public string Alias => "notify";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionProtect.cs
+++ b/src/Umbraco.Core/Actions/ActionProtect.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when a document is protected or unprotected
+///     This action is invoked when a document is protected or unprotected.
 /// </summary>
 public class ActionProtect : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'P';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "protect";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "protect";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;

--- a/src/Umbraco.Core/Actions/ActionProtect.cs
+++ b/src/Umbraco.Core/Actions/ActionProtect.cs
@@ -14,6 +14,12 @@ public class ActionProtect : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "protect";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
 

--- a/src/Umbraco.Core/Actions/ActionPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionPublish.cs
@@ -14,6 +14,12 @@ public class ActionPublish : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "publish";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
 

--- a/src/Umbraco.Core/Actions/ActionPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionPublish.cs
@@ -4,20 +4,15 @@
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when a document is being published
+///     This action is invoked when a document is being published.
 /// </summary>
 public class ActionPublish : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'U';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "publish";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "publish";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionRestore.cs
+++ b/src/Umbraco.Core/Actions/ActionRestore.cs
@@ -14,6 +14,12 @@ public class ActionRestore : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "restore";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string? Category => null;
 

--- a/src/Umbraco.Core/Actions/ActionRestore.cs
+++ b/src/Umbraco.Core/Actions/ActionRestore.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when the content/media item is to be restored from the recycle bin
+///     This action is invoked when the content/media item is to be restored from the recycle bin.
 /// </summary>
 public class ActionRestore : IAction
 {
-    /// <summary>
-    ///     The unique action alias
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
+    public const char ActionLetter = 'V';
+
+    /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "restore";
-
-    /// <inheritdoc />
-    public char Letter => 'V';
-
-    /// <inheritdoc />
-    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string? Category => null;

--- a/src/Umbraco.Core/Actions/ActionRights.cs
+++ b/src/Umbraco.Core/Actions/ActionRights.cs
@@ -14,6 +14,12 @@ public class ActionRights : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "rights";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
 

--- a/src/Umbraco.Core/Actions/ActionRights.cs
+++ b/src/Umbraco.Core/Actions/ActionRights.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when rights are changed on a document
+///     This action is invoked when rights are changed on a document.
 /// </summary>
 public class ActionRights : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'R';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "rights";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "rights";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionRollback.cs
+++ b/src/Umbraco.Core/Actions/ActionRollback.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when copying a document is being rolled back
+///     This action is invoked when copying a document is being rolled back.
 /// </summary>
 public class ActionRollback : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'K';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "rollback";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "rollback";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;

--- a/src/Umbraco.Core/Actions/ActionRollback.cs
+++ b/src/Umbraco.Core/Actions/ActionRollback.cs
@@ -14,6 +14,12 @@ public class ActionRollback : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "rollback";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;
 

--- a/src/Umbraco.Core/Actions/ActionSort.cs
+++ b/src/Umbraco.Core/Actions/ActionSort.cs
@@ -14,6 +14,12 @@ public class ActionSort : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "sort";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;
 

--- a/src/Umbraco.Core/Actions/ActionSort.cs
+++ b/src/Umbraco.Core/Actions/ActionSort.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when children to a document, media, member is being sorted
+///     This action is invoked when children to a document, media, member is being sorted.
 /// </summary>
 public class ActionSort : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'S';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "sort";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "sort";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;

--- a/src/Umbraco.Core/Actions/ActionToPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionToPublish.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when children to a document is being sent to published (by an editor without publishrights)
+///     This action is invoked when children to a document is being sent to published (by an editor without publishrights).
 /// </summary>
 public class ActionToPublish : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'H';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "sendtopublish";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "sendtopublish";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionToPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionToPublish.cs
@@ -14,6 +14,12 @@ public class ActionToPublish : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "sendtopublish";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
 

--- a/src/Umbraco.Core/Actions/ActionUnpublish.cs
+++ b/src/Umbraco.Core/Actions/ActionUnpublish.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when a document is being unpublished
+///     This action is invoked when a document is being unpublished.
 /// </summary>
 public class ActionUnpublish : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'Z';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "unpublish";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "unpublish";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionUnpublish.cs
+++ b/src/Umbraco.Core/Actions/ActionUnpublish.cs
@@ -14,6 +14,12 @@ public class ActionUnpublish : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "unpublish";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
 

--- a/src/Umbraco.Core/Actions/ActionUpdate.cs
+++ b/src/Umbraco.Core/Actions/ActionUpdate.cs
@@ -1,23 +1,18 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when copying a document or media
+///     This action is invoked when copying a document or media.
 /// </summary>
 public class ActionUpdate : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'A';
 
-    /// <inheritdoc />
-    public char Letter => ActionLetter;
-
-    /// <inheritdoc />
-    public string Alias => "update";
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "update";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionUpdate.cs
+++ b/src/Umbraco.Core/Actions/ActionUpdate.cs
@@ -14,6 +14,12 @@ public class ActionUpdate : IAction
     /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "update";
 
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
+
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;
 

--- a/src/Umbraco.Core/Actions/IAction.cs
+++ b/src/Umbraco.Core/Actions/IAction.cs
@@ -22,7 +22,7 @@ public interface IAction : IDiscoverable
     /// <summary>
     ///     Gets the letter used to assign a permission (must be unique).
     /// </summary>
-    char Letter => ActionLetter;
+    char Letter { get; }
 
     /// <summary>
     ///     Gets a value indicating whether whether to allow subscribing to notifications for this action
@@ -43,7 +43,7 @@ public interface IAction : IDiscoverable
     ///     Gets the alias for this action (must be unique).
     ///     This is all lower-case because of case sensitive filesystems, see issue: https://github.com/umbraco/Umbraco-CMS/issues/11670.
     /// </summary>
-    string Alias => ActionAlias;
+    string Alias { get; }
 
     /// <summary>
     ///     Gets the category used for this action

--- a/src/Umbraco.Core/Actions/IAction.cs
+++ b/src/Umbraco.Core/Actions/IAction.cs
@@ -13,10 +13,16 @@ namespace Umbraco.Cms.Core.Actions;
 /// </remarks>
 public interface IAction : IDiscoverable
 {
+    /// <inheritdoc cref="Letter"/>
+    const char ActionLetter = default;
+
+    /// <inheritdoc cref="Alias"/>
+    const string ActionAlias = default;
+
     /// <summary>
-    ///     Gets the letter used to assign a permission (must be unique)
+    ///     Gets the letter used to assign a permission (must be unique).
     /// </summary>
-    char Letter { get; }
+    char Letter => ActionLetter;
 
     /// <summary>
     ///     Gets a value indicating whether whether to allow subscribing to notifications for this action
@@ -34,9 +40,10 @@ public interface IAction : IDiscoverable
     string Icon { get; }
 
     /// <summary>
-    ///     Gets the alias for this action (must be unique)
+    ///     Gets the alias for this action (must be unique).
+    ///     This is all lower-case because of case sensitive filesystems, see issue: https://github.com/umbraco/Umbraco-CMS/issues/11670.
     /// </summary>
-    string Alias { get; }
+    string Alias => ActionAlias;
 
     /// <summary>
     ///     Gets the category used for this action


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
Some actions had these some did not, this standardises the approach, and also allows developers to access these values in notifications etc, without creating their own references to the permissions/aliases


Matt
