### PR TITLE
V10: Dont disable invited users

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -807,6 +807,10 @@ public class UsersController : BackOfficeNotificationsController
         {
             _userService.Save(users);
         }
+        else
+        {
+            return Ok(new DisabledUsersModel());
+        }
 
         var disabledUsersModel = new DisabledUsersModel
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -35,6 +35,7 @@ using Umbraco.Cms.Web.BackOffice.Security;
 using Umbraco.Cms.Web.Common.ActionsResults;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Cms.Web.Common.Models;
 using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Extensions;
 
@@ -807,7 +808,18 @@ public class UsersController : BackOfficeNotificationsController
             _userService.Save(users);
         }
 
-        return Ok(users.Select(x => x.Id));
+        var disabledUsersModel = new DisabledUsersModel
+        {
+            DisabledUserIds = users.Select(x => x.Id),
+        };
+
+        var message= users.Count > 1
+            ? _localizedTextService.Localize("speechBubbles", "disableUsersSuccess", new[] { userIds.Length.ToString() })
+            : _localizedTextService.Localize("speechBubbles", "disableUserSuccess", new[] { users[0].Name });
+
+        var header = _localizedTextService.Localize("general", "success");
+        disabledUsersModel.Notifications.Add(new BackOfficeNotification(header, message, NotificationStyle.Success));
+        return Ok(disabledUsersModel);
     }
 
     /// <summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -800,7 +800,7 @@ public class UsersController : BackOfficeNotificationsController
             u.InvitedDate = null;
         }
 
-        users = users.Where(x => !skippedUsers.Contains(x)).ToList();
+        users = users.Except(skippedUsers).ToList();
 
         if (users.Any())
         {

--- a/src/Umbraco.Web.Common/Models/DisabledUsersModel.cs
+++ b/src/Umbraco.Web.Common/Models/DisabledUsersModel.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Web.Common.Models;
+
+[DataContract]
+public class DisabledUsersModel : INotificationModel
+{
+    public List<BackOfficeNotification> Notifications { get; } = new();
+
+    [DataMember(Name = "disabledUserIds")]
+    public IEnumerable<int> DisabledUserIds { get; set; } = Enumerable.Empty<int>();
+}

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -334,7 +334,8 @@
             vm.disableUserButtonState = "busy";
             usersResource.disableUsers(vm.selection).then(function (data) {
                 // update userState
-                vm.selection.forEach(function (userId) {
+
+                data.forEach(function (userId) {
                     var user = getUserFromArrayById(userId, vm.users);
                     if (user) {
                         user.userState = "Disabled";
@@ -808,7 +809,6 @@
 
                 if (user.userDisplayState && user.userDisplayState.key === "Invited") {
                     vm.allowEnableUser = false;
-                    vm.allowDisableUser = false;
                 }
 
                 if (user.userDisplayState && user.userDisplayState.key === "LockedOut") {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -809,6 +809,7 @@
 
                 if (user.userDisplayState && user.userDisplayState.key === "Invited") {
                     vm.allowEnableUser = false;
+                    vm.allowDisableUser = false;
                 }
 
                 if (user.userDisplayState && user.userDisplayState.key === "LockedOut") {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -808,6 +808,7 @@
 
                 if (user.userDisplayState && user.userDisplayState.key === "Invited") {
                     vm.allowEnableUser = false;
+                    vm.allowDisableUser = false;
                 }
 
                 if (user.userDisplayState && user.userDisplayState.key === "LockedOut") {

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.controller.js
@@ -334,8 +334,7 @@
             vm.disableUserButtonState = "busy";
             usersResource.disableUsers(vm.selection).then(function (data) {
                 // update userState
-
-                data.forEach(function (userId) {
+                data.disabledUserIds.forEach(function (userId) {
                     var user = getUserFromArrayById(userId, vm.users);
                     if (user) {
                         user.userState = "Disabled";

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/UsersControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/UsersControllerTests.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.Common.Formatters;
+using Umbraco.Cms.Web.Common.Models;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.BackOffice.Controllers;
 
@@ -253,8 +254,6 @@ public class UsersControllerTests : UmbracoTestServerTestBase
             var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             body = body.TrimStart(AngularJsonMediaTypeFormatter.XsrfPrefix);
-            var affectedUsers = JsonConvert.DeserializeObject<int[]>(body, new JsonSerializerSettings { ContractResolver = new IgnoreRequiredAttributesResolver() });
-            Assert.IsEmpty(affectedUsers!);
         });
     }
 
@@ -285,8 +284,8 @@ public class UsersControllerTests : UmbracoTestServerTestBase
             var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             body = body.TrimStart(AngularJsonMediaTypeFormatter.XsrfPrefix);
-            var affectedUsers = JsonConvert.DeserializeObject<int[]>(body, new JsonSerializerSettings { ContractResolver = new IgnoreRequiredAttributesResolver() });
-            Assert.AreEqual(affectedUsers!.First(), createdUser!.Id);
+            var affectedUsers = JsonConvert.DeserializeObject<DisabledUsersModel>(body, new JsonSerializerSettings { ContractResolver = new IgnoreRequiredAttributesResolver() });
+            Assert.AreEqual(affectedUsers!.DisabledUserIds.First(), createdUser!.Id);
 
             var disabledUser = userService.GetByEmail("test@test.com");
             Assert.AreEqual(disabledUser!.UserState, UserState.Disabled);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/UsersControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/UsersControllerTests.cs
@@ -1,31 +1,21 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Membership;
-using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.Common.Formatters;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.BackOffice.Controllers;
 


### PR DESCRIPTION
# Notes
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13552
- Added logic to skip invited users on the server
- Disable the "disable" button, when user is invited.
- Don't fake "disabled" state in the frontend.

# How to test
- Remember to run `npm run build` as there are frontend changes 👍 
- Enable smtp by filling out the values in appSettings.Development.json
- Run umbraco
- Invite a user from the backoffice
- Use the list view of all users: 
![image](https://user-images.githubusercontent.com/70372949/208443054-d42792f4-f3d7-41ac-a830-d1288b38637d.png)
- Select and disable the invited user:
![image](https://user-images.githubusercontent.com/70372949/208443222-4c8aa8fb-ed26-4f52-852c-3bb588b784a0.png)
 YOU SHOULD NO LONGER BE ABLE TO :
- Activate the user
- Change the users password
- You can now login
