### PR TITLE
Adds in .NET 7 SDK to GitHub CodeSpaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,14 @@
 		"omnisharp.enableRoslynAnalyzers": true
 	},
 
+	"features": {
+		// Workaround until the image is updated to include the latest version of .NET Core - .NET7
+		// https://github.com/devcontainers/templates/issues/38#issuecomment-1310803259		
+		"ghcr.io/devcontainers/features/dotnet:1": {
+			"version": "7"
+		}
+	},
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-dotnettools.csharp"


### PR DESCRIPTION
This updates the .devcontainer json file to add in the .NET7 SDK as a feature, as Microsoft has not yet published the .NET7 Container image for CodeSpaces just yet.

## Suggestion
Suggestion from GitHub/Microsoft/CodeSpaces team @samruddhikhandale
https://github.com/devcontainers/templates/issues/38#issuecomment-1310803259

## More info on Features
https://containers.dev/features
https://github.com/devcontainers/features/tree/main/src/dotnet

## Screenshots
After using the feature JSON in the devcontainer.json you can see that .NET7 SDK is available along with the .NET6 from the main image in the terminal.

![image](https://user-images.githubusercontent.com/1389894/201414021-597e841d-8488-4cc8-9140-00a3a23d4853.png)


Working screenshot of Umbraco CMS 11 running on .NET7 with the extra part of the image for a development local SMTP server to see test emails sent out.

![image](https://user-images.githubusercontent.com/1389894/201414237-6484ddf0-72c7-4878-9244-b8aacf9acb35.png)
