### PR TITLE
Unbreak breaking change in #13066

### DIFF
--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -442,6 +442,12 @@ namespace Umbraco.Cms.Core.Services.Implement
             return OperationResult.Attempt.Succeed(MoveOperationStatusType.Success, evtMsgs);
         }
 
+        [Obsolete("Use the method which specifies the userId parameter")]
+        public Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId)
+        {
+            return Copy(copying, containerId, Constants.Security.SuperUserId);
+        }
+
         public Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId, int userId = Constants.Security.SuperUserId)
         {
             var evtMsgs = EventMessagesFactory.Get();

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -16,7 +16,7 @@ public interface IDataTypeService : IService
     IReadOnlyDictionary<Udi, IEnumerable<string>> GetReferences(int id);
 
     Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, Guid key, string name, int userId = Constants.Security.SuperUserId);
-
+    
     Attempt<OperationResult?> SaveContainer(EntityContainer container, int userId = Constants.Security.SuperUserId);
 
     EntityContainer? GetContainer(int containerId);
@@ -100,6 +100,9 @@ public interface IDataTypeService : IService
     IEnumerable<IDataType> GetByEditorAlias(string propertyEditorAlias);
 
     Attempt<OperationResult<MoveOperationStatusType>?> Move(IDataType toMove, int parentId);
+
+    [Obsolete("Use the method which specifies the userId parameter")]
+    Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId) => Copy(copying, containerId, Constants.Security.SuperUserId);
 
     /// <summary>
     /// Copies the give <see cref="IDataType"/> to a given container


### PR DESCRIPTION
The fix in #13066 was supposed to be merged before 10.3.0 came out, unfortunately we didn't get that done. #13066 introduces changes to public methods and interfaces, which is a breaking change. This PR should fix those so the new method will be available but the old one is still there as well.