### PR TITLE
add health-check basic tests

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
@@ -14,6 +14,7 @@
                         <umb-button type="button"
                                     button-style="success"
                                     label="Check All Groups"
+                                    data-element="healthchecks-checkall-btn"
                                     action="vm.checkAllGroups(vm.groups)">
                         </umb-button>
                 </div>

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/healthChecks.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/healthChecks.spec.ts
@@ -1,0 +1,26 @@
+﻿import {test, ApiHelpers, UiHelpers, ConstantHelper} from '@umbraco/playwright-testhelpers';
+import {expect} from "@playwright/test";
+
+test.describe('Health Checks', () => {
+    test.beforeEach(async ({page, umbracoApi}) => {
+        await umbracoApi.login();
+    });
+
+    test('Can check all groups', async ({page, umbracoApi, umbracoUi}) => {
+
+        await umbracoUi.goToSection("settings");
+        
+        await page.locator('[data-element="tab-settingsHealthCheck"]').click();
+
+        await page.waitForSelector('.umb-panel-group__details-status-actions > .ng-isolate-scope > .umb-button > .btn > .umb-button__content');
+        await page.click('.umb-panel-group__details-status-actions > .ng-isolate-scope > .umb-button > .btn > .umb-button__content');
+        
+        await expect(await page.locator('text=Configuration 2 failed')).toBeVisible();
+        await expect(await page.locator('text=Data Integrity 2 passed')).toBeVisible();
+        await expect(await page.locator('text=Live Environment 1 failed')).toBeVisible();
+        await expect(await page.locator('text=Permissions 4 passed')).toBeVisible();
+        await expect(await page.locator('text=Security 3 passed 2 warning 4 failed')).toBeVisible();
+        await expect(await page.locator('text=Services 1 failed')).toBeVisible();
+        
+    });
+});


### PR DESCRIPTION
Add's health-check tests that:

1) Clicks on the "Check all groups" buttons
2) Ensure that the default settings labels are accurate
