### PR TITLE
Added missing content-type header to BootFailedMiddleware response

### DIFF
--- a/src/Umbraco.Web.Common/Middleware/BootFailedMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/BootFailedMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -51,6 +52,7 @@ public class BootFailedMiddleware : IMiddleware
                 // Print a nice error page
                 context.Response.Clear();
                 context.Response.StatusCode = 500;
+                context.Response.ContentType = MediaTypeNames.Text.Html;
 
                 IFileInfo? fileInfo = GetBootErrorFileInfo();
                 if (fileInfo is not null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When Umbraco is configured with `X-Content-Type-Options` `nosniff` as is recommended (there's even a health check for it), any boot failure would simply show the html source code in the browser instead of properly rendering the html, as the content-type wasn't being set.

Reproduction steps:
- Set the `X-Content-Type-Options` header to `nosniff`
- Disable Umbraco's host settings debug mode
- Cause a boot failure

The following snippet can be placed at the top of startup's `Configure` method to set all 3 requirements:
```
app.ApplicationServices.GetRequiredService<IOptionsMonitor<HostingSettings>>().CurrentValue.Debug = false;
app.ApplicationServices.GetRequiredService<IRuntimeState>().Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, new Exception("Boot fail test"));
app.Use(async (context, next) =>
{
    await next(context);
    context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
});
...
```

Previous result:
![image](https://user-images.githubusercontent.com/279175/197964796-83a79347-9721-4434-943f-02338cb1343f.png)

New/expected result:
![image](https://user-images.githubusercontent.com/279175/197964937-161c0d4e-b58c-4018-b66c-33f7428eb47b.png)