### PR TITLE
Fixing some comments errors to reduce CodeQL warnings

### DIFF
--- a/src/Umbraco.Core/Composing/BuilderCollectionBase.cs
+++ b/src/Umbraco.Core/Composing/BuilderCollectionBase.cs
@@ -10,9 +10,8 @@ public abstract class BuilderCollectionBase<TItem> : IBuilderCollection<TItem>
 {
     private readonly LazyReadOnlyCollection<TItem> _items;
 
-    /// Initializes a new instance of the
-    /// <see cref="BuilderCollectionBase{TItem}" />
-    /// with items.
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="BuilderCollectionBase{TItem}" /> with items.
     /// </summary>
     /// <param name="items">The items.</param>
     public BuilderCollectionBase(Func<IEnumerable<TItem>> items) => _items = new LazyReadOnlyCollection<TItem>(items);

--- a/src/Umbraco.Core/Configuration/Models/SmtpSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SmtpSettings.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 ///     Matches MailKit.Security.SecureSocketOptions and defined locally to avoid having to take
 ///     a dependency on this external library into Umbraco.Core.
 /// </summary>
-/// <seealso cref="http://www.mimekit.net/docs/html/T_MailKit_Security_SecureSocketOptions.htm" />
+/// <seealso href="http://www.mimekit.net/docs/html/T_MailKit_Security_SecureSocketOptions.htm" />
 public enum SecureSocketOptions
 {
     /// <summary>

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -204,12 +204,20 @@ public static partial class UmbracoBuilderExtensions
         => builder.WithCollectionBuilder<DashboardCollectionBuilder>();
 
     /// <summary>
+    /// Gets the partial view snippets collection builder.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
     public static PartialViewSnippetCollectionBuilder? PartialViewSnippets(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<PartialViewSnippetCollectionBuilder>();
 
+    /// <summary>
+    /// Gets the partial view macro snippets collection builder.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
     public static PartialViewMacroSnippetCollectionBuilder? PartialViewMacroSnippets(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<PartialViewMacroSnippetCollectionBuilder>();
 
+    /// <summary>
     /// Gets the cache refreshers collection builder.
     /// </summary>
     /// <param name="builder">The builder.</param>

--- a/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListItem.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// <summary>
 ///     Represents a layout item for the Block List editor.
 /// </summary>
-/// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+/// <seealso cref="IBlockReference{IPublishedElement}" />
 [DataContract(Name = "block", Namespace = "")]
 public class BlockListItem : IBlockReference<IPublishedElement, IPublishedElement>
 {
@@ -74,7 +74,7 @@ public class BlockListItem : IBlockReference<IPublishedElement, IPublishedElemen
 ///     Represents a layout item with a generic content type for the Block List editor.
 /// </summary>
 /// <typeparam name="T">The type of the content.</typeparam>
-/// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+/// <seealso cref="IBlockReference{IPublishedElement}" />
 public class BlockListItem<T> : BlockListItem
     where T : IPublishedElement
 {
@@ -103,7 +103,7 @@ public class BlockListItem<T> : BlockListItem
 /// </summary>
 /// <typeparam name="TContent">The type of the content.</typeparam>
 /// <typeparam name="TSettings">The type of the settings.</typeparam>
-/// <seealso cref="Umbraco.Core.Models.Blocks.IBlockReference{Umbraco.Core.Models.PublishedContent.IPublishedElement}" />
+/// <seealso cref="IBlockReference{IPublishedElement}" />
 public class BlockListItem<TContent, TSettings> : BlockListItem<TContent>
     where TContent : IPublishedElement
     where TSettings : IPublishedElement

--- a/src/Umbraco.Core/Models/Range.cs
+++ b/src/Umbraco.Core/Models/Range.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Core.Models;
 ///     Represents a range with a minimum and maximum value.
 /// </summary>
 /// <typeparam name="T">The type of the minimum and maximum values.</typeparam>
-/// <seealso cref="System.IEquatable{Umbraco.Core.Models.Range{T}}" />
+/// <seealso cref="IEquatable{Range{T}}" />
 public class Range<T> : IEquatable<Range<T>>
     where T : IComparable<T>
 {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

#### What did you do

Edited some of the comments to try and reduce the warnings that CodeQL is reporting for new pull requests. This PR contains fixes for the obvious issues. In the process I learned things like:

- `<seealso cref` is for referencing code elements, `<seealso href` is for linking to urls
- the compiler respects using statements when looking for types in the cref attribute, so fully qualified namespaces are not usually going to be necessary 

According to my Visual Studio this PR won't have got rid of all the errors, but would be good to see these ones disappear! My VS reports any `cref` that uses nested '{' as malformed. So whilst `cref='IEquatable{T}'` and  `cref='Range{T}'` would be valid, `cref='IEquatable{Range{T}}'` is not. Not sure yet what to do about those. Also remaining are some issues from using the `&` character in a comment, again not sure yet how best to fix those ones.

#### Why did you do it

@nul800sebastiaan posted on Discord about the CodeQL errors. Looking at some recent pull requests I can see how fixing these errors and thus reducing those warnings would be a good idea!

#### How to test

Well I assume that CodeQL will have done the testing when I post this pull request! 🤞