### PR TITLE
Create `umbraco-jsonschema` .NET tool to generate JSON schemas

### DIFF
--- a/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
+++ b/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
@@ -41,9 +41,9 @@
   </ItemGroup>
 
   <!-- Generate JSON schema on build (and before copying to project) -->
-  <Target Name="GenerateAppsettingsSchema" BeforeTargets="Build;CopyUmbracoJsonSchemaFiles" Condition="!Exists('$(_UmbracoCmsJsonSchemaReference)')">
+  <Target Name="GenerateAppsettingsSchema" AfterTargets="Build" BeforeTargets="CopyUmbracoJsonSchemaFiles" Condition="!Exists('$(_UmbracoCmsJsonSchemaReference)')">
     <Message Text="Generating $(_UmbracoCmsJsonSchemaReference) because it doesn't exist" Importance="high" />
-    <Exec WorkingDirectory="$(MSBuildThisFileDirectory)..\..\tools\Umbraco.JsonSchema" Command="dotnet run --configuration $(Configuration) -- --outputFile &quot;$(MSBuildThisFileDirectory)$(_UmbracoCmsJsonSchemaReference)&quot;" />
+    <Exec WorkingDirectory="$(MSBuildThisFileDirectory)..\..\tools\Umbraco.JsonSchema" Command="dotnet run --configuration $(Configuration) -- --assembly &quot;$(TargetPath)&quot; --type &quot;Umbraco.Cms.Targets.UmbracoCmsSchema&quot; --output &quot;$(MSBuildThisFileDirectory)$(_UmbracoCmsJsonSchemaReference)&quot;" />
   </Target>
 
   <!-- Remove generated JSON schema on clean -->

--- a/src/Umbraco.Cms.Targets/UmbracoCmsSchema.cs
+++ b/src/Umbraco.Cms.Targets/UmbracoCmsSchema.cs
@@ -1,6 +1,8 @@
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 
+namespace Umbraco.Cms.Targets;
+
 internal class UmbracoCmsSchema
 {
     public UmbracoDefinition Umbraco { get; set; } = null!;

--- a/src/Umbraco.Core/Configuration/LoggingSettingsExtensions.cs
+++ b/src/Umbraco.Core/Configuration/LoggingSettingsExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Hosting;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Extensions;
+
+namespace Umbraco.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="LoggingSettings" />.
+/// </summary>
+public static class LoggingSettingsExtensions
+{
+    /// <summary>
+    /// Gets the absolute logging path (maps a virtual path to the applications content root).
+    /// </summary>
+    /// <param name="loggingSettings">The logging settings.</param>
+    /// <param name="hostEnvironment">The host environment.</param>
+    /// <returns>
+    /// The absolute logging path.
+    /// </returns>
+    public static string GetAbsoluteLoggingPath(this LoggingSettings loggingSettings, IHostEnvironment hostEnvironment)
+    {
+        var dir = loggingSettings.Directory;
+        if (dir.StartsWith("~/"))
+        {
+            return hostEnvironment.MapPathContentRoot(dir);
+        }
+
+        return dir;
+    }
+}

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -77,13 +77,12 @@ public class GlobalSettings
     public int VersionCheckPeriod { get; set; } = StaticVersionCheckPeriod;
 
     /// <summary>
-    ///     Gets or sets a value for the Umbraco back-office path.
+    /// Gets or sets a value for the Umbraco back-office path.
     /// </summary>
+    [Obsolete($"{nameof(UmbracoPath)} is no longer configurable, this property is scheduled for removal in V12.")]
     public string UmbracoPath
     {
         get => Constants.System.DefaultUmbracoPath;
-        [Obsolete($"{nameof(UmbracoPath)} is no longer configurable, this property setter is scheduled for removal in V12.")]
-        // NOTE: When removing this, also clean up the hardcoded removal of UmbracoPath in Umbraco.JsonSchema
         set { }
     }
 

--- a/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
@@ -2,13 +2,11 @@
 // See LICENSE for more details.
 
 using System.ComponentModel;
-using Microsoft.Extensions.Hosting;
-using Umbraco.Cms.Core.Extensions;
 
 namespace Umbraco.Cms.Core.Configuration.Models;
 
 /// <summary>
-///     Typed configuration options for logging settings.
+/// Typed configuration options for logging settings.
 /// </summary>
 [UmbracoOptions(Constants.Configuration.ConfigLogging)]
 public class LoggingSettings
@@ -17,25 +15,20 @@ public class LoggingSettings
     internal const string StaticDirectory = Constants.SystemDirectories.LogFiles;
 
     /// <summary>
-    ///     Gets or sets a value for the maximum age of a log file.
+    /// Gets or sets a value for the maximum age of a log file.
     /// </summary>
+    /// <value>
+    /// The maximum log age.
+    /// </value>
     [DefaultValue(StaticMaxLogAge)]
     public TimeSpan MaxLogAge { get; set; } = TimeSpan.Parse(StaticMaxLogAge);
 
     /// <summary>
-    ///     Gets or sets the folder to use for log files
+    /// Gets or sets the folder to use for log files.
     /// </summary>
+    /// <value>
+    /// The directory.
+    /// </value>
     [DefaultValue(StaticDirectory)]
     public string Directory { get; set; } = StaticDirectory;
-
-    public string GetAbsoluteLoggingPath(IHostEnvironment hostEnvironment)
-    {
-        var dir = Directory;
-        if (dir.StartsWith("~/"))
-        {
-            return hostEnvironment.MapPathContentRoot(dir);
-        }
-
-        return dir;
-    }
 }

