### PR TITLE
Use `getLocalDate` from dateHelper

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -2,7 +2,7 @@
     "use strict";
 
     function UserEditController($scope, eventsService, $q, $location, $routeParams, formHelper, usersResource, twoFactorLoginResource,
-        userService, contentEditingHelper, localizationService, mediaHelper, Upload, umbRequestHelper,
+        userService, contentEditingHelper, localizationService, dateHelper, mediaHelper, Upload, umbRequestHelper,
         usersHelper, authResource, dateHelper, editorService, overlayService, externalLoginInfoService) {
 
         var currentLoggedInUser = null;
@@ -108,23 +108,6 @@
                 vm.hasTwoFactorProviders = providers.length > 0;
               });
             });
-        }
-
-        function getLocalDate(date, culture, format) {
-            if (date) {
-                var dateVal;
-                var serverOffset = Umbraco.Sys.ServerVariables.application.serverTimeOffset;
-                var localOffset = new Date().getTimezoneOffset();
-                var serverTimeNeedsOffsetting = (-serverOffset !== localOffset);
-
-                if (serverTimeNeedsOffsetting) {
-                    dateVal = dateHelper.convertToLocalMomentTime(date, serverOffset);
-                } else {
-                    dateVal = moment(date, "YYYY-MM-DD HH:mm:ss");
-                }
-
-                return dateVal.locale(culture).format(format);
-            }
         }
 
         function toggleChangePassword() {
@@ -571,11 +554,11 @@
             userService.getCurrentUser().then(function (currentUser) {
                 currentLoggedInUser = currentUser;
 
-                user.formattedLastLogin = getLocalDate(user.lastLoginDate, currentUser.locale, "LLL");
-                user.formattedLastLockoutDate = getLocalDate(user.lastLockoutDate, currentUser.locale, "LLL");
-                user.formattedCreateDate = getLocalDate(user.createDate, currentUser.locale, "LLL");
-                user.formattedUpdateDate = getLocalDate(user.updateDate, currentUser.locale, "LLL");
-                user.formattedLastPasswordChangeDate = getLocalDate(user.lastPasswordChangeDate, currentUser.locale, "LLL");
+                user.formattedLastLogin = dateHelper.getLocalDate(user.lastLoginDate, currentUser.locale, "LLL");
+                user.formattedLastLockoutDate = dateHelper.getLocalDate(user.lastLockoutDate, currentUser.locale, "LLL");
+                user.formattedCreateDate = dateHelper.getLocalDate(user.createDate, currentUser.locale, "LLL");
+                user.formattedUpdateDate = dateHelper.getLocalDate(user.updateDate, currentUser.locale, "LLL");
+                user.formattedLastPasswordChangeDate = dateHelper.getLocalDate(user.lastPasswordChangeDate, currentUser.locale, "LLL");
             });
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -2,7 +2,7 @@
     "use strict";
 
     function UserEditController($scope, eventsService, $q, $location, $routeParams, formHelper, usersResource, twoFactorLoginResource,
-        userService, contentEditingHelper, localizationService, dateHelper, mediaHelper, Upload, umbRequestHelper,
+        userService, contentEditingHelper, localizationService, mediaHelper, Upload, umbRequestHelper,
         usersHelper, authResource, dateHelper, editorService, overlayService, externalLoginInfoService) {
 
         var currentLoggedInUser = null;

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -110,6 +110,12 @@
             });
         }
         
+        /**
+         * @ngdoc function
+         * @function    
+         *
+         * @deprecated
+         */
         function getLocalDate(date, culture, format) {
             return dateHelper.getLocaleDate(date, culture, format);
         }

--- a/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/user.controller.js
@@ -109,6 +109,10 @@
               });
             });
         }
+        
+        function getLocalDate(date, culture, format) {
+            return dateHelper.getLocaleDate(date, culture, format);
+        }
 
         function toggleChangePassword() {
             //reset it


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed in user controller, we have a `getLocalDate` defined, but this already exists in `dateHelper`, so we can just inject `dateHelper` instead and clean up a bit.

https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/src/Umbraco.Web.UI.Client/src/common/services/util.service.js#L104-L117