### PR TITLE
Change default `UpgradeUnattended` value to true

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 public class UnattendedSettings
 {
     private const bool StaticInstallUnattended = false;
-    private const bool StaticUpgradeUnattended = false;
+    private const bool StaticUpgradeUnattended = true;
 
     /// <summary>
     ///     Gets or sets a value indicating whether unattended installs are enabled.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Umbraco added unattended upgrades in v8.12, which has always been an opt-in feature (see PR https://github.com/umbraco/Umbraco-CMS/pull/9531 and [docs](https://our.umbraco.com/Documentation/Fundamentals/Setup/Upgrading/general-v8#run-an-unattended-upgrade)).

When left disabled, you'll get the `AuthorizeUpgrade` login screen when there are pending database migrations after updating to a newer version, requiring a user to login and manually approve the upgrade. This means all site visitors are redirected to the login screen, until this manual approval is performed.

This manual step seems redundant, as you already explicitly updated the site to a newer version and it previously also opened up the site to a [medium-severity security issue](https://umbraco.com/blog/security-advisory-september-6-2022-patch-is-now-available/).

In case there's an error during the upgrade, this will be written to the log and depending on this setting:
- Attended upgrade: in most cases the error is also displayed in the upgrader screen (only for the logged in user), even if this user is e.g. an editor or translator (in which case it might be a security issue, as the error details can expose sensitive information);
- Unattended upgrade: all users will get the `BootFailed.html` screen without exposing error details and that can be customized to match the site design/language.

The actual change is as simple as changing `false` to `true`, as I still think we should give users the possibility of opting-out of this behaviour (although we might want to remove attended upgrades in the future and only support unattended).