### PR TITLE
Adds dotnet build command for onCreateCommand to use in Prebuilds of CodeSpaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,11 @@
 		"ms-dotnettools.csharp"
 	],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [9000, 5000, 25]
+	// Use 'forwardPorts' to make a list of ports inside the container available locallAdd	"forwardPorts": [9000, 5000, 25],
+
+	// Use OnCreateCommand to run commands after the container is created
+	// This is used in the prebuilds - so dotnet build (nuget restore and node stuff) is done
+	"onCreateCommand": "dotnet build umbraco.sln",
 
 	// [Optional] To reuse of your local HTTPS dev cert:
 	//


### PR DESCRIPTION
For GitHub CodeSpaces the first time you perform `dotnet build umbraco.sln` at the root of the folder in the terminal in VSCode it can take a long time to perform (around ~10mins) to do Nuget downloads and restore, along with NPM installs of client side stuff needed for Umbraco backoffice to run.

With this set in the `onCreateCommand` in the devcontainer.json it will make the first time run of the CodeSpace image to be a lot faster for anyone wanting to contribute to Umbraco CMS project.

### Note
*It will increase the build time in our GitHub Action `Codespaces Prebuilds` and could eat up more minutes quicker.*