### PR TITLE
Add new 'Umbraco Package RCL' project template

### DIFF
--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Content Include="UmbracoPackage\**" Exclude="bin;obj" />
+    <Content Include="UmbracoPackageRcl\**" Exclude="bin;obj" />
     <Content Include="UmbracoProject\**" Exclude="bin;obj" />
     <Content Include="..\src\Umbraco.Web.UI\Program.cs">
       <Link>UmbracoProject\Program.cs</Link>

--- a/templates/UmbracoPackage/.template.config/dotnetcli.host.json
+++ b/templates/UmbracoPackage/.template.config/dotnetcli.host.json
@@ -2,12 +2,16 @@
   "$schema": "https://json.schemastore.org/dotnetcli.host.json",
   "symbolInfo": {
     "Framework": {
-      "longName": "Framework",
-      "shortName": "F"
+      "longName": "framework",
+      "isHidden": true
     },
     "UmbracoVersion": {
       "longName": "version",
-      "shortName": "v"
+      "shortName": ""
+    },
+    "SkipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
     }
   }
 }

--- a/templates/UmbracoPackage/.template.config/template.json
+++ b/templates/UmbracoPackage/.template.config/template.json
@@ -41,8 +41,15 @@
       "description": "The version of Umbraco.Cms to add as PackageReference.",
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "10.0.0-rc1",
+      "defaultValue": "11.0.0",
       "replaces": "UMBRACO_VERSION_FROM_TEMPLATE"
+    },
+    "SkipRestore": {
+      "displayName": "Skip restore",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
     },
     "Namespace": {
       "type": "derived",
@@ -82,6 +89,20 @@
   "primaryOutputs": [
     {
       "path": "UmbracoPackage.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!SkipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }

--- a/templates/UmbracoPackageRcl/.template.config/dotnetcli.host.json
+++ b/templates/UmbracoPackageRcl/.template.config/dotnetcli.host.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host.json",
+  "symbolInfo": {
+    "Framework": {
+      "longName": "framework",
+      "isHidden": true
+    },
+    "UmbracoVersion": {
+      "longName": "version",
+      "shortName": ""
+    },
+    "SkipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
+    "SupportPagesAndViews": {
+      "longName": "support-pages-and-views",
+      "shortName": "s"
+    }
+  }
+}

--- a/templates/UmbracoPackageRcl/.template.config/ide.host.json
+++ b/templates/UmbracoPackageRcl/.template.config/ide.host.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/ide.host.json",
+  "order": 0,
+  "icon": "../../icon.png",
+  "description": {
+    "id": "UmbracoPackageRcl",
+    "text": "Umbraco Package RCL - An empty Umbraco package/plugin (Razor Class Library)."
+  },
+  "symbolInfo": [
+    {
+      "id": "UmbracoVersion",
+      "isVisible": true
+    },
+    {
+      "id": "SupportPagesAndViews",
+      "isVisible": true,
+      "persistenceScope": "templateGroup"
+    }
+  ]
+}

--- a/templates/UmbracoPackageRcl/.template.config/template.json
+++ b/templates/UmbracoPackageRcl/.template.config/template.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json.schemastore.org/template.json",
+  "author": "Umbraco HQ",
+  "classifications": [
+    "Web",
+    "CMS",
+    "Umbraco",
+    "Package",
+    "Plugin",
+    "Razor Class Library"
+  ],
+  "name": "Umbraco Package RCL",
+  "description": "An empty Umbraco package/plugin (Razor Class Library).",
+  "groupIdentity": "Umbraco.Templates.UmbracoPackageRcl",
+  "identity": "Umbraco.Templates.UmbracoPackageRcl.CSharp",
+  "shortName": "umbracopackage-rcl",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "UmbracoPackage",
+  "defaultName": "UmbracoPackage1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "Framework": {
+      "displayName": "Framework",
+      "description": "The target framework for the project.",
+      "type": "parameter",
+      "datatype": "choice",
+      "choices": [
+        {
+          "displayName": ".NET 7.0",
+          "description": "Target net7.0",
+          "choice": "net7.0"
+        }
+      ],
+      "defaultValue": "net7.0",
+      "replaces": "net7.0"
+    },
+    "UmbracoVersion": {
+      "displayName": "Umbraco version",
+      "description": "The version of Umbraco.Cms to add as PackageReference.",
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "11.0.0",
+      "replaces": "UMBRACO_VERSION_FROM_TEMPLATE"
+    },
+    "SkipRestore": {
+      "displayName": "Skip restore",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "SupportPagesAndViews": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "displayName": "Support pages and views",
+      "description": "Whether to support adding traditional Razor pages and Views to this library."
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "UmbracoPackage.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!SkipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/UmbracoPackageRcl/UmbracoPackage.csproj
+++ b/templates/UmbracoPackageRcl/UmbracoPackage.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AddRazorSupportForMvc Condition="'$(SupportPagesAndViews)' == 'True'">true</AddRazorSupportForMvc>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">UmbracoPackage</RootNamespace>
+    <StaticWebAssetBasePath>App_Plugins/UmbracoPackage</StaticWebAssetBasePath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>UmbracoPackage</PackageId>
+    <Product>UmbracoPackage</Product>
+    <Title>UmbracoPackage</Title>
+    <Description>...</Description>
+    <PackageTags>umbraco plugin package</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SupportPagesAndViews)' == 'True'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+  </ItemGroup>
+</Project>

