### PR TITLE
Add margin-right to block card name and subname

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -103,15 +103,12 @@ umb-block-card {
             font-weight: bold;
             font-size: 14px;
             color: @ui-action-type;
-            margin-left: 16px;
-            margin-bottom: -1px;
+            margin: 0 16px -1px;
         }
         .__subname {
             color: @gray-4;
             font-size: 12px;
-            margin-left: 16px;
-            margin-top: 1px;
-            margin-bottom: -1px;
+            margin: 1px 16px -1px;
             line-height: 1.5em;
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Really small PR that adds `margin-right: 16px` to the name and subname elements on the block card, to match the current `margin-left` and prevent text running up to the right edge of block cards, like so:

![image](https://user-images.githubusercontent.com/1543222/209127854-2ceb2b93-e4b8-474a-a300-7cbcac107d5e.png)
