### PR TITLE
V11/bugfix/10502 listview node permissions

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
+++ b/src/Umbraco.Cms.ManagementApi/ManagementApiComposer.cs
@@ -84,24 +84,37 @@ public class ManagementApiComposer : IComposer
                 "BackofficeSwagger",
                 applicationBuilder =>
                 {
-                    applicationBuilder.UseExceptionHandler(exceptionBuilder => exceptionBuilder.Run(async context =>
-                    {
-                        Exception? exception = context.Features.Get<IExceptionHandlerPathFeature>()?.Error;
-                        if (exception is null)
+                    // Only use the API exception handler when we are requesting an API
+                    applicationBuilder.UseWhen(
+                        httpContext =>
                         {
-                            return;
-                        }
+                            GlobalSettings? settings = httpContext.RequestServices.GetRequiredService<IOptions<GlobalSettings>>().Value;
+                            IHostingEnvironment hostingEnvironment = httpContext.RequestServices.GetRequiredService<IHostingEnvironment>();
+                            var officePath = settings.GetBackOfficePath(hostingEnvironment);
 
-                        var response = new ProblemDetails
+                            return httpContext.Request.Path.Value?.StartsWith($"{officePath}/management/api/") ?? false;
+                        },
+                        innerBuilder =>
                         {
-                            Title = exception.Message,
-                            Detail = exception.StackTrace,
-                            Status = StatusCodes.Status500InternalServerError,
-                            Instance = exception.GetType().Name,
-                            Type = "Error",
-                        };
-                        await context.Response.WriteAsJsonAsync(response);
-                    }));
+                            innerBuilder.UseExceptionHandler(exceptionBuilder => exceptionBuilder.Run(async context =>
+                            {
+                                Exception? exception = context.Features.Get<IExceptionHandlerPathFeature>()?.Error;
+                                if (exception is null)
+                                {
+                                    return;
+                                }
+
+                                var response = new ProblemDetails
+                                {
+                                    Title = exception.Message,
+                                    Detail = exception.StackTrace,
+                                    Status = StatusCodes.Status500InternalServerError,
+                                    Instance = exception.GetType().Name,
+                                    Type = "Error",
+                                };
+                                await context.Response.WriteAsJsonAsync(response);
+                            }));
+                        });
                 },
                 applicationBuilder =>
                 {

--- a/src/Umbraco.Core/PropertyEditors/ListViewConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ListViewConfiguration.cs
@@ -54,9 +54,6 @@ public class ListViewConfiguration
     [ConfigurationField("pageSize", "Page Size", "number", Description = "Number of items per page")]
     public int PageSize { get; set; }
 
-    [ConfigurationField("orderBy", "Order By", "views/propertyeditors/listview/sortby.prevalues.html", Description = "The default sort order for the list")]
-    public string OrderBy { get; set; }
-
     [ConfigurationField("orderDirection", "Order Direction", "views/propertyeditors/listview/orderDirection.prevalues.html")]
     public string OrderDirection { get; set; }
 
@@ -66,6 +63,9 @@ public class ListViewConfiguration
         "views/propertyeditors/listview/includeproperties.prevalues.html",
         Description = "The properties that will be displayed for each column")]
     public Property[] IncludeProperties { get; set; }
+
+    [ConfigurationField("orderBy", "Order By", "views/propertyeditors/listview/sortby.prevalues.html", Description = "The default sort order for the list")]
+    public string OrderBy { get; set; }
 
     [ConfigurationField("layouts", "Layouts", "views/propertyeditors/listview/layouts.prevalues.html")]
     public Layout[] Layouts { get; set; }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
When a node has a list view enabled, the list view actions do not the parent's granular node permissions do not cascade down to the children. Note that if the user clicks into the node, they do thee the action in the Actions menu.

Also if you're using a list view with the "Edit in Infinite Editor", this would mean that users cannot do these actions (since they don't get the action menu on the node details in the infinite editor)

To test:

1. In the content tree, create an item with a list view, and a create some children
2. Create a new user group setup the permissions:
a. Set the main permissions to not allow a permission (delete/publish/unpublish/move/copy).
b. In granular permissions. choose the list node made in step 1, and allow the given permission for that node (eg delete/publish/unpublish/move/Copy).
3. Login as a user with this permission and go to the list view page.
4. Click on individual items on the list view and  validate that they can do the action in the list view.  Note that he actions should also be present when in the details view if you don't select "Edit in Infinite Editor" in the list view configuration.

There also was an issue with the permission check for unpublish. It was using "U" instead of "Z". It looks like there was an old comment in there related to how the unpublish logic used to work (based on the publish permission), but it looks like this should be updated so i did that too.


![image](https://user-images.githubusercontent.com/1120701/198172375-59ef0c32-9663-49a7-9893-9158029d7e1f.png)


<!-- Thanks for contributing to Umbraco CMS! -->
