### PR TITLE
Support readonly set via `SendingContentNotification`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -55,7 +55,7 @@
                         preview="(propertyEditorDisabled(property) && allowUpdate) || (!allowUpdate && !property.supportsReadOnly)"
                         allow-unlock="allowUpdate && allowEditInvariantFromNonDefault"
                         on-unlock="unlockInvariantValue(property)"
-                        ng-attr-readonly="{{!allowUpdate || undefined}}">
+                        ng-attr-readonly="{{property.readonly || (!allowUpdate && !property.supportsReadOnly) || undefined}}">
                     </umb-property-editor>
 
                 </umb-property>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -25,7 +25,7 @@
                 ng-click="openCurrentPicker()"
                 id="{{model.alias}}"
                 aria-label="{{model.label}}: {{labels.general_add}}"
-                ng-disabled="readonly">
+                ng-disabled="!allowAdd">
             <localize key="general_add">Add</localize>
             <span class="sr-only">...</span>
         </button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13545

### Description
Currently when using `SendingContentNotification` setting properties to readonly, this wasn't reflected in the UI, because it at the moment only set this based on `allowedActions` here. https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js#L18

Even though we also exclude `ActionUpdate.ActionLetter` (A) the property wasn't readonly in the UI. Besides that there can be use-cases where one want a specific property to be readonly based on certain conditions.