### PR TITLE
Revert breaking changes adding IContextCache to deploy connectors

### DIFF
--- a/src/Umbraco.Core/Deploy/DataTypeConfigurationConnectorExtensions.cs
+++ b/src/Umbraco.Core/Deploy/DataTypeConfigurationConnectorExtensions.cs
@@ -1,0 +1,48 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <summary>
+/// Extension methods adding backwards-compatability between <see cref="IDataTypeConfigurationConnector" /> and <see cref="IDataTypeConfigurationConnector2" />.
+/// </summary>
+/// <remarks>
+/// These extension methods will be removed in Umbraco 13.
+/// </remarks>
+public static class DataTypeConfigurationConnectorExtensions
+{
+    /// <summary>
+    /// Gets the artifact configuration value corresponding to a data type configuration and gather dependencies.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="dataType">The data type.</param>
+    /// <param name="dependencies">The dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The artifact configuration value.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IDataTypeConfigurationConnector2" />.
+    /// </remarks>
+    public static string? ToArtifact(this IDataTypeConfigurationConnector connector, IDataType dataType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
+            => connector is IDataTypeConfigurationConnector2 connector2
+                ? connector2.ToArtifact(dataType, dependencies, contextCache)
+                : connector.ToArtifact(dataType, dependencies);
+
+    /// <summary>
+    /// Gets the data type configuration corresponding to an artifact configuration value.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="dataType">The data type.</param>
+    /// <param name="configuration">The artifact configuration value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The data type configuration.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IDataTypeConfigurationConnector2" />.
+    /// </remarks>
+    public static object? FromArtifact(this IDataTypeConfigurationConnector connector, IDataType dataType, string? configuration, IContextCache contextCache)
+            => connector is IDataTypeConfigurationConnector2 connector2
+                ? connector2.FromArtifact(dataType, configuration, contextCache)
+                : connector.FromArtifact(dataType, configuration);
+}

--- a/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector.cs
+++ b/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector.cs
@@ -27,20 +27,8 @@ public interface IDataTypeConfigurationConnector
     /// <returns>
     /// The artifact configuration value.
     /// </returns>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
-        => ToArtifact(dataType, dependencies, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets the artifact configuration value corresponding to a data type configuration and gather dependencies.
-    /// </summary>
-    /// <param name="dataType">The data type.</param>
-    /// <param name="dependencies">The dependencies.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The artifact configuration value.
-    /// </returns>
-    string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IDataTypeConfigurationConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies);
 
     /// <summary>
     /// Gets the data type configuration corresponding to an artifact configuration value.
@@ -50,18 +38,6 @@ public interface IDataTypeConfigurationConnector
     /// <returns>
     /// The data type configuration.
     /// </returns>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    object? FromArtifact(IDataType dataType, string? configuration)
-        => FromArtifact(dataType, configuration, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets the data type configuration corresponding to an artifact configuration value.
-    /// </summary>
-    /// <param name="dataType">The data type.</param>
-    /// <param name="configuration">The artifact configuration value.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The data type configuration.
-    /// </returns>
-    object? FromArtifact(IDataType dataType, string? configuration, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IDataTypeConfigurationConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    object? FromArtifact(IDataType dataType, string? configuration);
 }

--- a/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector2.cs
+++ b/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector2.cs
@@ -1,0 +1,56 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <inheritdoc />
+/// <remarks>
+/// This interface will be merged back into <see cref="IDataTypeConfigurationConnector" /> and removed in Umbraco 13.
+/// </remarks>
+public interface IDataTypeConfigurationConnector2 : IDataTypeConfigurationConnector
+{
+    /// <summary>
+    /// Gets the artifact configuration value corresponding to a data type configuration and gather dependencies.
+    /// </summary>
+    /// <param name="dataType">The data type.</param>
+    /// <param name="dependencies">The dependencies.</param>
+    /// <returns>
+    /// The artifact configuration value.
+    /// </returns>
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    string? IDataTypeConfigurationConnector.ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies)
+        => ToArtifact(dataType, dependencies, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets the artifact configuration value corresponding to a data type configuration and gather dependencies.
+    /// </summary>
+    /// <param name="dataType">The data type.</param>
+    /// <param name="dependencies">The dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The artifact configuration value.
+    /// </returns>
+    string? ToArtifact(IDataType dataType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache);
+
+    /// <summary>
+    /// Gets the data type configuration corresponding to an artifact configuration value.
+    /// </summary>
+    /// <param name="dataType">The data type.</param>
+    /// <param name="configuration">The artifact configuration value.</param>
+    /// <returns>
+    /// The data type configuration.
+    /// </returns>
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    object? IDataTypeConfigurationConnector.FromArtifact(IDataType dataType, string? configuration)
+        => FromArtifact(dataType, configuration, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets the data type configuration corresponding to an artifact configuration value.
+    /// </summary>
+    /// <param name="dataType">The data type.</param>
+    /// <param name="configuration">The artifact configuration value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The data type configuration.
+    /// </returns>
+    object? FromArtifact(IDataType dataType, string? configuration, IContextCache contextCache);
+}

--- a/src/Umbraco.Core/Deploy/IServiceConnector.cs
+++ b/src/Umbraco.Core/Deploy/IServiceConnector.cs
@@ -15,19 +15,8 @@ public interface IServiceConnector : IDiscoverable
     /// <returns>
     /// The corresponding artifact, or null.
     /// </returns>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    IArtifact? GetArtifact(Udi udi)
-        => GetArtifact(udi, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets an artifact.
-    /// </summary>
-    /// <param name="udi">The entity identifier of the artifact.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The corresponding artifact, or null.
-    /// </returns>
-    IArtifact? GetArtifact(Udi udi, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IServiceConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    IArtifact? GetArtifact(Udi udi);
 
     /// <summary>
     /// Gets an artifact.
@@ -36,19 +25,8 @@ public interface IServiceConnector : IDiscoverable
     /// <returns>
     /// The corresponding artifact.
     /// </returns>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    IArtifact GetArtifact(object entity)
-        => GetArtifact(entity, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets an artifact.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The corresponding artifact.
-    /// </returns>
-    IArtifact GetArtifact(object entity, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IServiceConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    IArtifact GetArtifact(object entity);
 
     /// <summary>
     /// Initializes processing for an artifact.

--- a/src/Umbraco.Core/Deploy/IServiceConnector2.cs
+++ b/src/Umbraco.Core/Deploy/IServiceConnector2.cs
@@ -1,0 +1,38 @@
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <inheritdoc />
+/// <remarks>
+/// This interface will be merged back into <see cref="IServiceConnector" /> and removed in Umbraco 13.
+/// </remarks>
+public interface IServiceConnector2 : IServiceConnector
+{
+    /// <inheritdoc />
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    IArtifact? IServiceConnector.GetArtifact(Udi udi)
+        => GetArtifact(udi, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets an artifact.
+    /// </summary>
+    /// <param name="udi">The entity identifier of the artifact.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The corresponding artifact, or null.
+    /// </returns>
+    IArtifact? GetArtifact(Udi udi, IContextCache contextCache);
+
+    /// <inheritdoc />
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    IArtifact IServiceConnector.GetArtifact(object entity)
+       => GetArtifact(entity, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets an artifact.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The corresponding artifact.
+    /// </returns>
+    IArtifact GetArtifact(object entity, IContextCache contextCache);
+}

--- a/src/Umbraco.Core/Deploy/IValueConnector.cs
+++ b/src/Umbraco.Core/Deploy/IValueConnector.cs
@@ -29,21 +29,8 @@ public interface IValueConnector
     /// <returns>
     /// The deploy property value.
     /// </returns>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    string? ToArtifact(object? value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies)
-        => ToArtifact(value, propertyType, dependencies, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets the deploy property value corresponding to a content property value, and gather dependencies.
-    /// </summary>
-    /// <param name="value">The content property value.</param>
-    /// <param name="propertyType">The value property type</param>
-    /// <param name="dependencies">The content dependencies.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The deploy property value.
-    /// </returns>
-    string? ToArtifact(object? value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IValueConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    string? ToArtifact(object? value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies);
 
     /// <summary>
     /// Gets the content property value corresponding to a deploy property value.
@@ -54,19 +41,6 @@ public interface IValueConnector
     /// <returns>
     /// The content property value.
     /// </returns>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    object? FromArtifact(string? value, IPropertyType propertyType, object? currentValue)
-        => FromArtifact(value, propertyType, currentValue, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets the content property value corresponding to a deploy property value.
-    /// </summary>
-    /// <param name="value">The deploy property value.</param>
-    /// <param name="propertyType">The value property type</param>
-    /// <param name="currentValue">The current content property value.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The content property value.
-    /// </returns>
-    object? FromArtifact(string? value, IPropertyType propertyType, object? currentValue, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IValueConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    object? FromArtifact(string? value, IPropertyType propertyType, object? currentValue);
 }

--- a/src/Umbraco.Core/Deploy/IValueConnector2.cs
+++ b/src/Umbraco.Core/Deploy/IValueConnector2.cs
@@ -1,0 +1,44 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <inheritdoc />
+/// <remarks>
+/// This interface will be merged back into <see cref="IValueConnector" /> and removed in Umbraco 13.
+/// </remarks>
+public interface IValueConnector2 : IValueConnector
+{
+    /// <inheritdoc />
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    string? IValueConnector.ToArtifact(object? value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies)
+        => ToArtifact(value, propertyType, dependencies, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets the deploy property value corresponding to a content property value, and gather dependencies.
+    /// </summary>
+    /// <param name="value">The content property value.</param>
+    /// <param name="propertyType">The value property type</param>
+    /// <param name="dependencies">The content dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The deploy property value.
+    /// </returns>
+    string? ToArtifact(object? value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache);
+
+    /// <inheritdoc />
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    object? IValueConnector.FromArtifact(string? value, IPropertyType propertyType, object? currentValue)
+        => FromArtifact(value, propertyType, currentValue, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets the content property value corresponding to a deploy property value.
+    /// </summary>
+    /// <param name="value">The deploy property value.</param>
+    /// <param name="propertyType">The value property type</param>
+    /// <param name="currentValue">The current content property value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The content property value.
+    /// </returns>
+    object? FromArtifact(string? value, IPropertyType propertyType, object? currentValue, IContextCache contextCache);
+}

--- a/src/Umbraco.Core/Deploy/ServiceConnectorExtensions.cs
+++ b/src/Umbraco.Core/Deploy/ServiceConnectorExtensions.cs
@@ -1,0 +1,44 @@
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <summary>
+/// Extension methods adding backwards-compatability between <see cref="IServiceConnector" /> and <see cref="IServiceConnector2" />.
+/// </summary>
+/// <remarks>
+/// These extension methods will be removed in Umbraco 13.
+/// </remarks>
+public static class ServiceConnectorExtensions
+{
+    /// <summary>
+    /// Gets an artifact.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="udi">The entity identifier of the artifact.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The corresponding artifact, or null.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IServiceConnector2" />.
+    /// </remarks>
+    public static IArtifact? GetArtifact(this IServiceConnector connector, Udi udi, IContextCache contextCache)
+        => connector is IServiceConnector2 connector2
+            ? connector2.GetArtifact(udi, contextCache)
+            : connector.GetArtifact(udi);
+
+    /// <summary>
+    /// Gets an artifact.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="entity">The entity.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The corresponding artifact.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IServiceConnector2" />.
+    /// </remarks>
+    public static IArtifact GetArtifact(this IServiceConnector connector, object entity, IContextCache contextCache)
+        => connector is IServiceConnector2 connector2
+            ? connector2.GetArtifact(entity, contextCache)
+            : connector.GetArtifact(entity);
+}

--- a/src/Umbraco.Core/Deploy/ValueConnectorExtensions.cs
+++ b/src/Umbraco.Core/Deploy/ValueConnectorExtensions.cs
@@ -1,0 +1,50 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <summary>
+/// Extension methods adding backwards-compatability between <see cref="IValueConnector" /> and <see cref="IValueConnector2" />.
+/// </summary>
+/// <remarks>
+/// These extension methods will be removed in Umbraco 13.
+/// </remarks>
+public static class ValueConnectorExtensions
+{
+    /// <summary>
+    /// Gets the artifact value corresponding to a property value and gather dependencies.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="value">The property value.</param>
+    /// <param name="propertyType">The property type.</param>
+    /// <param name="dependencies">The dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The artifact value.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IValueConnector2" />.
+    /// </remarks>
+    public static string? ToArtifact(this IValueConnector connector, object? value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
+        => connector is IValueConnector2 connector2
+            ? connector2.ToArtifact(value, propertyType, dependencies, contextCache)
+            : connector.ToArtifact(value, propertyType, dependencies);
+
+    /// <summary>
+    /// Gets the property value corresponding to an artifact value.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="value">The artifact value.</param>
+    /// <param name="propertyType">The property type.</param>
+    /// <param name="currentValue">The current property value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The property value.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IValueConnector2" />.
+    /// </remarks>
+    public static object? FromArtifact(this IValueConnector connector, string? value, IPropertyType propertyType, object? currentValue, IContextCache contextCache)
+        => connector is IValueConnector2 connector2
+            ? connector2.FromArtifact(value, propertyType, currentValue, contextCache)
+            : connector.FromArtifact(value, propertyType, currentValue);
+}

--- a/src/Umbraco.Infrastructure/Deploy/GridCellValueConnectorExtensions.cs
+++ b/src/Umbraco.Infrastructure/Deploy/GridCellValueConnectorExtensions.cs
@@ -1,0 +1,51 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <summary>
+/// Extension methods adding backwards-compatability between <see cref="IGridCellValueConnector" /> and <see cref="IGridCellValueConnector2" />.
+/// </summary>
+/// <remarks>
+/// These extension methods will be removed in Umbraco 13.
+/// </remarks>
+public static class GridCellValueConnectorExtensions
+{
+    /// <summary>
+    /// Gets the value.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="gridControl">The grid control.</param>
+    /// <param name="dependencies">The dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The value.
+    /// </returns>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IGridCellValueConnector2" />.
+    /// </remarks>
+    public static string? GetValue(this IGridCellValueConnector connector, GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
+        => connector is IGridCellValueConnector2 connector2
+            ? connector2.GetValue(gridControl, dependencies, contextCache)
+            : connector.GetValue(gridControl, dependencies);
+
+    /// <summary>
+    /// Sets the value.
+    /// </summary>
+    /// <param name="connector">The connector.</param>
+    /// <param name="gridControl">The grid control.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <remarks>
+    /// This extension method tries to make use of the <see cref="IContextCache" /> on types also implementing <see cref="IGridCellValueConnector2" />.
+    /// </remarks>
+    public static void SetValue(this IGridCellValueConnector connector, GridValue.GridControl gridControl, IContextCache contextCache)
+    {
+        if (connector is IGridCellValueConnector2 connector2)
+        {
+            connector2.SetValue(gridControl, contextCache);
+        }
+        else
+        {
+            connector.SetValue(gridControl);
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Deploy/IGridCellValueConnector.cs
+++ b/src/Umbraco.Infrastructure/Deploy/IGridCellValueConnector.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.Models;
-using static Umbraco.Cms.Core.Models.GridValue;
 
 namespace Umbraco.Cms.Core.Deploy;
 
@@ -37,20 +36,8 @@ public interface IGridCellValueConnector
     /// <remarks>
     /// Note that
     /// </remarks>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    string? GetValue(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies)
-        => GetValue(gridControl, dependencies, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Gets the value to be deployed from the control value as a string.
-    /// </summary>
-    /// <param name="gridControl">The control containing the value.</param>
-    /// <param name="dependencies">The dependencies of the property.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <returns>
-    /// The grid cell value to be deployed.
-    /// </returns>
-    string? GetValue(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IGridCellValueConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    string? GetValue(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies);
 
     /// <summary>
     /// Allows you to modify the value of a control being deployed.
@@ -60,18 +47,6 @@ public interface IGridCellValueConnector
     /// Follows the pattern of the property value connectors (<see cref="IValueConnector" />).
     /// The SetValue method is used to modify the value of the <paramref name="gridControl" />.
     /// </remarks>
-    [Obsolete("Use the overload accepting IContextCache instead. This overload will be removed in a future version.")]
-    void SetValue(GridValue.GridControl gridControl)
-        => SetValue(gridControl, PassThroughCache.Instance);
-
-    /// <summary>
-    /// Allows you to modify the value of a control being deployed.
-    /// </summary>
-    /// <param name="gridControl">The control being deployed.</param>
-    /// <param name="contextCache">The context cache.</param>
-    /// <remarks>
-    /// Follows the pattern of the property value connectors (<see cref="IValueConnector" />).
-    /// The SetValue method is used to modify the value of the <paramref name="gridControl" />.
-    /// </remarks>
-    void SetValue(GridValue.GridControl gridControl, IContextCache contextCache);
+    [Obsolete($"Implement {nameof(IGridCellValueConnector2)} and use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    void SetValue(GridValue.GridControl gridControl);
 }

--- a/src/Umbraco.Infrastructure/Deploy/IGridCellValueConnector2.cs
+++ b/src/Umbraco.Infrastructure/Deploy/IGridCellValueConnector2.cs
@@ -1,0 +1,42 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Deploy;
+
+/// <inheritdoc />
+/// <remarks>
+/// This interface will be merged back into <see cref="IGridCellValueConnector" /> and removed in Umbraco 13.
+/// </remarks>
+public interface IGridCellValueConnector2 : IGridCellValueConnector
+{
+    /// <inheritdoc />
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    string? IGridCellValueConnector.GetValue(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies)
+        => GetValue(gridControl, dependencies, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Gets the value to be deployed from the control value as a string.
+    /// </summary>
+    /// <param name="gridControl">The control containing the value.</param>
+    /// <param name="dependencies">The dependencies of the property.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The grid cell value to be deployed.
+    /// </returns>
+    string? GetValue(GridValue.GridControl gridControl, ICollection<ArtifactDependency> dependencies, IContextCache contextCache);
+
+    /// <inheritdoc />
+    [Obsolete($"Use the overload accepting {nameof(IContextCache)} instead. This overload will be removed in Umbraco 13.")]
+    void IGridCellValueConnector.SetValue(GridValue.GridControl gridControl)
+        => SetValue(gridControl, PassThroughCache.Instance);
+
+    /// <summary>
+    /// Allows you to modify the value of a control being deployed.
+    /// </summary>
+    /// <param name="gridControl">The control being deployed.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <remarks>
+    /// Follows the pattern of the property value connectors (<see cref="IValueConnector" />).
+    /// The SetValue method is used to modify the value of the <paramref name="gridControl" />.
+    /// </remarks>
+    void SetValue(GridValue.GridControl gridControl, IContextCache contextCache);
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
@@ -305,7 +305,7 @@ public class UdiTests
     }
 
     [UdiDefinition("foo", UdiType.GuidUdi)]
-    public class FooConnector : IServiceConnector
+    public class FooConnector : IServiceConnector2
     {
         public IArtifact GetArtifact(Udi udi, IContextCache contextCache) => throw new NotImplementedException();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/13287 contained breaking changes that affected implementations of `IDataTypeConfigurationConnector`, `IServiceConnector`, `IValueConnector` and `IGridCellValueConnector`. This PR reverts these breaking changes by moving them into a new interface and providing extension methods that tries to use the overload accepting `IContextCache` when available.

Testing should ensure the breaking changes are reverted and after merging/releasing this, the Deploy/Deploy Contrib implementations should be updated and tested separately.