### PR TITLE
V10: parse lock id as invariant

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDistributedLockingMechanism.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
@@ -142,7 +143,7 @@ public class SqliteDistributedLockingMechanism : IDistributedLockingMechanism
                     "SqliteDistributedLockingMechanism requires a transaction to function.");
             }
 
-            var query = @$"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id = {LockId}";
+            var query = @$"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id = {LockId.ToString(CultureInfo.InvariantCulture)}";
 
             DbCommand command = db.CreateCommand(db.Connection, CommandType.Text, query);
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13260
# Notes
- As @bergmania mentions in the original issue, it was indeed the Swedish minus playing tricks on us again!
Here is the error message we got:
```
(0x80004005): SQLite Error 1: 'no such column: −333'.
```
We can clearly see the minus `−` is not the same as `-`

# How to test
- Run umbraco
- Switch your users language to swedish
- Try to create a document type
- This should no longer throw errors and actually save 👍 