### PR TITLE
V11: Fix ordering by published in list of content

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -152,19 +152,14 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
 
         if (ordering.OrderBy.InvariantEquals("published"))
         {
-            // no culture = can only work on the global 'published' flag
+            // no culture, assume invariant and simply order by published.
             if (ordering.Culture.IsNullOrWhiteSpace())
             {
-                // see notes in ApplyOrdering: the field MUST be selected + aliased, and we cannot have
-                // the whole CASE fragment in ORDER BY due to it not being detected by NPoco
-                sql = Sql(InsertBefore(sql, "FROM", ", (CASE WHEN pcv.id IS NULL THEN 0 ELSE 1 END) AS ordering "),
-                    sql.Arguments);
-                return "ordering";
+                return SqlSyntax.GetFieldName<DocumentDto>(x => x.Published);
             }
 
             // invariant: left join will yield NULL and we must use pcv to determine published
             // variant: left join may yield NULL or something, and that determines published
-
 
             Sql<ISqlContext> joins = Sql()
                 .InnerJoin<ContentTypeDto>("ctype").On<ContentDto, ContentTypeDto>(

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -185,9 +185,9 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
             // the whole CASE fragment in ORDER BY due to it not being detected by NPoco
             var sqlText = InsertBefore(sql.SQL, "FROM",
 
-                // when invariant, ie 'variations' does not have the culture flag (value 1), use the global 'published' flag on pcv.id,
+                // when invariant, ie 'variations' does not have the culture flag (value 1), it should be safe to simply use the published flag on umbracoDocument,
                 // otherwise check if there's a version culture variation for the lang, via ccv.id
-                ", (CASE WHEN (ctype.variations & 1) = 0 THEN (CASE WHEN pcv.id IS NULL THEN 0 ELSE 1 END) ELSE (CASE WHEN ccvp.id IS NULL THEN 0 ELSE 1 END) END) AS ordering "); // trailing space is important!
+                $", (CASE WHEN (ctype.variations & 1) = 0 THEN ({SqlSyntax.GetFieldName<DocumentDto>(x => x.Published)}) ELSE (CASE WHEN ccvp.id IS NULL THEN 0 ELSE 1 END) END) AS ordering "); // trailing space is important!
 
             sql = Sql(sqlText, sql.Arguments);
 


### PR DESCRIPTION
This fixes #13301.

The issue was that if you ordered your content by published the sort order would be incorrect.

Looking at this it was because we relied on the content version to return an id with a value of "null", however that will only happen if the content has never been published, leading to the weird behaviour described in the issue.

Looking a bit further it seems that the entire reason we use this query to order by published is because of variants (if a content node doesn't exist in a variant, we "fall back" to the default culture in the UI, which may be published).

Since we already have a check to see if the content varies, I just updated it to instead use the `Published` value of the umbracoDocument, since this is perfectly accurate for a non-varying piece of content. 

### Testing

Try the setup specified in the issue, but do try with both invariant content, and content that varies by culture

