### PR TITLE
Tree Roots are H1

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree.html
@@ -42,7 +42,7 @@
         ng-repeat="group in tree.root.children">
 
         <div class="umb-tree-root" data-element="tree-root" ng-class="getNodeCssClass(group)" ng-hide="hideheader === 'true'" on-right-click="altSelect(group, $event)">
-            <h5>
+            <h1>
                 <a ng-href="#/{{section}}" ng-click="select(group, $event)" class="umb-tree-root-link umb-outline" data-element="tree-root-link">
                     <umb-icon icon="icon-check"
                               class="umb-tree-icon"
@@ -51,7 +51,7 @@
                     </umb-icon>
                     {{group.name}}
                 </a>
-            </h5>
+            </h1>
 
             <umb-button-ellipsis element="tree-item-options"
                                  action="options(group, $event)"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [User management - Coded as H1 but different to other H1s seen on site #64](https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/64)

### Description

Sections across the backoffice had a variety of different headings

Previously, if the tree root contained a group it would be tagged with a heading of H1.  If the tree root contains multiple groups, then the items would be coded as H5.  This resulted in some sections having H5 as the main heading.

This has now been changed so that all tree root headings are H1 and styled the same

Log into Umbraco
Browse to any of the sections
The top level heading in the sidebar should always be H1

![image](https://user-images.githubusercontent.com/8383558/198356821-3eb0a942-fa26-4b9e-8e93-c24f00d740ed.png)


<!-- Thanks for contributing to Umbraco CMS! -->
