### PR TITLE
Postgresql prerequisites

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
             inputs:
               targetType: inline
               script: |
-                choco install docfx --version=2.59.2 -y
+                choco install docfx --version=2.59.4 -y
                 if ($lastexitcode -ne 0){
                     throw ("Error installing DocFX")
                 }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentType2ContentTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentType2ContentTypeDto.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(Constants.DatabaseSchema.Tables.ElementTypeTree)]
 [ExplicitColumns]
+[PrimaryKey("parentContentTypeId, childContentTypeId", AutoIncrement = false)]
 internal class ContentType2ContentTypeDto
 {
     [Column("parentContentTypeId")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/User2UserGroupDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/User2UserGroupDto.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(Constants.DatabaseSchema.Tables.User2UserGroup)]
 [ExplicitColumns]
+[PrimaryKey("userId, userGroupId", AutoIncrement = false)]
 public class User2UserGroupDto
 {
     [Column("userId")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2AppDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2AppDto.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(Constants.DatabaseSchema.Tables.UserGroup2App)]
 [ExplicitColumns]
+[PrimaryKey("userGroupId, app", AutoIncrement = false)]
 public class UserGroup2AppDto
 {
     [Column("userGroupId")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2LanguageDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2LanguageDto.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using NPoco;
 using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
 
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(Cms.Core.Constants.DatabaseSchema.Tables.UserGroup2Language)]
 [ExplicitColumns]
+[PrimaryKey("userGroupId, languageId", AutoIncrement = false)]
 public class UserGroup2LanguageDto
 {
     public const string TableName = Cms.Core.Constants.DatabaseSchema.Tables.UserGroup2Language;

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2NodeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2NodeDto.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(TableName)]
 [ExplicitColumns]
+[PrimaryKey("userGroupId, nodeId", AutoIncrement = false)]
 internal class UserGroup2NodeDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.UserGroup2Node;

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2NodePermissionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2NodePermissionDto.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(Constants.DatabaseSchema.Tables.UserGroup2NodePermission)]
 [ExplicitColumns]
+[PrimaryKey("userGroupId, nodeId, permission", AutoIncrement = false)]
 internal class UserGroup2NodePermissionDto
 {
     [Column("userGroupId")]

--- a/src/Umbraco.Infrastructure/Persistence/NPocoDatabaseTypeExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoDatabaseTypeExtensions.cs
@@ -12,4 +12,8 @@ internal static class NPocoDatabaseTypeExtensions
     [Obsolete("Usage of this method indicates a code smell.")]
     public static bool IsSqlite(this DatabaseType databaseType)
         => databaseType is SQLiteDatabaseType;
+
+    [Obsolete("Usage of this method indicates a code smell.")]
+    public static bool IsPostgresql(this DatabaseType databaseType)
+        => databaseType is PostgreSQLDatabaseType;
 }

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -94,7 +94,7 @@ namespace Umbraco.Extensions
         public static Sql<ISqlContext>.SqlJoinClause<ISqlContext> InnerJoinNested(this Sql<ISqlContext> sql, Sql<ISqlContext> nestedQuery, string alias)
         {
             return new Sql<ISqlContext>.SqlJoinClause<ISqlContext>(sql.Append("INNER JOIN (").Append(nestedQuery)
-                .Append($") [{alias}]"));
+                .Append($") {sql.SqlContext.SqlSyntax.GetQuotedColumnName(alias)}"));
         }
 
         public static Sql<ISqlContext> WhereLike<TDto>(this Sql<ISqlContext> sql, Expression<Func<TDto, object?>> fieldSelector, string likeValue)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentVersionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentVersionRepository.cs
@@ -25,13 +25,13 @@ internal class DocumentVersionRepository : IDocumentVersionRepository
     {
         Sql<ISqlContext>? query = _scopeAccessor.AmbientScope?.SqlContext.Sql();
 
-        query?.Select(@"umbracoDocument.nodeId as contentId,
+        query?.Select(@$"umbracoDocument.nodeId as contentId,
                            umbracoContent.contentTypeId as contentTypeId,
                            umbracoContentVersion.id as versionId,
                            umbracoContentVersion.userId as userId,
                            umbracoContentVersion.versionDate as versionDate,
                            umbracoDocumentVersion.published as currentPublishedVersion,
-                           umbracoContentVersion.[current] as currentDraftVersion,
+                           umbracoContentVersion.{query.SqlContext.SqlSyntax.GetQuotedColumnName("current")} as currentDraftVersion,
                            umbracoContentVersion.preventCleanup as preventCleanup,
                            umbracoUser.userName as username")
             .From<DocumentDto>()
@@ -66,13 +66,13 @@ internal class DocumentVersionRepository : IDocumentVersionRepository
     {
         Sql<ISqlContext>? query = _scopeAccessor.AmbientScope?.SqlContext.Sql();
 
-        query?.Select(@"umbracoDocument.nodeId as contentId,
+        query?.Select(@$"umbracoDocument.nodeId as contentId,
                            umbracoContent.contentTypeId as contentTypeId,
                            umbracoContentVersion.id as versionId,
                            umbracoContentVersion.userId as userId,
                            umbracoContentVersion.versionDate as versionDate,
                            umbracoDocumentVersion.published as currentPublishedVersion,
-                           umbracoContentVersion.[current] as currentDraftVersion,
+                           umbracoContentVersion.{query.SqlContext.SqlSyntax.GetQuotedColumnName("current")} as currentDraftVersion,
                            umbracoContentVersion.preventCleanup as preventCleanup,
                            umbracoUser.userName as username")
             .From<DocumentDto>()
@@ -155,13 +155,13 @@ internal class DocumentVersionRepository : IDocumentVersionRepository
     {
         Sql<ISqlContext>? query = _scopeAccessor.AmbientScope?.SqlContext.Sql();
 
-        query?.Select(@"umbracoDocument.nodeId as contentId,
+        query?.Select(@$"umbracoDocument.nodeId as contentId,
                            umbracoContent.contentTypeId as contentTypeId,
                            umbracoContentVersion.id as versionId,
                            umbracoContentVersion.userId as userId,
                            umbracoContentVersion.versionDate as versionDate,
                            umbracoDocumentVersion.published as currentPublishedVersion,
-                           umbracoContentVersion.[current] as currentDraftVersion,
+                           umbracoContentVersion.{query.SqlContext.SqlSyntax.GetQuotedColumnName("current")} as currentDraftVersion,
                            umbracoContentVersion.preventCleanup as preventCleanup,
                            umbracoUser.userName as username")
             .From<DocumentDto>()

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -150,8 +150,8 @@ internal class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelat
 
     public void DeleteByParent(int parentId, params string[] relationTypeAliases)
     {
-        // HACK: SQLite - hard to replace this without provider specific repositories/another ORM.
-        if (Database.DatabaseType.IsSqlite())
+        // HACK: SQLite/PostgreSQL - hard to replace this without provider specific repositories/another ORM.
+        if (Database.DatabaseType.IsSqlite() || Database.DatabaseType.IsPostgresql())
         {
             Sql<ISqlContext>? query = Sql().Append(@"delete from umbracoRelation");
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
@@ -26,10 +26,11 @@ internal class ServerRegistrationRepository : EntityRepositoryBase<int, IServerR
         DateTime timeoutDate = DateTime.Now.Subtract(staleTimeout);
 
         Database.Update<ServerRegistrationDto>(
-            "SET isActive=0, isSchedulingPublisher=0 WHERE lastNotifiedDate < @timeoutDate", new
+            "SET isActive=@false_, isSchedulingPublisher=@false_ WHERE lastNotifiedDate < @timeoutDate", new
             {
                 /*timeoutDate =*/
                 timeoutDate,
+                false_ = false
             });
         ClearCache();
     }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
@@ -26,21 +26,20 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             bool filterMustBeIsDependency, out long totalRecords)
         {
             Sql<ISqlContext> innerUnionSql = GetInnerUnionSql();
-
             var sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql()
                 .SelectDistinct(
-                    "[x].[id] as nodeId",
-                    "[n].[uniqueId] as nodeKey",
-                    "[n].[text] as nodeName",
-                    "[n].[nodeObjectType] as nodeObjectType",
-                    "[d].[published] as nodePublished",
-                    "[ct].[icon] as contentTypeIcon",
-                    "[ct].[alias] as contentTypeAlias",
-                    "[ctn].[text] as contentTypeName",
-                    "[x].[alias] as relationTypeAlias",
-                    "[x].[name] as relationTypeName",
-                    "[x].[isDependency] as relationTypeIsDependency",
-                    "[x].[dual] as relationTypeIsBidirectional")
+                    "x.id as nodeId",
+                    "n.uniqueId as nodeKey",
+                    "n.text as nodeName",
+                    "n.nodeObjectType as nodeObjectType",
+                    "d.published as nodePublished",
+                    "ct.icon as contentTypeIcon",
+                    "ct.alias as contentTypeAlias",
+                    "ctn.text as contentTypeName",
+                    "x.alias as relationTypeAlias",
+                    "x.name as relationTypeName",
+                    "x.isDependency as relationTypeIsDependency",
+                    "x.dual as relationTypeIsBidirectional")
                 .From<NodeDto>("n")
                 .InnerJoinNested(innerUnionSql, "x")
                 .On<NodeDto, UnionHelperDto>((n, x) => n.NodeId == x.Id, "n", "x")
@@ -92,23 +91,23 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             }
 
             var innerUnionSqlChild = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().Select(
-                    "[cr].childId as id", "[cr].parentId as otherId", "[rt].[alias]", "[rt].[name]",
-                    "[rt].[isDependency]", "[rt].[dual]")
+                    "cr.childId as id", "cr.parentId as otherId", "rt.alias", "rt.name",
+                    "rt.isDependency", "rt.dual")
                 .From<RelationDto>("cr")
                 .InnerJoin<RelationTypeDto>("rt")
                 .On<RelationDto, RelationTypeDto>((cr, rt) => rt.Dual == false && rt.Id == cr.RelationType, "cr", "rt");
 
             var innerUnionSqlDualParent = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().Select(
-                    "[dpr].parentId as id", "[dpr].childId as otherId", "[dprt].[alias]", "[dprt].[name]",
-                    "[dprt].[isDependency]", "[dprt].[dual]")
+                    "dpr.parentId as id", "dpr.childId as otherId", "dprt.alias", "dprt.name",
+                    "dprt.isDependency", "dprt.dual")
                 .From<RelationDto>("dpr")
                 .InnerJoin<RelationTypeDto>("dprt")
                 .On<RelationDto, RelationTypeDto>(
                     (dpr, dprt) => dprt.Dual == true && dprt.Id == dpr.RelationType, "dpr", "dprt");
 
             var innerUnionSql3 = _scopeAccessor.AmbientScope.Database.SqlContext.Sql().Select(
-                    "[dcr].childId as id", "[dcr].parentId as otherId", "[dcrt].[alias]", "[dcrt].[name]",
-                    "[dcrt].[isDependency]", "[dcrt].[dual]")
+                    "dcr.childId as id", "dcr.parentId as otherId", "dcrt.alias", "dcrt.name",
+                    "dcrt.isDependency", "dcrt.dual")
                 .From<RelationDto>("dcr")
                 .InnerJoin<RelationTypeDto>("dcrt")
                 .On<RelationDto, RelationTypeDto>(
@@ -129,7 +128,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
             // Gets the path of the parent with ",%" added
             var subsubQuery = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql()
-                .Select(syntax?.GetConcat("[node].[path]", "',%'"))
+                .Select(syntax?.GetConcat("node.path", "',%'"))
                 .From<NodeDto>("node")
                 .Where<NodeDto>(x => x.NodeId == parentId, "node");
 
@@ -142,18 +141,18 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             Sql<ISqlContext> innerUnionSql = GetInnerUnionSql();
 
             var sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql().SelectDistinct(
-                    "[x].[id] as nodeId",
-                    "[n].[uniqueId] as nodeKey",
-                    "[n].[text] as nodeName",
-                    "[n].[nodeObjectType] as nodeObjectType",
-                    "[d].[published] as nodePublished",
-                    "[ct].[icon] as contentTypeIcon",
-                    "[ct].[alias] as contentTypeAlias",
-                    "[ctn].[text] as contentTypeName",
-                    "[x].[alias] as relationTypeAlias",
-                    "[x].[name] as relationTypeName",
-                    "[x].[isDependency] as relationTypeIsDependency",
-                    "[x].[dual] as relationTypeIsBidirectional")
+                    "x.id as nodeId",
+                    "n.uniqueId as nodeKey",
+                    "n.text as nodeName",
+                    "n.nodeObjectType as nodeObjectType",
+                    "d.published as nodePublished",
+                    "ct.icon as contentTypeIcon",
+                    "ct.alias as contentTypeAlias",
+                    "ctn.text as contentTypeName",
+                    "x.alias as relationTypeAlias",
+                    "x.name as relationTypeName",
+                    "x.isDependency as relationTypeIsDependency",
+                    "x.dual as relationTypeIsBidirectional")
                 .From<NodeDto>("n")
                 .InnerJoinNested(innerUnionSql, "x")
                 .On<NodeDto, UnionHelperDto>((n, x) => n.NodeId == x.Id, "n", "x")
@@ -204,18 +203,18 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             Sql<ISqlContext> innerUnionSql = GetInnerUnionSql();
             var sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql().SelectDistinct(
-                    "[x].[otherId] as nodeId",
-                    "[n].[uniqueId] as nodeKey",
-                    "[n].[text] as nodeName",
-                    "[n].[nodeObjectType] as nodeObjectType",
-                    "[d].[published] as nodePublished",
-                    "[ct].[icon] as contentTypeIcon",
-                    "[ct].[alias] as contentTypeAlias",
-                    "[ctn].[text] as contentTypeName",
-                    "[x].[alias] as relationTypeAlias",
-                    "[x].[name] as relationTypeName",
-                    "[x].[isDependency] as relationTypeIsDependency",
-                    "[x].[dual] as relationTypeIsBidirectional")
+                    "x.otherId as nodeId",
+                    "n.uniqueId as nodeKey",
+                    "n.text as nodeName",
+                    "n.nodeObjectType as nodeObjectType",
+                    "d.published as nodePublished",
+                    "ct.icon as contentTypeIcon",
+                    "ct.alias as contentTypeAlias",
+                    "ctn.text as contentTypeName",
+                    "x.alias as relationTypeAlias",
+                    "x.name as relationTypeName",
+                    "x.isDependency as relationTypeIsDependency",
+                    "x.dual as relationTypeIsBidirectional")
                 .From<NodeDto>("n")
                 .InnerJoinNested(innerUnionSql, "x")
                 .On<NodeDto, UnionHelperDto>((n, x) => n.NodeId == x.OtherId, "n", "x")
@@ -264,17 +263,17 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             Sql<ISqlContext> innerUnionSql = GetInnerUnionSql();
             var sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql().SelectDistinct(
-                    "[x].[otherId] as nodeId",
-                    "[n].[uniqueId] as nodeKey",
-                    "[n].[text] as nodeName",
-                    "[n].[nodeObjectType] as nodeObjectType",
-                    "[ct].[icon] as contentTypeIcon",
-                    "[ct].[alias] as contentTypeAlias",
-                    "[ctn].[text] as contentTypeName",
-                    "[x].[alias] as relationTypeAlias",
-                    "[x].[name] as relationTypeName",
-                    "[x].[isDependency] as relationTypeIsDependency",
-                    "[x].[dual] as relationTypeIsBidirectional")
+                    "x.otherId as nodeId",
+                    "n.uniqueId as nodeKey",
+                    "n.text as nodeName",
+                    "n.nodeObjectType as nodeObjectType",
+                    "ct.icon as contentTypeIcon",
+                    "ct.alias as contentTypeAlias",
+                    "ctn.text as contentTypeName",
+                    "x.alias as relationTypeAlias",
+                    "x.name as relationTypeName",
+                    "x.isDependency as relationTypeIsDependency",
+                    "x.dual as relationTypeIsBidirectional")
                 .From<NodeDto>("n")
                 .InnerJoinNested(innerUnionSql, "x")
                 .On<NodeDto, UnionHelperDto>((n, x) => n.NodeId == x.OtherId, "n", "x")
@@ -313,17 +312,17 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             Sql<ISqlContext> innerUnionSql = GetInnerUnionSql();
             Sql<ISqlContext>? sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql().SelectDistinct(
-                    "[x].[id] as nodeId",
-                    "[n].[uniqueId] as nodeKey",
-                    "[n].[text] as nodeName",
-                    "[n].[nodeObjectType] as nodeObjectType",
-                    "[ct].[icon] as contentTypeIcon",
-                    "[ct].[alias] as contentTypeAlias",
-                    "[ctn].[text] as contentTypeName",
-                    "[x].[alias] as relationTypeAlias",
-                    "[x].[name] as relationTypeName",
-                    "[x].[isDependency] as relationTypeIsDependency",
-                    "[x].[dual] as relationTypeIsBidirectional")
+                    "x.id as nodeId",
+                    "n.uniqueId as nodeKey",
+                    "n.text as nodeName",
+                    "n.nodeObjectType as nodeObjectType",
+                    "ct.icon as contentTypeIcon",
+                    "ct.alias as contentTypeAlias",
+                    "ctn.text as contentTypeName",
+                    "x.alias as relationTypeAlias",
+                    "x.name as relationTypeName",
+                    "x.isDependency as relationTypeIsDependency",
+                    "x.dual as relationTypeIsBidirectional")
                 .From<NodeDto>("n")
                 .InnerJoinNested(innerUnionSql, "x")
                 .On<NodeDto, UnionHelperDto>((n, x) => n.NodeId == x.Id, "n", "x")
@@ -367,7 +366,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
             // Gets the path of the parent with ",%" added
             var subsubQuery = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql()
-                .Select(syntax?.GetConcat("[node].[path]", "',%'"))
+                .Select(syntax?.GetConcat("node.path", "',%'"))
                 .From<NodeDto>("node")
                 .Where<NodeDto>(x => x.NodeId == parentId, "node");
 
@@ -379,17 +378,17 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
             Sql<ISqlContext> innerUnionSql = GetInnerUnionSql();
             var sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql().SelectDistinct(
-                    "[x].[id] as nodeId",
-                    "[n].[uniqueId] as nodeKey",
-                    "[n].[text] as nodeName",
-                    "[n].[nodeObjectType] as nodeObjectType",
-                    "[ct].[icon] as contentTypeIcon",
-                    "[ct].[alias] as contentTypeAlias",
-                    "[ctn].[text] as contentTypeName",
-                    "[x].[alias] as relationTypeAlias",
-                    "[x].[name] as relationTypeName",
-                    "[x].[isDependency] as relationTypeIsDependency",
-                    "[x].[dual] as relationTypeIsBidirectional")
+                    "x.id as nodeId",
+                    "n.uniqueId as nodeKey",
+                    "n.text as nodeName",
+                    "n.nodeObjectType as nodeObjectType",
+                    "ct.icon as contentTypeIcon",
+                    "ct.alias as contentTypeAlias",
+                    "ctn.text as contentTypeName",
+                    "x.alias as relationTypeAlias",
+                    "x.name as relationTypeName",
+                    "x.isDependency as relationTypeIsDependency",
+                    "x.dual as relationTypeIsBidirectional")
                 .From<NodeDto>("n")
                 .InnerJoinNested(innerUnionSql, "x")
                 .On<NodeDto, UnionHelperDto>((n, x) => n.NodeId == x.Id, "n", "x")

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -72,7 +72,7 @@ public class NuCacheContentRepository : RepositoryBase, INuCacheContentRepositor
         if (content.PublishedState == PublishedState.Unpublishing)
         {
             // if unpublishing, remove published data from table
-            Database.Execute("DELETE FROM cmsContentNu WHERE nodeId=@id AND published=1", new { id = content.Id });
+            Database.Execute("DELETE FROM cmsContentNu WHERE nodeId=@id AND published=@true_", new { id = content.Id, true_ = true });
         }
         else if (content.PublishedState == PublishedState.Publishing)
         {
@@ -135,11 +135,11 @@ public class NuCacheContentRepository : RepositoryBase, INuCacheContentRepositor
             $@"SELECT COUNT(*)
 FROM umbracoNode
 JOIN {Constants.DatabaseSchema.Tables.Document} ON umbracoNode.id={Constants.DatabaseSchema.Tables.Document}.nodeId
-LEFT JOIN cmsContentNu nuEdited ON (umbracoNode.id=nuEdited.nodeId AND nuEdited.published=0)
-LEFT JOIN cmsContentNu nuPublished ON (umbracoNode.id=nuPublished.nodeId AND nuPublished.published=1)
+LEFT JOIN cmsContentNu nuEdited ON (umbracoNode.id=nuEdited.nodeId AND nuEdited.published=@false_)
+LEFT JOIN cmsContentNu nuPublished ON (umbracoNode.id=nuPublished.nodeId AND nuPublished.published=@true_)
 WHERE umbracoNode.nodeObjectType=@objType
-AND nuEdited.nodeId IS NULL OR ({Constants.DatabaseSchema.Tables.Document}.published=1 AND nuPublished.nodeId IS NULL);",
-            new { objType = contentObjectType });
+AND nuEdited.nodeId IS NULL OR ({Constants.DatabaseSchema.Tables.Document}.published=@true_ AND nuPublished.nodeId IS NULL);",
+            new { objType = contentObjectType, false_ = false, true_ = true });
 
         return count == 0;
     }
