### PR TITLE
Re-use any existing ReloadableLogger

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -96,11 +96,18 @@ public static class ServiceCollectionExtensions
         // Bootstrap logger setup
         ///////////////////////////////////////////////
 
-        LoggerConfiguration serilogConfig = new LoggerConfiguration()
+        Func<LoggerConfiguration, LoggerConfiguration> serilogConfig = cfg => cfg
             .MinimalConfiguration(hostEnvironment, loggingConfig, umbracoFileConfiguration)
             .ReadFrom.Configuration(configuration);
 
-        Log.Logger = serilogConfig.CreateBootstrapLogger();
+        if (Log.Logger is ReloadableLogger reloadableLogger)
+        {
+            reloadableLogger.Reload(serilogConfig);
+        }
+        else
+        {
+            Log.Logger = serilogConfig(new LoggerConfiguration()).CreateBootstrapLogger();
+        }
 
         ///////////////////////////////////////////////
         // Runtime logger setup


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
It's possible that consumers have already set up a bootstrap logger themselves before Umbraco had a chance too, if that's the case we should just reload it if possible, as that's better than simple replacing it with the Umbraco one.

This can be tested by adding the following snippet to the top of `Main` and seeing the logger gets reloaded instead of replaced:
```
Log.Logger = new LoggerConfiguration()
    .WriteTo.Async(configuration => configuration.Console())
    .CreateBootstrapLogger();
```