### PR TITLE
Handle StringValues in ObjectExtensions.TryConvertTo

### DIFF
--- a/src/Umbraco.Core/Extensions/ObjectExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ObjectExtensions.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Xml;
+using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Collections;
 
@@ -189,9 +190,10 @@ public static class ObjectExtensions
             else
             {
                 // target is not a generic type
-                if (input is string inputString)
+                var inputString = input as string ?? (input is StringValues sv ? sv.ToString() : null);
+                if (inputString != null)
                 {
-                    // Try convert from string, returns an Attempt if the string could be
+                    // Try convert from string or StringValues, returns an Attempt if the string could be
                     // processed (either succeeded or failed), else null if we need to try
                     // other methods
                     Attempt<object?>? result = TryConvertToFromString(inputString, target);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/ObjectExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/ObjectExtensionsTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Primitives;
 using NUnit.Framework;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Tests.Common.TestHelpers;
@@ -279,6 +280,56 @@ public class ObjectExtensionsTests
         var conv = "2016-06-07".TryConvertTo<DateTime?>();
         Assert.IsTrue(conv);
         Assert.AreEqual(new DateTime(2016, 6, 7), conv.Result);
+    }
+
+    [TestCase("d72f12a9-29db-42b4-9ffb-25a3ba4dcef5")]
+    [TestCase("D72F12A9-29DB-42B4-9FFB-25A3BA4DCEF5")]
+    public void CanConvertToGuid(string guidValue)
+    {
+        var conv = guidValue.TryConvertTo<Guid>();
+        Assert.IsTrue(conv);
+        Assert.AreEqual(Guid.Parse(guidValue), conv.Result);
+    }
+
+    [TestCase("d72f12a9-29db-42b4-9ffb-25a3ba4dcef5")]
+    [TestCase("D72F12A9-29DB-42B4-9FFB-25A3BA4DCEF5")]
+    public void CanConvertToNullableGuid(string guidValue)
+    {
+        var conv = guidValue.TryConvertTo<Guid?>();
+        Assert.IsTrue(conv);
+        Assert.AreEqual(Guid.Parse(guidValue), conv.Result);
+    }
+
+    [TestCase("d72f12a9-29db-42b4-9ffb-25a3ba4dcef5")]
+    [TestCase("D72F12A9-29DB-42B4-9FFB-25A3BA4DCEF5")]
+    public void CanConvertStringValuesToNullableGuid(string guidValue)
+    {
+        StringValues stringValues = guidValue;
+        var conv = stringValues.TryConvertTo<Guid?>();
+        Assert.IsTrue(conv);
+        Assert.AreEqual(Guid.Parse(guidValue), conv.Result);
+    }
+
+    [TestCase(10)]
+    [TestCase(0)]
+    [TestCase(-10)]
+    [TestCase(int.MinValue)]
+    [TestCase(int.MaxValue)]
+    public void CanConvertStringValuesToInt(int intValue)
+    {
+        StringValues stringValues = intValue.ToString();
+        var conv = stringValues.TryConvertTo<int>();
+        Assert.IsTrue(conv);
+        Assert.AreEqual(intValue, conv.Result);
+    }
+
+    [Test]
+    public void CanConvertStringValuesToString()
+    {
+        StringValues stringValues = "This is a string";
+        var conv = stringValues.TryConvertTo<string>();
+        Assert.IsTrue(conv);
+        Assert.AreEqual("This is a string", conv.Result);
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12832

### Description

For some reason our `ObjectExtensions.TryConvertTo` doesn't play nice with `StringValues` input types. This is the root cause for the linked issue.

I have added support for `StringValues` (treating them as `string`) and added some unit tests to prove that it works 😆 

### Testing this PR

As mentioned on the linked issue, this PR can be tested by using editors with limited content access and an MNTP that ignores user start nodes.

1. Create an editor with limited access to the content tree (a start node somewhere below the root).
2. Create an MNTP that is configured to pick content and to ignore user start nodes.
3. Add said MNTP to a content type which the editor is able to reach in the content tree.
4. Log in as the editor and ensure that the MNTP allows picking content outside the scope of the editor's allowed content tree access.
![image](https://user-images.githubusercontent.com/7405322/207554771-b77238b4-4929-4718-be4c-915df77b42f5.png)
5. Update the MNTP configuration so it respects user start nodes.
6. Verify that the editor is now only able to pick content within the scope of the allowed content tree access.
![image](https://user-images.githubusercontent.com/7405322/207555079-5d7b3ffc-eac3-4fe9-8cdc-edf915f99f51.png)
