### PR TITLE
Codespaces: dotnet devcert in the docker was not working so moved to updateContentCommand

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,3 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # https://docs.npmjs.com/cli/v6/using-npm/config#unsafe-perm
 # Default: false if running as root, true otherwise (we are ROOT)
 #RUN npm -g config set user vscode && npm -g config set unsafe-perm
-
-# Generate and trust a local developer certificate for Kestrel
-# This is needed for Kestrel to bind on https
-RUN dotnet dev-certs https --trust

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
 
 	
 	// This is used in the prebuilds - so dotnet build (nuget restore and node stuff) is done
-	"updateContentCommand": "dotnet build umbraco.sln",
+	"updateContentCommand": "dotnet build umbraco.sln && dotnet dev-certs https --trust",
 
 	// [Optional] To reuse of your local HTTPS dev cert:
 	//


### PR DESCRIPTION
The command for adding the developer SSL certificate command from dotnet cli was not working as part of the docker image so moved into `updateContentCommand`