### PR TITLE
standardising ActionLetter and ActionName for IAction

### DIFF
--- a/src/Umbraco.Core/Actions/ActionAssignDomain.cs
+++ b/src/Umbraco.Core/Actions/ActionAssignDomain.cs
@@ -8,17 +8,17 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionAssignDomain : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter" />
     public const char ActionLetter = 'I';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "assigndomain";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    // This is all lower-case because of case sensitive filesystems, see issue: https://github.com/umbraco/Umbraco-CMS/issues/11670
-    public string Alias => "assigndomain";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;

--- a/src/Umbraco.Core/Actions/ActionBrowse.cs
+++ b/src/Umbraco.Core/Actions/ActionBrowse.cs
@@ -16,13 +16,17 @@ namespace Umbraco.Cms.Core.Actions;
 /// </remarks>
 public class ActionBrowse : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter" />
     public const char ActionLetter = 'F';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "browse";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public bool ShowInNotifier => false;
@@ -33,8 +37,6 @@ public class ActionBrowse : IAction
     /// <inheritdoc />
     public string Icon => string.Empty;
 
-    /// <inheritdoc />
-    public string Alias => "browse";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionCopy.cs
+++ b/src/Umbraco.Core/Actions/ActionCopy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
@@ -8,16 +8,17 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionCopy : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter" />
     public const char ActionLetter = 'O';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "copy";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "copy";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;

