### PR TITLE
Hotfix: create and pack empty file to add TFM dependency to Umbraco.Cms and Umbraco.Cms.Targets

### DIFF
--- a/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
+++ b/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
@@ -52,10 +52,10 @@
   </Target>
 
   <!-- Create and pack empty file to add TFM dependency -->
-  <Target Name="PackTargetFrameworkFile" BeforeTargets="Build">
+  <Target Name="GetTargetFrameworkPackageFiles" BeforeTargets="GenerateNuspec">
     <WriteLinesToFile File="$(IntermediateOutputPath)_._" />
     <ItemGroup>
-      <None Include="$(IntermediateOutputPath)_._" Pack="true" PackagePath="lib\$(TargetFramework)" />
+      <_PackageFiles Include="$(IntermediateOutputPath)_._" PackagePath="lib\$(TargetFramework)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Umbraco.Cms/Umbraco.Cms.csproj
+++ b/src/Umbraco.Cms/Umbraco.Cms.csproj
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <!-- Create and pack empty file to add TFM dependency -->
-  <Target Name="PackTargetFrameworkFile" BeforeTargets="Build">
+  <Target Name="GetTargetFrameworkPackageFiles" BeforeTargets="GenerateNuspec">
     <WriteLinesToFile File="$(IntermediateOutputPath)_._" />
     <ItemGroup>
-      <None Include="$(IntermediateOutputPath)_._" Pack="true" PackagePath="lib\$(TargetFramework)" />
+      <_PackageFiles Include="$(IntermediateOutputPath)_._" PackagePath="lib\$(TargetFramework)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/13475 added an MSBuild target that added an empty file in a framework specific folder to the `Umbraco.Cms` and `Umbraco.Cms.Targets` meta-packages, so they can only be installed into projects with a compatible TFM.

This worked fine if the package was created using `dotnet pack`, but the target wasn't executed when doing a separate `dotnet build` and `dotnet pack --no-build` (as done by the build pipeline), causing the file to not be included.

This fixes this problem and only executes the target when the NuGet package is actually created, so it also doesn't have to write the empty file when only doing a build (reducing disk I/O).