### PR TITLE
Load Package.Manifest's from content root too

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -149,7 +149,7 @@ public static partial class UmbracoBuilderExtensions
 
         // WebRootFileProviderFactory is just a wrapper around the IWebHostEnvironment.WebRootFileProvider,
         // therefore no need to register it as singleton
-        builder.Services.AddSingleton<IManifestFileProviderFactory, WebRootFileProviderFactory>();
+        builder.Services.AddSingleton<IManifestFileProviderFactory, ContentAndWebRootFileProviderFactory>();
         builder.Services.AddSingleton<IGridEditorsConfigFileProviderFactory, WebRootFileProviderFactory>();
 
         // Must be added here because DbProviderFactories is netstandard 2.1 so cannot exist in Infra for now

--- a/src/Umbraco.Web.Common/FileProviders/ContentAndWebRootFileProviderFactory.cs
+++ b/src/Umbraco.Web.Common/FileProviders/ContentAndWebRootFileProviderFactory.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Web.Common.FileProviders;
+
+public class ContentAndWebRootFileProviderFactory : IManifestFileProviderFactory
+{
+    private readonly IWebHostEnvironment _webHostEnvironment;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentAndWebRootFileProviderFactory"/> class.
+    /// </summary>
+    /// <param name="webHostEnvironment">The web hosting environment an application is running in.</param>
+    public ContentAndWebRootFileProviderFactory(IWebHostEnvironment webHostEnvironment)
+    {
+        _webHostEnvironment = webHostEnvironment;
+    }
+
+    /// <summary>
+    ///     Creates a new <see cref="IFileProvider" /> instance, pointing at WebRootPath and ContentRootPath.
+    /// </summary>
+    /// <returns>
+    ///     The newly created <see cref="IFileProvider" /> instance.
+    /// </returns>
+    public IFileProvider Create() => new CompositeFileProvider(_webHostEnvironment.WebRootFileProvider, _webHostEnvironment.ContentRootFileProvider);
+}


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13565

This introduces a composite file provider for the `IManifestFileProviderFactory` to read from both the web-root and the content-root.

### Test
- Follow guide on https://github.com/umbraco/Umbraco-CMS/issues/13565