### PR TITLE
Added asserts to TagsCanBecomeInvariantByPropertyTypeAndBackToVariant

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTagsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTagsTests.cs
@@ -392,6 +392,9 @@ public class ContentServiceTagsTests : UmbracoIntegrationTest
     [Test]
     public void TagsCanBecomeInvariantByPropertyTypeAndBackToVariant()
     {
+        var frValue = new string[] { "hello", "world", "some", "tags", "plus" };
+        var enValue = new string[] { "hello", "world", "another", "one" };
+
         var language = new LanguageBuilder()
             .WithCultureInfo("fr-FR")
             .Build();
@@ -409,9 +412,9 @@ public class ContentServiceTagsTests : UmbracoIntegrationTest
         content1.SetCultureName("name-fr", "fr-FR");
         content1.SetCultureName("name-en", "en-US");
         content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "some", "tags", "plus" }, culture: "fr-FR");
+            frValue, culture: "fr-FR");
         content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "another", "one" }, culture: "en-US");
+            enValue, culture: "en-US");
         ContentService.SaveAndPublish(content1);
 
         propertyType.Variations = ContentVariation.Nothing;
@@ -421,7 +424,8 @@ public class ContentServiceTagsTests : UmbracoIntegrationTest
         propertyType.Variations = ContentVariation.Culture;
         ContentTypeService.Save(contentType);
 
-        // TODO: Assert results
+        Assert.AreEqual(frValue, Serializer.Deserialize<string[]>(content1.GetValue<string>("tags", "fr-FR")));
+        Assert.AreEqual(enValue, Serializer.Deserialize<string[]>(content1.GetValue<string>("tags", "en-US")));
     }
 
     [Test]
@@ -847,7 +851,7 @@ public class ContentServiceTagsTests : UmbracoIntegrationTest
 
         IContent content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
         content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello,world,tags", "new"});
+            new[] { "hello,world,tags", "new" });
 
         ContentService.SaveAndPublish(content);
 
@@ -882,7 +886,7 @@ public class ContentServiceTagsTests : UmbracoIntegrationTest
 
         IContent content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
         content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello,world,tags", "new"});
+            new[] { "hello,world,tags", "new" });
 
         ContentService.SaveAndPublish(content);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below



### Description
Test had a TODO instead of Asserts, so I added them.

Automated tests should handle testing for us all :)

<!-- Thanks for contributing to Umbraco CMS! -->
