### PR TITLE
Added various Block Grid translations (EN & NL)

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2790,7 +2790,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="allowBlockInRoot">Allow in root</key>
     <key alias="allowBlockInRootHelp">Make this block available in the root of the layout.</key>
     <key alias="allowBlockInAreas">Allow in areas</key>
-    <key alias="allowBlockInAreasHelp">Make this block available within other Blocks.</key>
+    <key alias="allowBlockInAreasHelp">Make this block available by default within the areas of other Blocks (unless explicit permissions are set for these areas)</key>
     <key alias="areaAllowedBlocksEmpty">When empty all Blocks allowed for Areas can be created.</key>
     <key alias="areas">Areas</key>
     <key alias="areasLayoutColumns">Grid Columns for Areas</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2790,7 +2790,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="allowBlockInRoot">Allow in root</key>
     <key alias="allowBlockInRootHelp">Make this block available in the root of the layout.</key>
     <key alias="allowBlockInAreas">Allow in areas</key>
-    <key alias="allowBlockInAreasHelp">Make this block available by default within the areas of other Blocks (unless explicit permissions are set for these areas)</key>
+    <key alias="allowBlockInAreasHelp">Make this block available by default within the areas of other Blocks (unless explicit permissions are set for these areas).</key>
     <key alias="areaAllowedBlocksEmpty">When empty all Blocks allowed for Areas can be created.</key>
     <key alias="areas">Areas</key>
     <key alias="areasLayoutColumns">Grid Columns for Areas</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2893,7 +2893,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="allowBlockInRoot">Allow in root</key>
     <key alias="allowBlockInRootHelp">Make this block available in the root of the layout.</key>
     <key alias="allowBlockInAreas">Allow in areas</key>
-    <key alias="allowBlockInAreasHelp">Make this block available within other Blocks.</key>
+    <key alias="allowBlockInAreasHelp">Make this block available by default within the areas of other Blocks (unless explicit permissions are set for these areas).</key>
     <key alias="areaAllowedBlocksEmpty">When empty all Blocks allowed for Areas can be created.</key>
     <key alias="areas">Areas</key>
     <key alias="areasLayoutColumns">Grid Columns for Areas</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -2545,6 +2545,7 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="block">Blok</key>
     <key alias="tabBlock">Blokken</key>
     <key alias="tabBlockTypeSettings">Instellingen</key>
+    <key alias="allowBlockInAreasHelp">Maak dit blok standaard beschikbaar binnen de gebieden van andere blokken (behalve wanneer expliciete rechten zijn gezet voor deze gebieden).</key>
     <key alias="areas">Gebieden</key>
     <key alias="tabAreas">Gebieden</key>
     <key alias="tabAdvanced">Geadvanceerd</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -2520,6 +2520,37 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="propertyEditorNotSupported">Eigenschap '%0%' gebruikt editor '%1%' die niet ondersteund wordt in
       blokken.
     </key>
+    <key alias="focusParentBlock">Geef focus aan het container blok</key>
+    <key alias="areaIdentification">Identificatie</key>
+    <key alias="areaValidation">Validatie</key>
+    <key alias="areaValidationEntriesShort"><![CDATA[<strong>%0%</strong> moet minimaal <strong>%2%</strong> keer aanwezig zijn.]]></key>
+    <key alias="areaValidationEntriesExceed"><![CDATA[<strong>%0%</strong>mag maximaal <strong>%3%</strong> keer aanwezig zijn.]]></key>
+    <key alias="areaNumberOfBlocks">Hoeveelheid blokken</key>
+    <key alias="areaDisallowAllBlocks">Sta alleen specifiek bloktype toe</key>
+    <key alias="areaAllowedBlocks">Toegestane bloktypes</key>
+    <key alias="areaAllowedBlocksHelp">Definieer de type blokken die zijn toegestaan in dit gebied, en optioneel hoeveel van ieder type aanwezig moet zijn.</key>
+    <key alias="confirmDeleteBlockAreaMessage">Weet je zeker dat je dit gebied wilt verwijderen?</key>
+    <key alias="confirmDeleteBlockAreaNotice">Alle blokken op dit moment aangemaakt binnen dit gebied zullen worden verwijderd.</key>
+    <key alias="layoutOptions">Lay-out opties</key>
+    <key alias="structuralOptions">Structuur</key>
+    <key alias="sizeOptions">Afmetingen</key>
+    <key alias="sizeOptionsHelp">Definiëer een of meer afmetingen, dit maakt het mogelijk blokken te vergroten/verkleinen</key>
+    <key alias="allowedBlockColumns">Beschikbare kolommen</key>
+    <key alias="allowedBlockColumnsHelp">Definieer de verschillende aantal kolombreedtes dat dit blok mag in nemen. Dit voorkomt niet dat blokken in gebieden met kleine kolombreedtes kan worden geplaatst.</key>
+    <key alias="allowedBlockRows">Beschikbare rijen</key>
+    <key alias="allowedBlockRowsHelp">Definiëer de verschillende aantal rijen dat dit blok mag innemen.</key>
+    <key alias="allowBlockInRoot">Sta toe in root</key>
+    <key alias="allowBlockInRootHelp">Maak dit blok beschikbaar in de root van de lay-out</key>
+    <key alias="allowBlockInAreas">Sta toe in gebieden</key>
+    <key alias="block">Blok</key>
+    <key alias="tabBlock">Blokken</key>
+    <key alias="tabBlockTypeSettings">Instellingen</key>
+    <key alias="areas">Gebieden</key>
+    <key alias="tabAreas">Gebieden</key>
+    <key alias="tabAdvanced">Geadvanceerd</key>
+    <key alias="headlineAllowance">Rechten</key>
+    <key alias="configureArea">Configureer gebied</key>
+    <key alias="deleteArea">Verwijder gebied</key>
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">Wat zijn Inhoudssjablonen?</key>


### PR DESCRIPTION
As per #13480, changed the allowBlockInAreasHelp translation text in English, and added various Dutch translations having to do with the Block Grid Editor while I was at it! (Not all of them yet, at this point in time!) 🙂