### PR TITLE
Multi URL picker improvements for V11

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -568,7 +568,7 @@ public class EntityController : UmbracoAuthorizedJsonController
     [HttpGet]
     public UrlAndAnchors GetUrlAndAnchors(int id, string? culture = "*")
     {
-        culture ??= ClientCulture();
+        culture = culture is null or "*" ? ClientCulture() : culture;
 
         var url = _publishedUrlProvider.GetUrl(id, culture: culture);
         IEnumerable<string> anchorValues = _contentService.GetAnchorValuesFromRTEs(id, culture);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/multiurlpicker/multiurlpicker.controller.js
@@ -21,10 +21,6 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
 
     $scope.renderModel = [];
 
-    if ($scope.preview) {
-        return;
-    }
-
     if ($scope.model.config && parseInt($scope.model.config.maxNumber) !== 1 && $scope.umbProperty) {
         var propertyActions = [
           removeAllEntriesAction
@@ -83,7 +79,7 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
             $scope.sortableOptions.disabled = $scope.renderModel.length === 1 || $scope.readonly;
 
             removeAllEntriesAction.isDisabled = $scope.renderModel.length === 0 || $scope.readonly;
-            
+
             //Update value
             $scope.model.value = $scope.renderModel;
         }
@@ -93,7 +89,7 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
         if (!$scope.allowRemove) return;
 
         $scope.renderModel.splice($index, 1);
-        
+
         setDirty();
     };
 
@@ -208,15 +204,23 @@ function multiUrlPickerController($scope, localizationService, entityResource, i
             $scope.model.config.minNumber = 1;
         }
 
-        _.each($scope.model.value, function (item) {
+        const ids = [];
+        $scope.model.value.forEach(item => {
             // we must reload the "document" link URLs to match the current editor culture
-            if (item.udi && item.udi.indexOf("/document/") > 0) {
+            if (item.udi && item.udi.indexOf("/document/") > 0 && ids.indexOf(item.udi) < 0) {
+                ids.push(item.udi);
                 item.url = null;
-                entityResource.getUrlByUdi(item.udi).then(data => {
-                    item.url = data;
-                });
             }
         });
+
+        if(ids.length){
+            entityResource.getUrlsByIds(ids, "Document").then(function(urlMap){
+                Object.keys(urlMap).forEach((udi) => {
+                    const items = $scope.model.value.filter(item => item.udi === udi);
+                    items.forEach(item => item.url = urlMap[udi]);
+                })
+            });
+        }
     }
 
     init();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13576

### Description

A few issues have turned up for the multi URL picker in V11:

1. It simply doesn't work when used as a culture invariant property on a culture variant content type.
2. The URLs displayed are either broken or wrong.

Turns out the multi URL picker simply doesn't render its items when displayed in "preview" mode. And since invariant properties are in "preview" mode by default, this is quite the issue for the multi URL picker. The resulting behaviour differs with the content item state:

- If the content item only has one saved culture, the multi URL picker seems to work, but only on that one saved culture; as soon as you change culture and attempt to "unlock" it for editing, it becomes entirely broken.
- If the content item has multiple saved cultures, the multi URL picker turns somewhat erratic; sometimes it looks empty on every culture even when it's not, sometimes changing culture can provoke a reload of the items within. And when "unlocked" for editing, the "Add" button doesn't do anything at all.

![13576-broken](https://user-images.githubusercontent.com/7405322/207851283-b132f5a2-c222-4966-99e9-8db3376889e7.gif)

When the multi URL picker does manage to show any items, the URLs displayed are weirdly wrong - here's a multi URL picker in comparison to a content picker (the content picker displays the URL correctly):

![image](https://user-images.githubusercontent.com/7405322/207850778-ad97f451-bc43-4c14-bb89-b28c64e5206c.png)

Lastly when one *does* manage to edit an item in the multi URL picker, the "Link" box consequently displays a "#" as URL, even when the item has a valid URL:

![image](https://user-images.githubusercontent.com/7405322/207851498-48069571-b8bc-4cc4-8d01-bf7276fbfed0.png)

### Testing this PR

1. Create a culture variant content type with a culture *invariant* multi URL picker.
2. Verify that you can edit the multi URL picker property in every language across multiple save/publish operations. The "unlock" feature should just work as it does for every other property type. Note that you must have `AllowEditInvariantFromNonDefault` enabled in appsettings:
![image](https://user-images.githubusercontent.com/7405322/207851874-1bd0be80-c791-4f64-b143-d168241ff13f.png)
3. Verify that the URLs are displayed correctly for each item in the list of items.
4. Verify that the URLs are displayed correctly when editing items (i.e. not a "#" in the "Link" box).

![13576-fixed](https://user-images.githubusercontent.com/7405322/207852105-1a631dd1-d707-43e3-9d3d-7001fabe7483.gif)

