### PR TITLE
Mark MultiUrlPickerValueConverter with DefaultValueConverter

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -12,6 +12,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
+[DefaultPropertyValueConverter(typeof(JsonValueConverter))]
 public class MultiUrlPickerValueConverter : PropertyValueConverterBase
 {
     private readonly IJsonSerializer _jsonSerializer;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

The `MultiUrlPickerValueConverter` was missing the `DefaultValueConverterAttribute`, making it a bit annoying when adding a custom value converter, given you need to remove it manually.

By adding the attribute it's not needed to manually remove the value converter when creating a custom one, since Umbraco will automatically use the custom and not the one built in.
