### PR TITLE
V11: Allow changing logging directory from configuration

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
@@ -33,7 +33,7 @@ public class LoggingSettings
         var dir = Directory;
         if (dir.StartsWith("~/"))
         {
-            hostEnvironment.MapPathContentRoot(dir);
+            return hostEnvironment.MapPathContentRoot(dir);
         }
 
         return dir;

--- a/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
@@ -2,6 +2,8 @@
 // See LICENSE for more details.
 
 using System.ComponentModel;
+using Microsoft.Extensions.Hosting;
+using Umbraco.Cms.Core.Extensions;
 
 namespace Umbraco.Cms.Core.Configuration.Models;
 
@@ -12,10 +14,28 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 public class LoggingSettings
 {
     internal const string StaticMaxLogAge = "1.00:00:00"; // TimeSpan.FromHours(24);
+    internal const string StaticLoggingDirectory = Constants.SystemDirectories.LogFiles;
 
     /// <summary>
     ///     Gets or sets a value for the maximum age of a log file.
     /// </summary>
     [DefaultValue(StaticMaxLogAge)]
     public TimeSpan MaxLogAge { get; set; } = TimeSpan.Parse(StaticMaxLogAge);
+
+    /// <summary>
+    ///     Gets or sets the folder to use for log files
+    /// </summary>
+    [DefaultValue(StaticLoggingDirectory)]
+    public string LoggingDirectory { get; set; } = StaticLoggingDirectory;
+
+    public string GetAbsoluteLoggingPath(IHostEnvironment hostEnvironment)
+    {
+        var dir = LoggingDirectory;
+        if (dir.StartsWith("~/"))
+        {
+            hostEnvironment.MapPathContentRoot(dir);
+        }
+
+        return dir;
+    }
 }

