### PR TITLE
Allow empty valuesets to be indexed so the back-offce does not hang when rebuilding empty indexes

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ContentIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentIndexPopulator.cs
@@ -99,15 +99,12 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
         {
             content = _contentService.GetPagedDescendants(contentParentId, pageIndex, pageSize, out _).ToArray();
 
-            if (content.Length > 0)
-            {
-                var valueSets = _contentValueSetBuilder.GetValueSets(content).ToList();
+            var valueSets = _contentValueSetBuilder.GetValueSets(content).ToList();
 
-                // ReSharper disable once PossibleMultipleEnumeration
-                foreach (IIndex index in indexes)
-                {
-                    index.IndexItems(valueSets);
-                }
+            // ReSharper disable once PossibleMultipleEnumeration
+            foreach (IIndex index in indexes)
+            {
+                index.IndexItems(valueSets);
             }
 
             pageIndex++;
@@ -127,35 +124,32 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
             // note: We will filter for published variants in the validator
             content = _contentService.GetPagedDescendants(contentParentId, pageIndex, pageSize, out _, PublishedQuery, Ordering.By("Path")).ToArray();
 
-            if (content.Length > 0)
+            var indexableContent = new List<IContent>();
+
+            foreach (IContent item in content)
             {
-                var indexableContent = new List<IContent>();
-
-                foreach (IContent item in content)
+                if (item.Level == 1)
                 {
-                    if (item.Level == 1)
+                    // first level pages are always published so no need to filter them
+                    indexableContent.Add(item);
+                    publishedPages.Add(item.Id);
+                }
+                else
+                {
+                    if (publishedPages.Contains(item.ParentId))
                     {
-                        // first level pages are always published so no need to filter them
-                        indexableContent.Add(item);
+                        // only index when parent is published
                         publishedPages.Add(item.Id);
-                    }
-                    else
-                    {
-                        if (publishedPages.Contains(item.ParentId))
-                        {
-                            // only index when parent is published
-                            publishedPages.Add(item.Id);
-                            indexableContent.Add(item);
-                        }
+                        indexableContent.Add(item);
                     }
                 }
+            }
 
-                var valueSets = _contentValueSetBuilder.GetValueSets(indexableContent.ToArray()).ToList();
+            var valueSets = _contentValueSetBuilder.GetValueSets(indexableContent.ToArray()).ToList();
 
-                foreach (IIndex index in indexes)
-                {
-                    index.IndexItems(valueSets);
-                }
+            foreach (IIndex index in indexes)
+            {
+                index.IndexItems(valueSets);
             }
 
             pageIndex++;

--- a/src/Umbraco.Infrastructure/Examine/MediaIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/MediaIndexPopulator.cs
@@ -59,13 +59,10 @@ public class MediaIndexPopulator : IndexPopulator<IUmbracoContentIndex>
         {
             media = _mediaService.GetPagedDescendants(mediaParentId, pageIndex, pageSize, out _).ToArray();
 
-            if (media.Length > 0)
+            // ReSharper disable once PossibleMultipleEnumeration
+            foreach (IIndex index in indexes)
             {
-                // ReSharper disable once PossibleMultipleEnumeration
-                foreach (IIndex index in indexes)
-                {
-                    index.IndexItems(_mediaValueSetBuilder.GetValueSets(media));
-                }
+                index.IndexItems(_mediaValueSetBuilder.GetValueSets(media));
             }
 
             pageIndex++;

--- a/src/Umbraco.Infrastructure/Examine/MemberIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/MemberIndexPopulator.cs
@@ -32,13 +32,10 @@ public class MemberIndexPopulator : IndexPopulator<IUmbracoMemberIndex>
         {
             members = _memberService.GetAll(pageIndex, pageSize, out _).ToArray();
 
-            if (members.Length > 0)
+            // ReSharper disable once PossibleMultipleEnumeration
+            foreach (IIndex index in indexes)
             {
-                // ReSharper disable once PossibleMultipleEnumeration
-                foreach (IIndex index in indexes)
-                {
-                    index.IndexItems(_valueSetBuilder.GetValueSets(members));
-                }
+                index.IndexItems(_valueSetBuilder.GetValueSets(members));
             }
 
             pageIndex++;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This PR fixes 13254

### Summary

This PR fixes an issue with examine indexes being rebuilt from the back-office and the screen 'hangs' when the index contains no items.  This happens because the flag indicating the index has been rebuilt is never set for empty indexes.

### Description

Currently, when an index is being rebuilt the button is disabled and a loading icon is displayed for the duration until the index rebuild has completed.  This is done by an AJAX call to the back office to check for a flag which is set when the index has been rebuilt.  This flag is never set when the index is empty as the index populator checks for any items in the value-set before indexing.  This fix removes that check in the index populator so empty value-sets are indexed and the completion event is raised (which set the flag).

This has been tested with no content, media and members to ensure that empty indexes don't cause the screen to 'hang' and with content, media and members to ensure they are indexed correctly when present.

### Steps to test

1. Delete all content, media and members from the CMS (make sure you have a backup first in case you want to restore them later!)
2. From the back office, rebuild the Internal, External and Member index and check the indexes are rebuilt with 0 items and the screen does not 'hang'
3. Add some content, media and members and rebuild the same three indexes ensuring the correct number of expected items are indexed as per the number of items you have added.

All tests have been run and pass.
