### PR TITLE
Support space (and more) in tag groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -92,7 +92,7 @@
                     var sources = {
                         //see: https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#options
                         // name = the data set name, we'll make this the tag group name + culture
-                        name: vm.config.group + (vm.culture ? vm.culture : ""),
+                        name: (vm.config.group + (vm.culture ? vm.culture : "")).replace(/\W/g, '-'),
                         display: "text",
                         //source: tagsHound
                         source: function (query, syncCallback, asyncCallback) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13146

### Description

The linked issue takes a bit of a detour, but here's the gist: If you create a Tags property with a space in the tag group (possibly also other special chars), the Tags editor throws a JS error in the console whenever you focus the editor (click inside the textbox):

![image](https://user-images.githubusercontent.com/7405322/208081885-ed123686-4618-491b-a9bf-dc032f015d02.png)

![image](https://user-images.githubusercontent.com/7405322/208082062-ddbf1e59-c338-4f0d-a072-da0e7a53c8f4.png)

Fortunately this is fixable by replacing all non-word chars in the tags group before putting it to use.

### Testing this PR

1. Create a Tags data type with a space in the tag group.
2. Create and publish some content with tags using this Tags data type (_publish_ being the magic word here).
3. Create new content of the same type and verify that the Tags property supports type-ahead using the previously published tags.

![tags-with-space](https://user-images.githubusercontent.com/7405322/208082884-147d5e80-2c63-46ae-9981-deaac3fa0f36.gif)
