### PR TITLE
V11: Fix Block Grid example on Linux

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BlockGridSampleHelper.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BlockGridSampleHelper.cs
@@ -172,7 +172,7 @@ public sealed class BlockGridSampleHelper
     internal void CreateSamplePartialViews()
     {
         var embeddedBasePath = $"{_partialViewPopulator.CoreEmbeddedPath}.BlockGrid.Components";
-        var fileSystemBasePath = "/Views/partials/blockgrid/Components";
+        var fileSystemBasePath = "/Views/Partials/blockgrid/Components";
         var filesToMove = new[]
         {
             "umbBlockGridDemoHeadlineBlock.cshtml",


### PR DESCRIPTION
There was a casing issue in the path in `BlockGridSampleHelper.CreateSamplePartialViews` that caused the example to not work. 