### PR TITLE
NullOrWhiteSpaceAsNull should be nullable

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -1239,7 +1239,7 @@ public static class StringExtensions
     /// <summary>
     ///     Turns an null-or-whitespace string into a null string.
     /// </summary>
-    public static string? NullOrWhiteSpaceAsNull(this string text)
+    public static string? NullOrWhiteSpaceAsNull(this string? text)
         => string.IsNullOrWhiteSpace(text) ? null : text;
 
     /// <summary>


### PR DESCRIPTION
### Description

I noticed that code analyses complains when using the `NullOrWhiteSpaceAsNull` extension on a `string?` value, while the implementation does support `null` values internally.

Changing the parameter from `string` to `string?` should take care of this 😄 

![image](https://user-images.githubusercontent.com/3634580/200512767-22243a90-aa5f-423e-8ac4-f136f70f2317.png)
