### PR TITLE
fix for #13623 by hiding Member Edit Action Menu on Infinite editing …

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/member/edit.html
@@ -11,6 +11,7 @@
          <umb-editor-header
             name="content.name"
             menu="page.menu"
+            hide-actions-menu="page.hideActionsMenu"
             hide-icon="true"
             hide-description="true"
             hide-alias="true"

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -33,7 +33,7 @@ function MemberEditController($scope, $routeParams, $location, $http, $q, appSta
     $scope.page.nameLocked = false;
     $scope.page.saveButtonState = "init";
     $scope.page.exportButton = "init";
-    $scope.page.hideActionsMenu = infiniteMode ? true : false
+    $scope.page.hideActionsMenu = infiniteMode ? true : false;
 
     //build a path to sync the tree with
     function buildTreePath(data) {

--- a/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.edit.controller.js
@@ -33,6 +33,7 @@ function MemberEditController($scope, $routeParams, $location, $http, $q, appSta
     $scope.page.nameLocked = false;
     $scope.page.saveButtonState = "init";
     $scope.page.exportButton = "init";
+    $scope.page.hideActionsMenu = infiniteMode ? true : false
 
     //build a path to sync the tree with
     function buildTreePath(data) {


### PR DESCRIPTION
…for consistency

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
This fixes #13623 by hiding the Action Menu when the Member is edited in the Infinite Editor.  This brings it in line with the experience of editing Media or Content items in the Infinite Editor.

For steps to reproduce, see ticket #13623 


<!-- Thanks for contributing to Umbraco CMS! -->
