### PR TITLE
Add support for tags in block editors and nested content

### DIFF
--- a/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
+++ b/src/Umbraco.Core/Models/PropertyTagsExtensions.cs
@@ -23,19 +23,15 @@ public static class PropertyTagsExtensions
 
         IDataEditor? editor = propertyEditors[property.PropertyType?.PropertyEditorAlias];
         TagsPropertyEditorAttribute? tagAttribute = editor?.GetTagAttribute();
-        if (tagAttribute == null)
-        {
-            return null;
-        }
 
         var configurationObject = property.PropertyType is null
             ? null
             : dataTypeService.GetDataType(property.PropertyType.DataTypeId)?.Configuration;
-        TagConfiguration? configuration = ConfigurationEditor.ConfigurationAs<TagConfiguration>(configurationObject);
+        TagConfiguration? configuration = configurationObject as TagConfiguration;
 
         if (configuration is not null && configuration.Delimiter == default)
         {
-            configuration.Delimiter = tagAttribute.Delimiter;
+            configuration.Delimiter = tagAttribute?.Delimiter ?? ',';
         }
 
         return configuration;

--- a/src/Umbraco.Core/PropertyEditors/IDataValueTags.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataValueTags.cs
@@ -1,0 +1,18 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Resolve tags from <see cref="IDataValueEditor" /> values
+/// </summary>
+public interface IDataValueTags
+{
+    /// <summary>
+    ///     Returns any tags contained in the value
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="dataTypeConfiguration"></param>
+    /// <param name="languageId"></param>
+    /// <returns></returns>
+    IEnumerable<ITag> GetTags(object? value, object? dataTypeConfiguration, int? languageId);
+}

--- a/src/Umbraco.Core/PropertyEditors/PropertyEditorTagsExtensions.cs
+++ b/src/Umbraco.Core/PropertyEditors/PropertyEditorTagsExtensions.cs
@@ -5,6 +5,7 @@ namespace Umbraco.Extensions;
 /// <summary>
 ///     Provides extension methods for the <see cref="IDataEditor" /> interface to manage tags.
 /// </summary>
