### PR TITLE
fixes #13146: eliminates possible JS error when saving tags datatype

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -23,7 +23,7 @@
             }
         });
 
-    function umbTagsEditorController($rootScope, assetsService, umbRequestHelper, angularHelper, $timeout, $element, $attrs) {
+    function umbTagsEditorController($rootScope, assetsService, umbRequestHelper, angularHelper, $timeout, $element, $attrs, entityResource) {
 
         let vm = this;
 
@@ -92,7 +92,7 @@
                     var sources = {
                         //see: https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#options
                         // name = the data set name, we'll make this the tag group name + culture
-                        name: vm.config.group + (vm.culture ? vm.culture : ""),
+                        name: entityResource.getSafeAlias(vm.config.group + (vm.culture ? vm.culture : "")),
                         display: "text",
                         //source: tagsHound
                         source: function (query, syncCallback, asyncCallback) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13146

### Description
When creating a custom Tags datatype it's possible to define a tag group (group name) without any restrictions for said name. However, the typeahead component used in the editor to look up existing tags, requires the group name to not have spaces (among other characters).
When using a tags editor where an invalid group name is set, a JS error appears in the console and the tags aren't always saved properly. More details in the issue.

This solution simply creates a safe "alias" from the combination of group name and culture that is set for the typeahead component, elminating the JS error.

There is, however, a possible inherent danger to this, as the group name field still allows invalid characters that are then replaced behind the scenes. I *think* this could lead to some confusion if the typeahead component can inadvertently end up looking for suggestions across defined group names. Eg. "group 1" and "group1" and "group|1" which will all get the same safe alias.

It may be somewhat of a corner case - I'm not too sure - but getting custom validation on the group name field could be a good idea, so that IF there are duplicate group names defined it is visible to the editor/admin/whatevs. That's one for the future, maybe, and not for me. I looked into it and got lost/stuck pretty quickly :-/

**To test** this fix, try creating Tags data types with characters that are not "underscores, dashes, letters (a-z), and numbers" (which are all that the typeahead component allows). Then add those datatype(s) to a document type and verify that

1. No JS errors happen
1. Tags are still being suggested.
1. If feeling fancy, check if suggestions are being "cross contaminated" between group names when they collide after being "rinsed".

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
