### PR TITLE
info panes not loading prerequisites

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js
@@ -6,10 +6,9 @@
  * @description
  * The controller for the info view of the datatype editor
  */
-function DataTypeInfoController($scope, $routeParams, dataTypeResource, eventsService, $timeout, editorService) {
+function DataTypeInfoController($scope, $routeParams, dataTypeResource, $timeout, editorService) {
 
     var vm = this;
-    var evts = [];
     var referencesLoaded = false;
 
     vm.references = {};
@@ -48,7 +47,7 @@ function DataTypeInfoController($scope, $routeParams, dataTypeResource, eventsSe
 
     function open(id, event, type) {
         // targeting a new tab/window?
-        if (event.ctrlKey || 
+        if (event.ctrlKey ||
             event.shiftKey ||
             event.metaKey || // apple
             (event.button && event.button === 1) // middle click, >IE9 + everyone else
@@ -85,25 +84,7 @@ function DataTypeInfoController($scope, $routeParams, dataTypeResource, eventsSe
         }
     }
 
-    // load data type references when the references tab is activated
-    evts.push(eventsService.on("app.tabChange", function (event, args) {
-        $timeout(function () {
-            if (args.alias === "info") {
-                loadRelations();
-            }
-        });
-    }));
-
-    //ensure to unregister from all events!
-    $scope.$on('$destroy', function () {
-        for (var e in evts) {
-            eventsService.unsubscribe(evts[e]);
-        }
-    });
-
-   
-
-
+    loadRelations();
 }
 
 angular.module("umbraco").controller("Umbraco.Editors.DataType.InfoController", DataTypeInfoController);

--- a/src/Umbraco.Web.UI.Client/src/views/relationTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/relationTypes/edit.controller.js
@@ -54,14 +54,7 @@ function RelationTypeEditController($scope, $routeParams, relationTypeResource, 
         });
 
         // load references when the 'relations' tab is first activated/switched to
-        var appTabChange =  eventsService.on("app.tabChange", function (event, args) {
-            if (args.alias === "relations") {
-                loadRelations();
-            }
-        });
-        $scope.$on('$destroy', function () {
-            appTabChange();
-        });
+        loadRelations();
 
         // Inital page/overview API call of relation type
         relationTypeResource.getById($routeParams.id)


### PR DESCRIPTION
### Prerequisites

Fixes #13479

### Description

Following the change of loading subviews conditionally with `ng-if`, some subviews were dependent on a global event called "app.tabChange", which still works but was now being fired too early since the components are now only loaded on demand. The same logic now makes it possible to just invoke the prerequisites for each subview directly on init, since it's only loaded if it's visible.
