### PR TITLE
Codespaces: Updated SQLite DevContainer feature after rename

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 
 		// Adds SQLite feature from apt install
 		// Also adds the SQLite VSCode extension
-		"ghcr.io/warrenbuckley/sqlite-codespace-feature/sqlite:1": {}
+		"ghcr.io/warrenbuckley/codespace-features/sqlite:1": {}
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
The repo & package for the SQLite DevContainer feature has moved after I renamed the repo

The repo was previously called `sqlite-codespace-feature`

```
"features": {
    "ghcr.io/warrenbuckley/codespace-features/sqlite:1": {}
}
```