--- a/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
+++ b/src/Umbraco.Core/Actions/ActionCreateBlueprintFromContent.cs
@@ -8,8 +8,17 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionCreateBlueprintFromContent : IAction
 {
-    /// <inheritdoc />
-    public char Letter => 'ï';
+    /// <inheritdoc cref="IAction.ActionLetter"/>
+    public const char ActionLetter = 'ï';
+
+    /// <inheritdoc cref="IAction.ActionAlias" />
+    public const string ActionAlias = "createblueprint";
+
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public bool ShowInNotifier => false;
@@ -19,9 +28,6 @@ public class ActionCreateBlueprintFromContent : IAction
 
     /// <inheritdoc />
     public string Icon => Constants.Icons.Blueprint;
-
-    /// <inheritdoc />
-    public string Alias => "createblueprint";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionDelete.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
@@ -8,15 +8,11 @@ namespace Umbraco.Cms.Core.Actions;
 /// </summary>
 public class ActionDelete : IAction
 {
-    /// <summary>
-    /// The unique action alias
-    /// </summary>
-    public const string ActionAlias = "delete";
-
-    /// <summary>
-    /// The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'D';
+
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "delete";
 
     /// <inheritdoc/>
     public char Letter => ActionLetter;

--- a/src/Umbraco.Core/Actions/ActionMove.cs
+++ b/src/Umbraco.Core/Actions/ActionMove.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked upon creation of a document, media, member
+///     This action is invoked upon creation of a document, media, member.
 /// </summary>
 public class ActionMove : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'M';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "move";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "move";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;

--- a/src/Umbraco.Core/Actions/ActionNew.cs
+++ b/src/Umbraco.Core/Actions/ActionNew.cs
@@ -1,27 +1,23 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked upon creation of a document
+///     This action is invoked upon creation of a document.
 /// </summary>
 public class ActionNew : IAction
 {
-    /// <summary>
-    ///     The unique action alias
-    /// </summary>
-    public const string ActionAlias = "create";
-
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'C';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "create";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public string Alias => ActionAlias;
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Actions/ActionNotify.cs
+++ b/src/Umbraco.Core/Actions/ActionNotify.cs
@@ -1,15 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked upon modifying the notification of a content
+///     This action is invoked upon modifying the notification of a content.
 /// </summary>
 public class ActionNotify : IAction
 {
-    /// <inheritdoc />
-    public char Letter => 'N';
+    /// <inheritdoc cref="IAction.ActionLetter"/>
+    public const char ActionLetter = 'N';
+
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "notify";
+
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
+
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public bool ShowInNotifier => false;
@@ -19,9 +28,6 @@ public class ActionNotify : IAction
 
     /// <inheritdoc />
     public string Icon => "icon-megaphone";
-
-    /// <inheritdoc />
-    public string Alias => "notify";
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionProtect.cs
+++ b/src/Umbraco.Core/Actions/ActionProtect.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when a document is protected or unprotected
+///     This action is invoked when a document is protected or unprotected.
 /// </summary>
 public class ActionProtect : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'P';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "protect";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "protect";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;

--- a/src/Umbraco.Core/Actions/ActionPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionPublish.cs
@@ -4,20 +4,21 @@
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when a document is being published
+///     This action is invoked when a document is being published.
 /// </summary>
 public class ActionPublish : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'U';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "publish";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "publish";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionRestore.cs
+++ b/src/Umbraco.Core/Actions/ActionRestore.cs
@@ -1,22 +1,23 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when the content/media item is to be restored from the recycle bin
+///     This action is invoked when the content/media item is to be restored from the recycle bin.
 /// </summary>
 public class ActionRestore : IAction
 {
-    /// <summary>
-    ///     The unique action alias
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
+    public const char ActionLetter = 'V';
+
+    /// <inheritdoc cref="IAction.ActionAlias"/>
     public const string ActionAlias = "restore";
 
-    /// <inheritdoc />
-    public char Letter => 'V';
+    /// <inheritdoc/>
+    public char Letter => ActionLetter;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public string Alias => ActionAlias;
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Actions/ActionRights.cs
+++ b/src/Umbraco.Core/Actions/ActionRights.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when rights are changed on a document
+///     This action is invoked when rights are changed on a document.
 /// </summary>
 public class ActionRights : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'R';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "rights";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "rights";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionRollback.cs
+++ b/src/Umbraco.Core/Actions/ActionRollback.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when copying a document is being rolled back
+///     This action is invoked when copying a document is being rolled back.
 /// </summary>
 public class ActionRollback : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'K';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "rollback";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "rollback";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.AdministrationCategory;

--- a/src/Umbraco.Core/Actions/ActionSort.cs
+++ b/src/Umbraco.Core/Actions/ActionSort.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when children to a document, media, member is being sorted
+///     This action is invoked when children to a document, media, member is being sorted.
 /// </summary>
 public class ActionSort : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'S';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "sort";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "sort";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.StructureCategory;

--- a/src/Umbraco.Core/Actions/ActionToPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionToPublish.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when children to a document is being sent to published (by an editor without publishrights)
+///     This action is invoked when children to a document is being sent to published (by an editor without publishrights).
 /// </summary>
 public class ActionToPublish : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'H';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "sendtopublish";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "sendtopublish";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionUnpublish.cs
+++ b/src/Umbraco.Core/Actions/ActionUnpublish.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when a document is being unpublished
+///     This action is invoked when a document is being unpublished.
 /// </summary>
 public class ActionUnpublish : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'Z';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "unpublish";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "unpublish";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/ActionUpdate.cs
+++ b/src/Umbraco.Core/Actions/ActionUpdate.cs
@@ -1,23 +1,24 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Actions;
 
 /// <summary>
-///     This action is invoked when copying a document or media
+///     This action is invoked when copying a document or media.
 /// </summary>
 public class ActionUpdate : IAction
 {
-    /// <summary>
-    ///     The unique action letter
-    /// </summary>
+    /// <inheritdoc cref="IAction.ActionLetter"/>
     public const char ActionLetter = 'A';
 
-    /// <inheritdoc />
+    /// <inheritdoc cref="IAction.ActionAlias"/>
+    public const string ActionAlias = "update";
+
+    /// <inheritdoc/>
     public char Letter => ActionLetter;
 
-    /// <inheritdoc />
-    public string Alias => "update";
+    /// <inheritdoc/>
+    public string Alias => ActionAlias;
 
     /// <inheritdoc />
     public string Category => Constants.Conventions.PermissionCategories.ContentCategory;

--- a/src/Umbraco.Core/Actions/IAction.cs
+++ b/src/Umbraco.Core/Actions/IAction.cs
@@ -13,8 +13,14 @@ namespace Umbraco.Cms.Core.Actions;
 /// </remarks>
 public interface IAction : IDiscoverable
 {
+    /// <inheritdoc cref="Letter"/>
+    const char ActionLetter = default;
+
+    /// <inheritdoc cref="Alias"/>
+    const string ActionAlias = default;
+
     /// <summary>
-    ///     Gets the letter used to assign a permission (must be unique)
+    ///     Gets the letter used to assign a permission (must be unique).
     /// </summary>
     char Letter { get; }
 
@@ -34,7 +40,8 @@ public interface IAction : IDiscoverable
     string Icon { get; }
 
     /// <summary>
-    ///     Gets the alias for this action (must be unique)
+    ///     Gets the alias for this action (must be unique).
+    ///     This is all lower-case because of case sensitive filesystems, see issue: https://github.com/umbraco/Umbraco-CMS/issues/11670.
     /// </summary>
     string Alias { get; }
 


### PR DESCRIPTION
Prerequisites
- [x] I have added steps to test this contribution in the description below

Description

Some actions had these some did not, this standardises the approach, and also allows developers to access these values in notifications etc, without creating their own references to the permissions/aliases

Matt

formally - https://github.com/umbraco/Umbraco-CMS/pull/13215