### PR TITLE
Added h2 for the package details heading

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
+++ b/src/Umbraco.Web.UI.Client/src/views/packages/views/repo.html
@@ -171,7 +171,7 @@
 
                     <umb-box>
                         <umb-box-content>
-                            <div class="umb-packages-view-title">{{ vm.package.name }}</div>
+                            <h2 class="umb-packages-view-title">{{ vm.package.name }}</h2>
                             <div class="umb-package-details__description" ng-bind-html="vm.package.description"></div>
                             <div class="umb-gallery">
                                 <div class="umb-gallery__thumbnails">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [Package details - Skipped heading level(s) #59](https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/59)

### Description

Fixed skipped heading on the package details page

Navigate to 'Packages' section
Open a package (e.g. Umbraco forms)
Heading levels now read correctly

The 'visual heading' was not configured as a heading:

`<div class="umb-packages-view-title ng-binding ng-scope">Umbraco Forms</div>`

![image](https://user-images.githubusercontent.com/8383558/197350878-fbf2f02a-bd1e-4f96-b7de-0293bb674e5b.png)

Now is changed to:

`<h2 class="umb-packages-view-title ng-binding ng-scope">Umbraco Forms</h2>`

![image](https://user-images.githubusercontent.com/8383558/197351657-46d91a8e-5882-4f60-af48-abd7b42db72a.png)

This heading is unique to the package description page so there does not appear to be any adverse effect elsewhere.  As the classes for the div have been used on the heading - there has not been any impacts on styling either on desktop or mobile sizes

<!-- Thanks for contributing to Umbraco CMS! -->
