### PR TITLE
Check if PublishedPropertyType modelType is null

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -190,13 +190,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
             }
 
             _cacheLevel = _converter?.GetPropertyCacheLevel(this) ?? PropertyCacheLevel.Snapshot;
-            Type modelClrType = _converter == null ? typeof (object) : _converter.GetPropertyValueType(this);
-            if(modelClrType == null)
-            {
-                throw new ArgumentNullException($"Unable to map DataType with Id {DataType.Id} to a C# type.");
-            }
-
-            _modelClrType= modelClrType;
+            _modelClrType = _converter?.GetPropertyValueType(this) ?? typeof(object);
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -190,7 +190,13 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
             }
 
             _cacheLevel = _converter?.GetPropertyCacheLevel(this) ?? PropertyCacheLevel.Snapshot;
-            _modelClrType = _converter == null ? typeof (object) : _converter.GetPropertyValueType(this);
+            Type modelClrType = _converter == null ? typeof (object) : _converter.GetPropertyValueType(this);
+            if(modelClrType == null)
+            {
+                throw new ArgumentNullException($"Unable to map DataType with Id {DataType.Id} to a C# type.");
+            }
+
+            _modelClrType= modelClrType;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes #13515 

### Description
Adding a null check for the modeltype right after the PropertyValueConverter has been called to check if a type has been set.
That the type returned is null should never happen when using default PropertyValueConverters but if you are using a custom PropertyValueConverter there could be a chance that null is returned.
Sadly we only have the Id of the datatype available, but thats still better than nothing.
