### PR TITLE
V11: InMemory - only add models assembly as runtime view reference if it exists

### DIFF
--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
@@ -396,26 +396,30 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
     private CSharpCompilation CreateCompilation(string compilationContent, string assemblyName)
     {
         IReadOnlyList<MetadataReference> refs = _referenceManager.CompilationReferences;
-        // We'll add the reference to the InMemory assembly directly, this means we don't have to hack around with assembly parts.
-        if (_loadContextManager.ModelsAssemblyLocation is null)
-        {
-            throw new InvalidOperationException("No InMemory assembly available, cannot compile views");
-        }
-
-        PortableExecutableReference inMemoryAutoReference = MetadataReference.CreateFromFile(_loadContextManager.ModelsAssemblyLocation);
-
 
         var sourceText = SourceText.From(compilationContent, Encoding.UTF8);
         SyntaxTree syntaxTree = SyntaxFactory
             .ParseSyntaxTree(sourceText, _compilationOptionsProvider.ParseOptions)
             .WithFilePath(assemblyName);
 
-        return CSharpCompilation
+        CSharpCompilation compilation = CSharpCompilation
                 .Create(assemblyName)
                 .AddSyntaxTrees(syntaxTree)
                 .AddReferences(refs)
-                .AddReferences(inMemoryAutoReference)
                 .WithOptions(_compilationOptionsProvider.CSharpCompilationOptions);
+
+        // We'll add the reference to the InMemory assembly directly, this means we don't have to hack around with assembly parts.
+        // We might be asked to compile views before the InMemory models assembly is created tho (if you replace the no-nodes for instance)
+        // In this case we'll just skip the InMemory models assembly reference
+        if (_loadContextManager.ModelsAssemblyLocation is null)
+        {
+            _logger.LogInformation("No InMemory models assembly available, skipping reference");
+            return compilation;
+        }
+
+        PortableExecutableReference inMemoryAutoReference = MetadataReference.CreateFromFile(_loadContextManager.ModelsAssemblyLocation);
+        compilation.AddReferences(inMemoryAutoReference);
+        return compilation;
     }
 
     private string GetNormalizedPath(string relativePath)

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
@@ -418,7 +418,7 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
         }
 
         PortableExecutableReference inMemoryAutoReference = MetadataReference.CreateFromFile(_loadContextManager.ModelsAssemblyLocation);
-        compilation.AddReferences(inMemoryAutoReference);
+        compilation = compilation.AddReferences(inMemoryAutoReference);
         return compilation;
     }
 


### PR DESCRIPTION
This fixes an issue if you replace a default view (like the no-nodes) page with a non-precompiled one. 

This would cause the RuntimeViewCompiler to explode because it couldn't find the InMemory model assembly to add as a reference. 

This PR switches it over so the reference is ignored if the InMemory models assembly doesn't exist. 