### PR TITLE
Remove timeouts from acceptance tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
@@ -11,9 +11,6 @@ import {
 test.describe('Content tests', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
   

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/recycleBin.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/recycleBin.spec.ts
@@ -5,9 +5,6 @@ import {ContentBuilder, DocumentTypeBuilder} from "@umbraco/json-models-builders
 test.describe('Recycle bin', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/routing.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/routing.spec.ts
@@ -12,9 +12,6 @@ test.describe('Routing', () => {
   const rootDocTypeName = "Test document type";
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
     await umbracoApi.content.deleteAllContent();
     await umbracoApi.documentTypes.ensureNameNotExists(rootDocTypeName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/textBoxVariation.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/textBoxVariation.spec.ts
@@ -5,9 +5,6 @@ import {ContentBuilder, DocumentTypeBuilder, DomainBuilder} from "@umbraco/json-
 test.describe('Vary by culture for TextBox', () => {
 
     test.beforeEach(async ({page, umbracoApi, umbracoUi}) => {
-        // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-        // Wait so we don't bombard the API
-        await page.waitForTimeout(1000);
         await umbracoApi.login();
     });
     

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/HelpPanel/systemInformation.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/HelpPanel/systemInformation.spec.ts
@@ -6,9 +6,6 @@ test.describe('System Information', () => {
   const dkCulture = "da-DK";
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
     await umbracoApi.users.setCurrentLanguage(enCulture);
   });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Languages/languages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Languages/languages.spec.ts
@@ -4,9 +4,6 @@ import {expect} from "@playwright/test";
 test.describe('Languages', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Login/login.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Login/login.spec.ts
@@ -2,9 +2,6 @@ import { test, expect } from '@playwright/test';
 test.describe('Login', () => {
 
     test.beforeEach(async ({ page }) => {
-      // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-      // Wait so we don't bombard the API
-      await page.waitForTimeout(1000);
       await page.goto(process.env.URL + '/umbraco');
     });
     test('Login with correct username and password', async ({page}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/mediaFiles.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/mediaFiles.spec.ts
@@ -4,9 +4,6 @@ import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 test.describe('media File Types', () => {
 
     test.beforeEach(async ({page, umbracoApi, umbracoUi}) => {
-        // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-        // Wait so we don't bombard the API
-        await page.waitForTimeout(1000);
         await umbracoApi.login();
         await umbracoUi.goToSection(ConstantHelper.sections.media);
         await umbracoApi.media.deleteAllMedia();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/mediaSection.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/mediaSection.spec.ts
@@ -4,9 +4,6 @@ import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 test.describe('Media', () => {
 
     test.beforeEach(async ({page, umbracoApi, umbracoUi}) => {
-        // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-        // Wait so we don't bombard the API
-        await page.waitForTimeout(1000);
         await umbracoApi.login();
         await umbracoUi.goToSection(ConstantHelper.sections.media);
         await umbracoApi.media.deleteAllMedia()

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/memberGroups.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/memberGroups.spec.ts
@@ -3,9 +3,6 @@ import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 test.describe('Packages', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/members.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/members.spec.ts
@@ -3,9 +3,6 @@ import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 test.describe('Packages', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/packages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/packages.spec.ts
@@ -8,9 +8,6 @@ test.describe('Packages', () => {
   const rootDocTypeName = "Test document type";
   const nodeName = "1) Home";
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/dataType.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/dataType.spec.ts
@@ -5,9 +5,6 @@ import {LabelDataTypeBuilder} from "@umbraco/json-models-builders";
 test.describe('Data Types', () => {
   
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
   

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/documentTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/documentTypes.spec.ts
@@ -4,9 +4,6 @@ import {DocumentTypeBuilder} from "@umbraco/json-models-builders";
 
 test.describe('Document types', () => {
   test.beforeEach(async ({ page, umbracoApi }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/languages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/languages.spec.ts
@@ -3,9 +3,6 @@ import {expect} from "@playwright/test";
 
 test.describe('Languages', () => {
   test.beforeEach(async ({ page, umbracoApi }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/mediaTypes.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/mediaTypes.ts
@@ -4,9 +4,6 @@ import {expect} from "@playwright/test";
 test.describe('Media types', () => {
 
   test.beforeEach(async ({ page, umbracoApi }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/memberTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/memberTypes.spec.ts
@@ -2,9 +2,6 @@ import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 
 test.describe('Member Types', () => {
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViewMacroFiles.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViewMacroFiles.spec.ts
@@ -5,9 +5,6 @@ import {PartialViewMacroBuilder} from "@umbraco/json-models-builders";
 test.describe('Partial View Macro Files', () => {
 
     test.beforeEach(async ({page, umbracoApi}) => {
-        // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-        // Wait so we don't bombard the API
-        await page.waitForTimeout(1000);
         await umbracoApi.login();
     });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViews.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViews.spec.ts
@@ -5,9 +5,6 @@ import {PartialViewBuilder} from "@umbraco/json-models-builders";
 test.describe('Partial Views', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/relationTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/relationTypes.spec.ts
@@ -4,9 +4,6 @@ import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 test.describe('Relation Types', () => {
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/scripts.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/scripts.spec.ts
@@ -4,9 +4,6 @@ import {ScriptBuilder} from "@umbraco/json-models-builders";
 
 test.describe('Scripts', () => {
   test.beforeEach(async ({ page, umbracoApi }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/stylesheets.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/stylesheets.spec.ts
@@ -8,9 +8,6 @@ test.describe('Stylesheets', () => {
   const fileName = name + ".css";
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/templates.spec.ts
@@ -4,9 +4,6 @@ import {TemplateBuilder} from "@umbraco/json-models-builders";
 
 test.describe('Templates', () => {
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
@@ -8,9 +8,6 @@ const tabsDocTypeAlias = AliasHelper.toAlias(tabsDocTypeName);
 test.describe('Tabs', () => {
   
   test.beforeEach(async ({ umbracoApi, page }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tour/tours.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tour/tours.spec.ts
@@ -4,9 +4,6 @@ import {test} from '@umbraco/playwright-testhelpers';
 test.describe('Tours', () => {
   const timeout = 60000;
   test.beforeEach(async ({page, umbracoApi}) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
     await resetTourData(umbracoApi);
   });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/userGroups.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/userGroups.spec.ts
@@ -10,9 +10,6 @@ test.describe('User groups', () => {
   }
 
   test.beforeEach(async ({ umbracoApi, page }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/users.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/users.spec.ts
@@ -24,9 +24,6 @@ test.describe('Users', () => {
     };
   
   test.beforeEach(async ({ umbracoApi, page }) => {
-    // TODO: REMOVE THIS WHEN SQLITE IS FIXED
-    // Wait so we don't bombard the API
-    await page.waitForTimeout(1000);
     await umbracoApi.login();
   });
 


### PR DESCRIPTION
We added these because of the SQLite locking issue we were having, which would cause these to fail on the pipelines.
This has now been fixed and therefore the timeouts can be removed 👍 