### PR TITLE
Fix media uploads for 413 errors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -151,17 +151,22 @@ angular.module("umbraco.directives")
                                     //Check if its the common "too large file" exception
                                     if (evt.InnerException.StackTrace &&
                                         evt.InnerException.StackTrace.indexOf("ValidateRequestEntityLength") > 0) {
-                                        file.messages.push({ message: "File too large to upload", type: "Error" });
+                                        file.messages.push({ message: "File too large to upload", type: "Error", header: "Error" });
                                     }
+                                } else if (status === 413) {
+                                    file.messages.push({ message: "File too large to upload", type: "Error", header: "Error" });
                                 } else if (evt.Message) {
-                                    file.messages.push({message: evt.Message, type: "Error"});
+                                    file.messages.push({message: evt.Message, type: "Error", header: "Error"});
                                 } else if (evt && typeof evt === "string") {
-                                    file.messages.push({message: evt, type: "Error"});
+                                    file.messages.push({message: evt, type: "Error", header: "Error"});
+                                } else if (status === 404) {
+                                  // If file not found, server will return a 404 and display this message
+                                  file.messages.push({ message: "File not found", type: "Error", header: "Error" });
+                                } else if (status !== 200) {
+                                    file.messages.push({ message: "An unknown error occurred", type: "Error", header: "Error" });
                                 }
-                                // If file not found, server will return a 404 and display this message
-                                if (status === 404) {
-                                    file.messages.push({message: "File not found", type: "Error"});
-                                }
+
+                                scope.processed.push(file);
                                 scope.currentFile = undefined;
                                 _processQueueItems();
                             });


### PR DESCRIPTION
Something must have changed at some point with the type of error being returned for request entities which exceed the max allowed content length. Added a check for a 413 error specifically and updated a few things to display the errors with a heading and add the file to the processed queue.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Upload a large file which exceeds your max allowed content length setting.
Verify that a message displays to tell you it is too large.

It's worth noting as well that since Angular 1.6 addition to prompt developers of unhandled promise rejections resulting in errors showing 
```
Possibly unhandled rejection: {"data":"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"> \n<html xmlns=\"http://www.w3.org/1999/xhtml\"> \n<head> \n<title>IIS 10.0 Detailed Error - 413.1 - Request Entity Too Large</title> \n<style type=\"text/css\">.......
```

This is an issue with the npm package `ng-file-upload` which is obviously not maintained anymore so I'm not sure if there is anything I can do to fix that error from showing up.