### PR TITLE
SQL Server Truncate when full nucache SQL rebuild.

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -108,7 +108,16 @@ public class NuCacheContentRepository : RepositoryBase, INuCacheContentRepositor
             | ContentCacheDataSerializerEntityType.Media
             | ContentCacheDataSerializerEntityType.Member);
 
-        if(contentTypeIds != null)
+        // If contentTypeIds, mediaTypeIds and memberTypeIds are null, truncate table as all records will be deleted (as these 3 are the only types in the table). SQL Server Only
+        if ((contentTypeIds == null || !contentTypeIds.Any())
+              && (mediaTypeIds == null || !mediaTypeIds.Any())
+              && (memberTypeIds == null || !memberTypeIds.Any())
+              && Database.DatabaseType.IsSqlServer())
+        {
+                Database.Execute($"TRUNCATE TABLE cmsContentNu");
+        }
+
+        if (contentTypeIds != null)
         {
             RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Optimize queries for rebuilding nucache when using SQL Server / SQL Azure / SQL Lite.
The rebuild queries time out when deleting existing nucache data on rebuild.
If all the cmsContentNu records will be deleted, truncates the table instead of running the deletes.
Added a todo with a suggestion on how to further optimize this in future.


How to test?
Rebuild nucache on SQL Server, SQL Azure, SQL Lite

<!-- Thanks for contributing to Umbraco CMS! -->
