### PR TITLE
Fix unpublished state for culture variant content in a single language site

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -131,7 +131,7 @@ public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeW
 
             var documentEntity = (IDocumentEntitySlim)entity;
 
-            if (!documentEntity.Variations.VariesByCulture())
+            if (!documentEntity.Variations.VariesByCulture() || culture.IsNullOrWhiteSpace())
             {
                 if (!documentEntity.Published)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13558

### Description

If your content type is set to vary by culture but you only have one language enabled, the unpublished state of a content item is not displayed correctly in the content tree. In the following screen shot, the underlined content item is not published:

![image](https://user-images.githubusercontent.com/7405322/207251711-19c747e2-d6ee-4625-8f39-6a89d5810e12.png)

Here is the same item with this PR applied:

![image](https://user-images.githubusercontent.com/7405322/207251822-f81aabeb-ee69-4f11-80a7-28631d2744d9.png)

### How to test

1. Ensure you only have one language.
![image](https://user-images.githubusercontent.com/7405322/207251992-243382af-5f81-4273-9107-423ab3a256f0.png)
2. Create a content type that is allowed to vary by culture.
![image](https://user-images.githubusercontent.com/7405322/207251481-d38bf435-63ca-459a-a90b-9c62a83d591c.png)
3. Verify that the published and unpublished state is reflected in the content tree when publishing and unpublishing content of that content type.
4. Change the content type so it is no longer allowed to vary by culture.
5. Repeat step 3.
