### PR TITLE
feat: Allow custom NuCache path

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -640,7 +640,7 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
 
     private string GetLocalFilesPath()
     {
-        var path = Path.Combine(_hostingEnvironment.LocalTempPath, "NuCache");
+        var path = Path.Combine(_options.CachePath ?? _hostingEnvironment.LocalTempPath, "NuCache");
 
         if (!Directory.Exists(path))
         {

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotServiceOptions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotServiceOptions.cs
@@ -35,7 +35,7 @@ public class PublishedSnapshotServiceOptions
     ///     The path to store the localDb files at.
     /// </summary>
     /// <remarks>
-    ///     By default <see cref="IHostingEnvironment.LocalTempPath"/> is used. On Linux storeing the localDb file outside tmp can be more performant.
+    ///     By default <see cref="IHostingEnvironment.LocalTempPath"/> is used. On Linux storing the localDb file outside tmp can be more performant.
     ///     See: https://github.com/mamift/CSharpTest.Net.Collections/issues/2#issuecomment-1328282778
     /// </remarks>
     public string? CachePath { get; set; }

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotServiceOptions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotServiceOptions.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Infrastructure.PublishedCache;
@@ -29,4 +30,13 @@ public class PublishedSnapshotServiceOptions
     ///     files.
     /// </remarks>
     public bool IgnoreLocalDb { get; set; }
+
+    /// <summary>
+    ///     The path to store the localDb files at.
+    /// </summary>
+    /// <remarks>
+    ///     By default <see cref="IHostingEnvironment.LocalTempPath"/> is used. On Linux storeing the localDb file outside tmp can be more performant.
+    ///     See: https://github.com/mamift/CSharpTest.Net.Collections/issues/2#issuecomment-1328282778
+    /// </remarks>
+    public string? CachePath { get; set; }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this adds a workaround for<!-- link to the issue here! --> #12159

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I looked a bit into #12159 and found that by changing the path where you store the NuCache cache will make the writing to the file much faster. Findings: https://github.com/mamift/CSharpTest.Net.Collections/issues/2#issuecomment-1328282778

Therefore, I've added the ability to change the default cache path for the NuCache.

**Note: I haven't been able to figure out what should make the write slower on Linux when using the tmp folder.**

How to test/use:

Add:
```csharp
services.AddTransient(factory => new PublishedSnapshotServiceOptions() { CachePath = "C:\\MyCacheFolder" });
```
In Startup.cs `ConfigureServices` before `services.AddUmbraco`.

<!-- Thanks for contributing to Umbraco CMS! -->
