### PR TITLE
Adds the SSH feature to allow the GitHub CLI SSH command to work

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,12 @@
 		// https://github.com/devcontainers/templates/issues/38#issuecomment-1310803259		
 		"ghcr.io/devcontainers/features/dotnet:1": {
 			"version": "7"
+		},
+
+		// Adds SSH support to the container
+		// Allowing the Github CLI `gh codespace ssh` to work
+		"ghcr.io/devcontainers/features/sshd:1": {
+			"version": "latest"
 		}
 	},
 


### PR DESCRIPTION
## GitHub CLI
Adds support for the GitHub CLI command `gh codespaces ssh` to work and allow you to SSH into the running machine/codespace

https://cli.github.com
https://cli.github.com/manual/gh_codespace_ssh

