### PR TITLE
"You have unsaved changes" on media with date picker even though I don't,  part 2

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -143,26 +143,29 @@ function dateTimePickerController($scope, angularHelper, dateHelper, validationM
     }
 
     function updateModelValue(momentDate) {
-        if ($scope.hasDatetimePickerValue) {
-            if ($scope.model.config.pickTime) {
-                //check if we are supposed to offset the time
-                if ($scope.model.value && Object.toBoolean($scope.model.config.offsetTime) && Umbraco.Sys.ServerVariables.application.serverTimeOffset !== undefined) {
-                    $scope.model.value = dateHelper.convertToServerStringTime(momentDate, Umbraco.Sys.ServerVariables.application.serverTimeOffset);
-                    $scope.serverTime = dateHelper.convertToServerStringTime(momentDate, Umbraco.Sys.ServerVariables.application.serverTimeOffset, "YYYY-MM-DD HH:mm:ss Z");
-                }
-                else {
-                    $scope.model.value = momentDate.format("YYYY-MM-DD HH:mm:ss");
-                }
-            }
-            else {
-                $scope.model.value = momentDate.format("YYYY-MM-DD");
-            }
+      var curMoment = moment($scope.model.value);
+      if ($scope.hasDatetimePickerValue) {
+        if ($scope.model.config.pickTime) {
+          //check if we are supposed to offset the time
+          if ($scope.model.value && Object.toBoolean($scope.model.config.offsetTime) && Umbraco.Sys.ServerVariables.application.serverTimeOffset !== undefined) {
+            $scope.model.value = dateHelper.convertToServerStringTime(momentDate, Umbraco.Sys.ServerVariables.application.serverTimeOffset);
+            $scope.serverTime = dateHelper.convertToServerStringTime(momentDate, Umbraco.Sys.ServerVariables.application.serverTimeOffset, "YYYY-MM-DD HH:mm:ss Z");
+          }
+          else {
+            $scope.model.value = momentDate.format("YYYY-MM-DD HH:mm:ss");
+          }
         }
         else {
-            $scope.model.value = null;
+          $scope.model.value = momentDate.format("YYYY-MM-DD");
         }
+      }
+      else {
+        $scope.model.value = null;
+      }
 
+      if (!curMoment.isSame(momentDate)) {
         setDirty();
+      }
     }
 
     function setDirty() {


### PR DESCRIPTION
This is kind of a follow-up to PR #12721 which was solving issue #12617 

I noticed that there was still an issue if you just entered and got out of the date field itself without changing anything, when leaving the page you would also get an "unsaved changes" alert.

So this PR fixes this.

### Steps to reproduce

1. Create Date Picker property on a media type
2. Create a new node of that type
3. Touch or change the date picker
4. Save the media node
5. Leave and reopen the node
6. Touch the date picker but do not change the value
7. Leve the page
8. You get an "unsaved changes" alert

### Expected result / actual result

When just touching/setting focus in the date picker and then leaving the node, no "You have unsaved changes" pop up should occur.