+[Obsolete]
 public static class PropertyEditorTagsExtensions
 {
     /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/TagsPropertyEditorAttribute.cs
+++ b/src/Umbraco.Core/PropertyEditors/TagsPropertyEditorAttribute.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 ///     Marks property editors that support tags.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
+[Obsolete("Implement a custom IDataValueEditor with the IDataValueTags interface instead")]
 public class TagsPropertyEditorAttribute : Attribute
 {
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -274,29 +274,59 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             foreach (IProperty property in entity.Properties)
             {
-                TagConfiguration? tagConfiguration = property.GetTagConfiguration(PropertyEditors, DataTypeService);
-                if (tagConfiguration == null)
+                if (PropertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out var editor) is false)
                 {
-                    continue; // not a tags property
+                    continue;
                 }
+
+                if (editor.GetValueEditor() is not IDataValueTags tagsProvider)
+                {
+                    // support for legacy tag editors, everything from here down to the last continue can be removed when TagsPropertyEditorAttribute is removed
+                    TagConfiguration? tagConfiguration = property.GetTagConfiguration(PropertyEditors, DataTypeService);
+                    if (tagConfiguration == null)
+                    {
+                        continue;
+                    }
+
+                    if (property.PropertyType.VariesByCulture())
+                    {
+                        var tags = new List<ITag>();
+                        foreach (IPropertyValue pvalue in property.Values)
+                        {
+                            IEnumerable<string> tagsValue = property.GetTagsValue(PropertyEditors, DataTypeService, serializer, pvalue.Culture);
+                            var languageId = LanguageRepository.GetIdByIsoCode(pvalue.Culture);
+                            IEnumerable<Tag> cultureTags = tagsValue.Select(x => new Tag { Group = tagConfiguration.Group, Text = x, LanguageId = languageId });
+                            tags.AddRange(cultureTags);
+                        }
+
+                        tagRepo.Assign(entity.Id, property.PropertyTypeId, tags);
+                    }
+                    else
+                    {
+                        IEnumerable<string> tagsValue = property.GetTagsValue(PropertyEditors, DataTypeService, serializer); // strings
+                        IEnumerable<Tag> tags = tagsValue.Select(x => new Tag { Group = tagConfiguration.Group, Text = x });
+                        tagRepo.Assign(entity.Id, property.PropertyTypeId, tags);
+                    }
+
+                    continue; // not implementing IDataValueTags, continue
+                }
+
+                object? configuration = DataTypeService.GetDataType(property.PropertyType.DataTypeId)?.Configuration;
 
                 if (property.PropertyType.VariesByCulture())
                 {
                     var tags = new List<ITag>();
                     foreach (IPropertyValue pvalue in property.Values)
                     {
-                        IEnumerable<string> tagsValue = property.GetTagsValue(PropertyEditors, DataTypeService, serializer, pvalue.Culture);
                         var languageId = LanguageRepository.GetIdByIsoCode(pvalue.Culture);
-                        IEnumerable<Tag> cultureTags = tagsValue.Select(x => new Tag { Group = tagConfiguration.Group, Text = x, LanguageId = languageId });
-                        tags.AddRange(cultureTags);
+                        tags.AddRange(tagsProvider.GetTags(pvalue.EditedValue, configuration, languageId));
                     }
 
                     tagRepo.Assign(entity.Id, property.PropertyTypeId, tags);
                 }
                 else
                 {
-                    IEnumerable<string> tagsValue = property.GetTagsValue(PropertyEditors, DataTypeService, serializer); // strings
-                    IEnumerable<Tag> tags = tagsValue.Select(x => new Tag { Group = tagConfiguration.Group, Text = x });
+                    IEnumerable<ITag> tags = tagsProvider.GetTags(property.GetValue(), configuration, null);
                     tagRepo.Assign(entity.Id, property.PropertyTypeId, tags);
                 }
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -13,7 +13,7 @@ using Umbraco.Cms.Core.Strings;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataValueReference
+internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataValueReference, IDataValueTags
 {
     private BlockEditorValues? _blockEditorValues;
     private readonly IDataTypeService _dataTypeService;
@@ -71,6 +71,40 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
                 IEnumerable<UmbracoEntityReference> refs = reference.GetReferences(val);
 
                 result.AddRange(refs);
+            }
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ITag> GetTags(object? value, object? dataTypeConfiguration, int? languageId)
+    {
+        var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
+
+        BlockEditorData? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
+        if (blockEditorData == null)
+        {
+            return Enumerable.Empty<ITag>();
+        }
+
+        var result = new List<ITag>();
+        // loop through all content and settings data
+        foreach (BlockItemData row in blockEditorData.BlockValue.ContentData.Concat(blockEditorData.BlockValue.SettingsData))
+        {
+            foreach (KeyValuePair<string, BlockItemData.BlockPropertyValue> prop in row.PropertyValues)
+            {
+                IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+
+                IDataValueEditor? valueEditor = propEditor?.GetValueEditor();
+                if (valueEditor is not IDataValueTags tagsProvider)
+                {
+                    continue;
+                }
+
+                object? configuration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.Configuration;
+
+                result.AddRange(tagsProvider.GetTags(prop.Value.Value, configuration, languageId));
             }
         }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -68,7 +68,7 @@ public class NestedContentPropertyEditor : DataEditor
     protected override IDataValueEditor CreateValueEditor()
         => DataValueEditorFactory.Create<NestedContentPropertyValueEditor>(Attribute!);
 
-    internal class NestedContentPropertyValueEditor : DataValueEditor, IDataValueReference
+    internal class NestedContentPropertyValueEditor : DataValueEditor, IDataValueReference, IDataValueTags
     {
         private readonly IDataTypeService _dataTypeService;
         private readonly ILogger<NestedContentPropertyEditor> _logger;
@@ -143,6 +143,36 @@ public class NestedContentPropertyEditor : DataEditor
                     IEnumerable<UmbracoEntityReference> refs = reference.GetReferences(val);
 
                     result.AddRange(refs);
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<ITag> GetTags(object? value, object? dataTypeConfiguration, int? languageId)
+        {
+            IReadOnlyList<NestedContentValues.NestedContentRowValue> rows =
+                _nestedContentValues.GetPropertyValues(value);
+
+            var result = new List<ITag>();
+
+            foreach (NestedContentValues.NestedContentRowValue row in rows.ToList())
+            {
+                foreach (KeyValuePair<string, NestedContentValues.NestedContentPropertyValue> prop in row.PropertyValues
+                             .ToList())
+                {
+                    IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+
+                    IDataValueEditor? valueEditor = propEditor?.GetValueEditor();
+                    if (valueEditor is not IDataValueTags tagsProvider)
+                    {
+                        continue;
+                    }
+
+                    object? configuration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.Configuration;
+
+                    result.AddRange(tagsProvider.GetTags(prop.Value.Value, configuration, languageId));
                 }
             }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -121,13 +121,12 @@ public class TagsPropertyEditor : DataEditor
                     throw new NotSupportedException($"Value \"{tagConfiguration.StorageType}\" is not a valid TagsStorageType.");
             }
 
-            return from tag in tags
-                   select new Tag
-                   {
-                       Group = tagConfiguration.Group,
-                       Text = tag,
-                       LanguageId = languageId
-                   };
+            return tags.Select(x => new Tag
+            {
+                Group = tagConfiguration.Group,
+                Text = x,
+                LanguageId = languageId,
+            });
         }
 
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -68,17 +69,67 @@ public class TagsPropertyEditor : DataEditor
     protected override IConfigurationEditor CreateConfigurationEditor() =>
         new TagConfigurationEditor(_validators, _ioHelper, _localizedTextService, _editorConfigurationParser);
 
-    internal class TagPropertyValueEditor : DataValueEditor
+    internal class TagPropertyValueEditor : DataValueEditor, IDataValueTags
     {
+        private readonly IDataTypeService _dataTypeService;
+
         public TagPropertyValueEditor(
             ILocalizedTextService localizedTextService,
             IShortStringHelper shortStringHelper,
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper,
-            DataEditorAttribute attribute)
+            DataEditorAttribute attribute,
+            IDataTypeService dataTypeService)
             : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
         {
+            _dataTypeService = dataTypeService;
         }
+
+        /// <inheritdoc />
+        public IEnumerable<ITag> GetTags(object? value, object? dataTypeConfiguration, int? languageId)
+        {
+            var strValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(strValue)) return Enumerable.Empty<ITag>();
+
+            var tagConfiguration = ConfigurationEditor.ConfigurationAs<TagConfiguration>(dataTypeConfiguration) ?? new TagConfiguration();
+
+            if (tagConfiguration.Delimiter == default)
+                tagConfiguration.Delimiter = ',';
+
+            IEnumerable<string> tags;
+
+            switch (tagConfiguration.StorageType)
+            {
+                case TagsStorageType.Csv:
+                    tags = strValue.Split(new[] { tagConfiguration.Delimiter }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+                    break;
+
+                case TagsStorageType.Json:
+                    try
+                    {
+                        tags = JsonConvert.DeserializeObject<string[]>(strValue)?.Select(x => x.Trim()) ?? Enumerable.Empty<string>();
+                    }
+                    catch (JsonException)
+                    {
+                        //cannot parse, malformed
+                        tags = Enumerable.Empty<string>();
+                    }
+
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Value \"{tagConfiguration.StorageType}\" is not a valid TagsStorageType.");
+            }
+
+            return from tag in tags
+                   select new Tag
+                   {
+                       Group = tagConfiguration.Group,
+                       Text = tag,
+                       LanguageId = languageId
+                   };
+        }
+
 
         /// <inheritdoc />
         public override IValueRequiredValidator RequiredValidator => new RequiredJsonValueValidator();
@@ -93,14 +144,33 @@ public class TagsPropertyEditor : DataEditor
                 return null;
             }
 
+            var tagConfiguration = editorValue.DataTypeConfiguration as TagConfiguration ?? new TagConfiguration();
+            if (tagConfiguration.Delimiter == default)
+                tagConfiguration.Delimiter = ',';
+
+            string[] trimmedTags = Array.Empty<string>();
+
             if (editorValue.Value is JArray json)
             {
-                return json.HasValues ? json.Select(x => x.Value<string>()) : null;
+                trimmedTags = json.HasValues ? json.Select(x => x.Value<string>()).OfType<string>().ToArray() : Array.Empty<string>();
+            }
+            else if (string.IsNullOrWhiteSpace(value) == false)
+            {
+                trimmedTags = value.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries);
             }
 
