### PR TITLE
Block Grid Editor: Replace "TODO" text in titles

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2825,6 +2825,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="actionEnterSortMode">Sort mode</key>
     <key alias="actionExitSortMode">End sort mode</key>
     <key alias="areaAliasIsNotUnique">This Areas Alias must be unique compared to the other Areas of this Block.</key>
+    <key alias="configureArea">Configure area</key>
+    <key alias="deleteArea">Delete area</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2928,6 +2928,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="actionEnterSortMode">Sort mode</key>
     <key alias="actionExitSortMode">End sort mode</key>
     <key alias="areaAliasIsNotUnique">This Areas Alias must be unique compared to the other Areas of this Block.</key>
+    <key alias="configureArea">Configure area</key>
+    <key alias="deleteArea">Delete area</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">What are Content Templates?</key>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
@@ -4,14 +4,14 @@
 
     <div class="umb-block-grid__area--actions">
 
-        <button type="button" class="btn-reset umb-outline action --edit" localize="title" title="TODO"
+        <button type="button" class="btn-reset umb-outline action --edit" localize="title" title="blockEditor_configureArea"
                 ng-click="vm.onEditClick($event);">
             <umb-icon icon="icon-edit" class="icon"></umb-icon>
             <span class="sr-only">
                 <localize key="general_edit">Edit</localize>
             </span>
         </button>
-        <button type="button" class="btn-reset umb-outline action --delete" localize="title" title="TODO"
+        <button type="button" class="btn-reset umb-outline action --delete" localize="title" title="blockEditor_deleteArea"
                 ng-click="vm.onDeleteClick($event);">
             <umb-icon icon="icon-trash" class="icon"></umb-icon>
             <span class="sr-only">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
@@ -4,14 +4,14 @@
 
     <div class="umb-block-grid__area--actions">
 
-        <button type="button" class="btn-reset umb-outline action --edit" localize="title" title="blockEditor_configureArea"
+        <button type="button" class="btn-reset umb-outline action --edit" localize="title" title="@blockEditor_configureArea"
                 ng-click="vm.onEditClick($event);">
             <umb-icon icon="icon-edit" class="icon"></umb-icon>
             <span class="sr-only">
                 <localize key="general_edit">Edit</localize>
             </span>
         </button>
-        <button type="button" class="btn-reset umb-outline action --delete" localize="title" title="blockEditor_deleteArea"
+        <button type="button" class="btn-reset umb-outline action --delete" localize="title" title="@blockEditor_deleteArea"
                 ng-click="vm.onDeleteClick($event);">
             <umb-icon icon="icon-trash" class="icon"></umb-icon>
             <span class="sr-only">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Having a play with the Block Grid Editor I noticed hovering the options in the areas it said "TODO". Unfortunately I can't grab a screendump of it but I guess it reads from looking at the code in the PR.

Now it will say "Configure Area" or "Delete area" depending, which option is hovered.

![edit-delete](https://user-images.githubusercontent.com/1932158/202478128-ed1952e4-5ba3-49fe-86d2-d4c2cd18af5c.png)
