### PR TITLE
Delete references using custom relation types

### DIFF
--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -276,7 +276,7 @@ public static partial class Constants
             public const string RelateParentMediaFolderOnDeleteAlias = "relateParentMediaFolderOnDelete";
 
             /// <summary>
-            ///     Returns the types of relations that are automatically tracked
+            ///     Returns the types of relations that are automatically tracked.
             /// </summary>
             /// <remarks>
             ///     Developers should not manually use these relation types since they will all be cleared whenever an entity
@@ -284,7 +284,7 @@ public static partial class Constants
             /// </remarks>
             public static string[] AutomaticRelationTypes { get; } = { RelatedMediaAlias, RelatedDocumentAlias };
 
-            // TODO: return a list of built in types so we can use that to prevent deletion in the uI
+            // TODO: return a list of built in types so we can use that to prevent deletion in the UI
         }
 
         public static class Udi

--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -282,6 +282,7 @@ public static partial class Constants
             ///     Developers should not manually use these relation types since they will all be cleared whenever an entity
             ///     (content, media or member) is saved since they are auto-populated based on property values.
             /// </remarks>
+            [Obsolete("This is no longer used, and will be removed in v12")]
             public static string[] AutomaticRelationTypes { get; } = { RelatedMediaAlias, RelatedDocumentAlias };
 
             // TODO: return a list of built in types so we can use that to prevent deletion in the UI

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1048,7 +1048,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .ToArray();
 
             // First delete all auto-relations for this entity
-            RelationRepository.DeleteByParent(entity.Id, relationTypeAliases); //Constants.Conventions.RelationTypes.AutomaticRelationTypes);
+            RelationRepository.DeleteByParent(entity.Id, relationTypeAliases);
 
             if (trackedRelations.Count == 0)
             {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1042,8 +1042,13 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             var trackedRelations = new List<UmbracoEntityReference>();
             trackedRelations.AddRange(_dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors));
 
+            var relationTypeAliases = trackedRelations
+                .Select(x => x.RelationTypeAlias)
+                .Distinct()
+                .ToArray();
+
             // First delete all auto-relations for this entity
