### PR TITLE
Added aria label to time period on log viewer dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
@@ -72,7 +72,7 @@ Use this directive to render a date time picker
 
     var umbDateTimePicker = {
         template: '<ng-transclude>' +
-            '<input type="text" ng-if="!$ctrl.options.inline" ng-model="$ctrl.ngModel" placeholder="Select Date.."></input>' +
+            '<input type="text" ng-if="!$ctrl.options.inline" ng-model="$ctrl.ngModel" placeholder="Select Date.." ng-attr-aria-labelledby="{{$ctrl.label}}"></input>' +
             '<div ng-if="$ctrl.options.inline"></div>' +
             '</ng-transclude>',
         controller: umbDateTimePickerCtrl,
@@ -88,7 +88,8 @@ Use this directive to render a date time picker
             onYearChange: '&?',
             onReady: '&?',
             onValueUpdate: '&?',
-            onDayCreate: '&?'
+            onDayCreate: '&?',
+            label: '@'
         }
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/logViewer/overview.html
+++ b/src/Umbraco.Web.UI.Client/src/views/logViewer/overview.html
@@ -83,12 +83,13 @@
 
                     <!-- Time period -->
                     <umb-box>
-                        <umb-box-header title="Time Period"></umb-box-header>
+                        <umb-box-header title="Time Period" id="timePeriod"></umb-box-header>
 
                         <umb-date-time-picker class="datepicker"
                                        ng-model="vm.period"
                                        options="vm.config"
-                                       on-close="vm.dateRangeChange(selectedDates, dateStr, instance)">
+                                       on-close="vm.dateRangeChange(selectedDates, dateStr, instance)"
+                                       label="timePeriod">
                         </umb-date-time-picker>
                     </umb-box>
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This PR fixes #13250

### Summary

Add an aria labelled by attribute to the umb-date-time-picker directive to allow a label to be set on the Time Period input on the log viewer dashboard.

### Description

As per the issue 13250, the input field for the Time Period on the log viewer dashboard is missing a label for accessibility.  I have added a label parameter to the umb-date-time-picker to allow the label to be passed to the input field for the date/time picker.

### Steps to test

1. Install the Wave accessibility plugin for your browser (https://wave.webaim.org/extension/)
2. Open the log view in the back office.
3. Run the Wave accessibility plugin on the log viewer dashboard and ensure no errors are displayed relating to missing form labels (there will still be other warnings).
4. Make sure the time period allows you to select a date range as before

All tests have been run and pass.