### PR TITLE
Make sure the property editor layout is contained within its container

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-property-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-property-editor.less
@@ -1,6 +1,6 @@
 .umb-property-editor {
   position: relative;
-  contain: style;
+  contain: layout;
 }
 
 .umb-property-editor--preview {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13495

### Description

This PR reverts #13033, which was created for V10 to fix #12989. This has been discussed internally, and it is safe to revert for V11.

Once reverted, the "z-index bleed-through" issue observed in #13495 is solved, because the property editor layout (and thus z-index assignment) is now contained within the property editor container.

### Testing this PR

1. Create at least three languages.
2. Create a content type that varies by culture.
3. Create a property on this content type that does *not* vary by culture. Note that the property *must* be the topmost one on the content type.
4. Enable editing invariant properties from non-default languages by adding `"AllowEditInvariantFromNonDefault": true` to app settings (under `Umbraco::CMS::Content`):
![image](https://user-images.githubusercontent.com/7405322/207831578-4ce867b6-3b30-48d3-b011-f19e71560cfa.png)
5. Edit content of the created content type in a non-default language.
6. Open the language selector.
7. Verify that the "{property} is shared across all languages" message remains behind the language selector.
![fix-locked-editor-z-index-13495](https://user-images.githubusercontent.com/7405322/207831953-c7fd1a15-a074-4381-9b44-16be0efdb8fb.gif)
