### PR TITLE
13226 resync content model on change

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -232,6 +232,7 @@
 
                     appendRuntimeData();
                     init();
+                    startWatches($scope.content);
 
                     syncTreeNode($scope.content, $scope.content.path, true);
 
@@ -565,7 +566,6 @@
             $scope.page.loading = true;
 
             loadContent().then(function () {
-                startWatches($scope.content);
                 $scope.page.loading = false;
             });
         }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js
@@ -64,6 +64,8 @@
                 setActiveVariant();
             } else if (changes.segment && !changes.segment.isFirstChange() && changes.segment.currentValue !== changes.segment.previousValue) {
                 setActiveVariant();
+            } else if (changes.content) {
+                setActiveVariant();
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13226

### Description
Updates the editors when the content model is changed.

### Test:
- Please verify that you can replicate the issue before checking out this PR.
- Verify that the issue is gone with this change.
- Test other cases where the content model might change, to verify that the update isn't breaking other stuff.