### PR TITLE
Block Grid: highlight Areas when moving blocks

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
@@ -234,26 +234,29 @@ ng-form.ng-invalid-val-server-match-content > .umb-block-grid__block:not(.--acti
     &:not(.--hovering-area):focus,
     &:not(.--hovering-area):focus-within,
     &.--active {
+
+        /** Avoid displaying hover when dragging-mode */
+        --umb-block-grid--block_ui-opacity: calc(1 - var(--umb-block-grid--dragging-mode, 0));
         
         > .umb-block-grid__block--context {
-            opacity: 1;
+            opacity: var(--umb-block-grid--block_ui-opacity);
         }
         &:not(.--scale-mode) {
             > .umb-block-grid__block--actions {
-                opacity: 1;
+                opacity: var(--umb-block-grid--block_ui-opacity);
             }
     
             > umb-block-grid-block > umb-block-grid-entries > .umb-block-grid__layout-container > .umb-block-grid__area-actions {
-                opacity: 1;
+                opacity: var(--umb-block-grid--block_ui-opacity);
             }
         }
         
         > .umb-block-grid__scale-handler {
-            opacity: 1;
+            opacity: var(--umb-block-grid--block_ui-opacity);
         }
         > .umb-block-grid__force-left, 
         > .umb-block-grid__force-right {
-            opacity: 1;
+            opacity: var(--umb-block-grid--block_ui-opacity);
         }
     }
 
@@ -584,6 +587,9 @@ umb-block-grid-block {
     top: 0px;
     position: absolute;
     z-index: 1;
+
+    /** Avoid showing inline-create in dragging-mode */
+    opacity: calc(1 - var(--umb-block-grid--dragging-mode, 0));
 }
 .umb-block-grid__block--inline-create-button.--above {
     left: 0;
@@ -776,7 +782,8 @@ umb-block-grid-block {
     background: transparent;
     border-radius: 3px;
 
-    border: @blueDark solid 1px;
+    border: solid 1px;
+    border-color: rgba(@blueDark, .5);
     border-radius: 3px;
 
     height: 100%;
@@ -862,9 +869,25 @@ umb-block-grid-block {
     transition: opacity 240ms;
 }
 .umb-block-grid__area.--highlight::after {
+    /** Avoid displaying highlight when in dragging-mode */
+    opacity: calc(1 - var(--umb-block-grid--dragging-mode, 0));
+    border-color: @blueDark;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, .7), inset 0 0 0 1px rgba(255, 255, 255, .7);
+}
+.umb-block-grid__area:has( .umb-block-grid__layout-item-placeholder )::after {
     opacity: 1;
     border-color: @blueDark;
     box-shadow: 0 0 0 1px rgba(255, 255, 255, .7), inset 0 0 0 1px rgba(255, 255, 255, .7);
+
+    /* Moved back to edge for this case */
+    top: 0;
+    bottom: 0;
+
+    animation: umb-block-grid__area-after__border-pulse 400ms ease-in-out alternate infinite;
+    @keyframes umb-block-grid__area-after__border-pulse {
+        0%   { border-color: rgba(@blueDark, 1); }
+        100% { border-color: rgba(@blueDark, 0.66); }
+    }
 }
 
 .umb-block-grid__scalebox-backdrop {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridentries.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridentries.component.js
@@ -619,6 +619,7 @@
                     }
                     window.removeEventListener('drag', _onDragMove);
                     window.removeEventListener('dragover', _onDragMove);
+                    document.documentElement.style.setProperty("--umb-block-grid--dragging-mode", 0);
 
                     if(ghostElIndicateForceLeft) {
                         ghostEl.removeChild(ghostElIndicateForceLeft);


### PR DESCRIPTION
Highlights Areas when Blocks are being dragged around.

Only supported by the newest browsers(Supporting CSS4 :has() selector), not breaking for older browsers.

![Screenshot 2022-10-17 at 15 21 18](https://user-images.githubusercontent.com/6791648/196188101-53707961-74b6-4561-ae30-52c3417ce717.png)