### PR TITLE
A11Y added missing iframe title to installer and preview controller.

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoInstall/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoInstall/Index.cshtml
@@ -35,7 +35,7 @@
             <div ng-switch-when="ysod">
                 <h1>A server error occurred</h1>
                 <p>This is most likely due to an error during application startup</p>
-                <iframe id="ysod"></iframe>
+                <iframe id="ysod" title="Error details"></iframe>
             </div>
             <div ng-switch-default>
                 <div ng-include="installer.current.view"></div>

--- a/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/preview/preview.controller.js
@@ -455,6 +455,7 @@ var app = angular.module("umbraco.preview", ['umbraco.resources', 'umbraco.servi
 
     $scope.onFrameLoaded = function (iframe) {
 
+      iframe.title = "Page preview";
       $scope.frameLoaded = true;
       configureSignalR(iframe);
       fixExternalLinks(iframe);


### PR DESCRIPTION
In order to support accessibility `iframe` elements should have titles on them (Ref https://www.w3.org/WAI/WCAG21/Techniques/html/H64). 

I have added the titles for the iframes in the preview controller and the YSOD area of the installer. 