@@ -153,11 +153,11 @@ AND nuEdited.nodeId IS NULL OR ({Constants.DatabaseSchema.Tables.Document}.publi
         var count = Database.ExecuteScalar<int>(
             @"SELECT COUNT(*)
 FROM umbracoNode
-LEFT JOIN cmsContentNu ON (umbracoNode.id=cmsContentNu.nodeId AND cmsContentNu.published=0)
+LEFT JOIN cmsContentNu ON (umbracoNode.id=cmsContentNu.nodeId AND cmsContentNu.published=@false_)
 WHERE umbracoNode.nodeObjectType=@objType
 AND cmsContentNu.nodeId IS NULL
 ",
-            new { objType = mediaObjectType });
+            new { objType = mediaObjectType, false_ = false });
 
         return count == 0;
     }
@@ -171,11 +171,11 @@ AND cmsContentNu.nodeId IS NULL
         var count = Database.ExecuteScalar<int>(
             @"SELECT COUNT(*)
 FROM umbracoNode
-LEFT JOIN cmsContentNu ON (umbracoNode.id=cmsContentNu.nodeId AND cmsContentNu.published=0)
+LEFT JOIN cmsContentNu ON (umbracoNode.id=cmsContentNu.nodeId AND cmsContentNu.published=@false_)
 WHERE umbracoNode.nodeObjectType=@objType
 AND cmsContentNu.nodeId IS NULL
 ",
-            new { objType = memberObjectType });
+            new { objType = memberObjectType, false_ = false });
 
         return count == 0;
     }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR fixes some prerequisites for PostgreSQL persistence implementation. It corrects sql quoting from hardcoded use of Sql Server specific syntax (also supported by Sqlite) `[]` to use of `SqlSyntax.GetQuotedColumnName`. Brackets are unsupported in PostgreSQL.

It also adds primary key settings for link tables. This is also a prerequisite for PostgreSQL since NPoco will return the primary key column for inserts to a PostgreSQL database, whereas for Sql Server it returns `SCOPE_IDENTITY()` and for Sqlite `last_insert_rowid()`. Insert queries will fail without these attributes since NPoco will try to return `ID`.

This should be a safe change to make. It means columns will be quoted with `"` as per the existing persistence implementations. As far as I can tell this works identical to `[]` quotes.

I've also made the initial insert of English language to use auto-increment to allow the primary key to advance. Otherwise the next language to insert will fail (but subsequent tries will succeed).

<!-- Thanks for contributing to Umbraco CMS! -->
