### PR TITLE
Added support for the new minimal hosting model

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Logging.Serilog.Enrichers;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Cms.Web.Common.Middleware;
 using Umbraco.Cms.Web.Common.Plugins;
 
@@ -27,6 +28,20 @@ public static class ApplicationBuilderExtensions
     /// </summary>
     public static IUmbracoApplicationBuilder UseUmbraco(this IApplicationBuilder app)
         => new UmbracoApplicationBuilder(app);
+
+    /// <summary>
+    ///     Configures and use services required for using Umbraco
+    /// </summary>
+    /// <remarks>
+    ///     To be used with the new ASP.NET Core 6.0 minimal hosting model.
+    /// </remarks>
+    public static IUmbracoApplicationBuilder UseUmbraco(this WebApplication app)
+    {
+        StaticServiceProvider.Instance = app.Services;
+        app.Services.GetRequiredService<IRuntimeState>().DetermineRuntimeLevel();
+
+        return new UmbracoApplicationBuilder(app);
+    }
 
     /// <summary>
     ///     Returns true if Umbraco <see cref="IRuntimeState" /> is greater than <see cref="RuntimeLevel.BootFailed" />

--- a/src/Umbraco.Web.Common/Hosting/WebApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Hosting/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+///     Umbraco specific extensions for the <see cref="WebApplicationBuilder" />.
+/// </summary>
+public static class WebApplicationBuilderExtensions
+{
+    /// <summary>
+    ///     Configures an existing <see cref="WebApplicationBuilder" /> with defaults for an Umbraco application.
+    /// </summary>
+    /// <remarks>
+    ///     To be used with the new ASP.NET Core 6.0 minimal hosting model.
+    /// </remarks>
+    public static WebApplicationBuilder ConfigureUmbracoDefaults(this WebApplicationBuilder builder)
+    {
+#if DEBUG
+        builder.Configuration.AddJsonFile(
+                "appsettings.Local.json",
+                true,
+                true);
+
+#endif
+        builder.Logging.ClearProviders();
+
+        return builder;
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR addresses the issue #12445.

### Description
Since ASP.NET Core 6 the new minimal hosting model is available: https://learn.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-6.0&tabs=visual-studio#new-hosting-model

But it couldn't be used by Umbraco consumers without workarounds, both because of some missing extension methods but more importantly due to the fact that hosted services now run after the main webhost is started. This caused a problem where the runtime level hadn't been determined yet when the routes were being registered, causing them to be skipped.

How to test:
- The current `Program.cs` and `Startup.cs` should continue to work without changes.
- Replacing them this single `Program.cs` using the new hosting model, should also work:
```
WebApplicationBuilder builder = WebApplication.CreateBuilder(args);

builder.ConfigureUmbracoDefaults();
builder.Services.AddUmbraco(builder.Environment, builder.Configuration)
    .AddBackOffice()
    .AddWebsite()
    .AddComposers()
    .Build();

WebApplication app = builder.Build();

if (app.Environment.IsDevelopment())
{
  app.UseDeveloperExceptionPage();
}
#if (UseHttpsRedirect)

    app.UseHttpsRedirection();
#endif

app.UseUmbraco()
    .WithMiddleware(u =>
    {
      u.UseBackOffice();
      u.UseWebsite();
    })
    .WithEndpoints(u =>
    {
      u.UseInstallerEndpoints();
      u.UseBackOfficeEndpoints();
      u.UseWebsiteEndpoints();
    });

app.Run();
```