--- a/templates/UmbracoPackageRcl/wwwroot/package.manifest
+++ b/templates/UmbracoPackageRcl/wwwroot/package.manifest
@@ -1,0 +1,5 @@
+{
+    "name": "UmbracoPackage",
+    "version": "",
+    "allowPackageTelemetry": true
+}

--- a/templates/UmbracoProject/.template.config/dotnetcli.host.json
+++ b/templates/UmbracoProject/.template.config/dotnetcli.host.json
@@ -2,12 +2,12 @@
   "$schema": "https://json.schemastore.org/dotnetcli.host.json",
   "symbolInfo": {
     "Framework": {
-      "longName": "Framework",
-      "shortName": "F"
+      "longName": "framework",
+      "isHidden": true
     },
     "UmbracoVersion": {
       "longName": "version",
-      "shortName": "v"
+      "shortName": ""
     },
     "UseHttpsRedirect": {
       "longName": "use-https-redirect",
@@ -55,14 +55,15 @@
     },
     "PackageProjectName": {
       "longName": "PackageTestSiteName",
-      "shortName": "p"
+      "shortName": "p",
+      "isHidden": true
     }
   },
   "usageExamples": [
-    "dotnet new umbraco -n MyNewProject",
-    "dotnet new umbraco -n MyNewProject --no-restore",
-    "dotnet new umbraco -n MyNewProject --development-database-type SQLite",
-    "dotnet new umbraco -n MyNewProject --development-database-type LocalDB",
-    "dotnet new umbraco -n MyNewProject --friendly-name \"Friendly Admin User\" --email admin@example.com --password password1234 --connection-string \"Server=ConnectionStringHere\""
+    "dotnet new umbraco --name MyNewProject",
+    "dotnet new umbraco --name MyNewProject --no-restore",
+    "dotnet new umbraco --name MyNewProject --development-database-type SQLite",
+    "dotnet new umbraco --name MyNewProject --development-database-type LocalDB",
+    "dotnet new umbraco --name MyNewProject --friendly-name \"Administrator\" --email admin@example.com --password 1234567890 --connection-string \"Server=(local);Database=MyNewProject;Trusted_Connection=True;\""
   ]
 }

