### PR TITLE
Tree picker support for selecting containers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -375,61 +375,32 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
 
         /** Method used for selecting a node */
         function select(text, id, entity) {
-            //if we get the root, we just return a constructed entity, no need for server data
-            if (id < 0) {
-
-                var rootNode = {
-                    alias: null,
-                    icon: "icon-folder",
-                    id: id,
-                    name: text
-                };
-
+            // we do not need to query the server in case a root (id < 0)
+            // or an entity was provided
+            if (id < 0 || !!entity) {
                 if (vm.multiPicker) {
-                    if (entity) {
-                        multiSelectItem(entity);
-                    }
-                    else {
-                        multiSelectItem(rootNode);
-                    }
+                    multiSelectItem(entity ? entity : getRootEntity(id, text));
                 }
                 else {
-                    $scope.model.selection.push(rootNode);
+                    if (entity) {
+                        $scope.model.selection.push(entity);
+                    } else {
+                        $scope.model.selection.push(getRootEntity(id, text));
+                    }
                     $scope.model.submit($scope.model);
                 }
             }
             else {
 
-                if (vm.multiPicker) {
-
-                    if (entity) {
-                        multiSelectItem(entity);
-                    }
-                    else {
-                        //otherwise we have to get it from the server
-                        entityResource.getById(id, vm.entityType).then(function (ent) {
-                            multiSelectItem(ent);
-                        });
-                    }
-
-                }
-                else {
-
-                    hideSearch();
-
-                    //if an entity has been passed in, use it
-                    if (entity) {
-                        $scope.model.selection.push(entity);
-                        $scope.model.submit($scope.model);
-                    }
-                    else {
-                        //otherwise we have to get it from the server
-                        entityResource.getById(id, vm.entityType).then(function (ent) {
-                            $scope.model.selection.push(ent);
-                            $scope.model.submit($scope.model);
-                        });
-                    }
-                }
+              // otherwise we have to get it from the server
+              entityResource.getById(id, vm.entityType).then(function (ent) {
+                  if (vm.multiPicker) {
+                      multiSelectItem(ent);
+                  } else {
+                      $scope.model.selection.push(ent);
+                      $scope.model.submit($scope.model);
+                  }
+              });
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -370,7 +370,10 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                         entity.metaData.IsContainer = true;
                         // end-mimic
                     }
+
+                    // apply the item to the model
                     select(args.node.name, args.node.id, entity);
+
                     //toggle checked state
                     args.node.selected = !args.node.selected;
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -577,7 +577,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                                             isSearchResult: true
                                         },
                                         hasChildren: false,
-                                        parent: () => parent                                        
+                                        parent: () => parent
                                     });
                                 }
                             });
@@ -605,12 +605,12 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             performFiltering(results);
 
             //now actually remove all filtered items so they are not even displayed
