### PR TITLE
BGE: Make Areas use Flexbox for easy customisation and better drag n' drop UX

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbraco-blockgridlayout-flexbox.css
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbraco-blockgridlayout-flexbox.css
@@ -22,6 +22,9 @@
 }
 .umb-block-grid__area {
     position: relative;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     --umb-block-grid__area-calc: calc(var(--umb-block-grid--area-column-span) / var(--umb-block-grid--area-grid-columns, 1));
     width: calc(var(--umb-block-grid__area-calc) * 100% - (1 - var(--umb-block-grid__area-calc)) * var(--umb-block-grid--areas-column-gap, 0px));
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbraco-blockgridlayout.css
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbraco-blockgridlayout.css
@@ -28,6 +28,9 @@
 }
 .umb-block-grid__area {
     position: relative;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     /* For small devices we scale columnSpan by three, to make everything bigger than 1/3 take full width: */
     grid-column-end: span min(calc(var(--umb-block-grid--area-column-span, 1) * 3), var(--umb-block-grid--grid-columns));
     grid-row: span var(--umb-block-grid--area-row-span, 1);


### PR DESCRIPTION
Ensures an Area is treated like Flexbox, making it easier to change the vertical alignment of its content. and ensuring it takes full height, so its easier to drag into the Areas.

Notes for testing:
This is already the way the layout is written in the Block Grid Example Website, so already a pretty stable solution.