### PR TITLE
Make it possible to drag multiple properties to other tabs in succession

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -158,6 +158,9 @@
                     items: ".umb-group-builder__property-sortable",
                     stop: (e, ui) => {
                         updatePropertiesSortOrder();
+
+                        // when a property is dropped we need to reset the requested tab hover alias
+                        scope.sortableRequestedTabAlias = undefined;
                     }
                 };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12810

Update: This also fixes https://github.com/umbraco/Umbraco-CMS/issues/12144

### Description

It is currently kinda hard to move several properties between tabs in succession. It *is* possible, but it requires just the right touch (or rather, just the right drag-fu).

This PR makes property dragging between tabs work as expected when dragging multiple properties in succession.

### Testing this PR

To test, create a content type with two (or more) tabs and two (or more) properties. Then start dragging properties around between tabs and verify that you can indeed do that several times in a row without getting stuck.

![drag-multiple-properties-between-tabs](https://user-images.githubusercontent.com/7405322/207589800-25e61fe1-57d4-4e4f-ba01-b333ad7ff293.gif)