-            results = results.filter(item => !item.filtered);          
+            results = results.filter(item => !item.filtered);
             vm.searchInfo.results = results;
 
             //sync with the curr selected results
             vm.searchInfo.results.forEach(result => {
-                var exists = $scope.model.selection.find(item => result.id === item.id);               
+                var exists = $scope.model.selection.find(item => result.id === item.id);
                 if (exists) {
                     result.selected = true;
                 }

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -360,11 +360,16 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                     $scope.model.select(args.node);
                 }
                 else {
-                    select(args.node.name, args.node.id);
+                    // If this is a container, construct a base entity to return immediately
+                    let entity = undefined;
+                    if (args.node.nodeType === "container") {
+                        entity = args.node;
+                        entity.metaData.IsContainer = true; // mimic the server response from the EntityController
+                    }
+                    select(args.node.name, args.node.id, entity);
                     //toggle checked state
-                    args.node.selected = args.node.selected === true ? false : true;
+                    args.node.selected = !args.node.selected;
                 }
-
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -408,20 +408,18 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
 
         function multiSelectItem(item) {
 
-            var found = false;
-            var foundIndex = 0;
-
-            if ($scope.model.selection.length > 0) {
-                for (var i = 0; $scope.model.selection.length > i; i++) {
-                    var selectedItem = $scope.model.selection[i];
-                    if (selectedItem.id === parseInt(item.id)) {
-                        found = true;
-                        foundIndex = i;
-                    }
-                }
+            if (!vm.multiPicker) {
+              $scope.model.selection.length = 0;
+              hideSearch();
             }
 
-            if (found) {
+            var foundIndex = -1;
+
+            if ($scope.model.selection.length) {
+                foundIndex = $scope.model.selection.findIndex(ent => ent.id === parseInt(item.id, 10));
+            }
+
+            if (foundIndex !== -1) {
                 $scope.model.selection.splice(foundIndex, 1);
             }
             else {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -364,7 +364,11 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                     let entity = undefined;
                     if (args.node.nodeType === "container") {
                         entity = args.node;
-                        entity.metaData.IsContainer = true; // mimic the server response from the EntityController
+
+                        // mimic the server response from the EntityController
+                        entity.id = parseInt(entity.id, 10);
+                        entity.metaData.IsContainer = true;
+                        // end-mimic
                     }
                     select(args.node.name, args.node.id, entity);
                     //toggle checked state

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -196,7 +196,7 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
                         {
                             var filter = Utilities.fromJson($scope.model.filter);
                             $scope.model.filter = function (node){ return _.isMatch(node.metaData, filter);};
-                        }            
+                        }
                         else
                         {
                             //convert to object

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -382,32 +382,27 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
 
         /** Method used for selecting a node */
         function select(text, id, entity) {
-            // we do not need to query the server in case a root (id < 0)
-            // or an entity was provided
-            if (id < 0 || !!entity) {
-                if (vm.multiPicker) {
-                    multiSelectItem(entity ? entity : getRootEntity(id, text));
-                }
-                else {
-                    if (entity) {
-                        $scope.model.selection.push(entity);
-                    } else {
-                        $scope.model.selection.push(getRootEntity(id, text));
-                    }
-                    $scope.model.submit($scope.model);
-                }
+            // we do not need to query the server in case an entity is provided
+            if (entity) {
+              applySelect(entity);
             }
+            // nor do we need to query if a root entity was selected (id < 0)
+            else if (id < 0) {
+              applySelect(entity || getRootEntity(id, text));
+            }
+            // otherwise we have to get it from the server
             else {
-
-              // otherwise we have to get it from the server
               entityResource.getById(id, vm.entityType).then(function (ent) {
-                  if (vm.multiPicker) {
-                      multiSelectItem(ent);
-                  } else {
-                      $scope.model.selection.push(ent);
-                      $scope.model.submit($scope.model);
-                  }
+                  applySelect(ent);
               });
+            }
+        }
+
+        /** Method used to apply the selected entity to selections and submit the form if need-be **/
+        function applySelect(entity) {
+            multiSelectItem(entity);
+            if (!vm.multiPicker) {
+              $scope.model.submit($scope.model);
             }
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js
@@ -314,6 +314,15 @@ angular.module("umbraco").controller("Umbraco.Editors.TreePickerController",
             }
         }
 
+        function getRootEntity(id, name) {
+          return {
+            icon: "icon-folder",
+            alias: null,
+            id,
+            name
+          };
+        }
+
         //wires up selection
         function nodeSelectHandler(args) {
             args.event.preventDefault();


### PR DESCRIPTION
Fixes #13463

### Description

This adds a feature to support selecting containers (folders) in tree pickers. While the use case is not there at the moment inside the Backoffice, it was possible before to click containers, but all you got was a 404 error with a flashy notification indicating something went wrong.

We are now constructing a shell for a container, so it behaves much like a real entity. Containers are seen primarily for data type and document type pickers.
