### PR TITLE
New Backoffice: Return AnalyticsLevelViewModel instead of TelemetryLevel

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/Controllers/Analytics/AllAnalyticsController.cs
+++ b/src/Umbraco.Cms.ManagementApi/Controllers/Analytics/AllAnalyticsController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.ManagementApi.ViewModels.Analytics;
 using Umbraco.Cms.ManagementApi.ViewModels.Pagination;
 
 namespace Umbraco.Cms.ManagementApi.Controllers.Analytics;
@@ -9,14 +10,14 @@ public class AllAnalyticsController : AnalyticsControllerBase
 {
     [HttpGet("all")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedViewModel<TelemetryLevel>), StatusCodes.Status200OK)]
-    public async Task<PagedViewModel<TelemetryLevel>> GetAll(int skip, int take)
+    [ProducesResponseType(typeof(PagedViewModel<AnalyticsLevelViewModel>), StatusCodes.Status200OK)]
+    public async Task<PagedViewModel<AnalyticsLevelViewModel>> GetAll(int skip, int take)
     {
         TelemetryLevel[] levels = Enum.GetValues<TelemetryLevel>();
-        return await Task.FromResult(new PagedViewModel<TelemetryLevel>
+        return await Task.FromResult(new PagedViewModel<AnalyticsLevelViewModel>
         {
             Total = levels.Length,
-            Items = levels.Skip(skip).Take(take),
+            Items = levels.Skip(skip).Take(take).Select(x => new AnalyticsLevelViewModel { AnalyticsLevel = x }),
         });
     }
 }

--- a/src/Umbraco.Cms.ManagementApi/OpenApi.json
+++ b/src/Umbraco.Cms.ManagementApi/OpenApi.json
@@ -3845,7 +3845,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedViewModelOfTelemetryLevel"
+                  "$ref": "#/components/schemas/PagedViewModelOfAnalyticsLevelViewModel"
                 }
               }
             }
@@ -5221,7 +5221,7 @@
           }
         }
       },
-      "PagedViewModelOfTelemetryLevel": {
+      "PagedViewModelOfAnalyticsLevelViewModel": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -5232,24 +5232,10 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TelemetryLevel2"
+              "$ref": "#/components/schemas/AnalyticsLevelViewModel"
             }
           }
         }
-      },
-      "TelemetryLevel2": {
-        "type": "integer",
-        "description": "",
-        "x-enumNames": [
-          "Minimal",
-          "Basic",
-          "Detailed"
-        ],
-        "enum": [
-          0,
-          1,
-          2
-        ]
       },
       "AnalyticsLevelViewModel": {
         "type": "object",


### PR DESCRIPTION
Fixes the duplicate TelemetryLevel property in the OpenApi schema. 

This was caused by the `PagedViewModel<Telemetry>`, basically it returns back the same issue we'd had before with being able to specify serialization settings, since enums gets serialize to integers by default.

Specifically this comes from `PagedViewModel<T>.Items` not having the `[JsonConverter(typeof(JsonStringEnumConverter))]` (and neither should it).

I fixed this by instead returning the `PagedViewModel<AnalyticsLevelViewModel>`. 

While it might be a bit overkill to create a ViewModel for only one property, I think it's pretty sensible since `TelemetryLevel` is a domain model, "it" should really not be concerned about presentation at all.