### PR TITLE
created an add current domain button to the cultures and hostnames sc…

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -90,7 +90,8 @@
   </area>
   <area alias="assignDomain">
     <key alias="permissionDenied">Permission denied.</key>
-    <key alias="addNew">Add new Domain</key>
+    <key alias="addNew">Add new domain</key>
+    <key alias="addCurrent">Add current domain</key>
     <key alias="remove">remove</key>
     <key alias="invalidNode">Invalid node.</key>
     <key alias="invalidDomain">One or more domains have an invalid format.</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -92,7 +92,8 @@
   </area>
   <area alias="assignDomain">
     <key alias="permissionDenied">Permission denied.</key>
-    <key alias="addNew">Add new Domain</key>
+    <key alias="addNew">Add new domain</key>
+    <key alias="addCurrent">Add current domain</key>
     <key alias="remove">remove</key>
     <key alias="invalidNode">Invalid node.</key>
     <key alias="invalidDomain">One or more domains have an invalid format.</key>

--- a/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/assigndomain.html
@@ -83,6 +83,13 @@
                     button-style="info">
                 </umb-button>
 
+                <umb-button
+                    label-key="assignDomain_addCurrent"
+                    action="vm.addCurrentDomain()"
+                    type="button"
+                    button-style="success">
+                </umb-button>
+
             </umb-pane>
 
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
@@ -76,7 +76,7 @@
             navigationService.hideDialog();
         }
 
-        function addDomain() { 
+        function addDomain() {
             vm.domains.push({
                 name: '',
                 lang: vm.defaultLanguage

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.assigndomain.controller.js
@@ -1,11 +1,12 @@
 (function () {
     "use strict";
 
-    function AssignDomainController($scope, localizationService, languageResource, contentResource, navigationService, notificationsService) {
+    function AssignDomainController($scope, localizationService, languageResource, contentResource, navigationService, notificationsService, $location) {
         var vm = this;
         
         vm.closeDialog = closeDialog;
         vm.addDomain = addDomain;
+        vm.addCurrentDomain = addCurrentDomain;
         vm.removeDomain = removeDomain;
         vm.save = save;
         vm.languages = [];
@@ -75,11 +76,23 @@
             navigationService.hideDialog();
         }
 
-        function addDomain() {
+        function addDomain() { 
             vm.domains.push({
                 name: '',
                 lang: vm.defaultLanguage
             });
+        }
+
+        function addCurrentDomain() {
+          var domainToAdd = $location.host();
+          var port = $location.port();
+          if (port != 80 && port != 443) {
+            domainToAdd += ":" + port;
+          }
+          vm.domains.push({
+            name: domainToAdd,
+            lang: vm.defaultLanguage
+          });
         }
 
         function removeDomain(index) {


### PR DESCRIPTION
**PR done at the Umbraco Together Hackathon.**

This PR adds a feature to the Cultures and Hostnames screen

The feature is a button which adds the current domain as a hostname.

![addcurrentdomain](https://user-images.githubusercontent.com/9142936/202504774-c87c6e81-72e3-4960-8ab6-5b2ae6d4ef95.gif)

If the URL is using a port other than 80 or 443 then it appends the port too, otherwise it just uses the host.

![image](https://user-images.githubusercontent.com/9142936/202505042-a9063751-a07e-416d-9678-d3eb5498b699.png)
