### PR TITLE
fixes data-element attribute on media section

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
@@ -37,7 +37,7 @@
 
             <div class="umb-group-panel__content" data-element="tab-content-{{group.type === 'Group' ? group.parentAlias : group.alias}}">
                 <umb-property
-                    data-element="property-{{property.alias}}"
+                    data-element="property-{{group.alias}}"
                     ng-repeat="property in group.properties track by property.alias"
                     property="property"
                     element-key="{{vm.model.key}}"

--- a/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/elementeditor/umb-element-editor-content.component.html
@@ -37,7 +37,7 @@
 
             <div class="umb-group-panel__content" data-element="tab-content-{{group.type === 'Group' ? group.parentAlias : group.alias}}">
                 <umb-property
-                    data-element="property-{{group.alias}}"
+                    data-element="property-{{property.alias}}"
                     ng-repeat="property in group.properties track by property.alias"
                     property="property"
                     element-key="{{vm.model.key}}"

--- a/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/apps/content/content.html
@@ -22,7 +22,7 @@
         </div>
         <div class="umb-group-panel__content" data-element="tab-content-{{group.type === 'Group' ? group.parentAlias : group.alias}}">
             <umb-property
-                data-element="property-{{group.alias}}"
+                data-element="property-{{property.alias}}"
                 ng-repeat="property in group.properties  track by property.alias"
                 property="property">
                 <umb-property-editor model="property"></umb-property-editor>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes #13619 

### Description
1. Create a new member based on the default member type.
2. Open the DevTools
3. You can see that the `data-element` attribute of the `umb-property` element is now changing for each property. Previously the alias displayed was from the group containing the property.

