### PR TITLE
LogViewer: Adding support for viewing destructed properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/logViewer/search.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logViewer/search.html
@@ -203,7 +203,12 @@
                                                         <a class="btn-reset" ng-switch-when="RequestUrl" href="{{val.Value}}" target="_blank" rel="noopener" localize="title" title="@logViewer_Open" aria-describedby="{{key}}">
                                                             {{val.Value}} <umb-icon icon="icon-link"></umb-icon>
                                                         </a>
-                                                        <span ng-switch-default>{{val.Value}}</span>
+                                                        <span ng-switch-default>
+                                                            <span ng-if="val.Value">
+                                                                {{val.Value}}
+                                                            </span>
+                                                            <pre ng-if="!val.Value">{{val | json}}</pre>
+                                                        </span>
                                                     </td>
                                                 </tr>
                                             </tbody>


### PR DESCRIPTION
## Description
This simple PR addes support for "destructed properties" for the log viewer in the back office. 

**What is a destructed property?**
Serilog stores properties associated with a log entry in different ways. *Stringification* is when Serilog will basically just call `.ToString()` on a parameter passed into the log method-call. Serilog also supports storing the property as a object, by *Destructuring* the object. This can be done in different ways but one simple way is to add a @ sign before the the name of the parameter inside the placeholder in the message template, like this:

```csharp
_logger.LogWarning("Not good {@Data1} and {@Data2}", data1, data2);
```

In this scenario, Serilog stores the variables as objects which makes them easier to look at in the logs. Some more info can be found here: https://github.com/serilog/serilog/wiki/Structured-Data. Using `Enrichers` we can also add more properties to the log entry that is not a part of the message template - hence before this PR it's impossible to see that data in the UI.

Umbraco supports this all the way until the data is displayed in the backoffice log viewer UI, the line above will look like this

![umb-logviewer-now](https://user-images.githubusercontent.com/1782524/200202831-88b894d7-5070-461a-a399-d4501a7a218d.PNG)

The data is passed from the backend controller to the view but before this PR the view did not know how to display it. With the fix in this PR the log entry details now looks like this.

![umb-logviewer-destructed](https://user-images.githubusercontent.com/1782524/200202953-879010ac-a2bc-4c9b-9b11-3004b241d771.PNG)

## Testing this PR

* Spin up Umbraco and create some C# that writes to the log.
* Make sure to pass a "complex object" as one of the parameters.
* Look at the log entry details and see the JSON-formatted representation of the destructed property.