### PR TITLE
Use GetRandomFileName for SQLite temp file

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseCreator.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseCreator.cs
@@ -69,7 +69,9 @@ public class SqliteDatabaseCreator : IDatabaseCreator
          * always initializing in this way and it probably helps for non azure scenarios also (anytime persisting on a cifs mount for example).
          */
 
-        var tempFile = Path.GetTempFileName();
+        // Create a random file name using cryptographically strong random number generator (RNGCryptoServiceProvider)
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
         var tempConnectionString = new SqliteConnectionStringBuilder { DataSource = tempFile, Pooling = false };
 
         using (var connection = new SqliteConnection(tempConnectionString.ConnectionString))


### PR DESCRIPTION
## Details
- The current workflow for creating a SQLite database file is by first creating a temporary file _(more info in the comments ⬇️)_ 
https://github.com/umbraco/Umbraco-CMS/blob/c2140cc042a27d35e77a00488da65c9fb482648c/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseCreator.cs#L62-L66
- In the old approach, we used `Path.GetTempFileName();` for the name of that temp file which generates a unique temporary file name and returns the full path of that file, something like `.../tmpVjKy2Q.tmp`;
  - The problem with this is that `GetTempFileName()` generates the same file name with just 6 chars being changed (`tmpXXXXXX.tmp`);
  - Since Windows treats file and directory names as case-insensitive, the chance of generating a predictable file name is higher;
- Therefore, we are switching to using `Path.GetRandomFileName()` which will give us a random file name, something like `11uccde5.m2j` where we will have 11 chars changing in total and thus, decreasing the risk for race conditions on file names.

## Test
- Make sure you can install Umbraco with SQLite database without a problem and that changed information is persisted in general.