### PR TITLE
Fix Content Tree Node Not Greyed Out

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -109,6 +109,11 @@ public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeW
     {
         var culture = queryStrings?["culture"].ToString();
 
+        if(culture.IsNullOrWhiteSpace())
+        {
+            culture = _localizationService.GetDefaultLanguageIsoCode();
+        }
+
         IEnumerable<MenuItem> allowedUserOptions = GetAllowedUserMenuItemsForNode(entity);
         if (CanUserAccessNode(entity, allowedUserOptions, culture))
         {


### PR DESCRIPTION
Added an additional logic which adds the default culture when there's only 1 language configured.

Here's the following use cases made while debugging:

1.) The issue can be replicable if it only have one language and the "Document Type" is set to vary by culture.
2.) The issue cannot be replicable when there's 2 languages configured since the query string for the "culture" is appended before making the request to the [API.](https://github.com/umbraco/Umbraco-CMS/blob/v10/contrib/src/Umbraco.Web.BackOffice/Trees/TreeControllerBase.cs#L172)

This fixes [#12279](https://github.com/umbraco/Umbraco-CMS/issues/12279)
