### PR TITLE
Codespaces: Removes the explicit build before attaching debugger launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,6 @@
             "name": ".NET Core Launch (web)",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "Dotnet build",
             "program": "dotnet",
             "args": ["run"],
             "cwd": "${workspaceFolder}/src/Umbraco.Web.UI",


### PR DESCRIPTION
Codespaces: Removes the explicit build before attaching debugger launch task now that we have prebuilt CodeSpaces now.