### PR TITLE
Trying Codespace prebuilds to use updateContentCommand that the docs refer to

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,9 +34,9 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locallAdd	"forwardPorts": [9000, 5000, 25],
 
-	// Use OnCreateCommand to run commands after the container is created
+	
 	// This is used in the prebuilds - so dotnet build (nuget restore and node stuff) is done
-	"onCreateCommand": "dotnet build umbraco.sln",
+	"updateContentCommand": "dotnet build umbraco.sln",
 
 	// [Optional] To reuse of your local HTTPS dev cert:
 	//


### PR DESCRIPTION
For GitHub CodeSpaces the first time you perform dotnet build umbraco.sln at the root of the folder in the terminal in VSCode it can take a long time to perform (around ~10mins) to do Nuget downloads and restore, along with NPM installs of client side stuff needed for Umbraco backoffice to run.


## Note
This should be a different approach of using `updateContentCommand` as opposed to `onCreateCommand` and replaces PR #13395

## Docs
https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds#configuring-time-consuming-tasks-to-be-included-in-the-prebuild