### PR TITLE
Disable BlockGridEditor

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Cms.Core;
@@ -43,6 +44,7 @@ public static partial class Constants
             /// <summary>
             /// Block Grid.
             /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
             public const string BlockGrid = "Umbraco.BlockGrid";
 
                 /// <summary>

--- a/src/Umbraco.Core/Models/Blocks/BlockGridArea.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridArea.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
 
 [DataContract(Name = "area", Namespace = "")]
+[EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
 public class BlockGridArea : BlockModelCollection<BlockGridItem>
 {
     /// <summary>

--- a/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs
@@ -118,7 +118,6 @@ namespace Umbraco.Cms.Core.Models.Blocks
     /// Represents a layout item with a generic content type for the Block List editor.
     /// </summary>
     /// <typeparam name="T">The type of the content.</typeparam>
-    /// <seealso cref="IPublishedElement" />
     public class BlockGridItem<T> : BlockGridItem
         where T : IPublishedElement
     {
@@ -151,7 +150,6 @@ namespace Umbraco.Cms.Core.Models.Blocks
     /// </summary>
     /// <typeparam name="TContent">The type of the content.</typeparam>
     /// <typeparam name="TSettings">The type of the settings.</typeparam>
-    /// <seealso cref="IPublishedElement" />
     public class BlockGridItem<TContent, TSettings> : BlockGridItem<TContent>
         where TContent : IPublishedElement
         where TSettings : IPublishedElement

--- a/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Core.Models.Blocks
     /// <summary>
     /// Represents a layout item for the Block Grid editor.
     /// </summary>
-    /// <seealso cref="IPublishedElement" />
+    /// <seealso cref="IBlockReference{TContent,TSettings}" />
     [DataContract(Name = "block", Namespace = "")]
     [EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
     public class BlockGridItem : IBlockReference<IPublishedElement, IPublishedElement>

--- a/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
 using System.Runtime.Serialization;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -9,8 +10,9 @@ namespace Umbraco.Cms.Core.Models.Blocks
     /// <summary>
     /// Represents a layout item for the Block Grid editor.
     /// </summary>
-    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement,Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+    /// <seealso cref="IPublishedElement" />
     [DataContract(Name = "block", Namespace = "")]
+    [EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
     public class BlockGridItem : IBlockReference<IPublishedElement, IPublishedElement>
     {
         /// <summary>
@@ -116,7 +118,7 @@ namespace Umbraco.Cms.Core.Models.Blocks
     /// Represents a layout item with a generic content type for the Block List editor.
     /// </summary>
     /// <typeparam name="T">The type of the content.</typeparam>
-    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+    /// <seealso cref="IPublishedElement" />
     public class BlockGridItem<T> : BlockGridItem
         where T : IPublishedElement
     {
@@ -149,7 +151,7 @@ namespace Umbraco.Cms.Core.Models.Blocks
     /// </summary>
     /// <typeparam name="TContent">The type of the content.</typeparam>
     /// <typeparam name="TSettings">The type of the settings.</typeparam>
-    /// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+    /// <seealso cref="IPublishedElement" />
     public class BlockGridItem<TContent, TSettings> : BlockGridItem<TContent>
         where TContent : IPublishedElement
         where TSettings : IPublishedElement

--- a/src/Umbraco.Core/Models/Blocks/BlockGridModel.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridModel.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
@@ -11,6 +12,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 /// <seealso cref="ReadOnlyCollection{BlockGridItem}" />
 [DataContract(Name = "blockgrid", Namespace = "")]
+[EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
 public class BlockGridModel : BlockModelCollection<BlockGridItem>
 {
     /// <summary>

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockGridEditorDataConverter.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockGridEditorDataConverter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Serialization;
 
@@ -9,6 +10,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// <summary>
 /// Data converter for the block grid property editor
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
 public class BlockGridEditorDataConverter : BlockEditorDataConverter
 {
     private readonly IJsonSerializer _jsonSerializer;

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutAreaItem.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutAreaItem.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.ComponentModel;
+using Newtonsoft.Json;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
 
+[EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
 public class BlockGridLayoutAreaItem
 {
     [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutItem.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutItem.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
 using Newtonsoft.Json;
 using Umbraco.Cms.Infrastructure.Serialization;
 
@@ -9,6 +10,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// <summary>
 /// Used for deserializing the block grid layout
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)] // TODO: Remove this for V11/V10.4
 public class BlockGridLayoutItem : IBlockLayoutItem
 {
     [JsonProperty("contentUdi", Required = Required.Always)]

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
@@ -8,13 +10,16 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 /// Represents a block list property editor.
 /// </summary>
-[DataEditor(
-    Constants.PropertyEditors.Aliases.BlockGrid,
-    "Block Grid",
-    "blockgrid",
-    ValueType = ValueTypes.Json,
-    Group = Constants.PropertyEditors.Groups.RichContent,
-    Icon = "icon-layout")]
+// TODO: Re-add this DataEditor attribute to re-enable the BlockGridEditor for V11/V10.4
+// [DataEditor(
+//     Constants.PropertyEditors.Aliases.BlockGrid,
+//     "Block Grid",
+//     "blockgrid",
+//     ValueType = ValueTypes.Json,
+//     Group = Constants.PropertyEditors.Groups.RichContent,
+//     Icon = "icon-layout")]
+[HideFromTypeFinder]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public class BlockGridPropertyEditor : BlockGridPropertyEditorBase
 {
     private readonly IIOHelper _ioHelper;

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -16,7 +18,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
 /// Abstract base class for block grid based editors.
-/// </summary>
+// /// </summary>
+[HideFromTypeFinder]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public abstract class BlockGridPropertyEditorBase : DataEditor
 {
     protected BlockGridPropertyEditorBase(IDataValueEditorFactory dataValueEditorFactory)

--- a/src/Umbraco.Web.Common/Extensions/BlockGridTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/BlockGridTemplateExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Extensions;
 
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class BlockGridTemplateExtensions
 {
     public const string DefaultFolder = "blockgrid/";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
@@ -174,7 +174,8 @@ public class TypeLoaderTests
     public void GetDataEditors()
     {
         var types = _typeLoader.GetDataEditors();
-        Assert.AreEqual(42, types.Count());
+        // TODO: Increase this to 42 when BlockGridEditor is re-added
+        Assert.AreEqual(41, types.Count());
     }
 
     /// <summary>


### PR DESCRIPTION
This PR disables the BlockGridEditor.

It does so by removing the `DataEditor` property and adding `HideFromTypeFinder` this ensure that it doesn't get picked up by the type finder and wont be displayed in the backoffice. 

For some additional QoL I've also added `[EditorBrowsable(EditorBrowsableState.Never)]` to some of the BlockGrid classes, so they won't show up in IntelliSense, most notably `BlockGridTemplateExtensions` so you only see the render methods for the BlockListEditor.


To test I did the following: 

* Pack the solution with `dotnet pack -c Release -o build_output` (EditorBrowsable only works for DLL references) 
* Add the build nuget files to a localfeed
* Create a new project using the template
* Run the site and ensure that the BlockGridEditor is no longer present 
* Create a template and ensure that the Html extension methods are no longer shown ( `Html.GetBlockListHtmlAsync`)