### PR TITLE
Remove limitation on nested content to 1,000 items where max items unset

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.controller.js
@@ -104,9 +104,6 @@
         vm.minItems = model.config.minItems || 0;
         vm.maxItems = model.config.maxItems || 0;
 
-        if (vm.maxItems === 0)
-            vm.maxItems = 1000;
-
         vm.singleMode = vm.minItems === 1 && vm.maxItems === 1 && model.config.contentTypes.length === 1;
         vm.expandsOnLoad = Object.toBoolean(model.config.expandsOnLoad)
         vm.showIcons = Object.toBoolean(model.config.showIcons);
@@ -204,9 +201,17 @@
             validate();
         };
 
+        vm.maxItemsExceeded = function () {
+            return vm.maxItems !== 0 && vm.nodes.length > vm.maxItems;
+        }
+
+        vm.maxItemsReached = function () {
+            return vm.maxItems !== 0 && vm.nodes.length >= vm.maxItems;
+        }
+
         vm.openNodeTypePicker = function ($event) {
 
-            if (vm.nodes.length >= vm.maxItems) {
+            if (vm.maxItemsReached()) {
                 return;
             }
 
@@ -767,7 +772,7 @@
                 $scope.nestedContentForm.minCount.$setValidity("minCount", true);
             }
 
-            if (vm.nodes.length > vm.maxItems) {
+            if (vm.maxItemsExceeded()) {
                 $scope.nestedContentForm.maxCount.$setValidity("maxCount", false);
             }
             else {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/nestedcontent/nestedcontent.propertyeditor.html
@@ -1,4 +1,4 @@
-﻿<div id="umb-nested-content--{{model.id}}" class="umb-nested-content" ng-class="{'umb-nested-content--narrow':!vm.wideMode, 'umb-nested-content--wide':vm.wideMode}">
+<div id="umb-nested-content--{{model.id}}" class="umb-nested-content" ng-class="{'umb-nested-content--narrow':!vm.wideMode, 'umb-nested-content--wide':vm.wideMode}">
 
     <umb-load-indicator class="mt2" ng-if="!vm.inited"></umb-load-indicator>
 
@@ -60,9 +60,9 @@
             <button
                 type="button"
                 class="btn-reset umb-nested-content__add-content umb-focus"
-                ng-class="{ '--disabled': (!vm.scaffolds.length || vm.nodes.length >= vm.maxItems) }"
+                ng-class="{ '--disabled': (!vm.scaffolds.length || vm.maxItemsReached()) }"
                 ng-click="vm.openNodeTypePicker($event)"
-                aria-disabled="{{!vm.scaffolds.length || vm.nodes.length >= vm.maxItems}}"
+                aria-disabled="{{!vm.scaffolds.length || vm.maxItemsReached()}}"
                 ng-disabled="!vm.allowAdd">
                 <localize key="grid_addElement">Add element</localize>
             </button>
@@ -78,7 +78,7 @@
                 <localize key="validation_entriesShort" tokens="[vm.minItems, vm.minItems - vm.nodes.length]" watch-tokens="true">Minimum %0% entries, needs <strong>%1%</strong> more.</localize>
             </div>
         </div>
-        <div ng-if="nestedContentForm.minCount.$error === true || vm.nodes.length > vm.maxItems">
+        <div ng-if="nestedContentForm.minCount.$error === true || vm.maxItemsExceeded()">
             <div class="help text-error">
                 <localize key="validation_entriesExceed" tokens="[vm.maxItems, vm.nodes.length - vm.maxItems]" watch-tokens="true">Maximum %0% entries, <strong>%1%</strong> too many.</localize>
             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #13585 

### Description

In order to meet the description within the [documentation](https://our.umbraco.com/Documentation/Fundamentals/Backoffice/property-editors/built-in-property-editors/Nested-Content/), rather than use an arbitrary limit, as is currently done on the content editor, I have added two methods to the angular js controller.

* maxItemsReached(): `vm.nodes.length >= vm.maxItems`
* maxItemsExceeded(): `vm.nodes.length > vm.maxItems`

This logic has been replaced everywhere it has been specified in the template view and the controller JavaScript.

The bounds can be easily tested by setting up a Nested Content within a page, and set the limits, check that the limits are enfoced. Go into the Nested Content and then change the limit, check the validaiton continues to be enforced, particularly if it's set to < the current number of items in the nested content.

Hitting the 1,000 items list is a bit more difficult, takes an awful lot of tedious button presses. I have a SQLite file of a trivial umbraco installation I can share, assuming it can be easily hooked up. I may add some unit tests, but there is no template atm for tests on the nested content controller.

See screenshots below.

**Setup**
![image](https://user-images.githubusercontent.com/3931242/208201765-3e987395-3e3d-4013-b5ca-8212b21e35c0.png)


**Ability to add nested content**
![image](https://user-images.githubusercontent.com/3931242/208201692-4991b702-d4b9-4d64-822c-4a9ff3a24a4c.png)
