### PR TITLE
Dynamically modify dashboards

### DIFF
--- a/src/Umbraco.Core/Notifications/SendingDashboardsNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendingDashboardsNotification.cs
@@ -14,5 +14,5 @@ public class SendingDashboardsNotification : INotification
 
     public IUmbracoContext UmbracoContext { get; }
 
-    public IEnumerable<Tab<IDashboardSlim>> Dashboards { get; }
+    public IEnumerable<Tab<IDashboardSlim>> Dashboards { get; set; }
 }

--- a/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
@@ -93,7 +93,7 @@ internal sealed class OutgoingEditorModelEventAttribute : TypeFilterAttribute
                             _eventAggregator.Publish(new SendingContentNotification(content, umbracoContext));
                             break;
 
-                            case ContentItemDisplayWithSchedule contentWithSchedule:
+                        case ContentItemDisplayWithSchedule contentWithSchedule:
                             // This is a bit weird, since ContentItemDisplayWithSchedule was introduced later,
                             // the SendingContentNotification only accepts ContentItemDisplay,
                             // which means we have to map it to this before sending the notification.
@@ -113,27 +113,29 @@ internal sealed class OutgoingEditorModelEventAttribute : TypeFilterAttribute
                             _mapper.Map(display, contentWithSchedule, mapperContext => mapperContext.Items[nameof(contentWithSchedule.Variants)] = contentWithSchedule.Variants);
                             break;
                         case MediaItemDisplay media:
-                                _eventAggregator.Publish(new SendingMediaNotification(media, umbracoContext));
-                                break;
-                            case MemberDisplay member:
-                                _eventAggregator.Publish(new SendingMemberNotification(member, umbracoContext));
-                                break;
-                            case UserDisplay user:
-                                _eventAggregator.Publish(new SendingUserNotification(user, umbracoContext));
-                                break;
-                            case IEnumerable<Tab<IDashboardSlim>> dashboards:
-                                _eventAggregator.Publish(new SendingDashboardsNotification(dashboards, umbracoContext));
-                                break;
-                            case IEnumerable<ContentTypeBasic> allowedChildren:
-                                // Changing the Enumerable will generate a new instance, so we need to update the context result with the new content
-                                var notification = new SendingAllowedChildrenNotification(allowedChildren, umbracoContext);
-                                _eventAggregator.Publish(notification);
-                                context.Result = new ObjectResult(notification.Children);
-                                break;
-                        }
+                            _eventAggregator.Publish(new SendingMediaNotification(media, umbracoContext));
+                            break;
+                        case MemberDisplay member:
+                            _eventAggregator.Publish(new SendingMemberNotification(member, umbracoContext));
+                            break;
+                        case UserDisplay user:
+                            _eventAggregator.Publish(new SendingUserNotification(user, umbracoContext));
+                            break;
+                        case IEnumerable<Tab<IDashboardSlim>> dashboards:
+                            var dashboardNotification = new SendingDashboardsNotification(dashboards, umbracoContext);
+                            _eventAggregator.Publish(dashboardNotification);
+                            context.Result = new ObjectResult(dashboardNotification.Dashboards);
+                            break;
+                        case IEnumerable<ContentTypeBasic> allowedChildren:
+                            // Changing the Enumerable will generate a new instance, so we need to update the context result with the new content
+                            var notification = new SendingAllowedChildrenNotification(allowedChildren, umbracoContext);
+                            _eventAggregator.Publish(notification);
+                            context.Result = new ObjectResult(notification.Children);
+                            break;
                     }
                 }
             }
+        }
 
         public void OnActionExecuting(ActionExecutingContext context)
         {


### PR DESCRIPTION
This is something that I did for the allowChildrenNotification and think will also be good for the sendingDashboardsNotification. It allows you to modify the dashboards before sending it to the user.

Example code
```
    public class EditorSendingDashboardNotificationHandler : INotificationHandler<SendingDashboardsNotification>
    {
        public void Handle(SendingDashboardsNotification notification)
        {
            var dashboards = notification.Dashboards.ToList();
            dashboards.RemoveAt(0);
            notification.Dashboards = dashboards;
        }
    }
```