### PR TITLE
Umbraco.MultipleTextstring: save using consistent newline and support parsing different newlines

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -68,6 +68,9 @@ public class MultipleTextStringPropertyEditor : DataEditor
     /// </summary>
     internal class MultipleTextStringPropertyValueEditor : DataValueEditor
     {
+        private static readonly string NewLine = "\n";
+        private static readonly string[] NewLineDelimiters = { "\r\n", "\r", "\n" };
+
         private readonly ILocalizedTextService _localizedTextService;
 
         public MultipleTextStringPropertyValueEditor(
@@ -119,10 +122,10 @@ public class MultipleTextStringPropertyEditor : DataEditor
             // only allow the max if over 0
             if (max > 0)
             {
-                return string.Join(Environment.NewLine, array.Take(max));
+                return string.Join(NewLine, array.Take(max));
             }
 
-            return string.Join(Environment.NewLine, array);
+            return string.Join(NewLine, array);
         }
 
         /// <summary>
@@ -131,7 +134,6 @@ public class MultipleTextStringPropertyEditor : DataEditor
         ///     cannot have 2 way binding, so to get around that each item in the array needs to be an object with a string.
         /// </summary>
         /// <param name="property"></param>
-        /// <param name="dataTypeService"></param>
         /// <param name="culture"></param>
         /// <param name="segment"></param>
         /// <returns></returns>
@@ -141,8 +143,9 @@ public class MultipleTextStringPropertyEditor : DataEditor
         public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
             var val = property.GetValue(culture, segment);
-            return val?.ToString()?.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => JObject.FromObject(new { value = x })) ?? new JObject[] { };
+
+            return val?.ToString()?.Split(NewLineDelimiters, StringSplitOptions.None).Select(x => JObject.FromObject(new { value = x }))
+                ?? Array.Empty<JObject>();
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco.Deploy.Issues/issues/143.

### Description
Although the linked issue was raised as being Umbraco Deploy specific, the `Umbraco.MultipleTextstring` property editor in the CMS is the root cause for not properly saving/showing the newline delimited values.

Because this editor currently uses `Environment.NewLine` for both combining and splitting the multiple text values, the stored data will change depending on the server OS/environment. This is an issue when saving the values locally on a Linux/Mac OS systems that uses `\n` and then deploys that value to a Windows environment (like Umbraco Cloud): when showing the value in the backoffice, it splits the value using `\r\n`, which results in a single value.

The same can happen when changing webserver OS, restoring a database backup or using other deployment tools (e.g. package migrations): basically anytime the `Environment.NewLine` changes but the stored value in the database doesn't.

One thing to note is that the value is correctly parsed by the PVC, as that already splits on all newline delimiters:
https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/src/Umbraco.Core/PropertyEditors/ValueConverters/MultipleTextStringValueConverter.cs#L6-L9

I've created this fix for v10: even though v8 contains the same issue, that can only run on Windows environments (and therefore won't experience it) and v9 is EOL.

Testing should ensure the value can be saved and correctly shown in the backoffice again, no matter what newlines are used. The easiest way is probably to change the value in the database (e.g. using `REPLACE(textValue, CHAR(13) + CHAR(10), CHAR(10))`).