### PR TITLE
Improved support for TinyMCE custom style formats

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -170,9 +170,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         }));
       });
     }
-    else {
-      styleFormats = fallbackStyles;
-    }
 
     return $q.all(promises).then(function () {
       // Always push our Umbraco RTE stylesheet
@@ -375,7 +372,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
           autoresize_bottom_margin: 10,
           content_css: styles.stylesheets,
           style_formats: styles.styleFormats,
-          style_formats_autohide: true,
           language: getLanguage(),
 
           //this would be for a theme other than inlite
@@ -450,7 +446,18 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             }
           }
 
+          // if we have style_formats at this point they originate from the RTE CSS config. we don't want any custom
+          // style_formats to interfere with the RTE CSS config, so let's explicitly remove the custom style_formats.
+          if(tinyMceConfig.customConfig.style_formats && config.style_formats && config.style_formats.length){
+            delete tinyMceConfig.customConfig.style_formats;
+          }
+
           Utilities.extend(config, tinyMceConfig.customConfig);
+        }
+
+        if(!config.style_formats || !config.style_formats.length){
+          // if we have no style_formats at this point we'll revert to using the default ones (fallbackStyles)
+          config.style_formats = fallbackStyles;
         }
 
         return config;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13577

### Description

This PR improves the handling of TinyMCE custom style formats defined in app settings.

After an internal discussion we've agreed on the following rules:

1. If an RTE is configured with one or more stylesheets in the backoffice, the stylesheet rules should be the only ones available in the TinyMCE style selector (do not merge with any custom or default styles).
2. If custom styles are defined in app settings and no stylesheets are configured for the RTE, the custom styles should be the only ones available in the TinyMCE style selector (do not merge with the default styles).
3. If neither stylesheets are configured for the RTE nor custom styles are defined in app settings, the TinyMCE style selector should show the default styles.

### Testing this PR

First and foremost create a content type with an RTE property. The backing datatype should *not* have any stylesheets configured, and "Style select" should be enabled.

Create some content of this content type for testing.

1. Verify that the TinyMCE style selector contains the default styles:
![image](https://user-images.githubusercontent.com/7405322/207826418-d2e69dae-6a88-482d-a6e8-16d806fa1b2e.png)
2. Define custom styles by adding the following to app settings (under `Umbraco::CMS`):
```json
"RichTextEditor": {
  "CustomConfig": {
    "style_formats": "[{\"title\": \"Headers\",\"items\": [{\"title\": \"Red header\",\"block\": \"h1\",\"styles\": {\"color\": \"#ff0000\"}}, {\"title\": \"Green header\",\"block\": \"h1\",\"styles\": {\"color\": \"#00ff00\"}}, {\"title\": \"Blue header\",\"block\": \"h1\",\"styles\": {\"color\": \"#0000ff\"}}]}, {\"title\": \"Blocks\",\"items\": [{\"title\": \"Red text\",\"inline\": \"span\",\"styles\": {\"color\": \"#ff0000\"}}, {\"title\": \"Green text\",\"inline\": \"span\",\"styles\": {\"color\": \"#00ff00\"}}, {\"title\": \"Blue text\",\"inline\": \"span\",\"styles\": {\"color\": \"#0000ff\"}}]}]"
  }
}
```
3. Restart the site and verify that the TinyMCE style selector now contains the custom styles:
![image](https://user-images.githubusercontent.com/7405322/207827495-0e1a322a-ad7b-4b83-8fc5-a940b04e1eef.png)
4. Create an RTE stylesheet and add it to the RTE configuration. The stylesheet could look like this:
```css
/**umb_name:Red*/
.red {
	color: red;
}

/**umb_name:Blue*/
.blue {
	color: blue;
}
```
5. Verify that the TinyMCE style selector now only contains the RTE stylesheet styles:
![image](https://user-images.githubusercontent.com/7405322/207827866-da9fc7f1-621f-47e2-be47-8d50c708c381.png)

