### PR TITLE
Remove the hidding of catelouge appearance

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -2247,9 +2247,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="scaleHandlerButtonTitle">Træk for at skalere</key>
     <key alias="areaCreateLabelTitle">Tilføj indhold label</key>
     <key alias="areaCreateLabelHelp">Overskriv labellen for tilføj indholds knappen i dette område.</key>
-    <key alias="addSizeOptions">Tilføj skalerings muligheder</key>
-    <key alias="addAreaOptions">Tilføj områder</key>
-    <key alias="addAppearanceOptions">Tilføj katalog udseende</key>
+    <key alias="showSizeOptions">Tilføj skalerings muligheder</key>
     <key alias="addBlockType">Tilføj Blok</key>
     <key alias="addBlockGroup">Tilføj gruppe</key>
     <key alias="pickSpecificAllowance">Tilføj gruppe eller Blok</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2800,7 +2800,6 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="areaCreateLabelTitle">Create Button Label</key>
     <key alias="areaCreateLabelHelp">Overwrite the label on the create button of this Area.</key>
     <key alias="showSizeOptions">Show resize options</key>
-    <key alias="showAppearanceOptions">Show catalogue appearance</key>
     <key alias="addBlockType">Add Block</key>
     <key alias="addBlockGroup">Add group</key>
     <key alias="pickSpecificAllowance">Pick group or Block</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2903,7 +2903,6 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="areaCreateLabelTitle">Create Button Label</key>
     <key alias="areaCreateLabelHelp">Overwrite the label on the create button of this Area.</key>
     <key alias="showSizeOptions">Show resize options</key>
-    <key alias="showAppearanceOptions">Show catalogue appearance</key>
     <key alias="addBlockType">Add Block</key>
     <key alias="addBlockGroup">Add group</key>
     <key alias="pickSpecificAllowance">Pick group or Block</key>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.html
@@ -327,12 +327,8 @@
 
                         <div class="umb-group-panel__content">
 
-                            <button ng-if="!vm.showAppearanceOptions" type="button" class="btn-reset __settings-input --noValue umb-outline" style="height: 80px;" ng-click="vm.showAppearanceOptions = true">
-                                <localize key="blockEditor_showAppearanceOptions">Show catalogue appearance</localize>
-                            </button>
-
                             <!-- backgroundColor -->
-                            <div ng-if="vm.showAppearanceOptions" class="control-group umb-control-group -no-border">
+                            <div class="control-group umb-control-group -no-border">
                                 <div class="umb-el-wrap">
                                     <label class="control-label" for="backgroundColor"><localize key="blockEditor_labelBackgroundColor">Background Color</localize></label>
                                     <div class="controls">
@@ -346,7 +342,7 @@
                             </div>
 
                             <!-- iconColor -->
-                            <div ng-if="vm.showAppearanceOptions" class="control-group umb-control-group -no-border">
+                            <div class="control-group umb-control-group -no-border">
                                 <div class="umb-el-wrap">
                                     <label class="control-label" for="iconColor"><localize key="blockEditor_labelIconColor">Icon Color</localize></label>
                                     <div class="controls">
@@ -360,7 +356,7 @@
                             </div>
 
                             <!-- thumbnail -->
-                            <div ng-if="vm.showAppearanceOptions" class="control-group umb-control-group -no-border">
+                            <div class="control-group umb-control-group -no-border">
                                 <div class="umb-el-wrap">
                                     <label class="control-label" for="iconcolor"><localize key="blockEditor_thumbnail">Thumbnail</localize></label>
                                     <div class="controls">


### PR DESCRIPTION
Partly solves the concern of https://github.com/umbraco/Umbraco-CMS/issues/13177

For now, the hiding of size options is kept to ensure the first impression of the BlockType overlay is as calm as it gets, to avoid giving users an overwhelming experience. This also helps newcomers ignore the sizing options until they need them.