### PR TITLE
V10: merge v8 blobstorage file deletion fix

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/CodeFileController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/CodeFileController.cs
@@ -842,7 +842,6 @@ public class CodeFileController : BackOfficeNotificationsController
         // Otherwise check the filesystem abstraction to see if the folder exists
         // Since this is used for delete, it presumably exists if we're trying to delete it
         return fileSystem.DirectoryExists(path);
-
     }
 
     // this is an internal class for passing stylesheet data from the client to the controller while editing

--- a/src/Umbraco.Web.BackOffice/Controllers/CodeFileController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/CodeFileController.cs
@@ -467,7 +467,7 @@ public class CodeFileController : BackOfficeNotificationsController
         {
             case Constants.Trees.PartialViews:
                 if (IsDirectory(
-                        _hostingEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.PartialViews, virtualPath))))
+                        _hostingEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.PartialViews, virtualPath)), _fileSystems.PartialViewsFileSystem!))
                 {
                     _fileService.DeletePartialViewFolder(virtualPath);
                     return Ok();
@@ -482,7 +482,7 @@ public class CodeFileController : BackOfficeNotificationsController
 
             case Constants.Trees.PartialViewMacros:
                 if (IsDirectory(
-                        _hostingEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.MacroPartials, virtualPath))))
+                        _hostingEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.MacroPartials, virtualPath)), _fileSystems.MacroPartialsFileSystem!))
                 {
                     _fileService.DeletePartialViewMacroFolder(virtualPath);
                     return Ok();
@@ -497,7 +497,7 @@ public class CodeFileController : BackOfficeNotificationsController
 
             case Constants.Trees.Scripts:
                 if (IsDirectory(
-                        _hostingEnvironment.MapPathWebRoot(Path.Combine(_globalSettings.UmbracoScriptsPath, virtualPath))))
+                        _hostingEnvironment.MapPathWebRoot(Path.Combine(_globalSettings.UmbracoScriptsPath, virtualPath)), _fileSystems.ScriptsFileSystem!))
                 {
                     _fileService.DeleteScriptFolder(virtualPath);
                     return Ok();
@@ -512,7 +512,7 @@ public class CodeFileController : BackOfficeNotificationsController
                 return new UmbracoProblemResult("No Script or folder found with the specified path", HttpStatusCode.NotFound);
             case Constants.Trees.Stylesheets:
                 if (IsDirectory(
-                        _hostingEnvironment.MapPathWebRoot(Path.Combine(_globalSettings.UmbracoCssPath, virtualPath))))
+                        _hostingEnvironment.MapPathWebRoot(Path.Combine(_globalSettings.UmbracoCssPath, virtualPath)), _fileSystems.StylesheetsFileSystem!))
                 {
                     _fileService.DeleteStyleSheetFolder(virtualPath);
                     return Ok();
@@ -827,13 +827,22 @@ public class CodeFileController : BackOfficeNotificationsController
         return value;
     }
 
-    private bool IsDirectory(string path)
+    private bool IsDirectory(string path, IFileSystem fileSystem)
     {
-        var dirInfo = new DirectoryInfo(path);
+        // If it's a physical filesystem check with directory info
+        if (fileSystem.CanAddPhysical)
+        {
+            var dirInfo = new DirectoryInfo(path);
 
-        // If you turn off indexing in Windows this will have the attribute:
-        // `FileAttributes.Directory | FileAttributes.NotContentIndexed`
-        return (dirInfo.Attributes & FileAttributes.Directory) != 0;
+            // If you turn off indexing in Windows this will have the attribute:
+            // `FileAttributes.Directory | FileAttributes.NotContentIndexed`
+            return (dirInfo.Attributes & FileAttributes.Directory) != 0;
+        }
+
+        // Otherwise check the filesystem abstraction to see if the folder exists
+        // Since this is used for delete, it presumably exists if we're trying to delete it
+        return fileSystem.DirectoryExists(path);
+
     }
 
     // this is an internal class for passing stylesheet data from the client to the controller while editing


### PR DESCRIPTION
This is a v10 port of https://github.com/umbraco/Umbraco-CMS/pull/11998

# How to test in v10
- Create a storage account, and a blob container
- In your Appsettings, add the `Storage:AzureBlob` (paste in your connection string and container name from step 1)
```
"Umbraco": {
    "Storage": {
      "AzureBlob": {
        "Stylesheets": {
          "ConnectionString": "yourConnectionStringHere",
          "ContainerName": "BlobContainerNameHere"
        }
      }
    },
```
- Add the `Umbraco.StorageProvider.AzureBlob` nuget package to the `Web.UI` project
- In your startupcs in the `ConfigureServices` method, add `AddAzureBlobFileSystem` like this:
``` 
services.AddUmbraco(_env, _config)
                .AddBackOffice()
                .AddWebsite()
                .AddComposers()
                .AddAzureBlobFileSystem("Stylesheets", options => options.VirtualPath = "~/css")
                .Build();
```

- Create a composer to swap out the PhysicalFileSystem for the Stylesheets to blobstorage:
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Infrastructure.DependencyInjection;
using Umbraco.StorageProviders.AzureBlob.IO;

namespace Umbraco.Cms.Web.UI;

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.ConfigureFileSystems((provider, fileSystems) => fileSystems.SetStylesheetFilesystem(provider.GetRequiredService<IAzureBlobFileSystemProvider>().GetFileSystem("Stylesheets")));
    }
}

```

- You should now be able to run Umbraco
- Create a stylesheet, assert it shows up in your blob container, and is not saved locally
- Delete the stylesheet, assert it actually gets deleted from your blob container.