### PR TITLE
Accessibility: Fix - Added missing button title to Umbraco badge in app header

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -726,6 +726,7 @@
     <key alias="other">Další</key>
     <key alias="articles">Články</key>
     <key alias="videos">Videa</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Modrá</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -870,6 +870,7 @@
     <key alias="clear">Clirio</key>
     <key alias="installing">Arsefydlu</key>
     <key alias="avatar">Avatar am</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="black">Du</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -857,6 +857,7 @@
     <key alias="avatar">Avatar til</key>
     <key alias="header">Overskrift</key>
     <key alias="systemField">system felt</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blå</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -726,6 +726,7 @@
     <key alias="current">Aktuelle(s)</key>
     <key alias="embed">Eingebettet</key>
     <key alias="selected">ausgewählt</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blau</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -874,6 +874,7 @@
     <key alias="header">Header</key>
     <key alias="systemField">system field</key>
     <key alias="lastUpdated">Last Updated</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blue</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -904,6 +904,7 @@
     <key alias="header">Header</key>
     <key alias="systemField">system field</key>
     <key alias="lastUpdated">Last Updated</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blue</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
@@ -559,6 +559,7 @@
     <key alias="current">actual</key>
     <key alias="embed">Insertar</key>
     <key alias="selected">seleccionado</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Azul</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -740,6 +740,7 @@
     <key alias="header">Entête</key>
     <key alias="systemField">champ système</key>
     <key alias="lastUpdated">Dernière mise à jour</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Bleu</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
@@ -333,6 +333,7 @@
     <key alias="yes">כן</key>
     <key alias="reorder">Reorder</key>
     <key alias="reorderDone">I am done reordering</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">צבע רקע</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -877,6 +877,7 @@
     <key alias="videos">Video</key>
     <key alias="installing">Installazione</key>
     <key alias="avatar">Avatar per</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blu</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
@@ -431,6 +431,7 @@
     <key alias="saving">保存...</key>
     <key alias="current">現在</key>
     <key alias="embed">埋め込み</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">ブルー</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
@@ -333,6 +333,7 @@
     <key alias="yes">예</key>
     <key alias="reorder">Reorder</key>
     <key alias="reorderDone">I am done reordering</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">배경색</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
@@ -398,6 +398,7 @@
     <key alias="embed">Innbygging</key>
     <key alias="retrieve">Hent</key>
     <key alias="selected">valgt</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Bakgrunnsfarge</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -833,6 +833,7 @@
     <key alias="articles">Artikels</key>
     <key alias="videos">Videos</key>
     <key alias="avatar">Avatar van</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blauw</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
@@ -538,6 +538,7 @@
     <key alias="current">bieżący</key>
     <key alias="embed">Osadzony</key>
     <key alias="selected">wybrany</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Niebieski</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
@@ -331,6 +331,7 @@
     <key alias="yes">Sim</key>
     <key alias="reorder">Reorder</key>
     <key alias="reorderDone">I am done reordering</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Cor de fundo</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
@@ -587,6 +587,7 @@
     <key alias="current">текущий</key>
     <key alias="selected">выбрано</key>
     <key alias="embed">Встроить</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Цвет фона</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -471,6 +471,7 @@
     <key alias="embed">Inbäddning</key>
     <key alias="retrieve">Hämta</key>
     <key alias="selected">valda</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="graphicheadline">
     <key alias="backgroundcolor">Bakgrundsfärg</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -751,6 +751,7 @@
     <key alias="other">Diğer</key>
     <key alias="articles">Makaleler</key>
     <key alias="videos">Videolar</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">Mavi</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
@@ -452,6 +452,7 @@
     <key alias="current">当前</key>
     <key alias="embed">嵌入</key>
     <key alias="selected">已选择</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">蓝色</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
@@ -445,6 +445,7 @@
     <key alias="current">目前</key>
     <key alias="embed">內嵌</key>
     <key alias="selected">選取的</key>
+    <key alias="umbracoBadge">Umbraco</key>
   </area>
   <area alias="colors">
     <key alias="blue">藍</key>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -3,7 +3,9 @@
         <div class="umb-app-header__logo" ng-if="hideBackofficeLogo !== true">
             <button type="button"
                     class="btn-reset"
-                    ng-click="toggleLogoModal()">
+                    ng-click="toggleLogoModal()"
+                    localize="title"
+                    title="@general_umbracoBadge">
                 <img src="assets/img/application/umbraco_logomark_white.svg"
                      alt="Umbraco"
                      width="30"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If you hover the mouse over the Umbraco Badge in the app header. No title appears at all. 

![image](https://user-images.githubusercontent.com/9142936/196558408-71373095-09be-4d1c-854b-b5d9e2bf2c20.png)

But if you hover the mouse over the search, help or user icon, you get a title to say what it is.

![image](https://user-images.githubusercontent.com/9142936/196558475-5363b35c-c90e-4321-ad1d-0fd98a92bff9.png)

### Description

In this PR I have added a localised title for the Umbraco badge and have added an entry into the general section for all of the language files for the localisation value. Currently they all say Umbraco but they could be updated if needed

![image](https://user-images.githubusercontent.com/9142936/196558729-44baa773-f420-4a63-bc97-e037c9fb9b4c.png)

