### PR TITLE
v11: Rich text editor - remove distraction-free mode and optimise inline mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -347,18 +347,18 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         plugins.push("autoresize");
 
         var modeInline = false;
-        var toolbar = args.toolbar.join(" ");
+        var toolbarActions = args.toolbar.join(" ");
+        var toolbar = toolbarActions;
+        var quickbar = toolbarActions;
 
         // Based on mode set
         // classic = Theme: modern, inline: false
         // inline = Theme: modern, inline: true,
-        // distraction-free = Theme: inlite, inline: true
-        if (args.mode === "inline") {
-          modeInline = true;
-        }
-        else if (args.mode === "distraction-free") {
+        // distraction-free = Same as inline - kept for legacy reasons due to older versions of Umbraco having this as a mode
+        if (args.mode === "inline" || args.mode === 'distraction-free') {
           modeInline = true;
           toolbar = false;
+          plugins.push('quickbars');
         }
 
         //create a baseline Config to extend upon
@@ -379,6 +379,8 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
           //this would be for a theme other than inlite
           toolbar: toolbar,
+          quickbars_insert_toolbar: quickbar,
+          quickbars_selection_toolbar: quickbar,
 
           body_class: "umb-rte",
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.controller.js
@@ -20,9 +20,9 @@ angular.module("umbraco")
             var width = editorConfig.dimensions ? parseInt(editorConfig.dimensions.width, 10) || null : null;
             var height = editorConfig.dimensions ? parseInt(editorConfig.dimensions.height, 10) || null : null;
 
-            $scope.containerWidth = editorConfig.mode === "distraction-free" ? (width ? width : "auto") : "auto";
-            $scope.containerHeight = editorConfig.mode === "distraction-free" ? (height ? height : "auto") : "auto";
-            $scope.containerOverflow = editorConfig.mode === "distraction-free" ? (height ? "auto" : "inherit") : "inherit";
+            $scope.containerWidth = "auto";
+            $scope.containerHeight = "auto";
+            $scope.containerOverflow = "inherit";
 
             var promises = [];
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -22,6 +22,10 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
         if (!$scope.model.value.mode) {
             $scope.model.value.mode = "classic";
         }
+        else if ($scope.model.value.mode === 'distraction-free') {
+            // Due to legacy reasons, the older 'distraction-free' mode is kept and remapped to 'inline'
+            $scope.model.value.mode = 'inline';
+        }
 
         tinyMceService.configuration().then(function(config){
             $scope.tinyMceConfig = config;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -40,9 +40,8 @@
     <umb-control-group label="Mode" description="Select mode">
         <div class="vertical-align-items">
             <select ng-model="model.value.mode">
-                <option value="classic">Classic</option> <!-- Theme:silver & inline:false-->
-                <option value="inline">Inline</option> <!-- Theme:silver & inline:true-->
-                <option value="distraction-free">Distraction Free</option> <!-- Theme:silver & toolbars:null & inline:true -->
+                <option value="classic">Classic</option> <!-- Theme:modern & inline:false-->
+                <option value="inline">Inline</option> <!-- Theme:modern & inline:true-->
             </select>
         </div>
     </umb-control-group>


### PR DESCRIPTION
### Distraction-free

This mode is now being removed and merged with the 'inline' mode. This allows us to simplify the rich text editor and on top of that, make a nicer experience for the editors in inline mode using the "quickbars" plugin.

**Prevalues config**
There are now only two modes, and any older databases set to 'distraction-free' is automatically mapped to 'inline':

![image](https://user-images.githubusercontent.com/752371/201672539-11c67b0a-81b6-43e0-8989-033199840ac7.png)

**The editor**
Now using the "quickbars" plugin, it gives the editor a nice hovering toolbar to edit their content:

![image](https://user-images.githubusercontent.com/752371/201672821-2f26fdf0-d8e0-4270-b157-fcedf5788e91.png)