-            RelationRepository.DeleteByParent(entity.Id, Constants.Conventions.RelationTypes.AutomaticRelationTypes);
+            RelationRepository.DeleteByParent(entity.Id, relationTypeAliases); //Constants.Conventions.RelationTypes.AutomaticRelationTypes);
 
             if (trackedRelations.Count == 0)
             {
@@ -1055,7 +1060,10 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 .ToDictionary(x => (Udi)x!, x => x!.Guid);
 
             // lookup in the DB all INT ids for the GUIDs and chuck into a dictionary
-            var keyToIds = Database.Fetch<NodeIdKey>(Sql().Select<NodeDto>(x => x.NodeId, x => x.UniqueId).From<NodeDto>().WhereIn<NodeDto>(x => x.UniqueId, udiToGuids.Values))
+            var keyToIds = Database.Fetch<NodeIdKey>(Sql()
+                .Select<NodeDto>(x => x.NodeId, x => x.UniqueId)
+                .From<NodeDto>()
+                .WhereIn<NodeDto>(x => x.UniqueId, udiToGuids.Values))
                 .ToDictionary(x => x.UniqueId, x => x.NodeId);
 
             var allRelationTypes = RelationTypeRepository.GetMany(Array.Empty<int>())?


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13364

### Description
When implementing `GetReferences()` method in a property editor using `UmbracoEntityReference` this didn't work for custom relation types, where it tries to insert records which already exists and doesn't remove any previous saved relations after removing items from picker.

An example with a custom property editor using `contentpicker` property editor and `myCustomRelation`:

```
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.IO;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.Editors;
using Umbraco.Cms.Core.PropertyEditors;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Strings;

namespace Umbraco.Cms.Web.UI.Editors;

[DataEditor(
    name: "Product Picker",
    alias: "productPicker",
    view: "contentpicker",
    Icon = "icon-tag",
    ValueType = ValueTypes.Text,
    Group = Umbraco.Cms.Core.Constants.PropertyEditors.Groups.Pickers)]
public class ProductPickerPropertyEditor : DataEditor
{
    private readonly IEditorConfigurationParser _editorConfigurationParser;
    private readonly IIOHelper _ioHelper;
    private readonly IJsonSerializer _jsonSerializer;

    public ProductPickerPropertyEditor(
        IDataValueEditorFactory dataValueEditorFactory,
        IIOHelper ioHelper,
        IJsonSerializer jsonSerializer,
        IEditorConfigurationParser editorConfigurationParser,
        EditorType type = EditorType.PropertyValue)
        : base(dataValueEditorFactory, type)
    {
        _ioHelper = ioHelper;
        _jsonSerializer = jsonSerializer;
        _editorConfigurationParser = editorConfigurationParser;
        SupportsReadOnly = true;
    }

    /// <inheritdoc />
    protected override IConfigurationEditor CreateConfigurationEditor() =>
        new MultiNodePickerConfigurationEditor(_ioHelper, _editorConfigurationParser);

    /// <inheritdoc />
    //protected override IDataValueEditor CreateValueEditor() =>
    //    DataValueEditorFactory.Create<MultipleValueEditor>(Attribute!);

    protected override IDataValueEditor CreateValueEditor() =>
        DataValueEditorFactory.Create<ProductPickerPropertyValueEditor>(Attribute!);

    public class ProductPickerPropertyValueEditor : DataValueEditor, IDataValueReferenceFactory, IDataValueReference
    {
        public ProductPickerPropertyValueEditor(
            ILocalizedTextService localizedTextService,
            IShortStringHelper shortStringHelper,
            IJsonSerializer jsonSerializer,
            IIOHelper ioHelper,
            DataEditorAttribute attribute)
            : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
        {

        }

        public IDataValueReference GetDataValueReference() => this;

        public bool IsForEditor(IDataEditor? dataEditor) => dataEditor?.Alias == "productPicker";

        public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
        {
            var asString = value == null ? string.Empty : value is string str ? str : value.ToString();

            if (string.IsNullOrEmpty(asString))
            {
                yield break;
            }

            var udiPaths = asString!.Split(',');

            foreach (var udiPath in udiPaths)
            {
                if (UdiParser.TryParse(udiPath, out Udi? udi))
                {
                    yield return new UmbracoEntityReference(udi, "myCustomRelation");
                }
            }
        }
    }
}
```

https://user-images.githubusercontent.com/2919859/201529241-d5821bd0-9ed8-48f4-b9d2-6b18e55d9b8f.mp4


After including changes in this PR it both get tracked references of type `umbDocument`, `umbMedia` and `myCustomRelation` which are deleted before inserting new/updated relations.

https://user-images.githubusercontent.com/2919859/201529303-4e310c98-bd0a-49b5-b582-1ff9011b48ad.mp4

Maybe the `AutomaticRelationTypes` constant should be marked as obsolete as it isn't used now? Not sure if it makes sense to have this when developers can implement references of own relation types, so it most likely would need to handle more than these two when it is possible to extend.

Maybe we also need to adjust `RelationRepository.DeleteByParent(parentId, relationTypeAliases)` with another method to delete for specific child ids e.g. `RelationRepository.DeleteByParent(parentId, childIds, relationTypeAliases)`

Currently it delete all relations by parent id and afterwards save the new relations, but it also seems to trigger `Deliting` and `Deleted` notifications for references which wasn't removed (just deleted and re-created).

```
var udiToGuids = trackedRelations.Select(x => x.Udi as GuidUdi)
      .ToDictionary(x => (Udi)x!, x => x!.Guid);

// lookup in the DB all INT ids for the GUIDs and chuck into a dictionary
var keyToIds = Database.Fetch<NodeIdKey>(Sql()
    .Select<NodeDto>(x => x.NodeId, x => x.UniqueId)
    .From<NodeDto>()
    .WhereIn<NodeDto>(x => x.UniqueId, udiToGuids.Values))
    .ToDictionary(x => x.UniqueId, x => x.NodeId);
```

Maybe we could do something like this, so it only delete relations which not exists in trackedRelations collection and saved afterwards again:

```
var keyToIds = Database.Fetch<NodeIdKey>(Sql()
    .Select<NodeDto>(x => x.NodeId, x => x.UniqueId)
    .From<NodeDto>()
    .WhereIn<NodeDto>(x => x.UniqueId, udiToGuids.Values))
    .ToDictionary(x => x.UniqueId, x => x.NodeId);

var childsToDelete = trackedRelations.Where(x => keyToIds.Any(y => y.Key == x.Udi.AsGuid()));

RelationRepository.DeleteByParent(entity.Id, childsToDelete, relationTypeAliases);
```