### PR TITLE
Updated Smidge, Npoco and MailKit

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Umbraco.Cms.Persistence.SqlServer.csproj
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Umbraco.Cms.Persistence.SqlServer.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NPoco.SqlServer" Version="5.4.0" />
+    <PackageReference Include="NPoco.SqlServer" Version="5.5.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Examine.Core" Version="3.0.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="IPNetwork2" Version="2.6.472" />
-    <PackageReference Include="MailKit" Version="3.4.1" />
+    <PackageReference Include="MailKit" Version="3.4.2" />
     <PackageReference Include="Markdown" Version="2.2.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0-rc.2.*" />
@@ -25,7 +25,7 @@
     <PackageReference Include="MiniProfiler.Shared" Version="4.2.22" />
     <PackageReference Include="ncrontab" Version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NPoco" Version="5.4.0" />
+    <PackageReference Include="NPoco" Version="5.5.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0-rc.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.0-rc.2.*" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
-    <PackageReference Include="Smidge.InMemory" Version="4.1.1" />
-    <PackageReference Include="Smidge.Nuglify" Version="4.1.1" />
+    <PackageReference Include="Smidge.InMemory" Version="4.2.0" />
+    <PackageReference Include="Smidge.Nuglify" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.Common/TestHelpers/TestDatabase.cs
+++ b/tests/Umbraco.Tests.Common/TestHelpers/TestDatabase.cs
@@ -78,6 +78,7 @@ public class TestDatabase : IUmbracoDatabase
     public DbTransaction Transaction { get; }
 
     public IDictionary<string, object> Data { get; }
+    public int CommandTimeout { get; set; }
 
     public ISqlContext SqlContext { get; }
 


### PR DESCRIPTION
Updated Smidge, Npoco and MailKit

NPoco 5.5 includes some undocumented breaking changes. I found this:
- IDatabase now have `int CommandTimeout { get; set; }`