### PR TITLE
Add template support for minimal hosting model

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Logging.Serilog.Enrichers;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Cms.Web.Common.Middleware;
 using Umbraco.Cms.Web.Common.Plugins;
 
@@ -27,6 +28,20 @@ public static class ApplicationBuilderExtensions
     /// </summary>
     public static IUmbracoApplicationBuilder UseUmbraco(this IApplicationBuilder app)
         => new UmbracoApplicationBuilder(app);
+
+    /// <summary>
+    ///     Configures and use services required for using Umbraco
+    /// </summary>
+    /// <remarks>
+    ///     To be used with the new ASP.NET Core 6.0 minimal hosting model.
+    /// </remarks>
+    public static IUmbracoApplicationBuilder UseUmbraco(this WebApplication app)
+    {
+        StaticServiceProvider.Instance = app.Services;
+        app.Services.GetRequiredService<IRuntimeState>().DetermineRuntimeLevel();
+
+        return new UmbracoApplicationBuilder(app);
+    }
 
     /// <summary>
     ///     Returns true if Umbraco <see cref="IRuntimeState" /> is greater than <see cref="RuntimeLevel.BootFailed" />

--- a/src/Umbraco.Web.Common/Hosting/WebApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Hosting/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+///     Umbraco specific extensions for the <see cref="WebApplicationBuilder" />.
+/// </summary>
+public static class WebApplicationBuilderExtensions
+{
+    /// <summary>
+    ///     Configures an existing <see cref="WebApplicationBuilder" /> with defaults for an Umbraco application.
+    /// </summary>
+    /// <remarks>
+    ///     To be used with the new ASP.NET Core 6.0 minimal hosting model.
+    /// </remarks>
+    public static WebApplicationBuilder ConfigureUmbracoDefaults(this WebApplicationBuilder builder)
+    {
+#if DEBUG
+        builder.Configuration.AddJsonFile(
+                "appsettings.Local.json",
+                true,
+                true);
+
+#endif
+        builder.Logging.ClearProviders();
+
+        return builder;
+    }
+}

--- a/src/Umbraco.Web.UI/Program.cs
+++ b/src/Umbraco.Web.UI/Program.cs
@@ -1,3 +1,35 @@
+#if (MinimalHostingModel)
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.ConfigureUmbracoDefaults();
+builder.Services.AddUmbraco(builder.Environment, builder.Configuration)
+    .AddBackOffice()
+    .AddWebsite()
+    .AddComposers()
+    .Build();
+
+WebApplication app = builder.Build();
+
+#if (UseHttpsRedirect)
+
+    app.UseHttpsRedirection();
+#endif
+
+app.UseUmbraco()
+    .WithMiddleware(u =>
+    {
+      u.UseBackOffice();
+      u.UseWebsite();
+    })
+    .WithEndpoints(u =>
+    {
+      u.UseInstallerEndpoints();
+      u.UseBackOfficeEndpoints();
+      u.UseWebsiteEndpoints();
+    });
+
+app.Run();
+#else
 namespace Umbraco.Cms.Web.UI
 {
     public class Program
@@ -17,3 +49,4 @@ namespace Umbraco.Cms.Web.UI
                 });
     }
 }
+#endif

--- a/src/Umbraco.Web.UI/Startup.cs
+++ b/src/Umbraco.Web.UI/Startup.cs
@@ -1,3 +1,4 @@
+#if (!MinimalHostingModel)
 namespace Umbraco.Cms.Web.UI
 {
     public class Startup
@@ -67,3 +68,4 @@ namespace Umbraco.Cms.Web.UI
         }
     }
 }
+#endif

--- a/templates/UmbracoProject/.template.config/dotnetcli.host.json
+++ b/templates/UmbracoProject/.template.config/dotnetcli.host.json
@@ -25,6 +25,10 @@
       "longName": "minimal-gitignore",
       "shortName": ""
     },
+    "MinimalHostingModel": {
+      "longName": "minimal-hosting-model",
+      "shortName": ""
+    },
     "ConnectionString": {
       "longName": "connection-string",
       "shortName": ""

--- a/templates/UmbracoProject/.template.config/template.json
+++ b/templates/UmbracoProject/.template.config/template.json
@@ -26,6 +26,12 @@
           "exclude": [
             ".gitignore"
           ]
+        },
+        {
+          "condition": "(MinimalHostingModel)",
+          "exclude": [
+            "Startup.cs"
+          ]
         }
       ]
     }
@@ -78,6 +84,13 @@
     "MinimalGitignore": {
       "displayName": "Minimal .gitignore",
       "description": "Whether to only include minimal (Umbraco specific) rules in the .gitignore.",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "MinimalHostingModel": {
+      "displayName": "Minimal hosting model",
+      "description": "Replaces Program.cs and Startup.cs with a single simpler Program.cs.",
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Dependent on #13302 being merged, I think it would make sense to make it possible for consumers to opt-in into this new `Program.cs` based on a template parameter.

Testing:
Just do a normal `dotnet pack` of the solution, install the resulting template nupkg and try it out.

@nul800sebastiaan 
I created this draft PR as I wasn't sure if this is really wanted, parameter naming and other things like documentation etc.
But the code itself does work as intended.