### PR TITLE
use custom prop for calculated width

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
@@ -419,7 +419,7 @@ ng-form.ng-invalid > .umb-block-grid__block:not(.--active) > .umb-block-grid__bl
 }
 .umb-block-grid__block--inline-create-button.--above {
     left: 0;
-    width: 100%;
+    width: var(--umb-block-grid-editor--inline-create-width, 100%);
 
     top: calc(var(--umb-block-grid--row-gap, 0px) * -0.5);
 }
@@ -431,7 +431,7 @@ ng-form.ng-invalid > .umb-block-grid__block:not(.--active) > .umb-block-grid__bl
     /* If at root, and full-width then become 40px wider: */
     --calc: clamp(0, calc(var(--umb-block-grid--item-column-span) - (var(--umb-block-grid--grid-columns)-1)), 1);
     left: calc(-20px * var(--calc));
-    width: calc(100% + 40px * var(--calc));
+    width: calc(var(--umb-block-grid-editor--inline-create-width, 100%) + 40px * var(--calc));
 }
 
 .umb-block-grid__block--inline-create-button.--after {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umb-block-grid-entry.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umb-block-grid-entry.html
@@ -1,7 +1,7 @@
 <uui-button-inline-create
     ng-if="!vm.blockEditorApi.readonly && !vm.hideInlineCreateAbove"
     class="umb-block-grid__block--inline-create-button --above"
-    style="width: {{vm.inlineCreateAboveWidth}};"
+    style="--umb-block-grid-editor--inline-create-width: {{vm.inlineCreateAboveWidth}};"
     ng-class="{'--at-root': vm.depth === '0'}"
     ng-click="vm.clickInlineCreateAbove()"
     ng-mouseover="vm.mouseOverInlineCreate()"


### PR DESCRIPTION
Fix issue with inline create button at root level not taking the right width.

in other words, make sure that the calculated width can be used in the CSS calculations not just overwriting them.

Fixies this issue:
![image](https://user-images.githubusercontent.com/6791648/203096791-b8e2be22-528f-424d-867d-b126de10393a.png)

To make it appear like this (only visible for root blocks):
![image](https://user-images.githubusercontent.com/6791648/203096858-58b5107d-e2aa-4986-82aa-4ab2daa39dde.png)

