### PR TITLE
Change `GetAbsoluteLoggingPath` to extension method

### DIFF
--- a/src/Umbraco.Core/Configuration/LoggingSettingsExtensions.cs
+++ b/src/Umbraco.Core/Configuration/LoggingSettingsExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Hosting;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Extensions;
+
+namespace Umbraco.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="LoggingSettings" />.
+/// </summary>
+public static class LoggingSettingsExtensions
+{
+    /// <summary>
+    /// Gets the absolute logging path (maps a virtual path to the applications content root).
+    /// </summary>
+    /// <param name="loggingSettings">The logging settings.</param>
+    /// <param name="hostEnvironment">The host environment.</param>
+    /// <returns>
+    /// The absolute logging path.
+    /// </returns>
+    public static string GetAbsoluteLoggingPath(this LoggingSettings loggingSettings, IHostEnvironment hostEnvironment)
+    {
+        var dir = loggingSettings.Directory;
+        if (dir.StartsWith("~/"))
+        {
+            return hostEnvironment.MapPathContentRoot(dir);
+        }
+
+        return dir;
+    }
+}

--- a/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
@@ -2,13 +2,11 @@
 // See LICENSE for more details.
 
 using System.ComponentModel;
-using Microsoft.Extensions.Hosting;
-using Umbraco.Cms.Core.Extensions;
 
 namespace Umbraco.Cms.Core.Configuration.Models;
 
 /// <summary>
-///     Typed configuration options for logging settings.
+/// Typed configuration options for logging settings.
 /// </summary>
 [UmbracoOptions(Constants.Configuration.ConfigLogging)]
 public class LoggingSettings
@@ -17,25 +15,20 @@ public class LoggingSettings
     internal const string StaticDirectory = Constants.SystemDirectories.LogFiles;
 
     /// <summary>
-    ///     Gets or sets a value for the maximum age of a log file.
+    /// Gets or sets a value for the maximum age of a log file.
     /// </summary>
+    /// <value>
+    /// The maximum log age.
+    /// </value>
     [DefaultValue(StaticMaxLogAge)]
     public TimeSpan MaxLogAge { get; set; } = TimeSpan.Parse(StaticMaxLogAge);
 
     /// <summary>
-    ///     Gets or sets the folder to use for log files
+    /// Gets or sets the folder to use for log files.
     /// </summary>
+    /// <value>
+    /// The directory.
+    /// </value>
     [DefaultValue(StaticDirectory)]
     public string Directory { get; set; } = StaticDirectory;
-
-    public string GetAbsoluteLoggingPath(IHostEnvironment hostEnvironment)
-    {
-        var dir = Directory;
-        if (dir.StartsWith("~/"))
-        {
-            return hostEnvironment.MapPathContentRoot(dir);
-        }
-
-        return dir;
-    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While changing the JSON schema generation to a .NET tool that loads an assembly to get the type to generate the schema from (see PR https://github.com/umbraco/Umbraco-CMS/pull/13560), I encountered the following error:

```
Could not load file or assembly 'Microsoft.Extensions.Hosting.Abstractions, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
```

I'm not a 100% sure why it can't find this assembly, since Umbraco.Core does have a dependency on Microsoft.Extensions.Hosting.Abstractions 7.0.0, but I see the `LoggingSettings` class does use the `IHostEnvironment` interface from this assembly since a recent change in PR https://github.com/umbraco/Umbraco-CMS/pull/13485.

Since these changes aren't released yet and the method using `IHostEnvironment` doesn't have to be on the settings class (and shouldn't be to make it a POCO), I've moved it into an extension method. This change is already included in PR #13560, but that might not get merged before the next v11 release, hence the reason for creating this PR 😄

Testing should be a simple case of checking the moved code and whether this still builds.