-            if (string.IsNullOrWhiteSpace(value) == false)
+            if (trimmedTags.Length == 0)
             {
-                return value.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries);
+                return null;
+            }
+
+            switch (tagConfiguration.StorageType)
+            {
+                case TagsStorageType.Csv:
+                    return string.Join(tagConfiguration.Delimiter.ToString(), trimmedTags).NullOrWhiteSpaceAsNull();
+
+                case TagsStorageType.Json:
+                    return trimmedTags.Length == 0 ? null : JsonConvert.SerializeObject(trimmedTags);
             }
 
             return null;

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
@@ -146,7 +146,9 @@ public abstract class ContentControllerBase : BackOfficeNotificationsController
 
             // set the value - tags are special
             TagsPropertyEditorAttribute? tagAttribute = propertyDto.PropertyEditor.GetTagAttribute();
-            if (tagAttribute != null)
+            // when TagsPropertyEditorAttribute is removed this whole if can also be removed
+            // since the call to sovePropertyValue is all that's needed now
+            if (tagAttribute != null && valueEditor is not IDataValueTags)
             {
                 TagConfiguration? tagConfiguration =
                     ConfigurationEditor.ConfigurationAs<TagConfiguration>(propertyDto.DataType?.Configuration);

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
@@ -148,7 +148,7 @@ public abstract class ContentControllerBase : BackOfficeNotificationsController
             TagsPropertyEditorAttribute? tagAttribute = propertyDto.PropertyEditor.GetTagAttribute();
             // when TagsPropertyEditorAttribute is removed this whole if can also be removed
             // since the call to sovePropertyValue is all that's needed now
-            if (tagAttribute != null && valueEditor is not IDataValueTags)
+            if (tagAttribute is not null && valueEditor is not IDataValueTags)
             {
                 TagConfiguration? tagConfiguration =
                     ConfigurationEditor.ConfigurationAs<TagConfiguration>(propertyDto.DataType?.Configuration);

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -206,7 +206,6 @@
          * Used to highlight unsupported properties for the user, changes unsupported properties into a unsupported-property.
          */
         var notSupportedProperties = [
-            "Umbraco.Tags",
             "Umbraco.UploadField",
             "Umbraco.ImageCropper",
             "Umbraco.NestedContent"
@@ -654,7 +653,7 @@
                             blockObject.__scope.$evalAsync();
                         });
                     });
