### PR TITLE
Enable CodeSpaces PortForwarding Config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,7 +51,7 @@
 		"44331": {
 			"label": "Umbraco HTTPS",
 			"protocol": "https",
-			"onAutoForward": "openBrowser"
+			"onAutoForward": "notify"
 		}
 	}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,11 @@
 	// This is used in the prebuilds - so dotnet build (nuget restore and node stuff) is done
 	"updateContentCommand": "dotnet build umbraco.sln",
 	"portsAttributes": {
+		"5000": {
+			"label": "SMTP4Dev",
+			"protocol": "http",
+			"onAutoForward": "notify"
+		},
 		"9000": {
 			"label": "Umbraco HTTP",
 			"protocol": "http",
@@ -46,7 +51,7 @@
 		"44331": {
 			"label": "Umbraco HTTPS",
 			"protocol": "https",
-			"onAutoForward": "notify"
+			"onAutoForward": "openBrowser"
 		}
 	}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,18 @@
 	
 	// This is used in the prebuilds - so dotnet build (nuget restore and node stuff) is done
 	"updateContentCommand": "dotnet build umbraco.sln",
+	"portsAttributes": {
+		"9000": {
+			"label": "Umbraco HTTP",
+			"protocol": "http",
+			"onAutoForward": "notify"
+		},
+		"44331": {
+			"label": "Umbraco HTTPS",
+			"protocol": "https",
+			"onAutoForward": "notify"
+		}
+	}
 
 	// [Optional] To reuse of your local HTTPS dev cert:
 	//


### PR DESCRIPTION
This PR adds config for Port Forwarding to give the ports meaningful labels and to ensure the correct protocol is used.
When changing to the prebuilds it does not auto show the SMTP4Dev port anymore so this adds it so it can be discovered easier.
