### PR TITLE
Avoid area scale label making overflow x

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-editor.less
@@ -163,9 +163,10 @@ Grid part:
 .umb-block-grid-area-editor__scale-label {
     position: absolute;
     display: block;
-    left: 100%;
-    margin-left: 6px;
+    right: 0;
+    top: 100%;
     margin-top: 6px;
+    transform: translateX(50%);
     z-index: 2;
 
     background-color: white;


### PR DESCRIPTION
Move scale-label below center, to avoid making overflow-x on viewport.

![image](https://user-images.githubusercontent.com/6791648/196171787-47ae59de-00a4-49b9-bc4f-343bf52a7c9c.png)
