### PR TITLE
Allow for configuration of additional languages to install and ensure one is set as default.

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1768,7 +1768,7 @@ internal class DatabaseDataCreator
                 {
                     IsoCode = culture.Name,
                     CultureName = culture.EnglishName,
-                    IsDefault = isDefault
+                    IsDefault = isDefault,
                 };
                 _database.Insert(Constants.DatabaseSchema.Tables.Language, "id", true, dto);
                 isDefault = false;

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NPoco;


### PR DESCRIPTION
This is a second go and supersedes [this PR](https://github.com/umbraco/Umbraco-CMS/pull/13286), resolving [this issue](https://github.com/umbraco/Umbraco.Cloud.Issues/issues/605).

To Test:

- Install with default configuration should create the `en-US` language as the default.
- Install with the following configuration should create the English (UK) and Italian languages, with the former as the default

```
      "InstallDefaultData": {
        "Languages": {
          "InstallData": "Values",
          "Values": [
            "en",
            "it"
          ]
        }
      },
```