### PR TITLE
Exposed media file provider configuration method

### DIFF
--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -1,14 +1,8 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Web.Common.Media;
 using Umbraco.Extensions;
-using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder;
 
@@ -77,24 +71,7 @@ public class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoEnd
     {
         UseUmbracoCoreMiddleware();
 
-        // Get media file provider and request path/URL
-        MediaFileManager mediaFileManager = AppBuilder.ApplicationServices.GetRequiredService<MediaFileManager>();
-        if (mediaFileManager.FileSystem.TryCreateFileProvider(out IFileProvider? mediaFileProvider))
-        {
-            GlobalSettings globalSettings =
-                AppBuilder.ApplicationServices.GetRequiredService<IOptions<GlobalSettings>>().Value;
-            IHostingEnvironment? hostingEnvironment = AppBuilder.ApplicationServices.GetService<IHostingEnvironment>();
-            var mediaRequestPath = hostingEnvironment?.ToAbsolute(globalSettings.UmbracoMediaPath);
-
-            // Configure custom file provider for media
-            IWebHostEnvironment? webHostEnvironment = AppBuilder.ApplicationServices.GetService<IWebHostEnvironment>();
-            if (webHostEnvironment is not null)
-            {
-                webHostEnvironment.WebRootFileProvider =
-                    webHostEnvironment.WebRootFileProvider.ConcatComposite(
-                        new MediaPrependBasePathFileProvider(mediaRequestPath, mediaFileProvider));
-            }
-        }
+        AppBuilder.UseUmbracoMediaFileProvider();
 
         AppBuilder.UseStaticFiles();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #12444

### Description

This is required for consumers that intend to use `WithCustomMiddleware` in order to customize the middleware order instead of `WithMiddleware`, as otherwise they are forced to re-implement this method.

In order to test the usage of `WithCustomMiddleware` the following example snippet can be used:
```
app.UseUmbraco()
.WithCustomMiddleware(u =>
{
    u.RunPrePipeline();

    app.UseUmbracoCore();
    app.UseUmbracoRequestLogging();
    app.UseUmbracoRouting();

    app.UseUmbracoMediaFileProvider();
    app.UseStaticFiles();
    app.UseUmbracoPluginsStaticFiles();

    app.UseRouting();
    app.UseAuthentication();
    app.UseAuthorization();

    app.UseRequestLocalization();
    app.UseSession();

    u.RunPostPipeline();

    u.UseBackOffice();
    u.UseWebsite();
})
.WithEndpoints(u =>
{
    u.UseInstallerEndpoints();
    u.UseBackOfficeEndpoints();
    u.UseWebsiteEndpoints();
});
```