### PR TITLE
Map AdditionalData

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentItemDisplay.cs
@@ -201,7 +201,7 @@ public class ContentItemDisplay<TVariant> :
     /// </summary>
     [DataMember(Name = "metaData")]
     [ReadOnly(true)]
-    public IDictionary<string, object> AdditionalData { get; private set; } = new Dictionary<string, object>();
+    public IDictionary<string, object> AdditionalData { get; set; } = new Dictionary<string, object>();
 
     /// <summary>
     ///     This is used for validation of a content item.

--- a/src/Umbraco.Core/Models/ContentEditing/ContentItemDisplay.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentItemDisplay.cs
@@ -201,7 +201,7 @@ public class ContentItemDisplay<TVariant> :
     /// </summary>
     [DataMember(Name = "metaData")]
     [ReadOnly(true)]
-    public IDictionary<string, object> AdditionalData { get; set; } = new Dictionary<string, object>();
+    public IDictionary<string, object> AdditionalData { get; private set; } = new Dictionary<string, object>();
 
     /// <summary>
     ///     This is used for validation of a content item.

--- a/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
@@ -130,6 +130,7 @@ internal class ContentMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private void Map(ContentItemDisplay source, ContentItemDisplayWithSchedule target, MapperContext context)
     {
+        target.AdditionalData = source.AdditionalData;
         target.AllowedActions = source.AllowedActions;
         target.AllowedTemplates = source.AllowedTemplates;
         target.AllowPreview = source.AllowPreview;
@@ -198,6 +199,7 @@ internal class ContentMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private static void Map(ContentItemDisplayWithSchedule source, ContentItemDisplay target, MapperContext context)
     {
+        target.AdditionalData = source.AdditionalData;
         target.AllowedActions = source.AllowedActions;
         target.AllowedTemplates = source.AllowedTemplates;
         target.AllowPreview = source.AllowPreview;
@@ -236,7 +238,7 @@ internal class ContentMapDefinition : IMapDefinition
     private static void Map(IContent source, ContentPropertyCollectionDto target, MapperContext context) =>
         target.Properties = context.MapEnumerable<IProperty, ContentPropertyDto>(source.Properties).WhereNotNull();
 
-    // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent
+    // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent -AdditionalData
     private void Map<TVariant>(IContent source, ContentItemDisplay<TVariant> target, MapperContext context)
         where TVariant : ContentVariantDisplay
     {

--- a/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
@@ -246,7 +246,7 @@ internal class ContentMapDefinition : IMapDefinition
     private static void Map(IContent source, ContentPropertyCollectionDto target, MapperContext context) =>
         target.Properties = context.MapEnumerable<IProperty, ContentPropertyDto>(source.Properties).WhereNotNull();
 
-    // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent -AdditionalData
+    // Umbraco.Code.MapAll -AllowPreview -Errors -PersistedContent
     private void Map<TVariant>(IContent source, ContentItemDisplay<TVariant> target, MapperContext context)
         where TVariant : ContentVariantDisplay
     {

--- a/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
@@ -130,7 +130,11 @@ internal class ContentMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private void Map(ContentItemDisplay source, ContentItemDisplayWithSchedule target, MapperContext context)
     {
-        target.AdditionalData = source.AdditionalData;
+        foreach (KeyValuePair<string, object> additionalData in source.AdditionalData)
+        {
+            target.AdditionalData.Add(additionalData);
+        }
+
         target.AllowedActions = source.AllowedActions;
         target.AllowedTemplates = source.AllowedTemplates;
         target.AllowPreview = source.AllowPreview;
@@ -199,7 +203,11 @@ internal class ContentMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private static void Map(ContentItemDisplayWithSchedule source, ContentItemDisplay target, MapperContext context)
     {
-        target.AdditionalData = source.AdditionalData;
+        foreach (KeyValuePair<string, object> additionalData in source.AdditionalData)
+        {
+            target.AdditionalData.Add(additionalData);
+        }
+
         target.AllowedActions = source.AllowedActions;
         target.AllowedTemplates = source.AllowedTemplates;
         target.AllowPreview = source.AllowPreview;


### PR DESCRIPTION
# Notes
- Added mapping for AdditionalData

# How to test
- I Used a SendingContentNoticiationHandler to add some values to additionalData.
- Create a document type with allow as root set to true
- Create a content for it
- Open dev tools and go to network tab
- Refresh the page
- Find the GetById request
- The metadata object should now be filled with your data like so:
 
![image](https://user-images.githubusercontent.com/70372949/207062340-1c09e9af-238b-4e07-a147-f5367d50b07b.png)


Code snippet: 
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI;
public class PreviewUrlSendingContentNotificationHandler : INotificationAsyncHandler<SendingContentNotification>
{
    public PreviewUrlSendingContentNotificationHandler()
    {
    }
    public async Task HandleAsync(SendingContentNotification notification, CancellationToken cancellationToken)
    {
        notification.Content.AdditionalData["someValue"] = "HelloWorld";
        notification.Content.AdditionalData["someObjectValue"] = new {Url = "http://google.com"};
        notification.Content.AdditionalData["myList"] = new List<string>() {"Dog", "Cat"};
    }
}

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder
        .AddNotificationAsyncHandler<SendingContentNotification, PreviewUrlSendingContentNotificationHandler>();
}

```