--- a/tools/Umbraco.JsonSchema/Options.cs
+++ b/tools/Umbraco.JsonSchema/Options.cs
@@ -2,6 +2,12 @@ using CommandLine;
 
 internal class Options
 {
-    [Option("outputFile", Default = "appsettings-schema.Umbraco.Cms.json", HelpText = "Output file to save the generated JSON schema for Umbraco CMS.")]
-    public string OutputFile { get; set; } = null!;
+    [Option('a', "assembly", Required = true, HelpText = "Assembly file (DLL) to load, get the specified type and generate the JSON schema from.")]
+    public string AssemblyFilePath { get; set; } = null!;
+
+    [Option('t', "type", Required = true, HelpText = "Type name (including namespace) to generate the JSON schema from.")]
+    public string TypeName { get; set; } = null!;
+
+    [Option('o', "output", Required = true, HelpText = "Output file path to write the generated JSON schema to.")]
+    public string OutputFilePath { get; set; } = null!;
 }

--- a/tools/Umbraco.JsonSchema/PluginLoadContext.cs
+++ b/tools/Umbraco.JsonSchema/PluginLoadContext.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+/// <inheritdoc />
+internal class PluginLoadContext : AssemblyLoadContext
+{
+    /// <summary>
+    /// The resolver.
+    /// </summary>
+    private readonly AssemblyDependencyResolver _resolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginLoadContext" /> class.
+    /// </summary>
+    /// <param name="pluginPath">The plugin path.</param>
+    public PluginLoadContext(string pluginPath)
+        => _resolver = new AssemblyDependencyResolver(pluginPath);
+
+    /// <inheritdoc />
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null)
+        {
+            return LoadFromAssemblyPath(assemblyPath);
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (libraryPath != null)
+        {
+            return LoadUnmanagedDllFromPath(libraryPath);
+        }
+
+        return IntPtr.Zero;
+    }
+}

--- a/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
+++ b/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
@@ -1,16 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IsPackable>false</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>umbraco-jsonschema</ToolCommandName>
     <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="NJsonSchema" Version="10.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Umbraco.Core\Umbraco.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
+++ b/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Title>Umbraco JSON schema generator</Title>
+    <Description>Generates a JSON schema from a specific type in an assembly file.</Description>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>umbraco-jsonschema</ToolCommandName>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This converts the `Umbraco.JsonSchema` console application into a .NET tool to generate JSON schemas from a specific type in an assembly file.

Although the CMS still directly invokes the console application to generate the JSON schema for the CMS (at least for now), it now does so in the same way as invoking it as a .NET tool.

To this this, first check whether the `Umbraco.Cms.Targets` NuGet package still includes the generated `appsettings-schema.Umbraco.Cms.json` file (both on a local build and in the Azure Pipeline build artifacts). Next, create a local build, install the tool and generate the JSON schema using:

```
dotnet pack --configuration Release --output build.out
dotnet tool install Umbraco.JsonSchema --global --add-source build.out --prerelease
umbraco-jsonschema --assembly src\Umbraco.Cms.Targets\bin\Release\net7.0\Umbraco.Cms.Targets.dll --type Umbraco.Cms.Targets.UmbracoCmsSchema --output appsettings-schema.Umbraco.Cms.json
```

After validating whether the generated JSON schema is correct, you can uninstall this global tool using `dotnet tool uninstall Umbraco.JsonSchema --global`.

------------------------

We might want to move this into a separate repository, since we don't need new releases with every CMS version and the CMS can then also use the tool. Either way, once this tool is published on NuGet, this can be used as a local tool by other packages:
```
dotnet new tool-manifest
dotnet tool install Umbraco.JsonSchema
```

You can then create the C# class to generate the JSON schema from (e.g. `Umbraco.Forms.UmbracoFormsSchema`) and add this to the same project file to automatically generate it on build and include it as part of the NuGet package (this generated JSON schema file can be added to `.gitignore`):

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <ItemGroup>
    <Content Include="buildTransitive\**" PackagePath="buildTransitive" />
    <Content Include="appsettings-schema.Umbraco.Forms.json" PackagePath="" Visible="false" />
  </ItemGroup>

  <!-- Generate JSON schema on build -->
  <Target Name="GenerateJsonSchema" AfterTargets="Build" Condition="!Exists('appsettings-schema.Umbraco.Forms.json')">
    <Exec Command="dotnet tool run umbraco-jsonschema --assembly &quot;$(TargetPath)&quot; --type &quot;Umbraco.Forms.UmbracoFormsSchema&quot; --output &quot;appsettings-schema.Umbraco.Forms.json&quot;" />
  </Target>

  <!-- Delete generated JSON schema on clean -->
  <Target Name="CleanJsonSchema" AfterTargets="Clean" Condition="Exists('appsettings-schema.Umbraco.Forms.json')">
    <Delete Files="appsettings-schema.Umbraco.Forms.json" />
  </Target>
</Project>
```

The following [build property file](https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets) (e.g. `buildTransitive\Umbraco.Forms.props`) ensures the JSON schema that's included in the NuGet package gets automatically copied into the Umbraco project directory and added as a reference in the `appsettings-schema.json` file:

```xml
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <ItemGroup>
    <UmbracoJsonSchemaFiles Include="$(MSBuildThisFileDirectory)..\appsettings-schema.Umbraco.Forms.json" />
  </ItemGroup>
</Project>
```