### PR TITLE
V10: AllowedUploadFiles appsetting not working

### DIFF
--- a/src/Umbraco.Core/Configuration/ContentSettingsExtensions.cs
+++ b/src/Umbraco.Core/Configuration/ContentSettingsExtensions.cs
@@ -10,9 +10,9 @@ public static class ContentSettingsExtensions
     ///     Allow upload if extension is whitelisted OR if there is no whitelist and extension is NOT blacklisted.
     /// </summary>
     public static bool IsFileAllowedForUpload(this ContentSettings contentSettings, string extension) =>
-        contentSettings.AllowedUploadFiles.Any(x => x.InvariantEquals(extension)) ||
-        (contentSettings.AllowedUploadFiles.Any() == false &&
-         contentSettings.DisallowedUploadFiles.Any(x => x.InvariantEquals(extension)) == false);
+        contentSettings.AllowedUploadedFileExtensions.Any(x => x.InvariantEquals(extension)) ||
+        (contentSettings.AllowedUploadedFileExtensions.Any() == false &&
+         contentSettings.DisAllowedUploadedFileExtensions.Any(x => x.InvariantEquals(extension)) == false);
 
     /// <summary>
     ///     Gets the auto-fill configuration for a specified property alias.

--- a/src/Umbraco.Core/Configuration/ContentSettingsExtensions.cs
+++ b/src/Umbraco.Core/Configuration/ContentSettingsExtensions.cs
@@ -12,7 +12,7 @@ public static class ContentSettingsExtensions
     public static bool IsFileAllowedForUpload(this ContentSettings contentSettings, string extension) =>
         contentSettings.AllowedUploadedFileExtensions.Any(x => x.InvariantEquals(extension)) ||
         (contentSettings.AllowedUploadedFileExtensions.Any() == false &&
-         contentSettings.DisAllowedUploadedFileExtensions.Any(x => x.InvariantEquals(extension)) == false);
+         contentSettings.DisallowedUploadedFileExtensions.Any(x => x.InvariantEquals(extension)) == false);
 
     /// <summary>
     ///     Gets the auto-fill configuration for a specified property alias.

--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -261,5 +261,5 @@ public class ContentSettings
     ///     Gets or sets a value for the collection of file extensions that are disallowed for upload.
     /// </summary>
     [DefaultValue(StaticDisallowedUploadFiles)]
-    public string[] DisAllowedUploadedFileExtensions { get; set; } = StaticDisallowedUploadFiles.Split(',');
+    public string[] DisallowedUploadedFileExtensions { get; set; } = StaticDisallowedUploadFiles.Split(',');
 }

--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -196,12 +196,14 @@ public class ContentSettings
     ///     Gets or sets a value for the collection of file extensions that are disallowed for upload.
     /// </summary>
     [DefaultValue(StaticDisallowedUploadFiles)]
+    [Obsolete("Please use DisAllowedUploadedFileExtensions instead, scheduled for removal in V13")]
     public IEnumerable<string> DisallowedUploadFiles { get; set; } = StaticDisallowedUploadFiles.Split(',');
 
     /// <summary>
     ///     Gets or sets a value for the collection of file extensions that are allowed for upload.
     /// </summary>
-    public string[] AllowedUploadFiles { get; set; } = Array.Empty<string>();
+    [Obsolete("Please use AllowedUploadedFileExtensions instead, scheduled for removal in V13")]
+    public IEnumerable<string> AllowedUploadFiles { get; set; } = Array.Empty<string>();
 
     /// <summary>
     ///     Gets or sets a value indicating whether deprecated property editors should be shown.

--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -201,7 +201,7 @@ public class ContentSettings
     /// <summary>
     ///     Gets or sets a value for the collection of file extensions that are allowed for upload.
     /// </summary>
-    public IEnumerable<string> AllowedUploadFiles { get; set; } = Array.Empty<string>();
+    public string[] AllowedUploadFiles { get; set; } = Array.Empty<string>();
 
     /// <summary>
     ///     Gets or sets a value indicating whether deprecated property editors should be shown.
@@ -249,4 +249,15 @@ public class ContentSettings
     /// </summary>
     [DefaultValue(StaticAllowEditInvariantFromNonDefault)]
     public bool AllowEditInvariantFromNonDefault { get; set; } = StaticAllowEditInvariantFromNonDefault;
