### PR TITLE
Remove nullability from AdditionalData on ContentItemDisplay

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentItemDisplay.cs
@@ -201,7 +201,7 @@ public class ContentItemDisplay<TVariant> :
     /// </summary>
     [DataMember(Name = "metaData")]
     [ReadOnly(true)]
-    public IDictionary<string, object>? AdditionalData { get; private set; }
+    public IDictionary<string, object> AdditionalData { get; private set; } = new Dictionary<string, object>();
 
     /// <summary>
     ///     This is used for validation of a content item.


### PR DESCRIPTION
@Zeegaan We have a use case where we need to set a value in the AdditionalData dictionary in a NotificationHandler, but as it can be null, it requires reflection to make sure that is not the case. As such, it would be nice if the following change could be implemented to ensure it is never null.