--- a/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 public class LoggingSettings
 {
     internal const string StaticMaxLogAge = "1.00:00:00"; // TimeSpan.FromHours(24);
-    internal const string StaticLoggingDirectory = Constants.SystemDirectories.LogFiles;
+    internal const string StaticDirectory = Constants.SystemDirectories.LogFiles;
 
     /// <summary>
     ///     Gets or sets a value for the maximum age of a log file.
@@ -25,12 +25,12 @@ public class LoggingSettings
     /// <summary>
     ///     Gets or sets the folder to use for log files
     /// </summary>
-    [DefaultValue(StaticLoggingDirectory)]
-    public string LoggingDirectory { get; set; } = StaticLoggingDirectory;
+    [DefaultValue(StaticDirectory)]
+    public string Directory { get; set; } = StaticDirectory;
 
     public string GetAbsoluteLoggingPath(IHostEnvironment hostEnvironment)
     {
-        var dir = LoggingDirectory;
+        var dir = Directory;
         if (dir.StartsWith("~/"))
         {
             hostEnvironment.MapPathContentRoot(dir);

--- a/src/Umbraco.Core/Constants-SystemDirectories.cs
+++ b/src/Umbraco.Core/Constants-SystemDirectories.cs
@@ -60,7 +60,7 @@ public static partial class Constants
         /// <summary>
         ///     The default folder where Umbraco log files are stored
         /// </summary>
-        [Obsolete("Use LoggingSettings.GetLoggingDirectory() instead")]
+        [Obsolete("Use LoggingSettings.GetLoggingDirectory() instead, will be removed in Umbraco 13.")]
         public const string LogFiles = Umbraco + "/Logs";
 
         [Obsolete("Use PluginIcons instead")]

--- a/src/Umbraco.Core/Constants-SystemDirectories.cs
+++ b/src/Umbraco.Core/Constants-SystemDirectories.cs
@@ -60,6 +60,7 @@ public static partial class Constants
         /// <summary>
         ///     The default folder where Umbraco log files are stored
         /// </summary>
+        [Obsolete("Use LoggingSettings.GetLoggingDirectory() instead")]
         public const string LogFiles = Umbraco + "/Logs";
 
         [Obsolete("Use PluginIcons instead")]

--- a/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
@@ -7,6 +7,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Compact;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Logging.Serilog.Enrichers;
@@ -21,7 +22,7 @@ namespace Umbraco.Extensions
         /// Such as adding ProcessID, Thread, AppDomain etc
         /// It is highly recommended that you keep/use this default in your own logging config customizations
         /// </summary>
-        [Obsolete("Please use an alternative method.")]
+        [Obsolete("Please use an alternative method. This will be removed in Umbraco 13.")]
         public static LoggerConfiguration MinimalConfiguration(
             this LoggerConfiguration logConfig,
             Umbraco.Cms.Core.Hosting.IHostingEnvironment hostingEnvironment,
@@ -36,7 +37,7 @@ namespace Umbraco.Extensions
         /// Such as adding ProcessID, Thread, AppDomain etc
         /// It is highly recommended that you keep/use this default in your own logging config customizations
         /// </summary>
-        [Obsolete("Please use an alternative method.")]
+        [Obsolete("Please use an alternative method. This will be removed in Umbraco 13.")]
         public static LoggerConfiguration MinimalConfiguration(
             this LoggerConfiguration logConfig,
             Umbraco.Cms.Core.Hosting.IHostingEnvironment hostingEnvironment,
@@ -126,6 +127,7 @@ namespace Umbraco.Extensions
         /// <param name="loggingConfiguration"></param>
         /// <param name="minimumLevel">The log level you wish the JSON file to collect - default is Verbose (highest)</param>
         /// <param name="retainedFileCount">The number of days to keep log files. Default is set to null which means all logs are kept</param>
+        [Obsolete("Will be removed in the Umbraco 13.")]
         public static LoggerConfiguration OutputDefaultTextFile(
             this LoggerConfiguration logConfig,
             Umbraco.Cms.Core.Hosting.IHostingEnvironment hostingEnvironment,
@@ -144,6 +146,31 @@ namespace Umbraco.Extensions
             return logConfig;
         }
 
+        /// <summary>
+        /// Outputs a .txt format log at /App_Data/Logs/
+        /// </summary>
+        /// <param name="logConfig">A Serilog LoggerConfiguration</param>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="loggingSettings"></param>
+        /// <param name="minimumLevel">The log level you wish the JSON file to collect - default is Verbose (highest)</param>
+        public static LoggerConfiguration OutputDefaultTextFile(
+            this LoggerConfiguration logConfig,
+            IHostEnvironment hostEnvironment,
+            LoggingSettings loggingSettings,
+            LogEventLevel minimumLevel = LogEventLevel.Verbose)
+        {
+            //Main .txt logfile - in similar format to older Log4Net output
+            //Ends with ..txt as Date is inserted before file extension substring
+            logConfig.WriteTo.File(
+                Path.Combine(loggingSettings.GetAbsoluteLoggingPath(hostEnvironment),  $"UmbracoTraceLog.{Environment.MachineName}..txt"),
+                shared: true,
+                rollingInterval: RollingInterval.Day,
+                restrictedToMinimumLevel: minimumLevel,
+                retainedFileCountLimit: null, //Setting to null means we keep all files - default is 31 days
+                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss,fff} [P{ProcessId}/D{AppDomainId}/T{ThreadId}] {Log4NetLevel}  {SourceContext} - {Message:lj}{NewLine}{Exception}");
+
+            return logConfig;
+        }
 
         /// <remarks>
         ///    Used in config - If renamed or moved to other assembly the config file also has be updated.
@@ -195,6 +222,7 @@ namespace Umbraco.Extensions
         /// <param name="minimumLevel">The log level you wish the JSON file to collect - default is Verbose (highest)</param>
         /// <param name="hostingEnvironment"></param>
         /// <param name="retainedFileCount">The number of days to keep log files. Default is set to null which means all logs are kept</param>
+        [Obsolete("Will be removed in the Umbraco 13.")]
         public static LoggerConfiguration OutputDefaultJsonFile(
             this LoggerConfiguration logConfig,
             Umbraco.Cms.Core.Hosting.IHostingEnvironment hostingEnvironment,
@@ -207,6 +235,34 @@ namespace Umbraco.Extensions
             logConfig.WriteTo.File(
                 new CompactJsonFormatter(),
                 Path.Combine(hostingEnvironment.MapPathContentRoot(Cms.Core.Constants.SystemDirectories.LogFiles) ,$"UmbracoTraceLog.{Environment.MachineName}..json"),
+                shared: true,
+                rollingInterval: RollingInterval.Day, // Create a new JSON file every day
+                retainedFileCountLimit: retainedFileCount, // Setting to null means we keep all files - default is 31 days
+                restrictedToMinimumLevel: minimumLevel);
+
+            return logConfig;
+        }
+
+        /// <summary>
+        /// Outputs a CLEF format JSON log at /App_Data/Logs/
+        /// </summary>
+        /// <param name="logConfig">A Serilog LoggerConfiguration</param>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="loggingSettings">The logging configuration</param>
+        /// <param name="minimumLevel">The log level you wish the JSON file to collect - default is Verbose (highest)</param>
+        /// <param name="retainedFileCount">The number of days to keep log files. Default is set to null which means all logs are kept</param>
+        public static LoggerConfiguration OutputDefaultJsonFile(
+            this LoggerConfiguration logConfig,
+            IHostEnvironment hostEnvironment,
+            LoggingSettings loggingSettings,
+            LogEventLevel minimumLevel = LogEventLevel.Verbose,
+            int? retainedFileCount = null)
+        {
+            // .clef format (Compact log event format, that can be imported into local SEQ & will make searching/filtering logs easier)
+            // Ends with ..txt as Date is inserted before file extension substring
+            logConfig.WriteTo.File(
+                new CompactJsonFormatter(),
+                Path.Combine(loggingSettings.GetAbsoluteLoggingPath(hostEnvironment) ,$"UmbracoTraceLog.{Environment.MachineName}..json"),
                 shared: true,
                 rollingInterval: RollingInterval.Day, // Create a new JSON file every day
                 retainedFileCountLimit: retainedFileCount, // Setting to null means we keep all files - default is 31 days

--- a/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
@@ -127,7 +127,7 @@ namespace Umbraco.Extensions
         /// <param name="loggingConfiguration"></param>
         /// <param name="minimumLevel">The log level you wish the JSON file to collect - default is Verbose (highest)</param>
         /// <param name="retainedFileCount">The number of days to keep log files. Default is set to null which means all logs are kept</param>
-        [Obsolete("Will be removed in the Umbraco 13.")]
+        [Obsolete("Will be removed in Umbraco 13.")]
         public static LoggerConfiguration OutputDefaultTextFile(
             this LoggerConfiguration logConfig,
             Umbraco.Cms.Core.Hosting.IHostingEnvironment hostingEnvironment,
@@ -222,7 +222,7 @@ namespace Umbraco.Extensions
         /// <param name="minimumLevel">The log level you wish the JSON file to collect - default is Verbose (highest)</param>
         /// <param name="hostingEnvironment"></param>
         /// <param name="retainedFileCount">The number of days to keep log files. Default is set to null which means all logs are kept</param>
-        [Obsolete("Will be removed in the Umbraco 13.")]
+        [Obsolete("Will be removed in Umbraco 13.")]
         public static LoggerConfiguration OutputDefaultJsonFile(
             this LoggerConfiguration logConfig,
             Umbraco.Cms.Core.Hosting.IHostingEnvironment hostingEnvironment,

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -373,7 +373,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             {
                 Message =
                     "The database configuration failed with the following message: " + ex.Message +
-                    $"\n Please check log file for additional information (can be found in '{Constants.SystemDirectories.LogFiles}')",
+                    $"\n Please check log file for additional information (can be found in '{nameof(LoggingSettings)}.{nameof(LoggingSettings.LoggingDirectory)}')",
                 Success = false,
                 Percentage = "90"
             };

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -373,7 +373,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             {
                 Message =
                     "The database configuration failed with the following message: " + ex.Message +
-                    $"\n Please check log file for additional information (can be found in '{nameof(LoggingSettings)}.{nameof(LoggingSettings.LoggingDirectory)}')",
+                    $"\n Please check log file for additional information (can be found in '{nameof(LoggingSettings)}.{nameof(LoggingSettings.Directory)}')",
                 Success = false,
                 Percentage = "90"
             };

--- a/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -82,14 +82,15 @@ public static class ServiceCollectionExtensions
         IHostEnvironment hostEnvironment,
         IConfiguration configuration)
     {
-        // TODO: WEBSITE_RUN_FROM_PACKAGE - can't assume this DIR is writable - we have an IConfiguration instance so a later refactor should be easy enough.
-        var loggingDir = hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.LogFiles);
+        LoggingSettings loggerSettings = GetLoggerSettings(configuration);
+
+        var loggingDir = loggerSettings.GetAbsoluteLoggingPath(hostEnvironment);
         ILoggingConfiguration loggingConfig = new LoggingConfiguration(loggingDir);
 
         var umbracoFileConfiguration = new UmbracoFileConfiguration(configuration);
 
-        services.TryAddSingleton(umbracoFileConfiguration);
-        services.TryAddSingleton(loggingConfig);
+        services.TryAddSingleton(x => umbracoFileConfiguration);
+        services.TryAddSingleton(x => loggingConfig);
         services.TryAddSingleton<ILogEventEnricher, ApplicationIdEnricher>();
 
         ///////////////////////////////////////////////
@@ -144,6 +145,13 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IDiagnosticContext>(diagnosticContext);
 
         return services;
+    }
+
+    private static LoggingSettings GetLoggerSettings(IConfiguration configuration)
+    {
+        var loggerSettings = new LoggingSettings();
+        configuration.GetSection(Constants.Configuration.ConfigLogging).Bind(loggerSettings);
+        return loggerSettings;
     }
 
     /// <summary>

--- a/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -89,8 +89,8 @@ public static class ServiceCollectionExtensions
 
         var umbracoFileConfiguration = new UmbracoFileConfiguration(configuration);
 
-        services.TryAddSingleton(x => umbracoFileConfiguration);
-        services.TryAddSingleton(x => loggingConfig);
+        services.TryAddSingleton(umbracoFileConfiguration);
+        services.TryAddSingleton(loggingConfig);
         services.TryAddSingleton<ILogEventEnricher, ApplicationIdEnricher>();
 
         ///////////////////////////////////////////////


### PR DESCRIPTION
Related to https://github.com/umbraco/Umbraco-CMS/discussions/13356

### Changes
- Introduced new setting `Umbraco.CMS.Logging.Directory`
- Obsoleted:
  -  `Constants.SystemDirectories.LogFiles` as this is now configurable
  -  A series of constructors that now points to new overloads with `IOptions<LoggingSettings>` parameter


### Tests
- Everything should continue to be like before this PR
- You should now be able to write another path
  - Starting with `~` will be relative to the content root
  - Absolute paths should work
 - Test that log viewer also reads from the custom location