+
+    /// <summary>
+    ///     Gets or sets a value for the collection of file extensions that are allowed for upload.
+    /// </summary>
+    public string[] AllowedUploadedFileExtensions { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    ///     Gets or sets a value for the collection of file extensions that are disallowed for upload.
+    /// </summary>
+    [DefaultValue(StaticDisallowedUploadFiles)]
+    public string[] DisAllowedUploadedFileExtensions { get; set; } = StaticDisallowedUploadFiles.Split(',');
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -119,6 +119,20 @@ public static partial class UmbracoBuilderExtensions
             }
         });
 
+        // TODO: Remove this in V13
+        // This is to avoid a breaking change in ContentSettings, if the old AllowedFileUploads has a value, and the new
+        // AllowedFileUploadExtensions does not, copy the value over, if the new has a value, use that instead.
+        builder.Services.Configure<ContentSettings>(settings =>
+        {
+            // We have to use Config.GetSection().Get<string[]>, as the GetSection.GetValue<string[]> simply cannot retrieve a string array
+            var allowedUploadedFileExtensionsValue = builder.Config.GetSection($"{Constants.Configuration.ConfigContent}:{nameof(ContentSettings.AllowedUploadedFileExtensions)}").Get<string[]>();
+            var allowedUploadFilesValue = builder.Config.GetSection($"{Constants.Configuration.ConfigContent}:{nameof(ContentSettings.AllowedUploadFiles)}").Get<string[]>();
+
+            if (allowedUploadedFileExtensionsValue is null && allowedUploadFilesValue is not null)
+            {
+                settings.AllowedUploadedFileExtensions = allowedUploadFilesValue;
+            }
+        });
         return builder;
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -142,7 +142,7 @@ public static partial class UmbracoBuilderExtensions
 
             if (disallowedUploadedFileExtensionsValue is null && disallowedUploadFilesValue is not null)
             {
-                settings.AllowedUploadedFileExtensions = disallowedUploadFilesValue;
+                settings.DisallowedUploadedFileExtensions = disallowedUploadFilesValue;
             }
         });
         return builder;

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -133,6 +133,18 @@ public static partial class UmbracoBuilderExtensions
                 settings.AllowedUploadedFileExtensions = allowedUploadFilesValue;
             }
         });
+
+        // TODO: Remove this in V13
+        builder.Services.Configure<ContentSettings>(settings =>
+        {
+            var disallowedUploadedFileExtensionsValue = builder.Config.GetSection($"{Constants.Configuration.ConfigContent}:{nameof(ContentSettings.DisallowedUploadedFileExtensions)}").Get<string[]>();
+            var disallowedUploadFilesValue = builder.Config.GetSection($"{Constants.Configuration.ConfigContent}:{nameof(ContentSettings.DisallowedUploadFiles)}").Get<string[]>();
+
+            if (disallowedUploadedFileExtensionsValue is null && disallowedUploadFilesValue is not null)
+            {
+                settings.AllowedUploadedFileExtensions = disallowedUploadFilesValue;
+            }
+        });
         return builder;
     }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -543,11 +543,11 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         },
                         {
                             "disallowedUploadFiles",
-                            string.Join(",", _contentSettings.DisallowedUploadFiles)
+                            string.Join(",", _contentSettings.DisallowedUploadedFileExtensions)
                         },
                         {
                             "allowedUploadFiles",
-                            string.Join(",", _contentSettings.AllowedUploadFiles)
+                            string.Join(",", _contentSettings.AllowedUploadedFileExtensions)
                         },
                         {
                             "maxFileSize",


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13308

# Notes
- Added 2 new AppSettings to ContentSettings: 
`AllowedUploadedFileExtensions` & `DisAllowedUploadedFileExtensions`
- Added logic in `UmbracoBuilder.Configuration` to copy the Value of `AllowedUploadFiles` to the new `AllowedUploadedFileExtensions`
- Could argue as this is not necessary because the setting has never worked.

# How to test
- Try to upload a file in the media library filed (besides the disallowed ones: ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,xamlx)
- This should upload the file.
- Try setting the Old AllowedUploadFiles:
```
"Umbraco": {
    "CMS": {
      "Content": {
        "AllowedUploadFiles": ["pdf"],
      }
  }
}
```
- Restart the site and try uploading a pdf in the media library, this should work
- Try uploading anything else than a pdf, this should not be possible.
- Set the new setting:
```
"Umbraco": {
    "CMS": {
      "Content": {
        "AllowedUploadedFileExtensions": ["png"],
      }
  }
}
```
- Try uploading a pdf, this should now fail, as the new settings should be in place instead.
- Try uploading a png file, this should work