### PR TITLE
Management API: SearchController improvements

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/Controllers/Search/SearcherSearchSearchController.cs
+++ b/src/Umbraco.Cms.ManagementApi/Controllers/Search/SearcherSearchSearchController.cs
@@ -19,7 +19,7 @@ public class SearcherSearchSearchController : SearchControllerBase
 
     [HttpGet("searcher/{searcherName}/search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedViewModel<PagedViewModel<SearchResultViewModel>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedViewModel<SearchResultViewModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PagedViewModel<SearchResultViewModel>>> GetSearchResults(string searcherName, string? query, int skip, int take)
     {

--- a/src/Umbraco.Cms.ManagementApi/Factories/IndexViewModelFactory.cs
+++ b/src/Umbraco.Cms.ManagementApi/Factories/IndexViewModelFactory.cs
@@ -37,6 +37,21 @@ public class IndexViewModelFactory : IIndexViewModelFactory
 
         Attempt<string?> isHealthy = indexDiag.IsHealthy();
 
+        var properties = new Dictionary<string, object?>();
+
+        foreach (var p in indexDiag.Metadata)
+        {
+            if (p.Value is null)
+            {
+                properties[p.Key] = null;
+            }
+            else
+            {
+                var t = p.Value.GetType();
+                properties[p.Key] = t.IsClass && !t.IsArray ? p.Value?.ToString() : p.Value;
+            }
+        }
+
         var indexerModel = new IndexViewModel
         {
             Name = index.Name,
@@ -45,6 +60,7 @@ public class IndexViewModelFactory : IIndexViewModelFactory
             SearcherName = index.Searcher.Name,
             DocumentCount = indexDiag.GetDocumentCount(),
             FieldCount = indexDiag.GetFieldNames().Count(),
+            ProviderProperties = properties,
         };
 
         return indexerModel;

--- a/src/Umbraco.Cms.ManagementApi/Factories/IndexViewModelFactory.cs
+++ b/src/Umbraco.Cms.ManagementApi/Factories/IndexViewModelFactory.cs
@@ -47,8 +47,8 @@ public class IndexViewModelFactory : IIndexViewModelFactory
             }
             else
             {
-                var t = property.Value.GetType();
-                properties[property.Key] = t.IsClass && !t.IsArray ? property.Value?.ToString() : property.Value;
+                var propertyType = property.Value.GetType();
+                properties[property.Key] = propertyType.IsClass && !propertyType.IsArray ? property.Value?.ToString() : property.Value;
             }
         }
 

--- a/src/Umbraco.Cms.ManagementApi/Factories/IndexViewModelFactory.cs
+++ b/src/Umbraco.Cms.ManagementApi/Factories/IndexViewModelFactory.cs
@@ -39,16 +39,16 @@ public class IndexViewModelFactory : IIndexViewModelFactory
 
         var properties = new Dictionary<string, object?>();
 
-        foreach (var p in indexDiag.Metadata)
+        foreach (var property in indexDiag.Metadata)
         {
-            if (p.Value is null)
+            if (property.Value is null)
             {
-                properties[p.Key] = null;
+                properties[property.Key] = null;
             }
             else
             {
-                var t = p.Value.GetType();
-                properties[p.Key] = t.IsClass && !t.IsArray ? p.Value?.ToString() : p.Value;
+                var t = property.Value.GetType();
+                properties[property.Key] = t.IsClass && !t.IsArray ? property.Value?.ToString() : property.Value;
             }
         }
 

--- a/src/Umbraco.Cms.ManagementApi/OpenApi.json
+++ b/src/Umbraco.Cms.ManagementApi/OpenApi.json
@@ -2827,7 +2827,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedPaged"
+                  "$ref": "#/components/schemas/PagedSearchResult"
                 }
               }
             }
@@ -4854,11 +4854,18 @@
         "additionalProperties": false
       },
       "Index": {
+        "required": [
+          "canRebuild",
+          "documentCount",
+          "fieldCount",
+          "isHealthy",
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": true
+            "minLength": 1,
+            "type": "string"
           },
           "healthStatus": {
             "type": "string",
@@ -4882,6 +4889,11 @@
           "fieldCount": {
             "type": "integer",
             "format": "int32"
+          },
+          "providerProperties": {
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -5749,26 +5761,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Language"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "PagedPaged": {
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PagedSearchResult"
             }
           }
         },

--- a/src/Umbraco.Cms.ManagementApi/ViewModels/Search/IndexViewModel.cs
+++ b/src/Umbraco.Cms.ManagementApi/ViewModels/Search/IndexViewModel.cs
@@ -1,18 +1,27 @@
-﻿namespace Umbraco.Cms.ManagementApi.ViewModels.Search;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Umbraco.Cms.ManagementApi.ViewModels.Search;
 
 public class IndexViewModel
 {
+    [Required]
     public string Name { get; init; } = null!;
 
     public string? HealthStatus { get; init; }
 
+    [Required]
     public bool IsHealthy => HealthStatus == "Healthy";
 
+    [Required]
     public bool CanRebuild { get; init; }
 
     public string SearcherName { get; init; } = null!;
 
+    [Required]
     public long DocumentCount { get; init; }
 
+    [Required]
     public int FieldCount { get; init; }
+
+    public IReadOnlyDictionary<string, object?>? ProviderProperties { get; init; }
 }


### PR DESCRIPTION
Optimizations of the search controller.

1. PagedViewModel was listed twice in a response type - removed one layer
2. ProviderProperties was missing from the IndexViewModel, but it worked a lot better in the old backoffice API with NewtonsoftJson, so I could not just add it again as we are now using System.Text.Json. I'm trying here to format the properties so they match our expectations in the frontend for this specific endpoint. We might want to improve on this on a more general level in the output formatter eventually.

Example output for MembersIndex, which has both arrays, objects, and primitives:

![image](https://user-images.githubusercontent.com/752371/202217446-71d46b32-38fd-4dab-abfc-3f4fbc8fe7c5.png)