-    
+
                     observer.observe(labelElement[0], {characterData: true, subtree:true});
 
                     blockObject.__watchers.push(() => {
@@ -671,9 +670,9 @@
                             $index: this.index + 1,
                             ... this.data
                         };
-    
+
                         this.__labelScope = Object.assign(this.__labelScope, labelVars);
-    
+
                         $compile(labelElement.contents())(this.__labelScope);
                     }.bind(blockObject)
                 } else {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -68,7 +68,7 @@
     function NestedContentController($scope, $interpolate, $filter, serverValidationManager, contentResource, localizationService, iconHelper, clipboardService, eventsService, overlayService, $attrs) {
 
         const vm = this;
-        
+
         var model = $scope.$parent.$parent.model;
 
         vm.readonly = false;
@@ -167,7 +167,7 @@
             isDisabled: true,
             useLegacyIcon: false
         };
-        
+
         function removeAllEntries() {
 
             localizationService.localizeMany(["content_nestedContentDeleteAllItems", "general_delete"]).then(data => {
@@ -186,7 +186,7 @@
                 });
             });
         }
-        
+
         // helper to force the current form into the dirty state
         function setDirty() {
             if (vm.umbProperty) {
@@ -531,7 +531,6 @@
             storageUpdate();
         });
         var notSupported = [
-            "Umbraco.Tags",
             "Umbraco.UploadField",
             "Umbraco.ImageCropper",
             "Umbraco.BlockList"


### PR DESCRIPTION
by introducing a new `IDataValueTags` that has a single `GetTags` method. When implemented on a `DataValueEditor` it gets called when the content is being saved so the tags can be updated in the tags repository. The tags will be associated with the outmost property (the one directly on the content item).

The block list and nested conten data value editors implements the interface and gets the tags from each nested property editor where the data value editor implements the `IDataValueTags` interface. 

The old implementation is still there but it isn't used if the editor implements `IDataValueTags`, its also marked as obsolete so it can be removed in a future version.

To test this add an element type with a tags property (both csv and json) editor to a block or nested content, create some content and add add some tags and save+publish, then create another content item and check that the auto-complete suggusts the tags added on the other content item.

In the frontend use the `ITagsQuery` to query by the tags entered in the tags editor on the nested element and check that the content is returned.

Also verify that the source value stored for both json and csv matches the values stored without these changes.