### PR TITLE
Ensure that all automatic relation types are updated

### DIFF
--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -282,7 +282,6 @@ public static partial class Constants
             ///     Developers should not manually use these relation types since they will all be cleared whenever an entity
             ///     (content, media or member) is saved since they are auto-populated based on property values.
             /// </remarks>
-            [Obsolete("This is no longer used, and will be removed in v12")]
             public static string[] AutomaticRelationTypes { get; } = { RelatedMediaAlias, RelatedDocumentAlias };
 
             // TODO: return a list of built in types so we can use that to prevent deletion in the UI

--- a/src/Umbraco.Core/PropertyEditors/IDataValueReference.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataValueReference.cs
@@ -14,4 +14,10 @@ public interface IDataValueReference
     /// <param name="value"></param>
     /// <returns></returns>
     IEnumerable<UmbracoEntityReference> GetReferences(object? value);
+
+    /// <summary>
+    ///     Returns all reference types that are automatically tracked.
+    /// </summary>
+    /// <returns></returns>
+    IEnumerable<string> GetAutomaticRelationTypesAliases() => Enumerable.Empty<string>();
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1042,10 +1042,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             var trackedRelations = new List<UmbracoEntityReference>();
             trackedRelations.AddRange(_dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors));
 
-            var relationTypeAliases = trackedRelations
-                .Select(x => x.RelationTypeAlias)
-                .Distinct()
-                .ToArray();
+            var relationTypeAliases = GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors).ToArray();
 
             // First delete all auto-relations for this entity
             RelationRepository.DeleteByParent(entity.Id, relationTypeAliases);
@@ -1091,6 +1088,31 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
             // Save bulk relations
             RelationRepository.SaveBulk(toSave);
+        }
+
+        private IEnumerable<string> GetAutomaticRelationTypesAliases(
+            IPropertyCollection properties,
+            PropertyEditorCollection propertyEditors)
+        {
+            var automaticRelationTypesAliases = new HashSet<string>(Constants.Conventions.RelationTypes.AutomaticRelationTypes);
+
+            foreach (IProperty property in properties)
+            {
+                if (propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? editor) is false )
+                {
+                    continue;
+                }
+
+                if (editor.GetValueEditor() is IDataValueReference reference)
+                {
+                    foreach (var alias in reference.GetAutomaticRelationTypesAliases())
+                    {
+                        automaticRelationTypesAliases.Add(alias);
+                    }
+                }
+            }
+
+            return automaticRelationTypesAliases;
         }
 
         /// <summary>


### PR DESCRIPTION
This is a continuation of #13389, see that PR and associated issue for more information. 

As I mention in that PR I realised that the solution wouldn't work in all cases, in particular, it won't allow you to remove a relation again, since it relies on the existing relation itself to tell you that it exists (by alias). 

Instead to solve this what I've done is added a new method to the `IDataValueReference` interface: `GetAutomaticRelationTypesAliases` this allows you to specify the aliases of your custom automatic relation types. This new method comes with a default implementation to make it non-breaking. 

This is then used to determine what relations to recreate.

### Testing

To test this add a custom property editor implementing `IDataValueReference` (see appendix), and ensure that all relevant relations gets deleted, especially when removing a relation entirely (such as removing all picked content from a content picker) 


### Appendix

This custom editor (Supplied by @bjarnef, thanks) will show the issue, and uses the build in content picker views, so it's nice and easy to use 😄 

```c#
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.IO;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.Editors;
using Umbraco.Cms.Core.PropertyEditors;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Strings;

namespace Umbraco.Cms.Web.UI.Editors;

[DataEditor(
    name: "Product Picker",
    alias: "productPicker",
    view: "contentpicker",
    Icon = "icon-tag",
    ValueType = ValueTypes.Text,
    Group = Umbraco.Cms.Core.Constants.PropertyEditors.Groups.Pickers)]
public class ProductPickerPropertyEditor : DataEditor
{
    private readonly IEditorConfigurationParser _editorConfigurationParser;
    private readonly IIOHelper _ioHelper;
    private readonly IJsonSerializer _jsonSerializer;

    public ProductPickerPropertyEditor(
        IDataValueEditorFactory dataValueEditorFactory,
        IIOHelper ioHelper,
        IJsonSerializer jsonSerializer,
        IEditorConfigurationParser editorConfigurationParser,
        EditorType type = EditorType.PropertyValue)
        : base(dataValueEditorFactory, type)
    {
        _ioHelper = ioHelper;
        _jsonSerializer = jsonSerializer;
        _editorConfigurationParser = editorConfigurationParser;
        SupportsReadOnly = true;
    }

    /// <inheritdoc />
    protected override IConfigurationEditor CreateConfigurationEditor() =>
        new MultiNodePickerConfigurationEditor(_ioHelper, _editorConfigurationParser);

    /// <inheritdoc />
    //protected override IDataValueEditor CreateValueEditor() =>
    //    DataValueEditorFactory.Create<MultipleValueEditor>(Attribute!);

    protected override IDataValueEditor CreateValueEditor() =>
        DataValueEditorFactory.Create<ProductPickerPropertyValueEditor>(Attribute!);

    public class ProductPickerPropertyValueEditor : DataValueEditor, IDataValueReferenceFactory, IDataValueReference
    {
        public ProductPickerPropertyValueEditor(
            ILocalizedTextService localizedTextService,
            IShortStringHelper shortStringHelper,
            IJsonSerializer jsonSerializer,
            IIOHelper ioHelper,
            DataEditorAttribute attribute)
            : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
        {

        }

        private const string RelationTypeAlias = "myCustomRelation";

        public IDataValueReference GetDataValueReference() => this;

        public IEnumerable<string> GetAutomaticRelationTypesAliases() => new[] { RelationTypeAlias };

        public bool IsForEditor(IDataEditor? dataEditor) => dataEditor?.Alias == "productPicker";

        public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
        {
            var asString = value == null ? string.Empty : value is string str ? str : value.ToString();

            if (string.IsNullOrEmpty(asString))
            {
                yield break;
            }

            var udiPaths = asString!.Split(',');

            foreach (var udiPath in udiPaths)
            {
                if (UdiParser.TryParse(udiPath, out Udi? udi))
                {
                    yield return new UmbracoEntityReference(udi, RelationTypeAlias);
                }
            }
        }
    }
}

``` 