### PR TITLE
Add `GetUmbracoBackOfficeUrl` extension methods

### DIFF
--- a/src/Umbraco.Web.BackOffice/Install/InstallAuthorizeAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Install/InstallAuthorizeAttribute.cs
@@ -42,7 +42,7 @@ public class InstallAuthorizeAttribute : TypeFilterAttribute
                 // Only authorize when the installer is enabled
                 context.Result = new ForbidResult(new AuthenticationProperties()
                 {
-                    RedirectUri = _linkGenerator.GetBackOfficeUrl(_hostingEnvironment)
+                    RedirectUri = _linkGenerator.GetUmbracoBackOfficeUrl(_hostingEnvironment)
                 });
             }
             else if (_runtimeState.Level == RuntimeLevel.Upgrade && (await context.HttpContext.AuthenticateBackOfficeAsync()).Succeeded == false)

--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -13,32 +13,25 @@ namespace Umbraco.Extensions;
 public static class LinkGeneratorExtensions
 {
     /// <summary>
-    ///     Return the back office url if the back office is installed
+    /// Gets the backoffice URL (if the back office is installed).
     /// </summary>
-    public static string? GetBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
-    {
-        Type? backOfficeControllerType;
-        try
-        {
-            backOfficeControllerType = Assembly.Load("Umbraco.Web.BackOffice")
-                .GetType("Umbraco.Web.BackOffice.Controllers.BackOfficeController");
-            if (backOfficeControllerType == null)
-            {
-                return "/"; // this would indicate that the installer is installed without the back office
-            }
-        }
-        catch
-        {
-            return
-                hostingEnvironment
-                    .ApplicationVirtualPath; // this would indicate that the installer is installed without the back office
-        }
+    /// <param name="linkGenerator">The link generator.</param>
+    /// <returns>
+    /// The backoffice URL.
+    /// </returns>
+    public static string? GetBackOfficeUrl(this LinkGenerator linkGenerator)
+        => linkGenerator.GetPathByAction("Default", "BackOffice", new { area = Constants.Web.Mvc.BackOfficeArea });
 
-        return linkGenerator.GetPathByAction(
-            "Default",
-            ControllerExtensions.GetControllerName(backOfficeControllerType),
-            new { area = Constants.Web.Mvc.BackOfficeApiArea });
-    }
+    /// <summary>
+    /// Gets the backoffice URL (if the back office is installed) or application virtual path (in most cases just <c>"/"</c>).
+    /// </summary>
+    /// <param name="linkGenerator">The link generator.</param>
+    /// <param name="hostingEnvironment">The hosting environment.</param>
+    /// <returns>
+    /// The backoffice URL.
+    /// </returns>
+    public static string GetBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
+         => GetBackOfficeUrl(linkGenerator) ?? hostingEnvironment.ApplicationVirtualPath;
 
     /// <summary>
     ///     Return the Url for a Web Api service

--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -13,25 +13,35 @@ namespace Umbraco.Extensions;
 public static class LinkGeneratorExtensions
 {
     /// <summary>
-    /// Gets the backoffice URL (if the back office is installed).
+    /// Gets the Umbraco backoffice URL (if Umbraco is installed).
     /// </summary>
     /// <param name="linkGenerator">The link generator.</param>
     /// <returns>
-    /// The backoffice URL.
+    /// The Umbraco backoffice URL.
     /// </returns>
-    public static string? GetBackOfficeUrl(this LinkGenerator linkGenerator)
+    public static string? GetUmbracoBackOfficeUrl(this LinkGenerator linkGenerator)
         => linkGenerator.GetPathByAction("Default", "BackOffice", new { area = Constants.Web.Mvc.BackOfficeArea });
 
     /// <summary>
-    /// Gets the backoffice URL (if the back office is installed) or application virtual path (in most cases just <c>"/"</c>).
+    /// Gets the Umbraco backoffice URL (if Umbraco is installed) or application virtual path (in most cases just <c>"/"</c>).
     /// </summary>
     /// <param name="linkGenerator">The link generator.</param>
     /// <param name="hostingEnvironment">The hosting environment.</param>
     /// <returns>
-    /// The backoffice URL.
+    /// The Umbraco backoffice URL.
     /// </returns>
-    public static string GetBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
-         => GetBackOfficeUrl(linkGenerator) ?? hostingEnvironment.ApplicationVirtualPath;
+    public static string GetUmbracoBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
+         => GetUmbracoBackOfficeUrl(linkGenerator) ?? hostingEnvironment.ApplicationVirtualPath;
+
+    /// <summary>
+    ///     Return the back office url if the back office is installed
+    /// </summary>
+    /// <remarks>
+    /// This method contained a bug that would result in always returning "/".
+    /// </remarks>
+    [Obsolete("Use the GetUmbracoBackOfficeUrl extension method instead. This method will be removed in Umbraco 13.")]
+    public static string? GetBackOfficeUrl(this LinkGenerator linkGenerator, IHostingEnvironment hostingEnvironment)
+        => "/";
 
     /// <summary>
     ///     Return the Url for a Web Api service

--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -23,20 +23,26 @@ namespace Umbraco.Extensions;
 public static class UrlHelperExtensions
 {
     /// <summary>
+    /// Gets the Umbraco backoffice URL (if Umbraco is installed).
+    /// </summary>
+    /// <param name="urlHelper">The URL helper.</param>
+    /// <returns>
+    /// The Umbraco backoffice URL.
+    /// </returns>
+    public static string? GetUmbracoBackOfficeUrl(this IUrlHelper urlHelper)
+        => urlHelper.Action("Default", "BackOffice", new { area = Constants.Web.Mvc.BackOfficeArea });
+
+    /// <summary>
     ///     Return the back office url if the back office is installed
     /// </summary>
     /// <param name="url"></param>
     /// <returns></returns>
+    /// <remarks>
+    /// This method contained a bug that would result in always returning "/".
+    /// </remarks>
+    [Obsolete("Use the GetUmbracoBackOfficeUrl extension method instead. This method will be removed in Umbraco 13.")]
     public static string? GetBackOfficeUrl(this IUrlHelper url)
-    {
-        var backOfficeControllerType = Type.GetType("Umbraco.Web.BackOffice.Controllers");
-        if (backOfficeControllerType == null)
-        {
-            return "/"; // this would indicate that the installer is installed without the back office
-        }
-
-        return url.Action("Default", ControllerExtensions.GetControllerName(backOfficeControllerType), new { area = Constants.Web.Mvc.BackOfficeApiArea });
-    }
+        => "/";
 
     /// <summary>
     ///     Return the Url for a Web Api service


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This replaces PR https://github.com/umbraco/Umbraco-CMS/pull/12968 (and retargets it to v11): the `GetBackOfficeUrl()` extension methods contained a bug in a type lookup (because of updated namespaces) and a wrong route area that caused it to always return `/`.

Instead of fixing the original extension methods, this obsoletes the existing ones (on both `LinkGenerator` and `IUrlHelper`) and adds new `GetUmbracoBackOfficeUrl()` extension methods.

You can test this by using the following view:
```
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@inject Microsoft.AspNetCore.Routing.LinkGenerator LinkGenerator;
@inject Umbraco.Cms.Core.Hosting.IHostingEnvironment HostingEnvironment;
<ul>
    <li><a href="@Url.GetBackOfficeUrl()">Url.GetBackOfficeUrl()</a></li>
    <li><a href="@LinkGenerator.GetBackOfficeUrl(HostingEnvironment)">LinkGenerator.GetBackOfficeUrl(HostingEnvironment)</a></li>
</ul>
<ul>
    <li><a href="@Url.GetUmbracoBackOfficeUrl()">Url.GetUmbracoBackOfficeUrl()</a></li>
    <li><a href="@LinkGenerator.GetUmbracoBackOfficeUrl()">LinkGenerator.GetUmbracoBackOfficeUrl()</a></li>
    <li><a href="@LinkGenerator.GetUmbracoBackOfficeUrl(HostingEnvironment)">LinkGenerator.GetUmbracoBackOfficeUrl(HostingEnvironment)</a></li>
</ul>
```

Note that this will cause the `InstallAuthorizeAttribute` to now redirect to the backoffice instead, but as this URL isn't configurable anymore and is also exposed by the new maintenance page introduced in https://github.com/umbraco/Umbraco-CMS/pull/13551, that shouldn't be an issue.