### PR TITLE
CodeSpaces: Scaffold out a file for a specific Codespace readme to auto open

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -54,7 +54,14 @@
 			"protocol": "https",
 			"onAutoForward": "notify"
 		}
-	}
+	},
+	"customizations": {
+		"codespaces": {
+		  "openFiles": [
+			".github/codespaces-readme.md"
+		  ]
+		}
+	  }
 
 	// [Optional] To reuse of your local HTTPS dev cert:
 	//

--- a/.github/codespaces-readme.md
+++ b/.github/codespaces-readme.md
@@ -1,0 +1,2 @@
+# GitHub CodeSpaces
+Get help at hackathon with this readme to list out steps or specific useful info to get up and running 


### PR DESCRIPTION
When CodeSpace opens up it will open up a new readme specific to CodeSpaces and helping to get new contributors onboarded.