### PR TITLE
GetAncestorIds throwing exception

### DIFF
--- a/src/Umbraco.Core/Extensions/ContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ContentExtensions.cs
@@ -269,11 +269,17 @@ public static class ContentExtensions
     /// </summary>
     /// <param name="content"><see cref="IContent" /> to retrieve ancestors for</param>
     /// <returns>An Enumerable list of integer ids</returns>
-    public static IEnumerable<int>? GetAncestorIds(this IContent content) =>
-        content.Path?.Split(Constants.CharArrays.Comma)
+    public static IEnumerable<int>? GetAncestorIds(this IContent content)
+    {
+        if (string.IsNullOrWhiteSpace(content.Path))
+        {
+            return null;
+        }
+
+        return content.Path.Split(Constants.CharArrays.Comma)
             .Where(x => x != Constants.System.RootString && x != content.Id.ToString(CultureInfo.InvariantCulture))
-            .Select(s =>
-                int.Parse(s, CultureInfo.InvariantCulture));
+            .Select(s => int.Parse(s, CultureInfo.InvariantCulture));
+    }
 
     #endregion
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12732

# Notes
- GetAncestorIds was throwing exceptions whenever the path to the content was empty.
- Add NullOrWhiteSpaceCheck to GetAncestorIds to avoid throwing exceptions
- Right now we are returning null when there are no ancestors, but we should probably return an empty collection instead.
- We can't change that for v10 as it would be breaking, but we probably should do a PR for v12 👍 

# How to test
- Add the notification handler to your project, here is the snippet: 
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

public class StrictNodeNameComposer : IComposer
{
    public StrictNodeNameComposer()
    {
    }

    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentSavingNotification, CustomContentSavingNotification>();
    }

    public class CustomContentSavingNotification : INotificationHandler<ContentSavingNotification>
    {
        public void Handle(ContentSavingNotification notification)
        {
            foreach (var savedEntity in notification.SavedEntities)
            {
                var savingCultures = savedEntity.AvailableCultures.Where(culture => notification.IsSavingCulture(savedEntity, culture)).ToList();

                foreach (var culture in savingCultures)
                {
                    var cultureName = savedEntity.GetCultureName(culture);
                    if (cultureName == "test")
                    {
                        notification.CancelOperation(new EventMessage("Custom", "Node name must not be set to 'test'", EventMessageType.Error));

                        // This line is meant to address the bug explained here: https://github.com/umbraco/Umbraco-CMS/issues/12732#issuecomment-1296942966
                        // if (string.IsNullOrWhiteSpace(savedEntity.Path)) savedEntity.Path = null!;
                        return;
                    }
                }
            }
        }
    }
}

```
- Run umbraco
- Add a second language
- Create a document type called "Child" with & `Vary by culture` enabled ✅ 
- Create a document type called "Home" with `Allow as root` & `Vary by culture` enabled ✅ 
- Also allow the "Child" document type as a child for the "Home" document type 👶
- Create Root content nodes for both languages called "Home"
- Try and create a child node for the root node, called "test", save and publish this.
- This should not throw exceptions at you, but instead give you an error notification telling you that you cannot name a node `test`