### PR TITLE
Fix wrongfully reported pending package migrations

### DIFF
--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -133,7 +133,7 @@ public class PackagingService : IPackagingService
             var currentPlans = installedPackage.PackageMigrationPlans.ToList();
             if (keyValues is null || keyValues.TryGetValue(
                 Constants.Conventions.Migrations.KeyValuePrefix + plan.Name,
-                out var currentState))
+                out var currentState) is false)
             {
                 currentState = null;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12883

### Description

As described on the linked issue, packages that support package migrations are always reported as having pending migrations under "Installed packages" - even when they don't have any pending migrations.

This is a regression issue caused by [this commit](https://github.com/umbraco/Umbraco-CMS/commit/2009f7585b1d7489f4f9e6c158edae8ff556c762#diff-2d1623773840660fdc71834dc86ebb3904dec868441778aca6f9b4c2bed7848e) as part of a large refactor.

Here is the "Installed packages" view before this PR:

![image](https://user-images.githubusercontent.com/7405322/207403766-8d305d09-55b3-4a77-85ad-ca1e6a6212c2.png)

And here is the same view with this PR applied (no migrations have been run in the meantime):

![image](https://user-images.githubusercontent.com/7405322/207403704-263eb227-4f6f-4fa1-bab6-766d3122165e.png)


### How to test

1. Install Umbraco.Forms from NuGet
2. Go to "Installed packages"
3. Verify that there are no pending migrations reported for Umbraco Forms