--- a/templates/UmbracoProject/.template.config/ide.host.json
+++ b/templates/UmbracoProject/.template.config/ide.host.json
@@ -13,19 +13,18 @@
     },
     {
       "id": "UseHttpsRedirect",
-      "isVisible": true
-    },
-    {
-      "id": "SkipRestore",
-      "isVisible": true
+      "isVisible": true,
+      "persistenceScope": "templateGroup"
     },
     {
       "id": "ExcludeGitignore",
-      "isVisible": true
+      "isVisible": true,
+      "persistenceScope": "templateGroup"
     },
     {
       "id": "MinimalGitignore",
-      "isVisible": true
+      "isVisible": true,
+      "persistenceScope": "templateGroup"
     },
     {
       "id": "ConnectionString",
@@ -37,7 +36,8 @@
     },
     {
       "id": "DevelopmentDatabaseType",
-      "isVisible": true
+      "isVisible": true,
+      "persistenceScope": "templateGroup"
     },
     {
       "id": "UnattendedUserName",
@@ -53,10 +53,6 @@
     },
     {
       "id": "NoNodesViewPath",
-      "isVisible": true
-    },
-    {
-      "id": "PackageProjectName",
       "isVisible": true
     }
   ]

--- a/templates/UmbracoProject/.template.config/template.json
+++ b/templates/UmbracoProject/.template.config/template.json
@@ -51,7 +51,7 @@
       "description": "The version of Umbraco.Cms to add as PackageReference.",
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "10.0.0-rc1",
+      "defaultValue": "11.0.0",
       "replaces": "UMBRACO_VERSION_FROM_TEMPLATE"
     },
     "UseHttpsRedirect": {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With PR https://github.com/umbraco/Umbraco-CMS/pull/13141 merged, packages targeting v11 can now be distributed as a Razor Class Library, removing the need for custom MSBuild targets that copy files into the Umbraco project and simplifying the reference between the package and test site project.

This PR adds a new 'Umbraco Package RCL' (`dotnet new umbracopackage-rcl`) project template that is basically the same as the default 'Razor Class Library' template, but includes references to the CMS and a sample `package.manifest` file. Developers can still choose to use existing 'Umbraco Package' (`dotnet new umbracopackage`) template, e.g. if they want to support an older Umbraco version.

------------------

To test, pack and install the templates from this PR using:
```
dotnet pack -c Release -o build.out
dotnet new uninstall Umbraco.Templates
dotnet new install build.out\Umbraco.Templates.*.nupkg
```

Then go to a new empty folder and create a new package including a test site using:
```
# Add Umbraco Prereleases NuGet feed (to install 11.0.0-rc5, can be omitted when released on NuGet.org)
dotnet new nugetconfig
dotnet nuget add source https://www.myget.org/F/umbracoprereleases/api/v3/index.json --name "Umbraco Prereleases"

# Create git repo and solution
git init
dotnet new gitignore
dotnet new sln

# Create package project
dotnet new umbracopackage-rcl --name Our.Umbraco.MyPackage --version 11.0.0-rc5 --support-pages-and-views --output src\Our.Umbraco.MyPackage
dotnet sln add --in-root src\Our.Umbraco.MyPackage

# Create test site project
dotnet new umbraco --name Our.Umbraco.MyPackage.TestSite --version 11.0.0-rc5 --minimal-gitignore --output examples\Our.Umbraco.MyPackage.TestSite
dotnet sln add --solution-folder Examples examples\Our.Umbraco.MyPackage.TestSite
dotnet add examples\Our.Umbraco.MyPackage.TestSite reference src\Our.Umbraco.MyPackage

# Commit
git add .
git commit -m "Initial commit"

# Create NuGet package and publish site
dotnet pack src\Our.Umbraco.MyPackage --configuration Release --output build.out
dotnet publish examples\Our.Umbraco.MyPackage.TestSite --configuration Release --output build.out\publish

# Run test site
dotnet run --project examples\Our.Umbraco.MyPackage.TestSite
```

Now inspect and ensure the following:
- `Our.Umbraco.MyPackage.1.0.0.nupkg` contains the default RCL build props and the `staticwebsassets` folder contains the `package.manifest` file;
- The RCL files are copied into the wwwroot of the published output (`publish\wwwroot\App_Plugins\Our.Umbraco.MyPackage\package.manifest` exists);
- Complete the Umbraco install of the test site and ensure the package is listed under 'Packages - Installed'.

_You can also do a sanity check and test whether adding tours, icons, dashboards, language files, etc. to the package works, but that is already done as part of the linked PR._