### PR TITLE
Fixed user invited badge color

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/usershelper.service.js
@@ -8,7 +8,7 @@
             { "value": 0, "name": "Active", "key": "Active", "color": "success" },
             { "value": 1, "name": "Disabled", "key": "Disabled", "color": "danger" },
             { "value": 2, "name": "Locked out", "key": "LockedOut", "color": "danger" },
-            { "value": 3, "name": "Invited", "key": "Invited", "color": "warning" },
+            { "value": 3, "name": "Invited", "key": "Invited", "color": "primary" },
             { "value": 4, "name": "Inactive", "key": "Inactive", "color": "warning" }
         ];
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [Invited tag - Fail minimum contrast #70](https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/70)

### Description
Previous badge color for 'invited' on user cards in the user section failed to meet color-contrast

This was because the badge colour used the 'warning' color attribute.

Therefore have changed the settings in the user service for the 'invited' property to use the 'primary' color attribute

This now meets color contrast standards (and I think looks better :D )

In order to test:

Ensure that build of Umbraco has SMTP configured
Browse to Users section
On the dashboard find the dropdown to invite new user
Create and send invite to new user
User now appears as a card with 'invited' badge
Invited badge background color and foreground color now meet color contrast standards
