### PR TITLE
Fix check for existing userStatesFilter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -187,7 +187,23 @@
         }
 
         function initUserStateSelections() {
-            initUsersOptionsFilterSelections(vm.userStatesFilter, vm.usersOptions.userStates, "key");
+            if (!vm.usersOptions.userStates && vm.userStatesFilter) {
+                  // create a new empty userStates array
+                  vm.usersOptions.userStates = [];
+
+                  // add selected userStatesFilters to usersOptions.userStates array
+                  for (var i = 0; i < vm.userStatesFilter.length; i++) {
+                      if (vm.userStatesFilter[i].selected) {
+                        vm.usersOptions.userStates.push(vm.userStatesFilter[i].key);
+                      }
+                  }
+
+                  // If there are any selected userStates, update location and change pagenumber
+                  if (vm.usersOptions.userStates.length > 0) {
+                      updateLocation("userStates", vm.usersOptions.userStates.join(","));
+                      changePageNumber(1);
+                  }
+              }
         }
 
         function initUserGroupSelections() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/12705

### Description

This PR fixes the issue where user state filters are forgotten when switching from tabs (dashboard). @nul800sebastiaan  made a video where the bug is visible: https://github.com/umbraco/Umbraco-CMS/issues/12705#issuecomment-1187457346

You can use the steps in the video to verify the bug is fixed in this PR.


<!-- Thanks for contributing to Umbraco CMS! -->
