### PR TITLE
Remove xml docs warnings using .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -248,6 +248,7 @@ csharp_preserve_single_line_blocks = true
 ##########################################
 
 [*.{cs,csx,cake,vb,vbx}]
+dotnet_diagnostic.CS1591.severity = suggestion
 
 ##########################################
 # Styles


### PR DESCRIPTION
Prerequisites
 I have added steps to test this contribution in the description below
Description
When working with the repo its hard to see any warning due to the amount of the xml docs warnings.
Resubmit of  https://github.com/umbraco/Umbraco-CMS/pull/13257 hopefully without the commit issues :)