### PR TITLE
Complete fix for https://github.com/umbraco/Umbraco-CMS/issues/8090 issue.

### DIFF
--- a/src/Umbraco.Core/Compose/AuditEventsComponent.cs
+++ b/src/Umbraco.Core/Compose/AuditEventsComponent.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Core.Compose
             get
             {
                 var httpContext = HttpContext.Current == null ? (HttpContextBase) null : new HttpContextWrapper(HttpContext.Current);
-                var ip = httpContext.GetCurrentRequestIpAddress();
+                var ip = httpContext?.GetCurrentRequestIpAddress();
                 if (ip == null || ip.ToLowerInvariant().StartsWith("unknown")) ip = "";
                 return ip;
             }

--- a/src/Umbraco.Core/Security/MembershipProviderBase.cs
+++ b/src/Umbraco.Core/Security/MembershipProviderBase.cs
@@ -965,7 +965,7 @@ namespace Umbraco.Core.Security
         protected string GetCurrentRequestIpAddress()
         {
             var httpContext = HttpContext.Current == null ? (HttpContextBase) null : new HttpContextWrapper(HttpContext.Current);
-            return httpContext.GetCurrentRequestIpAddress();
+            return httpContext?.GetCurrentRequestIpAddress();
         }
 
     }


### PR DESCRIPTION
### Prerequisites
Since U 8.16 we struggle with the problem of saving members' information.
We modify members' properties in Hangfire jobs and we always has problems with database locks.
That was because this issue:
https://github.com/umbraco/Umbraco-CMS/issues/8090
It was marked as resolved but the wrong code is still here.

### Description
So I just add a null-conditional operator to avoid a null reference exception.
Seems the code is self-explainable.
If HttpContext.Current == null we still have null reference in 
httpContext variable.
Also, i fixed another part of the code, by adding .? to the same expression.

The way how we achieve this:
We had hangfire jobs which are executed by schedule.
When nobody is logged in HttpContext.Current will be null.
Probably it will be null even if we made some console app to test this.