### PR TITLE
Use Applications Constants in Dashboard implementations instead of hardcoded strings

### DIFF
--- a/src/Umbraco.Core/Dashboards/AnalyticsDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/AnalyticsDashboard.cs
@@ -4,7 +4,7 @@ public class AnalyticsDashboard : IDashboard
 {
     public string Alias => "settingsAnalytics";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] { Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/analytics.html";
 

--- a/src/Umbraco.Core/Dashboards/ContentDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/ContentDashboard.cs
@@ -7,7 +7,7 @@ public class ContentDashboard : IDashboard
 {
     public string Alias => "contentIntro";
 
-    public string[] Sections => new[] { "content" };
+    public string[] Sections => new[] { Constants.Applications.Content };
 
     public string View => "views/dashboard/default/startupdashboardintro.html";
 

--- a/src/Umbraco.Core/Dashboards/ExamineDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/ExamineDashboard.cs
@@ -7,7 +7,7 @@ public class ExamineDashboard : IDashboard
 {
     public string Alias => "settingsExamine";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] { Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/examinemanagement.html";
 

--- a/src/Umbraco.Core/Dashboards/HealthCheckDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/HealthCheckDashboard.cs
@@ -7,7 +7,7 @@ public class HealthCheckDashboard : IDashboard
 {
     public string Alias => "settingsHealthCheck";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] { Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/healthcheck.html";
 

--- a/src/Umbraco.Core/Dashboards/MediaDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/MediaDashboard.cs
@@ -7,7 +7,7 @@ public class MediaDashboard : IDashboard
 {
     public string Alias => "mediaFolderBrowser";
 
-    public string[] Sections => new[] { "media" };
+    public string[] Sections => new[] { Constants.Applications.Media };
 
     public string View => "views/dashboard/media/mediafolderbrowser.html";
 

--- a/src/Umbraco.Core/Dashboards/MembersDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/MembersDashboard.cs
@@ -7,7 +7,7 @@ public class MembersDashboard : IDashboard
 {
     public string Alias => "memberIntro";
 
-    public string[] Sections => new[] { "member" };
+    public string[] Sections => new[] { Constants.Applications.Members };
 
     public string View => "views/dashboard/members/membersdashboardvideos.html";
 

--- a/src/Umbraco.Core/Dashboards/ModelsBuilderDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/ModelsBuilderDashboard.cs
@@ -7,7 +7,7 @@ public class ModelsBuilderDashboard : IDashboard
 {
     public string Alias => "settingsModelsBuilder";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] {Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/modelsbuildermanagement.html";
 

--- a/src/Umbraco.Core/Dashboards/ProfilerDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/ProfilerDashboard.cs
@@ -7,7 +7,7 @@ public class ProfilerDashboard : IDashboard
 {
     public string Alias => "settingsProfiler";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] { Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/profiler.html";
 

--- a/src/Umbraco.Core/Dashboards/PublishedStatusDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/PublishedStatusDashboard.cs
@@ -7,7 +7,7 @@ public class PublishedStatusDashboard : IDashboard
 {
     public string Alias => "settingsPublishedStatus";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] { Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/publishedstatus.html";
 

--- a/src/Umbraco.Core/Dashboards/RedirectUrlDashboard.cs
+++ b/src/Umbraco.Core/Dashboards/RedirectUrlDashboard.cs
@@ -7,7 +7,7 @@ public class RedirectUrlDashboard : IDashboard
 {
     public string Alias => "contentRedirectManager";
 
-    public string[] Sections => new[] { "content" };
+    public string[] Sections => new[] { Constants.Applications.Content };
 
     public string View => "views/dashboard/content/redirecturls.html";
 

--- a/src/Umbraco.Core/Dashboards/SettingsDashboards.cs
+++ b/src/Umbraco.Core/Dashboards/SettingsDashboards.cs
@@ -7,7 +7,7 @@ public class SettingsDashboard : IDashboard
 {
     public string Alias => "settingsWelcome";
 
-    public string[] Sections => new[] { "settings" };
+    public string[] Sections => new[] { Constants.Applications.Settings };
 
     public string View => "views/dashboard/settings/settingsdashboardintro.html";
 


### PR DESCRIPTION
Tiny improvement. Updated dashboards: 

- [x] AnalyticsDashboard.cs
- [x] ContentDashboard.cs
- [x] ExamineDashboard.cs
- [x] HealthCheckDashboard.cs
- [x] MediaDashboard.cs
- [x] MembersDashboard.cs
- [x] ModelsBuilderDashboard.cs
- [x] ProfilerDashboard.cs
- [x] PublishedStatusDashboard.cs 
- [x] RedirectUrlDashboard.cs
- [x] SettingsDashboard.cs
