### PR TITLE
v11: Fix for TinyMCE dropdowns

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -140,8 +140,10 @@
     }
 }
 
-.tox-tinymce-aux {
-  z-index: 65535 !important;
+.tox {
+  &.tox-tinymce-aux {
+    z-index: 65535;
+  }
 }
 
 .tox-tinymce-inline {

--- a/src/Umbraco.Web.UI.Client/src/less/rte.less
+++ b/src/Umbraco.Web.UI.Client/src/less/rte.less
@@ -140,6 +140,10 @@
     }
 }
 
+.tox-tinymce-aux {
+  z-index: 65535 !important;
+}
+
 .tox-tinymce-inline {
   z-index: 999;
 }


### PR DESCRIPTION
Set higher z-index for TinyMCE overlays as they were set below that of our property editor overlays. The z-index value is now the same as it was for Tiny v4/Umbraco 10.

Fixes #13414
