### PR TITLE
Create and pack empty file to add TFM dependency to Umbraco.Cms and Umbraco.Cms.Targets

### DIFF
--- a/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
+++ b/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
@@ -50,4 +50,12 @@
   <Target Name="RemoveAppsettingsSchema" AfterTargets="Clean" Condition="Exists('$(_UmbracoCmsJsonSchemaReference)')">
     <Delete Files="$(_UmbracoCmsJsonSchemaReference)" />
   </Target>
+
+  <!-- Create and pack empty file to add TFM dependency -->
+  <Target Name="PackTargetFrameworkFile" BeforeTargets="Build">
+    <WriteLinesToFile File="$(IntermediateOutputPath)_._" />
+    <ItemGroup>
+      <None Include="$(IntermediateOutputPath)_._" Pack="true" PackagePath="lib\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Umbraco.Cms/Umbraco.Cms.csproj
+++ b/src/Umbraco.Cms/Umbraco.Cms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Title>Umbraco CMS</Title>
     <Description>Installs Umbraco CMS with all default dependencies in your ASP.NET Core project.</Description>
@@ -12,4 +12,12 @@
     <ProjectReference Include="..\Umbraco.Cms.Persistence.Sqlite\Umbraco.Cms.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\Umbraco.Cms.Persistence.SqlServer\Umbraco.Cms.Persistence.SqlServer.csproj" />
   </ItemGroup>
+
+  <!-- Create and pack empty file to add TFM dependency -->
+  <Target Name="PackTargetFrameworkFile" BeforeTargets="Build">
+    <WriteLinesToFile File="$(IntermediateOutputPath)_._" />
+    <ItemGroup>
+      <None Include="$(IntermediateOutputPath)_._" Pack="true" PackagePath="lib\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Both the `Umbraco.Cms` and `Umbraco.Cms.Targets` packages don't include any framework specific contents, causing MSBuild to raise a [NU5128 warning during packaging](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) and NuGet.org not showing any supported frameworks.

This PR uses the `Add an empty _._ file` solution from the linked MS documentation:
> If your package does not contain any assemblies, such as a meta-package, consider adding an empty `_._` file to the `lib/<tfm>/` directories for the TFMs listed in the warning message.

Instead of creating and adding this file to the repository (and updating the path when the target framework changes), I've added an MSBuild task that automatically takes care of this.

Testing can be done by inspecting the generated NuGet files and optionally adding them to an empty .NET 7 project.